### PR TITLE
fix: sanitize official compaction inputs

### DIFF
--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -6537,6 +6537,36 @@ def _rewrite_internal_input_items(
     return changed
 
 
+def _sanitize_unsupported_compaction_input_items(payload: dict[str, Any]) -> bool:
+    input_items = payload.get("input")
+    if not isinstance(input_items, list):
+        return False
+
+    changed = False
+    rewritten_items: list[Any] = []
+    for item in input_items:
+        if not isinstance(item, dict):
+            rewritten_items.append(item)
+            continue
+
+        item_type = item.get("type")
+        if item_type == "compaction":
+            replacement = _compatible_compaction_message(item)
+            if replacement is not None:
+                rewritten_items.append(replacement)
+            changed = True
+            continue
+        if item_type == "compaction_trigger":
+            changed = True
+            continue
+
+        rewritten_items.append(item)
+
+    if changed:
+        payload["input"] = rewritten_items
+    return changed
+
+
 def _sanitize_official_system_messages(payload: dict[str, Any]) -> bool:
     input_items = payload.get("input")
     if not isinstance(input_items, list):
@@ -7857,6 +7887,8 @@ def official_passthrough_request_body(
     if isinstance(service_tier, str) and service_tier and next_payload.get("service_tier") != service_tier:
         next_payload["service_tier"] = service_tier
         changed = True
+    if _sanitize_unsupported_compaction_input_items(next_payload):
+        changed = True
     if next_payload.get("store") is not False:
         next_payload["store"] = False
         changed = True
@@ -7888,6 +7920,8 @@ def transparent_request_body(
             next_payload = dict(payload)
             changed = False
             if _normalize_responses_message_input_items(next_payload):
+                changed = True
+            if official_responses_backend and _sanitize_unsupported_compaction_input_items(next_payload):
                 changed = True
             if upstream_is_third_party and _rewrite_internal_input_items(next_payload):
                 changed = True
@@ -7925,6 +7959,8 @@ def transparent_request_body(
         next_payload["stream"] = True
         changed = True
     if official_responses_backend and _normalize_responses_string_input(next_payload):
+        changed = True
+    if official_responses_backend and _sanitize_unsupported_compaction_input_items(next_payload):
         changed = True
     if _normalize_responses_message_input_items(next_payload):
         changed = True
@@ -7968,6 +8004,8 @@ def compatible_request_body(
     changed = _normalize_responses_message_input_items(payload)
     if upstream_name == "official":
         if _sanitize_official_reasoning_items(payload):
+            changed = True
+        if _sanitize_unsupported_compaction_input_items(payload):
             changed = True
         if _normalize_responses_string_input(payload):
             changed = True

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1009,6 +1009,38 @@ class RoutingTests(unittest.TestCase):
         self.assertFalse(relayed[0]["defer_stream_errors"])
         self.assert_no_official_passthrough_gateway_events()
 
+    def test_official_http_passthrough_converts_compaction_input_before_upstream(self):
+        input_items = [
+            {"type": "message", "role": "user", "content": f"message {index}"}
+            for index in range(68)
+        ]
+        input_items.append({"type": "compaction", "summary": "release thread summary"})
+        body = json.dumps(
+            {
+                "model": "openai/gpt-5.5",
+                "input": input_items,
+                "stream": True,
+            }
+        ).encode("utf-8")
+        handler, _fake = post_handler("/v1/responses", body)
+        handler._relay_upstream_response = lambda response, upstream_name, **kwargs: 200
+
+        with (
+            patch("codex_proxy.codex_access_token", return_value="sub-token"),
+            patch("codex_proxy.codex_account_id", return_value="acct-1"),
+            patch("codex_proxy._open_upstream_response", return_value=FakeContextResponse(b'{"id":"resp_official","output":[]}')) as open_response,
+        ):
+            CodexProxyHandler.do_POST(handler)
+
+        request = open_response.call_args.args[0]
+        sent_payload = json.loads(request.data)
+        sent_raw = request.data.decode("utf-8")
+
+        self.assertEqual(sent_payload["input"][68]["type"], "message")
+        self.assertEqual(sent_payload["input"][68]["role"], "developer")
+        self.assertIn("release thread summary", sent_payload["input"][68]["content"])
+        self.assertNotIn('"type":"compaction"', sent_raw)
+
     def test_official_http_passthrough_does_not_call_image_proxy(self):
         body = json.dumps(
             {
@@ -4124,13 +4156,18 @@ class RoutingTests(unittest.TestCase):
 
         self.assertEqual(json.loads(transformed)["reasoning"]["effort"], "xhigh")
 
-    def test_official_body_keeps_compaction_input_unchanged(self):
+    def test_official_body_converts_compaction_input_to_developer_message(self):
         upstream = choose_upstream("gpt-5.5")
         body = b'{"model":"gpt-5.5","input":[{"type":"compaction","summary":"keep official shape"}]}'
 
         transformed = compatible_request_body(body, upstream)
+        payload = json.loads(transformed)
 
-        self.assertEqual(json.loads(transformed)["input"][0]["type"], "compaction")
+        self.assertEqual(payload["input"][0]["type"], "message")
+        self.assertEqual(payload["input"][0]["role"], "developer")
+        self.assertIn("Compacted conversation context", payload["input"][0]["content"])
+        self.assertIn("keep official shape", payload["input"][0]["content"])
+        self.assertNotIn('"type":"compaction"', transformed.decode("utf-8"))
 
     def test_official_body_keeps_custom_tool_items_unchanged(self):
         upstream = choose_upstream("gpt-5.5")


### PR DESCRIPTION
## Summary
- Sanitize unsupported Codex `compaction` items before sending official Responses requests.
- Cover both normal official compatibility and Codex App official HTTP passthrough paths.
- Preserve compaction summaries as developer messages; drop empty `compaction_trigger` items.

## Verification
- RED: `python -m pytest tests/test_routing.py -q -k "compaction_input"` failed before implementation on official/passthrough cases.
- GREEN: `python -m pytest tests/test_routing.py -q -k "compaction_input"` -> 5 passed.
- Full: `python -m pytest tests/test_routing.py -q` -> 346 passed, 61 subtests passed.
