### PR TITLE
fix: preserve compacted structured tool history for external providers

### DIFF
--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -5216,17 +5216,34 @@ def _rewrite_structured_tool_input_items(
 
     changed = False
     rewritten_items: list[Any] = []
+    preserved_structured_call_ids: set[str] = set()
     for item in input_items:
         if not isinstance(item, dict):
             rewritten_items.append(item)
             continue
         if item.get("type") == "function_call":
-            rewritten = _structured_tool_function_call_item(item)
-            rewritten_items.append(rewritten if rewritten is not None else item)
-            changed = changed or rewritten != item
+            if _multi_agent_function_call_name(item) is not None or _node_repl_function_call_name(item) is not None:
+                call_id = item.get("call_id")
+                if isinstance(call_id, str):
+                    preserved_structured_call_ids.add(call_id)
+                rewritten = _structured_tool_function_call_item(item)
+                rewritten_items.append(rewritten if rewritten is not None else item)
+                changed = changed or rewritten != item
+            else:
+                replacement = _compatible_internal_message(item)
+                if replacement is not None:
+                    rewritten_items.append(replacement)
+                changed = True
             continue
         if item.get("type") == "function_call_output":
-            rewritten_items.append(dict(item))
+            call_id = item.get("call_id")
+            if isinstance(call_id, str) and call_id in preserved_structured_call_ids:
+                rewritten_items.append(dict(item))
+            else:
+                replacement = _compatible_internal_message(item)
+                if replacement is not None:
+                    rewritten_items.append(replacement)
+                changed = True
             continue
         item_type = item.get("type")
         replacement = _compatible_internal_message(item)

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -5774,8 +5774,7 @@ def _joined_text(value: Any) -> str:
 def _active_user_request_text(value: Any) -> str:
     if not isinstance(value, list):
         return _joined_text(value)
-    messages: list[str] = []
-    for item in value:
+    for item in reversed(value):
         if not isinstance(item, Mapping) or item.get("type") != "message":
             continue
         if item.get("role") != "user":
@@ -5785,8 +5784,8 @@ def _active_user_request_text(value: Any) -> str:
         if first_line.startswith("Previous real Codex native ") or first_line.startswith("Codex native "):
             continue
         if text.strip():
-            messages.append(text)
-    return "\n".join(messages)
+            return text
+    return ""
 
 
 def _exact_child_prompts_from_request_text(text: str) -> list[str]:
@@ -8409,23 +8408,24 @@ def compatible_request_body(
                 )
                 changed = True
             required_tool_choice_name = None
-            if (
-                subagent_workflow_plan_read_required
-                and include_node_repl_for_subagent_workflow
-                and "mcp__node_repl__js" in _function_tool_names(payload.get("tools"))
-            ):
-                required_tool_choice_name = "mcp__node_repl__js"
-            else:
-                required_tool_choice_name = _required_subagent_tool_choice(
-                    tool_protocol=tool_protocol,
-                    lifecycle_complete=lifecycle_complete,
-                    include_spawn_agent=include_spawn_agent,
-                    include_wait_agent=include_wait_agent,
-                    include_close_agent=include_close_agent,
-                    include_resume_agent=include_resume_agent,
-                    include_send_input=include_send_input,
-                    include_node_repl_for_subagent_workflow=include_node_repl_for_subagent_workflow,
-                )
+            if subagent_state_active:
+                if (
+                    subagent_workflow_plan_read_required
+                    and include_node_repl_for_subagent_workflow
+                    and "mcp__node_repl__js" in _function_tool_names(payload.get("tools"))
+                ):
+                    required_tool_choice_name = "mcp__node_repl__js"
+                else:
+                    required_tool_choice_name = _required_subagent_tool_choice(
+                        tool_protocol=tool_protocol,
+                        lifecycle_complete=lifecycle_complete,
+                        include_spawn_agent=include_spawn_agent,
+                        include_wait_agent=include_wait_agent,
+                        include_close_agent=include_close_agent,
+                        include_resume_agent=include_resume_agent,
+                        include_send_input=include_send_input,
+                        include_node_repl_for_subagent_workflow=include_node_repl_for_subagent_workflow,
+                    )
             if semantic_repair_enabled and _restrict_tools_to_required_tool(payload, required_tool_choice_name):
                 _write_adapter_event(
                     event_context,

--- a/src-python/subagent_state.py
+++ b/src-python/subagent_state.py
@@ -1242,8 +1242,7 @@ def _active_request_text(value: Any) -> str:
 def _active_user_request_text(value: Any) -> str:
     if not isinstance(value, list):
         return _request_text(value)
-    messages: list[str] = []
-    for item in value:
+    for item in reversed(value):
         if not isinstance(item, Mapping) or item.get("type") != "message":
             continue
         if item.get("role") != "user":
@@ -1253,8 +1252,8 @@ def _active_user_request_text(value: Any) -> str:
         if first_line.startswith("Previous real Codex native ") or first_line.startswith("Codex native "):
             continue
         if text.strip():
-            messages.append(text)
-    return "\n".join(messages) if messages else _request_text(value)
+            return text
+    return _request_text(value)
 
 
 def _infer_role(text: str) -> str:

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -8332,6 +8332,44 @@ Required sequence:
             {"type": "function", "name": "multi_agent_v1__spawn_agent"},
         )
 
+    def test_stale_subagent_request_does_not_force_spawn_tool_for_latest_plain_user_turn(self):
+        body = json.dumps(
+            {
+                "model": "glm-5.2",
+                "input": [
+                    {
+                        "type": "message",
+                        "role": "user",
+                        "content": "请 spawn 1 个 subagent 来检查代码",
+                    },
+                    {"type": "message", "role": "assistant", "content": "好的。"},
+                    {"type": "message", "role": "user", "content": "test\n"},
+                ],
+                "tools": [],
+                "stream": True,
+            }
+        ).encode("utf-8")
+        event_context = {"request_id": "req", "repair_policy": codex_proxy.REPAIR_CODEX_SUBAGENT}
+
+        transformed = compatible_request_body(
+            body,
+            {
+                "name": "ollama_cloud",
+                "upstream_format": "responses",
+                "tool_protocol": "responses_structured",
+            },
+            event_context=event_context,
+        )
+
+        payload = json.loads(transformed)
+        tool_names = [tool.get("name") for tool in payload.get("tools", []) if isinstance(tool, dict)]
+        self.assertNotEqual(
+            payload.get("tool_choice"),
+            {"type": "function", "name": "multi_agent_v1__spawn_agent"},
+        )
+        self.assertIn("multi_agent_v1__spawn_agent", tool_names)
+        self.assertFalse(event_context["subagent_workflow_active"])
+
     def test_chat_tools_workflow_failed_node_repl_plan_read_still_blocks_spawn(self):
         workflow_prompt = """
 Use the real subagent-driven-development skill.

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -4508,6 +4508,57 @@ class RoutingTests(unittest.TestCase):
         for forbidden in ('"type":"compaction"', '"type":"compaction_trigger"', '"type":"reasoning"', "gAAAA"):
             self.assertNotIn(forbidden, raw)
 
+    def test_external_responses_structured_body_transcripts_ordinary_tool_history(self):
+        upstream = {
+            "name": "ollama_cloud",
+            "upstream_model": "glm-5.2",
+            "upstream_format": "responses",
+            "tool_protocol": "responses_structured",
+        }
+        body = json.dumps(
+            {
+                "model": "glm-5.2",
+                "input": [
+                    {"type": "message", "role": "user", "content": "Run echo first."},
+                    {
+                        "type": "function_call",
+                        "call_id": "call_shell",
+                        "name": "shell_command",
+                        "arguments": "{\"command\":\"echo hi\"}",
+                    },
+                    {
+                        "type": "function_call_output",
+                        "call_id": "call_shell",
+                        "output": "Exit code: 0\nOutput:\nhi",
+                    },
+                    {"type": "message", "role": "user", "content": "Now answer normally."},
+                ],
+                "tools": [
+                    {
+                        "type": "function",
+                        "name": "shell_command",
+                        "parameters": {"type": "object"},
+                    }
+                ],
+                "stream": True,
+            }
+        ).encode("utf-8")
+
+        transformed = compatible_request_body(body, upstream, model_id="glm-5.2")
+        payload = json.loads(transformed)
+        raw = transformed.decode("utf-8")
+
+        self.assertEqual(payload["model"], "glm-5.2")
+        self.assertEqual([item["type"] for item in payload["input"][:4]], ["message", "message", "message", "message"])
+        self.assertEqual(payload["input"][1]["role"], "developer")
+        self.assertIn("Read-only Codex function call transcript", payload["input"][1]["content"])
+        self.assertIn("shell_command", payload["input"][1]["content"])
+        self.assertEqual(payload["input"][2]["role"], "developer")
+        self.assertIn("Read-only Codex function result transcript", payload["input"][2]["content"])
+        self.assertIn("Output", payload["input"][2]["content"])
+        self.assertNotIn('"type":"function_call"', raw)
+        self.assertNotIn('"type":"function_call_output"', raw)
+
     def test_external_no_tool_protocol_body_sanitizes_internal_input_items(self):
         upstream = {
             "name": "no_tools",
@@ -7082,8 +7133,14 @@ class RoutingTests(unittest.TestCase):
         self.assertEqual(payload["input"][1]["type"], "message")
         self.assertEqual(payload["input"][1]["role"], "user")
         self.assertEqual(payload["input"][1]["content"], [{"type": "input_text", "text": "test"}])
-        self.assertEqual(payload["input"][2]["type"], "function_call")
-        self.assertEqual(payload["input"][3]["type"], "function_call_output")
+        self.assertEqual(payload["input"][2]["type"], "message")
+        self.assertEqual(payload["input"][2]["role"], "developer")
+        self.assertIn("Read-only Codex function call transcript", payload["input"][2]["content"])
+        self.assertIn("known_tool", payload["input"][2]["content"])
+        self.assertEqual(payload["input"][3]["type"], "message")
+        self.assertEqual(payload["input"][3]["role"], "developer")
+        self.assertIn("Read-only Codex function result transcript", payload["input"][3]["content"])
+        self.assertIn("ok", payload["input"][3]["content"])
 
     def test_responses_structured_provider_preserves_multi_agent_tool_history(self):
         body = json.dumps(
@@ -8369,6 +8426,44 @@ Required sequence:
         )
         self.assertIn("multi_agent_v1__spawn_agent", tool_names)
         self.assertFalse(event_context["subagent_workflow_active"])
+
+    def test_latest_explicit_subagent_request_still_forces_spawn_tool(self):
+        body = json.dumps(
+            {
+                "model": "glm-5.2",
+                "input": [
+                    {"type": "message", "role": "user", "content": "上一轮只是普通聊天。"},
+                    {"type": "message", "role": "assistant", "content": "好的。"},
+                    {
+                        "type": "message",
+                        "role": "user",
+                        "content": "请 spawn 1 个 subagent 来检查代码",
+                    },
+                ],
+                "tools": [],
+                "stream": True,
+            }
+        ).encode("utf-8")
+        event_context = {"request_id": "req", "repair_policy": codex_proxy.REPAIR_CODEX_SUBAGENT}
+
+        transformed = compatible_request_body(
+            body,
+            {
+                "name": "ollama_cloud",
+                "upstream_format": "responses",
+                "tool_protocol": "responses_structured",
+            },
+            event_context=event_context,
+        )
+
+        payload = json.loads(transformed)
+        tool_names = [tool.get("name") for tool in payload.get("tools", []) if isinstance(tool, dict)]
+        self.assertIn("multi_agent_v1__spawn_agent", tool_names)
+        self.assertEqual(
+            payload.get("tool_choice"),
+            {"type": "function", "name": "multi_agent_v1__spawn_agent"},
+        )
+        self.assertTrue(event_context["subagent_spawn_allowed"])
 
     def test_chat_tools_workflow_failed_node_repl_plan_read_still_blocks_spawn(self):
         workflow_prompt = """


### PR DESCRIPTION
## Summary
- Convert ordinary historical Responses `function_call` / `function_call_output` items into read-only developer transcript messages for external `responses_structured` providers.
- Preserve structured multi_agent and node_repl call history so subagent flows do not regress.
- Keep the stale-subagent forced `tool_choice` regression coverage from the prior hotfix.

## What this PR does not claim
- This PR does **not** fully fix upstreams that return a syntactically valid but semantically empty `response.completed` SSE stream.
- That follow-up is tracked separately in #43.

## Verification
- `python -m pytest tests/test_routing.py tests/test_subagent_state.py tests/test_subagent_protocol.py -q` → 416 passed, 61 subtests passed.
- `python -m pytest` → 698 passed, 1 skipped.
- Built Windows NSIS artifact locally with `scripts/build-windows-release.ps1 -SkipFrontendBuild`.
- Synthetic live GLM-5.2 test against local hotfix proxy on port 9100 with ordinary tool-call history + 228 dummy tools returned visible `response.output_text.delta` events.

## Local artifact
- `D:\Workstation\CodexHub\.worktrees\ollama-empty-output-hotfix\src-tauri\target\release\bundle\nsis\CodexHub_0.1.1_x64-setup.exe`
- SHA256: `8b1c547e4a1c8ed256f801cb5ecd2ba2c10fa1294d4f5bdcaa08e72a17aea4b1`
