### PR TITLE
fix: return cancelled official streams to pool

### DIFF
--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -230,6 +230,7 @@ class _OfficialPooledResponse:
             self._response.release_conn()
         else:
             self._response.close()
+            self._response.release_conn()
 
     def __enter__(self) -> "_OfficialPooledResponse":
         return self

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -2555,7 +2555,29 @@ class RoutingTests(unittest.TestCase):
                 response.read(65536)
 
         raw_response.close.assert_called_once()
-        raw_response.release_conn.assert_not_called()
+        raw_response.release_conn.assert_called_once()
+
+    def test_official_pooled_stream_cancellation_returns_pool_capacity(self):
+        pool = codex_proxy._OfficialHTTPSConnectionPool(
+            "chatgpt.com",
+            maxsize=1,
+            block=True,
+        )
+        connection = pool._get_conn(timeout=0.01)
+        raw_response = codex_proxy.urllib3.response.HTTPResponse(
+            body=io.BytesIO(b"unfinished stream"),
+            status=200,
+            preload_content=False,
+            pool=pool,
+            connection=connection,
+        )
+
+        with codex_proxy._OfficialPooledResponse(raw_response):
+            pass
+
+        returned = pool._get_conn(timeout=0.01)
+        self.assertIs(returned, connection)
+        pool._put_conn(returned)
 
     def test_official_pooled_stream_restores_timeout_before_reuse(self):
         raw_response = Mock()


### PR DESCRIPTION
## What changed

- Return cancelled or unfinished official HTTP responses to the urllib3 connection pool after closing the underlying connection.
- Add a blocking one-slot pool regression test for the observed exhaustion path.

## Why

Internal 0.1.4 App testing produced 16 cancelled official streams, exhausted the 16-slot pool, and made the next request wait for the 300-second pool timeout with EmptyPoolError.

## Validation

- Exact one-slot blocking-pool regression test passed.
- Full candidate validation: 818 Python tests passed (1 skipped, 88 subtests), 277 Rust tests passed, 130 UI contract tests passed, frontend production build and clippy passed.