### PR TITLE
docs: plan post 0.1.2 issue closeout

### DIFF
--- a/docs/superpowers/plans/2026-07-09-post-0.1.2-issue-closeout.md
+++ b/docs/superpowers/plans/2026-07-09-post-0.1.2-issue-closeout.md
@@ -1,0 +1,378 @@
+# Post 0.1.2 Issue Closeout Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the remaining CodexHub issue queue after `v0.1.2` without mixing unrelated transport, protocol, UI, and architecture work in the same PR.
+
+**Architecture:** The remaining issues are split into release trains by dependency and blast radius. Fast correctness/security fixes go first, transport evidence and hardening follow, protocol conversion changes land behind a seam, and broad architecture cleanup stays out of patch releases.
+
+**Tech Stack:** Python Gateway (`src-python/`), Rust/Tauri desktop backend (`src-tauri/`), React/Vite frontend (`frontend/`), GitHub Issues/PRs, `gh` CLI, Python `pytest`, Rust `cargo test`/`clippy`, frontend `npm run build`/UI contract tests.
+
+## Global Constraints
+
+- Branch flow remains `feature branch -> dev -> main`; close issues only after the fix reaches `main`.
+- Work in isolated worktrees under `D:/Workstation/CodexHub/.worktrees/`; do not use `D:/Workstation/CodexHub` while it has unrelated dirty reconnect/release artifacts.
+- Keep patch releases narrow. Do not combine transport reconnect work with protocol refactors or broad UI/Rust module splits.
+- Every PR must name the issue(s), include the required verification from those issues, and preserve existing release/update behavior.
+- For high-risk Gateway changes, prefer one issue per PR unless two issues share the same test fixture and code path.
+- `#22` remains blocked on evidence from `#12`/`#16`; do not implement retry-storm dampening before those diagnostics are reviewed.
+
+---
+
+## Current Issue State Snapshot
+
+Open issues after `v0.1.2` release:
+
+| Issue | Status | Recommended train | Notes |
+| --- | --- | --- | --- |
+| `#3` Restore Official OpenAI export-only explanation | ready | `0.1.3` quick closeout | Small frontend/UI-contract fix. |
+| `#5` Gateway request pipeline extraction | ready | `0.2` architecture | Broad Python extraction; do after correctness fixes. |
+| `#6` Python proxy telemetry async writer | ready | `0.2` architecture/perf | Needs bounded queue design; avoid mixing with transport retry work. |
+| `#7` Rust Gateway telemetry module split | ready | `0.2` architecture | Module split only, preserve schema/cost math. |
+| `#8` Rust Gateway client adapter split | ready | `0.2` architecture | Module split; likely touches same file as `#13/#28`. |
+| `#9` Provider page split | ready | `0.2` frontend architecture | Larger React refactor; keep out of patch train. |
+| `#10` Typed cross-layer error taxonomy | ready | `0.1.3` foundation | Relabeled from `needs-triage` to `ready-for-agent`; do before auth/downstream error shaping if possible. |
+| `#12` Official transport recurrence analyzer | ready | `0.1.3` diagnostics | Coordinate with reconnect thread/worktree before editing dirty files. |
+| `#13` Timeout/PATH-hardening for version probes | ready | `0.1.3` quick closeout | Small Rust safety fix. |
+| `#16` Generic Gateway transport instability diagnostics | ready | `0.1.3` diagnostics | Relabeled from `needs-triage` to `ready-for-agent`; can share analyzer with `#12`. |
+| `#17` Idempotency-safe non-official retries | ready | `0.1.4` transport semantics | Do after diagnostics and before dampening. |
+| `#18` Downstream disconnect classification | ready | `0.1.4` transport semantics | Helps separate client disconnect from upstream failure. |
+| `#19` Bounded upstream SSE reader queue | ready | `0.1.4` transport resource hardening | Requires careful lifecycle tests. |
+| `#20` Multi-line SSE data reassembly | ready | `0.1.4` protocol/transport parser | Do first in transport hardening train. |
+| `#21` Global Gateway concurrency limit | ready | `0.1.4` transport resource hardening | Do after failure classification is clearer. |
+| `#22` Retry-storm dampening | needs-info | after `#12/#16/#17/#21` | Keep blocked until evidence/policy is available. |
+| `#24` Local Gateway auth hardening | ready | `0.1.3` security | High priority; may use `#10` taxonomy. |
+| `#25` Extract protocol translation seam | ready | `0.1.5` protocol correctness | Must precede `#26`. |
+| `#26` Preserve semantic fields / reject unsafe missing tool IDs | ready | `0.1.5` protocol correctness | Depends on `#25`. |
+| `#28` Installer autostart/probe/catalog cleanup | ready | `0.1.3 optional` or `0.2` | Pair with `#13` only if scope remains small. |
+
+## Dependency Order
+
+```mermaid
+graph TD
+  "#10 error taxonomy" --> "#24 auth hardening"
+  "#12 official analyzer" --> "#22 retry dampening"
+  "#16 generic analyzer" --> "#22 retry dampening"
+  "#20 SSE reassembly" --> "#18 downstream disconnects"
+  "#18 downstream disconnects" --> "#19 SSE reader lifecycle"
+  "#17 idempotent retries" --> "#22 retry dampening"
+  "#21 concurrency limit" --> "#22 retry dampening"
+  "#25 protocol seam" --> "#26 semantic preservation"
+  "#13 version probe hardening" --> "#28 probe/catalog cleanup"
+```
+
+---
+
+## Train A: `0.1.3` Closeout Patch
+
+**Goal:** Close small/high-confidence issues and unblock later transport/security work without broad refactors.
+
+### Task A1: Frontend quick fix for `#3`
+
+**Files:**
+- Modify: `D:/Workstation/CodexHub/frontend/src/pages/ProvidersPage.tsx`
+- Modify if needed: `D:/Workstation/CodexHub/frontend/src/i18n/locales/en-US.ts`
+- Modify if needed: `D:/Workstation/CodexHub/frontend/src/i18n/locales/zh-CN.ts`
+- Test: `D:/Workstation/CodexHub/frontend/scripts/ui-contract.test.mjs`
+
+**Execution:**
+- [ ] Create branch `codex/issue-3-official-export-explanation` from `origin/main` in a clean worktree.
+- [ ] Add/restore a UI-contract test proving `OfficialDetail` explains `!officialIncluded` without changing source list/export hint behavior.
+- [ ] Implement the smallest copy/UI change.
+- [ ] Run `Push-Location frontend; npm run test:ui-contract; npm run build; Pop-Location`.
+- [ ] Open PR to `dev`; after merge to `dev`, include in next release PR to `main`; close `#3` only after `main`.
+
+### Task A2: Rust version probe hardening for `#13`
+
+**Files:**
+- Modify: `D:/Workstation/CodexHub/src-tauri/src/gateway.rs`
+- Test: existing Rust tests in `D:/Workstation/CodexHub/src-tauri/src/gateway.rs`
+
+**Execution:**
+- [ ] Create branch `codex/issue-13-version-probe-hardening` from `origin/main` or latest `origin/dev` after Task A1 lands.
+- [ ] Add tests for timeout returning unknown version and script-like unsupported paths not being executed.
+- [ ] Replace blocking `command.output()` version probes with a bounded timeout path.
+- [ ] Preserve normal known-client version display.
+- [ ] Run `Push-Location src-tauri; cargo test gateway_client; cargo test; Pop-Location`.
+- [ ] Open PR to `dev`.
+
+### Task A3: Minimal typed error taxonomy for `#10`
+
+**Files:**
+- Modify: `D:/Workstation/CodexHub/src-python/codex_proxy.py`
+- Modify: `D:/Workstation/CodexHub/src-tauri/src/gateway.rs` only if Rust command error shape needs representative coverage.
+- Modify: `D:/Workstation/CodexHub/frontend/scripts/ui-contract.test.mjs` only if frontend classification contracts are added.
+- Test: `D:/Workstation/CodexHub/tests/test_routing.py`
+
+**Execution:**
+- [ ] Create branch `codex/issue-10-error-taxonomy`.
+- [ ] Define the minimal shared fields exactly as the issue states: `code`, `message`, `source`, `retryable`, optional `details`.
+- [ ] Add representative Python routing tests for auth/upstream/protocol/config categories before changing implementation.
+- [ ] Add only representative Rust/frontend mappings if needed; do not convert every error path.
+- [ ] Run `python -m pytest tests/test_routing.py` plus any Rust/frontend targeted tests changed by the PR.
+- [ ] Open PR to `dev`.
+
+### Task A4: Local Gateway auth hardening for `#24`
+
+**Files:**
+- Modify: `D:/Workstation/CodexHub/src-python/codex_proxy.py`
+- Test: `D:/Workstation/CodexHub/tests/test_routing.py`
+- Docs if needed: `D:/Workstation/CodexHub/docs/reviews/` or existing auth/gateway docs.
+
+**Execution:**
+- [ ] Start only after Task A3 is merged or explicitly decide `#24` can use the existing `codexhub_error` shape.
+- [ ] Add failing tests for spoofed `User-Agent: codex-app` with no valid gateway key.
+- [ ] Add passing tests for legitimate configured-key traffic.
+- [ ] Replace spoofable identity trust with gateway-key match or a documented non-spoofable local trust signal.
+- [ ] Run `python -m pytest tests/test_routing.py`.
+- [ ] Open PR to `dev`.
+
+### Task A5: Transport diagnostics for `#12` and `#16`
+
+**Files:**
+- Modify: `D:/Workstation/CodexHub/scripts/analyze_transport_failures.py`
+- Modify: `D:/Workstation/CodexHub/tests/test_transport_failure_analyzer.py`
+- Modify if needed: `D:/Workstation/CodexHub/src-python/codex_proxy.py`
+- Modify docs: `D:/Workstation/CodexHub/docs/reviews/v0.2-codex-app-reconnect-diagnostics.md`
+
+**Execution:**
+- [ ] Before editing, inspect the dirty reconnect work in `D:/Workstation/CodexHub` and any active reconnect thread handoff; do not overwrite unmerged diagnostics.
+- [ ] Add analyzer fixture rows for official post-open `official_passthrough_stream_closed` and third-party `SSLEOFError`/`WinError 10060`.
+- [ ] Extend analyzer output to group by provider/model/client/error/failure phase/time window.
+- [ ] Document explicit proxy vs transparent/TUN A/B checklist.
+- [ ] Run `python -m pytest tests/test_transport_failure_analyzer.py tests/test_proxy_event_logging.py tests/test_routing.py`.
+- [ ] Open one PR that closes both `#12` and `#16` only if the shared analyzer/report cleanly covers both acceptance criteria; otherwise split into two PRs.
+
+### Task A6: Optional operational cleanup for `#28`
+
+**Files:**
+- Modify likely: `D:/Workstation/CodexHub/src-tauri/src/autostart.rs`
+- Modify likely: `D:/Workstation/CodexHub/src-tauri/src/gateway.rs`
+- Modify if needed: `D:/Workstation/CodexHub/src-python/catalog_sync.py`
+- Test: Rust `autostart`/`models`; Python `tests/test_catalog_sync.py`
+
+**Execution:**
+- [ ] Start only if Task A2 touched the same probe code or if installer cleanup is needed before the next public release.
+- [ ] Verify NSIS uninstall hook behavior before adding code.
+- [ ] Add bounded cache/parallelism only with clear invalidation semantics and tests.
+- [ ] Run `Push-Location src-tauri; cargo test autostart models; Pop-Location` and `python -m pytest tests/test_catalog_sync.py`.
+
+**Train A release gate:** Ship `0.1.3` after Tasks A1-A5 are merged and CI is green. Include A6 only if it stays small and independently green.
+
+---
+
+## Train B: `0.1.4` Transport/SSE Hardening
+
+**Goal:** Make stream parsing, retry, disconnect, and resource behavior explicit after diagnostics are available.
+
+### Task B1: Multi-line SSE parser correctness for `#20`
+
+**Files:**
+- Modify: `D:/Workstation/CodexHub/src-python/codex_proxy.py`
+- Test: `D:/Workstation/CodexHub/tests/test_routing.py`
+- Test if needed: `D:/Workstation/CodexHub/tests/test_chat_completions_gateway.py`
+
+**Execution:**
+- [ ] Add fixtures for multi-line `data:` events and normal `[DONE]` handling.
+- [ ] Reassemble complete SSE events before JSON parsing in CodexHub parser paths.
+- [ ] Preserve transparent byte-forwarding where raw relay is intended.
+- [ ] Run `python -m pytest tests/test_routing.py tests/test_chat_completions_gateway.py`.
+
+### Task B2: Downstream disconnect classification for `#18`
+
+**Files:**
+- Modify: `D:/Workstation/CodexHub/src-python/codex_proxy.py`
+- Test: `D:/Workstation/CodexHub/tests/test_routing.py`
+- Test: `D:/Workstation/CodexHub/tests/test_proxy_event_logging.py`
+
+**Execution:**
+- [ ] Add tests where downstream `wfile.write` raises `BrokenPipeError`/`OSError`.
+- [ ] Centralize streaming writes or wrap all direct branches.
+- [ ] Emit telemetry that clearly classifies downstream write failure separately from upstream read failure.
+- [ ] Run `python -m pytest tests/test_routing.py tests/test_proxy_event_logging.py tests/test_chat_completions_gateway.py`.
+
+### Task B3: SSE reader lifecycle and bounded queue for `#19`
+
+**Files:**
+- Modify: `D:/Workstation/CodexHub/src-python/codex_proxy.py`
+- Test: `D:/Workstation/CodexHub/tests/test_routing.py`
+- Test if present/created: `D:/Workstation/CodexHub/tests/test_proxy_shutdown.py`
+
+**Execution:**
+- [ ] Add tests for slow/downstream-stalled behavior with fake upstream responses.
+- [ ] Bound the upstream reader queue and document full-queue behavior.
+- [ ] Define close/join/abandon behavior for upstream EOF, idle timeout, downstream disconnect, and errors.
+- [ ] Run `python -m pytest tests/test_routing.py tests/test_chat_completions_gateway.py tests/test_proxy_shutdown.py` if that file exists; otherwise run the added lifecycle tests directly.
+
+### Task B4: Idempotency-safe non-official retries for `#17`
+
+**Files:**
+- Modify: `D:/Workstation/CodexHub/src-python/codex_proxy.py`
+- Test: `D:/Workstation/CodexHub/tests/test_routing.py`
+- Test: `D:/Workstation/CodexHub/tests/test_chat_completions_gateway.py`
+
+**Execution:**
+- [ ] Add tests that distinguish pre-open/connect retries from post-acceptance retries.
+- [ ] Disable unsafe retries or require explicit idempotency guarantee where needed.
+- [ ] Preserve official passthrough behavior required by diagnostics.
+- [ ] Run `python -m pytest tests/test_routing.py tests/test_chat_completions_gateway.py`.
+
+### Task B5: Global upstream concurrency limit for `#21`
+
+**Files:**
+- Modify: `D:/Workstation/CodexHub/src-python/codex_proxy.py`
+- Test: `D:/Workstation/CodexHub/tests/test_routing.py`
+- Test: `D:/Workstation/CodexHub/tests/test_proxy_event_logging.py`
+
+**Execution:**
+- [ ] Add tests for configurable saturation behavior.
+- [ ] Ensure health/status endpoints remain responsive where practical.
+- [ ] Emit distinct telemetry for saturation.
+- [ ] Run `python -m pytest tests/test_routing.py tests/test_proxy_event_logging.py`.
+
+### Task B6: Retry-storm dampening for `#22`
+
+**Files:**
+- Modify only after evidence: `D:/Workstation/CodexHub/src-python/codex_proxy.py`
+- Modify only after evidence: `D:/Workstation/CodexHub/scripts/analyze_transport_failures.py`
+- Test: `D:/Workstation/CodexHub/tests/test_routing.py`
+- Test: `D:/Workstation/CodexHub/tests/test_transport_failure_analyzer.py`
+
+**Execution:**
+- [ ] Start only after Tasks A5, B4, and B5 have produced enough evidence/policy.
+- [ ] Decide jitter/circuit-breaker/downstream notice behavior in an issue comment before implementation.
+- [ ] Implement the smallest dampener that preserves original upstream failure classification.
+- [ ] Run `python -m pytest tests/test_routing.py tests/test_transport_failure_analyzer.py tests/test_proxy_event_logging.py`.
+
+---
+
+## Train C: `0.1.5` Protocol Translation Correctness
+
+**Goal:** Make Responses ↔ Chat conversion safer without changing transport behavior.
+
+### Task C1: Extract protocol translation seam for `#25`
+
+**Files:**
+- Create: `D:/Workstation/CodexHub/src-python/protocol_translation.py`
+- Modify: `D:/Workstation/CodexHub/src-python/codex_proxy.py`
+- Create or modify: `D:/Workstation/CodexHub/tests/test_protocol_translation.py`
+- Existing tests: `D:/Workstation/CodexHub/tests/test_routing.py`, `D:/Workstation/CodexHub/tests/test_chat_completions_gateway.py`
+
+**Execution:**
+- [ ] Add seam-level tests for representative Chat→Responses, Responses→Chat, and stream conversion cases.
+- [ ] Move pure conversion helpers out of `codex_proxy.py` without changing public behavior.
+- [ ] Keep retry/transport/routing behavior untouched.
+- [ ] Run `python -m pytest tests/test_protocol_translation.py tests/test_chat_completions_gateway.py tests/test_routing.py` and then `python -m pytest`.
+
+### Task C2: Semantic preservation and missing tool ID safety for `#26`
+
+**Files:**
+- Modify: `D:/Workstation/CodexHub/src-python/protocol_translation.py`
+- Modify if needed: `D:/Workstation/CodexHub/src-python/codex_proxy.py`
+- Test: `D:/Workstation/CodexHub/tests/test_protocol_translation.py`
+- Test: `D:/Workstation/CodexHub/tests/test_routing.py`
+
+**Execution:**
+- [ ] Start only after Task C1 is merged.
+- [ ] Add tests for reasoning/refusal/search/custom tool/file/audio/annotation preservation or explicit unsupported reporting.
+- [ ] Add tests proving unsafe missing assistant tool-call ids and tool result ids no longer receive random unpairable ids.
+- [ ] Implement preservation/rejection behavior in the seam.
+- [ ] Run `python -m pytest tests/test_protocol_translation.py tests/test_routing.py tests/test_chat_completions_gateway.py`.
+
+---
+
+## Train D: `0.2` Architecture Cleanup
+
+**Goal:** Resume the original phase 1-4 architecture work after correctness/security/transport risk is reduced.
+
+### Task D1: Gateway request pipeline extraction for `#5`
+
+**Files:**
+- Modify: `D:/Workstation/CodexHub/src-python/codex_proxy.py`
+- Create likely: `D:/Workstation/CodexHub/src-python/gateway_pipeline.py`
+- Test: `D:/Workstation/CodexHub/tests/test_routing.py`
+- Test: `D:/Workstation/CodexHub/tests/test_chat_completions_gateway.py`
+
+**Execution:**
+- [ ] Extract upstream opener and downstream error mapper behind small pure/testable functions.
+- [ ] Preserve official passthrough pre-response retry semantics.
+- [ ] Run issue-required Python tests and full `python -m pytest`.
+
+### Task D2: Python proxy telemetry async writer for `#6`
+
+**Files:**
+- Modify: `D:/Workstation/CodexHub/src-python/proxy_telemetry.py`
+- Modify: `D:/Workstation/CodexHub/src-python/codex_proxy.py`
+- Test: `D:/Workstation/CodexHub/tests/test_proxy_event_logging.py`
+
+**Execution:**
+- [ ] Introduce bounded in-process telemetry queue and single writer worker.
+- [ ] Define explicit drop/backpressure behavior.
+- [ ] Run `python -m pytest tests/test_proxy_event_logging.py tests/test_routing.py` and full Python suite.
+
+### Task D3: Rust telemetry module split for `#7`
+
+**Files:**
+- Modify: `D:/Workstation/CodexHub/src-tauri/src/gateway.rs`
+- Create likely: `D:/Workstation/CodexHub/src-tauri/src/gateway_telemetry.rs`
+- Modify: `D:/Workstation/CodexHub/src-tauri/src/main.rs` if module wiring is required.
+
+**Execution:**
+- [ ] Move telemetry schema/ingestion/pricing/usage-window internals behind a dedicated module.
+- [ ] Preserve public command behavior and `GatewayUsageSnapshot` shape.
+- [ ] Run `Push-Location src-tauri; cargo test telemetry; cargo test usage_; cargo test; Pop-Location`.
+
+### Task D4: Rust client adapter module split for `#8`
+
+**Files:**
+- Modify: `D:/Workstation/CodexHub/src-tauri/src/gateway.rs`
+- Create likely: `D:/Workstation/CodexHub/src-tauri/src/gateway_clients/` module files.
+
+**Execution:**
+- [ ] Move concrete adapter preview/apply/restore implementations behind isolated modules.
+- [ ] Preserve generic/copy-only behavior and backup/restore semantics.
+- [ ] Run `Push-Location src-tauri; cargo test gateway_client; cargo test; Pop-Location`.
+
+### Task D5: Provider page/frontend state split for `#9`
+
+**Files:**
+- Modify: `D:/Workstation/CodexHub/frontend/src/pages/ProvidersPage.tsx`
+- Create likely: focused components/hooks under `D:/Workstation/CodexHub/frontend/src/components/` and `D:/Workstation/CodexHub/frontend/src/hooks/`.
+
+**Execution:**
+- [ ] Extract official usage panel, source navigation/dirty-draft workflow, provider editor, and probe/catalog actions.
+- [ ] Extract shared date/provider/update helpers.
+- [ ] Run `Push-Location frontend; npm run build; npm run test:ui-contract; Pop-Location`.
+
+### Task D6: Operational cleanup for `#28` if not completed in Train A
+
+**Files:**
+- Modify likely: `D:/Workstation/CodexHub/src-tauri/src/autostart.rs`
+- Modify likely: `D:/Workstation/CodexHub/src-tauri/src/gateway.rs`
+- Modify if needed: `D:/Workstation/CodexHub/src-python/catalog_sync.py`
+
+**Execution:**
+- [ ] Verify NSIS uninstall cleanup for autostart artifacts.
+- [ ] Measure probe/catalog bottlenecks before adding caching/parallelism.
+- [ ] Add bounded parallelism only when tests prove invalidation semantics.
+- [ ] Run issue-required Rust/Python tests.
+
+---
+
+## PR and Release Policy
+
+- `0.1.3`: Prefer 4-6 small PRs. Do not wait for all `0.2` architecture work.
+- `0.1.4`: Transport hardening PRs should be sequential because they touch the same streaming code.
+- `0.1.5`: `#25` and `#26` must be separate PRs unless `#25` lands as a pure extraction with no behavior changes.
+- `0.2`: Architecture phase PRs should remain separate by subsystem: Python pipeline, Python telemetry, Rust telemetry, Rust adapters, frontend provider page.
+
+## Immediate Next Action
+
+`dev` has been synced back to the `0.1.2` version line by PR `#46`. Start Train A from latest `origin/dev`.
+
+Recommended first implementation:
+
+1. Task A1 (`#3`) because it is a small frontend/UI-contract fix and does not conflict with reconnect diagnostics.
+2. Task A2 (`#13`) if a Rust backend task is preferred next.
+3. Task A5 (`#12/#16`) only after reconciling the dirty reconnect worktree/state in `D:/Workstation/CodexHub`.
+


### PR DESCRIPTION
## Summary
- Adds a durable post-0.1.2 issue closeout plan under `docs/superpowers/plans/`.
- Groups remaining open issues into release trains: 0.1.3 patch closeout, 0.1.4 transport/SSE hardening, 0.1.5 protocol correctness, and 0.2 architecture cleanup.
- Documents dependency ordering, per-task file/test scope, and release policy.

## Verification
- Documentation-only change.
- Plan branch rebased on latest `origin/dev` after PR #46 synced dev to the 0.1.2 version line.