### PR TITLE
fix: sanitize OpenAI compaction items across all request paths

### DIFF
--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -338,6 +338,7 @@ BROWSER_CONTEXT_GUIDANCE = (
 )
 INTERNAL_INPUT_ITEM_TYPES = {
     "compaction",
+    "compaction_trigger",
     "reasoning",
     "function_call",
     "function_call_output",
@@ -4747,7 +4748,9 @@ def _compatible_compaction_message(item: Mapping[str, Any]) -> dict[str, str] | 
             fragments.append(fragment)
 
     if not fragments:
-        return None
+        return _developer_text_message(
+            "[Compacted conversation context — opaque, details unavailable]"
+        )
 
     return _developer_text_message("[Compacted conversation context]\n" + "\n\n".join(fragments))
 
@@ -5225,9 +5228,14 @@ def _rewrite_structured_tool_input_items(
         if item.get("type") == "function_call_output":
             rewritten_items.append(dict(item))
             continue
+        item_type = item.get("type")
         replacement = _compatible_internal_message(item)
         if replacement is not None:
             rewritten_items.append(replacement)
+            changed = True
+        elif isinstance(item_type, str) and item_type in INTERNAL_INPUT_ITEM_TYPES:
+            # Internal item (e.g. reasoning, compaction_trigger) with no text
+            # replacement — drop it instead of leaking the raw item upstream.
             changed = True
         else:
             rewritten_items.append(item)
@@ -7874,11 +7882,14 @@ def transparent_request_body(
     upstream_name = upstream.get("name")
     upstream_model = upstream.get("upstream_model")
     official_responses_backend = upstream_name == "official"
+    upstream_is_third_party = upstream_name != "official"
     if not isinstance(upstream_model, str) or not upstream_model:
         if isinstance(payload, Mapping):
             next_payload = dict(payload)
             changed = False
             if _normalize_responses_message_input_items(next_payload):
+                changed = True
+            if upstream_is_third_party and _rewrite_internal_input_items(next_payload):
                 changed = True
             if official_responses_backend and "max_output_tokens" in next_payload:
                 del next_payload["max_output_tokens"]
@@ -7916,6 +7927,8 @@ def transparent_request_body(
     if official_responses_backend and _normalize_responses_string_input(next_payload):
         changed = True
     if _normalize_responses_message_input_items(next_payload):
+        changed = True
+    if upstream_is_third_party and _rewrite_internal_input_items(next_payload):
         changed = True
     if not changed:
         return body
@@ -8007,6 +8020,8 @@ def compatible_request_body(
                 if len(filtered_tools) != len(tools):
                     payload["tools"] = filtered_tools
                     changed = True
+            if _rewrite_internal_input_items(payload, event_context=event_context, upstream_name=upstream_name):
+                changed = True
         else:
             if _rewrite_internal_input_items(payload, event_context=event_context, upstream_name=upstream_name):
                 changed = True

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -4410,6 +4410,135 @@ class RoutingTests(unittest.TestCase):
                 self.assertIn("Earlier external-provider context.", payload["input"][1]["content"])
                 self.assertNotIn('"type":"compaction"', transformed.decode("utf-8"))
 
+    def test_external_text_compat_body_replaces_opaque_compaction_input(self):
+        upstream = dict(choose_upstream("volc/glm-5.2"))
+        upstream["tool_protocol"] = "text_compat"
+        body = json.dumps(
+            {
+                "model": "volc/glm-5.2",
+                "input": [
+                    {"type": "message", "role": "user", "content": "test"},
+                    {
+                        "type": "compaction",
+                        "encrypted_content": "gAAAA-opaque-context",
+                    },
+                ],
+            }
+        ).encode("utf-8")
+
+        transformed = compatible_request_body(body, upstream)
+        payload = json.loads(transformed)
+        raw = transformed.decode("utf-8")
+
+        self.assertEqual(payload["input"][1]["type"], "message")
+        self.assertEqual(payload["input"][1]["role"], "developer")
+        self.assertIn("opaque", payload["input"][1]["content"])
+        self.assertNotIn('"type":"compaction"', raw)
+        self.assertNotIn("gAAAA", raw)
+
+    def test_external_responses_structured_body_sanitizes_internal_input_items(self):
+        upstream = {
+            "name": "xunfei",
+            "upstream_model": "xopglm52",
+            "upstream_format": "responses",
+        }
+        body = json.dumps(
+            {
+                "model": "xunfei/xopglm52",
+                "input": [
+                    {"type": "message", "role": "user", "content": "test"},
+                    {
+                        "type": "compaction",
+                        "encrypted_content": "gAAAA-opaque-context",
+                    },
+                    {"type": "compaction_trigger", "threshold": 200000},
+                    {
+                        "type": "reasoning",
+                        "encrypted_content": "gAAAA-reasoning",
+                    },
+                ],
+            }
+        ).encode("utf-8")
+
+        transformed = compatible_request_body(body, upstream, model_id="xunfei/xopglm52")
+        payload = json.loads(transformed)
+        raw = transformed.decode("utf-8")
+
+        self.assertEqual(payload["model"], "xopglm52")
+        self.assertEqual([item["type"] for item in payload["input"]], ["message", "message"])
+        self.assertEqual(payload["input"][1]["role"], "developer")
+        self.assertIn("opaque", payload["input"][1]["content"])
+        for forbidden in ('"type":"compaction"', '"type":"compaction_trigger"', '"type":"reasoning"', "gAAAA"):
+            self.assertNotIn(forbidden, raw)
+
+    def test_external_no_tool_protocol_body_sanitizes_internal_input_items(self):
+        upstream = {
+            "name": "no_tools",
+            "upstream_model": "glm-5.2",
+            "tool_protocol": "none",
+        }
+        body = json.dumps(
+            {
+                "model": "volc/glm-5.2",
+                "tools": [
+                    {"type": "function", "name": "normal_tool", "parameters": {"type": "object"}},
+                    {"type": "function", "name": "multi_agent_v1__spawn_agent", "parameters": {"type": "object"}},
+                ],
+                "input": [
+                    {"type": "message", "role": "user", "content": "test"},
+                    {"type": "compaction_trigger", "threshold": 200000},
+                    {
+                        "type": "reasoning",
+                        "encrypted_content": "gAAAA-reasoning",
+                    },
+                ],
+            }
+        ).encode("utf-8")
+
+        transformed = compatible_request_body(body, upstream, model_id="volc/glm-5.2")
+        payload = json.loads(transformed)
+        raw = transformed.decode("utf-8")
+
+        self.assertEqual(payload["model"], "glm-5.2")
+        self.assertEqual(payload["tools"], [{"type": "function", "name": "normal_tool", "parameters": {"type": "object"}}])
+        self.assertEqual(payload["input"], [{"type": "message", "role": "user", "content": "test"}])
+        self.assertNotIn('"type":"compaction_trigger"', raw)
+        self.assertNotIn('"type":"reasoning"', raw)
+        self.assertNotIn("gAAAA", raw)
+
+    def test_third_party_transparent_body_sanitizes_internal_input_items(self):
+        upstream = {"name": "ollama_cloud", "upstream_model": "glm-5.2"}
+        body = json.dumps(
+            {
+                "model": "volc/glm-5.2",
+                "input": [
+                    {"type": "message", "role": "user", "content": "test"},
+                    {
+                        "type": "compaction",
+                        "encrypted_content": "gAAAA-opaque-context",
+                    },
+                    {"type": "compaction_trigger", "threshold": 200000},
+                ],
+            }
+        ).encode("utf-8")
+
+        transformed = codex_proxy.transparent_request_body(
+            body,
+            json.loads(body),
+            upstream,
+            model_id="volc/glm-5.2",
+        )
+        payload = json.loads(transformed)
+        raw = transformed.decode("utf-8")
+
+        self.assertEqual(payload["model"], "glm-5.2")
+        self.assertEqual([item["type"] for item in payload["input"]], ["message", "message"])
+        self.assertEqual(payload["input"][1]["role"], "developer")
+        self.assertIn("opaque", payload["input"][1]["content"])
+        self.assertNotIn('"type":"compaction"', raw)
+        self.assertNotIn('"type":"compaction_trigger"', raw)
+        self.assertNotIn("gAAAA", raw)
+
     def test_external_body_converts_custom_tool_items_to_developer_messages(self):
         for model_id, upstream_model in (
             ("volc/glm-5.2", "glm-5.2"),


### PR DESCRIPTION
## Problem

When a Codex session switches from an official model (e.g. GPT-5.5) to a third-party model (e.g. GLM-5.2), the conversation history may contain OpenAI-specific input items such as `compaction` and `compaction_trigger` that third-party providers reject with:

```
input[39]: unknown input item type: "compaction"
```

## Root Cause

The Gateway has 5 request body builder paths. Three of them failed to sanitize OpenAI-internal input items before sending to third-party upstreams:

| Path | Trigger | Before | After |
|------|---------|--------|-------|
| `compatible_request_body` → `responses_structured` | `upstream_format=responses` | Opaque compaction leaked | ✅ Replaced with placeholder |
| `compatible_request_body` → `chat_tools` | `upstream_format=chat_completions` | Opaque compaction leaked | ✅ Replaced with placeholder |
| `compatible_request_body` → `none` | `tool_protocol=none` | All internal types leaked | ✅ `_rewrite_internal_input_items` added |
| `transparent_request_body` | 3rd-party app → 3rd-party same format | All internal types leaked | ✅ Sanitize for non-official upstreams |
| `compatible_request_body` → `text_compat` | `upstream_format=auto` | Opaque compaction silently dropped | ✅ Replaced with placeholder |

## Changes

1. **`_compatible_compaction_message`**: Always return a placeholder developer message even when the compaction item is opaque/encrypted (no text fragments found)
2. **`_rewrite_structured_tool_input_items`**: Drop internal input items when no text replacement is available instead of leaking the raw item upstream
3. **`compatible_request_body` (`tool_protocol=none` path)**: Add `_rewrite_internal_input_items` call — previously no input items were processed at all
4. **`transparent_request_body`**: Sanitize internal input items for non-official upstreams (both branches)
5. **`INTERNAL_INPUT_ITEM_TYPES`**: Add `compaction_trigger`; update probe `FORBIDDEN_EXTERNAL_TYPES` and probe payload with opaque compaction + `compaction_trigger` test cases

## Testing

All 654 Python tests pass (including 328 routing tests and 120 chat completions gateway tests). No regressions.