### PR TITLE
feat: close typed error taxonomy gaps

### DIFF
--- a/frontend/scripts/ui-contract.test.mjs
+++ b/frontend/scripts/ui-contract.test.mjs
@@ -563,8 +563,21 @@ test("gateway page is wired to real usage and client backend APIs", async () => 
 });
 
 test("web preview falls back to the bridge when host Tauri IPC is unavailable", async () => {
-  const tauriSource = await readFile(tauriSourcePath, "utf8");
+  const [tauriSource, typesSource] = await Promise.all([
+    readFile(tauriSourcePath, "utf8"),
+    readFile(typesPath, "utf8"),
+  ]);
 
+  assert.match(typesSource, /export interface CodexHubError/);
+  assert.match(typesSource, /code: string;/);
+  assert.match(typesSource, /message: string;/);
+  assert.match(typesSource, /source: string;/);
+  assert.match(typesSource, /retryable: boolean;/);
+  assert.match(typesSource, /details\?: Record<string, unknown> \| null;/);
+  assert.match(tauriSource, /codexhub_error\?: CodexHubError \| null;/);
+  assert.match(tauriSource, /class CodexHubBridgeError extends Error/);
+  assert.match(tauriSource, /this\.codexhubError = codexhubError/);
+  assert.match(tauriSource, /throw new CodexHubBridgeError\(/);
   assert.match(tauriSource, /function shouldFallbackToBridge\(error: unknown\)/);
   assert.match(tauriSource, /catch \(error\)/);
   assert.match(tauriSource, /if \(!shouldFallbackToBridge\(error\)\) \{\s*throw error;\s*\}/s);

--- a/frontend/src/lib/tauri.ts
+++ b/frontend/src/lib/tauri.ts
@@ -7,6 +7,7 @@ import type {
   AppUpdateInstallStatus,
   AppUpdateStatus,
   AppVersionInfo,
+  CodexHubError,
   GatewayClientConfig,
   GatewayClientApplyResult,
   GatewayClientConfigPreview,
@@ -43,6 +44,17 @@ interface BridgeResponse<T> {
   ok: boolean;
   value?: T;
   error?: string;
+  codexhub_error?: CodexHubError | null;
+}
+
+export class CodexHubBridgeError extends Error {
+  readonly codexhubError: CodexHubError | null;
+
+  constructor(message: string, codexhubError: CodexHubError | null) {
+    super(message);
+    this.name = "CodexHubBridgeError";
+    this.codexhubError = codexhubError;
+  }
 }
 
 const DEFAULT_BRIDGE_URL = "http://127.0.0.1:1421/api/invoke";
@@ -79,7 +91,10 @@ async function bridgeInvoke<T>(command: string, args?: Record<string, unknown>):
 
   const payload = (await response.json().catch(() => null)) as BridgeResponse<T> | null;
   if (!response.ok || !payload?.ok) {
-    throw new Error(payload?.error || `CodexHub web bridge request failed: HTTP ${response.status}`);
+    throw new CodexHubBridgeError(
+      payload?.codexhub_error?.message || payload?.error || `CodexHub web bridge request failed: HTTP ${response.status}`,
+      payload?.codexhub_error ?? null,
+    );
   }
   return payload.value as T;
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -349,6 +349,14 @@ export interface GatewayClientApplyResult {
   message: string;
 }
 
+export interface CodexHubError {
+  code: string;
+  message: string;
+  source: string;
+  retryable: boolean;
+  details?: Record<string, unknown> | null;
+}
+
 export interface GatewayEvent {
   ts?: string | null;
   event?: string | null;

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -10339,6 +10339,12 @@ def _typed_error_code(
     exc: BaseException | None,
     status: int | None,
 ) -> str:
+    if error_type == "gateway_auth_error":
+        return "gateway.auth"
+    if error_type == "backend_error":
+        return "backend.command"
+    if error_type == "config_error":
+        return "config.origin"
     if error_type in {"invalid_request_error", "validation_error"}:
         return "provider.request"
     if error_code in {"UpstreamProtocolError", "upstream_stream_incomplete", "upstream_stream_idle_timeout"}:
@@ -11652,7 +11658,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
             self._safe_send_downstream_json_error(
                 400,
                 inbound_format=inbound_format,
-                upstream_name=upstream_name or "upstream_error",
+                upstream_name=upstream_name or provider_hint or "gateway",
                 request_id=request_id,
                 exc=exc,
                 error=type(exc).__name__,

--- a/src-tauri/src/web_bridge.rs
+++ b/src-tauri/src/web_bridge.rs
@@ -514,6 +514,26 @@ fn to_value<T: serde::Serialize>(result: Result<T, String>) -> Result<Value, Str
     })
 }
 
+fn bridge_error_code(status: u16, error: &str) -> &'static str {
+    let lowered = error.to_ascii_lowercase();
+    if status == 403 && lowered.contains("origin") {
+        return "config.origin";
+    }
+    "backend.command"
+}
+
+fn bridge_error_payload(status: u16, error: &str) -> Value {
+    json!({
+        "code": bridge_error_code(status, error),
+        "message": error,
+        "source": "web_bridge",
+        "retryable": false,
+        "details": {
+            "status": status,
+        },
+    })
+}
+
 fn string_arg(args: &Value, name: &str) -> Result<String, String> {
     args.get(name)
         .and_then(Value::as_str)
@@ -579,7 +599,15 @@ impl BridgeResponse {
     }
 
     fn error(status: u16, error: String) -> Self {
-        Self::json(status, json!({ "ok": false, "error": error }))
+        let codexhub_error = bridge_error_payload(status, &error);
+        Self::json(
+            status,
+            json!({
+                "ok": false,
+                "error": error,
+                "codexhub_error": codexhub_error,
+            }),
+        )
     }
 
     fn into_bytes(self) -> Vec<u8> {
@@ -649,7 +677,40 @@ mod tests {
         .expect("invoke");
 
         assert_eq!(response.status, 500);
-        assert!(String::from_utf8_lossy(&response.body).contains("missing_command"));
+        let body: serde_json::Value = serde_json::from_slice(&response.body).expect("json body");
+        assert_eq!(body["error"], "unknown CodexHub command: missing_command");
+        assert_eq!(body["codexhub_error"]["code"], "backend.command");
+        assert_eq!(
+            body["codexhub_error"]["message"],
+            "unknown CodexHub command: missing_command"
+        );
+        assert_eq!(body["codexhub_error"]["source"], "web_bridge");
+        assert_eq!(body["codexhub_error"]["retryable"], false);
+        assert_eq!(body["codexhub_error"]["details"]["status"], 500);
+    }
+
+    #[test]
+    fn disallowed_origin_returns_config_origin_error() {
+        let response = handle_request(
+            BridgeRequest {
+                method: "POST".to_string(),
+                path: "/api/invoke".to_string(),
+                origin: Some("http://example.com".to_string()),
+                body: serde_json::to_vec(&json!({
+                    "command": "get_app_flavor",
+                    "args": {}
+                }))
+                .unwrap(),
+            },
+            None,
+        )
+        .expect("invoke");
+
+        assert_eq!(response.status, 403);
+        let body: serde_json::Value = serde_json::from_slice(&response.body).expect("json body");
+        assert_eq!(body["codexhub_error"]["code"], "config.origin");
+        assert_eq!(body["codexhub_error"]["source"], "web_bridge");
+        assert_eq!(body["codexhub_error"]["retryable"], false);
     }
 
     #[test]

--- a/tests/test_chat_completions_gateway.py
+++ b/tests/test_chat_completions_gateway.py
@@ -295,6 +295,106 @@ class RequestKindDetectionTests(unittest.TestCase):
         self.assertEqual(request_kind, "compact")
 
 
+class CodexHubErrorPayloadTests(unittest.TestCase):
+    def test_typed_error_payload_maps_core_categories(self):
+        cases = [
+            (
+                "provider.request",
+                {
+                    "source": "external-provider",
+                    "message": "model is required",
+                    "status": 400,
+                    "error": "ValidationError",
+                    "error_type": "invalid_request_error",
+                },
+            ),
+            (
+                "provider.auth",
+                {
+                    "source": "external-provider",
+                    "message": "invalid provider key",
+                    "status": 401,
+                    "error": "HTTPError",
+                },
+            ),
+            (
+                "provider.rate_limit",
+                {
+                    "source": "external-provider",
+                    "message": "rate limited",
+                    "status": 429,
+                    "error": "HTTPError",
+                },
+            ),
+            (
+                "upstream.http",
+                {
+                    "source": "external-provider",
+                    "message": "bad gateway",
+                    "status": 502,
+                    "exc": HTTPError("https://example.test", 502, "Bad Gateway", {}, io.BytesIO(b"")),
+                },
+            ),
+            (
+                "upstream.transport",
+                {
+                    "source": "external-provider",
+                    "message": "connection reset",
+                    "status": 502,
+                    "exc": URLError(ConnectionResetError("connection reset")),
+                },
+            ),
+            (
+                "upstream.protocol",
+                {
+                    "source": "external-provider",
+                    "message": "stream incomplete",
+                    "status": 502,
+                    "error": "upstream_stream_incomplete",
+                    "error_type": "upstream_stream_error",
+                },
+            ),
+            (
+                "backend.command",
+                {
+                    "source": "web_bridge",
+                    "message": "unknown command",
+                    "status": 500,
+                    "error": "UnknownCommand",
+                    "error_type": "backend_error",
+                },
+            ),
+            (
+                "config.origin",
+                {
+                    "source": "web_bridge",
+                    "message": "origin is not allowed",
+                    "status": 403,
+                    "error": "OriginNotAllowed",
+                    "error_type": "config_error",
+                },
+            ),
+            (
+                "gateway.auth",
+                {
+                    "source": "gateway",
+                    "message": "missing or invalid local Gateway client key",
+                    "status": 401,
+                    "error": "UnauthorizedLocalClient",
+                    "error_type": "gateway_auth_error",
+                },
+            ),
+        ]
+
+        for expected_code, kwargs in cases:
+            with self.subTest(expected_code=expected_code):
+                payload = codex_proxy._codexhub_error_payload(**kwargs)
+                self.assertEqual(payload["code"], expected_code)
+                self.assertEqual(set(payload), {"code", "message", "source", "retryable", "details"})
+                self.assertIsInstance(payload["retryable"], bool)
+                self.assertEqual(payload["details"]["status"], kwargs["status"])
+
+
 class ChatToolChoiceTests(unittest.TestCase):
     def test_string_tool_choice(self):
         self.assertEqual(_chat_tool_choice_to_responses_tool_choice("auto"), "auto")
@@ -2451,6 +2551,10 @@ class ChatCompletionsEndpointTests(unittest.TestCase):
         result = json.loads(written)
         self.assertIn("model is required", result["error"]["message"])
         self.assertEqual(result["error"]["type"], "invalid_request_error")
+        self.assertEqual(result["codexhub_error"]["code"], "provider.request")
+        self.assertEqual(result["codexhub_error"]["message"], "model is required for provider path: volc")
+        self.assertEqual(result["codexhub_error"]["source"], "volc")
+        self.assertFalse(result["codexhub_error"]["retryable"])
         self.assertEqual(handler._fake.status, 400)
 
     def test_provider_scoped_chat_completions_routes_slash_model_as_provider_relative(self):
@@ -3336,6 +3440,10 @@ class ChatCompletionsEndpointTests(unittest.TestCase):
         self.assertEqual(result["error"]["type"], "upstream_error")
         self.assertEqual(result["error"]["code"], "URLError")
         self.assertEqual(result["error"]["status"], 502)
+        self.assertEqual(result["codexhub_error"]["code"], "upstream.transport")
+        self.assertEqual(result["codexhub_error"]["source"], "official")
+        self.assertTrue(result["codexhub_error"]["retryable"])
+        self.assertEqual(result["codexhub_error"]["details"]["error"], "URLError")
         self.assertEqual(handler._fake.status, 502)
 
     def test_post_responses_streaming_keeps_responses_sse_error_shape(self):
@@ -3360,6 +3468,8 @@ class ChatCompletionsEndpointTests(unittest.TestCase):
         self.assertIn(b"event: error\n", written)
         self.assertIn(b'"type":"upstream_stream_error"', written)
         self.assertIn(b'"error":"OSError"', written)
+        self.assertIn(b'"codexhub_error"', written)
+        self.assertIn(b'"code":"upstream.transport"', written)
 
     def test_auto_upstream_format_uses_responses_when_responses_succeeds(self):
         policy = codex_proxy.load_policy(codex_proxy.POLICY_PATH)


### PR DESCRIPTION
## Summary
- adds the frontend `CodexHubError` contract and bridge error carrier
- adds typed Rust web bridge error responses for backend command and origin/config failures
- tightens representative Python typed error mappings and tests JSON/SSE payload envelopes

## Verification
- `python -m pytest tests/test_chat_completions_gateway.py tests/test_routing.py -q`
- `cargo test web_bridge -- --nocapture`
- `npm run build`
- `npm run test:ui-contract`

Fixes #10 after this reaches `main`.