### PR TITLE
fix: require gateway key for local auth

### DIFF
--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -8882,9 +8882,7 @@ def _local_request_authorized(
     if expected_key is None:
         return True
     token = _bearer_token(headers)
-    if token and hmac.compare_digest(token, expected_key):
-        return True
-    return bool(token and _is_codex_app_context(request_context))
+    return bool(token and hmac.compare_digest(token, expected_key))
 
 
 def _has_explicit_third_party_client_identity(request_context: Mapping[str, str]) -> bool:
@@ -10407,6 +10405,21 @@ def _codexhub_error_payload(
     }
 
 
+def _local_gateway_auth_error_payload() -> dict[str, Any]:
+    message = "missing or invalid local Gateway client key"
+    return {
+        "error": "unauthorized",
+        "codexhub_error": _codexhub_error_payload(
+            source="gateway",
+            message=message,
+            status=401,
+            error="UnauthorizedLocalClient",
+            error_type="gateway_auth_error",
+            failure_class=RETRY_FAILURE_PERMANENT,
+        ),
+    }
+
+
 def _downstream_stream_error_payload(
     *,
     upstream_name: str,
@@ -10780,7 +10793,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
         if parsed.path == "/shutdown":
             request_context = request_context_from_headers(self.headers)
             if not _local_request_authorized(self.headers, request_context):
-                self._send_json(401, {"error": "unauthorized"})
+                self._send_json(401, _local_gateway_auth_error_payload())
                 self.close_connection = True
                 return
             self._send_json(200, {"ok": True, "message": "shutdown scheduled"})
@@ -10832,7 +10845,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 duration_ms=int((time.monotonic() - started_at) * 1000),
                 **request_context,
             )
-            self._send_json(401, {"error": "unauthorized"})
+            self._send_json(401, _local_gateway_auth_error_payload())
             self.close_connection = True
             return
         request_kind = RETRY_REQUEST_MAIN_GENERATION

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -403,9 +403,9 @@ class RoutingTests(unittest.TestCase):
                 )
             )
 
-    def test_local_request_auth_allows_codex_app_authorization_fallback(self):
+    def test_local_request_auth_rejects_spoofed_codex_app_context(self):
         with patch.dict(os.environ, {"CODEX_PROXY_GATEWAY_CLIENT_KEY": "local-key"}, clear=True):
-            self.assertTrue(
+            self.assertFalse(
                 codex_proxy._local_request_authorized(
                     {"Authorization": "Bearer codex-app-token"},
                     {"client_id": "codex-app"},
@@ -414,6 +414,24 @@ class RoutingTests(unittest.TestCase):
             self.assertFalse(
                 codex_proxy._local_request_authorized(
                     {},
+                    {"client_id": "codex-app"},
+                )
+            )
+            self.assertFalse(
+                codex_proxy._local_request_authorized(
+                    {
+                        "Authorization": "Bearer wrong",
+                        "User-Agent": "codex-app/0.1.3",
+                    },
+                    {"client_id": "codex-app"},
+                )
+            )
+            self.assertFalse(
+                codex_proxy._local_request_authorized(
+                    {
+                        "Authorization": "Bearer wrong",
+                        "X-Codex-Client-Id": "codex-app",
+                    },
                     {"client_id": "codex-app"},
                 )
             )
@@ -894,6 +912,10 @@ class RoutingTests(unittest.TestCase):
             CodexProxyHandler._proxy_post_request(handler, inbound_format="responses")
 
         self.assertEqual(fake.status, 401)
+        payload = json.loads(fake.wfile.writes[-1].decode("utf-8"))
+        self.assertEqual(payload["codexhub_error"]["code"], "gateway.auth")
+        self.assertEqual(payload["codexhub_error"]["source"], "gateway")
+        self.assertFalse(payload["codexhub_error"]["retryable"])
         self.assertTrue(handler.close_connection)
         event = self.write_proxy_event.call_args_list[-1]
         self.assertEqual(event.args[0], "request_error")


### PR DESCRIPTION
## Summary
- require exact configured Gateway bearer key for local authorization
- remove spoofable codex-app context fallback from local auth
- return typed gateway.auth payload for local 401 responses

## Verification
- python -m pytest tests/test_routing.py -q
- python -m pytest tests/test_chat_completions_gateway.py -q

Issue checkpoint: fixes #24 in dev; final close remains for dev -> main release PR.