### PR TITLE
chore: bump version to 0.1.3

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codexhub-frontend",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codexhub-frontend",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codexhub-frontend",
   "private": true,
-  "version": "0.1.2",
+  "version": "0.1.3",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "codexhub"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "dirs 5.0.1",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codexhub"
-version = "0.1.2"
+version = "0.1.3"
 description = "CodexHub desktop backend and CLI"
 authors = ["CodexHub"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "CodexHub",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "identifier": "com.codexhub.app",
   "build": {
     "frontendDist": "../frontend/dist",


### PR DESCRIPTION
## Summary
- bump CodexHub package/app versions from 0.1.2 to 0.1.3 for the release PR

## Verification
- Push-Location frontend; npm run test:ui-contract; Pop-Location
- Push-Location src-tauri; cargo metadata --format-version 1 --no-deps; Pop-Location

No issue-closing keywords; issue closure remains in dev -> main release PR.