### PR TITLE
chore: sync dev to 0.1.2 version

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codexhub-frontend",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codexhub-frontend",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codexhub-frontend",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.1.2",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "codexhub"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "dirs 5.0.1",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codexhub"
-version = "0.1.1"
+version = "0.1.2"
 description = "CodexHub desktop backend and CLI"
 authors = ["CodexHub"]
 license = "MIT"

--- a/src-tauri/src/proxy.rs
+++ b/src-tauri/src/proxy.rs
@@ -1723,7 +1723,7 @@ time.sleep(10)
 "#,
         );
 
-        let error = start_with_paths_and_timeout(&paths, Duration::from_millis(500))
+        let error = start_with_paths_and_timeout(&paths, Duration::from_secs(5))
             .expect_err("startup should time out");
 
         assert!(error.contains("did not become healthy"));

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "CodexHub",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "identifier": "com.codexhub.app",
   "build": {
     "frontendDist": "../frontend/dist",


### PR DESCRIPTION
## Summary

Sync `dev` version metadata to the released `0.1.2` state after publishing `v0.1.2` from the release branch.

This keeps future feature branches from starting with stale `0.1.1` package/app versions.

## Diff scope

Only version metadata files are changed:

- `frontend/package.json`
- `frontend/package-lock.json`
- `src-tauri/Cargo.toml`
- `src-tauri/Cargo.lock`
- `src-tauri/tauri.conf.json`

## Verification

- `python -m pytest -q` — 706 passed, 1 skipped, 68 subtests passed