### PR TITLE
chore: trim transport analyzer unused import

### DIFF
--- a/scripts/analyze_transport_failures.py
+++ b/scripts/analyze_transport_failures.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import sys
 from collections.abc import Iterable, Mapping
 from pathlib import Path
 from typing import Any


### PR DESCRIPTION
## Summary
- remove unused sys import from transport failure analyzer found during release quality-gate report

## Verification
- python -m pytest tests/test_transport_failure_analyzer.py -q
- python scripts/report_quality_gates.py

No issue-closing keywords; this is release verification cleanup.