### PR TITLE
chore: prepare 0.1.4 stable release

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codexhub-frontend",
-  "version": "0.1.4-beta.10",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codexhub-frontend",
-      "version": "0.1.4-beta.10",
+      "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codexhub-frontend",
   "private": true,
-  "version": "0.1.4-beta.10",
+  "version": "0.1.4",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "codexhub"
-version = "0.1.4-beta.10"
+version = "0.1.4"
 dependencies = [
  "dirs 5.0.1",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codexhub"
-version = "0.1.4-beta.10"
+version = "0.1.4"
 description = "CodexHub desktop backend and CLI"
 authors = ["CodexHub"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "CodexHub",
-  "version": "0.1.4-beta.10",
+  "version": "0.1.4",
   "identifier": "com.codexhub.app",
   "build": {
     "frontendDist": "../frontend/dist",

--- a/tests/test_release_channel_scripts.py
+++ b/tests/test_release_channel_scripts.py
@@ -19,8 +19,8 @@ def test_official_transport_wheel_is_pinned_and_packaged():
     assert tauri["bundle"]["resources"]["../src-python/vendor/*.whl"] == "src-python/vendor"
 
 
-def test_beta_candidate_version_is_consistent_across_manifests():
-    expected = "0.1.4-beta.10"
+def test_stable_release_version_is_consistent_across_manifests():
+    expected = "0.1.4"
     tauri = json.loads((ROOT / "src-tauri" / "tauri.conf.json").read_text(encoding="utf-8"))
     cargo = tomllib.loads((ROOT / "src-tauri" / "Cargo.toml").read_text(encoding="utf-8"))
     cargo_lock = tomllib.loads((ROOT / "src-tauri" / "Cargo.lock").read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary

- promote all application version sources from `0.1.4-beta.10` to stable `0.1.4`
- keep Cargo, Tauri, frontend package metadata, lockfiles, and release-channel contracts aligned
- prepare the exact stable source SHA used for the signed NSIS/updater artifacts

## Verification

- `python -m pytest -q`: 810 passed, 1 skipped, 88 subtests passed
- `cargo test --manifest-path src-tauri/Cargo.toml`: 271 passed
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`: passed
- `npm run test:ui-contract`: passed
- `npm run build`: passed (1639 modules)
- `python -m pytest tests/test_release_channel_scripts.py -q`: 22 passed
- report-only quality gates: parse errors 0
- signed NSIS build: `CodexHub_0.1.4_x64-setup.exe`
- installer SHA-256: `b94b39875b755fa0c2ba043a9b56deabcfd7033125de1456902befd65d4dca97`
- updater artifacts: non-empty `.sig`; `latest.json` version/url/signature round-trip passed
- virtual updater manifest: `0.1.2 -> 0.1.4` validated

## Release gate

This PR targets `dev`. After exact-SHA CI passes it can merge into `dev`; the subsequent `dev -> main` PR still requires the repository's human audit checklist approval before merge/tag/Release.