### PR TITLE
Harden runtime file writes

### DIFF
--- a/docs/reviews/v0.2-runtime-write-durability-audit.md
+++ b/docs/reviews/v0.2-runtime-write-durability-audit.md
@@ -1,0 +1,78 @@
+# v0.2 Runtime Write Durability Audit
+
+Date: 2026-07-09
+Issue: #30
+
+## Scope
+
+This audit covers production runtime writes that were explicitly left outside #23's config/catalog safety work. The goal is not to redesign storage; it is to classify the remaining writes and upgrade obviously durable user/runtime state to the existing Python `atomic_io` and Rust `safe_file` helpers.
+
+Out of scope for this issue:
+
+- transport/reconnect behavior (#12/#16 and follow-up reconnect work);
+- broad telemetry architecture changes;
+- replacing SQLite's own transaction model;
+- generated test fixtures and build artifacts.
+
+## Write contract used here
+
+The upgraded paths use the existing repo-local safe-write contracts:
+
+- Python: `src-python/atomic_io.py`
+  - per-target `.lock` file;
+  - stale lock recovery via `acquired_at_millis`;
+  - unique temp file in the target directory;
+  - file flush + fsync before publication;
+  - same-directory `os.replace`;
+  - optional Unix private file mode for secrets.
+- Rust: `src-tauri/src/safe_file.rs`
+  - per-target `.lock` file;
+  - stale lock recovery;
+  - unique temp file in the target directory;
+  - write + sync before publication;
+  - same-directory rename.
+
+## Upgraded durable/control writes
+
+| Category | Paths | Decision |
+| --- | --- | --- |
+| Auth/secret | `src-python/codex_auth.py`, `src-python/proxy_telemetry.py` | Token refresh uses `atomic_write_text`; telemetry HMAC secret creation uses locked `atomic_read_or_create_text` so concurrent creators return the same winning secret. Unix writes request `0600`. Windows ACL hardening remains a separate security-policy question. |
+| Runtime state repair | `src-python/global_state_repair.py` | Global state repair output now uses `atomic_write_text` after the existing backup copy. |
+| Bucket sync | `src-python/bucket_sync.py` | Missing-file copy, non-JSONL overwrite, and merged JSONL writes now use `atomic_write_bytes`; copy metadata is restored best-effort with `shutil.copystat` after atomic content publication. |
+| History consolidation | `src-python/history_consolidate.py` | Global state merge writes and backup metadata use `atomic_write_text`; existing JSONL rewrite helper remains same-directory temp + replace, but is not the full #23 lock/fsync helper contract. |
+| History overlay ledgers | `src-python/history_overlay.py` | Ledger JSON writes use a shared atomic JSON writer. JSONL rewrites still use the file-specific temp + replace helpers already present in the module, and are not upgraded to the full #23 lock/fsync helper contract in this issue. |
+| App update restart state | `src-tauri/src/app_updates.rs` | Pending update marker writes now use `safe_file::write_text_atomic`. |
+| OpenAI usage cache | `src-tauri/src/openai_usage.rs` | Usage cache writes now use `safe_file::write_text_atomic`; still a cache, but avoids torn JSON. |
+| Proxy PID/control | `src-tauri/src/proxy.rs` | Managed PID metadata writes now use `safe_file::write_text_atomic`. |
+
+## Reviewed but intentionally unchanged
+
+| Category | Paths | Rationale |
+| --- | --- | --- |
+| Telemetry event log | `src-python/codex_proxy.py` JSONL event append path | Append-only telemetry remains best-effort. Loss of the latest event is acceptable; failed SQLite writes are already isolated from request handling. |
+| Telemetry SQLite | `src-python/proxy_telemetry.py` | SQLite provides its own journaling/transaction semantics. This issue does not change DB mode, WAL, or busy-timeout strategy. |
+| History SQLite migrations | `src-python/history_overlay.py`, `src-python/history_consolidate.py` | Existing code uses SQLite transactions/backups for DB mutation. Cross-process migration locking is not introduced here; migrations should remain user/agent initiated. |
+| Autostart/system integration | `src-tauri/src/autostart.rs` | Writes are OS integration artifacts (`plist`, systemd service) or Windows scheduled-task commands. This path should follow OS-specific semantics rather than the config safe-file helper. |
+| Runtime-path/test fixture writes | Rust tests, `runtime_paths.rs` test helpers, scripts | Test/build artifacts are not production runtime durability surfaces. |
+
+## Remaining follow-up candidates
+
+No release-blocking follow-up is required from this audit. Two possible hardening issues remain useful if we want stricter guarantees later:
+
+1. Define a Windows private-file/ACL policy for `auth.json` refreshes and telemetry HMAC secrets. This branch adds Unix `0600`; Windows ACLs require explicit product/security policy.
+2. Add an explicit migration-level lock for history overlay/consolidation commands if those tools may be run concurrently by multiple agents/processes. Current file writes are safer, and SQLite writes are transactional, but the overall migration is still not a single global transaction.
+
+## Verification
+
+Targeted tests added or updated cover stale-lock recovery for:
+
+- Python atomic text writes;
+- Codex auth refresh writes;
+- telemetry secret creation;
+- bucket sync copy/overwrite/merge writes;
+- global state repair;
+- history consolidation global state writes;
+- history overlay ledger writes;
+- Rust pending update marker writes;
+- Rust OpenAI usage cache writes;
+- Rust proxy PID metadata writes.

--- a/src-python/atomic_io.py
+++ b/src-python/atomic_io.py
@@ -6,7 +6,7 @@ import os
 import time
 import uuid
 from pathlib import Path
-from typing import Iterator
+from typing import Callable, Iterator
 
 LOCK_WAIT_TIMEOUT_SECONDS = 10.0
 LOCK_RETRY_DELAY_SECONDS = 0.025
@@ -25,20 +25,18 @@ def file_lock_for(path: Path) -> Iterator[None]:
             fd = os.open(lock_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL)
         except FileExistsError:
             if _lock_is_stale(lock_path):
-                with contextlib.suppress(OSError):
-                    lock_path.unlink()
+                _remove_lock_file_best_effort(lock_path)
                 continue
             if time.monotonic() - started >= LOCK_WAIT_TIMEOUT_SECONDS:
-                raise TimeoutError(f"timed out waiting for config lock {lock_path}")
+                raise TimeoutError(f"timed out waiting for file lock {lock_path}")
             time.sleep(LOCK_RETRY_DELAY_SECONDS)
         except OSError as exc:
-            if exc.errno == errno.EEXIST:
+            if exc.errno in (errno.EEXIST, errno.EACCES):
                 if _lock_is_stale(lock_path):
-                    with contextlib.suppress(OSError):
-                        lock_path.unlink()
+                    _remove_lock_file_best_effort(lock_path)
                     continue
                 if time.monotonic() - started >= LOCK_WAIT_TIMEOUT_SECONDS:
-                    raise TimeoutError(f"timed out waiting for config lock {lock_path}") from exc
+                    raise TimeoutError(f"timed out waiting for file lock {lock_path}") from exc
                 time.sleep(LOCK_RETRY_DELAY_SECONDS)
                 continue
             raise
@@ -47,29 +45,66 @@ def file_lock_for(path: Path) -> Iterator[None]:
         yield
     finally:
         os.close(fd)
-        with contextlib.suppress(OSError):
-            lock_path.unlink()
+        _remove_lock_file_best_effort(lock_path)
 
 
-def atomic_write_text(path: Path, text: str, *, encoding: str = "utf-8") -> None:
-    atomic_write_bytes(path, text.encode(encoding))
+def atomic_write_text(path: Path, text: str, *, encoding: str = "utf-8", mode: int | None = None) -> None:
+    atomic_write_bytes(path, text.encode(encoding), mode=mode)
 
 
-def atomic_write_bytes(path: Path, data: bytes) -> None:
+def atomic_write_bytes(path: Path, data: bytes, *, mode: int | None = None) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     with file_lock_for(path):
-        temp_path = _unique_temp_path(path)
+        _atomic_write_bytes_unlocked(path, data, mode=mode)
+
+
+def atomic_read_or_create_text(
+    path: Path,
+    create_text: Callable[[], str],
+    *,
+    encoding: str = "utf-8",
+    mode: int | None = None,
+) -> str:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with file_lock_for(path):
         try:
-            with temp_path.open("wb") as temp_file:
-                temp_file.write(data)
-                temp_file.flush()
-                os.fsync(temp_file.fileno())
-            os.replace(temp_path, path)
-            _fsync_directory_best_effort(path.parent)
-        except Exception:
-            with contextlib.suppress(OSError):
-                temp_path.unlink()
-            raise
+            raw = path.read_text(encoding=encoding).strip()
+            if raw:
+                return raw
+        except OSError:
+            pass
+        text = create_text()
+        _atomic_write_bytes_unlocked(path, text.encode(encoding), mode=mode)
+        return text
+
+
+def _atomic_write_bytes_unlocked(path: Path, data: bytes, *, mode: int | None = None) -> None:
+    temp_path = _unique_temp_path(path)
+    try:
+        with temp_path.open("wb") as temp_file:
+            if mode is not None and os.name != "nt":
+                with contextlib.suppress(AttributeError, OSError):
+                    os.fchmod(temp_file.fileno(), mode)
+            temp_file.write(data)
+            temp_file.flush()
+            os.fsync(temp_file.fileno())
+        os.replace(temp_path, path)
+        _fsync_directory_best_effort(path.parent)
+    except Exception:
+        with contextlib.suppress(OSError):
+            temp_path.unlink()
+        raise
+
+
+def _remove_lock_file_best_effort(lock_path: Path) -> None:
+    for _ in range(50):
+        try:
+            lock_path.unlink()
+            return
+        except FileNotFoundError:
+            return
+        except OSError:
+            time.sleep(0.01)
 
 
 def _unique_temp_path(path: Path) -> Path:

--- a/src-python/bucket_sync.py
+++ b/src-python/bucket_sync.py
@@ -3,6 +3,8 @@ import json
 import shutil
 from pathlib import Path
 
+from atomic_io import atomic_write_bytes
+
 
 def equivalent_line_key(line: bytes) -> bytes:
     try:
@@ -62,14 +64,19 @@ def merged_jsonl_bytes(source: Path, destination: Path) -> bytes | None:
     return b"".join(merged)
 
 
+def copy_file_atomic(source: Path, destination: Path) -> None:
+    atomic_write_bytes(destination, source.read_bytes())
+    shutil.copystat(source, destination)
+
+
 def sync_file(source: Path, destination: Path) -> str:
     destination.parent.mkdir(parents=True, exist_ok=True)
     if not destination.exists():
-        shutil.copy2(source, destination)
+        copy_file_atomic(source, destination)
         return "copied"
 
     if source.suffix.lower() != ".jsonl":
-        shutil.copy2(source, destination)
+        copy_file_atomic(source, destination)
         return "overwritten"
 
     if (
@@ -82,7 +89,7 @@ def sync_file(source: Path, destination: Path) -> str:
     if merged is None:
         return "kept-destination"
 
-    destination.write_bytes(merged)
+    atomic_write_bytes(destination, merged)
     return "merged"
 
 

--- a/src-python/codex_auth.py
+++ b/src-python/codex_auth.py
@@ -17,9 +17,12 @@ from typing import Any
 from urllib.request import Request, urlopen
 from urllib.error import URLError, HTTPError
 
+from atomic_io import atomic_write_text
+
 CODEX_HOME_ENV = "CODEX_HOME"
 DEFAULT_CODEX_HOME = Path.home() / ".codex"
 AUTH_FILENAME = "auth.json"
+PRIVATE_AUTH_FILE_MODE = 0o600
 
 # Refresh when the access token has less than this many seconds of life left.
 REFRESH_SAFETY_MARGIN_SECONDS = 60
@@ -106,9 +109,11 @@ def load_auth_json(path: Path | None = None) -> dict[str, Any]:
 
 def _persist_auth_json(path: Path, data: dict[str, Any]) -> None:
     """Write ``auth.json`` back, preserving the original structure shape."""
-    path.write_text(
+    atomic_write_text(
+        path,
         json.dumps(data, indent=2, ensure_ascii=False) + "\n",
         encoding="utf-8",
+        mode=PRIVATE_AUTH_FILE_MODE,
     )
 
 

--- a/src-python/global_state_repair.py
+++ b/src-python/global_state_repair.py
@@ -7,6 +7,8 @@ import shutil
 import sys
 from typing import Any
 
+from atomic_io import atomic_write_text
+
 
 REMOTE_SELECTION_KEYS = (
     "selected-remote-host-id",
@@ -60,7 +62,11 @@ def repair_global_state(state_path: Path, backup_path: Path) -> dict[str, Any]:
 
     backup_path.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(state_path, backup_path)
-    state_path.write_text(json.dumps(state, ensure_ascii=False, separators=(",", ":")) + "\n", encoding="utf-8")
+    atomic_write_text(
+        state_path,
+        json.dumps(state, ensure_ascii=False, separators=(",", ":")) + "\n",
+        encoding="utf-8",
+    )
     return {
         "path": str(state_path),
         "changed": True,

--- a/src-python/history_consolidate.py
+++ b/src-python/history_consolidate.py
@@ -12,6 +12,8 @@ import sqlite3
 import tempfile
 from typing import Any, Iterable
 
+from atomic_io import atomic_write_text
+
 
 OPENAI_PROVIDER = "openai"
 CUSTOM_PROVIDER = "custom"
@@ -410,7 +412,11 @@ def merge_global_state(codex_dir: Path, source_dir: Path, backup_root: Path) -> 
         active_path.parent.mkdir(parents=True, exist_ok=True)
         source = json.loads(source_path.read_text(encoding="utf-8-sig"))
         removed_remote_keys = sanitize_global_state_remote_selection(source) if isinstance(source, dict) else 0
-        active_path.write_text(json.dumps(source, ensure_ascii=False, separators=(",", ":")) + "\n", encoding="utf-8")
+        atomic_write_text(
+            active_path,
+            json.dumps(source, ensure_ascii=False, separators=(",", ":")) + "\n",
+            encoding="utf-8",
+        )
         return {"copied": 1, "removed_remote_keys": removed_remote_keys}
 
     source = json.loads(source_path.read_text(encoding="utf-8-sig"))
@@ -464,7 +470,11 @@ def merge_global_state(codex_dir: Path, source_dir: Path, backup_root: Path) -> 
 
     if changed:
         backup_file(active_path, codex_dir, backup_root, "active-before")
-        active_path.write_text(json.dumps(active, ensure_ascii=False, separators=(",", ":")) + "\n", encoding="utf-8")
+        atomic_write_text(
+            active_path,
+            json.dumps(active, ensure_ascii=False, separators=(",", ":")) + "\n",
+            encoding="utf-8",
+        )
     return {"changed_fields": changed}
 
 
@@ -518,7 +528,11 @@ def official_main(codex_dir: Path, source_dir: Path, backup_root: Path, target_p
         "source_dir": str(source_dir),
         "target_provider": target_provider,
     }
-    (backup_root / "meta.json").write_text(json.dumps(meta, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+    atomic_write_text(
+        backup_root / "meta.json",
+        json.dumps(meta, indent=2, ensure_ascii=True) + "\n",
+        encoding="utf-8",
+    )
 
     jsonl_counts = merge_source_jsonl(source_dir, codex_dir, backup_root, target_provider)
     normalized = normalize_active_jsonl_files(codex_dir, backup_root, target_provider)

--- a/src-python/history_overlay.py
+++ b/src-python/history_overlay.py
@@ -14,6 +14,8 @@ import tempfile
 import time
 from typing import Any, Iterable
 
+from atomic_io import atomic_write_text
+
 
 SOURCE_PROVIDER = "openai"
 TARGET_PROVIDER = "custom"
@@ -29,6 +31,14 @@ def utc_now_iso() -> str:
 
 def default_codex_dir() -> Path:
     return Path(os.environ.get("CODEX_HOME") or Path.home() / ".codex")
+
+
+def write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
+    atomic_write_text(
+        path,
+        json.dumps(payload, indent=2, ensure_ascii=True) + "\n",
+        encoding="utf-8",
+    )
 
 
 def read_config_sqlite_home(codex_dir: Path) -> Path | None:
@@ -462,7 +472,7 @@ def apply_history_overlay(codex_dir: Path, backup_root: Path, ledger_path: Path)
         },
     }
     ledger_path.parent.mkdir(parents=True, exist_ok=True)
-    ledger_path.write_text(json.dumps(ledger, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+    write_json_atomic(ledger_path, ledger)
     return ledger
 
 
@@ -1000,7 +1010,7 @@ def repair_history_bucket(
         },
     }
     if status not in {"already-unified", "already-openai"}:
-        ledger_path.write_text(json.dumps(ledger, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+        write_json_atomic(ledger_path, ledger)
     return ledger
 
 
@@ -1038,7 +1048,7 @@ def ensure_unified_history_bucket(codex_dir: Path, backup_root: Path) -> dict[st
     result["status"] = "already-unified" if result.get("status") == "already-unified" else result.get("status", "completed")
     if result.get("status") != "already-unified":
         ledger_path = backup_root / "ledger.json"
-        ledger_path.write_text(json.dumps(result, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+        write_json_atomic(ledger_path, result)
     return result
 
 
@@ -1061,7 +1071,7 @@ def migrate_official_history_to_unified(codex_dir: Path, backup_root: Path) -> d
     if result.get("status") == "already-unified":
         return result
     ledger_path = backup_root / "ledger.json"
-    ledger_path.write_text(json.dumps(result, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+    write_json_atomic(ledger_path, result)
     return result
 
 
@@ -1074,7 +1084,7 @@ def restore_official_history_from_unified(
     result["mode"] = "restore-official-from-unified"
     if result.get("status") not in {"already-openai", "no-ledger"}:
         ledger_path = backup_root / "ledger.json"
-        ledger_path.write_text(json.dumps(result, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+        write_json_atomic(ledger_path, result)
     return result
 
 
@@ -1225,7 +1235,7 @@ def normalize_history_provider_fast(codex_dir: Path, backup_root: Path, target_p
             "plan_seconds": round(time.perf_counter() - started_at, 3),
         },
     }
-    ledger_path.write_text(json.dumps(ledger, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+    write_json_atomic(ledger_path, ledger)
 
     written_entries: list[dict[str, str]] = []
     jsonl_results: list[dict[str, str]] = []
@@ -1255,7 +1265,7 @@ def normalize_history_provider_fast(codex_dir: Path, backup_root: Path, target_p
         ledger["rolled_back_jsonl"] = len(written_entries)
         ledger["restored_state_backups"] = restored_states
         ledger["failed_at"] = utc_now_iso()
-        ledger_path.write_text(json.dumps(ledger, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+        write_json_atomic(ledger_path, ledger)
         raise
 
     jsonl_applied = sum(1 for entry in jsonl_results if entry.get("status") == "applied")
@@ -1273,7 +1283,7 @@ def normalize_history_provider_fast(codex_dir: Path, backup_root: Path, target_p
         "jsonl_seconds": round(jsonl_done_at - state_done_at, 3),
         "total_seconds": round(jsonl_done_at - started_at, 3),
     }
-    ledger_path.write_text(json.dumps(ledger, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+    write_json_atomic(ledger_path, ledger)
     return ledger
 
 

--- a/src-python/proxy_telemetry.py
+++ b/src-python/proxy_telemetry.py
@@ -9,9 +9,12 @@ import time
 from pathlib import Path
 from typing import Any, Mapping
 
+from atomic_io import atomic_read_or_create_text
+
 EVENT_SCHEMA_VERSION = 2
 TELEMETRY_DB_FILENAME = "codex-proxy-telemetry.sqlite"
 TELEMETRY_SECRET_FILENAME = "telemetry-secret"
+PRIVATE_TELEMETRY_SECRET_MODE = 0o600
 REQUEST_PREFIX_BYTES = 65536
 RUNTIME_SQLITE_TIMEOUT_SECONDS = 0.25
 RUNTIME_SQLITE_BUSY_TIMEOUT_MS = 250
@@ -501,15 +504,12 @@ def _apply_field_defaults(payload: dict[str, Any], codex_home: Path) -> None:
 
 def _load_or_create_secret(codex_home: Path) -> bytes:
     path = telemetry_secret_path(codex_home)
-    try:
-        raw = path.read_text(encoding="utf-8").strip()
-        if raw:
-            return raw.encode("utf-8")
-    except OSError:
-        pass
-    secret = secrets.token_hex(32)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(secret, encoding="utf-8")
+    secret = atomic_read_or_create_text(
+        path,
+        lambda: secrets.token_hex(32),
+        encoding="utf-8",
+        mode=PRIVATE_TELEMETRY_SECRET_MODE,
+    ).strip()
     return secret.encode("utf-8")
 
 

--- a/src-tauri/src/app_updates.rs
+++ b/src-tauri/src/app_updates.rs
@@ -1,4 +1,4 @@
-use crate::runtime_paths;
+use crate::{runtime_paths, safe_file};
 use serde::{Deserialize, Serialize};
 use std::{
     fs,
@@ -423,9 +423,10 @@ fn write_pending_update(path: &Path, target_version: &str) -> Result<(), String>
         target_version: target_version.to_string(),
         written_at: checked_at_now(),
     };
-    let body = serde_json::to_vec_pretty(&pending)
+    let body = serde_json::to_string_pretty(&pending)
         .map_err(|error| operation_error("write pending update", error))?;
-    fs::write(path, body).map_err(|error| operation_error("write pending update", error))
+    safe_file::write_text_atomic(path, &body)
+        .map_err(|error| operation_error("write pending update", error))
 }
 
 fn read_pending_update(path: &Path) -> Result<Option<PendingUpdate>, String> {
@@ -742,8 +743,35 @@ mod tests {
     }
 
     #[test]
+    fn pending_update_write_recovers_stale_atomic_lock() {
+        let path = unique_pending_update_path("stale-lock");
+        let lock = stale_lock_path(&path);
+        fs::write(&lock, "pid=0\nacquired_at_millis=0\n").expect("write stale lock");
+
+        write_pending_update(&path, "0.1.1").expect("write pending update");
+
+        assert!(!lock.exists());
+        assert_eq!(
+            read_pending_update(&path)
+                .expect("read pending update")
+                .as_ref()
+                .map(|pending| pending.target_version.as_str()),
+            Some("0.1.1"),
+        );
+    }
+
+    #[test]
     fn checked_at_now_is_unix_timestamp_string() {
         assert!(checked_at_now().starts_with("unix:"));
+    }
+
+    fn stale_lock_path(path: &std::path::Path) -> std::path::PathBuf {
+        path.with_file_name(format!(
+            "{}.lock",
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or("pending-update")
+        ))
     }
 
     fn unique_pending_update_path(name: &str) -> std::path::PathBuf {

--- a/src-tauri/src/openai_usage.rs
+++ b/src-tauri/src/openai_usage.rs
@@ -1,4 +1,4 @@
-use crate::config;
+use crate::{config, safe_file};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::{json, Map, Value};
 use std::cmp::Reverse;
@@ -288,7 +288,8 @@ fn write_usage_cache(path: &Path, cache: &CodexAccountUsageCache) -> Result<(), 
     }
     let body = serde_json::to_string(cache)
         .map_err(|error| format!("Failed to encode OpenAI usage cache: {error}"))?;
-    fs::write(path, body).map_err(|error| format!("Failed to write OpenAI usage cache: {error}"))
+    safe_file::write_text_atomic(path, &body)
+        .map_err(|error| format!("Failed to write OpenAI usage cache: {error}"))
 }
 
 fn enrich_usage_with_local_rate_limits(
@@ -1671,6 +1672,34 @@ mod tests {
     }
 
     #[test]
+    fn write_usage_cache_recovers_stale_atomic_lock() {
+        let root = temp_root("openai-usage-stale-lock");
+        let cache_path = root.join("usage-cache.json");
+        let lock = stale_lock_path(&cache_path);
+        fs::write(&lock, "pid=0\nacquired_at_millis=0\n").expect("write stale lock");
+        let usage: CodexAccountUsageResponse = serde_json::from_str(
+            r#"{
+              "summary": { "lifetimeTokens": 84 },
+              "dailyUsageBuckets": [
+                {"startDate": "2026-07-07", "tokens": 84}
+              ]
+            }"#,
+        )
+        .expect("usage parses");
+        let cache = CodexAccountUsageCache {
+            fetched_at: 10_300,
+            usage,
+        };
+
+        write_usage_cache(&cache_path, &cache).expect("write usage cache");
+
+        assert!(!lock.exists());
+        let written = fs::read_to_string(&cache_path).expect("cache text");
+        assert!(written.contains(r#""fetched_at":10300"#));
+        assert!(written.contains("2026-07-07"));
+    }
+
+    #[test]
     fn local_account_dates_are_not_filtered_out_by_utc_end_time() {
         let response: CodexAccountUsageResponse = serde_json::from_str(
             r#"{
@@ -1755,6 +1784,15 @@ mod tests {
         let usage: CodexAccountUsageResponse = serde_json::from_str(usage_json).unwrap();
         let cache = CodexAccountUsageCache { fetched_at, usage };
         fs::write(path, serde_json::to_string(&cache).unwrap()).unwrap();
+    }
+
+    fn stale_lock_path(path: &Path) -> PathBuf {
+        path.with_file_name(format!(
+            "{}.lock",
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or("cache")
+        ))
     }
 
     fn temp_root(name: &str) -> PathBuf {

--- a/src-tauri/src/proxy.rs
+++ b/src-tauri/src/proxy.rs
@@ -1,6 +1,6 @@
-use crate::runtime_paths;
 use crate::AppStatus;
 use crate::Settings;
+use crate::{runtime_paths, safe_file};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::io::{self, Read};
@@ -1247,7 +1247,7 @@ fn write_pid(paths: &ProxyPaths, pid: u32, port: u16, script: &Path) -> Result<(
     let metadata = ProxyPidMetadata::new(pid, port, script);
     let text = serde_json::to_string_pretty(&metadata)
         .map_err(|error| format!("failed to encode proxy PID metadata: {error}"))?;
-    fs::write(paths.pid_path(), format!("{text}\n")).map_err(|error| {
+    safe_file::write_text_atomic(&paths.pid_path(), &format!("{text}\n")).map_err(|error| {
         format!(
             "failed to write proxy PID file {}: {error}",
             paths.pid_path().display()
@@ -1566,6 +1566,20 @@ model_catalog_json = "model-catalogs/codex-proxy-official-ollama.json"
     }
 
     #[test]
+    fn pid_file_write_recovers_stale_atomic_lock() {
+        let root = temp_root("pid-stale-lock");
+        let paths = test_paths(&root);
+        fs::create_dir_all(paths.proxy_dir()).unwrap();
+        let lock = stale_lock_path(&paths.pid_path());
+        fs::write(&lock, "pid=0\nacquired_at_millis=0\n").expect("write stale lock");
+
+        write_pid(&paths, 42, 4555, &paths.proxy_script_path()).expect("write pid");
+
+        assert!(!lock.exists());
+        assert_eq!(read_pid(&paths).expect("read pid"), Some(42));
+    }
+
+    #[test]
     fn legacy_numeric_pid_file_is_read_conservatively() {
         let root = temp_root("legacy-pid");
         let paths = test_paths(&root);
@@ -1859,6 +1873,15 @@ time.sleep(10)
         let _ = fs::remove_dir_all(&path);
         fs::create_dir_all(&path).unwrap();
         path
+    }
+
+    fn stale_lock_path(path: &Path) -> PathBuf {
+        path.with_file_name(format!(
+            "{}.lock",
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or("pid")
+        ))
     }
 
     fn free_port() -> u16 {

--- a/src-tauri/src/safe_file.rs
+++ b/src-tauri/src/safe_file.rs
@@ -14,7 +14,7 @@ pub(crate) fn write_text_atomic(path: &Path, text: &str) -> Result<(), String> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).map_err(|error| {
             format!(
-                "failed to create config directory {}: {error}",
+                "failed to create file directory {}: {error}",
                 parent.display()
             )
         })?;
@@ -22,28 +22,21 @@ pub(crate) fn write_text_atomic(path: &Path, text: &str) -> Result<(), String> {
 
     let _lock = FileLock::acquire(path)?;
     let temp_path = unique_temp_path(path);
-    let mut temp_file = File::create(&temp_path).map_err(|error| {
-        format!(
-            "failed to write temp config {}: {error}",
-            temp_path.display()
-        )
-    })?;
+    let mut temp_file = File::create(&temp_path)
+        .map_err(|error| format!("failed to write temp file {}: {error}", temp_path.display()))?;
     temp_file
         .write_all(text.as_bytes())
         .and_then(|_| temp_file.sync_all())
         .map_err(|error| {
             let _ = fs::remove_file(&temp_path);
-            format!(
-                "failed to write temp config {}: {error}",
-                temp_path.display()
-            )
+            format!("failed to write temp file {}: {error}", temp_path.display())
         })?;
     drop(temp_file);
 
     fs::rename(&temp_path, path).map_err(|error| {
         let _ = fs::remove_file(&temp_path);
         format!(
-            "failed to move temp config {} to {}: {error}",
+            "failed to move temp file {} to {}: {error}",
             temp_path.display(),
             path.display()
         )
@@ -55,7 +48,7 @@ fn unique_temp_path(path: &Path) -> PathBuf {
         ".{}.{}.{}.tmp-codexhub",
         path.file_name()
             .and_then(|name| name.to_str())
-            .unwrap_or("config"),
+            .unwrap_or("file"),
         std::process::id(),
         timestamp_millis()
     ))
@@ -66,7 +59,7 @@ fn lock_path(path: &Path) -> PathBuf {
         "{}.lock",
         path.file_name()
             .and_then(|name| name.to_str())
-            .unwrap_or("config")
+            .unwrap_or("file")
     ))
 }
 
@@ -103,14 +96,17 @@ impl FileLock {
                     }
                     if started.elapsed() >= LOCK_WAIT_TIMEOUT {
                         return Err(format!(
-                            "timed out waiting for config lock {}",
+                            "timed out waiting for file lock {}",
                             path.display()
                         ));
                     }
                     thread::sleep(LOCK_RETRY_DELAY);
                 }
                 Err(error) => {
-                    return Err(format!("failed to create config lock {}: {error}", path.display()))
+                    return Err(format!(
+                        "failed to create file lock {}: {error}",
+                        path.display()
+                    ))
                 }
             }
         }
@@ -172,6 +168,18 @@ mod tests {
 
         assert_eq!(fs::read_to_string(&target).unwrap(), "new");
         assert_eq!(fs::read_to_string(&stale_temp).unwrap(), "stale-temp");
+    }
+
+    #[test]
+    fn write_text_atomic_overwrites_existing_target() {
+        let root = test_root("overwrite-existing");
+        fs::create_dir_all(&root).unwrap();
+        let target = root.join("usage-cache.json");
+        fs::write(&target, "old").unwrap();
+
+        write_text_atomic(&target, "new").unwrap();
+
+        assert_eq!(fs::read_to_string(&target).unwrap(), "new");
     }
 
     #[test]

--- a/tests/test_atomic_io.py
+++ b/tests/test_atomic_io.py
@@ -1,9 +1,11 @@
 import os
+import stat
+import threading
 from pathlib import Path
 
 import pytest
 
-from atomic_io import atomic_write_text
+from atomic_io import atomic_read_or_create_text, atomic_write_text
 
 
 def test_atomic_write_text_replaces_existing_file(tmp_path: Path) -> None:
@@ -39,3 +41,52 @@ def test_atomic_write_text_recovers_stale_lock_file(tmp_path: Path) -> None:
 
     assert target.read_text(encoding="utf-8") == "new"
     assert not target.with_name("catalog.json.lock").exists()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Windows private ACLs are documented separately")
+def test_atomic_write_text_can_apply_private_file_mode(tmp_path: Path) -> None:
+    target = tmp_path / "auth.json"
+
+    atomic_write_text(target, "secret\n", encoding="utf-8", mode=0o600)
+
+    assert target.read_text(encoding="utf-8") == "secret\n"
+    assert stat.S_IMODE(target.stat().st_mode) == 0o600
+
+
+def test_atomic_read_or_create_text_returns_single_winning_value_under_concurrency(tmp_path: Path) -> None:
+    target = tmp_path / "telemetry-secret"
+    barrier = threading.Barrier(8)
+    counter = 0
+    counter_lock = threading.Lock()
+    results: list[str] = []
+    errors: list[BaseException] = []
+    results_lock = threading.Lock()
+
+    def create_secret() -> str:
+        nonlocal counter
+        with counter_lock:
+            counter += 1
+            value = f"secret-{counter}"
+        return value
+
+    def worker() -> None:
+        try:
+            barrier.wait()
+            value = atomic_read_or_create_text(target, create_secret, encoding="utf-8", mode=0o600)
+            with results_lock:
+                results.append(value)
+        except BaseException as error:
+            with results_lock:
+                errors.append(error)
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert errors == []
+    assert len(results) == 8
+    assert len(set(results)) == 1
+    assert target.read_text(encoding="utf-8") == results[0]
+    assert counter == 1

--- a/tests/test_bucket_sync.py
+++ b/tests/test_bucket_sync.py
@@ -74,6 +74,44 @@ class BucketSyncTests(unittest.TestCase):
             )
             self.assertEqual(counts, {"merged": 1})
 
+    def test_merged_jsonl_write_recovers_stale_atomic_lock(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = root / "source"
+            destination = root / "destination"
+            source.mkdir()
+            destination.mkdir()
+            (source / "session.jsonl").write_bytes(b"a\nb\nc\n")
+            target = destination / "session.jsonl"
+            target.write_bytes(b"a\nb\n")
+            lock_path = target.with_name("session.jsonl.lock")
+            lock_path.write_text("pid=0\nacquired_at_millis=0\n", encoding="utf-8")
+
+            counts = sync_dir(source, destination)
+
+            self.assertEqual(target.read_bytes(), b"a\nb\nc\n")
+            self.assertEqual(counts, {"merged": 1})
+            self.assertFalse(lock_path.exists())
+
+    def test_non_jsonl_overwrite_recovers_stale_atomic_lock(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = root / "source"
+            destination = root / "destination"
+            source.mkdir()
+            destination.mkdir()
+            (source / "state.json").write_bytes(b'{"new":true}\n')
+            target = destination / "state.json"
+            target.write_bytes(b'{"old":true}\n')
+            lock_path = target.with_name("state.json.lock")
+            lock_path.write_text("pid=0\nacquired_at_millis=0\n", encoding="utf-8")
+
+            counts = sync_dir(source, destination)
+
+            self.assertEqual(target.read_bytes(), b'{"new":true}\n')
+            self.assertEqual(counts, {"overwritten": 1})
+            self.assertFalse(lock_path.exists())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_codex_auth.py
+++ b/tests/test_codex_auth.py
@@ -1,5 +1,7 @@
 import base64
 import json
+import os
+import stat
 import tempfile
 import time
 import unittest
@@ -160,6 +162,24 @@ class RefreshTests(unittest.TestCase):
             self.assertEqual(written["tokens"]["access_token"], new_token)
             self.assertEqual(written["tokens"]["refresh_token"], "rt.fresh")
             self.assertIn("last_refresh", written)
+
+    def test_refresh_writes_back_with_atomic_lock_recovery(self):
+        old_token = _make_jwt({"exp": int(time.time()) - 100, "client_id": "app_x", "scp": ["openid"]})
+        new_token = _make_jwt({"exp": int(time.time()) + 3600, "client_id": "app_x"})
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _make_auth_json(Path(tmp), access_token=old_token, refresh_token="rt.orig")
+            lock_path = path.with_name("auth.json.lock")
+            lock_path.write_text("pid=0\nacquired_at_millis=0\n", encoding="utf-8")
+            auth_data = json.loads(path.read_text(encoding="utf-8"))
+            fake = _FakeResponse({"access_token": new_token, "refresh_token": "rt.fresh"})
+
+            with patch("codex_auth.urlopen", return_value=fake):
+                codex_auth.refresh(auth_data, path)
+
+            self.assertFalse(lock_path.exists())
+            self.assertEqual(json.loads(path.read_text(encoding="utf-8"))["tokens"]["access_token"], new_token)
+            if os.name != "nt":
+                self.assertEqual(stat.S_IMODE(path.stat().st_mode), 0o600)
 
     def test_refresh_without_refresh_token_raises(self):
         token = _make_jwt({"exp": int(time.time()) + 3600, "client_id": "app_x"})

--- a/tests/test_global_state_repair.py
+++ b/tests/test_global_state_repair.py
@@ -59,6 +59,28 @@ class GlobalStateRepairTests(unittest.TestCase):
             self.assertFalse(result["changed"])
             self.assertFalse(backup_path.exists())
 
+    def test_repair_write_recovers_stale_atomic_lock(self):
+        original = {
+            "selected-remote-host-id": "remote-control:env_123",
+            "project-order": [],
+        }
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            state_path = tmp / ".codex-global-state.json"
+            backup_path = tmp / "backup" / ".codex-global-state.json"
+            state_path.write_text(json.dumps(original), encoding="utf-8")
+            lock_path = state_path.with_name(".codex-global-state.json.lock")
+            lock_path.write_text("pid=0\nacquired_at_millis=0\n", encoding="utf-8")
+
+            result = repair_global_state(state_path, backup_path)
+
+            self.assertTrue(result["changed"])
+            self.assertFalse(lock_path.exists())
+            self.assertNotIn(
+                "selected-remote-host-id",
+                json.loads(state_path.read_text(encoding="utf-8")),
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_history_consolidate.py
+++ b/tests/test_history_consolidate.py
@@ -124,7 +124,11 @@ class HistoryConsolidateTests(unittest.TestCase):
             root = Path(tmpdir)
             active = root / ".codex"
             official = root / "official"
+            active.mkdir(parents=True)
             official.mkdir(parents=True)
+            active_state_path = active / ".codex-global-state.json"
+            lock_path = active_state_path.with_name(".codex-global-state.json.lock")
+            lock_path.write_text("pid=0\nacquired_at_millis=0\n", encoding="utf-8")
             (official / ".codex-global-state.json").write_text(
                 json.dumps(
                     {
@@ -147,6 +151,7 @@ class HistoryConsolidateTests(unittest.TestCase):
             self.assertEqual(state["remote-connection-auto-connect-by-host-id"], {})
             self.assertNotIn("selected-remote-host-id", state["electron-persisted-atom-state"])
             self.assertEqual(state["electron-persisted-atom-state"]["remote-connection-auto-connect-by-host-id"], {})
+            self.assertFalse(lock_path.exists())
 
 
 if __name__ == "__main__":

--- a/tests/test_history_overlay.py
+++ b/tests/test_history_overlay.py
@@ -59,10 +59,14 @@ class HistoryOverlayTests(unittest.TestCase):
 
             backup_root = root / "backup"
             ledger_path = backup_root / "ledger.json"
+            backup_root.mkdir(parents=True)
+            ledger_lock_path = ledger_path.with_name("ledger.json.lock")
+            ledger_lock_path.write_text("pid=0\nacquired_at_millis=0\n", encoding="utf-8")
             ledger = apply_history_overlay(codex_dir, backup_root, ledger_path)
 
             self.assertEqual(len(ledger["state"][0]["thread_ids"]), 1)
             self.assertEqual(len(ledger["jsonl"]), 1)
+            self.assertFalse(ledger_lock_path.exists())
             connection = sqlite3.connect(db_path)
             try:
                 providers = dict(connection.execute("SELECT id, model_provider FROM threads"))

--- a/tests/test_proxy_event_logging.py
+++ b/tests/test_proxy_event_logging.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import importlib
 import json
+import os
 import queue
 import sqlite3
+import stat
 import tempfile
+import threading
 from pathlib import Path
 from unittest import TestCase
 from unittest.mock import patch
@@ -129,6 +132,55 @@ class ProxyEventLoggingTests(TestCase):
                 )
             finally:
                 connection.close()
+
+    def test_telemetry_secret_creation_recovers_stale_atomic_lock(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            import proxy_telemetry
+
+            codex_home = Path(tmpdir) / "codex-home"
+            secret_path = proxy_telemetry.telemetry_secret_path(codex_home)
+            secret_path.parent.mkdir(parents=True)
+            lock_path = secret_path.with_name("telemetry-secret.lock")
+            lock_path.write_text("pid=0\nacquired_at_millis=0\n", encoding="utf-8")
+
+            digest = proxy_telemetry.telemetry_hmac(codex_home, b"test", b"payload")
+
+            self.assertEqual(len(digest), 64)
+            self.assertFalse(lock_path.exists())
+            self.assertTrue(secret_path.read_text(encoding="utf-8").strip())
+            if os.name != "nt":
+                self.assertEqual(stat.S_IMODE(secret_path.stat().st_mode), 0o600)
+
+    def test_telemetry_secret_concurrent_creation_uses_one_secret(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            import proxy_telemetry
+
+            codex_home = Path(tmpdir) / "codex-home"
+            barrier = threading.Barrier(8)
+            digests: list[str] = []
+            errors: list[BaseException] = []
+            digests_lock = threading.Lock()
+
+            def worker() -> None:
+                try:
+                    barrier.wait()
+                    digest = proxy_telemetry.telemetry_hmac(codex_home, b"test", b"payload")
+                    with digests_lock:
+                        digests.append(digest)
+                except BaseException as error:
+                    with digests_lock:
+                        errors.append(error)
+
+            threads = [threading.Thread(target=worker) for _ in range(8)]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join()
+
+            self.assertEqual(errors, [])
+            self.assertEqual(len(digests), 8)
+            self.assertEqual(len(set(digests)), 1)
+            self.assertTrue(proxy_telemetry.telemetry_secret_path(codex_home).read_text(encoding="utf-8").strip())
 
     def test_usage_observed_updates_existing_gateway_request_usage(self):
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

- classify remaining non-config runtime writes in a repo audit document
- move durable/control runtime writes to existing Python/Rust safe-write helpers
- add locked create-if-absent secret creation to avoid concurrent telemetry HMAC secret races
- add stale-lock/concurrency regression tests for auth, telemetry secret, bucket sync, history ledgers, pending update, usage cache, and proxy PID writes

## Verification

- `python -m pytest -q` → 694 passed, 1 skipped, 68 subtests passed
- `cd src-tauri; cargo test --locked` → 197 passed
- `cd src-tauri; cargo clippy --locked --all-targets -- -D warnings` → passed

Refs #30.