### PR TITLE
Spike Claude Code Messages compatibility through CodexHub

### DIFF
--- a/docs/adr/0001-claude-messages-intermediate-representation.md
+++ b/docs/adr/0001-claude-messages-intermediate-representation.md
@@ -1,0 +1,104 @@
+# ADR-0001: Use an AnthropicMessage representation before any Messages route
+
+Date: 2026-07-12
+Status: Accepted for a future implementation seam; no production route is authorized
+
+## Context
+
+Issue #74 tested Claude Code as a **downstream Gateway client**. Claude Code
+sends Anthropic Messages requests with ordered content blocks, full history,
+opaque tool IDs, open-set headers/body fields, and an incremental Messages SSE
+response. CodexHub currently has only Responses and Chat Completions inbound
+formats; its implicit conversion helpers are coupled to the production Gateway
+handler.
+
+The Spike's strict prototype can translate a small text/tool subset and convert
+Responses or Chat Completions streams into named Messages SSE events. Its real
+Claude Code loopback evidence also observed default fields with no established
+non-Anthropic equivalent: adaptive thinking, effort output configuration,
+cache-control-bearing blocks, and open Anthropic beta/header fields.
+
+## Decision
+
+If a later issue adds an Anthropic Messages adapter, it will introduce a
+dedicated, pure `AnthropicMessage` intermediate representation. It will not add
+another set of implicit conversions inside `codex_proxy.py`.
+
+The representation's public interface must preserve:
+
+- message role and ordered content blocks;
+- tool-use and tool-result blocks, including the original opaque tool ID;
+- top-level system blocks without reordering them;
+- known request options plus an explicit collection of unmodelled fields;
+- case-insensitive headers classified as credential, transport, opaque client
+  metadata, or Anthropic semantic fields.
+
+Adapters from this representation to Responses and Chat Completions must return
+one of two explicit outcomes:
+
+1. a translated request plus a list of declared adaptations; or
+2. a non-forwardable result naming every unmodelled field.
+
+An adapter may not emit a request after silently dropping a field. A tool call's
+ID must round-trip unchanged through the assistant tool-use response and the
+following user tool-result request.
+
+## Version and extension policy
+
+- The evidence pin is `anthropic-version: 2023-06-01`, revalidated against the
+  Claude Code gateway protocol on 2026-07-12.
+- The public source pin is Claude Code `v2.1.207`; the local loopback evidence
+  used `v2.1.201` and is not interchangeable with the source pin.
+- `anthropic-*`, `anthropic-beta`, and `x-claude-code-*` are open sets. An
+  Anthropic-format upstream may forward the required semantic fields unchanged.
+  A non-Anthropic adapter must map a known semantic or return an explicit
+  unsupported result; it must never rely on an allowlist that silently strips a
+  new field.
+- Downstream Gateway credentials are consumed at the Gateway boundary and are
+  never used as upstream provider credentials or retained in traces.
+
+## Compatibility level
+
+**Scoped PARTIAL.** The prototype demonstrates explicit adaptation for basic
+text/history, client-tool ID lifecycle, Messages SSE, reported usage, a generic
+error envelope, and deterministic Responses/Chat protocol shapes. It does not
+establish safe production behavior for thinking, prompt caching, context
+compaction/resume, server tools, beta fields, count tokens, cancellation, or
+Claude Code automatic retry semantics.
+
+Therefore this decision explicitly prohibits, until a follow-up closes the
+named gaps:
+
+- production `POST /v1/messages` or `/v1/messages/count_tokens` handling;
+- changes to `codex_proxy.py` handler registration or routing;
+- Claude Code client auto-configuration or discovery UI;
+- treating Claude Code as an upstream ACP/AgentProvider.
+
+## Consequences
+
+The future module becomes the single seam callers and tests use for Messages
+translation. That gives tests a deep, in-memory interface and keeps protocol
+evolution localized. It also creates an intentional extra implementation step
+before a route can ship: each new Messages capability needs a representation
+decision and a test, rather than becoming an accidental omission inside an
+existing Gateway conversion helper.
+
+## Alternatives considered
+
+### Extend the current implicit Gateway conversion helpers
+
+Rejected. They are shaped around Responses and Chat Completions HTTP handling,
+would couple Messages evolution to the production route, and cannot expose an
+honest non-forwardable result before upstream I/O.
+
+### Forward every field to a non-Anthropic upstream
+
+Rejected. Responses and Chat Completions do not share the Anthropic Messages
+schema; forwarding beta/body pairs or cache controls unchanged would cause
+opaque failures or semantic loss.
+
+### Model Claude Code as an AgentProvider
+
+Rejected for this scope. A downstream Messages client is distinct from the
+separate upstream Claude Code/ACP AgentProvider roadmap. No AgentProvider,
+session, permission, or ACP lifecycle is introduced by this decision.

--- a/docs/adr/0001-claude-messages-intermediate-representation.md
+++ b/docs/adr/0001-claude-messages-intermediate-representation.md
@@ -43,6 +43,11 @@ An adapter may not emit a request after silently dropping a field. A tool call's
 ID must round-trip unchanged through the assistant tool-use response and the
 following user tool-result request.
 
+Usage mapping may omit only a validated redundant total. Cache, reasoning, or
+provider-detail usage fields require a named representation/mapping decision;
+until then the adapter must return an explicit non-forwardable result rather
+than collapse them into base token counts.
+
 ## Version and extension policy
 
 - The evidence pin is `anthropic-version: 2023-06-01`, revalidated against the
@@ -60,11 +65,12 @@ following user tool-result request.
 ## Compatibility level
 
 **Scoped PARTIAL.** The prototype demonstrates explicit adaptation for basic
-text/history, client-tool ID lifecycle, Messages SSE, reported usage, a generic
-error envelope, and deterministic Responses/Chat protocol shapes. It does not
-establish safe production behavior for thinking, prompt caching, context
-compaction/resume, server tools, beta fields, count tokens, cancellation, or
-Claude Code automatic retry semantics.
+text/history, client-tool ID lifecycle, Messages SSE, reported base usage (with
+validated totals), a generic error envelope, and deterministic Responses/Chat
+protocol shapes. It explicitly rejects unmapped cache/reasoning/provider usage
+detail. It does not establish safe production behavior for thinking, prompt
+caching, context compaction/resume, server tools, beta fields, count tokens,
+cancellation, or Claude Code automatic retry semantics.
 
 Therefore this decision explicitly prohibits, until a follow-up closes the
 named gaps:

--- a/docs/research/2026-07-12-claude-code-external-client-support.md
+++ b/docs/research/2026-07-12-claude-code-external-client-support.md
@@ -1,0 +1,280 @@
+# Claude Code external-client support: Messages gateway evidence
+
+Date: 2026-07-12
+Scope: Issue #74 research only. This note records the official Claude Code / Anthropic Messages contract relevant to a downstream Claude Code client of CodexHub. It does not add, imply, or authorize a production route, client auto-configuration, or a non-Claude upstream configuration.
+
+## Evidence boundary and source pins
+
+All protocol claims below are from primary Anthropic / Claude Code documentation or Anthropic's official release repository, accessed on 2026-07-12. The JSON and SSE fragments in this note are schema-only sanitized fixtures: they use invented identifiers and placeholder text and are not captures from a user session.
+
+| Source | Pinned / accessed evidence | What it establishes |
+| --- | --- | --- |
+| [Claude Code gateway protocol reference](https://code.claude.com/docs/en/llm-gateway-protocol) | Accessed 2026-07-12 | Gateway endpoints, streaming requirement, forwarding rules, Claude Code headers, open-list policy, beta/body pairing, retry/error forwarding, discovery. |
+| [Other LLM gateways overview](https://code.claude.com/docs/en/llm-gateway) | Accessed 2026-07-12 | Anthropic does not support routing Claude Code to non-Claude models through a gateway. |
+| [Claude Code v2.1.207 release](https://github.com/anthropics/claude-code/releases/tag/v2.1.207) and [pinned changelog](https://github.com/anthropics/claude-code/blob/v2.1.207/CHANGELOG.md) | v2.1.207, tag commit d4d8fbbb333c627d8fe2c1c583a5ccc26fdb1aed, published 2026-07-11 | Public CLI release pin for a repeatable smoke plan. |
+| [Using the Messages API](https://platform.claude.com/docs/en/build-with-claude/working-with-messages) | Accessed 2026-07-12 | Response shape and stateless full-history behavior. |
+| [Streaming messages](https://platform.claude.com/docs/en/build-with-claude/streaming) and [API versions](https://platform.claude.com/docs/en/api/versioning) | Accessed 2026-07-12 | Named SSE event flow, deltas, errors, unknown events, and version guarantees. |
+| [Handle tool calls](https://platform.claude.com/docs/en/agents-and-tools/tool-use/handle-tool-calls) | Accessed 2026-07-12 | Client-tool use/result lifecycle and ordering constraints. |
+| [Prompt caching](https://platform.claude.com/docs/en/build-with-claude/prompt-caching), [Vision](https://platform.claude.com/docs/en/build-with-claude/vision), and [Token counting](https://platform.claude.com/docs/en/build-with-claude/token-counting) | Accessed 2026-07-12 | Cache, image, and count-token input/usage implications. |
+| [Errors](https://platform.claude.com/docs/en/api/errors) | Accessed 2026-07-12 | HTTP/SSE error envelope and retry facts. |
+| [OpenAI Responses create reference](https://developers.openai.com/api/reference/resources/responses/methods/create), [OpenAI function calling guide](https://developers.openai.com/api/docs/guides/function-calling), and [OpenAI Responses streaming guide](https://developers.openai.com/api/docs/guides/streaming-responses) | Accessed 2026-07-12 | Official OpenAI request, function-call, and stream shapes used only for the deterministic Responses/Chat adapter fixtures. |
+
+### CLI and platform pin
+
+Verified locally without sending an API request:
+
+| Item | Observation |
+| --- | --- |
+| Installed Claude Code | 2.1.201 |
+| Runtime | Node.js v25.7.0 |
+| Platform | Windows NT 10.0.26200.0 |
+
+The local executable is not the public-release pin above. A real smoke must record the exact executable version it actually uses; it may use the installed 2.1.201 only if that version is recorded in its fixture metadata, or upgrade to the pinned public v2.1.207 and record that change. This note makes no claim that either version completed a real gateway request.
+
+## Verified Claude Code gateway contract
+
+### Endpoint selection and startup traffic
+
+With **ANTHROPIC_BASE_URL**, Claude Code speaks the Anthropic Messages format to:
+
+- POST /v1/messages
+- POST /v1/messages/count_tokens (optional)
+
+The official protocol reference says inference currently targets /v1/messages?beta=true. Routing therefore must match the path rather than require an exact query string. A gateway may also see a best-effort HEAD / connectivity probe. Model discovery is optional and, when enabled, requests GET /v1/models?limit=1000 with a three-second timeout; it is not required for the narrow translator spike.
+
+Claude Code consumes inference responses as they arrive. Buffering a full result before relaying it stalls the client, so a compatibility layer must emit a live Anthropic SSE stream rather than an OpenAI-style terminal-only response.
+
+The official support boundary matters: Anthropic documents gateway support for the formats it describes, but explicitly does **not** support routing Claude Code to non-Claude models through a gateway. Therefore, any CodexHub-to-OpenAI Responses or Chat Completions work is a scoped translation experiment only, not an officially supported Claude Code deployment.
+
+### Headers: verified facts and required policy
+
+Header names are case-insensitive on the wire. The protocol reference differentiates fields to forward unchanged from fields a gateway may consume. It also says headers and request body fields are open lists: new Anthropic and Claude Code fields can arrive in later CLI releases.
+
+| Header / class | Verified behavior | Spike handling policy |
+| --- | --- | --- |
+| **anthropic-version** | Required by the Messages API; the protocol reference currently identifies 2023-06-01. Forward unchanged to an Anthropic-format upstream. | Preserve the raw value in the intermediate request. Never substitute an OpenAI version for it. |
+| **anthropic-beta** | Comma-separated capability values. Forward verbatim; do not allowlist individual values. It can include an OAuth capability needed when Claude Code uses a claude.ai login, and stripping it can yield 401. | Treat as an open list. Preserve it for an Anthropic-compatible upstream. For a non-Anthropic upstream, an unmappable beta/body pair must receive an explicit unsupported result, never a silent drop. |
+| **anthropic-workspace-id** | Forward when the upstream is Claude Platform on AWS. | Out of scope for the Responses/Chat experiment; retain as an explicit unsupported/unknown field rather than discard it. |
+| **Authorization** and **x-api-key** | Gateway credentials may appear in one or both. Claude Code maps ANTHROPIC_AUTH_TOKEN to bearer Authorization, ANTHROPIC_API_KEY to x-api-key, and an apiKeyHelper can use both. | Consume at the Gateway boundary. Redact values from every trace and do not reuse a downstream gateway credential as an upstream provider credential. |
+| **x-claude-code-session-id** | Unique Claude Code session identifier. | Accept as opaque correlation metadata; pseudonymize it in fixtures and logs. |
+| **x-claude-code-agent-id** | Present on requests from a spawned subagent. | Accept as opaque agent-attribution metadata; do not treat it as a human or device identity. |
+| **x-claude-code-parent-agent-id** | Present for nested agents. | Retain relation metadata only when a later adapter can represent it; otherwise report it as unsupported, not dropped. |
+| Future **x-claude-code-*** and **anthropic-*** headers; custom headers | The protocol explicitly warns that new headers and body fields can be introduced. | Admit them into a structured open header collection. Anthropic-format paths forward the required Anthropic fields unchanged. A non-Anthropic adapter must either map a known semantic or return a precise unsupported outcome; it must not silently strip the field. |
+
+The documented Claude Code agent IDs identify an agent, not a person or device. That distinction is a privacy and telemetry requirement for CodexHub as well.
+
+### Request and response shape
+
+The Messages API is stateless: each request carries the full conversation history. The normal successful Message object includes an identifier, type, assistant role, ordered content blocks, model, stop reason, optional stop sequence, and usage. A top-level system prompt is supported; newer Messages capabilities can add fields, so the following is deliberately not a closed schema.
+
+~~~json
+{
+  "model": "fixture-model",
+  "max_tokens": 128,
+  "stream": true,
+  "system": [
+    {
+      "type": "text",
+      "text": "[sanitized-system]"
+    }
+  ],
+  "messages": [
+    {
+      "role": "user",
+      "content": [
+        {
+          "type": "text",
+          "text": "[sanitized-user-turn]"
+        }
+      ]
+    }
+  ]
+}
+~~~
+
+~~~json
+{
+  "id": "msg_fixture_01",
+  "type": "message",
+  "role": "assistant",
+  "content": [
+    {
+      "type": "text",
+      "text": "[sanitized-assistant-output]"
+    }
+  ],
+  "model": "fixture-model",
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
+  "usage": {
+    "input_tokens": 0,
+    "output_tokens": 0
+  }
+}
+~~~
+
+The zero token values above are placeholders, not reported usage. A translator must not manufacture token counts when an upstream does not provide a reliable mapping.
+
+### SSE contract
+
+For stream: true, the documented named-event order is:
+
+1. message_start, with a Message whose content is empty;
+2. zero or more content blocks, each with content_block_start, one or more content_block_delta events, and content_block_stop;
+3. one or more message_delta events;
+4. message_stop.
+
+Ping events may occur anywhere. The usage values in message_delta are cumulative. An error event can occur after an HTTP 200 response, and new event types may be added; a translator must therefore retain or explicitly surface unknown events instead of assuming a finite event enum.
+
+~~~text
+event: message_start
+data: {"type":"message_start","message":{"id":"msg_fixture_01","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":0,"output_tokens":0}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"[sanitized-delta]"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":0}}
+
+event: message_stop
+data: {"type":"message_stop"}
+~~~
+
+Tool input arrives as partial JSON through input_json_delta events. Accumulate those deltas and validate the resulting object only when the corresponding content block stops. Thinking streams have thinking_delta and a signature_delta before the block closes; a converter must not invent a signature it cannot preserve.
+
+### Tool use and result follow-up
+
+For a client tool, a successful assistant turn ends with stop_reason: tool_use and one or more tool_use blocks. Each block supplies an opaque unique id, name, and input object. The subsequent request must include the assistant tool call in history followed immediately by a user message whose tool_result block references that exact id. Tool results must come first in the user content array; a tool result can carry content or is_error: true.
+
+~~~json
+{
+  "role": "assistant",
+  "content": [
+    {
+      "type": "tool_use",
+      "id": "toolu_fixture_01",
+      "name": "read_fixture",
+      "input": {
+        "path": "[sanitized-path]"
+      }
+    }
+  ]
+}
+~~~
+
+~~~json
+{
+  "role": "user",
+  "content": [
+    {
+      "type": "tool_result",
+      "tool_use_id": "toolu_fixture_01",
+      "content": "[sanitized-tool-result]"
+    }
+  ]
+}
+~~~
+
+This is not an OpenAI tool role. The official tool guide specifically notes that Messages embeds tool use in assistant/user content blocks. A later Responses or Chat adapter must keep a one-to-one internal mapping while returning the original Messages tool ID to Claude Code. Changing, losing, or reordering that ID breaks the follow-up lifecycle.
+
+### Errors, retries, and cancellation
+
+Documented non-streaming errors are JSON with a top-level type, an error object containing type and message, and a request_id. The official error guide lists 400, 401, 402, 403, 404, 409, 413, 429, 500, 504, and 529 classes. SSE can instead emit:
+
+~~~text
+event: error
+data: {"type":"error","error":{"type":"overloaded_error","message":"[sanitized-message]"}}
+~~~
+
+The gateway protocol states that Claude Code retries some rejections and disables a rejected capability for the rest of a conversation. Its retry logic matches upstream error wording; a gateway that wraps the error in a new envelope can break recovery even if it preserves the status code. The prototype must retain a stable Anthropic error shape and avoid misleading remapping of retryable failure semantics.
+
+**Cancellation is unknown at the wire level.** The public gateway contract defines no cancellation endpoint and does not specify what Ctrl+C, Escape, a client disconnect, or a watchdog abort becomes over HTTP. Do not infer an abort event or synthesize message_stop. A real sanitized CLI smoke is the only acceptable evidence for downstream disconnect detection and upstream cancellation propagation.
+
+### Usage and token counting
+
+Usage is observable in the successful Message response and cumulatively during message_delta. It can include input/output totals and cache-related fields. Map only values the upstream actually reports; retain their provenance and make absent values explicit.
+
+The token-count endpoint accepts the same structured inputs as a message request, including system prompts, tools, images, and documents, and returns input_tokens. It is optional for a Claude Code gateway: when absent, Claude Code estimates context usage locally. A non-Anthropic upstream must therefore not return a guessed Anthropic count as though it were authoritative.
+
+## Compatibility classification before live proof
+
+These are conservative translator classifications, not claims that the Issue #74 prototype has already implemented or smoke-tested them. “Preserved” means only an Anthropic-compatible upstream can receive the feature unchanged. “Adapted” means a translator must maintain explicit semantic/ID/event mappings. “Explicitly unsupported” means the minimal non-Anthropic adapter should reject or omit the optional endpoint with a documented result, not silently erase data.
+
+| Capability | Classification for a Messages-to-Responses/Chat experiment | Evidence / safe behavior |
+| --- | --- | --- |
+| Text request and stateless multi-turn history | Adapted | Preserve ordered history and content blocks; Responses/Chat role models differ. Live history equivalence remains to be tested. |
+| Anthropic-compatible Messages pass-through | Preserved | Forward required Anthropic headers and body fields unchanged; do not reshape the system array. |
+| Text SSE | Adapted | Emit the named Messages SSE lifecycle incrementally; no buffered terminal-only response. |
+| Usage | Adapted | Map only reported upstream usage; keep unknown cache details absent/explicit. |
+| Client tool call and tool-result follow-up | Adapted | Maintain opaque tool IDs and strict follow-up ordering; validate a real read-file lifecycle. |
+| Server tools and server-side result blocks | Unknown | The public Messages protocol has behaviors not demonstrated by the initial client-tool fixture. |
+| Images | Unknown | Messages accepts image blocks and several source types; map only when the selected upstream/provider advertises a verified equivalent, otherwise return a precise unsupported result. |
+| Thinking / adaptive reasoning / thinking signatures | Explicitly unsupported in the minimal non-Anthropic adapter | Claude Code can send adaptive thinking and Messages streams signed thinking blocks. Do not convert it to fabricated text or a fabricated signature. A future adapter needs an explicit, tested capability contract. |
+| Prompt caching and attribution block | Unknown | Cache control affects ordered tools/system/messages content. With a custom base URL, preserve the system array; the protocol notes attribution-header stability from Claude Code v2.1.181. No OpenAI cache-equivalence claim is justified. |
+| Context compaction and resume | Unknown | Context-management beta/body pairing is documented, but the exact 2.1.201 / 2.1.207 CLI wire trace for compact/resume is not in this note. Do not conflate a local resumed transcript with server context management. |
+| Subagent attribution | Adapted for documented headers; unknown for full lifecycle | Accept session/agent/parent-agent metadata as opaque and sanitized. Actual spawned/nested request traces remain a smoke gate. |
+| Beta fields and future body fields | Explicitly unsupported per field until mapped | Treat header/body pairs as open; preserve or reject together. Never silently drop just the header or just the body field. |
+| Error and retry behavior | Adapted | Preserve an Anthropic-shaped error and the relevant upstream wording; test a deterministic upstream failure and an SSE error. |
+| Cancellation | Unknown | Capture downstream close and upstream abort behavior with a real CLI; no documented cancel endpoint exists. |
+| Count tokens | Explicitly unsupported when endpoint is absent | Omitting the optional endpoint is a documented degradation to CLI local estimation. Do not fabricate input_tokens. |
+
+## Sanitized capture plan
+
+The required live evidence can be collected without exposing a credential or user content:
+
+1. Record CLI version, Node version, OS, adapter commit, and fixture schema version before the run.
+2. Use a temporary, isolated Claude Code configuration and a local loopback test gateway. Supply only a non-secret fixture credential accepted by that gateway; never load, print, commit, or proxy a real API key, OAuth token, cookie, or auth file.
+3. Replace every message/system/tool-result text value with a fixture label. Replace filesystem paths, URLs, hostnames, session IDs, agent IDs, tool IDs, request IDs, and model identifiers with stable typed placeholders where the exact value is not required for an ID-equality assertion.
+4. Record header names and only safe values such as anthropic-version. Redact Authorization, x-api-key, cookies, custom header values, and any OAuth-bearing beta value. Record the beta policy as an open comma-separated list rather than committing a sensitive or version-fragile observed list.
+5. Capture structural request JSON, normal response JSON, raw named SSE event order, cumulative usage shape, a deterministic upstream failure, and a client-abort attempt after streaming starts. Keep synthetic fixtures visibly separate from real sanitized trace metadata.
+6. Exercise a text stream, a read-file client tool followed by the matching tool_result, and at least one additional history turn. Prove tool ID equality using placeholder IDs only.
+7. Run the same isolated translator through the official Codex/OpenAI route and one Chat Completions Provider. Classify any divergence by field/event rather than masking it with fallback text.
+
+## Local loopback CLI evidence
+
+The committed, sanitized structural trace is
+`tests/fixtures/claude_messages_real_cli_smoke.json`. It was captured with the
+locally installed Claude Code **2.1.201** rather than the public **2.1.207**
+source pin. The harness used only a temporary loopback server and a throwaway
+fixture credential; it did not contact an Anthropic, OpenAI, or third-party
+provider and did not load an existing credential or configuration.
+
+- **Text streaming:** Claude Code made `POST /v1/messages`, consumed a synthetic
+  Responses-to-Messages SSE stream, returned the expected fixture marker, and
+  exited successfully. The strict input translator deliberately rejected the
+  observed request as non-forwardable because it contained `thinking`,
+  `output_config.effort`, cache-control-bearing system/message blocks, and
+  open-set Anthropic headers. This is successful client/SSE evidence, not a
+  claim that the complete request can safely route to a non-Anthropic upstream.
+- **Tool lifecycle:** the first request received a synthetic `Read` tool call;
+  Claude Code issued a second Messages request whose first user content block
+  was a `tool_result` with the exact fixture tool ID, then consumed the final
+  response successfully. The trace retains only the boolean ID-equality/order
+  proof and redacted structural fields. The same strict input blockers remained
+  present on both turns.
+- **Cancellation:** after named SSE output began, the harness forcibly ended the
+  local CLI process and observed the loopback connection close before the next
+  write. This is an attempted downstream-disconnect observation only; it does
+  not establish Ctrl+C/Escape behavior or upstream abort semantics.
+- **Error/usage shapes:** deterministic unit fixtures cover a 529-to-
+  `overloaded_error` SSE translation, cumulative usage fields, and the named
+  Messages SSE event order. They are not live upstream error or billing proof.
+
+The in-memory test suite also exercises the same translator seam with a
+Responses-shaped upstream fixture (the official Codex/OpenAI protocol shape)
+and a Chat Completions-shaped provider fixture. Neither is a real provider call;
+the run is protocol-shape evidence only.
+
+## Research conclusion and remaining gates
+
+The official contract is sufficiently specific to build an isolated in-memory translator prototype and fixtures: endpoint selection, mandatory incremental SSE, open header/body behavior, tool-result ID ordering, error shapes, usage, and optional token counting are documented. The real loopback evidence proves the current CLI's basic downstream Messages/SSE and tool-result behavior, but it also proves that a strict non-Anthropic translator sees current default fields with no safe mapping yet.
+
+The decision is **scoped PARTIAL**, not GO. Anthropic does not officially support Claude Code routed to non-Claude models, and current Claude Code defaults require explicit capability decisions for adaptive thinking, effort output configuration, cache-control-bearing blocks, Anthropic beta/header pairs, and count tokens. No production `/v1/messages` route, client auto-configuration, or handler integration is warranted.
+
+Before any production route consideration, a follow-up must select and test an explicit policy for every rejected field, verify the chosen policy against a real official Codex/OpenAI route and a real Chat Completions Provider with approved credentials, prove error/retry behavior without wrapping upstream wording, and repeat the trace against the pinned/upgraded Claude Code version. The canonical representation/version-policy ADR added by this Spike applies only to that later implementation seam. This Issue remains strictly downstream Claude Code Messages compatibility and does not cover ACP AgentProvider work.

--- a/docs/research/2026-07-12-claude-code-external-client-support.md
+++ b/docs/research/2026-07-12-claude-code-external-client-support.md
@@ -211,7 +211,7 @@ These are conservative translator classifications, not claims that the Issue #74
 | Text request and stateless multi-turn history | Adapted | Preserve ordered history and content blocks; Responses/Chat role models differ. Live history equivalence remains to be tested. |
 | Anthropic-compatible Messages pass-through | Preserved | Forward required Anthropic headers and body fields unchanged; do not reshape the system array. |
 | Text SSE | Adapted | Emit the named Messages SSE lifecycle incrementally; no buffered terminal-only response. |
-| Usage | Adapted | Map only reported upstream usage; keep unknown cache details absent/explicit. |
+| Usage | Adapted for base input/output counts; cache/reasoning details explicitly unsupported | Map only reported base counts and validate a redundant total when supplied. Reject cache/reasoning/provider-detail usage until a tested semantic mapping exists; do not collapse it into input/output totals. |
 | Client tool call and tool-result follow-up | Adapted | Maintain opaque tool IDs and strict follow-up ordering; validate a real read-file lifecycle. |
 | Server tools and server-side result blocks | Unknown | The public Messages protocol has behaviors not demonstrated by the initial client-tool fixture. |
 | Images | Unknown | Messages accepts image blocks and several source types; map only when the selected upstream/provider advertises a verified equivalent, otherwise return a precise unsupported result. |

--- a/docs/reviews/v0.3-agent-provider-roadmap.md
+++ b/docs/reviews/v0.3-agent-provider-roadmap.md
@@ -1,0 +1,147 @@
+# v0.3 AgentProvider / ACP Roadmap
+
+Date: 2026-07-09
+Updated: 2026-07-12 after Issue #74 Messages compatibility Spike
+
+## Purpose
+
+This roadmap separates two Claude Code relationships that have different
+interfaces, risks, ownership, and delivery gates:
+
+| Relationship | Direction | Product shape | Current decision |
+| --- | --- | --- | --- |
+| Claude Code as a Gateway client | Claude Code -> CodexHub -> model upstream | Anthropic Messages compatibility adapter | Scoped PARTIAL Spike only; no production route yet |
+| Claude Code as an agent runtime | CodexHub -> Claude Code / ACP process | AgentProvider, session, workspace, permissions, and event lifecycle | Separate v0.3 AgentProvider/ACP work; not changed by Issue #74 |
+
+Do not use the word “provider” alone when the direction is relevant. A
+downstream Claude Code client is not an `AgentProvider`, and an `AgentProvider`
+is not a model-inference `ModelProvider`.
+
+## Existing AgentProvider decision
+
+Claude Code/ACP is not a normal `ModelProvider`. A model request is mostly
+stateless inference, while an agent runtime has a workspace, permission prompts,
+tool/process lifecycle, resumable state, diffs, and task-level telemetry.
+
+If CodexHub later supports ACP or a Claude Code agent runtime, it needs distinct
+domain objects:
+
+- `AgentProvider`: command, arguments, environment policy, workspace policy,
+  MCP configuration, authentication, permission policy, enabled state;
+- `AgentSession`: provider, workspace root, lifecycle status, timestamps,
+  capabilities, last event;
+- `AgentEvent`: messages, tool lifecycle, permission requests, diffs, terminal
+  output, completion/failure/cancellation, and optional usage.
+
+That work belongs behind a separate Agent Runtime seam and should not be forced
+into `src-tauri/src/gateway.rs`, Gateway request rows, `/v1/responses`, or
+`/v1/chat/completions`.
+
+## Downstream Messages clarification from Issue #74
+
+Issue #74 investigated only an external Claude Code client talking to a future
+CodexHub Gateway. The official Claude Code gateway contract selects Anthropic
+Messages with `ANTHROPIC_BASE_URL`; it requires incremental Messages SSE and
+uses open-set Anthropic/Claude Code headers and request fields.
+
+The isolated prototype established these limited points:
+
+- basic Messages text/history and client-tool IDs can adapt in memory to
+  Responses and Chat Completions shapes;
+- Responses and Chat Completions event fixtures can emit a valid Messages SSE
+  lifecycle with reported usage and an explicit error envelope;
+- a real local Claude Code 2.1.201 loopback smoke returned text, performed a
+  `Read` tool -> matching `tool_result` follow-up with a stable fixture ID, and
+  showed a downstream connection close after forced process termination;
+- the same real request included adaptive thinking, effort output configuration,
+  cache-control-bearing blocks, and open Anthropic beta/header fields that the
+  strict non-Anthropic translator correctly marked non-forwardable.
+
+The resulting decision is **scoped PARTIAL**, not a release gate. See
+[ADR-0001](../adr/0001-claude-messages-intermediate-representation.md) and
+[the evidence note](../research/2026-07-12-claude-code-external-client-support.md).
+
+## Architectural consequences
+
+Before any downstream Messages implementation, introduce a pure
+`AnthropicMessage` intermediate representation. It is a model-protocol seam,
+not an agent-session model. It owns ordered content blocks, tool IDs, header
+classification, explicit adaptations, and non-forwardable outcomes. It must not
+be hidden inside the existing Gateway HTTP handler.
+
+The downstream path may eventually look like this:
+
+```mermaid
+flowchart LR
+  ClaudeCode["Claude Code\n(downstream client)"] --> Messages["Future Messages adapter\nAnthropicMessage seam"]
+  Messages --> Responses["CodexHub Responses route\n(existing upstream family)"]
+  Messages --> Chat["CodexHub Chat Completions route\n(existing upstream family)"]
+  Responses --> ModelUpstream["Model upstream"]
+  Chat --> ModelUpstream
+```
+
+The separate upstream-agent path remains:
+
+```mermaid
+flowchart LR
+  UI["CodexHub UI"] --> Registry["Provider registry split"]
+  Registry --> ModelProviders["ModelProviders"]
+  Registry --> AgentProviders["AgentProviders"]
+  AgentProviders --> AgentRuntime["Agent Runtime\nsession + permissions + workspace"]
+  AgentRuntime --> ACP["ACP client adapter\nJSON-RPC stdio first"]
+  ACP --> ClaudeAgent["Claude Code / Claude Agent ACP"]
+```
+
+Neither diagram authorizes the other path.
+
+## Sequencing
+
+```text
+Issue #74 protocol Spike (scoped PARTIAL)
+  -> future Messages field-policy and real-upstream validation
+  -> optional production Messages adapter
+  -> optional Claude Code client configuration UI
+
+Separate AgentProvider / ACP design and implementation
+  -> Agent Runtime with session + permission semantics
+  -> local ACP smoke
+  -> optional Agent Gateway, never implicit model Gateway reuse
+```
+
+The downstream track must not wait for ACP work merely because both mention
+Claude Code. Conversely, it must not introduce `AgentProvider`, ACP, workspace
+permissions, or agent telemetry as a shortcut around Messages compatibility.
+
+## Required gates before either path advances
+
+### Future downstream Messages route
+
+1. Decide, document, and test an explicit policy for every current strict
+   rejection: thinking, output effort, cache controls, beta/body pairs, headers,
+   image/provider capability, count tokens, retries, and cancellation.
+2. Validate against an approved real official Codex/OpenAI route and a real Chat
+   Completions Provider; fixture-shape tests are insufficient.
+3. Preserve or reject new open-set fields with a named outcome. Never silently
+   strip only a header or only its paired body field.
+4. Keep a real pinned Claude Code text/tool/history/cancellation trace sanitized
+   and repeat it on CLI upgrades.
+5. Add the production route only after these gates are accepted in a follow-up
+   issue. Client auto-configuration follows the route, not the reverse.
+
+### Separate AgentProvider / ACP work
+
+1. Create the provider registry split and Agent Runtime seam.
+2. Prove local stdio startup, session creation, permission events, cancellation,
+   and safe workspace policy in a standalone harness.
+3. Keep agent task telemetry separate from Gateway model-request telemetry.
+4. Consider an Agent Gateway only after real agent-session clients require it.
+
+## Explicit non-goals
+
+This roadmap update does not implement or authorize:
+
+- `POST /v1/messages` or `/v1/messages/count_tokens` in the production Gateway;
+- changes to `codex_proxy.py` route handling;
+- Claude Code launcher, config writer, or model-discovery UI;
+- AgentProvider/ACP work tracked separately, including Issue #85;
+- treating a Claude Code subscription as an upstream provider credential.

--- a/docs/reviews/v0.3-agent-provider-roadmap.md
+++ b/docs/reviews/v0.3-agent-provider-roadmap.md
@@ -49,7 +49,8 @@ The isolated prototype established these limited points:
 - basic Messages text/history and client-tool IDs can adapt in memory to
   Responses and Chat Completions shapes;
 - Responses and Chat Completions event fixtures can emit a valid Messages SSE
-  lifecycle with reported usage and an explicit error envelope;
+  lifecycle with reported base usage, explicit rejection of unmapped
+  cache/reasoning usage detail, and an explicit error envelope;
 - a real local Claude Code 2.1.201 loopback smoke returned text, performed a
   `Read` tool -> matching `tool_result` follow-up with a stable fixture ID, and
   showed a downstream connection close after forced process termination;

--- a/scripts/run_claude_messages_spike_smoke.py
+++ b/scripts/run_claude_messages_spike_smoke.py
@@ -1,0 +1,494 @@
+"""Run a credential-free Claude Code -> in-memory Messages prototype smoke.
+
+The harness is intentionally outside the Gateway handler.  It starts a local
+loopback-only server, accepts a throwaway fixture credential, converts synthetic
+Responses events through the Issue #74 prototype, and persists only a
+structural/sanitized trace.  It never reads or writes a real provider credential.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import platform
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, Mapping
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "src-python"))
+
+from anthropic_messages_spike import (  # noqa: E402
+    classify_claude_headers,
+    messages_to_responses,
+    responses_events_to_messages_sse,
+)
+
+
+FIXTURE_TOOL_ID = "toolu_smoke_read_001"
+
+
+def _text_response_events(text: str) -> list[dict[str, Any]]:
+    return [
+        {"type": "response.created", "response": {"id": "resp_smoke_text", "model": "fixture-model"}},
+        {
+            "type": "response.output_item.added",
+            "output_index": 0,
+            "item": {"id": "msg_smoke_text", "type": "message", "role": "assistant", "content": []},
+        },
+        {"type": "response.output_text.delta", "output_index": 0, "delta": text},
+        {
+            "type": "response.output_item.done",
+            "output_index": 0,
+            "item": {"id": "msg_smoke_text", "type": "message", "role": "assistant", "content": []},
+        },
+        {
+            "type": "response.completed",
+            "response": {
+                "id": "resp_smoke_text",
+                "model": "fixture-model",
+                "usage": {"input_tokens": 11, "output_tokens": 2},
+            },
+        },
+    ]
+
+
+def _tool_response_events() -> list[dict[str, Any]]:
+    return [
+        {"type": "response.created", "response": {"id": "resp_smoke_tool", "model": "fixture-model"}},
+        {
+            "type": "response.output_item.added",
+            "output_index": 0,
+            "item": {
+                "id": "fc_smoke_read",
+                "type": "function_call",
+                "call_id": FIXTURE_TOOL_ID,
+                "name": "Read",
+                "arguments": "",
+            },
+        },
+        {
+            "type": "response.function_call_arguments.delta",
+            "output_index": 0,
+            "delta": '{"file_path":"fixture.txt"}',
+        },
+        {
+            "type": "response.output_item.done",
+            "output_index": 0,
+            "item": {
+                "id": "fc_smoke_read",
+                "type": "function_call",
+                "call_id": FIXTURE_TOOL_ID,
+                "name": "Read",
+            },
+        },
+        {
+            "type": "response.completed",
+            "response": {
+                "id": "resp_smoke_tool",
+                "model": "fixture-model",
+                "usage": {"input_tokens": 13, "output_tokens": 3},
+            },
+        },
+    ]
+
+
+def _content_block_types(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return ["text"]
+    if not isinstance(value, list):
+        return ["<invalid>"]
+    return [str(item.get("type", "<missing>")) for item in value if isinstance(item, Mapping)]
+
+
+def _shape(value: Any, *, depth: int = 0) -> Any:
+    """Return key/type structure only; never retain a request value."""
+
+    if depth >= 2:
+        return "<nested>"
+    if isinstance(value, Mapping):
+        return {"keys": sorted(str(key) for key in value)}
+    if isinstance(value, list):
+        return [_shape(item, depth=depth + 1) for item in value]
+    if isinstance(value, str):
+        return "<string>"
+    if isinstance(value, bool):
+        return "<boolean>"
+    if isinstance(value, int | float):
+        return "<number>"
+    if value is None:
+        return "<null>"
+    return f"<{type(value).__name__}>"
+
+
+class SmokeScenario:
+    def __init__(self, kind: str) -> None:
+        self.kind = kind
+        self.request_received = threading.Event()
+        self.stream_started = threading.Event()
+        self.complete = threading.Event()
+        self.request_summaries: list[dict[str, Any]] = []
+        self._step = 0
+        self.tool_follow_up_verified = False
+        self.disconnect_observed = False
+        self.lock = threading.Lock()
+
+    def summarize_request(self, body: Mapping[str, Any], headers: Mapping[str, str], path: str) -> None:
+        policy = classify_claude_headers(headers, upstream_format="responses")
+        messages = body.get("messages")
+        message_summaries: list[dict[str, Any]] = []
+        tool_result_ids: list[str] = []
+        tool_result_is_first_content_block = False
+        if isinstance(messages, list):
+            for item in messages:
+                if not isinstance(item, Mapping):
+                    continue
+                content = item.get("content")
+                message_summaries.append(
+                    {
+                        "role": item.get("role") if isinstance(item.get("role"), str) else "<invalid>",
+                        "content_block_types": _content_block_types(content),
+                    }
+                )
+                if isinstance(content, list):
+                    if (
+                        item.get("role") == "user"
+                        and content
+                        and isinstance(content[0], Mapping)
+                        and content[0].get("type") == "tool_result"
+                    ):
+                        tool_result_is_first_content_block = True
+                    tool_result_ids.extend(
+                        str(block.get("tool_use_id"))
+                        for block in content
+                        if isinstance(block, Mapping)
+                        and block.get("type") == "tool_result"
+                        and isinstance(block.get("tool_use_id"), str)
+                    )
+        translated = messages_to_responses(body)
+        summary = {
+            "path": path.split("?", 1)[0],
+            "header_policy": {
+                "consumed": list(policy.consumed),
+                "unsupported": list(policy.unsupported),
+                "sanitized": policy.sanitized,
+            },
+            "request_keys": sorted(str(key) for key in body),
+            "selected_field_shapes": {
+                key: _shape(body[key])
+                for key in ("metadata", "thinking", "output_config", "system", "tools")
+                if key in body
+            },
+            "message_history": message_summaries,
+            "messages_to_responses_forwardable": translated.forwardable,
+            "messages_to_responses_unsupported": list(translated.unsupported),
+            "contains_expected_tool_result": FIXTURE_TOOL_ID in tool_result_ids,
+            "tool_result_is_first_content_block": tool_result_is_first_content_block,
+        }
+        with self.lock:
+            self.request_summaries.append(summary)
+            if FIXTURE_TOOL_ID in tool_result_ids:
+                self.tool_follow_up_verified = True
+
+    def response_records(self) -> tuple[bytes, ...]:
+        with self.lock:
+            step = self._step
+            self._step += 1
+        if self.kind == "tool" and step == 0:
+            return responses_events_to_messages_sse(_tool_response_events())
+        if self.kind == "tool":
+            return responses_events_to_messages_sse(_text_response_events("SPIKE_TOOL_OK"))
+        if self.kind == "cancel":
+            return responses_events_to_messages_sse(_text_response_events("SPIKE_CANCEL_PENDING"))
+        return responses_events_to_messages_sse(_text_response_events("SPIKE_TEXT_OK"))
+
+
+def _make_handler(scenario: SmokeScenario):
+    class Handler(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def log_message(self, _format: str, *_args: object) -> None:
+            return
+
+        def do_HEAD(self) -> None:  # noqa: N802
+            self.send_response(200)
+            self.end_headers()
+
+        def do_GET(self) -> None:  # noqa: N802
+            self.send_response(404)
+            self.end_headers()
+
+        def do_POST(self) -> None:  # noqa: N802
+            if not self.path.startswith("/v1/messages"):
+                self.send_response(404)
+                self.end_headers()
+                return
+            content_length = int(self.headers.get("Content-Length", "0"))
+            raw = self.rfile.read(content_length)
+            try:
+                body = json.loads(raw.decode("utf-8"))
+            except (UnicodeDecodeError, json.JSONDecodeError):
+                self.send_response(400)
+                self.end_headers()
+                return
+            if not isinstance(body, Mapping):
+                self.send_response(400)
+                self.end_headers()
+                return
+            scenario.summarize_request(body, {name: value for name, value in self.headers.items()}, self.path)
+            scenario.request_received.set()
+            records = scenario.response_records()
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream; charset=utf-8")
+            self.send_header("Cache-Control", "no-cache")
+            self.send_header("Connection", "close")
+            self.end_headers()
+            try:
+                for index, record in enumerate(records):
+                    self.wfile.write(record)
+                    self.wfile.flush()
+                    if scenario.kind == "cancel" and index == 2:
+                        scenario.stream_started.set()
+                        time.sleep(2)
+            except (BrokenPipeError, ConnectionResetError):
+                scenario.disconnect_observed = True
+            finally:
+                scenario.complete.set()
+
+    return Handler
+
+
+def _safe_environment(base_url: str, config_dir: Path) -> dict[str, str]:
+    env = os.environ.copy()
+    for name in list(env):
+        if name.startswith("ANTHROPIC_") or name.startswith("CLAUDE_CODE_"):
+            env.pop(name, None)
+    env.update(
+        {
+            "ANTHROPIC_BASE_URL": base_url,
+            "ANTHROPIC_API_KEY": "fixture-only-gateway-credential",
+            "CLAUDE_CONFIG_DIR": str(config_dir),
+            "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1",
+            "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING": "1",
+            "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+            "CLAUDE_CODE_ATTRIBUTION_HEADER": "0",
+            "NO_PROXY": "127.0.0.1,localhost",
+            "no_proxy": "127.0.0.1,localhost",
+        }
+    )
+    return env
+
+
+def _command(cli: str, kind: str) -> tuple[list[str], str]:
+    if kind == "tool":
+        expected = "SPIKE_TOOL_OK"
+        prompt = "Use the Read tool on fixture.txt, then return the tool result."
+        return (
+            [
+                cli,
+                "--bare",
+                "--print",
+                prompt,
+                "--output-format",
+                "text",
+                "--no-session-persistence",
+                "--system-prompt",
+                "Protocol fixture client. Use only the requested fixture tool.",
+                "--model",
+                "sonnet",
+                "--tools",
+                "Read",
+                "--allow-dangerously-skip-permissions",
+                "--permission-mode",
+                "bypassPermissions",
+            ],
+            expected,
+        )
+    expected = "SPIKE_TEXT_OK"
+    prompt = "Return exactly SPIKE_TEXT_OK."
+    return (
+        [
+            cli,
+            "--bare",
+            "--print",
+            prompt,
+            "--output-format",
+            "text",
+            "--no-session-persistence",
+            "--system-prompt",
+            "Protocol fixture client. Return only the requested marker.",
+            "--model",
+            "sonnet",
+            "--tools",
+            "",
+        ],
+        expected,
+    )
+
+
+def _run_scenario(cli: str, kind: str) -> dict[str, Any]:
+    scenario = SmokeScenario(kind)
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _make_handler(scenario))
+    server.daemon_threads = True
+    server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+    server_thread.start()
+    try:
+        with tempfile.TemporaryDirectory(prefix="codexhub-claude-spike-") as temporary:
+            temporary_path = Path(temporary)
+            (temporary_path / "fixture.txt").write_text("SPIKE_FIXTURE_FILE", encoding="utf-8")
+            command, expected = _command(cli, kind)
+            environment = _safe_environment(f"http://127.0.0.1:{server.server_port}", temporary_path / "config")
+            if kind == "cancel":
+                process = subprocess.Popen(
+                    command,
+                    cwd=temporary_path,
+                    env=environment,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                )
+                stream_started = scenario.stream_started.wait(timeout=30)
+                if stream_started:
+                    process.terminate()
+                else:
+                    process.kill()
+                try:
+                    stdout, stderr = process.communicate(timeout=20)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    stdout, stderr = process.communicate(timeout=10)
+                scenario.complete.wait(timeout=5)
+                client = {
+                    "returncode": process.returncode,
+                    "expected_output_seen": expected in stdout,
+                    "stdout_length": len(stdout),
+                    "stderr_length": len(stderr),
+                    "forced_process_termination": True,
+                }
+            else:
+                completed = subprocess.run(
+                    command,
+                    cwd=temporary_path,
+                    env=environment,
+                    capture_output=True,
+                    text=True,
+                    timeout=60,
+                )
+                client = {
+                    "returncode": completed.returncode,
+                    "expected_output_seen": expected in completed.stdout,
+                    "stdout_length": len(completed.stdout),
+                    "stderr_length": len(completed.stderr),
+                }
+        translation_forwardable = all(
+            item["messages_to_responses_forwardable"] for item in scenario.request_summaries
+        )
+        if kind == "tool":
+            passed = (
+                client["returncode"] == 0
+                and client["expected_output_seen"]
+                and scenario.tool_follow_up_verified
+                and translation_forwardable
+            )
+        elif kind == "cancel":
+            passed = scenario.stream_started.is_set() and scenario.disconnect_observed
+        else:
+            passed = client["returncode"] == 0 and client["expected_output_seen"] and translation_forwardable
+        return {
+            "scenario": kind,
+            "passed": passed,
+            "client": client,
+            "request_summaries": scenario.request_summaries,
+            "tool_follow_up_verified": scenario.tool_follow_up_verified,
+            "stream_started": scenario.stream_started.is_set(),
+            "disconnect_observed": scenario.disconnect_observed,
+        }
+    except (OSError, subprocess.SubprocessError) as exc:
+        return {"scenario": kind, "passed": False, "blocker": type(exc).__name__}
+    finally:
+        server.shutdown()
+        server.server_close()
+        server_thread.join(timeout=2)
+
+
+def _version(command: list[str]) -> str | None:
+    try:
+        completed = subprocess.run(command, capture_output=True, text=True, timeout=15)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    version = completed.stdout.strip()
+    return version if completed.returncode == 0 and version else None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cli", default="claude", help="Claude Code executable name or path")
+    parser.add_argument(
+        "--scenarios",
+        choices=("text", "tool", "cancel", "all"),
+        default="all",
+        help="Which safe local-loopback smoke scenarios to run",
+    )
+    parser.add_argument(
+        "--write-trace",
+        type=Path,
+        default=REPO_ROOT / "tests" / "fixtures" / "claude_messages_real_cli_smoke.json",
+        help="Where to write the sanitized structural result",
+    )
+    parser.add_argument(
+        "--require-full",
+        action="store_true",
+        help="Exit nonzero when the captured evidence is scoped PARTIAL rather than fully forwardable",
+    )
+    args = parser.parse_args()
+    cli_version = _version([args.cli, "--version"])
+    node_version = _version(["node", "--version"])
+    scenarios = ("text", "tool", "cancel") if args.scenarios == "all" else (args.scenarios,)
+    results = [_run_scenario(args.cli, scenario) for scenario in scenarios]
+    capture_succeeded = all(
+        isinstance(item.get("request_summaries"), list) and bool(item["request_summaries"])
+        for item in results
+    )
+    full_compatibility = all(item.get("passed") for item in results)
+    trace = {
+        "fixture_schema": "codexhub-claude-messages-real-smoke/v1",
+        "sanitized": True,
+        "capture_kind": "real_cli_to_local_loopback_prototype",
+        "local_cli_version": cli_version,
+        "node_version": node_version,
+        "platform": platform.system(),
+        "capture_succeeded": capture_succeeded,
+        "full_compatibility": full_compatibility,
+        "compatibility_outcome": "GO" if full_compatibility else "scoped PARTIAL",
+        "scenarios": results,
+        "cancellation_interpretation": (
+            "Forced process termination is an attempted downstream disconnect only; "
+            "it does not prove Ctrl+C/Escape wire semantics."
+        ),
+    }
+    args.write_trace.parent.mkdir(parents=True, exist_ok=True)
+    args.write_trace.write_text(json.dumps(trace, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+    print(
+        json.dumps(
+            {
+                "written": args.write_trace.name,
+                "capture_succeeded": capture_succeeded,
+                "full_compatibility": full_compatibility,
+            },
+            indent=2,
+        )
+    )
+    if not capture_succeeded:
+        return 1
+    return 0 if full_compatibility or not args.require_full else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src-python/anthropic_messages_spike.py
+++ b/src-python/anthropic_messages_spike.py
@@ -1015,6 +1015,12 @@ def _chat_usage_to_responses_usage(value: Any) -> dict[str, int]:
     return usage
 
 
+def _reject_unsupported_chat_fields(value: Mapping[str, Any], allowed: set[str], scope: str) -> None:
+    unsupported_fields = sorted(str(field) for field in set(value).difference(allowed))
+    if unsupported_fields:
+        raise ValueError(f"Unsupported Chat Completions {scope} field: {unsupported_fields[0]}")
+
+
 def _chat_chunks_to_responses_events(chunks: list[Mapping[str, Any]]) -> list[dict[str, Any]]:
     if not chunks:
         raise ValueError("Chat Completions stream is empty")
@@ -1022,21 +1028,42 @@ def _chat_chunks_to_responses_events(chunks: list[Mapping[str, Any]]) -> list[di
     events: list[dict[str, Any]] = []
     response_id = "resp_chat_spike"
     model = "unknown"
+    established_chunk_id: str | None = None
+    established_chunk_model: str | None = None
     created = False
     next_output_index = 0
     text_output_index: int | None = None
     tool_states: dict[int, dict[str, Any]] = {}
+    tool_id_indexes: dict[str, int] = {}
     terminal = False
     latest_usage: dict[str, int] | None = None
 
     for chunk in chunks:
         if not isinstance(chunk, Mapping):
             raise ValueError("Chat Completions stream chunk is not an object")
+        _reject_unsupported_chat_fields(
+            chunk,
+            {"id", "model", "choices", "usage", "service_tier", "system_fingerprint"},
+            "chunk",
+        )
+        for nullable_field in ("service_tier", "system_fingerprint"):
+            if chunk.get(nullable_field) is not None:
+                raise ValueError(f"Unsupported Chat Completions chunk field: {nullable_field}")
         chunk_id = chunk.get("id")
         chunk_model = chunk.get("model")
-        if isinstance(chunk_id, str) and chunk_id:
+        if "id" in chunk and (not isinstance(chunk_id, str) or not chunk_id):
+            raise ValueError("Chat Completions chunk id is not a non-empty string")
+        if "model" in chunk and (not isinstance(chunk_model, str) or not chunk_model):
+            raise ValueError("Chat Completions chunk model is not a non-empty string")
+        if isinstance(chunk_id, str):
+            if established_chunk_id is not None and chunk_id != established_chunk_id:
+                raise ValueError("Chat Completions chunk id changed during stream")
+            established_chunk_id = chunk_id
             response_id = chunk_id
-        if isinstance(chunk_model, str) and chunk_model:
+        if isinstance(chunk_model, str):
+            if established_chunk_model is not None and chunk_model != established_chunk_model:
+                raise ValueError("Chat Completions chunk model changed during stream")
+            established_chunk_model = chunk_model
             model = chunk_model
         if not created:
             events.append(
@@ -1048,20 +1075,46 @@ def _chat_chunks_to_responses_events(chunks: list[Mapping[str, Any]]) -> list[di
             created = True
         if "usage" in chunk:
             latest_usage = _chat_usage_to_responses_usage(chunk.get("usage"))
-        choices = chunk.get("choices")
-        if not isinstance(choices, list):
+        if "choices" not in chunk:
             continue
+        choices = chunk["choices"]
+        if not isinstance(choices, list):
+            raise ValueError("Chat Completions choices is not a list")
+        if len(choices) > 1:
+            raise ValueError("Multiple Chat Completions choices are unsupported")
         for choice in choices:
             if not isinstance(choice, Mapping):
-                continue
-            delta = choice.get("delta")
-            if not isinstance(delta, Mapping):
+                raise ValueError("Chat Completions choice is not an object")
+            _reject_unsupported_chat_fields(choice, {"index", "delta", "finish_reason", "logprobs"}, "choice")
+            if choice.get("logprobs") is not None:
+                raise ValueError("Unsupported Chat Completions choice field: logprobs")
+            choice_index = choice.get("index")
+            if "index" in choice and (
+                isinstance(choice_index, bool) or not isinstance(choice_index, int) or choice_index < 0
+            ):
+                raise ValueError("Chat Completions choice index is not a non-negative integer")
+            if isinstance(choice_index, int) and choice_index != 0:
+                raise ValueError(f"Unsupported Chat Completions choice index: {choice_index}")
+            if "delta" not in choice:
                 delta = {}
-            unsupported_delta_fields = set(delta).difference({"role", "content", "tool_calls"})
-            if unsupported_delta_fields:
-                field = sorted(str(name) for name in unsupported_delta_fields)[0]
-                raise ValueError(f"Unsupported Chat Completions delta field: {field}")
+            else:
+                delta = choice["delta"]
+                if not isinstance(delta, Mapping):
+                    raise ValueError("Chat Completions delta is not an object")
+            _reject_unsupported_chat_fields(
+                delta,
+                {"role", "content", "tool_calls", "function_call", "refusal"},
+                "delta",
+            )
+            for nullable_field in ("function_call", "refusal"):
+                if delta.get(nullable_field) is not None:
+                    raise ValueError(f"Unsupported Chat Completions delta field: {nullable_field}")
+            role = delta.get("role")
+            if "role" in delta and role is not None and role != "assistant":
+                raise ValueError("Chat Completions delta role is not assistant or null")
             content = delta.get("content")
+            if "content" in delta and content is not None and not isinstance(content, str):
+                raise ValueError("Chat Completions delta content is not a string or null")
             if isinstance(content, str) and content:
                 if text_output_index is None:
                     text_output_index = next_output_index
@@ -1086,22 +1139,51 @@ def _chat_chunks_to_responses_events(chunks: list[Mapping[str, Any]]) -> list[di
                     }
                 )
             raw_tool_calls = delta.get("tool_calls")
+            if "tool_calls" in delta and raw_tool_calls is not None and not isinstance(raw_tool_calls, list):
+                raise ValueError("Chat Completions delta tool_calls is not a list or null")
             if isinstance(raw_tool_calls, list):
                 for fallback_index, raw_call in enumerate(raw_tool_calls):
                     if not isinstance(raw_call, Mapping):
                         raise ValueError("Chat Completions tool call is not an object")
-                    tool_index = raw_call.get("index")
-                    if not isinstance(tool_index, int):
+                    _reject_unsupported_chat_fields(
+                        raw_call,
+                        {"index", "id", "type", "function"},
+                        "tool call",
+                    )
+                    if "index" not in raw_call:
                         tool_index = fallback_index
+                    else:
+                        tool_index = raw_call["index"]
+                        if isinstance(tool_index, bool) or not isinstance(tool_index, int) or tool_index < 0:
+                            raise ValueError("Chat Completions tool call index is not a non-negative integer")
+                    call_type = raw_call.get("type")
+                    if "type" in raw_call and call_type is not None and call_type != "function":
+                        raise ValueError("Chat Completions tool call type is not function or null")
                     function = raw_call.get("function")
                     if not isinstance(function, Mapping):
                         raise ValueError("Chat Completions tool call has no function")
+                    _reject_unsupported_chat_fields(function, {"name", "arguments"}, "function")
+                    arguments = function.get("arguments")
+                    if "arguments" in function and arguments is not None and not isinstance(arguments, str):
+                        raise ValueError("Chat Completions function arguments is not a string or null")
+                    call_id = raw_call.get("id")
+                    if "id" in raw_call and call_id is not None and (
+                        not isinstance(call_id, str) or not call_id
+                    ):
+                        raise ValueError("Chat Completions tool call id is not a non-empty string or null")
+                    name = function.get("name")
+                    if "name" in function and name is not None and (not isinstance(name, str) or not name):
+                        raise ValueError("Chat Completions function name is not a non-empty string or null")
                     state = tool_states.get(tool_index)
                     if state is None:
-                        call_id = raw_call.get("id")
-                        name = function.get("name")
                         if not isinstance(call_id, str) or not call_id or not isinstance(name, str) or not name:
                             raise ValueError("First Chat Completions tool delta needs id and function name")
+                        previous_index = tool_id_indexes.get(call_id)
+                        if previous_index is not None and previous_index != tool_index:
+                            raise ValueError(
+                                f"Chat Completions tool call id reused for indexes {previous_index} and {tool_index}"
+                            )
+                        tool_id_indexes[call_id] = tool_index
                         output_index = next_output_index
                         next_output_index += 1
                         state = {"output_index": output_index, "call_id": call_id, "name": name}
@@ -1119,7 +1201,11 @@ def _chat_chunks_to_responses_events(chunks: list[Mapping[str, Any]]) -> list[di
                                 },
                             }
                         )
-                    arguments = function.get("arguments")
+                    else:
+                        if call_id is not None and call_id != state["call_id"]:
+                            raise ValueError(f"Chat Completions tool call id changed for index {tool_index}")
+                        if name is not None and name != state["name"]:
+                            raise ValueError(f"Chat Completions function name changed for index {tool_index}")
                     if isinstance(arguments, str) and arguments:
                         events.append(
                             {
@@ -1128,7 +1214,12 @@ def _chat_chunks_to_responses_events(chunks: list[Mapping[str, Any]]) -> list[di
                                 "delta": arguments,
                             }
                         )
-            if choice.get("finish_reason") is not None:
+            finish_reason = choice.get("finish_reason")
+            if "finish_reason" in choice and finish_reason is not None and not isinstance(finish_reason, str):
+                raise ValueError("Chat Completions finish_reason is not a string or null")
+            if isinstance(finish_reason, str) and finish_reason not in {"stop", "tool_calls"}:
+                raise ValueError(f"Unsupported Chat Completions finish_reason: {finish_reason}")
+            if finish_reason is not None:
                 terminal = True
 
     if not terminal:

--- a/src-python/anthropic_messages_spike.py
+++ b/src-python/anthropic_messages_spike.py
@@ -220,26 +220,6 @@ def _text_input(block: Mapping[str, Any], field: str) -> tuple[dict[str, Any] | 
     return {"type": "input_text", "text": text}, None
 
 
-def _image_input(block: Mapping[str, Any], field: str) -> tuple[dict[str, Any] | None, str | None]:
-    source = block.get("source")
-    if not isinstance(source, Mapping):
-        return None, field
-    source_type = source.get("type")
-    if source_type == "url" and isinstance(source.get("url"), str):
-        image_url = source["url"]
-    elif (
-        source_type == "base64"
-        and isinstance(source.get("media_type"), str)
-        and isinstance(source.get("data"), str)
-    ):
-        image_url = f"data:{source['media_type']};base64,{source['data']}"
-    else:
-        return None, field
-    if set(block).difference({"type", "source"}):
-        return None, field
-    return {"type": "input_image", "image_url": image_url}, None
-
-
 def _tool_result_output(value: Any, field: str) -> tuple[str | None, str | None]:
     if isinstance(value, str):
         return value, None
@@ -273,11 +253,9 @@ def _messages_to_responses_input(
                     text_and_image.append(item)
                 continue
             if block_type == "image":
-                item, failure = _image_input(block, field)
-                if failure is not None:
-                    unsupported.append(failure)
-                elif item is not None:
-                    text_and_image.append(item)
+                # A syntactically valid data URL is not evidence that the
+                # selected upstream/provider accepts the same image contract.
+                unsupported.append(field)
                 continue
             if block_type == "tool_use" and message.role == "assistant":
                 call_id = block.get("id")
@@ -351,6 +329,46 @@ def _messages_to_responses_input(
                 }
             )
     return input_items, unsupported
+
+
+def _tool_history_failures(messages: tuple[AnthropicMessage, ...]) -> list[str]:
+    """Reject incomplete, reordered, or unmatched tool-call history."""
+
+    pending_tool_ids: dict[str, str] = {}
+    unsupported: list[str] = []
+    for message_index, message in enumerate(messages):
+        if pending_tool_ids and message.role != "user":
+            unsupported.extend(f"{field}.unresolved" for field in pending_tool_ids.values())
+            pending_tool_ids.clear()
+        seen_non_tool_result = False
+        for block_index, block in enumerate(message.content):
+            field = f"messages[{message_index}].content[{block_index}]"
+            block_type = block.get("type")
+            if message.role == "assistant" and block_type == "tool_use":
+                call_id = block.get("id")
+                if isinstance(call_id, str) and call_id:
+                    if call_id in pending_tool_ids:
+                        unsupported.append(f"{field}.id")
+                    else:
+                        pending_tool_ids[call_id] = field
+                continue
+            if message.role == "user" and block_type == "tool_result":
+                call_id = block.get("tool_use_id")
+                if seen_non_tool_result:
+                    unsupported.append(f"{field}.tool_result_order")
+                if not isinstance(call_id, str) or call_id not in pending_tool_ids:
+                    unsupported.append(f"{field}.tool_use_id")
+                else:
+                    pending_tool_ids.pop(call_id)
+                continue
+            if message.role == "user":
+                seen_non_tool_result = True
+        if message.role == "user" and pending_tool_ids:
+            unsupported.extend(f"{field}.unresolved" for field in pending_tool_ids.values())
+            pending_tool_ids.clear()
+    if pending_tool_ids:
+        unsupported.extend(f"{field}.unresolved" for field in pending_tool_ids.values())
+    return unsupported
 
 
 def _system_to_instructions(value: Any) -> tuple[str | None, list[str], list[str]]:
@@ -445,6 +463,7 @@ def messages_to_responses(request: Mapping[str, Any]) -> TranslationResult:
 
     messages, message_failures = _parse_messages(request.get("messages"))
     unsupported.extend(message_failures)
+    unsupported.extend(_tool_history_failures(messages))
     input_items, input_failures = _messages_to_responses_input(messages)
     unsupported.extend(input_failures)
 
@@ -508,8 +527,6 @@ def _responses_request_to_chat_completions_body(body: bytes) -> bytes:
                     raise ValueError("Responses message content is incomplete")
                 if part.get("type") == "input_text" and isinstance(part.get("text"), str):
                     chat_content.append({"type": "text", "text": part["text"]})
-                elif part.get("type") == "input_image" and isinstance(part.get("image_url"), str):
-                    chat_content.append({"type": "image_url", "image_url": {"url": part["image_url"]}})
                 else:
                     raise ValueError("Responses message content has no Chat Completions equivalent")
             if len(chat_content) == 1 and chat_content[0]["type"] == "text":
@@ -633,15 +650,45 @@ def upstream_error_to_messages_sse(
     )
 
 
+def _usage_count(value: Mapping[str, Any], field: str, source: str) -> int | None:
+    if field not in value:
+        return None
+    count = value[field]
+    if not isinstance(count, int) or isinstance(count, bool) or count < 0:
+        raise ValueError(f"{source} usage field {field} is not a non-negative integer")
+    return count
+
+
+def _validate_usage_total(
+    value: Mapping[str, Any],
+    input_tokens: int | None,
+    output_tokens: int | None,
+    source: str,
+) -> None:
+    total_tokens = _usage_count(value, "total_tokens", source)
+    if total_tokens is None:
+        return
+    if input_tokens is None or output_tokens is None or total_tokens != input_tokens + output_tokens:
+        raise ValueError(f"{source} total_tokens cannot be represented from input/output tokens")
+
+
 def _anthropic_usage(value: Any) -> dict[str, int]:
+    if value is None:
+        return {}
     if not isinstance(value, Mapping):
-        return {"input_tokens": 0, "output_tokens": 0}
-    input_tokens = value.get("input_tokens")
-    output_tokens = value.get("output_tokens")
-    return {
-        "input_tokens": input_tokens if isinstance(input_tokens, int) else 0,
-        "output_tokens": output_tokens if isinstance(output_tokens, int) else 0,
-    }
+        raise ValueError("Responses usage is not an object")
+    unknown_fields = sorted(str(field) for field in set(value).difference({"input_tokens", "output_tokens", "total_tokens"}))
+    if unknown_fields:
+        raise ValueError(f"Unsupported Responses usage field: {unknown_fields[0]}")
+    input_tokens = _usage_count(value, "input_tokens", "Responses")
+    output_tokens = _usage_count(value, "output_tokens", "Responses")
+    _validate_usage_total(value, input_tokens, output_tokens, "Responses")
+    usage: dict[str, int] = {}
+    if input_tokens is not None:
+        usage["input_tokens"] = input_tokens
+    if output_tokens is not None:
+        usage["output_tokens"] = output_tokens
+    return usage
 
 
 def responses_events_to_messages_sse(events: list[Mapping[str, Any]]) -> tuple[bytes, ...]:
@@ -657,7 +704,7 @@ def responses_events_to_messages_sse(events: list[Mapping[str, Any]]) -> tuple[b
     model = "unknown"
     started = False
     next_block_index = 0
-    active_blocks: dict[int, tuple[int, str]] = {}
+    active_blocks: dict[int, dict[str, Any]] = {}
     active_item_ids: dict[str, int] = {}
     emitted_tool_use = False
     terminal = False
@@ -698,12 +745,62 @@ def responses_events_to_messages_sse(events: list[Mapping[str, Any]]) -> tuple[b
                         "content": [],
                         "stop_reason": None,
                         "stop_sequence": None,
-                        "usage": {"input_tokens": 0, "output_tokens": 0},
+                        "usage": _anthropic_usage(response.get("usage")),
                     },
                 },
             )
         )
         started = True
+
+    def emit_tool_argument_delta(active: Mapping[str, Any], value: str) -> None:
+        records.append(
+            _sse_record(
+                "content_block_delta",
+                {
+                    "type": "content_block_delta",
+                    "index": active["index"],
+                    "delta": {"type": "input_json_delta", "partial_json": value},
+                },
+            )
+        )
+
+    def emit_text_delta(active: Mapping[str, Any], value: str) -> None:
+        records.append(
+            _sse_record(
+                "content_block_delta",
+                {
+                    "type": "content_block_delta",
+                    "index": active["index"],
+                    "delta": {"type": "text_delta", "text": value},
+                },
+            )
+        )
+
+    def validate_text_snapshot(active: dict[str, Any], snapshot: Any) -> None:
+        if not isinstance(snapshot, str):
+            raise ValueError("Responses output text snapshot is missing")
+        streamed_text = "".join(active["text"])
+        if streamed_text and streamed_text != snapshot:
+            raise ValueError("Responses text deltas do not match final text")
+        if not streamed_text:
+            active["text"].append(snapshot)
+            emit_text_delta(active, snapshot)
+
+    def validate_tool_arguments(active: dict[str, Any], fallback: Any = None) -> None:
+        arguments = "".join(active["arguments"])
+        if isinstance(fallback, str):
+            if arguments and arguments != fallback:
+                raise ValueError("Responses tool argument deltas do not match final arguments")
+            if not arguments:
+                arguments = fallback
+                active["arguments"].append(fallback)
+                emit_tool_argument_delta(active, fallback)
+        try:
+            parsed = json.loads(arguments)
+        except (TypeError, json.JSONDecodeError) as exc:
+            raise ValueError("Responses tool arguments must be a JSON object") from exc
+        if not isinstance(parsed, Mapping):
+            raise ValueError("Responses tool arguments must be a JSON object")
 
     for event in events:
         if not isinstance(event, Mapping):
@@ -720,8 +817,6 @@ def responses_events_to_messages_sse(events: list[Mapping[str, Any]]) -> tuple[b
         if event_type in {
             "response.in_progress",
             "response.content_part.added",
-            "response.output_text.done",
-            "response.function_call_arguments.done",
         }:
             # These confirmed upstream transitions are represented by the
             # Messages start/delta/stop events emitted around their item.
@@ -750,7 +845,12 @@ def responses_events_to_messages_sse(events: list[Mapping[str, Any]]) -> tuple[b
                 raise ValueError(f"Unsupported Responses output item type: {item_type}")
             block_index = next_block_index
             next_block_index += 1
-            active_blocks[output_index] = (block_index, block_kind)
+            active: dict[str, Any] = {"index": block_index, "kind": block_kind}
+            if block_kind == "text":
+                active["text"] = []
+            elif block_kind == "tool_use":
+                active["arguments"] = []
+            active_blocks[output_index] = active
             item_id = item.get("id")
             if isinstance(item_id, str) and item_id:
                 active_item_ids[item_id] = output_index
@@ -760,6 +860,10 @@ def responses_events_to_messages_sse(events: list[Mapping[str, Any]]) -> tuple[b
                     {"type": "content_block_start", "index": block_index, "content_block": block},
                 )
             )
+            initial_arguments = item.get("arguments")
+            if block_kind == "tool_use" and isinstance(initial_arguments, str) and initial_arguments:
+                active["arguments"].append(initial_arguments)
+                emit_tool_argument_delta(active, initial_arguments)
             continue
         if event_type in {"response.output_text.delta", "response.function_call_arguments.delta"}:
             output_index = event.get("output_index")
@@ -770,44 +874,80 @@ def responses_events_to_messages_sse(events: list[Mapping[str, Any]]) -> tuple[b
             delta = event.get("delta")
             if active is None or not isinstance(delta, str):
                 raise ValueError("Responses delta has no active compatible content block")
-            block_index, block_kind = active
-            if event_type == "response.output_text.delta" and block_kind == "text":
+            if event_type == "response.output_text.delta" and active["kind"] == "text":
+                active["text"].append(delta)
                 downstream_delta = {"type": "text_delta", "text": delta}
-            elif event_type == "response.function_call_arguments.delta" and block_kind == "tool_use":
+            elif event_type == "response.function_call_arguments.delta" and active["kind"] == "tool_use":
+                active["arguments"].append(delta)
                 downstream_delta = {"type": "input_json_delta", "partial_json": delta}
             else:
                 raise ValueError("Responses delta does not match its active content block")
             records.append(
                 _sse_record(
                     "content_block_delta",
-                    {"type": "content_block_delta", "index": block_index, "delta": downstream_delta},
+                    {"type": "content_block_delta", "index": active["index"], "delta": downstream_delta},
                 )
             )
             continue
-        if event_type == "response.output_item.done":
+        if event_type == "response.output_text.done":
             output_index = event.get("output_index")
             if not isinstance(output_index, int):
-                item = event.get("item")
+                item_id = event.get("item_id")
+                output_index = active_item_ids.get(item_id) if isinstance(item_id, str) else None
+            active = active_blocks.get(output_index) if isinstance(output_index, int) else None
+            if active is None or active["kind"] != "text":
+                raise ValueError("Responses output text has no active text block")
+            validate_text_snapshot(active, event.get("text"))
+            continue
+        if event_type == "response.function_call_arguments.done":
+            output_index = event.get("output_index")
+            if not isinstance(output_index, int):
+                item_id = event.get("item_id")
+                output_index = active_item_ids.get(item_id) if isinstance(item_id, str) else None
+            active = active_blocks.get(output_index) if isinstance(output_index, int) else None
+            if active is None or active["kind"] != "tool_use":
+                raise ValueError("Responses function call arguments have no active tool block")
+            arguments = event.get("arguments")
+            if not isinstance(arguments, str):
+                raise ValueError("Responses function call arguments are missing")
+            streamed_arguments = "".join(active["arguments"])
+            if streamed_arguments and streamed_arguments != arguments:
+                raise ValueError("Responses tool argument deltas do not match final arguments")
+            if not streamed_arguments:
+                active["arguments"].append(arguments)
+                emit_tool_argument_delta(active, arguments)
+            validate_tool_arguments(active)
+            continue
+        if event_type == "response.output_item.done":
+            output_index = event.get("output_index")
+            item = event.get("item")
+            if not isinstance(output_index, int):
                 item_id = item.get("id") if isinstance(item, Mapping) else None
                 output_index = active_item_ids.get(item_id) if isinstance(item_id, str) else None
-            active = active_blocks.pop(output_index, None) if isinstance(output_index, int) else None
+            active = active_blocks.get(output_index) if isinstance(output_index, int) else None
             if active is None:
                 raise ValueError("Responses output item stop has no active content block")
+            if active["kind"] == "tool_use":
+                fallback = item.get("arguments") if isinstance(item, Mapping) else None
+                validate_tool_arguments(active, fallback)
+            active_blocks.pop(output_index)
             records.append(
                 _sse_record(
                     "content_block_stop",
-                    {"type": "content_block_stop", "index": active[0]},
+                    {"type": "content_block_stop", "index": active["index"]},
                 )
             )
             continue
         if event_type == "response.completed":
             response_payload = response if isinstance(response, Mapping) else {}
             start_message(response_payload)
-            for block_index, _block_kind in active_blocks.values():
+            for active in active_blocks.values():
+                if active["kind"] == "tool_use":
+                    validate_tool_arguments(active)
                 records.append(
                     _sse_record(
                         "content_block_stop",
-                        {"type": "content_block_stop", "index": block_index},
+                        {"type": "content_block_stop", "index": active["index"]},
                     )
                 )
             active_blocks.clear()
@@ -844,14 +984,35 @@ def responses_events_to_messages_sse(events: list[Mapping[str, Any]]) -> tuple[b
 
 
 def _chat_usage_to_responses_usage(value: Any) -> dict[str, int]:
+    if value is None:
+        return {}
     if not isinstance(value, Mapping):
-        return {"input_tokens": 0, "output_tokens": 0}
-    input_tokens = value.get("prompt_tokens", value.get("input_tokens", 0))
-    output_tokens = value.get("completion_tokens", value.get("output_tokens", 0))
-    return {
-        "input_tokens": input_tokens if isinstance(input_tokens, int) else 0,
-        "output_tokens": output_tokens if isinstance(output_tokens, int) else 0,
-    }
+        raise ValueError("Chat Completions usage is not an object")
+    unknown_fields = sorted(
+        str(field)
+        for field in set(value).difference(
+            {"prompt_tokens", "completion_tokens", "input_tokens", "output_tokens", "total_tokens"}
+        )
+    )
+    if unknown_fields:
+        raise ValueError(f"Unsupported Chat Completions usage field: {unknown_fields[0]}")
+    prompt_tokens = _usage_count(value, "prompt_tokens", "Chat Completions")
+    input_alias = _usage_count(value, "input_tokens", "Chat Completions")
+    completion_tokens = _usage_count(value, "completion_tokens", "Chat Completions")
+    output_alias = _usage_count(value, "output_tokens", "Chat Completions")
+    if prompt_tokens is not None and input_alias is not None and prompt_tokens != input_alias:
+        raise ValueError("Chat Completions input token aliases disagree")
+    if completion_tokens is not None and output_alias is not None and completion_tokens != output_alias:
+        raise ValueError("Chat Completions output token aliases disagree")
+    input_tokens = prompt_tokens if prompt_tokens is not None else input_alias
+    output_tokens = completion_tokens if completion_tokens is not None else output_alias
+    _validate_usage_total(value, input_tokens, output_tokens, "Chat Completions")
+    usage: dict[str, int] = {}
+    if input_tokens is not None:
+        usage["input_tokens"] = input_tokens
+    if output_tokens is not None:
+        usage["output_tokens"] = output_tokens
+    return usage
 
 
 def _chat_chunks_to_responses_events(chunks: list[Mapping[str, Any]]) -> list[dict[str, Any]]:
@@ -866,7 +1027,7 @@ def _chat_chunks_to_responses_events(chunks: list[Mapping[str, Any]]) -> list[di
     text_output_index: int | None = None
     tool_states: dict[int, dict[str, Any]] = {}
     terminal = False
-    latest_usage: dict[str, int] = {"input_tokens": 0, "output_tokens": 0}
+    latest_usage: dict[str, int] | None = None
 
     for chunk in chunks:
         if not isinstance(chunk, Mapping):
@@ -993,12 +1154,14 @@ def _chat_chunks_to_responses_events(chunks: list[Mapping[str, Any]]) -> list[di
                 },
             }
         )
-    events.append(
-        {
-            "type": "response.completed",
-            "response": {"id": response_id, "model": model, "status": "completed", "usage": latest_usage},
-        }
-    )
+    completed_response: dict[str, Any] = {
+        "id": response_id,
+        "model": model,
+        "status": "completed",
+    }
+    if latest_usage is not None:
+        completed_response["usage"] = latest_usage
+    events.append({"type": "response.completed", "response": completed_response})
     return events
 
 

--- a/src-python/anthropic_messages_spike.py
+++ b/src-python/anthropic_messages_spike.py
@@ -70,6 +70,7 @@ class HeaderPolicy:
     forwarded: tuple[str, ...]
     consumed: tuple[str, ...]
     unsupported: tuple[str, ...]
+    semantic_headers: dict[str, str]
     sanitized: dict[str, str]
 
 
@@ -122,6 +123,7 @@ def classify_claude_headers(
     forwarded: list[str] = []
     consumed: list[str] = []
     unsupported: list[str] = []
+    semantic_headers: dict[str, str] = {}
     sanitized: dict[str, str] = {}
     for raw_name, raw_value in headers.items():
         if not isinstance(raw_name, str):
@@ -134,6 +136,7 @@ def classify_claude_headers(
             continue
         if name.startswith("x-claude-code-"):
             consumed.append(name)
+            semantic_headers[name] = value
             sanitized[name] = "<pseudonymized>"
             continue
         if name in {
@@ -150,6 +153,7 @@ def classify_claude_headers(
             sanitized[name] = "<transport>"
             continue
         if name.startswith("anthropic-"):
+            semantic_headers[name] = value
             if name == "anthropic-version":
                 sanitized[name] = value
             else:
@@ -167,6 +171,7 @@ def classify_claude_headers(
         forwarded=tuple(dict.fromkeys(forwarded)),
         consumed=tuple(dict.fromkeys(consumed)),
         unsupported=tuple(dict.fromkeys(unsupported)),
+        semantic_headers=semantic_headers,
         sanitized=sanitized,
     )
 

--- a/src-python/anthropic_messages_spike.py
+++ b/src-python/anthropic_messages_spike.py
@@ -1,0 +1,1037 @@
+"""In-memory Anthropic Messages compatibility prototype.
+
+This module deliberately has no HTTP handler, Gateway configuration, upstream I/O,
+or retry dependencies.  It is a test-only design seam for Issue #74, where an
+Anthropic Messages request can be translated and assessed before any production
+route is considered.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+import json
+from typing import Any, Mapping
+
+
+@dataclass(frozen=True)
+class TranslationResult:
+    """A translated payload plus every deliberate adaptation or rejection.
+
+    ``body`` is ``None`` whenever a field cannot be represented safely.  That
+    keeps a prospective HTTP caller from forwarding a lossy request by mistake.
+    """
+
+    body: bytes | None
+    adapted: tuple[str, ...] = ()
+    unsupported: tuple[str, ...] = ()
+
+    @property
+    def forwardable(self) -> bool:
+        return self.body is not None and not self.unsupported
+
+
+@dataclass(frozen=True)
+class PrototypeExchange:
+    """Evidence from exercising one in-memory upstream adapter."""
+
+    upstream_kind: str
+    translation: TranslationResult
+    outbound_body: bytes | None
+    downstream_sse: tuple[bytes, ...]
+
+
+@dataclass(frozen=True)
+class AnthropicMessage:
+    """Canonical in-memory form for one Claude Messages history entry.
+
+    This is intentionally narrower than an HTTP request: it preserves role and
+    ordered content blocks so both Responses and Chat Completions adapters can
+    share the same conversation/history interpretation.
+    """
+
+    role: str
+    content: tuple[dict[str, Any], ...]
+
+
+class CompatibilityStatus(str, Enum):
+    """Conservative status labels used by the Spike report and tests."""
+
+    PRESERVED = "preserved"
+    ADAPTED = "adapted"
+    UNSUPPORTED = "unsupported"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class HeaderPolicy:
+    """Open-set header classification with safe trace values only."""
+
+    forwarded: tuple[str, ...]
+    consumed: tuple[str, ...]
+    unsupported: tuple[str, ...]
+    sanitized: dict[str, str]
+
+
+_SUPPORTED_TOP_LEVEL_FIELDS = frozenset(
+    {
+        "model",
+        "max_tokens",
+        "system",
+        "messages",
+        "tools",
+        "tool_choice",
+        "stream",
+        "temperature",
+        "top_p",
+    }
+)
+
+
+def compatibility_matrix() -> dict[str, CompatibilityStatus]:
+    """Return the explicit non-production compatibility decision for each capability."""
+
+    return {
+        "text": CompatibilityStatus.ADAPTED,
+        "tools": CompatibilityStatus.ADAPTED,
+        "images": CompatibilityStatus.UNKNOWN,
+        "thinking": CompatibilityStatus.UNSUPPORTED,
+        "prompt_caching": CompatibilityStatus.UNKNOWN,
+        "compact_resume": CompatibilityStatus.UNKNOWN,
+        "subagents": CompatibilityStatus.UNKNOWN,
+        "beta_fields": CompatibilityStatus.UNSUPPORTED,
+        "errors": CompatibilityStatus.ADAPTED,
+        "retries": CompatibilityStatus.UNKNOWN,
+        "cancellation": CompatibilityStatus.UNKNOWN,
+        "count_tokens": CompatibilityStatus.UNSUPPORTED,
+    }
+
+
+def classify_claude_headers(
+    headers: Mapping[str, str],
+    *,
+    upstream_format: str,
+) -> HeaderPolicy:
+    """Classify Claude Code headers without retaining secret trace values.
+
+    The policy is deliberately open-set: new ``x-claude-code-*`` names become
+    consumed opaque metadata; new ``anthropic-*`` names are only forwardable to
+    an Anthropic-format upstream and otherwise become explicit work items.
+    """
+
+    forwarded: list[str] = []
+    consumed: list[str] = []
+    unsupported: list[str] = []
+    sanitized: dict[str, str] = {}
+    for raw_name, raw_value in headers.items():
+        if not isinstance(raw_name, str):
+            continue
+        name = raw_name.lower()
+        value = raw_value if isinstance(raw_value, str) else ""
+        if name in {"authorization", "x-api-key", "proxy-authorization", "cookie"}:
+            consumed.append(name)
+            sanitized[name] = "<redacted>"
+            continue
+        if name.startswith("x-claude-code-"):
+            consumed.append(name)
+            sanitized[name] = "<pseudonymized>"
+            continue
+        if name in {
+            "accept",
+            "content-type",
+            "user-agent",
+            "connection",
+            "host",
+            "accept-encoding",
+            "content-length",
+            "x-app",
+        } or name.startswith("x-stainless-"):
+            consumed.append(name)
+            sanitized[name] = "<transport>"
+            continue
+        if name.startswith("anthropic-"):
+            if name == "anthropic-version":
+                sanitized[name] = value
+            else:
+                sanitized[name] = "<redacted-open-set>"
+            if upstream_format == "anthropic_messages":
+                forwarded.append(name)
+            elif name == "anthropic-version":
+                consumed.append(name)
+            else:
+                unsupported.append(f"header.{name}")
+            continue
+        sanitized[name] = "<redacted>"
+        unsupported.append(f"header.{name}")
+    return HeaderPolicy(
+        forwarded=tuple(dict.fromkeys(forwarded)),
+        consumed=tuple(dict.fromkeys(consumed)),
+        unsupported=tuple(dict.fromkeys(unsupported)),
+        sanitized=sanitized,
+    )
+
+
+def _content_blocks(value: Any) -> tuple[dict[str, Any], ...] | None:
+    if isinstance(value, str):
+        return ({"type": "text", "text": value},)
+    if not isinstance(value, list):
+        return None
+    blocks: list[dict[str, Any]] = []
+    for item in value:
+        if not isinstance(item, Mapping):
+            return None
+        blocks.append(dict(item))
+    return tuple(blocks)
+
+
+def _parse_messages(value: Any) -> tuple[tuple[AnthropicMessage, ...], list[str]]:
+    if not isinstance(value, list):
+        return (), ["messages"]
+
+    parsed: list[AnthropicMessage] = []
+    unsupported: list[str] = []
+    for index, item in enumerate(value):
+        if not isinstance(item, Mapping):
+            unsupported.append(f"messages[{index}]")
+            continue
+        role = item.get("role")
+        blocks = _content_blocks(item.get("content"))
+        if role not in {"user", "assistant"}:
+            unsupported.append(f"messages[{index}].role")
+            continue
+        if blocks is None:
+            unsupported.append(f"messages[{index}].content")
+            continue
+        parsed.append(AnthropicMessage(role=role, content=blocks))
+    return tuple(parsed), unsupported
+
+
+def _text_input(block: Mapping[str, Any], field: str) -> tuple[dict[str, Any] | None, str | None]:
+    text = block.get("text")
+    if not isinstance(text, str):
+        return None, field
+    if set(block).difference({"type", "text"}):
+        return None, field
+    return {"type": "input_text", "text": text}, None
+
+
+def _image_input(block: Mapping[str, Any], field: str) -> tuple[dict[str, Any] | None, str | None]:
+    source = block.get("source")
+    if not isinstance(source, Mapping):
+        return None, field
+    source_type = source.get("type")
+    if source_type == "url" and isinstance(source.get("url"), str):
+        image_url = source["url"]
+    elif (
+        source_type == "base64"
+        and isinstance(source.get("media_type"), str)
+        and isinstance(source.get("data"), str)
+    ):
+        image_url = f"data:{source['media_type']};base64,{source['data']}"
+    else:
+        return None, field
+    if set(block).difference({"type", "source"}):
+        return None, field
+    return {"type": "input_image", "image_url": image_url}, None
+
+
+def _tool_result_output(value: Any, field: str) -> tuple[str | None, str | None]:
+    if isinstance(value, str):
+        return value, None
+    blocks = _content_blocks(value)
+    if blocks is None:
+        return None, field
+    text_parts: list[str] = []
+    for index, block in enumerate(blocks):
+        text, unsupported = _text_input(block, f"{field}[{index}]")
+        if unsupported is not None or text is None:
+            return None, unsupported or field
+        text_parts.append(text["text"])
+    return "".join(text_parts), None
+
+
+def _messages_to_responses_input(
+    messages: tuple[AnthropicMessage, ...],
+) -> tuple[list[dict[str, Any]], list[str]]:
+    input_items: list[dict[str, Any]] = []
+    unsupported: list[str] = []
+    for message_index, message in enumerate(messages):
+        text_and_image: list[dict[str, Any]] = []
+        for block_index, block in enumerate(message.content):
+            field = f"messages[{message_index}].content[{block_index}]"
+            block_type = block.get("type")
+            if block_type == "text":
+                item, failure = _text_input(block, field)
+                if failure is not None:
+                    unsupported.append(failure)
+                elif item is not None:
+                    text_and_image.append(item)
+                continue
+            if block_type == "image":
+                item, failure = _image_input(block, field)
+                if failure is not None:
+                    unsupported.append(failure)
+                elif item is not None:
+                    text_and_image.append(item)
+                continue
+            if block_type == "tool_use" and message.role == "assistant":
+                call_id = block.get("id")
+                name = block.get("name")
+                arguments = block.get("input")
+                if (
+                    not isinstance(call_id, str)
+                    or not call_id
+                    or not isinstance(name, str)
+                    or not name
+                    or not isinstance(arguments, Mapping)
+                    or set(block).difference({"type", "id", "name", "input"})
+                ):
+                    unsupported.append(field)
+                    continue
+                if text_and_image:
+                    input_items.append(
+                        {
+                            "type": "message",
+                            "role": message.role,
+                            "content": text_and_image,
+                        }
+                    )
+                    text_and_image = []
+                input_items.append(
+                    {
+                        "id": f"fc_{call_id}",
+                        "type": "function_call",
+                        "call_id": call_id,
+                        "name": name,
+                        "arguments": json.dumps(arguments, ensure_ascii=True, separators=(",", ":")),
+                    }
+                )
+                continue
+            if block_type == "tool_result" and message.role == "user":
+                call_id = block.get("tool_use_id")
+                output, failure = _tool_result_output(block.get("content"), f"{field}.content")
+                if (
+                    not isinstance(call_id, str)
+                    or not call_id
+                    or failure is not None
+                    or output is None
+                    or set(block).difference({"type", "tool_use_id", "content"})
+                ):
+                    unsupported.append(failure or field)
+                    continue
+                if text_and_image:
+                    input_items.append(
+                        {
+                            "type": "message",
+                            "role": message.role,
+                            "content": text_and_image,
+                        }
+                    )
+                    text_and_image = []
+                input_items.append(
+                    {
+                        "type": "function_call_output",
+                        "call_id": call_id,
+                        "output": output,
+                    }
+                )
+                continue
+            unsupported.append(field)
+        if text_and_image:
+            input_items.append(
+                {
+                    "type": "message",
+                    "role": message.role,
+                    "content": text_and_image,
+                }
+            )
+    return input_items, unsupported
+
+
+def _system_to_instructions(value: Any) -> tuple[str | None, list[str], list[str]]:
+    if value is None:
+        return None, [], []
+    blocks = _content_blocks(value)
+    if blocks is None:
+        return None, [], ["system"]
+    texts: list[str] = []
+    for index, block in enumerate(blocks):
+        item, failure = _text_input(block, f"system[{index}]")
+        if failure is not None or item is None:
+            return None, [], [failure or f"system[{index}]"]
+        texts.append(item["text"])
+    return "\n\n".join(texts), (["system.text_blocks_joined"] if len(texts) > 1 else []), []
+
+
+def _tools_to_responses(value: Any) -> tuple[list[dict[str, Any]], list[str]]:
+    if value is None:
+        return [], []
+    if not isinstance(value, list):
+        return [], ["tools"]
+    tools: list[dict[str, Any]] = []
+    unsupported: list[str] = []
+    for index, raw_tool in enumerate(value):
+        field = f"tools[{index}]"
+        if not isinstance(raw_tool, Mapping):
+            unsupported.append(field)
+            continue
+        tool = dict(raw_tool)
+        name = tool.get("name")
+        schema = tool.get("input_schema")
+        if (
+            tool.get("type", "custom") != "custom"
+            or not isinstance(name, str)
+            or not name
+            or not isinstance(schema, Mapping)
+            or set(tool).difference({"type", "name", "description", "input_schema", "strict"})
+        ):
+            unsupported.append(field)
+            continue
+        translated: dict[str, Any] = {
+            "type": "function",
+            "name": name,
+            "parameters": dict(schema),
+        }
+        if isinstance(tool.get("description"), str):
+            translated["description"] = tool["description"]
+        if isinstance(tool.get("strict"), bool):
+            translated["strict"] = tool["strict"]
+        tools.append(translated)
+    return tools, unsupported
+
+
+def _tool_choice_to_responses(value: Any) -> tuple[Any, list[str]]:
+    if value is None:
+        return None, []
+    if not isinstance(value, Mapping):
+        return None, ["tool_choice"]
+    choice_type = value.get("type")
+    if choice_type == "auto" and set(value) == {"type"}:
+        return "auto", []
+    if choice_type == "any" and set(value) == {"type"}:
+        return "required", []
+    if choice_type == "none" and set(value) == {"type"}:
+        return "none", []
+    if choice_type == "tool" and isinstance(value.get("name"), str) and set(value) == {"type", "name"}:
+        return {"type": "function", "name": value["name"]}, []
+    return None, ["tool_choice"]
+
+
+def messages_to_responses(request: Mapping[str, Any]) -> TranslationResult:
+    """Translate an Anthropic Messages request into a Responses request.
+
+    The return value refuses to provide a serializable body when an unmodelled
+    field is present.  Production code must make an explicit policy decision
+    before accepting any new Messages capability.
+    """
+
+    unsupported = [
+        f"request.{key}"
+        for key in request
+        if key not in _SUPPORTED_TOP_LEVEL_FIELDS
+    ]
+    adapted: list[str] = []
+    model = request.get("model")
+    if not isinstance(model, str) or not model:
+        unsupported.append("model")
+    max_tokens = request.get("max_tokens")
+    if not isinstance(max_tokens, int) or isinstance(max_tokens, bool) or max_tokens <= 0:
+        unsupported.append("max_tokens")
+
+    messages, message_failures = _parse_messages(request.get("messages"))
+    unsupported.extend(message_failures)
+    input_items, input_failures = _messages_to_responses_input(messages)
+    unsupported.extend(input_failures)
+
+    instructions, system_adapted, system_failures = _system_to_instructions(request.get("system"))
+    adapted.extend(system_adapted)
+    unsupported.extend(system_failures)
+
+    tools, tool_failures = _tools_to_responses(request.get("tools"))
+    unsupported.extend(tool_failures)
+    tool_choice, tool_choice_failures = _tool_choice_to_responses(request.get("tool_choice"))
+    unsupported.extend(tool_choice_failures)
+
+    if unsupported:
+        return TranslationResult(
+            body=None,
+            adapted=tuple(dict.fromkeys(adapted)),
+            unsupported=tuple(dict.fromkeys(unsupported)),
+        )
+
+    payload: dict[str, Any] = {
+        "model": model,
+        "max_output_tokens": max_tokens,
+        "input": input_items,
+    }
+    if instructions is not None:
+        payload["instructions"] = instructions
+    for key in ("stream", "temperature", "top_p"):
+        if key in request:
+            payload[key] = request[key]
+    if tools:
+        payload["tools"] = tools
+    if tool_choice is not None:
+        payload["tool_choice"] = tool_choice
+    return TranslationResult(
+        body=json.dumps(payload, ensure_ascii=True, separators=(",", ":")).encode("utf-8"),
+        adapted=tuple(dict.fromkeys(adapted)),
+    )
+
+
+def _responses_request_to_chat_completions_body(body: bytes) -> bytes:
+    payload = json.loads(body.decode("utf-8"))
+    if not isinstance(payload, Mapping):
+        raise ValueError("Responses prototype request must be a JSON object")
+
+    messages: list[dict[str, Any]] = []
+    instructions = payload.get("instructions")
+    if isinstance(instructions, str) and instructions:
+        messages.append({"role": "system", "content": instructions})
+    for item in payload.get("input", []):
+        if not isinstance(item, Mapping):
+            continue
+        item_type = item.get("type")
+        if item_type == "message":
+            role = item.get("role")
+            content = item.get("content")
+            if not isinstance(role, str) or not isinstance(content, list):
+                raise ValueError("Responses message input is incomplete")
+            chat_content: list[dict[str, Any]] = []
+            for part in content:
+                if not isinstance(part, Mapping):
+                    raise ValueError("Responses message content is incomplete")
+                if part.get("type") == "input_text" and isinstance(part.get("text"), str):
+                    chat_content.append({"type": "text", "text": part["text"]})
+                elif part.get("type") == "input_image" and isinstance(part.get("image_url"), str):
+                    chat_content.append({"type": "image_url", "image_url": {"url": part["image_url"]}})
+                else:
+                    raise ValueError("Responses message content has no Chat Completions equivalent")
+            if len(chat_content) == 1 and chat_content[0]["type"] == "text":
+                messages.append({"role": role, "content": chat_content[0]["text"]})
+            else:
+                messages.append({"role": role, "content": chat_content})
+        elif item_type == "function_call":
+            call_id = item.get("call_id")
+            name = item.get("name")
+            arguments = item.get("arguments")
+            if not isinstance(call_id, str) or not isinstance(name, str) or not isinstance(arguments, str):
+                raise ValueError("Responses function call is incomplete")
+            messages.append(
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": call_id,
+                            "type": "function",
+                            "function": {"name": name, "arguments": arguments},
+                        }
+                    ],
+                }
+            )
+        elif item_type == "function_call_output":
+            call_id = item.get("call_id")
+            output = item.get("output")
+            if not isinstance(call_id, str) or not isinstance(output, str):
+                raise ValueError("Responses function output is incomplete")
+            messages.append({"role": "tool", "tool_call_id": call_id, "content": output})
+        else:
+            raise ValueError("Responses input item has no Chat Completions equivalent")
+
+    chat_payload: dict[str, Any] = {"model": payload.get("model"), "messages": messages}
+    if "max_output_tokens" in payload:
+        chat_payload["max_tokens"] = payload["max_output_tokens"]
+    for key in ("stream", "temperature", "top_p"):
+        if key in payload:
+            chat_payload[key] = payload[key]
+    tools = payload.get("tools")
+    if isinstance(tools, list) and tools:
+        chat_tools: list[dict[str, Any]] = []
+        for tool in tools:
+            if not isinstance(tool, Mapping) or tool.get("type") != "function":
+                raise ValueError("Responses tool has no Chat Completions equivalent")
+            function: dict[str, Any] = {
+                "name": tool.get("name"),
+                "parameters": tool.get("parameters"),
+            }
+            if isinstance(tool.get("description"), str):
+                function["description"] = tool["description"]
+            if isinstance(tool.get("strict"), bool):
+                function["strict"] = tool["strict"]
+            chat_tools.append({"type": "function", "function": function})
+        chat_payload["tools"] = chat_tools
+    tool_choice = payload.get("tool_choice")
+    if isinstance(tool_choice, Mapping) and tool_choice.get("type") == "function":
+        name = tool_choice.get("name")
+        if not isinstance(name, str):
+            raise ValueError("Responses function tool choice is incomplete")
+        chat_payload["tool_choice"] = {"type": "function", "function": {"name": name}}
+    elif tool_choice is not None:
+        chat_payload["tool_choice"] = tool_choice
+    return json.dumps(chat_payload, ensure_ascii=True, separators=(",", ":")).encode("utf-8")
+
+
+def messages_to_chat_completions(request: Mapping[str, Any]) -> TranslationResult:
+    """Translate the supported Messages subset into an OpenAI Chat request."""
+
+    responses_result = messages_to_responses(request)
+    if responses_result.body is None:
+        return responses_result
+    return TranslationResult(
+        body=_responses_request_to_chat_completions_body(responses_result.body),
+        adapted=responses_result.adapted + ("responses_to_chat.request_shape",),
+        unsupported=responses_result.unsupported,
+    )
+
+
+def _sse_record(event_name: str, payload: Mapping[str, Any]) -> bytes:
+    encoded = json.dumps(payload, ensure_ascii=True, separators=(",", ":"))
+    return f"event: {event_name}\ndata: {encoded}\n\n".encode("utf-8")
+
+
+def upstream_error_to_messages_sse(
+    status: int,
+    payload: Mapping[str, Any],
+) -> tuple[bytes, ...]:
+    """Translate a deterministic upstream error into the Messages SSE envelope.
+
+    The upstream message is intentionally retained for Claude Code's documented
+    capability fallback matching.  Trace capture must sanitize it separately.
+    """
+
+    error_type_by_status = {
+        400: "invalid_request_error",
+        401: "authentication_error",
+        403: "permission_error",
+        404: "not_found_error",
+        413: "request_too_large",
+        429: "rate_limit_error",
+        529: "overloaded_error",
+    }
+    raw_error = payload.get("error")
+    if isinstance(raw_error, Mapping):
+        message = raw_error.get("message")
+    else:
+        message = None
+    if not isinstance(message, str) or not message:
+        message = f"Upstream request failed with status {status}"
+    error_type = error_type_by_status.get(status, "api_error")
+    return (
+        _sse_record(
+            "error",
+            {
+                "type": "error",
+                "error": {"type": error_type, "message": message},
+            },
+        ),
+    )
+
+
+def _anthropic_usage(value: Any) -> dict[str, int]:
+    if not isinstance(value, Mapping):
+        return {"input_tokens": 0, "output_tokens": 0}
+    input_tokens = value.get("input_tokens")
+    output_tokens = value.get("output_tokens")
+    return {
+        "input_tokens": input_tokens if isinstance(input_tokens, int) else 0,
+        "output_tokens": output_tokens if isinstance(output_tokens, int) else 0,
+    }
+
+
+def responses_events_to_messages_sse(events: list[Mapping[str, Any]]) -> tuple[bytes, ...]:
+    """Adapt a finite OpenAI Responses event sequence into Anthropic SSE records.
+
+    This in-memory prototype deliberately takes a finite list so its output can
+    be inspected as a fixture.  A production adapter must preserve the same
+    event ordering without buffering upstream output.
+    """
+
+    records: list[bytes] = []
+    response_id = "resp_spike"
+    model = "unknown"
+    started = False
+    next_block_index = 0
+    active_blocks: dict[int, tuple[int, str]] = {}
+    active_item_ids: dict[str, int] = {}
+    emitted_tool_use = False
+    terminal = False
+    supported_event_types = {
+        "response.created",
+        "response.in_progress",
+        "response.output_item.added",
+        "response.content_part.added",
+        "response.output_text.delta",
+        "response.output_text.done",
+        "response.function_call_arguments.delta",
+        "response.function_call_arguments.done",
+        "response.output_item.done",
+        "response.completed",
+        "response.failed",
+    }
+
+    def start_message(response: Mapping[str, Any]) -> None:
+        nonlocal response_id, model, started
+        if started:
+            return
+        candidate_id = response.get("id")
+        candidate_model = response.get("model")
+        if isinstance(candidate_id, str) and candidate_id:
+            response_id = candidate_id
+        if isinstance(candidate_model, str) and candidate_model:
+            model = candidate_model
+        records.append(
+            _sse_record(
+                "message_start",
+                {
+                    "type": "message_start",
+                    "message": {
+                        "id": response_id,
+                        "type": "message",
+                        "role": "assistant",
+                        "model": model,
+                        "content": [],
+                        "stop_reason": None,
+                        "stop_sequence": None,
+                        "usage": {"input_tokens": 0, "output_tokens": 0},
+                    },
+                },
+            )
+        )
+        started = True
+
+    for event in events:
+        if not isinstance(event, Mapping):
+            raise ValueError("Responses stream event is not an object")
+        event_type = event.get("type")
+        if not isinstance(event_type, str) or event_type not in supported_event_types:
+            raise ValueError(f"Unsupported Responses event type: {event_type}")
+        if terminal:
+            raise ValueError("Responses stream has an event after its terminal event")
+        response = event.get("response")
+        if event_type == "response.created":
+            start_message(response if isinstance(response, Mapping) else {})
+            continue
+        if event_type in {
+            "response.in_progress",
+            "response.content_part.added",
+            "response.output_text.done",
+            "response.function_call_arguments.done",
+        }:
+            # These confirmed upstream transitions are represented by the
+            # Messages start/delta/stop events emitted around their item.
+            continue
+        if event_type == "response.output_item.added":
+            start_message({})
+            item = event.get("item")
+            if not isinstance(item, Mapping):
+                raise ValueError("Responses output item is not an object")
+            output_index = event.get("output_index")
+            if not isinstance(output_index, int):
+                output_index = len(active_blocks)
+            item_type = item.get("type")
+            if item_type == "message":
+                block = {"type": "text", "text": ""}
+                block_kind = "text"
+            elif item_type == "function_call":
+                call_id = item.get("call_id")
+                name = item.get("name")
+                if not isinstance(call_id, str) or not call_id or not isinstance(name, str) or not name:
+                    raise ValueError("Responses function call is missing call_id or name")
+                block = {"type": "tool_use", "id": call_id, "name": name, "input": {}}
+                block_kind = "tool_use"
+                emitted_tool_use = True
+            else:
+                raise ValueError(f"Unsupported Responses output item type: {item_type}")
+            block_index = next_block_index
+            next_block_index += 1
+            active_blocks[output_index] = (block_index, block_kind)
+            item_id = item.get("id")
+            if isinstance(item_id, str) and item_id:
+                active_item_ids[item_id] = output_index
+            records.append(
+                _sse_record(
+                    "content_block_start",
+                    {"type": "content_block_start", "index": block_index, "content_block": block},
+                )
+            )
+            continue
+        if event_type in {"response.output_text.delta", "response.function_call_arguments.delta"}:
+            output_index = event.get("output_index")
+            if not isinstance(output_index, int):
+                item_id = event.get("item_id")
+                output_index = active_item_ids.get(item_id) if isinstance(item_id, str) else None
+            active = active_blocks.get(output_index) if isinstance(output_index, int) else None
+            delta = event.get("delta")
+            if active is None or not isinstance(delta, str):
+                raise ValueError("Responses delta has no active compatible content block")
+            block_index, block_kind = active
+            if event_type == "response.output_text.delta" and block_kind == "text":
+                downstream_delta = {"type": "text_delta", "text": delta}
+            elif event_type == "response.function_call_arguments.delta" and block_kind == "tool_use":
+                downstream_delta = {"type": "input_json_delta", "partial_json": delta}
+            else:
+                raise ValueError("Responses delta does not match its active content block")
+            records.append(
+                _sse_record(
+                    "content_block_delta",
+                    {"type": "content_block_delta", "index": block_index, "delta": downstream_delta},
+                )
+            )
+            continue
+        if event_type == "response.output_item.done":
+            output_index = event.get("output_index")
+            if not isinstance(output_index, int):
+                item = event.get("item")
+                item_id = item.get("id") if isinstance(item, Mapping) else None
+                output_index = active_item_ids.get(item_id) if isinstance(item_id, str) else None
+            active = active_blocks.pop(output_index, None) if isinstance(output_index, int) else None
+            if active is None:
+                raise ValueError("Responses output item stop has no active content block")
+            records.append(
+                _sse_record(
+                    "content_block_stop",
+                    {"type": "content_block_stop", "index": active[0]},
+                )
+            )
+            continue
+        if event_type == "response.completed":
+            response_payload = response if isinstance(response, Mapping) else {}
+            start_message(response_payload)
+            for block_index, _block_kind in active_blocks.values():
+                records.append(
+                    _sse_record(
+                        "content_block_stop",
+                        {"type": "content_block_stop", "index": block_index},
+                    )
+                )
+            active_blocks.clear()
+            usage = _anthropic_usage(response_payload.get("usage"))
+            records.append(
+                _sse_record(
+                    "message_delta",
+                    {
+                        "type": "message_delta",
+                        "delta": {
+                            "stop_reason": "tool_use" if emitted_tool_use else "end_turn",
+                            "stop_sequence": None,
+                        },
+                        "usage": usage,
+                    },
+                )
+            )
+            records.append(_sse_record("message_stop", {"type": "message_stop"}))
+            terminal = True
+            continue
+        if event_type == "response.failed":
+            response_payload = response if isinstance(response, Mapping) else {}
+            status = event.get("status")
+            if not isinstance(status, int):
+                status = 500
+            error_payload = {"error": response_payload.get("error")}
+            records.extend(upstream_error_to_messages_sse(status, error_payload))
+            terminal = True
+            continue
+
+    if not terminal:
+        raise ValueError("Responses event sequence ended without response.completed")
+    return tuple(records)
+
+
+def _chat_usage_to_responses_usage(value: Any) -> dict[str, int]:
+    if not isinstance(value, Mapping):
+        return {"input_tokens": 0, "output_tokens": 0}
+    input_tokens = value.get("prompt_tokens", value.get("input_tokens", 0))
+    output_tokens = value.get("completion_tokens", value.get("output_tokens", 0))
+    return {
+        "input_tokens": input_tokens if isinstance(input_tokens, int) else 0,
+        "output_tokens": output_tokens if isinstance(output_tokens, int) else 0,
+    }
+
+
+def _chat_chunks_to_responses_events(chunks: list[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    if not chunks:
+        raise ValueError("Chat Completions stream is empty")
+
+    events: list[dict[str, Any]] = []
+    response_id = "resp_chat_spike"
+    model = "unknown"
+    created = False
+    next_output_index = 0
+    text_output_index: int | None = None
+    tool_states: dict[int, dict[str, Any]] = {}
+    terminal = False
+    latest_usage: dict[str, int] = {"input_tokens": 0, "output_tokens": 0}
+
+    for chunk in chunks:
+        if not isinstance(chunk, Mapping):
+            raise ValueError("Chat Completions stream chunk is not an object")
+        chunk_id = chunk.get("id")
+        chunk_model = chunk.get("model")
+        if isinstance(chunk_id, str) and chunk_id:
+            response_id = chunk_id
+        if isinstance(chunk_model, str) and chunk_model:
+            model = chunk_model
+        if not created:
+            events.append(
+                {
+                    "type": "response.created",
+                    "response": {"id": response_id, "model": model, "status": "in_progress"},
+                }
+            )
+            created = True
+        if "usage" in chunk:
+            latest_usage = _chat_usage_to_responses_usage(chunk.get("usage"))
+        choices = chunk.get("choices")
+        if not isinstance(choices, list):
+            continue
+        for choice in choices:
+            if not isinstance(choice, Mapping):
+                continue
+            delta = choice.get("delta")
+            if not isinstance(delta, Mapping):
+                delta = {}
+            unsupported_delta_fields = set(delta).difference({"role", "content", "tool_calls"})
+            if unsupported_delta_fields:
+                field = sorted(str(name) for name in unsupported_delta_fields)[0]
+                raise ValueError(f"Unsupported Chat Completions delta field: {field}")
+            content = delta.get("content")
+            if isinstance(content, str) and content:
+                if text_output_index is None:
+                    text_output_index = next_output_index
+                    next_output_index += 1
+                    events.append(
+                        {
+                            "type": "response.output_item.added",
+                            "output_index": text_output_index,
+                            "item": {
+                                "id": f"msg_{response_id}",
+                                "type": "message",
+                                "role": "assistant",
+                                "content": [],
+                            },
+                        }
+                    )
+                events.append(
+                    {
+                        "type": "response.output_text.delta",
+                        "output_index": text_output_index,
+                        "delta": content,
+                    }
+                )
+            raw_tool_calls = delta.get("tool_calls")
+            if isinstance(raw_tool_calls, list):
+                for fallback_index, raw_call in enumerate(raw_tool_calls):
+                    if not isinstance(raw_call, Mapping):
+                        raise ValueError("Chat Completions tool call is not an object")
+                    tool_index = raw_call.get("index")
+                    if not isinstance(tool_index, int):
+                        tool_index = fallback_index
+                    function = raw_call.get("function")
+                    if not isinstance(function, Mapping):
+                        raise ValueError("Chat Completions tool call has no function")
+                    state = tool_states.get(tool_index)
+                    if state is None:
+                        call_id = raw_call.get("id")
+                        name = function.get("name")
+                        if not isinstance(call_id, str) or not call_id or not isinstance(name, str) or not name:
+                            raise ValueError("First Chat Completions tool delta needs id and function name")
+                        output_index = next_output_index
+                        next_output_index += 1
+                        state = {"output_index": output_index, "call_id": call_id, "name": name}
+                        tool_states[tool_index] = state
+                        events.append(
+                            {
+                                "type": "response.output_item.added",
+                                "output_index": output_index,
+                                "item": {
+                                    "id": f"fc_{call_id}",
+                                    "type": "function_call",
+                                    "call_id": call_id,
+                                    "name": name,
+                                    "arguments": "",
+                                },
+                            }
+                        )
+                    arguments = function.get("arguments")
+                    if isinstance(arguments, str) and arguments:
+                        events.append(
+                            {
+                                "type": "response.function_call_arguments.delta",
+                                "output_index": state["output_index"],
+                                "delta": arguments,
+                            }
+                        )
+            if choice.get("finish_reason") is not None:
+                terminal = True
+
+    if not terminal:
+        raise ValueError("Chat Completions stream ended without finish_reason")
+    if text_output_index is not None:
+        events.append(
+            {
+                "type": "response.output_item.done",
+                "output_index": text_output_index,
+                "item": {"id": f"msg_{response_id}", "type": "message", "role": "assistant", "content": []},
+            }
+        )
+    for state in tool_states.values():
+        events.append(
+            {
+                "type": "response.output_item.done",
+                "output_index": state["output_index"],
+                "item": {
+                    "id": f"fc_{state['call_id']}",
+                    "type": "function_call",
+                    "call_id": state["call_id"],
+                    "name": state["name"],
+                },
+            }
+        )
+    events.append(
+        {
+            "type": "response.completed",
+            "response": {"id": response_id, "model": model, "status": "completed", "usage": latest_usage},
+        }
+    )
+    return events
+
+
+def chat_chunks_to_messages_sse(chunks: list[Mapping[str, Any]]) -> tuple[bytes, ...]:
+    """Adapt a Chat Completions tool/text stream through the isolated seam."""
+
+    return responses_events_to_messages_sse(_chat_chunks_to_responses_events(chunks))
+
+
+def exercise_responses_upstream(
+    request: Mapping[str, Any],
+    response_events: list[Mapping[str, Any]],
+) -> PrototypeExchange:
+    """Exercise a Responses-shaped upstream without touching the HTTP handler."""
+
+    translation = messages_to_responses(request)
+    if translation.body is None:
+        return PrototypeExchange("responses", translation, None, ())
+    return PrototypeExchange(
+        "responses",
+        translation,
+        translation.body,
+        responses_events_to_messages_sse(response_events),
+    )
+
+
+def exercise_chat_completions_upstream(
+    request: Mapping[str, Any],
+    chunks: list[Mapping[str, Any]],
+) -> PrototypeExchange:
+    """Exercise a Chat Completions-shaped upstream without touching the HTTP handler."""
+
+    translation = messages_to_chat_completions(request)
+    if translation.body is None:
+        return PrototypeExchange("chat_completions", translation, None, ())
+    return PrototypeExchange(
+        "chat_completions",
+        translation,
+        translation.body,
+        chat_chunks_to_messages_sse(chunks),
+    )

--- a/tests/fixtures/anthropic_messages_spike_trace.json
+++ b/tests/fixtures/anthropic_messages_spike_trace.json
@@ -1,0 +1,95 @@
+{
+  "fixture_schema": "codexhub-claude-messages-spike/v1",
+  "sanitized": true,
+  "source": "synthetic structural fixture; not a user-session capture",
+  "protocol": {
+    "anthropic_version": "2023-06-01",
+    "required_path": "/v1/messages",
+    "query_tolerance": "path matched even when beta=true is present"
+  },
+  "headers": {
+    "authorization": "<redacted>",
+    "x-api-key": "<redacted>",
+    "anthropic-version": "2023-06-01",
+    "anthropic-beta": "<redacted-open-set>",
+    "x-claude-code-session-id": "<pseudonymized>",
+    "x-claude-code-agent-id": "<pseudonymized>"
+  },
+  "text_stream": {
+    "request": {
+      "model": "<model>",
+      "max_tokens": 64,
+      "stream": true,
+      "messages": [
+        {
+          "role": "user",
+          "content": "<redacted-message-content>"
+        }
+      ]
+    },
+    "response_json": {
+      "id": "<response-id>",
+      "type": "message",
+      "role": "assistant",
+      "content": [
+        {
+          "type": "text",
+          "text": "<redacted-assistant-content>"
+        }
+      ],
+      "model": "<model>",
+      "stop_reason": "end_turn",
+      "stop_sequence": null,
+      "usage": {
+        "input_tokens": 7,
+        "output_tokens": 3
+      }
+    },
+    "sse_event_order": [
+      "message_start",
+      "content_block_start",
+      "content_block_delta",
+      "content_block_stop",
+      "message_delta",
+      "message_stop"
+    ]
+  },
+  "tool_follow_up": {
+    "first_response": {
+      "stop_reason": "tool_use",
+      "tool_use": {
+        "id": "<tool-id-1>",
+        "name": "read_fixture",
+        "input": {
+          "path": "<redacted-path>"
+        }
+      }
+    },
+    "next_request": {
+      "history_contains_same_tool_id": true,
+      "first_user_content_block_type": "tool_result",
+      "tool_result": "<redacted-tool-result>"
+    },
+    "final_response": {
+      "stop_reason": "end_turn",
+      "text": "<redacted-assistant-content>"
+    }
+  },
+  "failure": {
+    "upstream_status": 529,
+    "sse_event": "error",
+    "anthropic_error_type": "overloaded_error",
+    "message": "<redacted-upstream-error>"
+  },
+  "cancellation": {
+    "attempt": "downstream close after stream start",
+    "documented_wire_mapping": "unknown",
+    "synthesizes_message_stop": false,
+    "requires_upstream_abort_propagation": true
+  },
+  "count_tokens": {
+    "route": "/v1/messages/count_tokens",
+    "availability": "optional",
+    "non_anthropic_adapter_behavior": "explicitly unsupported; client may estimate locally"
+  }
+}

--- a/tests/fixtures/claude_messages_real_cli_smoke.json
+++ b/tests/fixtures/claude_messages_real_cli_smoke.json
@@ -1,0 +1,556 @@
+{
+  "fixture_schema": "codexhub-claude-messages-real-smoke/v1",
+  "sanitized": true,
+  "capture_kind": "real_cli_to_local_loopback_prototype",
+  "local_cli_version": "2.1.201 (Claude Code)",
+  "node_version": "v25.7.0",
+  "platform": "Windows",
+  "capture_succeeded": true,
+  "full_compatibility": false,
+  "compatibility_outcome": "scoped PARTIAL",
+  "scenarios": [
+    {
+      "scenario": "text",
+      "passed": false,
+      "client": {
+        "returncode": 0,
+        "expected_output_seen": true,
+        "stdout_length": 14,
+        "stderr_length": 0
+      },
+      "request_summaries": [
+        {
+          "path": "/v1/messages",
+          "header_policy": {
+            "consumed": [
+              "accept",
+              "content-type",
+              "user-agent",
+              "x-claude-code-session-id",
+              "x-stainless-arch",
+              "x-stainless-lang",
+              "x-stainless-os",
+              "x-stainless-package-version",
+              "x-stainless-retry-count",
+              "x-stainless-runtime",
+              "x-stainless-runtime-version",
+              "x-stainless-timeout",
+              "anthropic-version",
+              "x-api-key",
+              "x-app",
+              "connection",
+              "host",
+              "accept-encoding",
+              "content-length"
+            ],
+            "unsupported": [
+              "header.anthropic-beta",
+              "header.anthropic-dangerous-direct-browser-access"
+            ],
+            "sanitized": {
+              "accept": "<transport>",
+              "content-type": "<transport>",
+              "user-agent": "<transport>",
+              "x-claude-code-session-id": "<pseudonymized>",
+              "x-stainless-arch": "<transport>",
+              "x-stainless-lang": "<transport>",
+              "x-stainless-os": "<transport>",
+              "x-stainless-package-version": "<transport>",
+              "x-stainless-retry-count": "<transport>",
+              "x-stainless-runtime": "<transport>",
+              "x-stainless-runtime-version": "<transport>",
+              "x-stainless-timeout": "<transport>",
+              "anthropic-beta": "<redacted-open-set>",
+              "anthropic-dangerous-direct-browser-access": "<redacted-open-set>",
+              "anthropic-version": "2023-06-01",
+              "x-api-key": "<redacted>",
+              "x-app": "<transport>",
+              "connection": "<transport>",
+              "host": "<transport>",
+              "accept-encoding": "<transport>",
+              "content-length": "<transport>"
+            }
+          },
+          "request_keys": [
+            "max_tokens",
+            "messages",
+            "metadata",
+            "model",
+            "output_config",
+            "stream",
+            "system",
+            "thinking",
+            "tools"
+          ],
+          "selected_field_shapes": {
+            "metadata": {
+              "keys": [
+                "user_id"
+              ]
+            },
+            "thinking": {
+              "keys": [
+                "type"
+              ]
+            },
+            "output_config": {
+              "keys": [
+                "effort"
+              ]
+            },
+            "system": [
+              {
+                "keys": [
+                  "cache_control",
+                  "text",
+                  "type"
+                ]
+              },
+              {
+                "keys": [
+                  "cache_control",
+                  "text",
+                  "type"
+                ]
+              }
+            ],
+            "tools": []
+          },
+          "message_history": [
+            {
+              "role": "user",
+              "content_block_types": [
+                "text",
+                "text"
+              ]
+            }
+          ],
+          "messages_to_responses_forwardable": false,
+          "messages_to_responses_unsupported": [
+            "request.metadata",
+            "request.thinking",
+            "request.output_config",
+            "messages[0].content[1]",
+            "system[0]"
+          ],
+          "contains_expected_tool_result": false,
+          "tool_result_is_first_content_block": false
+        }
+      ],
+      "tool_follow_up_verified": false,
+      "stream_started": false,
+      "disconnect_observed": false
+    },
+    {
+      "scenario": "tool",
+      "passed": false,
+      "client": {
+        "returncode": 0,
+        "expected_output_seen": true,
+        "stdout_length": 14,
+        "stderr_length": 0
+      },
+      "request_summaries": [
+        {
+          "path": "/v1/messages",
+          "header_policy": {
+            "consumed": [
+              "accept",
+              "content-type",
+              "user-agent",
+              "x-claude-code-session-id",
+              "x-stainless-arch",
+              "x-stainless-lang",
+              "x-stainless-os",
+              "x-stainless-package-version",
+              "x-stainless-retry-count",
+              "x-stainless-runtime",
+              "x-stainless-runtime-version",
+              "x-stainless-timeout",
+              "anthropic-version",
+              "x-api-key",
+              "x-app",
+              "connection",
+              "host",
+              "accept-encoding",
+              "content-length"
+            ],
+            "unsupported": [
+              "header.anthropic-beta",
+              "header.anthropic-dangerous-direct-browser-access"
+            ],
+            "sanitized": {
+              "accept": "<transport>",
+              "content-type": "<transport>",
+              "user-agent": "<transport>",
+              "x-claude-code-session-id": "<pseudonymized>",
+              "x-stainless-arch": "<transport>",
+              "x-stainless-lang": "<transport>",
+              "x-stainless-os": "<transport>",
+              "x-stainless-package-version": "<transport>",
+              "x-stainless-retry-count": "<transport>",
+              "x-stainless-runtime": "<transport>",
+              "x-stainless-runtime-version": "<transport>",
+              "x-stainless-timeout": "<transport>",
+              "anthropic-beta": "<redacted-open-set>",
+              "anthropic-dangerous-direct-browser-access": "<redacted-open-set>",
+              "anthropic-version": "2023-06-01",
+              "x-api-key": "<redacted>",
+              "x-app": "<transport>",
+              "connection": "<transport>",
+              "host": "<transport>",
+              "accept-encoding": "<transport>",
+              "content-length": "<transport>"
+            }
+          },
+          "request_keys": [
+            "max_tokens",
+            "messages",
+            "metadata",
+            "model",
+            "output_config",
+            "stream",
+            "system",
+            "thinking",
+            "tools"
+          ],
+          "selected_field_shapes": {
+            "metadata": {
+              "keys": [
+                "user_id"
+              ]
+            },
+            "thinking": {
+              "keys": [
+                "type"
+              ]
+            },
+            "output_config": {
+              "keys": [
+                "effort"
+              ]
+            },
+            "system": [
+              {
+                "keys": [
+                  "cache_control",
+                  "text",
+                  "type"
+                ]
+              },
+              {
+                "keys": [
+                  "cache_control",
+                  "text",
+                  "type"
+                ]
+              }
+            ],
+            "tools": [
+              {
+                "keys": [
+                  "description",
+                  "input_schema",
+                  "name"
+                ]
+              }
+            ]
+          },
+          "message_history": [
+            {
+              "role": "user",
+              "content_block_types": [
+                "text",
+                "text"
+              ]
+            }
+          ],
+          "messages_to_responses_forwardable": false,
+          "messages_to_responses_unsupported": [
+            "request.metadata",
+            "request.thinking",
+            "request.output_config",
+            "messages[0].content[1]",
+            "system[0]"
+          ],
+          "contains_expected_tool_result": false,
+          "tool_result_is_first_content_block": false
+        },
+        {
+          "path": "/v1/messages",
+          "header_policy": {
+            "consumed": [
+              "accept",
+              "content-type",
+              "user-agent",
+              "x-claude-code-session-id",
+              "x-stainless-arch",
+              "x-stainless-lang",
+              "x-stainless-os",
+              "x-stainless-package-version",
+              "x-stainless-retry-count",
+              "x-stainless-runtime",
+              "x-stainless-runtime-version",
+              "x-stainless-timeout",
+              "anthropic-version",
+              "x-api-key",
+              "x-app",
+              "connection",
+              "host",
+              "accept-encoding",
+              "content-length"
+            ],
+            "unsupported": [
+              "header.anthropic-beta",
+              "header.anthropic-dangerous-direct-browser-access"
+            ],
+            "sanitized": {
+              "accept": "<transport>",
+              "content-type": "<transport>",
+              "user-agent": "<transport>",
+              "x-claude-code-session-id": "<pseudonymized>",
+              "x-stainless-arch": "<transport>",
+              "x-stainless-lang": "<transport>",
+              "x-stainless-os": "<transport>",
+              "x-stainless-package-version": "<transport>",
+              "x-stainless-retry-count": "<transport>",
+              "x-stainless-runtime": "<transport>",
+              "x-stainless-runtime-version": "<transport>",
+              "x-stainless-timeout": "<transport>",
+              "anthropic-beta": "<redacted-open-set>",
+              "anthropic-dangerous-direct-browser-access": "<redacted-open-set>",
+              "anthropic-version": "2023-06-01",
+              "x-api-key": "<redacted>",
+              "x-app": "<transport>",
+              "connection": "<transport>",
+              "host": "<transport>",
+              "accept-encoding": "<transport>",
+              "content-length": "<transport>"
+            }
+          },
+          "request_keys": [
+            "max_tokens",
+            "messages",
+            "metadata",
+            "model",
+            "output_config",
+            "stream",
+            "system",
+            "thinking",
+            "tools"
+          ],
+          "selected_field_shapes": {
+            "metadata": {
+              "keys": [
+                "user_id"
+              ]
+            },
+            "thinking": {
+              "keys": [
+                "type"
+              ]
+            },
+            "output_config": {
+              "keys": [
+                "effort"
+              ]
+            },
+            "system": [
+              {
+                "keys": [
+                  "cache_control",
+                  "text",
+                  "type"
+                ]
+              },
+              {
+                "keys": [
+                  "cache_control",
+                  "text",
+                  "type"
+                ]
+              }
+            ],
+            "tools": [
+              {
+                "keys": [
+                  "description",
+                  "input_schema",
+                  "name"
+                ]
+              }
+            ]
+          },
+          "message_history": [
+            {
+              "role": "user",
+              "content_block_types": [
+                "text",
+                "text"
+              ]
+            },
+            {
+              "role": "assistant",
+              "content_block_types": [
+                "tool_use"
+              ]
+            },
+            {
+              "role": "user",
+              "content_block_types": [
+                "tool_result"
+              ]
+            }
+          ],
+          "messages_to_responses_forwardable": false,
+          "messages_to_responses_unsupported": [
+            "request.metadata",
+            "request.thinking",
+            "request.output_config",
+            "messages[2].content[0]",
+            "system[0]"
+          ],
+          "contains_expected_tool_result": true,
+          "tool_result_is_first_content_block": true
+        }
+      ],
+      "tool_follow_up_verified": true,
+      "stream_started": false,
+      "disconnect_observed": false
+    },
+    {
+      "scenario": "cancel",
+      "passed": true,
+      "client": {
+        "returncode": 1,
+        "expected_output_seen": false,
+        "stdout_length": 0,
+        "stderr_length": 0,
+        "forced_process_termination": true
+      },
+      "request_summaries": [
+        {
+          "path": "/v1/messages",
+          "header_policy": {
+            "consumed": [
+              "accept",
+              "content-type",
+              "user-agent",
+              "x-claude-code-session-id",
+              "x-stainless-arch",
+              "x-stainless-lang",
+              "x-stainless-os",
+              "x-stainless-package-version",
+              "x-stainless-retry-count",
+              "x-stainless-runtime",
+              "x-stainless-runtime-version",
+              "x-stainless-timeout",
+              "anthropic-version",
+              "x-api-key",
+              "x-app",
+              "connection",
+              "host",
+              "accept-encoding",
+              "content-length"
+            ],
+            "unsupported": [
+              "header.anthropic-beta",
+              "header.anthropic-dangerous-direct-browser-access"
+            ],
+            "sanitized": {
+              "accept": "<transport>",
+              "content-type": "<transport>",
+              "user-agent": "<transport>",
+              "x-claude-code-session-id": "<pseudonymized>",
+              "x-stainless-arch": "<transport>",
+              "x-stainless-lang": "<transport>",
+              "x-stainless-os": "<transport>",
+              "x-stainless-package-version": "<transport>",
+              "x-stainless-retry-count": "<transport>",
+              "x-stainless-runtime": "<transport>",
+              "x-stainless-runtime-version": "<transport>",
+              "x-stainless-timeout": "<transport>",
+              "anthropic-beta": "<redacted-open-set>",
+              "anthropic-dangerous-direct-browser-access": "<redacted-open-set>",
+              "anthropic-version": "2023-06-01",
+              "x-api-key": "<redacted>",
+              "x-app": "<transport>",
+              "connection": "<transport>",
+              "host": "<transport>",
+              "accept-encoding": "<transport>",
+              "content-length": "<transport>"
+            }
+          },
+          "request_keys": [
+            "max_tokens",
+            "messages",
+            "metadata",
+            "model",
+            "output_config",
+            "stream",
+            "system",
+            "thinking",
+            "tools"
+          ],
+          "selected_field_shapes": {
+            "metadata": {
+              "keys": [
+                "user_id"
+              ]
+            },
+            "thinking": {
+              "keys": [
+                "type"
+              ]
+            },
+            "output_config": {
+              "keys": [
+                "effort"
+              ]
+            },
+            "system": [
+              {
+                "keys": [
+                  "cache_control",
+                  "text",
+                  "type"
+                ]
+              },
+              {
+                "keys": [
+                  "cache_control",
+                  "text",
+                  "type"
+                ]
+              }
+            ],
+            "tools": []
+          },
+          "message_history": [
+            {
+              "role": "user",
+              "content_block_types": [
+                "text",
+                "text"
+              ]
+            }
+          ],
+          "messages_to_responses_forwardable": false,
+          "messages_to_responses_unsupported": [
+            "request.metadata",
+            "request.thinking",
+            "request.output_config",
+            "messages[0].content[1]",
+            "system[0]"
+          ],
+          "contains_expected_tool_result": false,
+          "tool_result_is_first_content_block": false
+        }
+      ],
+      "tool_follow_up_verified": false,
+      "stream_started": true,
+      "disconnect_observed": true
+    }
+  ],
+  "cancellation_interpretation": "Forced process termination is an attempted downstream disconnect only; it does not prove Ctrl+C/Escape wire semantics."
+}

--- a/tests/test_anthropic_messages_spike.py
+++ b/tests/test_anthropic_messages_spike.py
@@ -1,0 +1,498 @@
+"""Focused contract tests for the isolated Claude Messages compatibility spike."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import re
+import unittest
+
+from anthropic_messages_spike import (
+    CompatibilityStatus,
+    chat_chunks_to_messages_sse,
+    classify_claude_headers,
+    compatibility_matrix,
+    exercise_chat_completions_upstream,
+    exercise_responses_upstream,
+    messages_to_chat_completions,
+    messages_to_responses,
+    responses_events_to_messages_sse,
+    upstream_error_to_messages_sse,
+)
+
+
+def _decode_sse(records: tuple[bytes, ...]) -> list[tuple[str, dict[str, object]]]:
+    decoded: list[tuple[str, dict[str, object]]] = []
+    for record in records:
+        lines = record.decode("utf-8").splitlines()
+        event_name = lines[0].removeprefix("event: ")
+        payload = json.loads(lines[1].removeprefix("data: "))
+        decoded.append((event_name, payload))
+    return decoded
+
+
+class MessagesToResponsesTests(unittest.TestCase):
+    def test_text_request_preserves_model_and_adapts_text_input(self):
+        result = messages_to_responses(
+            {
+                "model": "gateway-text-model",
+                "max_tokens": 64,
+                "messages": [{"role": "user", "content": "SANITIZED_TEXT"}],
+            }
+        )
+
+        self.assertEqual(
+            json.loads(result.body),
+            {
+                "model": "gateway-text-model",
+                "max_output_tokens": 64,
+                "input": [
+                    {
+                        "type": "message",
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": "SANITIZED_TEXT"}],
+                    }
+                ],
+            },
+        )
+        self.assertEqual(result.unsupported, ())
+
+    def test_unmapped_messages_field_blocks_forwarding_instead_of_being_dropped(self):
+        result = messages_to_responses(
+            {
+                "model": "gateway-text-model",
+                "max_tokens": 64,
+                "thinking": {"type": "adaptive"},
+                "messages": [{"role": "user", "content": "SANITIZED_TEXT"}],
+            }
+        )
+
+        self.assertIsNone(result.body)
+        self.assertFalse(result.forwardable)
+        self.assertEqual(result.unsupported, ("request.thinking",))
+
+
+class ResponsesToMessagesSseTests(unittest.TestCase):
+    def test_text_stream_has_anthropic_lifecycle_and_usage(self):
+        records = responses_events_to_messages_sse(
+            [
+                {
+                    "type": "response.created",
+                    "response": {"id": "resp_text_001", "model": "gpt-test"},
+                },
+                {
+                    "type": "response.output_item.added",
+                    "output_index": 0,
+                    "item": {"id": "msg_001", "type": "message", "role": "assistant", "content": []},
+                },
+                {
+                    "type": "response.output_text.delta",
+                    "output_index": 0,
+                    "delta": "SANITIZED_REPLY",
+                },
+                {
+                    "type": "response.output_item.done",
+                    "output_index": 0,
+                    "item": {"id": "msg_001", "type": "message", "role": "assistant", "content": []},
+                },
+                {
+                    "type": "response.completed",
+                    "response": {
+                        "id": "resp_text_001",
+                        "model": "gpt-test",
+                        "usage": {"input_tokens": 7, "output_tokens": 3},
+                    },
+                },
+            ]
+        )
+
+        events = _decode_sse(records)
+        self.assertEqual([event_name for event_name, _payload in events], [
+            "message_start",
+            "content_block_start",
+            "content_block_delta",
+            "content_block_stop",
+            "message_delta",
+            "message_stop",
+        ])
+        self.assertEqual(events[0][1]["message"]["id"], "resp_text_001")
+        self.assertEqual(events[2][1]["delta"], {"type": "text_delta", "text": "SANITIZED_REPLY"})
+        self.assertEqual(events[4][1]["usage"], {"input_tokens": 7, "output_tokens": 3})
+
+    def test_tool_stream_uses_upstream_call_id_for_the_follow_up_turn(self):
+        records = responses_events_to_messages_sse(
+            [
+                {
+                    "type": "response.created",
+                    "response": {"id": "resp_tool_001", "model": "gpt-test"},
+                },
+                {
+                    "type": "response.output_item.added",
+                    "output_index": 0,
+                    "item": {
+                        "id": "fc_toolu_read_001",
+                        "type": "function_call",
+                        "call_id": "toolu_read_001",
+                        "name": "read_file",
+                    },
+                },
+                {
+                    "type": "response.function_call_arguments.delta",
+                    "output_index": 0,
+                    "delta": '{"path":"fixture.txt"}',
+                },
+                {
+                    "type": "response.output_item.done",
+                    "output_index": 0,
+                    "item": {"id": "fc_toolu_read_001", "type": "function_call"},
+                },
+                {
+                    "type": "response.completed",
+                    "response": {
+                        "id": "resp_tool_001",
+                        "model": "gpt-test",
+                        "usage": {"input_tokens": 11, "output_tokens": 4},
+                    },
+                },
+            ]
+        )
+
+        events = _decode_sse(records)
+        self.assertEqual(events[1][1]["content_block"], {
+            "type": "tool_use",
+            "id": "toolu_read_001",
+            "name": "read_file",
+            "input": {},
+        })
+        self.assertEqual(events[2][1]["delta"], {
+            "type": "input_json_delta",
+            "partial_json": '{"path":"fixture.txt"}',
+        })
+        self.assertEqual(events[4][1]["delta"]["stop_reason"], "tool_use")
+
+    def test_unknown_responses_output_item_fails_explicitly(self):
+        with self.assertRaisesRegex(ValueError, "Unsupported Responses output item type: reasoning"):
+            responses_events_to_messages_sse(
+                [
+                    {
+                        "type": "response.created",
+                        "response": {"id": "resp_reasoning_001", "model": "gpt-test"},
+                    },
+                    {
+                        "type": "response.output_item.added",
+                        "output_index": 0,
+                        "item": {"id": "rs_001", "type": "reasoning"},
+                    },
+                ]
+            )
+
+
+class ChatCompletionsPrototypeTests(unittest.TestCase):
+    def test_messages_request_adapts_to_chat_completions_tool_history(self):
+        result = messages_to_chat_completions(
+            {
+                "model": "gateway-chat-model",
+                "max_tokens": 64,
+                "tools": [
+                    {
+                        "name": "read_file",
+                        "input_schema": {"type": "object", "properties": {}},
+                    }
+                ],
+                "messages": [
+                    {
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "id": "toolu_read_001",
+                                "name": "read_file",
+                                "input": {"path": "fixture.txt"},
+                            }
+                        ],
+                    },
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": "toolu_read_001",
+                                "content": "SANITIZED_TOOL_RESULT",
+                            }
+                        ],
+                    },
+                ],
+            }
+        )
+
+        payload = json.loads(result.body)
+        self.assertEqual(payload["max_tokens"], 64)
+        self.assertEqual(payload["messages"][0]["tool_calls"][0]["id"], "toolu_read_001")
+        self.assertEqual(payload["messages"][1], {
+            "role": "tool",
+            "tool_call_id": "toolu_read_001",
+            "content": "SANITIZED_TOOL_RESULT",
+        })
+        self.assertEqual(payload["tools"][0]["function"]["name"], "read_file")
+
+    def test_chat_tool_stream_returns_anthropic_tool_use_events(self):
+        records = chat_chunks_to_messages_sse(
+            [
+                {
+                    "id": "chatcmpl_tool_001",
+                    "model": "chat-test",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {
+                                "tool_calls": [
+                                    {
+                                        "index": 0,
+                                        "id": "toolu_read_001",
+                                        "type": "function",
+                                        "function": {
+                                            "name": "read_file",
+                                            "arguments": '{"path":',
+                                        },
+                                    }
+                                ]
+                            },
+                            "finish_reason": None,
+                        }
+                    ],
+                },
+                {
+                    "id": "chatcmpl_tool_001",
+                    "model": "chat-test",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {
+                                "tool_calls": [
+                                    {"index": 0, "function": {"arguments": '"fixture.txt"}'}}
+                                ]
+                            },
+                            "finish_reason": "tool_calls",
+                        }
+                    ],
+                    "usage": {"prompt_tokens": 9, "completion_tokens": 4},
+                },
+            ]
+        )
+
+        events = _decode_sse(records)
+        self.assertEqual(events[1][1]["content_block"]["id"], "toolu_read_001")
+        self.assertEqual(events[2][1]["delta"]["partial_json"], '{"path":')
+        self.assertEqual(events[3][1]["delta"]["partial_json"], '"fixture.txt"}')
+        self.assertEqual(events[-2][1]["usage"], {"input_tokens": 9, "output_tokens": 4})
+
+    def test_unknown_chat_delta_fails_explicitly(self):
+        with self.assertRaisesRegex(ValueError, "Unsupported Chat Completions delta field: reasoning_content"):
+            chat_chunks_to_messages_sse(
+                [
+                    {
+                        "id": "chatcmpl_reasoning_001",
+                        "model": "chat-test",
+                        "choices": [
+                            {
+                                "index": 0,
+                                "delta": {"reasoning_content": "<redacted>"},
+                                "finish_reason": "stop",
+                            }
+                        ],
+                    }
+                ]
+            )
+
+
+class InMemoryUpstreamExerciseTests(unittest.TestCase):
+    def test_responses_upstream_exercise_keeps_the_gateway_seam_in_memory(self):
+        exchange = exercise_responses_upstream(
+            {
+                "model": "gateway-responses-model",
+                "max_tokens": 32,
+                "messages": [{"role": "user", "content": "SANITIZED_TEXT"}],
+            },
+            [
+                {"type": "response.created", "response": {"id": "resp_001", "model": "gpt-test"}},
+                {
+                    "type": "response.output_item.added",
+                    "output_index": 0,
+                    "item": {"id": "msg_001", "type": "message", "role": "assistant", "content": []},
+                },
+                {"type": "response.output_text.delta", "output_index": 0, "delta": "SANITIZED_REPLY"},
+                {
+                    "type": "response.output_item.done",
+                    "output_index": 0,
+                    "item": {"id": "msg_001", "type": "message", "role": "assistant", "content": []},
+                },
+                {
+                    "type": "response.completed",
+                    "response": {"id": "resp_001", "model": "gpt-test", "usage": {}},
+                },
+            ],
+        )
+
+        self.assertEqual(exchange.upstream_kind, "responses")
+        self.assertTrue(exchange.translation.forwardable)
+        self.assertIn("input", json.loads(exchange.outbound_body))
+        self.assertEqual(_decode_sse(exchange.downstream_sse)[2][1]["delta"]["text"], "SANITIZED_REPLY")
+
+    def test_chat_provider_exercise_uses_chat_request_and_tool_sse(self):
+        exchange = exercise_chat_completions_upstream(
+            {
+                "model": "gateway-chat-model",
+                "max_tokens": 32,
+                "messages": [{"role": "user", "content": "SANITIZED_TEXT"}],
+            },
+            [
+                {
+                    "id": "chatcmpl_001",
+                    "model": "chat-test",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {"content": "SANITIZED_REPLY"},
+                            "finish_reason": "stop",
+                        }
+                    ],
+                    "usage": {"prompt_tokens": 5, "completion_tokens": 2},
+                }
+            ],
+        )
+
+        self.assertEqual(exchange.upstream_kind, "chat_completions")
+        self.assertTrue(exchange.translation.forwardable)
+        self.assertIn("messages", json.loads(exchange.outbound_body))
+        self.assertEqual(_decode_sse(exchange.downstream_sse)[2][1]["delta"]["text"], "SANITIZED_REPLY")
+
+
+class SafetyPolicyTests(unittest.TestCase):
+    def test_open_headers_are_classified_and_credentials_are_redacted(self):
+        policy = classify_claude_headers(
+            {
+                "Authorization": "Bearer SHOULD_NOT_APPEAR",
+                "anthropic-version": "2023-06-01",
+                "anthropic-beta": "future-capability",
+                "x-claude-code-session-id": "session-private-value",
+                "x-claude-code-future-field": "opaque-value",
+                "x-custom-header": "custom-private-value",
+            },
+            upstream_format="responses",
+        )
+
+        self.assertEqual(policy.sanitized["authorization"], "<redacted>")
+        self.assertEqual(policy.sanitized["x-claude-code-session-id"], "<pseudonymized>")
+        self.assertIn("anthropic-version", policy.consumed)
+        self.assertIn("x-claude-code-future-field", policy.consumed)
+        self.assertEqual(policy.unsupported, ("header.anthropic-beta", "header.x-custom-header"))
+
+    def test_upstream_error_becomes_an_anthropic_sse_error(self):
+        records = upstream_error_to_messages_sse(
+            529,
+            {"error": {"type": "server_error", "message": "SANITIZED_OVERLOAD"}},
+        )
+
+        event_name, payload = _decode_sse(records)[0]
+        self.assertEqual(event_name, "error")
+        self.assertEqual(payload, {
+            "type": "error",
+            "error": {"type": "overloaded_error", "message": "SANITIZED_OVERLOAD"},
+        })
+
+    def test_compatibility_matrix_keeps_high_risk_features_explicit(self):
+        matrix = compatibility_matrix()
+
+        self.assertEqual(matrix["text"], CompatibilityStatus.ADAPTED)
+        self.assertEqual(matrix["thinking"], CompatibilityStatus.UNSUPPORTED)
+        self.assertEqual(matrix["beta_fields"], CompatibilityStatus.UNSUPPORTED)
+        self.assertEqual(matrix["cancellation"], CompatibilityStatus.UNKNOWN)
+        self.assertEqual(matrix["count_tokens"], CompatibilityStatus.UNSUPPORTED)
+
+    def test_sanitized_trace_fixture_has_required_shapes_without_credentials(self):
+        fixture_path = Path(__file__).parent / "fixtures" / "anthropic_messages_spike_trace.json"
+        fixture_text = fixture_path.read_text(encoding="utf-8")
+        fixture = json.loads(fixture_text)
+
+        self.assertTrue(fixture["sanitized"])
+        self.assertEqual(fixture["protocol"]["anthropic_version"], "2023-06-01")
+        self.assertIn("response_json", fixture["text_stream"])
+        self.assertIn("sse_event_order", fixture["text_stream"])
+        self.assertTrue(fixture["tool_follow_up"]["next_request"]["history_contains_same_tool_id"])
+        self.assertFalse(fixture["cancellation"]["synthesizes_message_stop"])
+        self.assertIsNone(re.search(r"(?i)(sk-[a-z0-9]|gho_[a-z0-9]|bearer\s+[a-z0-9])", fixture_text))
+
+    def test_real_cli_loopback_trace_records_partial_input_and_tool_id_evidence(self):
+        fixture_path = Path(__file__).parent / "fixtures" / "claude_messages_real_cli_smoke.json"
+        fixture_text = fixture_path.read_text(encoding="utf-8")
+        fixture = json.loads(fixture_text)
+        scenarios = {item["scenario"]: item for item in fixture["scenarios"]}
+
+        self.assertTrue(fixture["sanitized"])
+        self.assertEqual(fixture["capture_kind"], "real_cli_to_local_loopback_prototype")
+        self.assertTrue(fixture["capture_succeeded"])
+        self.assertFalse(fixture["full_compatibility"])
+        self.assertEqual(fixture["compatibility_outcome"], "scoped PARTIAL")
+        self.assertTrue(scenarios["text"]["client"]["expected_output_seen"])
+        self.assertFalse(scenarios["text"]["request_summaries"][0]["messages_to_responses_forwardable"])
+        self.assertTrue(scenarios["tool"]["tool_follow_up_verified"])
+        self.assertTrue(scenarios["tool"]["request_summaries"][1]["tool_result_is_first_content_block"])
+        self.assertTrue(scenarios["cancel"]["disconnect_observed"])
+        self.assertIsNone(re.search(r"(?i)(sk-[a-z0-9]|gho_[a-z0-9]|bearer\s+[a-z0-9])", fixture_text))
+
+    def test_tool_call_result_history_keeps_the_same_call_id(self):
+        result = messages_to_responses(
+            {
+                "model": "gateway-tool-model",
+                "max_tokens": 128,
+                "system": [{"type": "text", "text": "SANITIZED_SYSTEM"}],
+                "tools": [
+                    {
+                        "name": "read_file",
+                        "description": "Read a fixture file",
+                        "input_schema": {
+                            "type": "object",
+                            "properties": {"path": {"type": "string"}},
+                            "required": ["path"],
+                        },
+                    }
+                ],
+                "messages": [
+                    {"role": "user", "content": [{"type": "text", "text": "SANITIZED_FIRST"}]},
+                    {
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "id": "toolu_read_001",
+                                "name": "read_file",
+                                "input": {"path": "fixture.txt"},
+                            }
+                        ],
+                    },
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": "toolu_read_001",
+                                "content": "SANITIZED_TOOL_RESULT",
+                            }
+                        ],
+                    },
+                    {"role": "user", "content": [{"type": "text", "text": "SANITIZED_FOLLOW_UP"}]},
+                ],
+            }
+        )
+
+        payload = json.loads(result.body)
+        self.assertEqual(payload["instructions"], "SANITIZED_SYSTEM")
+        self.assertEqual(payload["tools"][0]["name"], "read_file")
+        self.assertEqual(payload["input"][1]["call_id"], "toolu_read_001")
+        self.assertEqual(payload["input"][2], {
+            "type": "function_call_output",
+            "call_id": "toolu_read_001",
+            "output": "SANITIZED_TOOL_RESULT",
+        })
+        self.assertEqual(payload["input"][3]["content"][0]["text"], "SANITIZED_FOLLOW_UP")
+        self.assertEqual(result.unsupported, ())

--- a/tests/test_anthropic_messages_spike.py
+++ b/tests/test_anthropic_messages_spike.py
@@ -619,6 +619,616 @@ class ChatCompletionsPrototypeTests(unittest.TestCase):
                 ]
             )
 
+    def test_present_non_list_chat_choices_fail_closed(self):
+        with self.assertRaisesRegex(ValueError, "Chat Completions choices is not a list"):
+            chat_chunks_to_messages_sse(
+                [
+                    {
+                        "id": "chatcmpl_bad_choices_001",
+                        "model": "chat-test",
+                        "choices": {"index": 0},
+                    }
+                ]
+            )
+
+    def test_present_non_object_chat_choice_fails_closed(self):
+        with self.assertRaisesRegex(ValueError, "Chat Completions choice is not an object"):
+            chat_chunks_to_messages_sse(
+                [
+                    {
+                        "id": "chatcmpl_bad_choice_001",
+                        "model": "chat-test",
+                        "choices": ["not-an-object"],
+                    }
+                ]
+            )
+
+    def test_present_non_object_chat_delta_fails_closed(self):
+        with self.assertRaisesRegex(ValueError, "Chat Completions delta is not an object"):
+            chat_chunks_to_messages_sse(
+                [
+                    {
+                        "id": "chatcmpl_bad_delta_001",
+                        "model": "chat-test",
+                        "choices": [
+                            {
+                                "index": 0,
+                                "delta": "not-an-object",
+                                "finish_reason": "stop",
+                            }
+                        ],
+                    }
+                ]
+            )
+
+    def test_present_non_string_chat_content_fails_closed(self):
+        with self.assertRaisesRegex(ValueError, "Chat Completions delta content is not a string or null"):
+            chat_chunks_to_messages_sse(
+                [
+                    {
+                        "id": "chatcmpl_bad_content_001",
+                        "model": "chat-test",
+                        "choices": [
+                            {
+                                "index": 0,
+                                "delta": {"content": ["not", "a", "string"]},
+                                "finish_reason": "stop",
+                            }
+                        ],
+                    }
+                ]
+            )
+
+    def test_present_non_list_chat_tool_calls_fail_closed(self):
+        with self.assertRaisesRegex(ValueError, "Chat Completions delta tool_calls is not a list or null"):
+            chat_chunks_to_messages_sse(
+                [
+                    {
+                        "id": "chatcmpl_bad_tool_calls_001",
+                        "model": "chat-test",
+                        "choices": [
+                            {
+                                "index": 0,
+                                "delta": {"tool_calls": {"index": 0}},
+                                "finish_reason": "tool_calls",
+                            }
+                        ],
+                    }
+                ]
+            )
+
+    def test_present_invalid_chat_chunk_identity_fields_fail_closed(self):
+        invalid_fields = (
+            ("id", 7, "Chat Completions chunk id is not a non-empty string"),
+            ("model", [], "Chat Completions chunk model is not a non-empty string"),
+        )
+
+        for field, value, error in invalid_fields:
+            with self.subTest(field=field):
+                chunk = {
+                    "id": "chatcmpl_valid_identity_001",
+                    "model": "chat-test",
+                    "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+                }
+                chunk[field] = value
+                with self.assertRaisesRegex(ValueError, error):
+                    chat_chunks_to_messages_sse([chunk])
+
+    def test_present_non_string_chat_finish_reason_fails_closed(self):
+        with self.assertRaisesRegex(ValueError, "Chat Completions finish_reason is not a string or null"):
+            chat_chunks_to_messages_sse(
+                [
+                    {
+                        "id": "chatcmpl_bad_finish_reason_001",
+                        "model": "chat-test",
+                        "choices": [
+                            {
+                                "index": 0,
+                                "delta": {"content": "SANITIZED_REPLY"},
+                                "finish_reason": 7,
+                            }
+                        ],
+                    }
+                ]
+            )
+
+    def test_present_invalid_chat_tool_call_index_fails_closed(self):
+        with self.assertRaisesRegex(ValueError, "Chat Completions tool call index is not a non-negative integer"):
+            chat_chunks_to_messages_sse(
+                [
+                    {
+                        "id": "chatcmpl_bad_tool_index_001",
+                        "model": "chat-test",
+                        "choices": [
+                            {
+                                "index": 0,
+                                "delta": {
+                                    "tool_calls": [
+                                        {
+                                            "index": "0",
+                                            "id": "toolu_bad_index_001",
+                                            "type": "function",
+                                            "function": {"name": "read_file", "arguments": "{}"},
+                                        }
+                                    ]
+                                },
+                                "finish_reason": "tool_calls",
+                            }
+                        ],
+                    }
+                ]
+            )
+
+    def test_present_non_string_chat_function_arguments_fail_closed(self):
+        with self.assertRaisesRegex(ValueError, "Chat Completions function arguments is not a string or null"):
+            chat_chunks_to_messages_sse(
+                [
+                    {
+                        "id": "chatcmpl_bad_arguments_001",
+                        "model": "chat-test",
+                        "choices": [
+                            {
+                                "index": 0,
+                                "delta": {
+                                    "tool_calls": [
+                                        {
+                                            "index": 0,
+                                            "id": "toolu_bad_arguments_001",
+                                            "type": "function",
+                                            "function": {"name": "read_file", "arguments": {}},
+                                        }
+                                    ]
+                                },
+                                "finish_reason": "tool_calls",
+                            }
+                        ],
+                    }
+                ]
+            )
+
+    def test_chat_tool_continuation_rejects_invalid_or_changed_identity(self):
+        continuation_cases = (
+            (
+                "invalid_id",
+                {"index": 0, "id": 7, "function": {"arguments": '"fixture.txt"}'}},
+                "Chat Completions tool call id is not a non-empty string or null",
+            ),
+            (
+                "changed_id",
+                {
+                    "index": 0,
+                    "id": "toolu_other_001",
+                    "function": {"arguments": '"fixture.txt"}'},
+                },
+                "Chat Completions tool call id changed for index 0",
+            ),
+            (
+                "invalid_name",
+                {"index": 0, "function": {"name": 7, "arguments": '"fixture.txt"}'}},
+                "Chat Completions function name is not a non-empty string or null",
+            ),
+            (
+                "changed_name",
+                {
+                    "index": 0,
+                    "function": {"name": "write_file", "arguments": '"fixture.txt"}'},
+                },
+                "Chat Completions function name changed for index 0",
+            ),
+        )
+
+        for case, continuation, error in continuation_cases:
+            with self.subTest(case=case):
+                with self.assertRaisesRegex(ValueError, error):
+                    chat_chunks_to_messages_sse(
+                        [
+                            {
+                                "id": "chatcmpl_identity_001",
+                                "model": "chat-test",
+                                "choices": [
+                                    {
+                                        "index": 0,
+                                        "delta": {
+                                            "tool_calls": [
+                                                {
+                                                    "index": 0,
+                                                    "id": "toolu_identity_001",
+                                                    "type": "function",
+                                                    "function": {
+                                                        "name": "read_file",
+                                                        "arguments": '{"path":',
+                                                    },
+                                                }
+                                            ]
+                                        },
+                                        "finish_reason": None,
+                                    }
+                                ],
+                            },
+                            {
+                                "id": "chatcmpl_identity_001",
+                                "model": "chat-test",
+                                "choices": [
+                                    {
+                                        "index": 0,
+                                        "delta": {"tool_calls": [continuation]},
+                                        "finish_reason": "tool_calls",
+                                    }
+                                ],
+                            },
+                        ]
+                    )
+
+    def test_chat_tool_call_id_cannot_be_reused_by_another_index(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "Chat Completions tool call id reused for indexes 0 and 1",
+        ):
+            chat_chunks_to_messages_sse(
+                [
+                    {
+                        "id": "chatcmpl_duplicate_tool_id_001",
+                        "model": "chat-test",
+                        "choices": [
+                            {
+                                "index": 0,
+                                "delta": {
+                                    "tool_calls": [
+                                        {
+                                            "index": 0,
+                                            "id": "toolu_duplicate_001",
+                                            "type": "function",
+                                            "function": {"name": "read_file", "arguments": "{}"},
+                                        },
+                                        {
+                                            "index": 1,
+                                            "id": "toolu_duplicate_001",
+                                            "type": "function",
+                                            "function": {"name": "write_file", "arguments": "{}"},
+                                        },
+                                    ]
+                                },
+                                "finish_reason": "tool_calls",
+                            }
+                        ],
+                    }
+                ]
+            )
+
+    def test_present_invalid_known_chat_discriminators_fail_closed(self):
+        invalid_chunks = (
+            (
+                "choice_index",
+                {
+                    "id": "chatcmpl_bad_choice_index_001",
+                    "model": "chat-test",
+                    "choices": [{"index": "0", "delta": {}, "finish_reason": "stop"}],
+                },
+                "Chat Completions choice index is not a non-negative integer",
+            ),
+            (
+                "delta_role",
+                {
+                    "id": "chatcmpl_bad_role_001",
+                    "model": "chat-test",
+                    "choices": [
+                        {"index": 0, "delta": {"role": 7}, "finish_reason": "stop"}
+                    ],
+                },
+                "Chat Completions delta role is not assistant or null",
+            ),
+            (
+                "tool_call_type",
+                {
+                    "id": "chatcmpl_bad_tool_type_001",
+                    "model": "chat-test",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {
+                                "tool_calls": [
+                                    {
+                                        "index": 0,
+                                        "id": "toolu_bad_type_001",
+                                        "type": "custom",
+                                        "function": {"name": "read_file", "arguments": "{}"},
+                                    }
+                                ]
+                            },
+                            "finish_reason": "tool_calls",
+                        }
+                    ],
+                },
+                "Chat Completions tool call type is not function or null",
+            ),
+        )
+
+        for case, chunk, error in invalid_chunks:
+            with self.subTest(case=case):
+                with self.assertRaisesRegex(ValueError, error):
+                    chat_chunks_to_messages_sse([chunk])
+
+    def test_unsupported_chat_choice_cardinality_fails_closed(self):
+        invalid_streams = (
+            (
+                "nonzero_index",
+                [
+                    {
+                        "id": "chatcmpl_choice_index_001",
+                        "model": "chat-test",
+                        "choices": [{"index": 1, "delta": {}, "finish_reason": "stop"}],
+                    }
+                ],
+                "Unsupported Chat Completions choice index: 1",
+            ),
+            (
+                "multiple_choices",
+                [
+                    {
+                        "id": "chatcmpl_multiple_choices_001",
+                        "model": "chat-test",
+                        "choices": [
+                            {"index": 0, "delta": {"content": "FIRST"}, "finish_reason": "stop"},
+                            {"index": 1, "delta": {"content": "SECOND"}, "finish_reason": "stop"},
+                        ],
+                    }
+                ],
+                "Multiple Chat Completions choices are unsupported",
+            ),
+        )
+
+        for case, chunks, error in invalid_streams:
+            with self.subTest(case=case):
+                with self.assertRaisesRegex(ValueError, error):
+                    chat_chunks_to_messages_sse(chunks)
+
+    def test_chat_chunk_identity_cannot_change_during_stream(self):
+        conflicts = (
+            (
+                "id",
+                "chatcmpl_identity_other_001",
+                "Chat Completions chunk id changed during stream",
+            ),
+            (
+                "model",
+                "chat-other",
+                "Chat Completions chunk model changed during stream",
+            ),
+        )
+
+        for field, conflicting_value, error in conflicts:
+            with self.subTest(field=field):
+                terminal_chunk = {
+                    "id": "chatcmpl_stable_identity_001",
+                    "model": "chat-test",
+                    "choices": [
+                        {"index": 0, "delta": {"content": "SECOND"}, "finish_reason": "stop"}
+                    ],
+                }
+                terminal_chunk[field] = conflicting_value
+                with self.assertRaisesRegex(ValueError, error):
+                    chat_chunks_to_messages_sse(
+                        [
+                            {
+                                "id": "chatcmpl_stable_identity_001",
+                                "model": "chat-test",
+                                "choices": [
+                                    {
+                                        "index": 0,
+                                        "delta": {"content": "FIRST"},
+                                        "finish_reason": None,
+                                    }
+                                ],
+                            },
+                            terminal_chunk,
+                        ]
+                    )
+
+    def test_unsupported_chat_finish_reasons_fail_closed(self):
+        for finish_reason in ("length", "content_filter", "function_call"):
+            with self.subTest(finish_reason=finish_reason):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    f"Unsupported Chat Completions finish_reason: {finish_reason}",
+                ):
+                    chat_chunks_to_messages_sse(
+                        [
+                            {
+                                "id": "chatcmpl_unsupported_finish_001",
+                                "model": "chat-test",
+                                "choices": [
+                                    {
+                                        "index": 0,
+                                        "delta": {"content": "SANITIZED_REPLY"},
+                                        "finish_reason": finish_reason,
+                                    }
+                                ],
+                            }
+                        ]
+                    )
+
+    def test_unsupported_chat_container_fields_fail_closed(self):
+        invalid_chunks = (
+            (
+                "chunk",
+                {
+                    "id": "chatcmpl_unknown_chunk_field_001",
+                    "model": "chat-test",
+                    "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+                    "service_tier": "priority",
+                },
+                "Unsupported Chat Completions chunk field: service_tier",
+            ),
+            (
+                "choice",
+                {
+                    "id": "chatcmpl_unknown_choice_field_001",
+                    "model": "chat-test",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {},
+                            "finish_reason": "stop",
+                            "logprobs": {"content": []},
+                        }
+                    ],
+                },
+                "Unsupported Chat Completions choice field: logprobs",
+            ),
+            (
+                "delta",
+                {
+                    "id": "chatcmpl_unsupported_refusal_001",
+                    "model": "chat-test",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {"refusal": "SANITIZED_REFUSAL"},
+                            "finish_reason": "stop",
+                        }
+                    ],
+                },
+                "Unsupported Chat Completions delta field: refusal",
+            ),
+            (
+                "tool_call",
+                {
+                    "id": "chatcmpl_unknown_tool_field_001",
+                    "model": "chat-test",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {
+                                "tool_calls": [
+                                    {
+                                        "index": 0,
+                                        "id": "toolu_unknown_field_001",
+                                        "type": "function",
+                                        "function": {"name": "read_file", "arguments": "{}"},
+                                        "provider_detail": {},
+                                    }
+                                ]
+                            },
+                            "finish_reason": "tool_calls",
+                        }
+                    ],
+                },
+                "Unsupported Chat Completions tool call field: provider_detail",
+            ),
+            (
+                "function",
+                {
+                    "id": "chatcmpl_unknown_function_field_001",
+                    "model": "chat-test",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {
+                                "tool_calls": [
+                                    {
+                                        "index": 0,
+                                        "id": "toolu_unknown_function_field_001",
+                                        "type": "function",
+                                        "function": {
+                                            "name": "read_file",
+                                            "arguments": "{}",
+                                            "provider_detail": {},
+                                        },
+                                    }
+                                ]
+                            },
+                            "finish_reason": "tool_calls",
+                        }
+                    ],
+                },
+                "Unsupported Chat Completions function field: provider_detail",
+            ),
+        )
+
+        for scope, chunk, error in invalid_chunks:
+            with self.subTest(scope=scope):
+                with self.assertRaisesRegex(ValueError, error):
+                    chat_chunks_to_messages_sse([chunk])
+
+    def test_absent_and_nullable_chat_stream_fields_remain_permitted(self):
+        records = chat_chunks_to_messages_sse(
+            [
+                {
+                    "id": "chatcmpl_optional_fields_001",
+                    "model": "chat-test",
+                    "usage": None,
+                    "service_tier": None,
+                    "system_fingerprint": None,
+                },
+                {
+                    "id": "chatcmpl_optional_fields_001",
+                    "model": "chat-test",
+                    "choices": [
+                        {
+                            "delta": {
+                                "role": "assistant",
+                                "content": None,
+                                "tool_calls": None,
+                                "function_call": None,
+                                "refusal": None,
+                            },
+                            "finish_reason": None,
+                            "logprobs": None,
+                        }
+                    ],
+                },
+                {
+                    "id": "chatcmpl_optional_fields_001",
+                    "model": "chat-test",
+                    "choices": [
+                        {
+                            "delta": {
+                                "tool_calls": [
+                                    {
+                                        "id": "toolu_optional_fields_001",
+                                        "type": "function",
+                                        "function": {
+                                            "name": "read_file",
+                                            "arguments": '{"path":',
+                                        },
+                                    }
+                                ]
+                            },
+                            "finish_reason": None,
+                        }
+                    ],
+                },
+                {
+                    "id": "chatcmpl_optional_fields_001",
+                    "model": "chat-test",
+                    "choices": [
+                        {
+                            "delta": {
+                                "tool_calls": [
+                                    {
+                                        "id": None,
+                                        "type": None,
+                                        "function": {
+                                            "name": None,
+                                            "arguments": '"fixture.txt"}',
+                                        },
+                                    }
+                                ]
+                            },
+                            "finish_reason": "tool_calls",
+                        }
+                    ],
+                },
+            ]
+        )
+
+        events = _decode_sse(records)
+        self.assertEqual(events[1][1]["content_block"]["id"], "toolu_optional_fields_001")
+        self.assertEqual(
+            [payload["delta"]["partial_json"] for event, payload in events if event == "content_block_delta"],
+            ['{"path":', '"fixture.txt"}'],
+        )
+
 
 class InMemoryUpstreamExerciseTests(unittest.TestCase):
     def test_responses_upstream_exercise_keeps_the_gateway_seam_in_memory(self):

--- a/tests/test_anthropic_messages_spike.py
+++ b/tests/test_anthropic_messages_spike.py
@@ -71,6 +71,112 @@ class MessagesToResponsesTests(unittest.TestCase):
         self.assertFalse(result.forwardable)
         self.assertEqual(result.unsupported, ("request.thinking",))
 
+    def test_image_is_nonforwardable_until_the_upstream_capability_is_verified(self):
+        result = messages_to_responses(
+            {
+                "model": "gateway-vision-model",
+                "max_tokens": 64,
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "image",
+                                "source": {
+                                    "type": "base64",
+                                    "media_type": "image/png",
+                                    "data": "SANITIZED_IMAGE_BYTES",
+                                },
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+
+        self.assertIsNone(result.body)
+        self.assertEqual(result.unsupported, ("messages[0].content[0]",))
+
+    def test_tool_result_requires_a_prior_call_and_first_content_position(self):
+        unmatched = messages_to_responses(
+            {
+                "model": "gateway-tool-model",
+                "max_tokens": 64,
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": "toolu_missing",
+                                "content": "SANITIZED_TOOL_RESULT",
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+        out_of_order = messages_to_responses(
+            {
+                "model": "gateway-tool-model",
+                "max_tokens": 64,
+                "messages": [
+                    {
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "id": "toolu_read_001",
+                                "name": "read_file",
+                                "input": {"path": "fixture.txt"},
+                            }
+                        ],
+                    },
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "text", "text": "SANITIZED_TEXT"},
+                            {
+                                "type": "tool_result",
+                                "tool_use_id": "toolu_read_001",
+                                "content": "SANITIZED_TOOL_RESULT",
+                            },
+                        ],
+                    },
+                ],
+            }
+        )
+
+        self.assertIsNone(unmatched.body)
+        self.assertEqual(unmatched.unsupported, ("messages[0].content[0].tool_use_id",))
+        self.assertIsNone(out_of_order.body)
+        self.assertEqual(out_of_order.unsupported, ("messages[1].content[1].tool_result_order",))
+
+    def test_unresolved_tool_call_history_is_nonforwardable(self):
+        result = messages_to_responses(
+            {
+                "model": "gateway-tool-model",
+                "max_tokens": 64,
+                "messages": [
+                    {
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "id": "toolu_read_001",
+                                "name": "read_file",
+                                "input": {"path": "fixture.txt"},
+                            }
+                        ],
+                    },
+                    {"role": "user", "content": "SANITIZED_TEXT"},
+                ],
+            }
+        )
+
+        self.assertIsNone(result.body)
+        self.assertEqual(result.unsupported, ("messages[0].content[0].unresolved",))
+
 
 class ResponsesToMessagesSseTests(unittest.TestCase):
     def test_text_stream_has_anthropic_lifecycle_and_usage(self):
@@ -89,6 +195,11 @@ class ResponsesToMessagesSseTests(unittest.TestCase):
                     "type": "response.output_text.delta",
                     "output_index": 0,
                     "delta": "SANITIZED_REPLY",
+                },
+                {
+                    "type": "response.output_text.done",
+                    "output_index": 0,
+                    "text": "SANITIZED_REPLY",
                 },
                 {
                     "type": "response.output_item.done",
@@ -118,6 +229,37 @@ class ResponsesToMessagesSseTests(unittest.TestCase):
         self.assertEqual(events[0][1]["message"]["id"], "resp_text_001")
         self.assertEqual(events[2][1]["delta"], {"type": "text_delta", "text": "SANITIZED_REPLY"})
         self.assertEqual(events[4][1]["usage"], {"input_tokens": 7, "output_tokens": 3})
+
+    def test_text_stream_rejects_a_final_snapshot_that_conflicts_with_deltas(self):
+        with self.assertRaisesRegex(ValueError, "Responses text deltas do not match final text"):
+            responses_events_to_messages_sse(
+                [
+                    {
+                        "type": "response.created",
+                        "response": {"id": "resp_text_mismatch_001", "model": "gpt-test"},
+                    },
+                    {
+                        "type": "response.output_item.added",
+                        "output_index": 0,
+                        "item": {
+                            "id": "msg_text_mismatch_001",
+                            "type": "message",
+                            "role": "assistant",
+                            "content": [],
+                        },
+                    },
+                    {
+                        "type": "response.output_text.delta",
+                        "output_index": 0,
+                        "delta": "SANITIZED_REPLY",
+                    },
+                    {
+                        "type": "response.output_text.done",
+                        "output_index": 0,
+                        "text": "SANITIZED_DIFFERENT_REPLY",
+                    },
+                ]
+            )
 
     def test_tool_stream_uses_upstream_call_id_for_the_follow_up_turn(self):
         records = responses_events_to_messages_sse(
@@ -170,6 +312,76 @@ class ResponsesToMessagesSseTests(unittest.TestCase):
         })
         self.assertEqual(events[4][1]["delta"]["stop_reason"], "tool_use")
 
+    def test_tool_stream_accepts_a_matching_final_argument_snapshot(self):
+        records = responses_events_to_messages_sse(
+            [
+                {
+                    "type": "response.created",
+                    "response": {"id": "resp_tool_done_001", "model": "gpt-test"},
+                },
+                {
+                    "type": "response.output_item.added",
+                    "output_index": 0,
+                    "item": {
+                        "id": "fc_done_001",
+                        "type": "function_call",
+                        "call_id": "toolu_done_001",
+                        "name": "read_file",
+                    },
+                },
+                {
+                    "type": "response.function_call_arguments.delta",
+                    "output_index": 0,
+                    "delta": '{"path":"fixture.txt"}',
+                },
+                {
+                    "type": "response.function_call_arguments.done",
+                    "output_index": 0,
+                    "arguments": '{"path":"fixture.txt"}',
+                },
+                {
+                    "type": "response.output_item.done",
+                    "output_index": 0,
+                    "item": {"id": "fc_done_001", "type": "function_call"},
+                },
+                {
+                    "type": "response.completed",
+                    "response": {
+                        "id": "resp_tool_done_001",
+                        "model": "gpt-test",
+                        "usage": {"input_tokens": 7, "output_tokens": 3, "total_tokens": 10},
+                    },
+                },
+            ]
+        )
+
+        events = _decode_sse(records)
+        deltas = [payload["delta"] for event, payload in events if event == "content_block_delta"]
+        self.assertEqual(deltas, [{"type": "input_json_delta", "partial_json": '{"path":"fixture.txt"}'}])
+
+    def test_cache_usage_details_are_explicitly_rejected(self):
+        with self.assertRaisesRegex(ValueError, "Unsupported Responses usage field: input_tokens_details"):
+            responses_events_to_messages_sse(
+                [
+                    {
+                        "type": "response.created",
+                        "response": {"id": "resp_usage_detail_001", "model": "gpt-test"},
+                    },
+                    {
+                        "type": "response.completed",
+                        "response": {
+                            "id": "resp_usage_detail_001",
+                            "model": "gpt-test",
+                            "usage": {
+                                "input_tokens": 7,
+                                "output_tokens": 3,
+                                "input_tokens_details": {"cached_tokens": 1},
+                            },
+                        },
+                    },
+                ]
+            )
+
     def test_unknown_responses_output_item_fails_explicitly(self):
         with self.assertRaisesRegex(ValueError, "Unsupported Responses output item type: reasoning"):
             responses_events_to_messages_sse(
@@ -185,6 +397,92 @@ class ResponsesToMessagesSseTests(unittest.TestCase):
                     },
                 ]
             )
+
+    def test_tool_stream_rejects_arguments_that_are_not_a_json_object(self):
+        with self.assertRaisesRegex(ValueError, "Responses tool arguments must be a JSON object"):
+            responses_events_to_messages_sse(
+                [
+                    {
+                        "type": "response.created",
+                        "response": {"id": "resp_tool_bad_001", "model": "gpt-test"},
+                    },
+                    {
+                        "type": "response.output_item.added",
+                        "output_index": 0,
+                        "item": {
+                            "id": "fc_bad_001",
+                            "type": "function_call",
+                            "call_id": "toolu_bad_001",
+                            "name": "read_file",
+                            "arguments": "",
+                        },
+                    },
+                    {
+                        "type": "response.function_call_arguments.delta",
+                        "output_index": 0,
+                        "delta": "not-json",
+                    },
+                    {
+                        "type": "response.output_item.done",
+                        "output_index": 0,
+                        "item": {"id": "fc_bad_001", "type": "function_call"},
+                    },
+                ]
+            )
+
+    def test_tool_stream_rejects_a_final_argument_snapshot_that_conflicts_with_deltas(self):
+        with self.assertRaisesRegex(ValueError, "Responses tool argument deltas do not match final arguments"):
+            responses_events_to_messages_sse(
+                [
+                    {
+                        "type": "response.created",
+                        "response": {"id": "resp_tool_mismatch_001", "model": "gpt-test"},
+                    },
+                    {
+                        "type": "response.output_item.added",
+                        "output_index": 0,
+                        "item": {
+                            "id": "fc_mismatch_001",
+                            "type": "function_call",
+                            "call_id": "toolu_mismatch_001",
+                            "name": "read_file",
+                        },
+                    },
+                    {
+                        "type": "response.function_call_arguments.delta",
+                        "output_index": 0,
+                        "delta": '{"path":"fixture.txt"}',
+                    },
+                    {
+                        "type": "response.function_call_arguments.done",
+                        "output_index": 0,
+                        "arguments": '{"path":"other.txt"}',
+                    },
+                ]
+            )
+
+    def test_missing_upstream_usage_stays_absent_instead_of_zero_filled(self):
+        records = responses_events_to_messages_sse(
+            [
+                {"type": "response.created", "response": {"id": "resp_no_usage", "model": "gpt-test"}},
+                {
+                    "type": "response.output_item.added",
+                    "output_index": 0,
+                    "item": {"id": "msg_no_usage", "type": "message", "role": "assistant", "content": []},
+                },
+                {"type": "response.output_text.delta", "output_index": 0, "delta": "SANITIZED_REPLY"},
+                {
+                    "type": "response.output_item.done",
+                    "output_index": 0,
+                    "item": {"id": "msg_no_usage", "type": "message", "role": "assistant", "content": []},
+                },
+                {"type": "response.completed", "response": {"id": "resp_no_usage", "model": "gpt-test"}},
+            ]
+        )
+
+        events = _decode_sse(records)
+        self.assertEqual(events[0][1]["message"]["usage"], {})
+        self.assertEqual(events[-2][1]["usage"], {})
 
 
 class ChatCompletionsPrototypeTests(unittest.TestCase):
@@ -300,6 +598,23 @@ class ChatCompletionsPrototypeTests(unittest.TestCase):
                                 "finish_reason": "stop",
                             }
                         ],
+                    }
+                ]
+            )
+
+    def test_chat_cache_usage_details_are_explicitly_rejected(self):
+        with self.assertRaisesRegex(ValueError, "Unsupported Chat Completions usage field: prompt_tokens_details"):
+            chat_chunks_to_messages_sse(
+                [
+                    {
+                        "id": "chatcmpl_usage_detail_001",
+                        "model": "chat-test",
+                        "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+                        "usage": {
+                            "prompt_tokens": 5,
+                            "completion_tokens": 2,
+                            "prompt_tokens_details": {"cached_tokens": 1},
+                        },
                     }
                 ]
             )

--- a/tests/test_anthropic_messages_spike.py
+++ b/tests/test_anthropic_messages_spike.py
@@ -383,6 +383,8 @@ class SafetyPolicyTests(unittest.TestCase):
 
         self.assertEqual(policy.sanitized["authorization"], "<redacted>")
         self.assertEqual(policy.sanitized["x-claude-code-session-id"], "<pseudonymized>")
+        self.assertEqual(policy.semantic_headers["anthropic-beta"], "future-capability")
+        self.assertEqual(policy.semantic_headers["x-claude-code-future-field"], "opaque-value")
         self.assertIn("anthropic-version", policy.consumed)
         self.assertIn("x-claude-code-future-field", policy.consumed)
         self.assertEqual(policy.unsupported, ("header.anthropic-beta", "header.x-custom-header"))


### PR DESCRIPTION
## Summary
- Adds an isolated, in-memory Anthropic Messages ↔ Responses/Chat Completions translator spike with fail-closed field, tool-history, SSE, and usage handling.
- Hardens Chat stream conversion so omitted/known-null optionals remain permitted, while malformed or unsupported chunk/choice/delta/tool/function shapes, multi-choice output, unstable response/tool identity, and unsupported finish reasons fail with precise errors.
- Captures sanitized Claude Code loopback evidence for text, tool-result follow-up, multi-turn history, headers, SSE, errors, usage shape, and attempted downstream disconnect.
- Records the canonical `AnthropicMessage` seam decision and compatibility matrix; updates the agent-provider roadmap without changing ACP work.

## Decision

**Scoped PARTIAL**. Basic text, history, tool IDs, Messages SSE, and deterministic upstream protocol shapes are evidenced. Thinking, cache controls, images, beta/open fields, detailed usage, count tokens, cancellation propagation, retries, and real provider behavior remain explicit gates.

## Verification

- `python -m pytest tests/test_anthropic_messages_spike.py -q` — 43 passed, 21 subtests passed
- `python -m pytest tests/test_routing.py tests/test_chat_completions_gateway.py` — 468 passed
- `python -m pytest -q` — 861 passed, 1 skipped, 109 subtests passed
- `python scripts/run_claude_messages_spike_smoke.py --scenarios all --write-trace <temporary-sanitized-path>` — capture succeeded; full compatibility false as expected for scoped PARTIAL
- `python scripts/report_quality_gates.py` — report-only baseline findings, exit 0
- Standards review — no hard findings; Spec review — clean

## Scope / remaining external gate

No production `/v1/messages` route, `codex_proxy.py` handler integration, Claude Code auto-configuration, provider configuration, shared runtime, or ACP AgentProvider changes. No real official OpenAI/Responses or Chat Completions provider call was made because approved provider credentials were not available; the research note documents that concrete gate.

Refs #74