### PR TITLE
test: correct Codex runtime tool discovery trace

### DIFF
--- a/docs/evidence/issue-62/README.md
+++ b/docs/evidence/issue-62/README.md
@@ -1,0 +1,79 @@
+# Issue #62 runtime-plan evidence
+
+This evidence set captures one sanitized current-side Codex runtime plan and
+one replay-consistency fixture. Opaque aliases replace request, response, call,
+and item identifiers. Prompt text, tool arguments, tool output, and upstream
+payloads are redacted.
+
+## Facts established by the capture
+
+- The captured codex_app dynamic namespace registers 15 functions.
+- Three functions omit deferLoading; the installed runtime maps that to Direct.
+  Twelve functions set deferLoading true; the runtime maps those to Deferred.
+- The caller request includes client-executed tool_search. Its codex_app
+  namespace contains the three Direct functions; Deferred functions remain
+  discoverable through tool_search.
+- The captured Gateway route is official Responses-to-Responses. Route
+  classification comes from the Gateway upstream route and catalog binding, not
+  from configured provider id custom.
+- A caller/upstream request-prefix match was observed for 65,536 bytes.
+  Full-body request and response fingerprints were not captured. The manually
+  derived replay fixture checks internal consistency only; it does not rule out
+  Gateway filtering beyond the observed prefix. The exact-version Desktop core
+  and Code Mode app-server controls pass.
+
+The source snapshot is OpenAI Codex commit
+9e552e9d15ba52bed7077d5357f3e18e330f8f38. At that revision, the dynamic
+tool protocol defines optional deferLoading; the dynamic handler maps true to
+Deferred and missing or false to Direct. ToolExposure keeps Direct,
+DirectModelOnly, Deferred, and Hidden distinct. Tool search is planned only
+when model supports_search_tool and provider namespace_tools are both true.
+
+## State coverage
+
+| State | Evidence status | Meaning in this artifact |
+| --- | --- | --- |
+| Direct | Observed | Three codex_app functions omit deferLoading. |
+| DirectModelOnly | Source contract | Distinct planner state; not used by the captured namespace. |
+| Deferred | Observed | Twelve codex_app functions set deferLoading true. |
+| Hidden | Source contract | Distinct planner state; not used by the captured namespace. |
+| hosted-only | Sentinel | Host-binding tag retained distinctly; not inferred as a planner enum. |
+| host-unavailable | Sentinel | Host-binding tag retained distinctly; not inferred as a planner enum. |
+
+Unknown tags in the wire fixture are deliberately opaque sentinels. A replay
+must preserve them rather than delete or normalize them.
+
+## Wire and replay coverage
+
+The wire fixture records sanitized pre-Gateway and post-Gateway request and
+response/SSE shapes, request/history/response item aliases, call/item links,
+observed streaming SSE event kinds, a non-streaming contract sentinel, and a
+separate choice-control sentinel. The catalog source includes a read-only
+fingerprint and model-entry validation for the captured catalog binding. The
+replay checks:
+
+1. reconcile registered, contributor, pre-Gateway, and post-Gateway tool
+   surfaces in the replay fixture;
+2. validate request/history/response call-to-output identities;
+3. preserve tagged unknown SSE and non-streaming items; and
+4. assert every required thread tool is registered, Deferred, and discoverable;
+   and
+5. fail visibly for in-memory mutation, deletion, loss, required-set deletion,
+   and required-membership mutation controls.
+
+## Fact/hypothesis boundary and remaining gap
+
+Observed: the Desktop host/model did not select an available tool_search during
+this trace. The retained evidence is insufficient to conclude whether Gateway
+filtering contributed outside the observed request prefix.
+
+The complete installed model-visible plan remains partial: this retained
+sanitized capture contains the codex_app contributor only. Other contributors
+and namespaces have not been inferred from this one capture.
+
+Unproven: that a post-rewrite catalog timeline created a stale
+StaticModelsManager, or that a clean restart for the current CodexHub binding
+changes selection. The in-process rewrite and clean-cold-start cases remain
+separate; no shared-runtime restart or configuration experiment was run for
+this evidence update. Reluctant-model and tool_search lifecycle work belongs
+to #63.

--- a/docs/evidence/issue-62/codexhub-runtime-wire-fixture.json
+++ b/docs/evidence/issue-62/codexhub-runtime-wire-fixture.json
@@ -1,0 +1,122 @@
+{
+  "schema_version": 1,
+  "fixture_kind": "sanitized_artifact_backed_replay",
+  "redaction": {"identifiers": "stable synthetic aliases", "content": "prompt, argument, output, and opaque payloads are redacted"},
+  "evidence_limit": {
+    "transport_observation": "Only a 65,536-byte caller/upstream request-prefix equality observation is retained; no full request or response body fingerprint is available.",
+    "replay_fixture": "Pre-Gateway and post-Gateway objects are sanitized replay fixtures derived from artifacts. Their equality validates replay consistency, not independent full-wire identity."
+  },
+  "route": {
+    "inbound_format": "responses",
+    "upstream_format": "responses",
+    "configured_provider_id": "custom",
+    "upstream_route": "official",
+    "catalog_binding": "official Codex catalog entry for openai/gpt-5.6-sol",
+    "classification_basis": "upstream_route and catalog_binding; never configured_provider_id alone"
+  },
+  "exposure_state_tags": ["Direct", "DirectModelOnly", "Deferred", "Hidden", "hosted-only", "host-unavailable"],
+  "pre_gateway": {
+    "request_id": "request_001",
+    "stream": true,
+    "model": "gpt-5.6-sol",
+    "input_items": [
+      {"item_id": "item_request_tools_001", "type": "additional_tools", "content": "<redacted>"},
+      {"item_id": "item_request_message_001", "type": "message", "content": "<redacted>"}
+    ],
+    "tool_surface": {
+      "tool_search": {"type": "tool_search", "execution": "client"},
+      "namespaces": [
+        {
+          "name": "codex_app",
+          "direct_tools": ["navigate_to_codex_page", "read_thread_terminal", "load_workspace_dependencies"],
+          "deferred_tools": ["automation_update", "fork_thread", "handoff_thread", "get_handoff_status", "list_projects", "create_thread", "list_threads", "read_thread", "send_message_to_thread", "set_thread_pinned", "set_thread_archived", "set_thread_title"]
+        }
+      ]
+    },
+    "choice_controls": {"captured": false, "fixture_kind": "contract_sentinel", "tool_choice": "auto", "parallel_tool_calls": true},
+    "response": {
+      "streaming": {"response_id": "response_001", "sse_event_sequence": ["response.in_progress", "response.function_call_arguments.delta", "response.function_call_arguments.done", "response.custom_tool_call_input.done", "response.reasoning_summary_part.done", "response.output_text.done", "unknown.future_event"]},
+      "non_streaming": {"response_id": "response_nonstreaming_001", "response_item_ids": ["item_nonstreaming_message_001", "item_nonstreaming_call_001", "item_nonstreaming_output_001", "item_nonstreaming_unknown_001"]}
+    }
+  },
+  "post_gateway": {
+    "request_id": "request_001",
+    "stream": true,
+    "model": "gpt-5.6-sol",
+    "input_items": [
+      {"item_id": "item_request_tools_001", "type": "additional_tools", "content": "<redacted>"},
+      {"item_id": "item_request_message_001", "type": "message", "content": "<redacted>"}
+    ],
+    "tool_surface": {
+      "tool_search": {"type": "tool_search", "execution": "client"},
+      "namespaces": [
+        {
+          "name": "codex_app",
+          "direct_tools": ["navigate_to_codex_page", "read_thread_terminal", "load_workspace_dependencies"],
+          "deferred_tools": ["automation_update", "fork_thread", "handoff_thread", "get_handoff_status", "list_projects", "create_thread", "list_threads", "read_thread", "send_message_to_thread", "set_thread_pinned", "set_thread_archived", "set_thread_title"]
+        }
+      ]
+    },
+    "choice_controls": {"captured": false, "fixture_kind": "contract_sentinel", "tool_choice": "auto", "parallel_tool_calls": true},
+    "response": {
+      "streaming": {"response_id": "response_001", "sse_event_sequence": ["response.in_progress", "response.function_call_arguments.delta", "response.function_call_arguments.done", "response.custom_tool_call_input.done", "response.reasoning_summary_part.done", "response.output_text.done", "unknown.future_event"]},
+      "non_streaming": {"response_id": "response_nonstreaming_001", "response_item_ids": ["item_nonstreaming_message_001", "item_nonstreaming_call_001", "item_nonstreaming_output_001", "item_nonstreaming_unknown_001"]}
+    }
+  },
+  "history": {
+    "captured_source_counts": {
+      "reasoning": 716,
+      "message": 189,
+      "agent_message": 19,
+      "function_call": 356,
+      "function_call_output": 356,
+      "custom_tool_call": 177,
+      "custom_tool_call_output": 177,
+      "paired_calls": 533,
+      "unpaired_calls": 0,
+      "unpaired_outputs": 0
+    },
+    "required_call_ids": ["call_001", "call_002", "call_003"],
+    "call_links": [
+      {"call_id": "call_001", "call_item_id": "item_call_001", "output_item_id": "item_output_001", "call_type": "function_call", "output_type": "function_call_output"},
+      {"call_id": "call_002", "call_item_id": "item_call_002", "output_item_id": "item_output_002", "call_type": "custom_tool_call", "output_type": "custom_tool_call_output"},
+      {"call_id": "call_003", "call_item_id": "item_call_003", "output_item_id": "item_output_003", "call_type": "function_call", "output_type": "function_call_output"}
+    ]
+  },
+  "response": {
+    "streaming": {
+      "captured": true,
+      "observed_event_counts": [
+        {"event": "response.in_progress", "count": 37},
+        {"event": "response.function_call_arguments.delta", "count": 96},
+        {"event": "response.function_call_arguments.done", "count": 6},
+        {"event": "response.custom_tool_call_input.done", "count": 28},
+        {"event": "response.reasoning_summary_part.done", "count": 55},
+        {"event": "response.content_part.added", "count": 10},
+        {"event": "response.output_text.done", "count": 10},
+        {"event": "response.content_part.done", "count": 10},
+        {"event": "codex.response.metadata", "count": 37}
+      ],
+      "events": [
+        {"sequence": 1, "event": "response.in_progress", "response_id": "response_001"},
+        {"sequence": 2, "event": "response.function_call_arguments.delta", "item_id": "item_call_001", "call_id": "call_001", "arguments": "<redacted>"},
+        {"sequence": 3, "event": "response.function_call_arguments.done", "item_id": "item_call_001", "call_id": "call_001", "arguments": "<redacted>"},
+        {"sequence": 4, "event": "response.custom_tool_call_input.done", "item_id": "item_call_002", "call_id": "call_002", "input": "<redacted>"},
+        {"sequence": 5, "event": "response.reasoning_summary_part.done", "item_id": "item_reasoning_001", "summary": "<redacted>"},
+        {"sequence": 6, "event": "response.output_text.done", "item_id": "item_message_001", "text": "<redacted>"},
+        {"sequence": 7, "event": "unknown.future_event", "tag": "unknown", "opaque_payload": "<redacted>"}
+      ]
+    },
+    "non_streaming": {
+      "captured": false,
+      "fixture_kind": "contract_sentinel",
+      "response_id": "response_nonstreaming_001",
+      "response_items": [
+        {"item_id": "item_nonstreaming_message_001", "type": "message", "content": "<redacted>"},
+        {"item_id": "item_nonstreaming_call_001", "type": "function_call", "call_id": "call_nonstreaming_001", "arguments": "<redacted>"},
+        {"item_id": "item_nonstreaming_output_001", "type": "function_call_output", "call_id": "call_nonstreaming_001", "output": "<redacted>"},
+        {"item_id": "item_nonstreaming_unknown_001", "type": "unknown", "tag": "unknown", "opaque_payload": "<redacted>"}
+      ]
+    }
+  }
+}

--- a/docs/evidence/issue-62/current-codexhub-thread-tool-surface.json
+++ b/docs/evidence/issue-62/current-codexhub-thread-tool-surface.json
@@ -1,0 +1,175 @@
+{
+  "schema_version": 4,
+  "captured_at": "2026-07-12T14:57:55+08:00",
+  "source": {
+    "capture_id": "sanitized-current-side-capture",
+    "originator": "Codex Desktop",
+    "cli_version": "0.144.0-alpha.4",
+    "configured_provider_id": "custom",
+    "model": "gpt-5.6-sol",
+    "reasoning_effort": "xhigh",
+    "collaboration_mode": "default",
+    "multi_agent_version": "v2"
+  },
+  "gateway_route": {
+    "requested_model": "gpt-5.6-sol",
+    "canonical_model": "openai/gpt-5.6-sol",
+    "upstream": "official",
+    "catalog_binding": "official Codex catalog entry for openai/gpt-5.6-sol",
+    "classification_basis": "concrete Gateway upstream route and catalog binding, not configured_provider_id",
+    "behavior_profile": "official_codex_app_http_passthrough",
+    "route_mode": "official",
+    "inbound_format": "responses",
+    "upstream_format": "responses",
+    "wire_format_adapter": "transparent",
+    "codex_semantic_adapter": "none",
+    "repair_policy": "none"
+  },
+  "gateway_observability": {
+    "request_prefix_equality_observed": true,
+    "request_prefix_bytes_observed": 65536,
+    "full_request_body_fingerprint": "not_captured",
+    "full_response_body_fingerprint": "not_captured",
+    "conclusion_limit": "prefix-level observation and replay-fixture consistency only; Gateway filtering is not ruled out beyond that evidence"
+  },
+  "registered_codex_app_tools": [
+    "automation_update",
+    "navigate_to_codex_page",
+    "read_thread_terminal",
+    "load_workspace_dependencies",
+    "fork_thread",
+    "handoff_thread",
+    "get_handoff_status",
+    "list_projects",
+    "create_thread",
+    "list_threads",
+    "read_thread",
+    "send_message_to_thread",
+    "set_thread_pinned",
+    "set_thread_archived",
+    "set_thread_title"
+  ],
+  "dynamic_tool_contributors": [
+    {
+      "contributor": "Codex Desktop",
+      "contributor_kind": "dynamic_tool_namespace",
+      "namespace": "codex_app",
+      "registered_tool_count": 15,
+      "tools": [
+        {"name": "automation_update", "type": "function", "deferLoading": true, "planner_exposure": "Deferred"},
+        {"name": "navigate_to_codex_page", "type": "function", "deferLoading": false, "deferLoading_source": "omitted_defaults_false", "planner_exposure": "Direct"},
+        {"name": "read_thread_terminal", "type": "function", "deferLoading": false, "deferLoading_source": "omitted_defaults_false", "planner_exposure": "Direct"},
+        {"name": "load_workspace_dependencies", "type": "function", "deferLoading": false, "deferLoading_source": "omitted_defaults_false", "planner_exposure": "Direct"},
+        {"name": "fork_thread", "type": "function", "deferLoading": true, "planner_exposure": "Deferred"},
+        {"name": "handoff_thread", "type": "function", "deferLoading": true, "planner_exposure": "Deferred"},
+        {"name": "get_handoff_status", "type": "function", "deferLoading": true, "planner_exposure": "Deferred"},
+        {"name": "list_projects", "type": "function", "deferLoading": true, "planner_exposure": "Deferred"},
+        {"name": "create_thread", "type": "function", "deferLoading": true, "planner_exposure": "Deferred"},
+        {"name": "list_threads", "type": "function", "deferLoading": true, "planner_exposure": "Deferred"},
+        {"name": "read_thread", "type": "function", "deferLoading": true, "planner_exposure": "Deferred"},
+        {"name": "send_message_to_thread", "type": "function", "deferLoading": true, "planner_exposure": "Deferred"},
+        {"name": "set_thread_pinned", "type": "function", "deferLoading": true, "planner_exposure": "Deferred"},
+        {"name": "set_thread_archived", "type": "function", "deferLoading": true, "planner_exposure": "Deferred"},
+        {"name": "set_thread_title", "type": "function", "deferLoading": true, "planner_exposure": "Deferred"}
+      ]
+    }
+  ],
+  "dynamic_tool_exposure": {
+    "direct": ["navigate_to_codex_page", "read_thread_terminal", "load_workspace_dependencies"],
+    "deferred": ["automation_update", "fork_thread", "handoff_thread", "get_handoff_status", "list_projects", "create_thread", "list_threads", "read_thread", "send_message_to_thread", "set_thread_pinned", "set_thread_archived", "set_thread_title"]
+  },
+  "exposure_state_catalog": [
+    {"state": "Direct", "plane": "planner", "runtime_observed": true, "evidence": "three codex_app functions omit deferLoading"},
+    {"state": "DirectModelOnly", "plane": "planner", "runtime_observed": false, "evidence": "source-contract state; not used by the captured namespace"},
+    {"state": "Deferred", "plane": "planner", "runtime_observed": true, "evidence": "twelve codex_app functions set deferLoading=true"},
+    {"state": "Hidden", "plane": "planner", "runtime_observed": false, "evidence": "source-contract state; not used by the captured namespace"},
+    {"state": "hosted-only", "plane": "host-binding", "runtime_observed": false, "evidence": "tagged reconciliation sentinel only; not inferred as a ToolExposure enum variant"},
+    {"state": "host-unavailable", "plane": "host-binding", "runtime_observed": false, "evidence": "tagged reconciliation sentinel only; not inferred as a ToolExposure enum variant"}
+  ],
+  "planner_gates": {
+    "source_commit": "9e552e9d15ba52bed7077d5357f3e18e330f8f38",
+    "predicate": "model_info.supports_search_tool && provider.capabilities.namespace_tools",
+    "catalog_source": {
+      "post_switch_catalog_basename": "codexhub-model-catalog.json",
+      "post_switch_model_supports_search_tool": true,
+      "read_only_snapshot_validation": {
+        "artifact_basename": "codexhub-model-catalog.json",
+        "sha256": "307a09f22b0c827ae77192a4beaf7059efcf8a698ec4f252aa4ba4787f8d1876",
+        "model_entry_id": "gpt-5.6-sol",
+        "model_entry_supports_search_tool": true
+      }
+    },
+    "config_source": {
+      "configured_provider_id": "custom",
+      "provider_namespace_tools": true,
+      "classification_rule": "configured_provider_id is not evidence of official versus third-party routing"
+    },
+    "caller_request": {
+      "source": "sanitized local transport record",
+      "additional_tools_contains_tool_search": true,
+      "tool_search_type": "tool_search",
+      "tool_search_execution": "client"
+    },
+    "model_visible_plan": {
+      "tool_search_available": true,
+      "codex_app_direct_tools": ["navigate_to_codex_page", "read_thread_terminal", "load_workspace_dependencies"],
+      "codex_app_deferred_tools_discoverable_through_tool_search": ["automation_update", "fork_thread", "handoff_thread", "get_handoff_status", "list_projects", "create_thread", "list_threads", "read_thread", "send_message_to_thread", "set_thread_pinned", "set_thread_archived", "set_thread_title"]
+    },
+    "runtime_gate_evaluation_for_this_trace": "not_independently_captured"
+  },
+  "independent_controls": [
+    {"name": "Desktop core exact-version app-server control", "result": "pass"},
+    {"name": "Code Mode exact-version app-server control", "result": "pass"}
+  ],
+  "control_boundaries": {
+    "in_process_provider_config_rewrite": {"status": "historical timeline observation", "causal_result": "does_not_prove_planner_state_drift"},
+    "clean_cold_start_for_current_codexhub_binding": {"status": "not_run", "reason": "kept separate from in-process rewrite; no shared-runtime experiment was expanded"}
+  },
+  "capture_coverage": {
+    "complete_model_visible_plan": {
+      "status": "partial",
+      "captured_contributors": ["codex_app"],
+      "gap": "other installed contributors and namespaces were not present in the retained sanitized capture"
+    },
+    "clean_cold_start_current_binding": {
+      "status": "not_run",
+      "gap": "requires a separately authorized shared-runtime control"
+    }
+  },
+  "process_and_catalog_timeline": {
+    "task_created_at": "2026-07-11T14:56:06.8960000Z",
+    "codexhub_app_started_at": "2026-07-12T05:05:13.8143112Z",
+    "codex_desktop_started_at": "2026-07-12T05:05:22.8667276Z",
+    "app_server_started_at": "2026-07-12T05:05:25.5581137Z",
+    "startup_catalog_basename": "openai-plus-ollama-cloud.json",
+    "startup_catalog_written_at": "2026-07-12T05:05:15.2166839Z",
+    "startup_catalog_sol_supports_search_tool_field_present": false,
+    "codexhub_gateway_started_at": "2026-07-12T05:32:25.2976813Z",
+    "provider_config_rewritten_at": "2026-07-12T05:40:06.8047490Z",
+    "post_switch_catalog_basename": "codexhub-model-catalog.json",
+    "post_switch_catalog_written_at": "2026-07-12T05:50:22.1550082Z",
+    "post_switch_catalog_sol_supports_search_tool": true,
+    "cold_start_for_initial_official_binding": true,
+    "cold_start_for_current_codexhub_binding": false,
+    "causal_interpretation": "timeline_only_not_runtime_manager_identity_proof"
+  },
+  "unknown_tagged_sentinels": [
+    {"tag": "unknown", "scope": "response_item_and_sse_replay", "preservation_rule": "retain tag and opaque payload rather than deleting or reclassifying"}
+  ],
+  "diagnosis": {
+    "status": "fact_hypothesis_split",
+    "facts": [
+      "The caller request contains client-executed tool_search in additional_tools.",
+      "The three Direct codex_app tools are direct; the twelve Deferred codex_app tools are discoverable through tool_search.",
+      "A 65,536-byte caller/upstream request-prefix match was observed; full request and response fingerprints were not captured."
+    ],
+    "observed_behavior": "The Desktop host/model did not select an available tool_search during this trace.",
+    "unproven_hypotheses": [
+      "The post-rewrite catalog timeline caused a stale StaticModelsManager snapshot.",
+      "A clean Desktop restart for the current CodexHub binding changes tool_search selection."
+    ],
+    "follow_up": "#63 owns reluctant-model and tool_search lifecycle investigation."
+  },
+  "observed_callable_codex_app_tools": ["load_workspace_dependencies", "navigate_to_codex_page", "read_thread_terminal"],
+  "required_thread_tools": ["fork_thread", "handoff_thread", "get_handoff_status", "list_projects", "create_thread", "list_threads", "read_thread", "send_message_to_thread", "set_thread_pinned", "set_thread_archived", "set_thread_title"]
+}

--- a/scripts/check-codex-thread-tool-surface.ps1
+++ b/scripts/check-codex-thread-tool-surface.ps1
@@ -1,0 +1,285 @@
+param(
+    [string]$TracePath = (Join-Path (Split-Path -Parent $PSScriptRoot) 'docs\evidence\issue-62\current-codexhub-thread-tool-surface.json'),
+    [string]$WireFixturePath = (Join-Path (Split-Path -Parent $PSScriptRoot) 'docs\evidence\issue-62\codexhub-runtime-wire-fixture.json'),
+    [ValidateSet('identity', 'mutation', 'deletion', 'loss', 'required-set-deletion', 'required-membership-mutation')]
+    [string]$ReplayCase = 'identity'
+)
+
+$ErrorActionPreference = 'Stop'
+
+foreach ($path in @($TracePath, $WireFixturePath)) {
+    if (-not (Test-Path -LiteralPath $path)) {
+        throw "Evidence file not found: $path"
+    }
+}
+
+$trace = Get-Content -Raw -LiteralPath $TracePath | ConvertFrom-Json
+$wire = Get-Content -Raw -LiteralPath $WireFixturePath | ConvertFrom-Json
+$mismatches = [System.Collections.Generic.List[string]]::new()
+
+function Add-Mismatch {
+    param([string]$Message)
+    $script:mismatches.Add($Message)
+}
+
+function Assert-Set {
+    param(
+        [string]$Name,
+        [string[]]$Expected,
+        [string[]]$Actual
+    )
+
+    $expected = @($Expected | Sort-Object -Unique)
+    $actual = @($Actual | Sort-Object -Unique)
+    $missing = @($expected | Where-Object { $_ -notin $actual })
+    $unexpected = @($actual | Where-Object { $_ -notin $expected })
+    if ($missing.Count -gt 0 -or $unexpected.Count -gt 0) {
+        Add-Mismatch "$Name missing=[$($missing -join ', ')] unexpected=[$($unexpected -join ', ')]"
+    }
+}
+
+function Get-Namespace {
+    param(
+        [object[]]$Namespaces,
+        [string]$Name,
+        [string]$Plane
+    )
+
+    $matches = @($Namespaces | Where-Object { $_.name -eq $Name })
+    if ($matches.Count -ne 1) {
+        Add-Mismatch "$Plane expected exactly one namespace named $Name but found $($matches.Count)"
+        return $null
+    }
+    return $matches[0]
+}
+
+$registered = @($trace.registered_codex_app_tools)
+$direct = @($trace.dynamic_tool_exposure.direct)
+$deferred = @($trace.dynamic_tool_exposure.deferred)
+$observed = @($trace.observed_callable_codex_app_tools)
+$required = @($trace.required_thread_tools)
+$expectedRequiredThreadTools = @(
+    'fork_thread',
+    'handoff_thread',
+    'get_handoff_status',
+    'list_projects',
+    'create_thread',
+    'list_threads',
+    'read_thread',
+    'send_message_to_thread',
+    'set_thread_pinned',
+    'set_thread_archived',
+    'set_thread_title'
+)
+$modelPlan = $trace.planner_gates.model_visible_plan
+$discoverable = @($modelPlan.codex_app_deferred_tools_discoverable_through_tool_search)
+
+$dynamicEntries = [System.Collections.Generic.List[object]]::new()
+foreach ($contributor in @($trace.dynamic_tool_contributors)) {
+    foreach ($tool in @($contributor.tools)) {
+        $dynamicEntries.Add($tool)
+    }
+}
+$dynamicNames = @($dynamicEntries | ForEach-Object { $_.name })
+$dynamicDirect = @($dynamicEntries | Where-Object { $_.planner_exposure -eq 'Direct' } | ForEach-Object { $_.name })
+$dynamicDeferred = @($dynamicEntries | Where-Object { $_.planner_exposure -eq 'Deferred' } | ForEach-Object { $_.name })
+
+if ($trace.source.PSObject.Properties.Name -contains 'session_id') {
+    Add-Mismatch 'sanitized trace retains a session_id'
+}
+if ($trace.PSObject.Properties.Name -contains 'missing_visible_thread_tools') {
+    Add-Mismatch 'trace retains the legacy missing Deferred-tools assertion'
+}
+if ($trace.diagnosis.PSObject.Properties.Name -contains 'root_cause') {
+    Add-Mismatch 'trace retains a confirmed root_cause assertion'
+}
+if ($trace.diagnosis.status -ne 'fact_hypothesis_split') {
+    Add-Mismatch "diagnosis status is $($trace.diagnosis.status), not fact_hypothesis_split"
+}
+
+Assert-Set -Name 'registered versus contributor tools' -Expected $registered -Actual $dynamicNames
+Assert-Set -Name 'registered versus exposure union' -Expected $registered -Actual @($direct + $deferred)
+Assert-Set -Name 'direct exposure versus contributor metadata' -Expected $direct -Actual $dynamicDirect
+Assert-Set -Name 'deferred exposure versus contributor metadata' -Expected $deferred -Actual $dynamicDeferred
+Assert-Set -Name 'observed callable versus Direct tools' -Expected $direct -Actual $observed
+Assert-Set -Name 'model-plan direct versus Direct tools' -Expected $direct -Actual @($modelPlan.codex_app_direct_tools)
+
+foreach ($entry in $dynamicEntries) {
+    if ($entry.planner_exposure -eq 'Direct' -and $entry.deferLoading -ne $false) {
+        Add-Mismatch "Direct tool $($entry.name) does not have effective deferLoading=false"
+    }
+    if ($entry.planner_exposure -eq 'Deferred' -and $entry.deferLoading -ne $true) {
+        Add-Mismatch "Deferred tool $($entry.name) does not have deferLoading=true"
+    }
+}
+
+if (
+    $trace.planner_gates.caller_request.additional_tools_contains_tool_search -ne $true -or
+    $trace.planner_gates.caller_request.tool_search_execution -ne 'client' -or
+    $modelPlan.tool_search_available -ne $true
+) {
+    Add-Mismatch 'caller request and model-visible plan do not retain client-executed tool_search'
+}
+if ($trace.gateway_route.upstream -ne 'official' -or $wire.route.upstream_route -ne 'official') {
+    Add-Mismatch 'Gateway upstream route is not the recorded official route'
+}
+if (
+    $trace.gateway_observability.request_prefix_equality_observed -ne $true -or
+    $trace.gateway_observability.request_prefix_bytes_observed -ne 65536 -or
+    $trace.gateway_observability.full_request_body_fingerprint -ne 'not_captured' -or
+    $trace.gateway_observability.full_response_body_fingerprint -ne 'not_captured'
+) {
+    Add-Mismatch 'bounded request-prefix observation is invalid'
+}
+if ($wire.route.classification_basis -notmatch 'never configured_provider_id alone') {
+    Add-Mismatch 'wire fixture permits provider-id route classification'
+}
+if (
+    $wire.evidence_limit.transport_observation -notmatch 'no full request or response body fingerprint' -or
+    $wire.evidence_limit.replay_fixture -notmatch 'not independent full-wire identity'
+) {
+    Add-Mismatch 'wire fixture overstates its transport evidence'
+}
+
+$expectedStates = @('Direct', 'DirectModelOnly', 'Deferred', 'Hidden', 'hosted-only', 'host-unavailable')
+Assert-Set -Name 'exposure-state catalog' -Expected $expectedStates -Actual @($trace.exposure_state_catalog | ForEach-Object { $_.state })
+Assert-Set -Name 'exposure-state catalog versus wire tags' -Expected $expectedStates -Actual @($wire.exposure_state_tags)
+
+$preNamespace = Get-Namespace -Namespaces @($wire.pre_gateway.tool_surface.namespaces) -Name 'codex_app' -Plane 'pre-Gateway'
+$postNamespace = Get-Namespace -Namespaces @($wire.post_gateway.tool_surface.namespaces) -Name 'codex_app' -Plane 'post-Gateway'
+
+$preDirect = if ($null -ne $preNamespace) { @($preNamespace.direct_tools) } else { @() }
+$preDeferred = if ($null -ne $preNamespace) { @($preNamespace.deferred_tools) } else { @() }
+$postDirect = if ($null -ne $postNamespace) { @($postNamespace.direct_tools) } else { @() }
+$postDeferred = if ($null -ne $postNamespace) { @($postNamespace.deferred_tools) } else { @() }
+$modelPlanDeferred = @($modelPlan.codex_app_deferred_tools_discoverable_through_tool_search)
+$requiredForReplay = @($required)
+$callLinks = @($wire.history.call_links)
+
+switch ($ReplayCase) {
+    'mutation' {
+        if ($postDirect.Count -gt 0) {
+            $postDirect[0] = "$($postDirect[0])_mutated"
+        }
+    }
+    'deletion' {
+        $postDeferred = @($postDeferred | Where-Object { $_ -ne 'fork_thread' })
+    }
+    'loss' {
+        $modelPlanDeferred = @($modelPlanDeferred | Where-Object { $_ -ne 'fork_thread' })
+    }
+    'required-set-deletion' {
+        $requiredForReplay = @($requiredForReplay | Where-Object { $_ -ne 'fork_thread' })
+    }
+    'required-membership-mutation' {
+        $modelPlanDeferred = @(
+            $modelPlanDeferred | ForEach-Object {
+                if ($_ -eq 'fork_thread') { 'fork_thread_mutated' } else { $_ }
+            }
+        )
+    }
+}
+
+Assert-Set -Name 'trace Direct versus pre-Gateway' -Expected $direct -Actual $preDirect
+Assert-Set -Name 'pre-Gateway Direct versus post-Gateway' -Expected $preDirect -Actual $postDirect
+Assert-Set -Name 'trace Deferred versus pre-Gateway' -Expected $deferred -Actual $preDeferred
+Assert-Set -Name 'pre-Gateway Deferred versus post-Gateway' -Expected $preDeferred -Actual $postDeferred
+Assert-Set -Name 'model-plan discoverable versus Deferred tools' -Expected $deferred -Actual $modelPlanDeferred
+Assert-Set -Name 'required thread tool contract' -Expected $expectedRequiredThreadTools -Actual $requiredForReplay
+
+$requiredNotRegistered = @($requiredForReplay | Where-Object { $_ -notin $registered })
+$requiredNotDeferred = @($requiredForReplay | Where-Object { $_ -notin $deferred })
+$requiredNotDiscoverable = @($requiredForReplay | Where-Object { $_ -notin $modelPlanDeferred })
+if (
+    $requiredNotRegistered.Count -gt 0 -or
+    $requiredNotDeferred.Count -gt 0 -or
+    $requiredNotDiscoverable.Count -gt 0
+) {
+    Add-Mismatch (
+        "required tool membership failed registered=[$($requiredNotRegistered -join ', ')] " +
+        "deferred=[$($requiredNotDeferred -join ', ')] " +
+        "discoverable=[$($requiredNotDiscoverable -join ', ')]"
+    )
+}
+
+if (
+    $wire.pre_gateway.request_id -ne $wire.post_gateway.request_id -or
+    $wire.pre_gateway.stream -ne $wire.post_gateway.stream -or
+    $wire.pre_gateway.model -ne $wire.post_gateway.model
+) {
+    Add-Mismatch 'pre-Gateway and post-Gateway request identity changed'
+}
+if (
+    $wire.pre_gateway.tool_surface.tool_search.type -ne 'tool_search' -or
+    $wire.pre_gateway.tool_surface.tool_search.execution -ne 'client' -or
+    $wire.post_gateway.tool_surface.tool_search.type -ne 'tool_search' -or
+    $wire.post_gateway.tool_surface.tool_search.execution -ne 'client'
+) {
+    Add-Mismatch 'tool_search identity changed across the Gateway route'
+}
+$preResponse = $wire.pre_gateway.response | ConvertTo-Json -Depth 20 -Compress
+$postResponse = $wire.post_gateway.response | ConvertTo-Json -Depth 20 -Compress
+if ($preResponse -ne $postResponse) {
+    Add-Mismatch 'pre-Gateway and post-Gateway response/SSE identity changed'
+}
+$preChoice = $wire.pre_gateway.choice_controls
+$postChoice = $wire.post_gateway.choice_controls
+if (
+    $preChoice.tool_choice -ne 'auto' -or
+    $preChoice.fixture_kind -ne 'contract_sentinel' -or
+    $preChoice.captured -ne $false -or
+    ($preChoice | ConvertTo-Json -Depth 10 -Compress) -ne ($postChoice | ConvertTo-Json -Depth 10 -Compress)
+) {
+    Add-Mismatch 'pre-Gateway and post-Gateway choice-control fixture is invalid'
+}
+
+$requiredCallIds = @($wire.history.required_call_ids)
+$linkedCallIds = @($callLinks | ForEach-Object { $_.call_id })
+Assert-Set -Name 'history call links' -Expected $requiredCallIds -Actual $linkedCallIds
+foreach ($link in $callLinks) {
+    if (
+        [string]::IsNullOrWhiteSpace($link.call_item_id) -or
+        [string]::IsNullOrWhiteSpace($link.output_item_id) -or
+        $link.call_type -notin @('function_call', 'custom_tool_call') -or
+        $link.output_type -notin @('function_call_output', 'custom_tool_call_output')
+    ) {
+        Add-Mismatch "invalid history call link for $($link.call_id)"
+    }
+}
+
+$streamUnknown = @($wire.response.streaming.events | Where-Object { $_.tag -eq 'unknown' })
+$nonStreamingUnknown = @($wire.response.non_streaming.response_items | Where-Object { $_.tag -eq 'unknown' })
+if ($streamUnknown.Count -ne 1 -or $nonStreamingUnknown.Count -ne 1) {
+    Add-Mismatch 'unknown tagged sentinels were not preserved in both response modes'
+}
+if (
+    $wire.response.streaming.captured -ne $true -or
+    $wire.response.non_streaming.captured -ne $false -or
+    $wire.response.non_streaming.fixture_kind -ne 'contract_sentinel'
+) {
+    Add-Mismatch 'streaming and non-streaming fixture boundary is invalid'
+}
+if (@($wire.response.streaming.observed_event_counts).Count -eq 0) {
+    Add-Mismatch 'streaming SSE event evidence is empty'
+}
+
+Write-Output "Capture: $($trace.source.capture_id)"
+Write-Output "Provider/model: $($trace.source.configured_provider_id) / $($trace.source.model)"
+Write-Output "Gateway route: $($trace.gateway_route.behavior_profile)"
+Write-Output "Registered Codex app tools: $($registered.Count)"
+Write-Output "Direct / Deferred: $($direct.Count) / $($deferred.Count)"
+Write-Output "Deferred tools discoverable through tool_search: $($discoverable.Count)"
+Write-Output "Replay case: $ReplayCase"
+
+if ($mismatches.Count -gt 0) {
+    [Console]::Error.WriteLine('RECONCILIATION_MISMATCH: ' + ($mismatches -join ' | '))
+    exit 1
+}
+
+if ($ReplayCase -ne 'identity') {
+    [Console]::Error.WriteLine("NEGATIVE_REPLAY_CONTROL_DID_NOT_FAIL: $ReplayCase")
+    exit 2
+}
+
+Write-Output 'THREAD_TOOL_SURFACE_COMPLETE'
+exit 0

--- a/tests/test_issue_62_runtime_trace.py
+++ b/tests/test_issue_62_runtime_trace.py
@@ -1,0 +1,144 @@
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TRACE = ROOT / "docs" / "evidence" / "issue-62" / "current-codexhub-thread-tool-surface.json"
+WIRE_FIXTURE = ROOT / "docs" / "evidence" / "issue-62" / "codexhub-runtime-wire-fixture.json"
+REPLAY_SCRIPT = ROOT / "scripts" / "check-codex-thread-tool-surface.ps1"
+
+
+def run_replay(case: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            "powershell",
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(REPLAY_SCRIPT),
+            "-ReplayCase",
+            case,
+        ],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_trace_covers_dynamic_tool_exposure_and_sanitizes_session_identity() -> None:
+    trace = json.loads(TRACE.read_text(encoding="utf-8"))
+
+    assert trace["schema_version"] == 4
+    assert "session_id" not in trace["source"]
+    assert len(trace["registered_codex_app_tools"]) == 15
+    required = set(trace["required_thread_tools"])
+    assert required <= set(trace["registered_codex_app_tools"])
+    assert required <= set(trace["dynamic_tool_exposure"]["deferred"])
+    assert required <= set(
+        trace["planner_gates"]["model_visible_plan"][
+            "codex_app_deferred_tools_discoverable_through_tool_search"
+        ]
+    )
+
+    contributor = trace["dynamic_tool_contributors"][0]
+    assert contributor["namespace"] == "codex_app"
+    assert contributor["registered_tool_count"] == 15
+
+    direct = {
+        tool["name"]
+        for tool in contributor["tools"]
+        if tool["planner_exposure"] == "Direct"
+    }
+    deferred = {
+        tool["name"]
+        for tool in contributor["tools"]
+        if tool["planner_exposure"] == "Deferred"
+    }
+    assert direct == set(trace["dynamic_tool_exposure"]["direct"])
+    assert deferred == set(trace["dynamic_tool_exposure"]["deferred"])
+    assert all(
+        tool["deferLoading"] is True
+        for tool in contributor["tools"]
+        if tool["planner_exposure"] == "Deferred"
+    )
+
+    states = {entry["state"] for entry in trace["exposure_state_catalog"]}
+    assert states == {
+        "Direct",
+        "DirectModelOnly",
+        "Deferred",
+        "Hidden",
+        "hosted-only",
+        "host-unavailable",
+    }
+    snapshot = trace["planner_gates"]["catalog_source"]["read_only_snapshot_validation"]
+    assert snapshot["model_entry_id"] == "gpt-5.6-sol"
+    assert snapshot["model_entry_supports_search_tool"] is True
+    assert len(snapshot["sha256"]) == 64
+
+
+def test_wire_fixture_keeps_identity_and_unknown_sentinels() -> None:
+    wire = json.loads(WIRE_FIXTURE.read_text(encoding="utf-8"))
+
+    assert wire["route"]["upstream_route"] == "official"
+    assert "no full request or response body fingerprint" in wire["evidence_limit"][
+        "transport_observation"
+    ]
+    assert "not independent full-wire identity" in wire["evidence_limit"][
+        "replay_fixture"
+    ]
+    assert wire["pre_gateway"]["tool_surface"] == wire["post_gateway"]["tool_surface"]
+    assert wire["pre_gateway"]["response"] == wire["post_gateway"]["response"]
+    assert wire["pre_gateway"]["choice_controls"] == wire["post_gateway"]["choice_controls"]
+    assert wire["pre_gateway"]["choice_controls"]["fixture_kind"] == "contract_sentinel"
+    assert wire["exposure_state_tags"] == [
+        "Direct",
+        "DirectModelOnly",
+        "Deferred",
+        "Hidden",
+        "hosted-only",
+        "host-unavailable",
+    ]
+    assert wire["pre_gateway"]["tool_surface"]["tool_search"]["execution"] == "client"
+    assert wire["history"]["captured_source_counts"]["paired_calls"] == 533
+    assert wire["history"]["captured_source_counts"]["unpaired_calls"] == 0
+    assert wire["history"]["captured_source_counts"]["unpaired_outputs"] == 0
+    assert wire["response"]["streaming"]["captured"] is True
+    assert wire["response"]["non_streaming"]["captured"] is False
+    assert any(
+        event.get("tag") == "unknown"
+        for event in wire["response"]["streaming"]["events"]
+    )
+    assert any(
+        item.get("tag") == "unknown"
+        for item in wire["response"]["non_streaming"]["response_items"]
+    )
+
+
+def test_identity_replay_passes() -> None:
+    result = run_replay("identity")
+
+    assert result.returncode == 0, result.stderr
+    assert "THREAD_TOOL_SURFACE_COMPLETE" in result.stdout
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        "mutation",
+        "deletion",
+        "loss",
+        "required-set-deletion",
+        "required-membership-mutation",
+    ],
+)
+def test_negative_replays_fail_visibly(case: str) -> None:
+    result = run_replay(case)
+
+    assert result.returncode == 1
+    assert "RECONCILIATION_MISMATCH:" in result.stderr


### PR DESCRIPTION
## Summary

- rebuild the PR from current `dev` as one sanitized evidence commit
- preserve the corrected caller-plan interpretation: `additional_tools` contains client-executed `tool_search`
- capture the observed `codex_app` contributor: 3 Direct and 12 `deferLoading: true` Deferred tools
- record concrete official Gateway upstream/catalog provenance without inferring route type from `configured_provider_id`
- add sanitized pre/post request and response/SSE replay fixtures, call/item-link aliases, choice-control and unknown sentinels
- require exact registered, Deferred, and discoverable membership for every `required_thread_tools` entry; negative replays fail for identity mutation, deletion, loss, required-set deletion, and required-membership mutation

## Evidence boundary

The preserved capture establishes only 65,536-byte caller/upstream request-prefix equality and sanitized fixture consistency. No independently derived full request-body or response-body fingerprints were captured, so this PR does not rule out Gateway filtering beyond that observed prefix-level evidence.

## Verification

- `python -m json.tool docs/evidence/issue-62/current-codexhub-thread-tool-surface.json`
- `python -m json.tool docs/evidence/issue-62/codexhub-runtime-wire-fixture.json`
- `powershell -NoProfile -ExecutionPolicy Bypass -File scripts/check-codex-thread-tool-surface.ps1`
- all five negative replay cases visibly fail with `RECONCILIATION_MISMATCH`
- `python -m pytest -q tests/test_issue_62_runtime_trace.py` (8 passed)
- `python -m pytest -q` (829 passed, 1 skipped, 88 subtests passed)

## Scope and remaining evidence gaps

This remains an evidence-only, partial PR. It preserves the fact/hypothesis split and does not claim a stale `StaticModelsManager` root cause.

The retained capture covers the `codex_app` contributor only. Other installed contributors, runtime gate evaluation, a clean cold start for the current CodexHub binding, captured non-streaming/choice evidence, and observed non-Direct states were not artifact-captured or run. The in-process rewrite and clean-cold-start controls remain deliberately separate. The observed Desktop-host/model non-selection of available `tool_search` and its reluctant-model lifecycle belongs to #63.

#62 remains open until its full acceptance contract is met.

Refs #62