### PR TITLE
test: audit bounded Issue 62 runtime evidence

### DIFF
--- a/docs/evidence/issue-62/README.md
+++ b/docs/evidence/issue-62/README.md
@@ -77,3 +77,64 @@ changes selection. The in-process rewrite and clean-cold-start cases remain
 separate; no shared-runtime restart or configuration experiment was run for
 this evidence update. Reluctant-model and tool_search lifecycle work belongs
 to #63.
+
+## Bounded read-only gate audit
+
+`read-only-gate-audit.json` is a frozen, sanitized audit of the already-existing
+Codex request log and Gateway telemetry database. The reusable auditor opens
+both SQLite inputs in `mode=ro` and emits only schema names, field presence,
+counts, booleans, and enums. It never emits paths, headers, credentials,
+request bodies, prompts, descriptions, arguments, results, HMAC values, or any
+session, task, turn, call, item, request, or response identifiers.
+
+The bounded audit establishes these additional facts without a restart,
+reconnect, configuration write, or production-handler change:
+
+- Forty-three retained Sol transport rows resolve to three actual
+  model-visible planner surfaces. The largest retained surface includes the
+  base functions, collaboration namespace, goal functions, image generation,
+  the three Direct codex_app functions, and client-executed tool_search.
+- Every retained Sol surface is a real streaming request with
+  `tool_choice=auto` and `parallel_tool_calls=false`. This replaces the prior
+  choice-control sentinel with observed request evidence, but it does not
+  supply a non-streaming control.
+- The bounded request rows contain eight classified input item types and zero
+  unknown item types. This is request-side classification only; it cannot
+  satisfy full pre/post identity while full response evidence is absent.
+- The current Gateway-process window contains 525 official Responses identity
+  route starts. All 525 have equal caller/upstream 65,536-byte prefix HMACs and
+  no prefix mismatches. All 525 are streaming, all 525 deliberately skipped
+  full-body HMACs, and the telemetry schema has no response-body fingerprint.
+- The current app-server process predates the current configuration write,
+  there are no Gateway requests after that app-server start, and the retained
+  post-start Sol transport rows classify as direct official endpoints. A clean
+  cold start for the current binding is therefore not proved. The configured
+  provider id is not used as route provenance.
+
+The recovery observation remains deliberately non-causal: repeated task-level
+system errors affected both continued and fresh Terra tasks on unchanged clean
+branches, unrelated already-running Terra tasks continued, and fresh Sol tasks
+started normally with no intervening shared-state mutation. This supports only
+task-start recovery and model-binding fallback classification. The route-level
+cause is unknown, model-only causality is not claimed, and full collaboration
+lifecycle closure remains owned by #64.
+
+Run the sanitizer with explicit bounded inputs and observation cutoffs:
+
+```powershell
+python scripts/audit_issue_62_runtime_artifacts.py `
+  --codex-log-db <codex-log-db> `
+  --gateway-db <gateway-telemetry-db> `
+  --model gpt-5.6-sol `
+  --gateway-started-at <gateway-start-utc> `
+  --app-server-started-at <app-server-start-utc> `
+  --config-written-at <config-write-utc> `
+  --catalog-written-at <catalog-write-utc> `
+  --snapshot-ended-at <snapshot-end-utc>
+```
+
+The remaining gates require a separately authorized live control: complete
+registered contributor/defer-loading capture, a clean current-binding cold
+start, independently fingerprinted full caller/upstream/downstream requests
+and responses, a real non-streaming request, and observed non-Direct states.
+No such control was run for this audit.

--- a/docs/evidence/issue-62/read-only-gate-audit.json
+++ b/docs/evidence/issue-62/read-only-gate-audit.json
@@ -1,0 +1,413 @@
+{
+  "capture_kind": "sanitized_bounded_read_only_audit",
+  "gate_classification": {
+    "choice_controls": "observed",
+    "clean_cold_start_current_binding": "live_control_required",
+    "complete_contributors_runtime_gate": "partial",
+    "full_pre_post_request_response": "live_control_required",
+    "non_direct_states": "live_control_required",
+    "non_streaming": "live_control_required",
+    "zero_unclassified_identity": "partial"
+  },
+  "gateway_identity_route": {
+    "full_body_hmac_both_skipped": 525,
+    "full_body_hmac_pairs": 0,
+    "non_streaming_requests": 0,
+    "observed_sse_event_type_counts": {
+      "keepalive": 1,
+      "response.completed": 515,
+      "response.content_part.added": 148,
+      "response.content_part.done": 148,
+      "response.created": 520,
+      "response.custom_tool_call_input.delta": 22,
+      "response.custom_tool_call_input.done": 22,
+      "response.function_call_arguments.delta": 453,
+      "response.function_call_arguments.done": 460,
+      "response.in_progress": 520,
+      "response.metadata": 9,
+      "response.output_item.added": 520,
+      "response.output_item.done": 520,
+      "response.output_text.delta": 148,
+      "response.output_text.done": 148,
+      "response.reasoning_summary_part.added": 424,
+      "response.reasoning_summary_part.done": 424,
+      "response.reasoning_summary_text.delta": 424,
+      "response.reasoning_summary_text.done": 424
+    },
+    "prefix_equal": 525,
+    "prefix_mismatch": 0,
+    "prefix_unavailable": 0,
+    "request_starts": 525,
+    "response_body_fingerprint_fields_present": false,
+    "route_variants": [
+      {
+        "behavior_profile": "official_codex_app_http_passthrough",
+        "codex_semantic_adapter": "none",
+        "inbound_format": "responses",
+        "repair_policy": "none",
+        "request_starts": 525,
+        "route": "route_01",
+        "route_mode": "official",
+        "upstream": "official",
+        "upstream_format": "responses",
+        "wire_format_adapter": "transparent"
+      }
+    ],
+    "streaming_requests": 525
+  },
+  "model_visible_request_plan": {
+    "model": "gpt-5.6-sol",
+    "observed_input_item_type_counts": {
+      "additional_tools": 43,
+      "agent_message": 52,
+      "custom_tool_call": 10,
+      "custom_tool_call_output": 10,
+      "function_call": 992,
+      "function_call_output": 992,
+      "message": 789,
+      "reasoning": 1061
+    },
+    "plan_variants": [
+      {
+        "parallel_tool_calls": false,
+        "plan": "plan_01",
+        "stream": true,
+        "tool_choice": "auto",
+        "tool_surface": "surface_01",
+        "transport_log_rows": 28
+      },
+      {
+        "parallel_tool_calls": false,
+        "plan": "plan_02",
+        "stream": true,
+        "tool_choice": "auto",
+        "tool_surface": "surface_02",
+        "transport_log_rows": 11
+      },
+      {
+        "parallel_tool_calls": false,
+        "plan": "plan_03",
+        "stream": true,
+        "tool_choice": "auto",
+        "tool_surface": "surface_03",
+        "transport_log_rows": 4
+      }
+    ],
+    "tool_surfaces": {
+      "surface_01": [
+        {
+          "defer_loading_present": false,
+          "name": "shell_command",
+          "type": "function"
+        },
+        {
+          "defer_loading_present": false,
+          "name": "list_mcp_resources",
+          "type": "function"
+        },
+        {
+          "defer_loading_present": false,
+          "name": "list_mcp_resource_templates",
+          "type": "function"
+        },
+        {
+          "defer_loading_present": false,
+          "name": "read_mcp_resource",
+          "type": "function"
+        },
+        {
+          "defer_loading_present": false,
+          "name": "update_plan",
+          "type": "function"
+        },
+        {
+          "defer_loading_present": false,
+          "name": "request_user_input",
+          "type": "function"
+        },
+        {
+          "defer_loading_present": false,
+          "name": "request_plugin_install",
+          "type": "function"
+        },
+        {
+          "defer_loading_present": false,
+          "name": "apply_patch",
+          "type": "custom"
+        },
+        {
+          "defer_loading_present": false,
+          "name": "view_image",
+          "type": "function"
+        },
+        {
+          "defer_loading_present": false,
+          "name": "collaboration",
+          "namespace_tools": [
+            "followup_task",
+            "interrupt_agent",
+            "list_agents",
+            "send_message",
+            "spawn_agent",
+            "wait_agent"
+          ],
+          "type": "namespace"
+        },
+        {
+          "defer_loading_present": false,
+          "name": "get_goal",
+          "type": "function"
+        },
+        {
+          "defer_loading_present": false,
+          "name": "create_goal",
+          "type": "function"
+        },
+        {
+          "defer_loading_present": false,
+          "name": "update_goal",
+          "type": "function"
+        },
+        {
+          "defer_loading_present": false,
+          "name": "image_gen",
+          "namespace_tools": [
+            "imagegen"
+          ],
+          "type": "namespace"
+        },
+        {
+          "defer_loading_present": false,
+          "name": "codex_app",
+          "namespace_tools": [
+            "load_workspace_dependencies",
+            "navigate_to_codex_page",
+            "read_thread_terminal"
+          ],
+          "type": "namespace"
+        },
+        {
+          "defer_loading_present": false,
+          "execution": "client",
+          "name": null,
+          "type": "tool_search"
+        }
+      ],
+      "surface_02": [
+        {
+          "defer_loading_present": false,
+          "name": "shell_command",
+          "type": "function"
+        },
+        {
+          "defer_loading_present": false,
+          "name": "list_mcp_resources",
+          "type": "function"
+        },
+        {
+          "defer_loading_present": false,
+          "name": "list_mcp_resource_templates",
+          "type": "function"
+        },
+        {
+          "defer_loading_present": false,
+          "name": "read_mcp_resource",
+          "type": "function"
+        },
+        {
+          "defer_loading_present": false,
+          "name": "update_plan",
+          "type": "function"
+        },
+        {
+          "defer_loading_present": false,
+          "name": "request_user_input",
+          "type": "function"
+        },
+        {
+          "defer_loading_present": false,
+          "name": "request_plugin_install",
+          "type": "function"
+        },
+        {
+          "defer_loading_present": false,
+          "name": "apply_patch",
+          "type": "custom"
+        },
+        {
+          "defer_loading_present": false,
+          "name": "view_image",
+          "type": "function"
+        },
+        {
+          "defer_loading_present": false,
+          "name": "get_goal",
+          "type": "function"
+        },
+        {
+          "defer_loading_present": false,
+          "name": "create_goal",
+          "type": "function"
+        },
+        {
+          "defer_loading_present": false,
+          "name": "update_goal",
+          "type": "function"
+        },
+        {
+          "defer_loading_present": false,
+          "name": "image_gen",
+          "namespace_tools": [
+            "imagegen"
+          ],
+          "type": "namespace"
+        },
+        {
+          "defer_loading_present": false,
+          "name": "codex_app",
+          "namespace_tools": [
+            "load_workspace_dependencies",
+            "navigate_to_codex_page",
+            "read_thread_terminal"
+          ],
+          "type": "namespace"
+        },
+        {
+          "defer_loading_present": false,
+          "execution": "client",
+          "name": null,
+          "type": "tool_search"
+        }
+      ],
+      "surface_03": [
+        {
+          "defer_loading_present": false,
+          "name": "shell_command",
+          "type": "function"
+        },
+        {
+          "defer_loading_present": false,
+          "name": "list_mcp_resources",
+          "type": "function"
+        },
+        {
+          "defer_loading_present": false,
+          "name": "list_mcp_resource_templates",
+          "type": "function"
+        },
+        {
+          "defer_loading_present": false,
+          "name": "read_mcp_resource",
+          "type": "function"
+        },
+        {
+          "defer_loading_present": false,
+          "name": "update_plan",
+          "type": "function"
+        },
+        {
+          "defer_loading_present": false,
+          "name": "request_user_input",
+          "type": "function"
+        },
+        {
+          "defer_loading_present": false,
+          "name": "request_plugin_install",
+          "type": "function"
+        },
+        {
+          "defer_loading_present": false,
+          "name": "apply_patch",
+          "type": "custom"
+        },
+        {
+          "defer_loading_present": false,
+          "name": "view_image",
+          "type": "function"
+        },
+        {
+          "defer_loading_present": false,
+          "name": "image_gen",
+          "namespace_tools": [
+            "imagegen"
+          ],
+          "type": "namespace"
+        },
+        {
+          "defer_loading_present": false,
+          "name": "probe_ns",
+          "namespace_tools": [
+            "direct_probe"
+          ],
+          "type": "namespace"
+        },
+        {
+          "defer_loading_present": false,
+          "execution": "client",
+          "name": null,
+          "type": "tool_search"
+        }
+      ]
+    },
+    "top_level_field_presence": [
+      "client_metadata",
+      "include",
+      "input",
+      "model",
+      "parallel_tool_calls",
+      "prompt_cache_key",
+      "reasoning",
+      "store",
+      "stream",
+      "text",
+      "tool_choice"
+    ],
+    "transport_log_rows": 43,
+    "unclassified_item_types": []
+  },
+  "recovery_observation": {
+    "causal_attribution": "not_assigned_to_model_alone",
+    "collaboration_lifecycle_owner": "#64",
+    "existing_terra_tasks_repeated_system_error": true,
+    "fresh_sol_same_clean_branches_started_normally": true,
+    "fresh_terra_same_clean_branches_failed_before_agent_response": true,
+    "intervening_shared_state_mutation": false,
+    "permitted_classification": [
+      "task_start_recovery",
+      "model_binding_fallback"
+    ],
+    "route_level_cause": "unknown",
+    "source": "orchestrator_read_only_observation",
+    "unrelated_existing_terra_tasks_continued_normally": true
+  },
+  "runtime_timeline": {
+    "catalog_written_before_app_server_start": true,
+    "clean_cold_start_for_current_binding_proven": false,
+    "config_written_after_app_server_start": true,
+    "current_request_endpoint_classes": {
+      "official_direct": 80
+    },
+    "gateway_requests_after_app_server_start": 0
+  },
+  "sanitization": {
+    "emits_existing_hash_values": false,
+    "emits_full_bodies": false,
+    "emits_headers_or_credentials": false,
+    "emits_paths": false,
+    "emits_prompt_arguments_or_outputs": false,
+    "emits_session_task_or_call_identifiers": false,
+    "output_classes": [
+      "booleans",
+      "counts",
+      "enums",
+      "field_presence",
+      "schema_names"
+    ]
+  },
+  "schema_version": 1,
+  "sources": {
+    "codex_transport_requests": "read_only_sqlite",
+    "gateway_events": "read_only_sqlite",
+    "merged_baseline": "PR_95"
+  }
+}

--- a/scripts/audit_issue_62_runtime_artifacts.py
+++ b/scripts/audit_issue_62_runtime_artifacts.py
@@ -36,6 +36,7 @@ KNOWN_INPUT_ITEM_TYPES = {
     "tool_search_output",
     "web_search_call",
 }
+VALID_TOOL_CHOICE_STRINGS = {"auto", "none", "required"}
 ROUTE_FIELDS = (
     "upstream",
     "route_mode",
@@ -45,6 +46,30 @@ ROUTE_FIELDS = (
     "wire_format_adapter",
     "codex_semantic_adapter",
     "repair_policy",
+)
+# Only these pairs declare both sides of the comparison. Other response-body
+# fingerprint-shaped fields remain presence diagnostics and cannot open a gate.
+KNOWN_RESPONSE_BODY_FINGERPRINT_PAIRS = (
+    (
+        "upstream_response_body_hmac",
+        "downstream_response_body_hmac",
+        "upstream_downstream_hmac",
+    ),
+    (
+        "upstream_response_body_sha256",
+        "downstream_response_body_sha256",
+        "upstream_downstream_sha256",
+    ),
+    (
+        "pre_gateway_response_body_hmac",
+        "post_gateway_response_body_hmac",
+        "pre_post_hmac",
+    ),
+    (
+        "pre_gateway_response_body_sha256",
+        "post_gateway_response_body_sha256",
+        "pre_post_sha256",
+    ),
 )
 
 
@@ -85,19 +110,33 @@ def _endpoint_class(endpoint: str) -> str:
 
 
 def _sanitize_tool_choice(value: Any) -> Any:
-    if value is None or isinstance(value, (str, bool, int, float)):
+    if value is None:
         return value
+    if isinstance(value, str):
+        return value if value in VALID_TOOL_CHOICE_STRINGS else "unclassified"
     if not isinstance(value, dict):
         return "unclassified"
-    sanitized: dict[str, Any] = {}
-    if isinstance(value.get("type"), str):
-        sanitized["type"] = value["type"]
-    if isinstance(value.get("name"), str):
-        sanitized["name"] = value["name"]
+    if value.get("type") != "function":
+        return "unclassified"
+    name = value.get("name")
     function = value.get("function")
-    if isinstance(function, dict) and isinstance(function.get("name"), str):
-        sanitized["function_name"] = function["name"]
-    return sanitized or "unclassified"
+    if not isinstance(name, str) or not name:
+        if isinstance(function, dict):
+            name = function.get("name")
+    if not isinstance(name, str) or not name:
+        return "unclassified"
+    return {"name": name, "type": "function"}
+
+
+def _is_proven_tool_choice(value: Any) -> bool:
+    if isinstance(value, str):
+        return value in VALID_TOOL_CHOICE_STRINGS
+    return (
+        isinstance(value, dict)
+        and value.get("type") == "function"
+        and isinstance(value.get("name"), str)
+        and bool(value["name"])
+    )
 
 
 def _sanitize_tool(tool: dict[str, Any]) -> dict[str, Any]:
@@ -284,6 +323,9 @@ def _gateway_evidence(
     prefix_equal = 0
     prefix_mismatch = 0
     prefix_unavailable = 0
+    full_body_hmac_equal = 0
+    full_body_hmac_mismatch = 0
+    full_body_hmac_unavailable = 0
     full_body_hmac_pairs = 0
     full_body_hmac_both_skipped = 0
     gateway_requests_after_app_server_start = 0
@@ -291,6 +333,11 @@ def _gateway_evidence(
     route_counts: Counter[str] = Counter()
     routes: dict[str, dict[str, Any]] = {}
     response_fingerprint_keys: set[str] = set()
+    official_request_ids: set[str] = set()
+    response_body_fingerprint_equal = 0
+    response_body_fingerprint_mismatch = 0
+    response_body_fingerprint_unavailable = 0
+    response_body_fingerprint_pair_semantics = "unavailable"
     app_server_time = _parse_iso_timestamp(app_server_started_at)
 
     connection = _read_only_connection(path)
@@ -320,6 +367,9 @@ def _gateway_evidence(
                 continue
             if event == "request_start":
                 request_starts += 1
+                request_id = payload.get("request_id")
+                if isinstance(request_id, str) and request_id:
+                    official_request_ids.add(request_id)
                 is_stream = payload.get("is_stream")
                 if is_stream is True or is_stream == 1:
                     streaming_requests += 1
@@ -336,10 +386,21 @@ def _gateway_evidence(
                 else:
                     prefix_unavailable += 1
 
-                if isinstance(payload.get("caller_request_body_hmac"), str) and isinstance(
-                    payload.get("upstream_request_body_hmac"), str
+                caller_body_hmac = payload.get("caller_request_body_hmac")
+                upstream_body_hmac = payload.get("upstream_request_body_hmac")
+                if (
+                    isinstance(caller_body_hmac, str)
+                    and caller_body_hmac.strip()
+                    and isinstance(upstream_body_hmac, str)
+                    and upstream_body_hmac.strip()
                 ):
                     full_body_hmac_pairs += 1
+                    if caller_body_hmac == upstream_body_hmac:
+                        full_body_hmac_equal += 1
+                    else:
+                        full_body_hmac_mismatch += 1
+                else:
+                    full_body_hmac_unavailable += 1
                 if (
                     payload.get("caller_request_body_hmac_skipped") is True
                     and payload.get("upstream_request_body_hmac_skipped") is True
@@ -372,6 +433,46 @@ def _gateway_evidence(
             for name in table_names
             if _is_response_body_fingerprint_field(name)
         )
+        known_pairs = [
+            pair
+            for pair in KNOWN_RESPONSE_BODY_FINGERPRINT_PAIRS
+            if pair[0] in table_names and pair[1] in table_names
+        ]
+        if len(known_pairs) == 1 and "request_id" in table_names:
+            before_field, after_field, pair_semantics = known_pairs[0]
+            response_body_fingerprint_pair_semantics = pair_semantics
+            rows_by_request_id = {
+                request_id: (before_value, after_value)
+                for request_id, before_value, after_value in connection.execute(
+                    f"SELECT request_id, {before_field}, {after_field} FROM gateway_requests"
+                )
+                if isinstance(request_id, str) and request_id in official_request_ids
+            }
+            for request_id in official_request_ids:
+                before_value, after_value = rows_by_request_id.get(
+                    request_id,
+                    (None, None),
+                )
+                if (
+                    isinstance(before_value, str)
+                    and before_value.strip()
+                    and isinstance(after_value, str)
+                    and after_value.strip()
+                ):
+                    if before_value == after_value:
+                        response_body_fingerprint_equal += 1
+                    else:
+                        response_body_fingerprint_mismatch += 1
+                else:
+                    response_body_fingerprint_unavailable += 1
+            response_body_fingerprint_unavailable += max(
+                0,
+                request_starts - len(official_request_ids),
+            )
+        else:
+            if len(known_pairs) > 1:
+                response_body_fingerprint_pair_semantics = "ambiguous"
+            response_body_fingerprint_unavailable = request_starts
     finally:
         connection.close()
 
@@ -388,7 +489,10 @@ def _gateway_evidence(
         "gateway_requests_after_app_server_start": gateway_requests_after_app_server_start,
         "gateway_identity_route": {
             "full_body_hmac_both_skipped": full_body_hmac_both_skipped,
+            "full_body_hmac_equal": full_body_hmac_equal,
+            "full_body_hmac_mismatch": full_body_hmac_mismatch,
             "full_body_hmac_pairs": full_body_hmac_pairs,
+            "full_body_hmac_unavailable": full_body_hmac_unavailable,
             "non_streaming_requests": non_streaming_requests,
             "observed_sse_event_type_counts": dict(sorted(sse_event_types.items())),
             "prefix_equal": prefix_equal,
@@ -396,6 +500,10 @@ def _gateway_evidence(
             "prefix_unavailable": prefix_unavailable,
             "request_starts": request_starts,
             "response_body_fingerprint_fields_present": bool(response_fingerprint_keys),
+            "response_body_fingerprint_equal": response_body_fingerprint_equal,
+            "response_body_fingerprint_mismatch": response_body_fingerprint_mismatch,
+            "response_body_fingerprint_pair_semantics": response_body_fingerprint_pair_semantics,
+            "response_body_fingerprint_unavailable": response_body_fingerprint_unavailable,
             "route_variants": route_variants,
             "streaming_requests": streaming_requests,
         },
@@ -442,17 +550,25 @@ def audit_artifacts(
     planner = codex["model_visible_request_plan"]
     identity = gateway["gateway_identity_route"]
     choice_observed = any(
-        variant.get("tool_choice") is not None
+        _is_proven_tool_choice(variant.get("tool_choice"))
         and isinstance(variant.get("parallel_tool_calls"), bool)
         for variant in planner["plan_variants"]
     )
     full_pre_post_met = (
         identity["request_starts"] > 0
-        and identity["full_body_hmac_pairs"] == identity["request_starts"]
-        and identity["response_body_fingerprint_fields_present"]
+        and identity["full_body_hmac_equal"] == identity["request_starts"]
+        and identity["full_body_hmac_mismatch"] == 0
+        and identity["full_body_hmac_unavailable"] == 0
+        and identity["response_body_fingerprint_equal"] == identity["request_starts"]
+        and identity["response_body_fingerprint_mismatch"] == 0
+        and identity["response_body_fingerprint_unavailable"] == 0
     )
     zero_unclassified = (
-        not planner["unclassified_item_types"] and identity["prefix_mismatch"] == 0
+        not planner["unclassified_item_types"]
+        and identity["request_starts"] > 0
+        and identity["prefix_equal"] == identity["request_starts"]
+        and identity["prefix_mismatch"] == 0
+        and identity["prefix_unavailable"] == 0
     )
 
     return {

--- a/scripts/audit_issue_62_runtime_artifacts.py
+++ b/scripts/audit_issue_62_runtime_artifacts.py
@@ -116,16 +116,12 @@ def _sanitize_tool_choice(value: Any) -> Any:
         return value if value in VALID_TOOL_CHOICE_STRINGS else "unclassified"
     if not isinstance(value, dict):
         return "unclassified"
-    if value.get("type") != "function":
+    if set(value) != {"type", "name"} or value.get("type") != "function":
         return "unclassified"
     name = value.get("name")
-    function = value.get("function")
-    if not isinstance(name, str) or not name:
-        if isinstance(function, dict):
-            name = function.get("name")
-    if not isinstance(name, str) or not name:
+    if not isinstance(name, str) or not name.strip():
         return "unclassified"
-    return {"name": name, "type": "function"}
+    return {"name": name.strip(), "type": "function"}
 
 
 def _is_proven_tool_choice(value: Any) -> bool:
@@ -133,9 +129,11 @@ def _is_proven_tool_choice(value: Any) -> bool:
         return value in VALID_TOOL_CHOICE_STRINGS
     return (
         isinstance(value, dict)
+        and set(value) == {"type", "name"}
         and value.get("type") == "function"
         and isinstance(value.get("name"), str)
-        and bool(value["name"])
+        and bool(value["name"].strip())
+        and value["name"] == value["name"].strip()
     )
 
 
@@ -378,7 +376,12 @@ def _gateway_evidence(
 
                 caller_prefix = payload.get("caller_request_prefix_hmac")
                 upstream_prefix = payload.get("upstream_request_prefix_hmac")
-                if isinstance(caller_prefix, str) and isinstance(upstream_prefix, str):
+                if (
+                    isinstance(caller_prefix, str)
+                    and caller_prefix.strip()
+                    and isinstance(upstream_prefix, str)
+                    and upstream_prefix.strip()
+                ):
                     if caller_prefix == upstream_prefix:
                         prefix_equal += 1
                     else:
@@ -539,13 +542,11 @@ def audit_artifacts(
     config_after_start = _parse_iso_timestamp(config_written_at) > app_server_time
     catalog_before_start = _parse_iso_timestamp(catalog_written_at) <= app_server_time
     current_endpoint_classes = codex["current_request_endpoint_classes"]
-    current_codexhub_rows = current_endpoint_classes.get("codexhub_local", 0)
-    clean_cold_start_proven = (
-        not config_after_start
-        and catalog_before_start
-        and current_codexhub_rows > 0
-        and gateway["gateway_requests_after_app_server_start"] > 0
-    )
+    # Timestamp ordering and independently observed post-start rows do not bind a
+    # specific request to the catalog/config identity that was current at start.
+    # None of the bounded artifacts supplies that correlation, so this gate must
+    # remain a live-control requirement.
+    clean_cold_start_proven = False
 
     planner = codex["model_visible_request_plan"]
     identity = gateway["gateway_identity_route"]

--- a/scripts/audit_issue_62_runtime_artifacts.py
+++ b/scripts/audit_issue_62_runtime_artifacts.py
@@ -1,0 +1,542 @@
+#!/usr/bin/env python3
+"""Sanitize the bounded read-only runtime evidence used by Issue #62."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sqlite3
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+
+TRANSPORT_TARGET = "codex_http_client::transport"
+POST_BODY_PATTERN = re.compile(
+    r": POST to (?P<endpoint>https?://.+?): (?P<body>\{.*\})\s*$",
+    re.DOTALL,
+)
+KNOWN_INPUT_ITEM_TYPES = {
+    "additional_tools",
+    "agent_message",
+    "compaction",
+    "compaction_trigger",
+    "computer_initialize_state",
+    "custom_tool_call",
+    "custom_tool_call_output",
+    "function_call",
+    "function_call_output",
+    "local_shell_call",
+    "message",
+    "reasoning",
+    "tool_search_call",
+    "tool_search_output",
+    "web_search_call",
+}
+ROUTE_FIELDS = (
+    "upstream",
+    "route_mode",
+    "behavior_profile",
+    "inbound_format",
+    "upstream_format",
+    "wire_format_adapter",
+    "codex_semantic_adapter",
+    "repair_policy",
+)
+
+
+def _is_response_body_fingerprint_field(name: Any) -> bool:
+    if not isinstance(name, str):
+        return False
+    normalized = name.lower()
+    return "response_body" in normalized and any(
+        marker in normalized
+        for marker in ("digest", "fingerprint", "hash", "hmac", "sha")
+    )
+
+
+def _read_only_connection(path: Path) -> sqlite3.Connection:
+    uri = f"{path.resolve().as_uri()}?mode=ro"
+    return sqlite3.connect(uri, uri=True)
+
+
+def _parse_iso_timestamp(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _unix_seconds(value: str) -> int:
+    return int(_parse_iso_timestamp(value).timestamp())
+
+
+def _endpoint_class(endpoint: str) -> str:
+    parsed = urlparse(endpoint)
+    host = (parsed.hostname or "").lower()
+    if host in {"127.0.0.1", "localhost", "::1"} and parsed.port == 9099:
+        return "codexhub_local"
+    if host == "chatgpt.com" or host.endswith(".chatgpt.com"):
+        return "official_direct"
+    return "other"
+
+
+def _sanitize_tool_choice(value: Any) -> Any:
+    if value is None or isinstance(value, (str, bool, int, float)):
+        return value
+    if not isinstance(value, dict):
+        return "unclassified"
+    sanitized: dict[str, Any] = {}
+    if isinstance(value.get("type"), str):
+        sanitized["type"] = value["type"]
+    if isinstance(value.get("name"), str):
+        sanitized["name"] = value["name"]
+    function = value.get("function")
+    if isinstance(function, dict) and isinstance(function.get("name"), str):
+        sanitized["function_name"] = function["name"]
+    return sanitized or "unclassified"
+
+
+def _sanitize_tool(tool: dict[str, Any]) -> dict[str, Any]:
+    tool_type = tool.get("type") if isinstance(tool.get("type"), str) else None
+    name = tool.get("name") if isinstance(tool.get("name"), str) else None
+    sanitized: dict[str, Any] = {
+        "defer_loading_present": "defer_loading" in tool or "deferLoading" in tool,
+        "name": name,
+        "type": tool_type,
+    }
+    if "defer_loading" in tool or "deferLoading" in tool:
+        sanitized["defer_loading"] = bool(
+            tool.get("defer_loading", tool.get("deferLoading"))
+        )
+    if tool_type == "namespace":
+        sanitized["namespace_tools"] = [
+            nested["name"]
+            for nested in tool.get("tools", [])
+            if isinstance(nested, dict) and isinstance(nested.get("name"), str)
+        ]
+    if tool_type == "tool_search" and isinstance(tool.get("execution"), str):
+        sanitized["execution"] = tool["execution"]
+    return sanitized
+
+
+def _sanitize_request_plan(payload: dict[str, Any]) -> dict[str, Any]:
+    item_types: Counter[str] = Counter()
+    tool_surface: list[dict[str, Any]] = []
+    for item in payload.get("input", []):
+        if not isinstance(item, dict):
+            item_types["<non_object>"] += 1
+            continue
+        item_type = item.get("type") if isinstance(item.get("type"), str) else "<missing>"
+        item_types[item_type] += 1
+        if item_type != "additional_tools":
+            continue
+        tool_surface.extend(
+            _sanitize_tool(tool)
+            for tool in item.get("tools", [])
+            if isinstance(tool, dict)
+        )
+
+    tool_surface.extend(
+        _sanitize_tool(tool)
+        for tool in payload.get("tools", [])
+        if isinstance(tool, dict)
+    )
+    return {
+        "input_item_type_counts": dict(sorted(item_types.items())),
+        "parallel_tool_calls": payload.get("parallel_tool_calls")
+        if isinstance(payload.get("parallel_tool_calls"), bool)
+        else None,
+        "stream": payload.get("stream") if isinstance(payload.get("stream"), bool) else None,
+        "tool_choice": _sanitize_tool_choice(payload.get("tool_choice")),
+        "tool_surface": tool_surface,
+        "top_level_field_presence": sorted(payload),
+    }
+
+
+def _codex_request_evidence(
+    path: Path,
+    *,
+    model: str,
+    gateway_started_at: str,
+    app_server_started_at: str,
+    snapshot_ended_at: str,
+) -> dict[str, Any]:
+    gateway_cutoff = _unix_seconds(gateway_started_at)
+    app_server_cutoff = _unix_seconds(app_server_started_at)
+    snapshot_cutoff = _unix_seconds(snapshot_ended_at)
+    query_cutoff = min(gateway_cutoff, app_server_cutoff)
+    plan_counts: Counter[str] = Counter()
+    sanitized_plans: dict[str, dict[str, Any]] = {}
+    observed_item_types: Counter[str] = Counter()
+    current_endpoint_classes: Counter[str] = Counter()
+    top_level_fields: set[str] = set()
+    transport_log_rows = 0
+
+    connection = _read_only_connection(path)
+    try:
+        rows = connection.execute(
+            """
+            SELECT ts, feedback_log_body
+            FROM logs
+            WHERE target = ? AND ts >= ? AND ts <= ?
+            ORDER BY ts, id
+            """,
+            (TRANSPORT_TARGET, query_cutoff, snapshot_cutoff),
+        )
+        for ts, log_body in rows:
+            if not isinstance(log_body, str):
+                continue
+            match = POST_BODY_PATTERN.search(log_body)
+            if match is None:
+                continue
+            endpoint_class = _endpoint_class(match.group("endpoint"))
+            try:
+                payload = json.loads(match.group("body"))
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(payload, dict) or payload.get("model") != model:
+                continue
+
+            if ts >= app_server_cutoff:
+                current_endpoint_classes[endpoint_class] += 1
+            if ts < gateway_cutoff or endpoint_class != "codexhub_local":
+                continue
+
+            transport_log_rows += 1
+            sanitized = _sanitize_request_plan(payload)
+            for item_type, count in sanitized["input_item_type_counts"].items():
+                observed_item_types[item_type] += count
+            top_level_fields.update(sanitized["top_level_field_presence"])
+            plan_shape = {
+                key: value
+                for key, value in sanitized.items()
+                if key not in {"input_item_type_counts", "top_level_field_presence"}
+            }
+            key = json.dumps(
+                plan_shape,
+                ensure_ascii=True,
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+            plan_counts[key] += 1
+            sanitized_plans[key] = plan_shape
+    finally:
+        connection.close()
+
+    variants = []
+    surface_names: dict[str, str] = {}
+    tool_surfaces: dict[str, list[dict[str, Any]]] = {}
+    for index, (key, count) in enumerate(
+        sorted(plan_counts.items(), key=lambda item: (-item[1], item[0])),
+        start=1,
+    ):
+        variant = dict(sanitized_plans[key])
+        surface = variant.pop("tool_surface")
+        surface_key = json.dumps(surface, sort_keys=True, separators=(",", ":"))
+        surface_name = surface_names.get(surface_key)
+        if surface_name is None:
+            surface_name = f"surface_{len(surface_names) + 1:02d}"
+            surface_names[surface_key] = surface_name
+            tool_surfaces[surface_name] = surface
+        variant["tool_surface"] = surface_name
+        variant["plan"] = f"plan_{index:02d}"
+        variant["transport_log_rows"] = count
+        variants.append(variant)
+
+    unclassified = sorted(set(observed_item_types) - KNOWN_INPUT_ITEM_TYPES)
+    return {
+        "current_request_endpoint_classes": dict(sorted(current_endpoint_classes.items())),
+        "model_visible_request_plan": {
+            "model": model,
+            "observed_input_item_type_counts": dict(sorted(observed_item_types.items())),
+            "plan_variants": variants,
+            "tool_surfaces": tool_surfaces,
+            "top_level_field_presence": sorted(top_level_fields),
+            "transport_log_rows": transport_log_rows,
+            "unclassified_item_types": unclassified,
+        },
+    }
+
+
+def _safe_route(payload: dict[str, Any]) -> dict[str, Any]:
+    return {
+        field: payload.get(field)
+        if isinstance(payload.get(field), (str, bool, int, float))
+        else None
+        for field in ROUTE_FIELDS
+    }
+
+
+def _gateway_evidence(
+    path: Path,
+    *,
+    gateway_started_at: str,
+    app_server_started_at: str,
+    snapshot_ended_at: str,
+) -> dict[str, Any]:
+    request_starts = 0
+    streaming_requests = 0
+    non_streaming_requests = 0
+    prefix_equal = 0
+    prefix_mismatch = 0
+    prefix_unavailable = 0
+    full_body_hmac_pairs = 0
+    full_body_hmac_both_skipped = 0
+    gateway_requests_after_app_server_start = 0
+    sse_event_types: Counter[str] = Counter()
+    route_counts: Counter[str] = Counter()
+    routes: dict[str, dict[str, Any]] = {}
+    response_fingerprint_keys: set[str] = set()
+    app_server_time = _parse_iso_timestamp(app_server_started_at)
+
+    connection = _read_only_connection(path)
+    try:
+        rows = connection.execute(
+            """
+            SELECT ts, event, payload_json
+            FROM gateway_events
+            WHERE ts >= ? AND ts <= ?
+            ORDER BY event_id
+            """,
+            (gateway_started_at, snapshot_ended_at),
+        )
+        for event_ts, event, payload_json in rows:
+            try:
+                payload = json.loads(payload_json)
+            except (TypeError, json.JSONDecodeError):
+                continue
+            if not isinstance(payload, dict):
+                continue
+            response_fingerprint_keys.update(
+                key
+                for key in payload
+                if _is_response_body_fingerprint_field(key)
+            )
+            if payload.get("upstream") != "official":
+                continue
+            if event == "request_start":
+                request_starts += 1
+                is_stream = payload.get("is_stream")
+                if is_stream is True or is_stream == 1:
+                    streaming_requests += 1
+                elif is_stream is False or is_stream == 0:
+                    non_streaming_requests += 1
+
+                caller_prefix = payload.get("caller_request_prefix_hmac")
+                upstream_prefix = payload.get("upstream_request_prefix_hmac")
+                if isinstance(caller_prefix, str) and isinstance(upstream_prefix, str):
+                    if caller_prefix == upstream_prefix:
+                        prefix_equal += 1
+                    else:
+                        prefix_mismatch += 1
+                else:
+                    prefix_unavailable += 1
+
+                if isinstance(payload.get("caller_request_body_hmac"), str) and isinstance(
+                    payload.get("upstream_request_body_hmac"), str
+                ):
+                    full_body_hmac_pairs += 1
+                if (
+                    payload.get("caller_request_body_hmac_skipped") is True
+                    and payload.get("upstream_request_body_hmac_skipped") is True
+                ):
+                    full_body_hmac_both_skipped += 1
+
+                route = _safe_route(payload)
+                route_key = json.dumps(route, sort_keys=True, separators=(",", ":"))
+                route_counts[route_key] += 1
+                routes[route_key] = route
+                try:
+                    if _parse_iso_timestamp(event_ts) >= app_server_time:
+                        gateway_requests_after_app_server_start += 1
+                except (TypeError, ValueError):
+                    pass
+            elif event == "request_complete":
+                values = payload.get("sse_event_types")
+                if isinstance(values, list):
+                    for value in values:
+                        if isinstance(value, str):
+                            sse_event_types[value] += 1
+
+        table_names = {
+            row[1]
+            for row in connection.execute("PRAGMA table_info(gateway_requests)")
+            if len(row) > 1 and isinstance(row[1], str)
+        }
+        response_fingerprint_keys.update(
+            name
+            for name in table_names
+            if _is_response_body_fingerprint_field(name)
+        )
+    finally:
+        connection.close()
+
+    route_variants = []
+    for index, (key, count) in enumerate(
+        sorted(route_counts.items(), key=lambda item: (-item[1], item[0])),
+        start=1,
+    ):
+        route_variants.append(
+            {"request_starts": count, "route": f"route_{index:02d}", **routes[key]}
+        )
+
+    return {
+        "gateway_requests_after_app_server_start": gateway_requests_after_app_server_start,
+        "gateway_identity_route": {
+            "full_body_hmac_both_skipped": full_body_hmac_both_skipped,
+            "full_body_hmac_pairs": full_body_hmac_pairs,
+            "non_streaming_requests": non_streaming_requests,
+            "observed_sse_event_type_counts": dict(sorted(sse_event_types.items())),
+            "prefix_equal": prefix_equal,
+            "prefix_mismatch": prefix_mismatch,
+            "prefix_unavailable": prefix_unavailable,
+            "request_starts": request_starts,
+            "response_body_fingerprint_fields_present": bool(response_fingerprint_keys),
+            "route_variants": route_variants,
+            "streaming_requests": streaming_requests,
+        },
+    }
+
+
+def audit_artifacts(
+    *,
+    codex_log_db: Path,
+    gateway_db: Path,
+    model: str,
+    gateway_started_at: str,
+    app_server_started_at: str,
+    config_written_at: str,
+    catalog_written_at: str,
+    snapshot_ended_at: str,
+) -> dict[str, Any]:
+    codex = _codex_request_evidence(
+        codex_log_db,
+        model=model,
+        gateway_started_at=gateway_started_at,
+        app_server_started_at=app_server_started_at,
+        snapshot_ended_at=snapshot_ended_at,
+    )
+    gateway = _gateway_evidence(
+        gateway_db,
+        gateway_started_at=gateway_started_at,
+        app_server_started_at=app_server_started_at,
+        snapshot_ended_at=snapshot_ended_at,
+    )
+
+    app_server_time = _parse_iso_timestamp(app_server_started_at)
+    config_after_start = _parse_iso_timestamp(config_written_at) > app_server_time
+    catalog_before_start = _parse_iso_timestamp(catalog_written_at) <= app_server_time
+    current_endpoint_classes = codex["current_request_endpoint_classes"]
+    current_codexhub_rows = current_endpoint_classes.get("codexhub_local", 0)
+    clean_cold_start_proven = (
+        not config_after_start
+        and catalog_before_start
+        and current_codexhub_rows > 0
+        and gateway["gateway_requests_after_app_server_start"] > 0
+    )
+
+    planner = codex["model_visible_request_plan"]
+    identity = gateway["gateway_identity_route"]
+    choice_observed = any(
+        variant.get("tool_choice") is not None
+        and isinstance(variant.get("parallel_tool_calls"), bool)
+        for variant in planner["plan_variants"]
+    )
+    full_pre_post_met = (
+        identity["request_starts"] > 0
+        and identity["full_body_hmac_pairs"] == identity["request_starts"]
+        and identity["response_body_fingerprint_fields_present"]
+    )
+    zero_unclassified = (
+        not planner["unclassified_item_types"] and identity["prefix_mismatch"] == 0
+    )
+
+    return {
+        "capture_kind": "sanitized_bounded_read_only_audit",
+        "gate_classification": {
+            "choice_controls": "observed" if choice_observed else "unclassified",
+            "clean_cold_start_current_binding": "met"
+            if clean_cold_start_proven
+            else "live_control_required",
+            "complete_contributors_runtime_gate": "partial",
+            "full_pre_post_request_response": "met"
+            if full_pre_post_met
+            else "live_control_required",
+            "non_direct_states": "live_control_required",
+            "non_streaming": "observed"
+            if identity["non_streaming_requests"] > 0
+            else "live_control_required",
+            "zero_unclassified_identity": "partial"
+            if zero_unclassified and not full_pre_post_met
+            else ("met" if zero_unclassified else "not_met"),
+        },
+        "gateway_identity_route": identity,
+        "model_visible_request_plan": planner,
+        "runtime_timeline": {
+            "catalog_written_before_app_server_start": catalog_before_start,
+            "clean_cold_start_for_current_binding_proven": clean_cold_start_proven,
+            "config_written_after_app_server_start": config_after_start,
+            "current_request_endpoint_classes": current_endpoint_classes,
+            "gateway_requests_after_app_server_start": gateway[
+                "gateway_requests_after_app_server_start"
+            ],
+        },
+        "sanitization": {
+            "emits_existing_hash_values": False,
+            "emits_full_bodies": False,
+            "emits_headers_or_credentials": False,
+            "emits_paths": False,
+            "emits_prompt_arguments_or_outputs": False,
+            "emits_session_task_or_call_identifiers": False,
+            "output_classes": [
+                "booleans",
+                "counts",
+                "enums",
+                "field_presence",
+                "schema_names",
+            ],
+        },
+        "schema_version": 1,
+        "sources": {
+            "codex_transport_requests": "read_only_sqlite",
+            "gateway_events": "read_only_sqlite",
+            "merged_baseline": "PR_95",
+        },
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--codex-log-db", type=Path, required=True)
+    parser.add_argument("--gateway-db", type=Path, required=True)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--gateway-started-at", required=True)
+    parser.add_argument("--app-server-started-at", required=True)
+    parser.add_argument("--config-written-at", required=True)
+    parser.add_argument("--catalog-written-at", required=True)
+    parser.add_argument("--snapshot-ended-at", required=True)
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    audit = audit_artifacts(
+        codex_log_db=args.codex_log_db,
+        gateway_db=args.gateway_db,
+        model=args.model,
+        gateway_started_at=args.gateway_started_at,
+        app_server_started_at=args.app_server_started_at,
+        config_written_at=args.config_written_at,
+        catalog_written_at=args.catalog_written_at,
+        snapshot_ended_at=args.snapshot_ended_at,
+    )
+    print(json.dumps(audit, ensure_ascii=True, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check-codex-thread-tool-surface.ps1
+++ b/scripts/check-codex-thread-tool-surface.ps1
@@ -1,13 +1,14 @@
 param(
     [string]$TracePath = (Join-Path (Split-Path -Parent $PSScriptRoot) 'docs\evidence\issue-62\current-codexhub-thread-tool-surface.json'),
     [string]$WireFixturePath = (Join-Path (Split-Path -Parent $PSScriptRoot) 'docs\evidence\issue-62\codexhub-runtime-wire-fixture.json'),
+    [string]$AuditPath = (Join-Path (Split-Path -Parent $PSScriptRoot) 'docs\evidence\issue-62\read-only-gate-audit.json'),
     [ValidateSet('identity', 'mutation', 'deletion', 'loss', 'required-set-deletion', 'required-membership-mutation')]
     [string]$ReplayCase = 'identity'
 )
 
 $ErrorActionPreference = 'Stop'
 
-foreach ($path in @($TracePath, $WireFixturePath)) {
+foreach ($path in @($TracePath, $WireFixturePath, $AuditPath)) {
     if (-not (Test-Path -LiteralPath $path)) {
         throw "Evidence file not found: $path"
     }
@@ -15,6 +16,7 @@ foreach ($path in @($TracePath, $WireFixturePath)) {
 
 $trace = Get-Content -Raw -LiteralPath $TracePath | ConvertFrom-Json
 $wire = Get-Content -Raw -LiteralPath $WireFixturePath | ConvertFrom-Json
+$audit = Get-Content -Raw -LiteralPath $AuditPath | ConvertFrom-Json
 $mismatches = [System.Collections.Generic.List[string]]::new()
 
 function Add-Mismatch {
@@ -263,12 +265,98 @@ if (@($wire.response.streaming.observed_event_counts).Count -eq 0) {
     Add-Mismatch 'streaming SSE event evidence is empty'
 }
 
+if ($audit.schema_version -ne 1 -or $audit.capture_kind -ne 'sanitized_bounded_read_only_audit') {
+    Add-Mismatch 'bounded read-only audit schema is invalid'
+}
+$auditGateway = $audit.gateway_identity_route
+if (
+    $auditGateway.request_starts -le 0 -or
+    $auditGateway.streaming_requests -ne $auditGateway.request_starts -or
+    $auditGateway.non_streaming_requests -ne 0 -or
+    $auditGateway.prefix_equal -ne $auditGateway.request_starts -or
+    $auditGateway.prefix_mismatch -ne 0 -or
+    $auditGateway.prefix_unavailable -ne 0 -or
+    $auditGateway.full_body_hmac_pairs -ne 0 -or
+    $auditGateway.full_body_hmac_both_skipped -ne $auditGateway.request_starts -or
+    $auditGateway.response_body_fingerprint_fields_present -ne $false
+) {
+    Add-Mismatch 'bounded Gateway identity evidence or its full-wire boundary is invalid'
+}
+if (@($auditGateway.observed_sse_event_type_counts.PSObject.Properties).Count -eq 0) {
+    Add-Mismatch 'bounded Gateway SSE event-type evidence is empty'
+}
+
+$auditPlan = $audit.model_visible_request_plan
+if (
+    $auditPlan.model -ne 'gpt-5.6-sol' -or
+    $auditPlan.transport_log_rows -le 0 -or
+    @($auditPlan.unclassified_item_types).Count -ne 0 -or
+    @($auditPlan.plan_variants).Count -eq 0
+) {
+    Add-Mismatch 'bounded model-visible request-plan evidence is invalid'
+}
+foreach ($variant in @($auditPlan.plan_variants)) {
+    if (
+        $variant.stream -ne $true -or
+        $variant.tool_choice -ne 'auto' -or
+        $variant.parallel_tool_calls -ne $false -or
+        -not ($auditPlan.tool_surfaces.PSObject.Properties.Name -contains $variant.tool_surface)
+    ) {
+        Add-Mismatch "invalid bounded planner variant $($variant.plan)"
+    }
+}
+
+$auditTimeline = $audit.runtime_timeline
+if (
+    $auditTimeline.catalog_written_before_app_server_start -ne $true -or
+    $auditTimeline.config_written_after_app_server_start -ne $true -or
+    $auditTimeline.clean_cold_start_for_current_binding_proven -ne $false -or
+    $auditTimeline.gateway_requests_after_app_server_start -ne 0 -or
+    $auditTimeline.current_request_endpoint_classes.official_direct -le 0
+) {
+    Add-Mismatch 'bounded runtime timeline no longer preserves the missing current-binding cold-start control'
+}
+
+$auditGates = $audit.gate_classification
+if (
+    $auditGates.choice_controls -ne 'observed' -or
+    $auditGates.complete_contributors_runtime_gate -ne 'partial' -or
+    $auditGates.zero_unclassified_identity -ne 'partial' -or
+    $auditGates.clean_cold_start_current_binding -ne 'live_control_required' -or
+    $auditGates.full_pre_post_request_response -ne 'live_control_required' -or
+    $auditGates.non_streaming -ne 'live_control_required' -or
+    $auditGates.non_direct_states -ne 'live_control_required'
+) {
+    Add-Mismatch 'bounded audit overstates or misclassifies a remaining Issue #62 gate'
+}
+
+$recovery = $audit.recovery_observation
+if (
+    $recovery.route_level_cause -ne 'unknown' -or
+    $recovery.causal_attribution -ne 'not_assigned_to_model_alone' -or
+    $recovery.intervening_shared_state_mutation -ne $false -or
+    $recovery.collaboration_lifecycle_owner -ne '#64'
+) {
+    Add-Mismatch 'recovery observation exceeds its non-causal classification boundary'
+}
+$sanitization = $audit.sanitization
+if (
+    $sanitization.emits_full_bodies -ne $false -or
+    $sanitization.emits_headers_or_credentials -ne $false -or
+    $sanitization.emits_paths -ne $false -or
+    $sanitization.emits_prompt_arguments_or_outputs -ne $false -or
+    $sanitization.emits_session_task_or_call_identifiers -ne $false
+) {
+    Add-Mismatch 'bounded audit sanitization contract is invalid'
+}
+
 Write-Output "Capture: $($trace.source.capture_id)"
 Write-Output "Provider/model: $($trace.source.configured_provider_id) / $($trace.source.model)"
 Write-Output "Gateway route: $($trace.gateway_route.behavior_profile)"
 Write-Output "Registered Codex app tools: $($registered.Count)"
 Write-Output "Direct / Deferred: $($direct.Count) / $($deferred.Count)"
 Write-Output "Deferred tools discoverable through tool_search: $($discoverable.Count)"
+Write-Output "Bounded audit transport rows / Gateway starts: $($auditPlan.transport_log_rows) / $($auditGateway.request_starts)"
 Write-Output "Replay case: $ReplayCase"
 
 if ($mismatches.Count -gt 0) {

--- a/tests/test_issue_62_runtime_audit.py
+++ b/tests/test_issue_62_runtime_audit.py
@@ -4,6 +4,8 @@ import re
 import sqlite3
 from pathlib import Path
 
+import pytest
+
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "audit_issue_62_runtime_artifacts.py"
@@ -19,7 +21,20 @@ def load_audit_module():
     return module
 
 
-def create_codex_log_db(path: Path) -> None:
+def run_audit(module, codex_db: Path, gateway_db: Path):
+    return module.audit_artifacts(
+        codex_log_db=codex_db,
+        gateway_db=gateway_db,
+        model="gpt-5.6-sol",
+        gateway_started_at="1970-01-01T00:03:00Z",
+        app_server_started_at="1970-01-01T00:05:00Z",
+        config_written_at="1970-01-01T00:06:00Z",
+        catalog_written_at="1970-01-01T00:02:00Z",
+        snapshot_ended_at="1970-01-01T00:10:00Z",
+    )
+
+
+def create_codex_log_db(path: Path, *, gateway_tool_choice: object = "auto") -> None:
     connection = sqlite3.connect(path)
     connection.execute(
         """
@@ -71,7 +86,7 @@ def create_codex_log_db(path: Path) -> None:
                 "output": "must not be retained",
             },
         ],
-        "tool_choice": "auto",
+        "tool_choice": gateway_tool_choice,
         "parallel_tool_calls": False,
         "stream": True,
         "client_metadata": {"session_id": "must-not-be-retained"},
@@ -113,8 +128,11 @@ def create_codex_log_db(path: Path) -> None:
 def create_gateway_db(
     path: Path,
     *,
+    prefix_available: bool = True,
     prefix_mismatch: bool = False,
+    request_hmac_pair: tuple[str, str] | None = None,
     response_fingerprint_column: bool = False,
+    response_fingerprint_pair: tuple[str | None, str | None] | None = None,
 ) -> None:
     connection = sqlite3.connect(path)
     connection.execute(
@@ -140,6 +158,27 @@ def create_gateway_db(
         connection.execute(
             "ALTER TABLE gateway_requests ADD COLUMN downstream_response_body_sha256 TEXT"
         )
+    if response_fingerprint_pair is not None:
+        connection.execute(
+            "ALTER TABLE gateway_requests ADD COLUMN upstream_response_body_sha256 TEXT"
+        )
+        connection.execute(
+            "ALTER TABLE gateway_requests ADD COLUMN downstream_response_body_sha256 TEXT"
+        )
+        connection.execute(
+            """
+            INSERT INTO gateway_requests (
+                request_id,
+                upstream_response_body_sha256,
+                downstream_response_body_sha256
+            ) VALUES (?, ?, ?)
+            """,
+            (
+                "must-not-be-retained",
+                response_fingerprint_pair[0],
+                response_fingerprint_pair[1],
+            ),
+        )
 
     request_start = {
         "event": "request_start",
@@ -152,12 +191,19 @@ def create_gateway_db(
         "codex_semantic_adapter": "none",
         "repair_policy": "none",
         "is_stream": True,
-        "caller_request_prefix_hmac": "prefix-a",
-        "upstream_request_prefix_hmac": "prefix-b" if prefix_mismatch else "prefix-a",
-        "caller_request_body_hmac_skipped": True,
-        "upstream_request_body_hmac_skipped": True,
         "request_id": "must-not-be-retained",
     }
+    if prefix_available:
+        request_start["caller_request_prefix_hmac"] = "prefix-a"
+        request_start["upstream_request_prefix_hmac"] = (
+            "prefix-b" if prefix_mismatch else "prefix-a"
+        )
+    if request_hmac_pair is None:
+        request_start["caller_request_body_hmac_skipped"] = True
+        request_start["upstream_request_body_hmac_skipped"] = True
+    else:
+        request_start["caller_request_body_hmac"] = request_hmac_pair[0]
+        request_start["upstream_request_body_hmac"] = request_hmac_pair[1]
     request_complete = {
         "event": "request_complete",
         "upstream": "official",
@@ -183,16 +229,7 @@ def test_audit_reports_only_sanitized_schema_and_gate_facts(tmp_path: Path) -> N
     create_codex_log_db(codex_db)
     create_gateway_db(gateway_db)
 
-    audit = module.audit_artifacts(
-        codex_log_db=codex_db,
-        gateway_db=gateway_db,
-        model="gpt-5.6-sol",
-        gateway_started_at="1970-01-01T00:03:00Z",
-        app_server_started_at="1970-01-01T00:05:00Z",
-        config_written_at="1970-01-01T00:06:00Z",
-        catalog_written_at="1970-01-01T00:02:00Z",
-        snapshot_ended_at="1970-01-01T00:10:00Z",
-    )
+    audit = run_audit(module, codex_db, gateway_db)
 
     assert audit["schema_version"] == 1
     planner = audit["model_visible_request_plan"]
@@ -280,16 +317,7 @@ def test_audit_surfaces_unclassified_items_and_prefix_mismatch(tmp_path: Path) -
     connection.commit()
     connection.close()
 
-    audit = module.audit_artifacts(
-        codex_log_db=codex_db,
-        gateway_db=gateway_db,
-        model="gpt-5.6-sol",
-        gateway_started_at="1970-01-01T00:03:00Z",
-        app_server_started_at="1970-01-01T00:05:00Z",
-        config_written_at="1970-01-01T00:06:00Z",
-        catalog_written_at="1970-01-01T00:02:00Z",
-        snapshot_ended_at="1970-01-01T00:10:00Z",
-    )
+    audit = run_audit(module, codex_db, gateway_db)
 
     assert audit["model_visible_request_plan"]["unclassified_item_types"] == [
         "future_item"
@@ -331,18 +359,98 @@ def test_audit_detects_generic_response_body_fingerprint_fields(tmp_path: Path) 
     create_codex_log_db(codex_db)
     create_gateway_db(gateway_db, response_fingerprint_column=True)
 
-    audit = module.audit_artifacts(
-        codex_log_db=codex_db,
-        gateway_db=gateway_db,
-        model="gpt-5.6-sol",
-        gateway_started_at="1970-01-01T00:03:00Z",
-        app_server_started_at="1970-01-01T00:05:00Z",
-        config_written_at="1970-01-01T00:06:00Z",
-        catalog_written_at="1970-01-01T00:02:00Z",
-        snapshot_ended_at="1970-01-01T00:10:00Z",
-    )
+    audit = run_audit(module, codex_db, gateway_db)
 
     assert (
         audit["gateway_identity_route"]["response_body_fingerprint_fields_present"]
         is True
     )
+
+
+def test_full_pre_post_stays_live_when_request_hmacs_differ(tmp_path: Path) -> None:
+    module = load_audit_module()
+    codex_db = tmp_path / "codex.sqlite"
+    gateway_db = tmp_path / "gateway.sqlite"
+    create_codex_log_db(codex_db)
+    create_gateway_db(
+        gateway_db,
+        request_hmac_pair=("caller-value", "upstream-value"),
+        response_fingerprint_column=True,
+    )
+
+    audit = run_audit(module, codex_db, gateway_db)
+
+    identity = audit["gateway_identity_route"]
+    assert identity["full_body_hmac_equal"] == 0
+    assert identity["full_body_hmac_mismatch"] == 1
+    assert identity["full_body_hmac_unavailable"] == 0
+    assert (
+        audit["gate_classification"]["full_pre_post_request_response"]
+        == "live_control_required"
+    )
+
+
+def test_full_pre_post_stays_live_when_response_fingerprints_are_empty(
+    tmp_path: Path,
+) -> None:
+    module = load_audit_module()
+    codex_db = tmp_path / "codex.sqlite"
+    gateway_db = tmp_path / "gateway.sqlite"
+    create_codex_log_db(codex_db)
+    create_gateway_db(
+        gateway_db,
+        request_hmac_pair=("same-request-value", "same-request-value"),
+        response_fingerprint_pair=(None, ""),
+    )
+
+    audit = run_audit(module, codex_db, gateway_db)
+
+    identity = audit["gateway_identity_route"]
+    assert identity["response_body_fingerprint_equal"] == 0
+    assert identity["response_body_fingerprint_mismatch"] == 0
+    assert identity["response_body_fingerprint_unavailable"] == 1
+    assert (
+        audit["gate_classification"]["full_pre_post_request_response"]
+        == "live_control_required"
+    )
+
+
+def test_zero_unclassified_identity_rejects_unavailable_prefixes(
+    tmp_path: Path,
+) -> None:
+    module = load_audit_module()
+    codex_db = tmp_path / "codex.sqlite"
+    gateway_db = tmp_path / "gateway.sqlite"
+    create_codex_log_db(codex_db)
+    create_gateway_db(gateway_db, prefix_available=False)
+
+    audit = run_audit(module, codex_db, gateway_db)
+
+    assert audit["model_visible_request_plan"]["unclassified_item_types"] == []
+    assert audit["gateway_identity_route"]["prefix_equal"] == 0
+    assert audit["gateway_identity_route"]["prefix_mismatch"] == 0
+    assert audit["gateway_identity_route"]["prefix_unavailable"] == 1
+    assert audit["gate_classification"]["zero_unclassified_identity"] == "not_met"
+
+
+@pytest.mark.parametrize(
+    "tool_choice",
+    [True, 7, 1.5, "sometimes", {"unexpected": "shape"}],
+)
+def test_choice_controls_reject_unclassified_and_invalid_scalar_shapes(
+    tmp_path: Path,
+    tool_choice: object,
+) -> None:
+    module = load_audit_module()
+    codex_db = tmp_path / "codex.sqlite"
+    gateway_db = tmp_path / "gateway.sqlite"
+    create_codex_log_db(codex_db, gateway_tool_choice=tool_choice)
+    create_gateway_db(gateway_db)
+
+    audit = run_audit(module, codex_db, gateway_db)
+
+    assert {
+        variant["tool_choice"]
+        for variant in audit["model_visible_request_plan"]["plan_variants"]
+    } == {"unclassified"}
+    assert audit["gate_classification"]["choice_controls"] == "unclassified"

--- a/tests/test_issue_62_runtime_audit.py
+++ b/tests/test_issue_62_runtime_audit.py
@@ -1,0 +1,348 @@
+import importlib.util
+import json
+import re
+import sqlite3
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "audit_issue_62_runtime_artifacts.py"
+AUDIT = ROOT / "docs" / "evidence" / "issue-62" / "read-only-gate-audit.json"
+
+
+def load_audit_module():
+    spec = importlib.util.spec_from_file_location("issue_62_runtime_audit", SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def create_codex_log_db(path: Path) -> None:
+    connection = sqlite3.connect(path)
+    connection.execute(
+        """
+        CREATE TABLE logs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            ts INTEGER NOT NULL,
+            target TEXT NOT NULL,
+            feedback_log_body TEXT
+        )
+        """
+    )
+
+    gateway_payload = {
+        "model": "gpt-5.6-sol",
+        "input": [
+            {
+                "type": "additional_tools",
+                "role": "developer",
+                "tools": [
+                    {
+                        "type": "function",
+                        "name": "shell_command",
+                        "description": "must not be retained",
+                        "parameters": {"secret": "must not be retained"},
+                    },
+                    {
+                        "type": "namespace",
+                        "name": "codex_app",
+                        "tools": [
+                            {"type": "function", "name": "read_thread_terminal"},
+                        ],
+                    },
+                    {
+                        "type": "tool_search",
+                        "execution": "client",
+                        "parameters": {"secret": "must not be retained"},
+                    },
+                ],
+            },
+            {"type": "message", "content": "must not be retained"},
+            {
+                "type": "function_call",
+                "call_id": "must-not-be-retained",
+                "arguments": "must not be retained",
+            },
+            {
+                "type": "function_call_output",
+                "call_id": "must-not-be-retained",
+                "output": "must not be retained",
+            },
+        ],
+        "tool_choice": "auto",
+        "parallel_tool_calls": False,
+        "stream": True,
+        "client_metadata": {"session_id": "must-not-be-retained"},
+    }
+    direct_payload = {
+        "model": "gpt-5.6-sol",
+        "input": [{"type": "message", "content": "must not be retained"}],
+        "tool_choice": "auto",
+        "parallel_tool_calls": False,
+        "stream": True,
+    }
+
+    gateway_body = json.dumps(gateway_payload, separators=(",", ":"))
+    direct_body = json.dumps(direct_payload, separators=(",", ":"))
+    connection.executemany(
+        "INSERT INTO logs (ts, target, feedback_log_body) VALUES (?, ?, ?)",
+        [
+            (
+                200,
+                "codex_http_client::transport",
+                f"span: POST to http://127.0.0.1:9099/v1/responses: {gateway_body}",
+            ),
+            (
+                201,
+                "codex_http_client::transport",
+                f"span: POST to http://127.0.0.1:9099/v1/responses: {gateway_body}",
+            ),
+            (
+                400,
+                "codex_http_client::transport",
+                f"span: POST to https://chatgpt.com/backend-api/codex/responses: {direct_body}",
+            ),
+        ],
+    )
+    connection.commit()
+    connection.close()
+
+
+def create_gateway_db(
+    path: Path,
+    *,
+    prefix_mismatch: bool = False,
+    response_fingerprint_column: bool = False,
+) -> None:
+    connection = sqlite3.connect(path)
+    connection.execute(
+        """
+        CREATE TABLE gateway_events (
+            event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            ts TEXT NOT NULL,
+            event TEXT NOT NULL,
+            payload_json TEXT NOT NULL
+        )
+        """
+    )
+    connection.execute(
+        """
+        CREATE TABLE gateway_requests (
+            request_id TEXT PRIMARY KEY,
+            request_body_hmac TEXT,
+            request_prefix_hmac TEXT
+        )
+        """
+    )
+    if response_fingerprint_column:
+        connection.execute(
+            "ALTER TABLE gateway_requests ADD COLUMN downstream_response_body_sha256 TEXT"
+        )
+
+    request_start = {
+        "event": "request_start",
+        "upstream": "official",
+        "route_mode": "official",
+        "behavior_profile": "official_codex_app_http_passthrough",
+        "inbound_format": "responses",
+        "upstream_format": "responses",
+        "wire_format_adapter": "transparent",
+        "codex_semantic_adapter": "none",
+        "repair_policy": "none",
+        "is_stream": True,
+        "caller_request_prefix_hmac": "prefix-a",
+        "upstream_request_prefix_hmac": "prefix-b" if prefix_mismatch else "prefix-a",
+        "caller_request_body_hmac_skipped": True,
+        "upstream_request_body_hmac_skipped": True,
+        "request_id": "must-not-be-retained",
+    }
+    request_complete = {
+        "event": "request_complete",
+        "upstream": "official",
+        "status": 200,
+        "sse_event_types": ["response.created", "response.completed"],
+        "request_id": "must-not-be-retained",
+    }
+    connection.executemany(
+        "INSERT INTO gateway_events (ts, event, payload_json) VALUES (?, ?, ?)",
+        [
+            ("1970-01-01T00:03:20Z", "request_start", json.dumps(request_start)),
+            ("1970-01-01T00:03:21Z", "request_complete", json.dumps(request_complete)),
+        ],
+    )
+    connection.commit()
+    connection.close()
+
+
+def test_audit_reports_only_sanitized_schema_and_gate_facts(tmp_path: Path) -> None:
+    module = load_audit_module()
+    codex_db = tmp_path / "codex.sqlite"
+    gateway_db = tmp_path / "gateway.sqlite"
+    create_codex_log_db(codex_db)
+    create_gateway_db(gateway_db)
+
+    audit = module.audit_artifacts(
+        codex_log_db=codex_db,
+        gateway_db=gateway_db,
+        model="gpt-5.6-sol",
+        gateway_started_at="1970-01-01T00:03:00Z",
+        app_server_started_at="1970-01-01T00:05:00Z",
+        config_written_at="1970-01-01T00:06:00Z",
+        catalog_written_at="1970-01-01T00:02:00Z",
+        snapshot_ended_at="1970-01-01T00:10:00Z",
+    )
+
+    assert audit["schema_version"] == 1
+    planner = audit["model_visible_request_plan"]
+    assert planner["transport_log_rows"] == 2
+    assert planner["unclassified_item_types"] == []
+    assert planner["plan_variants"][0]["tool_choice"] == "auto"
+    assert planner["plan_variants"][0]["parallel_tool_calls"] is False
+    assert planner["plan_variants"][0]["tool_surface"] == "surface_01"
+    assert planner["tool_surfaces"]["surface_01"] == [
+        {
+            "defer_loading_present": False,
+            "name": "shell_command",
+            "type": "function",
+        },
+        {
+            "defer_loading_present": False,
+            "name": "codex_app",
+            "namespace_tools": ["read_thread_terminal"],
+            "type": "namespace",
+        },
+        {
+            "defer_loading_present": False,
+            "execution": "client",
+            "name": None,
+            "type": "tool_search",
+        },
+    ]
+
+    gateway = audit["gateway_identity_route"]
+    assert gateway["request_starts"] == 1
+    assert gateway["streaming_requests"] == 1
+    assert gateway["non_streaming_requests"] == 0
+    assert gateway["prefix_equal"] == 1
+    assert gateway["full_body_hmac_pairs"] == 0
+    assert gateway["full_body_hmac_both_skipped"] == 1
+    assert gateway["response_body_fingerprint_fields_present"] is False
+
+    timeline = audit["runtime_timeline"]
+    assert timeline["config_written_after_app_server_start"] is True
+    assert timeline["gateway_requests_after_app_server_start"] == 0
+    assert timeline["current_request_endpoint_classes"] == {"official_direct": 1}
+    assert audit["gate_classification"]["choice_controls"] == "observed"
+    assert (
+        audit["gate_classification"]["clean_cold_start_current_binding"]
+        == "live_control_required"
+    )
+
+    serialized = json.dumps(audit, sort_keys=True)
+    for forbidden in (
+        "must not be retained",
+        "must-not-be-retained",
+        "prefix-a",
+        "chatgpt.com",
+        "127.0.0.1",
+        str(codex_db),
+        str(gateway_db),
+    ):
+        assert forbidden not in serialized
+
+
+def test_audit_surfaces_unclassified_items_and_prefix_mismatch(tmp_path: Path) -> None:
+    module = load_audit_module()
+    codex_db = tmp_path / "codex.sqlite"
+    gateway_db = tmp_path / "gateway.sqlite"
+    create_codex_log_db(codex_db)
+    create_gateway_db(gateway_db, prefix_mismatch=True)
+
+    connection = sqlite3.connect(codex_db)
+    payload = {
+        "model": "gpt-5.6-sol",
+        "input": [{"type": "future_item", "opaque": "must not be retained"}],
+        "tool_choice": "auto",
+        "parallel_tool_calls": False,
+        "stream": True,
+    }
+    connection.execute(
+        "INSERT INTO logs (ts, target, feedback_log_body) VALUES (?, ?, ?)",
+        (
+            202,
+            "codex_http_client::transport",
+            "span: POST to http://127.0.0.1:9099/v1/responses: "
+            + json.dumps(payload),
+        ),
+    )
+    connection.commit()
+    connection.close()
+
+    audit = module.audit_artifacts(
+        codex_log_db=codex_db,
+        gateway_db=gateway_db,
+        model="gpt-5.6-sol",
+        gateway_started_at="1970-01-01T00:03:00Z",
+        app_server_started_at="1970-01-01T00:05:00Z",
+        config_written_at="1970-01-01T00:06:00Z",
+        catalog_written_at="1970-01-01T00:02:00Z",
+        snapshot_ended_at="1970-01-01T00:10:00Z",
+    )
+
+    assert audit["model_visible_request_plan"]["unclassified_item_types"] == [
+        "future_item"
+    ]
+    assert audit["gateway_identity_route"]["prefix_mismatch"] == 1
+    assert audit["gate_classification"]["zero_unclassified_identity"] == "not_met"
+
+
+def test_committed_audit_preserves_the_bounded_fact_and_sanitization_boundary() -> None:
+    audit = json.loads(AUDIT.read_text(encoding="utf-8"))
+
+    assert audit["gateway_identity_route"]["request_starts"] == 525
+    assert audit["gateway_identity_route"]["prefix_equal"] == 525
+    assert audit["gateway_identity_route"]["prefix_mismatch"] == 0
+    assert audit["gateway_identity_route"]["full_body_hmac_pairs"] == 0
+    assert audit["gateway_identity_route"]["non_streaming_requests"] == 0
+    assert audit["model_visible_request_plan"]["unclassified_item_types"] == []
+    assert {
+        variant["tool_choice"]
+        for variant in audit["model_visible_request_plan"]["plan_variants"]
+    } == {"auto"}
+    assert audit["runtime_timeline"]["config_written_after_app_server_start"] is True
+    assert audit["runtime_timeline"]["gateway_requests_after_app_server_start"] == 0
+    assert audit["recovery_observation"]["route_level_cause"] == "unknown"
+    assert audit["recovery_observation"]["intervening_shared_state_mutation"] is False
+
+    serialized = json.dumps(audit, sort_keys=True)
+    assert "http://" not in serialized
+    assert "https://" not in serialized
+    assert ".codex" not in serialized.lower()
+    assert not re.search(r"[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}", serialized)
+    assert not re.search(r'(?<![A-Za-z0-9])[a-f0-9]{64}(?![A-Za-z0-9])', serialized)
+
+
+def test_audit_detects_generic_response_body_fingerprint_fields(tmp_path: Path) -> None:
+    module = load_audit_module()
+    codex_db = tmp_path / "codex.sqlite"
+    gateway_db = tmp_path / "gateway.sqlite"
+    create_codex_log_db(codex_db)
+    create_gateway_db(gateway_db, response_fingerprint_column=True)
+
+    audit = module.audit_artifacts(
+        codex_log_db=codex_db,
+        gateway_db=gateway_db,
+        model="gpt-5.6-sol",
+        gateway_started_at="1970-01-01T00:03:00Z",
+        app_server_started_at="1970-01-01T00:05:00Z",
+        config_written_at="1970-01-01T00:06:00Z",
+        catalog_written_at="1970-01-01T00:02:00Z",
+        snapshot_ended_at="1970-01-01T00:10:00Z",
+    )
+
+    assert (
+        audit["gateway_identity_route"]["response_body_fingerprint_fields_present"]
+        is True
+    )

--- a/tests/test_issue_62_runtime_audit.py
+++ b/tests/test_issue_62_runtime_audit.py
@@ -21,20 +21,31 @@ def load_audit_module():
     return module
 
 
-def run_audit(module, codex_db: Path, gateway_db: Path):
+def run_audit(
+    module,
+    codex_db: Path,
+    gateway_db: Path,
+    *,
+    config_written_at: str = "1970-01-01T00:06:00Z",
+):
     return module.audit_artifacts(
         codex_log_db=codex_db,
         gateway_db=gateway_db,
         model="gpt-5.6-sol",
         gateway_started_at="1970-01-01T00:03:00Z",
         app_server_started_at="1970-01-01T00:05:00Z",
-        config_written_at="1970-01-01T00:06:00Z",
+        config_written_at=config_written_at,
         catalog_written_at="1970-01-01T00:02:00Z",
         snapshot_ended_at="1970-01-01T00:10:00Z",
     )
 
 
-def create_codex_log_db(path: Path, *, gateway_tool_choice: object = "auto") -> None:
+def create_codex_log_db(
+    path: Path,
+    *,
+    gateway_tool_choice: object = "auto",
+    post_start_gateway_request: bool = False,
+) -> None:
     connection = sqlite3.connect(path)
     connection.execute(
         """
@@ -101,25 +112,34 @@ def create_codex_log_db(path: Path, *, gateway_tool_choice: object = "auto") -> 
 
     gateway_body = json.dumps(gateway_payload, separators=(",", ":"))
     direct_body = json.dumps(direct_payload, separators=(",", ":"))
+    rows = [
+        (
+            200,
+            "codex_http_client::transport",
+            f"span: POST to http://127.0.0.1:9099/v1/responses: {gateway_body}",
+        ),
+        (
+            201,
+            "codex_http_client::transport",
+            f"span: POST to http://127.0.0.1:9099/v1/responses: {gateway_body}",
+        ),
+        (
+            400,
+            "codex_http_client::transport",
+            f"span: POST to https://chatgpt.com/backend-api/codex/responses: {direct_body}",
+        ),
+    ]
+    if post_start_gateway_request:
+        rows.append(
+            (
+                350,
+                "codex_http_client::transport",
+                f"span: POST to http://127.0.0.1:9099/v1/responses: {gateway_body}",
+            )
+        )
     connection.executemany(
         "INSERT INTO logs (ts, target, feedback_log_body) VALUES (?, ?, ?)",
-        [
-            (
-                200,
-                "codex_http_client::transport",
-                f"span: POST to http://127.0.0.1:9099/v1/responses: {gateway_body}",
-            ),
-            (
-                201,
-                "codex_http_client::transport",
-                f"span: POST to http://127.0.0.1:9099/v1/responses: {gateway_body}",
-            ),
-            (
-                400,
-                "codex_http_client::transport",
-                f"span: POST to https://chatgpt.com/backend-api/codex/responses: {direct_body}",
-            ),
-        ],
+        rows,
     )
     connection.commit()
     connection.close()
@@ -130,9 +150,12 @@ def create_gateway_db(
     *,
     prefix_available: bool = True,
     prefix_mismatch: bool = False,
+    prefix_pair: tuple[str, str] | None = None,
     request_hmac_pair: tuple[str, str] | None = None,
     response_fingerprint_column: bool = False,
     response_fingerprint_pair: tuple[str | None, str | None] | None = None,
+    request_started_at: str = "1970-01-01T00:03:20Z",
+    request_completed_at: str = "1970-01-01T00:03:21Z",
 ) -> None:
     connection = sqlite3.connect(path)
     connection.execute(
@@ -194,10 +217,12 @@ def create_gateway_db(
         "request_id": "must-not-be-retained",
     }
     if prefix_available:
-        request_start["caller_request_prefix_hmac"] = "prefix-a"
-        request_start["upstream_request_prefix_hmac"] = (
-            "prefix-b" if prefix_mismatch else "prefix-a"
+        caller_prefix, upstream_prefix = prefix_pair or (
+            "prefix-a",
+            "prefix-b" if prefix_mismatch else "prefix-a",
         )
+        request_start["caller_request_prefix_hmac"] = caller_prefix
+        request_start["upstream_request_prefix_hmac"] = upstream_prefix
     if request_hmac_pair is None:
         request_start["caller_request_body_hmac_skipped"] = True
         request_start["upstream_request_body_hmac_skipped"] = True
@@ -214,8 +239,8 @@ def create_gateway_db(
     connection.executemany(
         "INSERT INTO gateway_events (ts, event, payload_json) VALUES (?, ?, ?)",
         [
-            ("1970-01-01T00:03:20Z", "request_start", json.dumps(request_start)),
-            ("1970-01-01T00:03:21Z", "request_complete", json.dumps(request_complete)),
+            (request_started_at, "request_start", json.dumps(request_start)),
+            (request_completed_at, "request_complete", json.dumps(request_complete)),
         ],
     )
     connection.commit()
@@ -288,6 +313,38 @@ def test_audit_reports_only_sanitized_schema_and_gate_facts(tmp_path: Path) -> N
         str(gateway_db),
     ):
         assert forbidden not in serialized
+
+
+def test_clean_cold_start_requires_correlated_current_binding_identity(
+    tmp_path: Path,
+) -> None:
+    module = load_audit_module()
+    codex_db = tmp_path / "codex.sqlite"
+    gateway_db = tmp_path / "gateway.sqlite"
+    create_codex_log_db(codex_db, post_start_gateway_request=True)
+    create_gateway_db(
+        gateway_db,
+        request_started_at="1970-01-01T00:05:20Z",
+        request_completed_at="1970-01-01T00:05:21Z",
+    )
+
+    audit = run_audit(
+        module,
+        codex_db,
+        gateway_db,
+        config_written_at="1970-01-01T00:04:00Z",
+    )
+
+    timeline = audit["runtime_timeline"]
+    assert timeline["config_written_after_app_server_start"] is False
+    assert timeline["catalog_written_before_app_server_start"] is True
+    assert timeline["current_request_endpoint_classes"]["codexhub_local"] == 1
+    assert timeline["gateway_requests_after_app_server_start"] == 1
+    assert timeline["clean_cold_start_for_current_binding_proven"] is False
+    assert (
+        audit["gate_classification"]["clean_cold_start_current_binding"]
+        == "live_control_required"
+    )
 
 
 def test_audit_surfaces_unclassified_items_and_prefix_mismatch(tmp_path: Path) -> None:
@@ -433,6 +490,26 @@ def test_zero_unclassified_identity_rejects_unavailable_prefixes(
     assert audit["gate_classification"]["zero_unclassified_identity"] == "not_met"
 
 
+@pytest.mark.parametrize("prefix_pair", [("", ""), ("   ", "   ")])
+def test_zero_unclassified_identity_rejects_blank_prefixes(
+    tmp_path: Path,
+    prefix_pair: tuple[str, str],
+) -> None:
+    module = load_audit_module()
+    codex_db = tmp_path / "codex.sqlite"
+    gateway_db = tmp_path / "gateway.sqlite"
+    create_codex_log_db(codex_db)
+    create_gateway_db(gateway_db, prefix_pair=prefix_pair)
+
+    audit = run_audit(module, codex_db, gateway_db)
+
+    identity = audit["gateway_identity_route"]
+    assert identity["prefix_equal"] == 0
+    assert identity["prefix_mismatch"] == 0
+    assert identity["prefix_unavailable"] == 1
+    assert audit["gate_classification"]["zero_unclassified_identity"] == "not_met"
+
+
 @pytest.mark.parametrize(
     "tool_choice",
     [True, 7, 1.5, "sometimes", {"unexpected": "shape"}],
@@ -449,8 +526,40 @@ def test_choice_controls_reject_unclassified_and_invalid_scalar_shapes(
 
     audit = run_audit(module, codex_db, gateway_db)
 
-    assert {
+    assert [
         variant["tool_choice"]
         for variant in audit["model_visible_request_plan"]["plan_variants"]
-    } == {"unclassified"}
+    ] == ["unclassified"]
+    assert audit["gate_classification"]["choice_controls"] == "unclassified"
+
+
+@pytest.mark.parametrize(
+    "tool_choice",
+    [
+        {"type": "function", "name": "   "},
+        {
+            "type": "function",
+            "name": "first_selector",
+            "function": {"name": "second_selector"},
+        },
+        {"type": "function", "name": "selector", "unexpected": True},
+        {"type": "function", "function": {"name": "selector"}},
+    ],
+)
+def test_choice_controls_reject_malformed_function_objects(
+    tmp_path: Path,
+    tool_choice: object,
+) -> None:
+    module = load_audit_module()
+    codex_db = tmp_path / "codex.sqlite"
+    gateway_db = tmp_path / "gateway.sqlite"
+    create_codex_log_db(codex_db, gateway_tool_choice=tool_choice)
+    create_gateway_db(gateway_db)
+
+    audit = run_audit(module, codex_db, gateway_db)
+
+    assert [
+        variant["tool_choice"]
+        for variant in audit["model_visible_request_plan"]["plan_variants"]
+    ] == ["unclassified"]
     assert audit["gate_classification"]["choice_controls"] == "unclassified"


### PR DESCRIPTION
## Summary

- add a read-only SQLite auditor for the bounded Issue #62 runtime evidence
- freeze a sanitized planner/choice/Gateway audit without prompts, identifiers, paths, bodies, headers, credentials, arguments, results, or HMAC values
- extend the existing replay gate to enforce the audit's facts and deliberate live-control boundaries
- retain the non-causal Terra-to-Sol recovery observation with route cause unknown and collaboration lifecycle owned by #64

## Evidence established

- 43 retained Sol transport rows resolve to three observed model-visible request surfaces
- real controls show `tool_choice=auto`, `parallel_tool_calls=false`, and streaming enabled
- the bounded request rows contain zero unclassified input item types
- the current Gateway-process window contains 525 official Responses identity starts with 525 equal 65,536-byte caller/upstream prefix HMACs and zero prefix mismatches
- concrete route evidence is official Responses-to-Responses transparent passthrough; `provider_id=custom` is not used as provenance

## Review follow-up

- compare full caller/upstream request HMAC values and report explicit equal, mismatch, and unavailable counts
- treat response fingerprint schema names as diagnostic only; equivalence requires one recognized two-sided schema, populated per-request values, and explicit equality
- require complete available prefix coverage before zero-unclassified identity can be partial or met
- accept only proven `tool_choice` enums or a non-empty function selector, plus a real parallel-control boolean

## Deliberate boundary

This remains an evidence-only partial slice. Full-body request HMACs were skipped for all 525 official starts, the retained telemetry schema has no response-body fingerprint, no real non-streaming request exists, and no Gateway request occurred after the current app-server start. Complete contributor/defer-loading capture, current-binding clean cold start, full independently fingerprinted pre/post request/response evidence, and observed non-Direct states still require a separately authorized live control.

No runtime/config/catalog mutation, restart, reload, reconnect, or production-handler change was performed.

## Verification

- `powershell -NoProfile -ExecutionPolicy Bypass -File scripts/check-codex-thread-tool-surface.ps1`
- `python -m pytest -q` — 846 passed, 1 skipped, 88 subtests passed
- `python scripts/report_quality_gates.py --json` — report-only baseline, zero parse errors
- JSON parsing, Python compilation, diff whitespace, negative replay, redaction, generic response-fingerprint detection, request/response mismatch, unavailable-prefix, and invalid-choice controls pass

Refs #62