### PR TITLE
refactor: isolate Gateway opener and error mapper

### DIFF
--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -11156,6 +11156,17 @@ def _parse_gateway_request_input(
     )
 
 
+def _open_upstream_once(
+    request: Request,
+    *,
+    upstream_name: str,
+    timeout: int,
+) -> Any:
+    if upstream_name == "official":
+        return _official_urlopen(request, timeout=timeout)
+    return urlopen(request, timeout=timeout)
+
+
 def _open_upstream_response(
     request: Request,
     *,
@@ -11175,9 +11186,11 @@ def _open_upstream_response(
     attempt = 1
     while True:
         try:
-            if upstream_name == "official":
-                return _official_urlopen(request, timeout=timeout)
-            return urlopen(request, timeout=timeout)
+            return _open_upstream_once(
+                request,
+                upstream_name=upstream_name,
+                timeout=timeout,
+            )
         except (HTTPError, IncompleteRead, OSError, URLError) as exc:
             if isinstance(exc, HTTPError) and not retry_http_errors:
                 raise
@@ -12734,7 +12747,13 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
     def _write_sse_error_event(self, upstream_name: str, exc: BaseException) -> None:
         self._write_sse_event(
             "error",
-            _downstream_stream_error_payload(upstream_name=upstream_name, exc=exc),
+            _downstream_sse_error_payload_for_inbound_format(
+                DownstreamErrorSpec(
+                    inbound_format="responses",
+                    upstream_name=upstream_name,
+                    exc=exc,
+                )
+            ),
         )
 
     def _write_downstream_sse_error(
@@ -12768,10 +12787,6 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
             self.wfile.flush()
             self.close_connection = True
             return
-        if exc is not None:
-            self._write_sse_event("error", _downstream_sse_error_payload_for_inbound_format(error_spec))
-            self.close_connection = True
-            return
         self._write_sse_event("error", _downstream_sse_error_payload_for_inbound_format(error_spec))
         self.close_connection = True
 
@@ -12785,11 +12800,14 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
     ) -> None:
         self._write_sse_event(
             "error",
-            _downstream_stream_error_payload(
-                upstream_name=upstream_name,
-                status=status,
-                error=error,
-                detail=detail,
+            _downstream_sse_error_payload_for_inbound_format(
+                DownstreamErrorSpec(
+                    inbound_format="responses",
+                    upstream_name=upstream_name,
+                    status=status,
+                    error=error,
+                    detail=detail,
+                )
             ),
         )
 

--- a/tests/test_chat_completions_gateway.py
+++ b/tests/test_chat_completions_gateway.py
@@ -447,6 +447,39 @@ class CodexHubErrorPayloadTests(unittest.TestCase):
                 self.assertEqual(payload["details"]["status"], kwargs["status"])
 
 
+class DownstreamErrorMapperTests(unittest.TestCase):
+    def test_chat_json_error_mapper_preserves_chat_error_object_shape(self):
+        error = codex_proxy.DownstreamErrorSpec(
+            inbound_format="chat_completions",
+            upstream_name="official",
+            status=502,
+            exc=URLError(ConnectionResetError("connection reset")),
+        )
+
+        payload = codex_proxy._downstream_json_error_payload(error)
+
+        self.assertEqual(payload["error"]["type"], "upstream_error")
+        self.assertEqual(payload["error"]["code"], "URLError")
+        self.assertEqual(payload["error"]["status"], 502)
+        self.assertEqual(payload["error"]["upstream"], "official")
+
+    def test_responses_sse_error_mapper_preserves_stream_error_payload_shape(self):
+        error = codex_proxy.DownstreamErrorSpec(
+            inbound_format="responses",
+            upstream_name="official",
+            status=429,
+            exc=URLError(TimeoutError("upstream timed out")),
+        )
+
+        payload = codex_proxy._downstream_sse_error_payload_for_inbound_format(error)
+
+        self.assertEqual(payload["type"], "upstream_stream_error")
+        self.assertEqual(payload["status"], 502)
+        self.assertEqual(payload["upstream"], "official")
+        self.assertEqual(payload["error"], "URLError")
+        self.assertEqual(payload["retry_owner"], "client")
+
+
 class ChatToolChoiceTests(unittest.TestCase):
     def test_string_tool_choice(self):
         self.assertEqual(_chat_tool_choice_to_responses_tool_choice("auto"), "auto")

--- a/tests/test_proxy_event_logging.py
+++ b/tests/test_proxy_event_logging.py
@@ -11,6 +11,7 @@ import threading
 from pathlib import Path
 from unittest import TestCase
 from unittest.mock import patch
+from urllib.error import URLError
 
 import codex_proxy
 
@@ -33,6 +34,53 @@ class ProxyEventLoggingTests(TestCase):
                     payload = json.loads(codex_proxy.PROXY_EVENT_LOG_PATH.read_text(encoding="utf-8").strip())
                     self.assertEqual(payload["event"], "request_complete")
                     self.assertEqual(payload["request_id"], "req-test")
+            finally:
+                importlib.reload(codex_proxy)
+
+    def test_upstream_open_retry_event_preserves_transport_failure_phase(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            codex_home = Path(tmpdir) / "codex-home"
+            try:
+                with patch.dict("os.environ", {"CODEX_HOME": str(codex_home)}, clear=False):
+                    importlib.reload(codex_proxy)
+                    request = codex_proxy.Request("https://example.test/v1/responses", data=b"{}", method="POST")
+                    success = object()
+
+                    with (
+                        patch.dict(
+                            os.environ,
+                            {
+                                "CODEX_PROXY_AUTO_RETRY_ENABLED": "1",
+                                "CODEX_PROXY_AUTO_RETRY_MAX_ATTEMPTS": "2",
+                            },
+                            clear=False,
+                        ),
+                        patch(
+                            "codex_proxy._open_upstream_once",
+                            side_effect=[URLError(TimeoutError("upstream timed out")), success],
+                        ) as open_once,
+                        patch("codex_proxy.time.sleep"),
+                    ):
+                        response = codex_proxy._open_upstream_response(
+                            request,
+                            upstream_name="official",
+                            upstream_format="responses",
+                            timeout=1,
+                            event_context={"request_id": "req-open-seam", "model": "openai/gpt-5.5"},
+                        )
+
+                    self.assertIs(response, success)
+                    self.assertEqual(open_once.call_count, 2)
+                    self.assertTrue(codex_proxy.flush_proxy_event_writer())
+                    payloads = [
+                        json.loads(line)
+                        for line in codex_proxy.PROXY_EVENT_LOG_PATH.read_text(encoding="utf-8").splitlines()
+                        if line.strip()
+                    ]
+                    retry = next(payload for payload in payloads if payload["event"] == "upstream_retry")
+                    self.assertEqual(retry["request_id"], "req-open-seam")
+                    self.assertEqual(retry["upstream"], "official")
+                    self.assertEqual(retry["failure_phase"], "tcp_connect")
             finally:
                 importlib.reload(codex_proxy)
 

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -2331,7 +2331,7 @@ class RoutingTests(unittest.TestCase):
 
         self.assertEqual(len(client_ports), 1)
 
-    def test_official_then_third_party_does_not_leak_keepalive_transport(self):
+    def test_open_upstream_once_keeps_official_transport_isolated_from_third_party(self):
         official_request = codex_proxy.Request(
             "https://chatgpt.com/backend-api/codex/responses", data=b"{}", method="POST"
         )
@@ -2345,19 +2345,15 @@ class RoutingTests(unittest.TestCase):
             patch("codex_proxy._official_urlopen", return_value=official_success) as official_urlopen,
             patch("codex_proxy.urlopen", return_value=third_party_success) as mock_urlopen,
         ):
-            official_response = codex_proxy._open_upstream_response(
+            official_response = codex_proxy._open_upstream_once(
                 official_request,
                 upstream_name="official",
-                upstream_format="responses",
                 timeout=1,
-                event_context={"request_id": "req-official-transport"},
             )
-            third_party_response = codex_proxy._open_upstream_response(
+            third_party_response = codex_proxy._open_upstream_once(
                 third_party_request,
                 upstream_name="volcengine",
-                upstream_format="responses",
                 timeout=1,
-                event_context={"request_id": "req-non-official-transport"},
             )
 
         self.assertIs(official_response, official_success)


### PR DESCRIPTION
## Summary

- Extract the one-attempt Gateway upstream opener from the retry coordinator.
- Route all response-SSE error writers through the existing `DownstreamErrorSpec` mapper.
- Add focused routing, Chat Gateway payload, and proxy retry-telemetry coverage.

## Why

The Gateway request pipeline mixed transport selection with retry coordination, and a few response-SSE paths bypassed the common error mapper. This makes those boundaries directly testable without changing routing, payloads, or retry policy.

## Validation

- `python -m pytest tests/test_routing.py tests/test_chat_completions_gateway.py tests/test_proxy_event_logging.py`
- `python -m pytest`
- `python scripts/report_quality_gates.py` (report-only; existing findings)

Closes #5
