### PR TITLE
Add minimal PR validation CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,130 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - dev
+      - main
+  push:
+    branches:
+      - dev
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  python-tests:
+    name: Python tests
+    runs-on: windows-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+          cache: pip
+
+      - name: Install test dependencies
+        run: python -m pip install --upgrade pip pytest
+
+      - name: Run pytest
+        run: python -m pytest -q
+
+  frontend:
+    name: Frontend build and UI contract
+    runs-on: windows-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build frontend
+        run: npm run build
+
+      - name: Run UI contract tests
+        run: npm run test:ui-contract
+
+  rust-tests:
+    name: Rust tests
+    runs-on: windows-latest
+    defaults:
+      run:
+        working-directory: src-tauri
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Rust stable
+        run: rustup toolchain install stable --profile minimal
+
+      - name: Cache cargo artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            src-tauri/target
+          key: ${{ runner.os }}-cargo-test-${{ hashFiles('src-tauri/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-test-
+
+      - name: Prepare Tauri resource placeholder
+        run: |
+          New-Item -ItemType Directory -Force resources/python | Out-Null
+          Set-Content -Path resources/python/.ci-placeholder -Value ''
+
+      - name: Run cargo tests
+        run: cargo test --locked
+
+  rust-clippy:
+    name: Rust clippy
+    runs-on: windows-latest
+    defaults:
+      run:
+        working-directory: src-tauri
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Rust stable with clippy
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup component add clippy
+
+      - name: Cache cargo artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            src-tauri/target
+          key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('src-tauri/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-clippy-
+
+      - name: Prepare Tauri resource placeholder
+        run: |
+          New-Item -ItemType Directory -Force resources/python | Out-Null
+          Set-Content -Path resources/python/.ci-placeholder -Value ''
+
+      - name: Run clippy
+        run: cargo clippy --locked --all-targets -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.13'
-          cache: pip
 
       - name: Install test dependencies
         run: python -m pip install --upgrade pip pytest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,3 +11,7 @@ Five canonical labels used as-is: needs-triage, needs-info, ready-for-agent, rea
 ### Domain docs
 
 Single-context layout — one `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.
+
+### CI and manual verification
+
+Use GitHub Actions PR checks for `dev` and `main`; when unavailable, run the documented fallback commands. See `docs/agents/ci.md`.

--- a/docs/agents/ci.md
+++ b/docs/agents/ci.md
@@ -1,0 +1,35 @@
+# CI and manual verification
+
+GitHub Actions runs the required PR validation for branches targeting `dev` and `main`.
+
+## CI jobs
+
+- Python tests: `python -m pytest -q`
+- Frontend build and UI contract: `npm ci`, `npm run build`, `npm run test:ui-contract` in `frontend/`
+- Rust tests: `cargo test --locked` in `src-tauri/`
+- Rust clippy: `cargo clippy --locked --all-targets -- -D warnings` in `src-tauri/`
+
+The Rust jobs create a temporary `src-tauri/resources/python/.ci-placeholder` file during CI because Tauri's resource glob requires at least one runtime Python resource file. The placeholder is not committed.
+
+## Manual fallback
+
+Use these commands when GitHub Actions is unavailable or before opening a PR:
+
+```powershell
+python -m pytest -q
+
+Push-Location frontend
+npm ci
+npm run build
+npm run test:ui-contract
+Pop-Location
+
+New-Item -ItemType Directory -Force -Path src-tauri/resources/python | Out-Null
+Set-Content -Path src-tauri/resources/python/.ci-placeholder -Value ''
+Push-Location src-tauri
+cargo test --locked
+cargo clippy --locked --all-targets -- -D warnings
+Pop-Location
+```
+
+Do not commit generated frontend output, local Tauri resource placeholders, or `dist/` artifacts.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+pythonpath = src-python
+testpaths = tests

--- a/src-tauri/src/gateway.rs
+++ b/src-tauri/src/gateway.rs
@@ -1062,6 +1062,19 @@ fn default_gateway_client_sync_model(
     if models.iter().any(|model| model.id == DEFAULT_MODEL) {
         return Ok(DEFAULT_MODEL.to_string());
     }
+    for (id, _, _) in OFFICIAL_MODELS {
+        if *id == DEFAULT_MODEL {
+            continue;
+        }
+        if models.iter().any(|model| model.id == *id) {
+            return Ok((*id).to_string());
+        }
+    }
+    for (_, id, _, _) in OFFICIAL_FAST_VARIANTS {
+        if models.iter().any(|model| model.id == *id) {
+            return Ok((*id).to_string());
+        }
+    }
     models
         .into_iter()
         .map(|model| model.id)

--- a/src-tauri/src/openai_usage.rs
+++ b/src-tauri/src/openai_usage.rs
@@ -1,6 +1,7 @@
 use crate::config;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::{json, Map, Value};
+use std::cmp::Reverse;
 use std::fs;
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
@@ -327,7 +328,7 @@ fn latest_local_rate_limit_usage_limits(codex_dir: &Path) -> Option<Vec<CodexAcc
     let mut files = Vec::new();
     collect_rate_limit_log_files(&codex_dir.join("sessions"), &mut files);
     collect_rate_limit_log_files(&codex_dir.join("archived_sessions"), &mut files);
-    files.sort_by(|left, right| right.modified.cmp(&left.modified));
+    files.sort_by_key(|file| Reverse(file.modified));
     files.truncate(RATE_LIMIT_LOG_FILE_LIMIT);
 
     let mut latest: Option<(u8, String, Vec<CodexAccountUsageLimit>)> = None;


### PR DESCRIPTION
## Summary
- add GitHub Actions PR/push validation for Python, frontend, Rust tests, and Rust clippy
- document manual fallback verification commands
- add pytest.ini so root `python -m pytest -q` works in CI
- unblock Rust CI by preserving official model fallback ordering when the default model is disabled

## Verification
- `python -m pytest -q` -> 652 passed, 68 subtests passed
- `npm ci` in `frontend/` -> passed
- `npm run build` in `frontend/` -> passed
- `npm run test:ui-contract` in `frontend/` -> 102 passed
- `cargo test --locked` in `src-tauri/` -> 188 passed
- `cargo clippy --locked --all-targets -- -D warnings` in `src-tauri/` -> passed

Refs #32.
Refs #2.
Refs #4.