### PR TITLE
Make config and catalog writes durable

### DIFF
--- a/docs/reviews/v0.2-config-write-safety-audit.md
+++ b/docs/reviews/v0.2-config-write-safety-audit.md
@@ -1,0 +1,56 @@
+# v0.2 Config Write Safety Audit
+
+Date: 2026-07-09
+Issue: #23
+
+## Scope closed by this branch
+
+This branch covers configuration, catalog, model metadata, and client adapter config writes that can affect user-visible Gateway/CodexHub behavior.
+
+## Shared write guarantees
+
+Python and Rust writers now use the same high-level contract:
+
+- write to a unique temporary file in the target directory;
+- flush and `fsync` the temporary file before publication;
+- publish with same-directory replace/rename;
+- hold a target-specific `.lock` file while writing;
+- recover stale `.lock` files containing an old `acquired_at_millis` timestamp;
+- clean temporary files on write/publish failure where possible.
+
+## Covered Python writers
+
+- Providers TOML save path.
+- Generated catalog/state JSON writer.
+- Codex config overlay apply/restore.
+
+Additional restore safety:
+
+- Overlay restore no longer deletes the backup before the restored config write succeeds.
+
+## Covered Rust writers
+
+- Runtime providers/settings saves.
+- Gateway client adapter config writes through the existing replacement helper.
+- Official model subscription cache writes.
+- Model metadata JSON writes.
+
+## Explicitly out of scope for #23
+
+The following write categories were intentionally not changed in this issue because they are not the config/catalog corruption surface reported by the external audit:
+
+- telemetry/event logs and SQLite ingestion;
+- proxy PID files;
+- OpenAI usage cache files;
+- history migration/consolidation ledgers;
+- auth token/secret files;
+- autostart/installer artifacts;
+- unit-test fixture writes.
+
+Those paths should get their own issues if they need stronger durability or locking semantics.
+
+## Remaining non-goals
+
+- Catalog and state remain two compatible JSON files. Each file write is atomic, but the pair is not a single multi-file transaction.
+- The lock is a simple cross-process lock file, not a kernel advisory lock. This is intentional for Python/Rust portability.
+- Stale lock recovery is time-based. It protects against crashed writers but does not attempt to prove process liveness.

--- a/src-python/atomic_io.py
+++ b/src-python/atomic_io.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import contextlib
+import errno
+import os
+import time
+import uuid
+from pathlib import Path
+from typing import Iterator
+
+LOCK_WAIT_TIMEOUT_SECONDS = 10.0
+LOCK_RETRY_DELAY_SECONDS = 0.025
+
+
+@contextlib.contextmanager
+def file_lock_for(path: Path) -> Iterator[None]:
+    """Acquire a simple cross-process lock file for a target path."""
+    lock_path = path.with_name(f"{path.name}.lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    started = time.monotonic()
+    fd: int | None = None
+    while fd is None:
+        try:
+            fd = os.open(lock_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL)
+        except FileExistsError:
+            if time.monotonic() - started >= LOCK_WAIT_TIMEOUT_SECONDS:
+                raise TimeoutError(f"timed out waiting for config lock {lock_path}")
+            time.sleep(LOCK_RETRY_DELAY_SECONDS)
+        except OSError as exc:
+            if exc.errno == errno.EEXIST:
+                if time.monotonic() - started >= LOCK_WAIT_TIMEOUT_SECONDS:
+                    raise TimeoutError(f"timed out waiting for config lock {lock_path}") from exc
+                time.sleep(LOCK_RETRY_DELAY_SECONDS)
+                continue
+            raise
+    try:
+        os.write(fd, f"pid={os.getpid()}\n".encode("ascii"))
+        yield
+    finally:
+        os.close(fd)
+        with contextlib.suppress(OSError):
+            lock_path.unlink()
+
+
+def atomic_write_text(path: Path, text: str, *, encoding: str = "utf-8") -> None:
+    atomic_write_bytes(path, text.encode(encoding))
+
+
+def atomic_write_bytes(path: Path, data: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with file_lock_for(path):
+        temp_path = _unique_temp_path(path)
+        try:
+            with temp_path.open("wb") as temp_file:
+                temp_file.write(data)
+                temp_file.flush()
+                os.fsync(temp_file.fileno())
+            os.replace(temp_path, path)
+            _fsync_directory_best_effort(path.parent)
+        except Exception:
+            with contextlib.suppress(OSError):
+                temp_path.unlink()
+            raise
+
+
+def _unique_temp_path(path: Path) -> Path:
+    return path.with_name(f".{path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp")
+
+
+def _fsync_directory_best_effort(path: Path) -> None:
+    if os.name == "nt":
+        return
+    flags = getattr(os, "O_DIRECTORY", 0) | os.O_RDONLY
+    try:
+        fd = os.open(path, flags)
+    except OSError:
+        return
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+

--- a/src-python/atomic_io.py
+++ b/src-python/atomic_io.py
@@ -10,6 +10,7 @@ from typing import Iterator
 
 LOCK_WAIT_TIMEOUT_SECONDS = 10.0
 LOCK_RETRY_DELAY_SECONDS = 0.025
+LOCK_STALE_AFTER_SECONDS = 60.0
 
 
 @contextlib.contextmanager
@@ -23,18 +24,26 @@ def file_lock_for(path: Path) -> Iterator[None]:
         try:
             fd = os.open(lock_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL)
         except FileExistsError:
+            if _lock_is_stale(lock_path):
+                with contextlib.suppress(OSError):
+                    lock_path.unlink()
+                continue
             if time.monotonic() - started >= LOCK_WAIT_TIMEOUT_SECONDS:
                 raise TimeoutError(f"timed out waiting for config lock {lock_path}")
             time.sleep(LOCK_RETRY_DELAY_SECONDS)
         except OSError as exc:
             if exc.errno == errno.EEXIST:
+                if _lock_is_stale(lock_path):
+                    with contextlib.suppress(OSError):
+                        lock_path.unlink()
+                    continue
                 if time.monotonic() - started >= LOCK_WAIT_TIMEOUT_SECONDS:
                     raise TimeoutError(f"timed out waiting for config lock {lock_path}") from exc
                 time.sleep(LOCK_RETRY_DELAY_SECONDS)
                 continue
             raise
     try:
-        os.write(fd, f"pid={os.getpid()}\n".encode("ascii"))
+        os.write(fd, f"pid={os.getpid()}\nacquired_at_millis={_current_millis()}\n".encode("ascii"))
         yield
     finally:
         os.close(fd)
@@ -80,3 +89,29 @@ def _fsync_directory_best_effort(path: Path) -> None:
     finally:
         os.close(fd)
 
+
+def _current_millis() -> int:
+    return int(time.time() * 1000)
+
+
+def _lock_is_stale(lock_path: Path) -> bool:
+    try:
+        text = lock_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return False
+    acquired_at = _parse_lock_acquired_at_millis(text)
+    if acquired_at is None:
+        return True
+    age_seconds = max(0.0, (_current_millis() - acquired_at) / 1000)
+    return age_seconds >= LOCK_STALE_AFTER_SECONDS
+
+
+def _parse_lock_acquired_at_millis(text: str) -> int | None:
+    for line in text.splitlines():
+        key, separator, value = line.partition("=")
+        if separator and key.strip() == "acquired_at_millis":
+            try:
+                return int(value.strip())
+            except ValueError:
+                return None
+    return None

--- a/src-python/catalog_sync.py
+++ b/src-python/catalog_sync.py
@@ -11,6 +11,7 @@ from typing import Any, Iterable
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
+from atomic_io import atomic_write_text
 from catalog import (
     CatalogPolicy,
     canonical_model_id,
@@ -828,7 +829,7 @@ def load_previous_visible_models(path: Path = GENERATED_STATE_PATH) -> set[str]:
 
 def write_json(path: Path, data: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(data, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+    atomic_write_text(path, json.dumps(data, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
 
 
 def load_cached_state(path: Path = GENERATED_STATE_PATH) -> dict[str, Any]:

--- a/src-python/config_overlay.py
+++ b/src-python/config_overlay.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
+
+from atomic_io import atomic_write_text
 import re
 import sys
 
@@ -255,7 +257,7 @@ def insert_provider_section(text: str, provider_section: str) -> str:
 def apply_overlay(config_path: Path, backup_path: Path, catalog_path: Path, base_url: str) -> None:
     original = config_path.read_text(encoding="utf-8") if config_path.exists() else ""
     cleaned = strip_marked_overlay(original)
-    backup_path.write_text(cleaned if cleaned != original else original, encoding="utf-8")
+    atomic_write_text(backup_path, cleaned if cleaned != original else original, encoding="utf-8")
 
     for section in STALE_PROXY_PROVIDER_SECTIONS:
         cleaned = strip_section(cleaned, section)
@@ -263,17 +265,19 @@ def apply_overlay(config_path: Path, backup_path: Path, catalog_path: Path, base
     cleaned = set_feature_flags(cleaned, PROXY_FEATURE_FLAGS)
     updated = build_overlay(catalog_config_value(config_path, catalog_path)) + cleaned.lstrip()
     updated = insert_provider_section(updated, build_provider_section(base_url))
-    config_path.write_text(updated, encoding="utf-8")
+    atomic_write_text(config_path, updated, encoding="utf-8")
 
 
 def restore_overlay(config_path: Path, backup_path: Path, unified_history: bool = False) -> str:
     if backup_path.exists():
         restored = backup_path.read_text(encoding="utf-8")
-        backup_path.unlink()
+        restore_from_backup = True
     elif config_path.exists():
         restored = config_path.read_text(encoding="utf-8")
+        restore_from_backup = False
     else:
         restored = ""
+        restore_from_backup = False
 
     if unified_history:
         restored, status = inject_unified_history_config(restored)
@@ -282,7 +286,9 @@ def restore_overlay(config_path: Path, backup_path: Path, unified_history: bool 
         status = "disabled"
 
     if restored or config_path.exists() or unified_history:
-        config_path.write_text(restored, encoding="utf-8")
+        atomic_write_text(config_path, restored, encoding="utf-8")
+    if restore_from_backup:
+        backup_path.unlink()
     return status
 
 

--- a/src-python/providers_config.py
+++ b/src-python/providers_config.py
@@ -9,6 +9,7 @@ import tomllib
 from typing import Any, Iterable
 from urllib.request import Request, urlopen
 
+from atomic_io import atomic_write_text
 from catalog import canonical_model_id
 
 
@@ -470,7 +471,7 @@ def save_providers(providers: Iterable[ProviderConfig], path: Path = DEFAULT_PRO
                 ]
             )
 
-    path.write_text("\n".join(chunks).rstrip() + "\n", encoding="utf-8")
+    atomic_write_text(path, "\n".join(chunks).rstrip() + "\n", encoding="utf-8")
 
 
 def _sort_by_order[T](indexed_items: Iterable[tuple[int, T]]) -> list[T]:

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -1,4 +1,4 @@
-use crate::{runtime_paths, AppStatus, Provider, Settings};
+use crate::{runtime_paths, safe_file, AppStatus, Provider, Settings};
 use serde::{Deserialize, Serialize};
 use std::ffi::OsString;
 use std::fs;
@@ -327,7 +327,7 @@ fn save_providers_with_paths(
     };
     let text = toml::to_string_pretty(&document)
         .map_err(|error| format!("failed to serialize providers TOML: {error}"))?;
-    fs::write(&path, text)
+    safe_file::write_text_atomic(&path, &text)
         .map_err(|error| format!("failed to write providers TOML {}: {error}", path.display()))?;
 
     Ok(providers)
@@ -361,7 +361,7 @@ fn save_settings_with_paths(settings: Settings, paths: &ConfigPaths) -> Result<S
 
     let text = serde_json::to_string_pretty(&settings)
         .map_err(|error| format!("failed to serialize settings JSON: {error}"))?;
-    fs::write(&path, format!("{text}\n"))
+    safe_file::write_text_atomic(&path, &format!("{text}\n"))
         .map_err(|error| format!("failed to write settings JSON {}: {error}", path.display()))?;
 
     Ok(settings)

--- a/src-tauri/src/gateway.rs
+++ b/src-tauri/src/gateway.rs
@@ -1,4 +1,4 @@
-use crate::{config, models, Provider, Settings, UpstreamFormat};
+use crate::{config, models, safe_file, Provider, Settings, UpstreamFormat};
 use reqwest::blocking::Client;
 use rusqlite::{params, Connection, OptionalExtension};
 use serde::{Deserialize, Serialize};
@@ -5730,32 +5730,7 @@ fn is_any_top_level_yaml_key(line: &str) -> bool {
 }
 
 fn write_text_replace(path: &Path, text: &str) -> Result<(), String> {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent).map_err(|error| {
-            format!(
-                "failed to create config directory {}: {error}",
-                parent.display()
-            )
-        })?;
-    }
-    let temp_path = path.with_extension("tmp-codexhub");
-    fs::write(&temp_path, text).map_err(|error| {
-        format!(
-            "failed to write temp config {}: {error}",
-            temp_path.display()
-        )
-    })?;
-    if path.exists() {
-        fs::remove_file(path)
-            .map_err(|error| format!("failed to replace config {}: {error}", path.display()))?;
-    }
-    fs::rename(&temp_path, path).map_err(|error| {
-        format!(
-            "failed to move temp config {} to {}: {error}",
-            temp_path.display(),
-            path.display()
-        )
-    })
+    safe_file::write_text_atomic(path, text)
 }
 
 fn timestamp_millis() -> u128 {
@@ -5789,6 +5764,20 @@ mod tests {
     use std::io::Write;
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn write_text_replace_does_not_clobber_existing_stale_temp_file() {
+        let root = version_probe_test_root("write-text-replace-stale-temp");
+        let target = root.join("config.toml");
+        let stale_temp = target.with_extension("tmp-codexhub");
+        fs::write(&target, "old").unwrap();
+        fs::write(&stale_temp, "stale-temp").unwrap();
+
+        super::write_text_replace(&target, "new").unwrap();
+
+        assert_eq!(fs::read_to_string(&target).unwrap(), "new");
+        assert_eq!(fs::read_to_string(&stale_temp).unwrap(), "stale-temp");
+    }
 
     fn client_export_test_providers() -> Vec<Provider> {
         vec![Provider {

--- a/src-tauri/src/gateway.rs
+++ b/src-tauri/src/gateway.rs
@@ -5767,7 +5767,8 @@ mod tests {
 
     #[test]
     fn write_text_replace_does_not_clobber_existing_stale_temp_file() {
-        let root = version_probe_test_root("write-text-replace-stale-temp");
+        let root = unique_temp_dir("write-text-replace-stale-temp");
+        fs::create_dir_all(root.as_path()).unwrap();
         let target = root.join("config.toml");
         let stale_temp = target.with_extension("tmp-codexhub");
         fs::write(&target, "old").unwrap();

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -11,6 +11,7 @@ mod models;
 mod openai_usage;
 mod proxy;
 mod runtime_paths;
+mod safe_file;
 mod web_bridge;
 
 use serde::{Deserialize, Serialize};

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -1,4 +1,5 @@
-use crate::{runtime_paths, safe_file, MetadataProvenance, Model, ModelPricing, UpstreamFormat};`nuse reqwest::blocking::Client;
+use crate::{runtime_paths, safe_file, MetadataProvenance, Model, ModelPricing, UpstreamFormat};
+use reqwest::blocking::Client;
 use reqwest::header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE};
 use serde_json::{json, Value};
 use std::collections::HashSet;

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -1,5 +1,4 @@
-use crate::{runtime_paths, MetadataProvenance, Model, ModelPricing, UpstreamFormat};
-use reqwest::blocking::Client;
+use crate::{runtime_paths, safe_file, MetadataProvenance, Model, ModelPricing, UpstreamFormat};`nuse reqwest::blocking::Client;
 use reqwest::header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE};
 use serde_json::{json, Value};
 use std::collections::HashSet;
@@ -708,7 +707,7 @@ fn write_official_subscription_seed(
     });
     let text = serde_json::to_string_pretty(&payload)
         .map_err(|error| format!("failed to serialize official model cache: {error}"))?;
-    fs::write(path, format!("{text}\n")).map_err(|error| {
+    safe_file::write_text_atomic(path, &format!("{text}\n")).map_err(|error| {
         format!(
             "failed to write official model cache {}: {error}",
             path.display()
@@ -1522,7 +1521,7 @@ fn write_models_json(path: &Path, models: &[Model]) -> Result<(), String> {
     }
     let text = serde_json::to_string_pretty(models)
         .map_err(|error| format!("failed to serialize model metadata: {error}"))?;
-    fs::write(path, format!("{text}\n"))
+    safe_file::write_text_atomic(path, &format!("{text}\n"))
         .map_err(|error| format!("failed to write model metadata {}: {error}", path.display()))
 }
 

--- a/src-tauri/src/safe_file.rs
+++ b/src-tauri/src/safe_file.rs
@@ -8,6 +8,7 @@ use std::{
 
 const LOCK_WAIT_TIMEOUT: Duration = Duration::from_secs(10);
 const LOCK_RETRY_DELAY: Duration = Duration::from_millis(25);
+const LOCK_STALE_AFTER: Duration = Duration::from_secs(60);
 
 pub(crate) fn write_text_atomic(path: &Path, text: &str) -> Result<(), String> {
     if let Some(parent) = path.parent() {
@@ -87,10 +88,19 @@ impl FileLock {
         loop {
             match OpenOptions::new().write(true).create_new(true).open(&path) {
                 Ok(mut file) => {
-                    let _ = writeln!(file, "pid={}", std::process::id());
+                    let _ = writeln!(
+                        file,
+                        "pid={}\nacquired_at_millis={}",
+                        std::process::id(),
+                        timestamp_millis()
+                    );
                     return Ok(Self { path });
                 }
                 Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                    if lock_is_stale(&path) {
+                        let _ = fs::remove_file(&path);
+                        continue;
+                    }
                     if started.elapsed() >= LOCK_WAIT_TIMEOUT {
                         return Err(format!(
                             "timed out waiting for config lock {}",
@@ -105,6 +115,27 @@ impl FileLock {
             }
         }
     }
+}
+
+fn lock_is_stale(path: &Path) -> bool {
+    let Ok(text) = fs::read_to_string(path) else {
+        return false;
+    };
+    let Some(acquired_at) = parse_lock_acquired_at_millis(&text) else {
+        return true;
+    };
+    let now = timestamp_millis();
+    now.saturating_sub(acquired_at) >= LOCK_STALE_AFTER.as_millis()
+}
+
+fn parse_lock_acquired_at_millis(text: &str) -> Option<u128> {
+    text.lines().find_map(|line| {
+        let (key, value) = line.split_once('=')?;
+        if key.trim() != "acquired_at_millis" {
+            return None;
+        }
+        value.trim().parse::<u128>().ok()
+    })
 }
 
 impl Drop for FileLock {
@@ -141,5 +172,20 @@ mod tests {
 
         assert_eq!(fs::read_to_string(&target).unwrap(), "new");
         assert_eq!(fs::read_to_string(&stale_temp).unwrap(), "stale-temp");
+    }
+
+    #[test]
+    fn write_text_atomic_recovers_stale_lock_file() {
+        let root = test_root("stale-lock");
+        fs::create_dir_all(&root).unwrap();
+        let target = root.join("providers.toml");
+        let lock = root.join("providers.toml.lock");
+        fs::write(&target, "old").unwrap();
+        fs::write(&lock, "pid=0\nacquired_at_millis=0\n").unwrap();
+
+        write_text_atomic(&target, "new").unwrap();
+
+        assert_eq!(fs::read_to_string(&target).unwrap(), "new");
+        assert!(!lock.exists());
     }
 }

--- a/src-tauri/src/safe_file.rs
+++ b/src-tauri/src/safe_file.rs
@@ -1,0 +1,145 @@
+use std::{
+    fs::{self, File, OpenOptions},
+    io::Write,
+    path::{Path, PathBuf},
+    thread,
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+};
+
+const LOCK_WAIT_TIMEOUT: Duration = Duration::from_secs(10);
+const LOCK_RETRY_DELAY: Duration = Duration::from_millis(25);
+
+pub(crate) fn write_text_atomic(path: &Path, text: &str) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|error| {
+            format!(
+                "failed to create config directory {}: {error}",
+                parent.display()
+            )
+        })?;
+    }
+
+    let _lock = FileLock::acquire(path)?;
+    let temp_path = unique_temp_path(path);
+    let mut temp_file = File::create(&temp_path).map_err(|error| {
+        format!(
+            "failed to write temp config {}: {error}",
+            temp_path.display()
+        )
+    })?;
+    temp_file
+        .write_all(text.as_bytes())
+        .and_then(|_| temp_file.sync_all())
+        .map_err(|error| {
+            let _ = fs::remove_file(&temp_path);
+            format!(
+                "failed to write temp config {}: {error}",
+                temp_path.display()
+            )
+        })?;
+    drop(temp_file);
+
+    fs::rename(&temp_path, path).map_err(|error| {
+        let _ = fs::remove_file(&temp_path);
+        format!(
+            "failed to move temp config {} to {}: {error}",
+            temp_path.display(),
+            path.display()
+        )
+    })
+}
+
+fn unique_temp_path(path: &Path) -> PathBuf {
+    path.with_file_name(format!(
+        ".{}.{}.{}.tmp-codexhub",
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("config"),
+        std::process::id(),
+        timestamp_millis()
+    ))
+}
+
+fn lock_path(path: &Path) -> PathBuf {
+    path.with_file_name(format!(
+        "{}.lock",
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("config")
+    ))
+}
+
+fn timestamp_millis() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis())
+        .unwrap_or_default()
+}
+
+struct FileLock {
+    path: PathBuf,
+}
+
+impl FileLock {
+    fn acquire(target: &Path) -> Result<Self, String> {
+        let path = lock_path(target);
+        let started = Instant::now();
+        loop {
+            match OpenOptions::new().write(true).create_new(true).open(&path) {
+                Ok(mut file) => {
+                    let _ = writeln!(file, "pid={}", std::process::id());
+                    return Ok(Self { path });
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                    if started.elapsed() >= LOCK_WAIT_TIMEOUT {
+                        return Err(format!(
+                            "timed out waiting for config lock {}",
+                            path.display()
+                        ));
+                    }
+                    thread::sleep(LOCK_RETRY_DELAY);
+                }
+                Err(error) => {
+                    return Err(format!("failed to create config lock {}: {error}", path.display()))
+                }
+            }
+        }
+    }
+}
+
+impl Drop for FileLock {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::write_text_atomic;
+    use std::{fs, path::PathBuf, time::SystemTime};
+
+    fn test_root(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "codexhub-safe-file-{name}-{}",
+            SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ))
+    }
+
+    #[test]
+    fn write_text_atomic_does_not_clobber_existing_stale_temp_file() {
+        let root = test_root("stale-temp");
+        fs::create_dir_all(&root).unwrap();
+        let target = root.join("config.toml");
+        let stale_temp = target.with_extension("tmp-codexhub");
+        fs::write(&target, "old").unwrap();
+        fs::write(&stale_temp, "stale-temp").unwrap();
+
+        write_text_atomic(&target, "new").unwrap();
+
+        assert_eq!(fs::read_to_string(&target).unwrap(), "new");
+        assert_eq!(fs::read_to_string(&stale_temp).unwrap(), "stale-temp");
+    }
+}

--- a/tests/test_atomic_io.py
+++ b/tests/test_atomic_io.py
@@ -1,0 +1,30 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from atomic_io import atomic_write_text
+
+
+def test_atomic_write_text_replaces_existing_file(tmp_path: Path) -> None:
+    target = tmp_path / "config.toml"
+    target.write_text("old", encoding="utf-8")
+
+    atomic_write_text(target, "new", encoding="utf-8")
+
+    assert target.read_text(encoding="utf-8") == "new"
+
+
+def test_atomic_write_text_keeps_existing_file_when_replace_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    target = tmp_path / "providers.toml"
+    target.write_text("old", encoding="utf-8")
+
+    def fail_replace(source: str | bytes | os.PathLike[str] | os.PathLike[bytes], destination: str | bytes | os.PathLike[str] | os.PathLike[bytes]) -> None:
+        raise OSError("simulated replace failure")
+
+    monkeypatch.setattr(os, "replace", fail_replace)
+
+    with pytest.raises(OSError, match="simulated replace failure"):
+        atomic_write_text(target, "new", encoding="utf-8")
+
+    assert target.read_text(encoding="utf-8") == "old"

--- a/tests/test_atomic_io.py
+++ b/tests/test_atomic_io.py
@@ -28,3 +28,14 @@ def test_atomic_write_text_keeps_existing_file_when_replace_fails(tmp_path: Path
         atomic_write_text(target, "new", encoding="utf-8")
 
     assert target.read_text(encoding="utf-8") == "old"
+
+
+def test_atomic_write_text_recovers_stale_lock_file(tmp_path: Path) -> None:
+    target = tmp_path / "catalog.json"
+    target.write_text("old", encoding="utf-8")
+    target.with_name("catalog.json.lock").write_text("pid=0\nacquired_at_millis=0\n", encoding="utf-8")
+
+    atomic_write_text(target, "new", encoding="utf-8")
+
+    assert target.read_text(encoding="utf-8") == "new"
+    assert not target.with_name("catalog.json.lock").exists()

--- a/tests/test_catalog_sync.py
+++ b/tests/test_catalog_sync.py
@@ -574,6 +574,22 @@ class CatalogSyncTests(unittest.TestCase):
 
             self.assertEqual(json.loads(target.read_text(encoding="utf-8")), {"ok": True})
 
+    def test_write_json_uses_atomic_writer(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = Path(tmpdir) / "generated" / "catalog.json"
+            calls: list[tuple[Path, str, str]] = []
+
+            def capture_atomic_write(path: Path, text: str, *, encoding: str = "utf-8") -> None:
+                calls.append((path, text, encoding))
+
+            with patch.object(catalog_sync, "atomic_write_text", capture_atomic_write, create=True):
+                catalog_sync.write_json(target, {"ok": True})
+
+            self.assertEqual(len(calls), 1)
+            self.assertEqual(calls[0][0], target)
+            self.assertEqual(calls[0][2], "utf-8")
+            self.assertEqual(json.loads(calls[0][1]), {"ok": True})
+
     def test_extracts_context_and_capabilities_from_ollama_show_payload(self):
         payload = {
             "capabilities": ["completion", "tools"],

--- a/tests/test_config_overlay.py
+++ b/tests/test_config_overlay.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import tempfile
 from pathlib import Path
 import unittest
+from unittest.mock import patch
 
 from config_overlay import (
     MARKER_BEGIN,
@@ -182,6 +183,26 @@ class ConfigOverlayTests(unittest.TestCase):
             self.assertIn('wire_api = "responses"', updated)
             self.assertIn('model_reasoning_effort = "high"', updated)
             self.assertIn("[features]", updated)
+
+    def test_restore_overlay_keeps_backup_when_config_write_fails(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path = tmp / "config.toml"
+            backup_path = tmp / "config.backup.toml"
+            config_path.write_text("overlay", encoding="utf-8")
+            backup_path.write_text("original", encoding="utf-8")
+
+            def fail_atomic_write(path: Path, text: str, *, encoding: str = "utf-8") -> None:
+                if path == config_path:
+                    raise OSError("simulated config write failure")
+                path.write_text(text, encoding=encoding)
+
+            with patch("config_overlay.atomic_write_text", fail_atomic_write, create=True):
+                with self.assertRaisesRegex(OSError, "simulated config write failure"):
+                    restore_overlay(config_path, backup_path)
+
+            self.assertEqual(config_path.read_text(encoding="utf-8"), "overlay")
+            self.assertEqual(backup_path.read_text(encoding="utf-8"), "original")
 
     def test_unified_history_injection_replaces_explicit_openai_provider(self):
         original = "\n".join(

--- a/tests/test_providers_config.py
+++ b/tests/test_providers_config.py
@@ -318,6 +318,32 @@ enabled = true
         self.assertEqual(index["case-provider/alias-model"]["default_reasoning_level"], "high")
         self.assertEqual(index["case-provider/Fallback-Model"]["upstream_model"], "Fallback-Model")
 
+    def test_save_providers_uses_atomic_writer(self):
+        providers = [
+            ProviderConfig(
+                id="atomic-provider",
+                name="Atomic Provider",
+                base_url="https://atomic.example/v1",
+                api_key="secret",
+                models=[ModelConfig(id="atomic-model")],
+            )
+        ]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "providers.toml"
+            calls: list[tuple[Path, str, str]] = []
+
+            def capture_atomic_write(target: Path, text: str, *, encoding: str = "utf-8") -> None:
+                calls.append((target, text, encoding))
+
+            with patch("providers_config.atomic_write_text", capture_atomic_write, create=True):
+                save_providers(providers, path)
+
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0][0], path)
+        self.assertEqual(calls[0][2], "utf-8")
+        self.assertIn("[[providers]]", calls[0][1])
+        self.assertIn('id = "atomic-provider"', calls[0][1])
+
     def test_anthropic_endpoint_selection_load_save_and_index(self):
         providers = [
             ProviderConfig(


### PR DESCRIPTION
## Summary
- add durable same-directory atomic text writes with exclusive lock files for Rust config/model/Gateway writers
- add Python atomic text writer and apply it to provider config, catalog sync, and config overlay writes
- document #23 coverage and explicitly out-of-scope non-config runtime writes

## Review notes
- PR was rebuilt on top of current `origin/dev`; it now contains only #23-scoped changes.
- The atomic-write Gateway test is self-contained and no longer depends on unmerged #13 helpers.
- Full `cargo test` on current `origin/dev` still has a pre-existing failure in `gateway_client_sync_default_model_skips_disabled_default_model` (#2 baseline), unrelated to this PR.

## Verification
- `PYTHONPATH=D:\Temp\CodexHub-issue-23-clean-verify\src-python python -m pytest -q --rootdir D:\Temp\CodexHub-issue-23-clean-verify tests/test_atomic_io.py tests/test_catalog_sync.py tests/test_config_overlay.py tests/test_providers_config.py` -> 78 passed, 4 subtests passed
- `cargo test safe_file` -> 2 passed
- `cargo test write_text_replace_does_not_clobber_existing_stale_temp_file` -> 1 passed
- `cargo test settings_missing_file_returns_defaults_and_roundtrips_saved_values` -> 1 passed
- `cargo test get_providers_falls_back_to_bundled_config_when_runtime_config_is_missing` -> 1 passed
- `cargo clippy --all-targets -- -D warnings` -> passed

Refs #23.