### PR TITLE
fix: preserve protocol semantics and reject unsafe tool IDs

### DIFF
--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -50,6 +50,7 @@ import urllib3
 from protocol_translation import (
     ChatToResponsesStreamConverter,
     ResponsesToChatStreamConverter,
+    UnsupportedProtocolTranslationError,
     UpstreamStreamIncompleteError,
     chat_completion_body_to_stream_chunks,
     chat_completion_error_body,
@@ -2978,6 +2979,14 @@ def _incomplete_stream_json_error_body(upstream_name: str) -> bytes:
     )
 
 
+class UpstreamProtocolTranslationError(ValueError):
+    """Marks an unsupported upstream wire shape for the downstream error mapper."""
+
+    def __init__(self, cause: UnsupportedProtocolTranslationError):
+        self.cause = cause
+        super().__init__(str(cause))
+
+
 _responses_content_to_chat_content = responses_content_to_chat_content
 _responses_input_to_chat_messages = responses_input_to_chat_messages
 _responses_tools_to_chat_tools = responses_tools_to_chat_tools
@@ -3041,13 +3050,16 @@ def _repair_chat_completion_response_payload(payload: dict[str, Any]) -> dict[st
 
 
 def _chat_completion_to_response_body(body: bytes, *, repair: bool = True) -> bytes:
-    return chat_completion_to_response_body(
-        body,
-        repair=repair,
-        chat_content_text=_chat_content_text,
-        xmlish_tool_outputs=_xmlish_tool_call_outputs_from_text,
-        repair_response=_repair_chat_completion_response_payload,
-    )
+    try:
+        return chat_completion_to_response_body(
+            body,
+            repair=repair,
+            chat_content_text=_chat_content_text,
+            xmlish_tool_outputs=_xmlish_tool_call_outputs_from_text,
+            repair_response=_repair_chat_completion_response_payload,
+        )
+    except UnsupportedProtocolTranslationError as exc:
+        raise UpstreamProtocolTranslationError(exc) from exc
 
 
 def _normalize_chat_function_call_name(name: str) -> str:
@@ -3062,11 +3074,14 @@ def _normalize_chat_function_call_name(name: str) -> str:
 
 
 def _chat_stream_chunks_to_response_events(chunks: list[Mapping[str, Any] | str]) -> list[dict[str, Any]]:
-    return chat_stream_chunks_to_response_events(
-        chunks,
-        normalize_function_name=_normalize_chat_function_call_name,
-        xmlish_tool_outputs=_xmlish_tool_call_outputs_from_text,
-    )
+    try:
+        return chat_stream_chunks_to_response_events(
+            chunks,
+            normalize_function_name=_normalize_chat_function_call_name,
+            xmlish_tool_outputs=_xmlish_tool_call_outputs_from_text,
+        )
+    except UnsupportedProtocolTranslationError as exc:
+        raise UpstreamProtocolTranslationError(exc) from exc
 
 
 def _response_events_shape_summary(events: list[Mapping[str, Any]]) -> dict[str, Any]:
@@ -3502,15 +3517,21 @@ def _chat_function_name_from_response_item(item: Mapping[str, Any]) -> str | Non
 
 
 def _response_body_to_chat_completion_body(body: bytes) -> bytes:
-    return response_body_to_chat_completion_body(
-        body,
-        function_name_from_response_item=_chat_function_name_from_response_item,
-        error_body=_chat_completion_error_body,
-    )
+    try:
+        return response_body_to_chat_completion_body(
+            body,
+            function_name_from_response_item=_chat_function_name_from_response_item,
+            error_body=_chat_completion_error_body,
+        )
+    except UnsupportedProtocolTranslationError as exc:
+        raise UpstreamProtocolTranslationError(exc) from exc
 
 
 def _chat_completion_body_to_stream_chunks(body: bytes) -> list[dict[str, Any]]:
-    return chat_completion_body_to_stream_chunks(body)
+    try:
+        return chat_completion_body_to_stream_chunks(body)
+    except UnsupportedProtocolTranslationError as exc:
+        raise UpstreamProtocolTranslationError(exc) from exc
 
 
 def _chat_completion_error_body(payload: Mapping[str, Any]) -> bytes:
@@ -3573,14 +3594,41 @@ def _chat_stream_chunks_have_terminal(chunks: list[Mapping[str, Any] | str]) -> 
     return False
 
 
-_response_events_to_chat_stream_chunks = partial(
-    response_events_to_chat_stream_chunks,
-    function_name_from_response_item=_chat_function_name_from_response_item,
-)
+def _response_events_to_chat_stream_chunks(
+    events: list[Mapping[str, Any]],
+    *,
+    require_completed: bool = False,
+) -> list[dict[str, Any]]:
+    try:
+        return response_events_to_chat_stream_chunks(
+            events,
+            require_completed=require_completed,
+            function_name_from_response_item=_chat_function_name_from_response_item,
+        )
+    except UnsupportedProtocolTranslationError as exc:
+        raise UpstreamProtocolTranslationError(exc) from exc
 
 
-_ResponsesToChatStreamConverter = ResponsesToChatStreamConverter
-_ChatToResponsesStreamConverter = ChatToResponsesStreamConverter
+class _ResponsesToChatStreamConverter(ResponsesToChatStreamConverter):
+    def chunks_for_event(self, event: Mapping[str, Any]) -> list[dict[str, Any]]:
+        try:
+            return super().chunks_for_event(event)
+        except UnsupportedProtocolTranslationError as exc:
+            raise UpstreamProtocolTranslationError(exc) from exc
+
+
+class _ChatToResponsesStreamConverter(ChatToResponsesStreamConverter):
+    def events_for_chunk(self, chunk: Mapping[str, Any]) -> list[dict[str, Any]]:
+        try:
+            return super().events_for_chunk(chunk)
+        except UnsupportedProtocolTranslationError as exc:
+            raise UpstreamProtocolTranslationError(exc) from exc
+
+    def events_for_done(self) -> list[dict[str, Any]]:
+        try:
+            return super().events_for_done()
+        except UnsupportedProtocolTranslationError as exc:
+            raise UpstreamProtocolTranslationError(exc) from exc
 
 
 def _is_reasoning_sse_payload(payload: Mapping[str, Any] | None) -> bool:
@@ -10680,6 +10728,45 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 error="image_proxy_error",
                 detail=str(exc),
                 error_type="image_proxy_error",
+            )
+        except UpstreamProtocolTranslationError as exc:
+            detail = str(exc)
+            error_code = exc.cause.code
+            write_proxy_event(
+                "request_error",
+                request_id=request_id,
+                model=canonical_model_id(model) if model else None,
+                model_requested=model_requested,
+                upstream=upstream_name,
+                provider_hint=provider_hint,
+                upstream_format=upstream_format,
+                behavior_profile=behavior_profile,
+                inbound_format=inbound_format,
+                status=502,
+                error=error_code,
+                detail=detail[:300],
+                duration_ms=int((time.monotonic() - started_at) * 1000),
+                **proxy_request_context,
+            )
+            if downstream_sse_started:
+                self._write_downstream_sse_error(
+                    inbound_format=inbound_format,
+                    upstream_name=upstream_name or "upstream_error",
+                    status=502,
+                    exc=exc,
+                    error=error_code,
+                    detail=detail,
+                )
+                return
+            self._safe_send_downstream_json_error(
+                502,
+                inbound_format=inbound_format,
+                upstream_name=upstream_name or "upstream_error",
+                request_id=request_id,
+                exc=exc,
+                error=error_code,
+                detail=detail,
+                error_type=error_code,
             )
         except ValueError as exc:
             write_proxy_event(

--- a/src-python/protocol_translation.py
+++ b/src-python/protocol_translation.py
@@ -113,6 +113,40 @@ def _require_supported_fields(value: Mapping[str, Any], allowed: set[str], label
         )
 
 
+def _function_arguments(value: Mapping[str, Any], label: str) -> str:
+    if "arguments" not in value:
+        return ""
+    arguments = value.get("arguments")
+    if not isinstance(arguments, str):
+        raise UnsupportedProtocolTranslationError(
+            "unsupported_protocol_semantics",
+            f"Cannot translate non-string {label} arguments.",
+        )
+    return arguments
+
+
+def _validate_function_tool_fields(value: Mapping[str, Any], allowed: set[str], label: str) -> None:
+    _require_supported_fields(value, allowed, label)
+    description = value.get("description")
+    if description is not None and not isinstance(description, str):
+        raise UnsupportedProtocolTranslationError(
+            "unsupported_protocol_semantics",
+            f"Cannot translate non-string {label} description.",
+        )
+    parameters = value.get("parameters")
+    if parameters is not None and not isinstance(parameters, dict):
+        raise UnsupportedProtocolTranslationError(
+            "unsupported_protocol_semantics",
+            f"Cannot translate non-object {label} parameters.",
+        )
+    strict = value.get("strict")
+    if strict is not None and not isinstance(strict, bool):
+        raise UnsupportedProtocolTranslationError(
+            "unsupported_protocol_semantics",
+            f"Cannot translate non-boolean {label} strict value.",
+        )
+
+
 def responses_content_to_chat_content(value: Any) -> str | list[dict[str, Any]]:
     if isinstance(value, str):
         return value
@@ -185,6 +219,7 @@ def responses_input_to_chat_messages(value: Any) -> list[dict[str, Any]]:
             )
         item_type = item.get("type")
         if item_type == "message" or (item_type is None and ("role" in item or "content" in item)):
+            _require_supported_fields(item, {"type", "role", "content"}, "Responses message input item")
             role = item.get("role")
             if role == "developer":
                 role = "system"
@@ -196,6 +231,11 @@ def responses_input_to_chat_messages(value: Any) -> list[dict[str, Any]]:
             messages.append({"role": role, "content": responses_content_to_chat_content(item.get("content"))})
             continue
         if item_type == "function_call":
+            _require_supported_fields(
+                item,
+                {"type", "call_id", "name", "arguments"},
+                "Responses function-call input item",
+            )
             call_id = item.get("call_id")
             name = item.get("name")
             if not isinstance(call_id, str) or not call_id:
@@ -208,9 +248,7 @@ def responses_input_to_chat_messages(value: Any) -> list[dict[str, Any]]:
                     "unsupported_protocol_semantics",
                     "Cannot translate a function call without a non-empty name.",
                 )
-            arguments = item.get("arguments")
-            if not isinstance(arguments, str):
-                arguments = json.dumps(arguments if arguments is not None else {}, ensure_ascii=True, separators=(",", ":"))
+            arguments = _function_arguments(item, "Responses function-call")
             messages.append(
                 {
                     "role": "assistant",
@@ -226,6 +264,11 @@ def responses_input_to_chat_messages(value: Any) -> list[dict[str, Any]]:
             )
             continue
         if item_type == "function_call_output":
+            _require_supported_fields(
+                item,
+                {"type", "call_id", "output"},
+                "Responses function-call output item",
+            )
             call_id = item.get("call_id")
             if not isinstance(call_id, str) or not call_id:
                 raise UnsupportedProtocolTranslationError(
@@ -233,8 +276,12 @@ def responses_input_to_chat_messages(value: Any) -> list[dict[str, Any]]:
                     "Cannot translate a function result without a non-empty call_id.",
                 )
             output = item.get("output")
-            content = output if isinstance(output, str) else json.dumps(output, ensure_ascii=True, separators=(",", ":"))
-            messages.append({"role": "tool", "tool_call_id": call_id, "content": content})
+            if not isinstance(output, str):
+                raise UnsupportedProtocolTranslationError(
+                    "unsupported_protocol_semantics",
+                    "Cannot translate a non-string Responses function-call output to Chat Completions.",
+                )
+            messages.append({"role": "tool", "tool_call_id": call_id, "content": output})
             continue
         raise UnsupportedProtocolTranslationError(
             "unsupported_protocol_semantics",
@@ -254,6 +301,11 @@ def responses_tools_to_chat_tools(value: Any) -> list[dict[str, Any]]:
                 "unsupported_protocol_semantics",
                 f"Cannot translate Responses tool type {tool_type!r} to Chat Completions.",
             )
+        _validate_function_tool_fields(
+            item,
+            {"type", "name", "description", "parameters", "strict"},
+            "Responses function tool",
+        )
         name = item.get("name")
         if not isinstance(name, str) or not name:
             raise UnsupportedProtocolTranslationError(
@@ -283,6 +335,7 @@ def responses_tool_choice_to_chat_tool_choice(value: Any) -> Any:
             "unsupported_protocol_semantics",
             f"Cannot translate Responses tool_choice type {choice_type!r} to Chat Completions.",
         )
+    _require_supported_fields(value, {"type", "name"}, "Responses function tool_choice")
     name = value.get("name")
     if not isinstance(name, str) or not name:
         raise UnsupportedProtocolTranslationError(
@@ -495,13 +548,13 @@ def chat_messages_to_responses_input(
                         "unpaired_tool_call",
                         "Cannot translate an assistant tool call without a non-empty id.",
                     )
-                arguments = function.get("arguments")
+                arguments = _function_arguments(function, "Chat Completions function-call")
                 input_items.append(
                     {
                         "type": "function_call",
                         "call_id": call_id,
                         "name": name,
-                        "arguments": arguments if isinstance(arguments, str) else "",
+                        "arguments": arguments,
                     }
                 )
             continue
@@ -568,12 +621,18 @@ def chat_tools_to_responses_tools(value: Any) -> list[dict[str, Any]]:
                 "unsupported_protocol_semantics",
                 f"Cannot translate Chat Completions tool type {tool_type!r} to Responses.",
             )
+        _require_supported_fields(item, {"type", "function"}, "Chat Completions function tool")
         function = item.get("function")
         if not isinstance(function, dict):
             raise UnsupportedProtocolTranslationError(
                 "unsupported_protocol_semantics",
                 "Cannot translate a Chat Completions function tool without a function payload.",
             )
+        _validate_function_tool_fields(
+            function,
+            {"name", "description", "parameters", "strict"},
+            "Chat Completions function tool",
+        )
         name = function.get("name")
         if not isinstance(name, str) or not name:
             raise UnsupportedProtocolTranslationError(
@@ -605,7 +664,10 @@ def chat_tool_choice_to_responses_tool_choice(value: Any) -> Any:
             "unsupported_protocol_semantics",
             f"Cannot translate Chat Completions tool_choice type {choice_type!r} to Responses.",
         )
+    _require_supported_fields(value, {"type", "function"}, "Chat Completions function tool_choice")
     function = value.get("function")
+    if isinstance(function, Mapping):
+        _require_supported_fields(function, {"name"}, "Chat Completions function tool_choice")
     if not isinstance(function, dict) or not isinstance(function.get("name"), str) or not function["name"]:
         raise UnsupportedProtocolTranslationError(
             "unsupported_protocol_semantics",
@@ -737,6 +799,11 @@ def _chat_completion_tool_outputs(
                 "unsupported_protocol_semantics",
                 "Cannot translate a non-object assistant tool call.",
             )
+        _require_supported_fields(
+            tool_call,
+            {"id", "type", "function"},
+            "Chat Completions assistant tool call",
+        )
         tool_type = tool_call.get("type")
         if tool_type not in (None, "function"):
             raise UnsupportedProtocolTranslationError(
@@ -749,6 +816,11 @@ def _chat_completion_tool_outputs(
                 "unsupported_protocol_semantics",
                 "Cannot translate an assistant tool call without a function payload.",
             )
+        _require_supported_fields(
+            function,
+            {"name", "arguments"},
+            "Chat Completions assistant function call",
+        )
         name = function.get("name")
         if not isinstance(name, str) or not name:
             raise UnsupportedProtocolTranslationError(
@@ -761,7 +833,7 @@ def _chat_completion_tool_outputs(
                 "unpaired_tool_call",
                 "Cannot translate an assistant tool call without a non-empty id.",
             )
-        arguments = function.get("arguments")
+        arguments = _function_arguments(function, "Chat Completions function-call")
         output.append(
             {
                 "id": f"fc_{call_id}",
@@ -769,7 +841,7 @@ def _chat_completion_tool_outputs(
                 "status": "completed",
                 "call_id": call_id,
                 "name": name,
-                "arguments": arguments if isinstance(arguments, str) else "",
+                "arguments": arguments,
             }
         )
     return output
@@ -924,6 +996,11 @@ def response_body_to_chat_completion_body(
                     "Cannot translate a non-object Responses output item.",
                 )
             if item.get("type") == "message":
+                _require_supported_fields(
+                    item,
+                    {"id", "type", "status", "role", "content"},
+                    "Responses output message item",
+                )
                 content = item.get("content")
                 role = item.get("role")
                 if role not in (None, "assistant"):
@@ -946,6 +1023,11 @@ def response_body_to_chat_completion_body(
                         "Cannot translate a non-text Responses output message content value.",
                     )
             elif item.get("type") == "function_call":
+                _require_supported_fields(
+                    item,
+                    {"id", "type", "status", "call_id", "namespace", "name", "arguments"},
+                    "Responses output function-call item",
+                )
                 call_id = item.get("call_id")
                 if not isinstance(call_id, str) or not call_id:
                     raise UnsupportedProtocolTranslationError(
@@ -953,7 +1035,7 @@ def response_body_to_chat_completion_body(
                         "Cannot translate a function call without a non-empty call_id.",
                     )
                 name = function_name_from_response_item(item)
-                arguments = item.get("arguments")
+                arguments = _function_arguments(item, "Responses function-call")
                 if not isinstance(name, str) or not name:
                     raise UnsupportedProtocolTranslationError(
                         "unsupported_protocol_semantics",
@@ -965,7 +1047,7 @@ def response_body_to_chat_completion_body(
                         "type": "function",
                         "function": {
                             "name": name,
-                            "arguments": arguments if isinstance(arguments, str) else "",
+                            "arguments": arguments,
                         },
                     }
                 )
@@ -1083,7 +1165,7 @@ def chat_completion_body_to_stream_chunks(body: bytes) -> list[dict[str, Any]]:
                         "unpaired_tool_call",
                         "Cannot translate an assistant tool call without a non-empty id into Chat Completions chunks.",
                     )
-                arguments = function.get("arguments") if isinstance(function.get("arguments"), str) else ""
+                arguments = _function_arguments(function, "Chat Completions function-call")
                 chunks.append(
                     {
                         "id": response_id,
@@ -1127,6 +1209,54 @@ def _identity_function_name(name: str) -> str:
     return name
 
 
+def _validate_chat_stream_choices(chunk: Mapping[str, Any]) -> None:
+    choices = chunk.get("choices")
+    if choices is None and "choices" not in chunk:
+        return
+    if not isinstance(choices, list):
+        raise UnsupportedProtocolTranslationError(
+            "unsupported_protocol_semantics",
+            "Cannot translate a non-list Chat Completions stream choices payload.",
+        )
+    if not choices:
+        return
+    if len(choices) != 1:
+        raise UnsupportedProtocolTranslationError(
+            "unsupported_protocol_semantics",
+            "Cannot translate multiple Chat Completions stream choices to one Responses stream.",
+        )
+    choice = choices[0]
+    if not isinstance(choice, Mapping):
+        raise UnsupportedProtocolTranslationError(
+            "unsupported_protocol_semantics",
+            "Cannot translate a non-object Chat Completions stream choice.",
+        )
+    choice_index = choice.get("index", 0)
+    if choice_index != 0:
+        raise UnsupportedProtocolTranslationError(
+            "unsupported_protocol_semantics",
+            f"Cannot translate Chat Completions stream choice index {choice_index!r} to one Responses stream.",
+        )
+
+
+def _validate_chat_stream_source(source: Mapping[str, Any]) -> None:
+    _require_supported_fields(
+        source,
+        {
+            "role",
+            "content",
+            "tool_calls",
+            "refusal",
+            "audio",
+            "annotations",
+            "reasoning",
+            "reasoning_content",
+        },
+        "Chat Completions stream delta",
+    )
+    _raise_for_unsupported_chat_message_semantics(source)
+
+
 def chat_stream_chunks_to_response_events(
     chunks: list[Mapping[str, Any] | str],
     *,
@@ -1141,6 +1271,12 @@ def chat_stream_chunks_to_response_events(
     incomplete_details: dict[str, str] | None = None
     response_id = f"resp_{uuid.uuid4().hex[:12]}"
     model: str | None = None
+    next_output_index = 0
+    message_output_index: int | None = None
+
+    for chunk in chunks:
+        if isinstance(chunk, Mapping):
+            _validate_chat_stream_choices(chunk)
 
     for chunk in chunks:
         if not isinstance(chunk, Mapping):
@@ -1160,11 +1296,16 @@ def chat_stream_chunks_to_response_events(
         created_response["model"] = model
     events.append({"type": "response.created", "response": created_response})
 
+    def allocate_output_index() -> int:
+        nonlocal next_output_index
+        output_index = next_output_index
+        next_output_index += 1
+        return output_index
+
     def state_for(index: int) -> dict[str, Any]:
         if index not in states:
-            output_index = len(states)
             states[index] = {
-                "output_index": output_index,
+                "output_index": allocate_output_index(),
                 "item_id": "",
                 "call_id": "",
                 "name": "",
@@ -1220,9 +1361,11 @@ def chat_stream_chunks_to_response_events(
             source = delta if isinstance(delta, dict) else message if isinstance(message, dict) else None
             if not isinstance(source, dict):
                 continue
-            _raise_for_unsupported_chat_message_semantics(source)
+            _validate_chat_stream_source(source)
             content = source.get("content")
             if isinstance(content, str) and content:
+                if message_output_index is None:
+                    message_output_index = allocate_output_index()
                 text_parts.append(content)
             elif content is not None:
                 raise UnsupportedProtocolTranslationError(
@@ -1243,6 +1386,11 @@ def chat_stream_chunks_to_response_events(
                         "unsupported_protocol_semantics",
                         "Cannot translate a non-object assistant tool-call stream delta.",
                     )
+                _require_supported_fields(
+                    tool_call,
+                    {"index", "id", "type", "function"},
+                    "Chat Completions assistant tool-call stream delta",
+                )
                 tool_type = tool_call.get("type")
                 if tool_type not in (None, "function"):
                     raise UnsupportedProtocolTranslationError(
@@ -1250,25 +1398,62 @@ def chat_stream_chunks_to_response_events(
                         f"Cannot translate assistant tool type {tool_type!r} to Responses stream events.",
                     )
                 raw_index = tool_call.get("index", fallback_index)
-                index = raw_index if isinstance(raw_index, int) else fallback_index
+                if not isinstance(raw_index, int):
+                    raise UnsupportedProtocolTranslationError(
+                        "unsupported_protocol_semantics",
+                        "Cannot translate a non-integer assistant tool-call stream index.",
+                    )
+                index = raw_index
                 state = state_for(index)
                 call_id = tool_call.get("id")
-                if isinstance(call_id, str) and call_id and not state["call_id"]:
-                    state["call_id"] = call_id
+                if call_id is not None:
+                    if not isinstance(call_id, str):
+                        raise UnsupportedProtocolTranslationError(
+                            "unpaired_tool_call",
+                            "Cannot translate a tool-call stream delta with an invalid id.",
+                        )
+                    if call_id:
+                        if state["call_id"] and state["call_id"] != call_id:
+                            raise UnsupportedProtocolTranslationError(
+                                "unpaired_tool_call",
+                                "Cannot translate conflicting tool-call ids for one stream index.",
+                            )
+                        state["call_id"] = call_id
 
                 function = tool_call.get("function")
+                if function is not None and not isinstance(function, dict):
+                    raise UnsupportedProtocolTranslationError(
+                        "unsupported_protocol_semantics",
+                        "Cannot translate a non-object assistant function-call stream delta.",
+                    )
                 if isinstance(function, dict):
+                    _require_supported_fields(
+                        function,
+                        {"name", "arguments"},
+                        "Chat Completions assistant function-call stream delta",
+                    )
                     name = function.get("name")
-                    if isinstance(name, str) and name and not state["name"]:
-                        state["name"] = normalize_function_name(name)
-                    arguments = function.get("arguments")
-                    if isinstance(arguments, str) and arguments:
+                    if name is not None:
+                        if not isinstance(name, str) or not name:
+                            raise UnsupportedProtocolTranslationError(
+                                "unsupported_protocol_semantics",
+                                "Cannot translate an invalid assistant function name in a stream delta.",
+                            )
+                        normalized_name = normalize_function_name(name)
+                        if state["name"] and state["name"] != normalized_name:
+                            raise UnsupportedProtocolTranslationError(
+                                "unsupported_protocol_semantics",
+                                "Cannot translate conflicting function names for one stream index.",
+                            )
+                        state["name"] = normalized_name
+                    arguments = _function_arguments(function, "Chat Completions function-call stream")
+                    if arguments:
                         state["arguments"].append(arguments)
 
                 maybe_emit_added(state)
                 if state["added"] and isinstance(function, dict):
-                    arguments = function.get("arguments")
-                    if isinstance(arguments, str) and arguments:
+                    arguments = _function_arguments(function, "Chat Completions function-call stream")
+                    if arguments:
                         events.append(
                             {
                                 "type": "response.function_call_arguments.delta",
@@ -1281,7 +1466,7 @@ def chat_stream_chunks_to_response_events(
     if not finished:
         return events
 
-    output: list[dict[str, Any]] = []
+    output_by_index: dict[int, dict[str, Any]] = {}
     text = "".join(text_parts)
     extracted_xmlish_tool_outputs = xmlish_tool_outputs(text) if text and xmlish_tool_outputs is not None else []
     for state in sorted(states.values(), key=lambda item: item["output_index"]):
@@ -1314,11 +1499,10 @@ def chat_stream_chunks_to_response_events(
             }
         )
         events.append({"type": "response.output_item.done", "output_index": state["output_index"], "item": item})
-        output.append(item)
+        output_by_index[state["output_index"]] = item
 
-    if extracted_xmlish_tool_outputs and not output:
-        for item in extracted_xmlish_tool_outputs:
-            output_index = len(output)
+    if extracted_xmlish_tool_outputs and not output_by_index:
+        for output_index, item in enumerate(extracted_xmlish_tool_outputs):
             in_progress_item = dict(item)
             in_progress_item["status"] = "in_progress"
             in_progress_item["arguments"] = ""
@@ -1338,9 +1522,9 @@ def chat_stream_chunks_to_response_events(
                 }
             )
             events.append({"type": "response.output_item.done", "output_index": output_index, "item": item})
-            output.append(item)
-    elif text and not output:
-        output_index = len(output)
+            output_by_index[output_index] = item
+    elif text:
+        output_index = message_output_index if message_output_index is not None else allocate_output_index()
         item_id = f"msg_{uuid.uuid4().hex[:12]}"
         item = {
             "id": item_id,
@@ -1382,7 +1566,9 @@ def chat_stream_chunks_to_response_events(
             }
         )
         events.append({"type": "response.output_item.done", "output_index": output_index, "item": item})
-        output.append(item)
+        output_by_index[output_index] = item
+
+    output = [item for _, item in sorted(output_by_index.items(), key=lambda pair: pair[0])]
 
     completed_response: dict[str, Any] = {
         "id": response_id,
@@ -1411,7 +1597,7 @@ def _validated_responses_stream_output_item(
     item: Any,
     *,
     function_name_from_response_item: FunctionNameFromResponseItem = _default_function_name_from_response_item,
-) -> tuple[str, str | None, str | None]:
+) -> tuple[str, str | None, str | None, str | None]:
     if not isinstance(item, Mapping):
         raise UnsupportedProtocolTranslationError(
             "unsupported_protocol_semantics",
@@ -1419,14 +1605,24 @@ def _validated_responses_stream_output_item(
         )
     item_type = item.get("type")
     if item_type == "message":
+        _require_supported_fields(
+            item,
+            {"id", "type", "status", "role", "content"},
+            "Responses stream message item",
+        )
         if item.get("content") is not None:
             responses_content_to_chat_content(item.get("content"))
-        return "message", None, None
+        return "message", None, None, None
     if item_type != "function_call":
         raise UnsupportedProtocolTranslationError(
             "unsupported_protocol_semantics",
             f"Cannot translate Responses stream output item type {item_type!r} to Chat Completions.",
         )
+    _require_supported_fields(
+        item,
+        {"id", "type", "status", "call_id", "namespace", "name", "arguments"},
+        "Responses stream function-call item",
+    )
     call_id = item.get("call_id")
     if not isinstance(call_id, str) or not call_id:
         raise UnsupportedProtocolTranslationError(
@@ -1439,7 +1635,19 @@ def _validated_responses_stream_output_item(
             "unsupported_protocol_semantics",
             "Cannot translate a function-call stream item without a non-empty name.",
         )
-    return "function_call", call_id, name
+    arguments = _function_arguments(item, "Responses function-call stream")
+    return "function_call", call_id, name, arguments
+
+
+def _function_argument_suffix(current: str, final: str, label: str) -> str:
+    if final == current:
+        return ""
+    if final.startswith(current):
+        return final[len(current) :]
+    raise UnsupportedProtocolTranslationError(
+        "unsupported_protocol_semantics",
+        f"Cannot translate disagreeing {label} argument deltas and final value.",
+    )
 
 
 def response_events_to_chat_stream_chunks(
@@ -1468,6 +1676,39 @@ def response_events_to_chat_stream_chunks(
                 "emitted_header": False,
             }
         return tool_states[item_id]
+
+    def append_final_arguments(state: dict[str, Any], final_arguments: str, label: str) -> None:
+        if not state["emitted_header"]:
+            raise UnsupportedProtocolTranslationError(
+                "unpaired_tool_call",
+                f"Cannot translate {label} arguments without a paired function-call stream item.",
+            )
+        suffix = _function_argument_suffix(state["arguments"], final_arguments, label)
+        if not suffix:
+            return
+        chunks.append(
+            {
+                "id": response_id or f"chatcmpl_{uuid.uuid4().hex[:12]}",
+                "object": "chat.completion.chunk",
+                "created": int(time.time()),
+                "model": model,
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {
+                            "tool_calls": [
+                                {
+                                    "index": state["index"],
+                                    "function": {"arguments": suffix},
+                                }
+                            ]
+                        },
+                        "finish_reason": None,
+                    }
+                ],
+            }
+        )
+        state["arguments"] += suffix
 
     for event in events:
         if not isinstance(event, Mapping):
@@ -1517,33 +1758,23 @@ def response_events_to_chat_stream_chunks(
             continue
         if event_type == "response.output_item.added":
             item = event.get("item")
-            if not isinstance(item, Mapping):
-                raise UnsupportedProtocolTranslationError(
-                    "unsupported_protocol_semantics",
-                    "Cannot translate a non-object Responses stream output item.",
-                )
-            if item.get("type") == "message":
-                if item.get("content") is not None:
-                    responses_content_to_chat_content(item.get("content"))
+            item_type, call_id, name, arguments = _validated_responses_stream_output_item(
+                item,
+                function_name_from_response_item=function_name_from_response_item,
+            )
+            if item_type == "message":
                 continue
-            if item.get("type") != "function_call":
-                raise UnsupportedProtocolTranslationError(
-                    "unsupported_protocol_semantics",
-                    f"Cannot translate Responses stream output item type {item.get('type')!r} to Chat Completions.",
-                )
             item_id = item.get("id") or item.get("call_id") or ""
             state = tool_state(str(item_id))
-            call_id = item.get("call_id")
-            if not isinstance(call_id, str) or not call_id:
+            if state["id"] and state["id"] != call_id:
                 raise UnsupportedProtocolTranslationError(
                     "unpaired_tool_call",
-                    "Cannot translate a function-call stream item without a non-empty call_id.",
+                    "Cannot translate conflicting function-call ids for one Responses stream item.",
                 )
-            name = function_name_from_response_item(item)
-            if not isinstance(name, str) or not name:
+            if state["name"] and state["name"] != name:
                 raise UnsupportedProtocolTranslationError(
                     "unsupported_protocol_semantics",
-                    "Cannot translate a function-call stream item without a non-empty name.",
+                    "Cannot translate conflicting function names for one Responses stream item.",
                 )
             state["id"] = call_id
             state["name"] = name
@@ -1573,11 +1804,17 @@ def response_events_to_chat_stream_chunks(
                     }
                 )
                 state["emitted_header"] = True
+            append_final_arguments(state, arguments or "", "function-call item")
             continue
         if event_type == "response.function_call_arguments.delta":
             item_id = event.get("item_id") or ""
             state = tool_state(str(item_id))
             delta_args = event.get("delta")
+            if delta_args is not None and not isinstance(delta_args, str):
+                raise UnsupportedProtocolTranslationError(
+                    "unsupported_protocol_semantics",
+                    "Cannot translate non-string function-call argument delta.",
+                )
             if isinstance(delta_args, str) and delta_args:
                 if not state["emitted_header"]:
                     if not state["id"]:
@@ -1638,10 +1875,27 @@ def response_events_to_chat_stream_chunks(
                             ],
                         }
                     )
+                state["arguments"] += delta_args
+            continue
+        if event_type == "response.function_call_arguments.done":
+            item_id = str(event.get("item_id") or "")
+            state = tool_states.get(item_id)
+            arguments = event.get("arguments")
+            if not isinstance(arguments, str):
+                raise UnsupportedProtocolTranslationError(
+                    "unsupported_protocol_semantics",
+                    "Cannot translate non-string final function-call arguments.",
+                )
+            if state is None:
+                raise UnsupportedProtocolTranslationError(
+                    "unpaired_tool_call",
+                    "Cannot translate final function-call arguments without a paired stream item.",
+                )
+            append_final_arguments(state, arguments, "function-call done")
             continue
         if event_type == "response.output_item.done":
             item = event.get("item")
-            item_type, call_id, _ = _validated_responses_stream_output_item(
+            item_type, call_id, name, arguments = _validated_responses_stream_output_item(
                 item,
                 function_name_from_response_item=function_name_from_response_item,
             )
@@ -1653,6 +1907,12 @@ def response_events_to_chat_stream_chunks(
                         "unpaired_tool_call",
                         "Cannot translate a completed function call that was never paired with a stream item.",
                     )
+                if state["id"] != call_id or state["name"] != name:
+                    raise UnsupportedProtocolTranslationError(
+                        "unpaired_tool_call",
+                        "Cannot translate a completed function call with conflicting identity.",
+                    )
+                append_final_arguments(state, arguments or "", "completed function-call item")
             continue
         if event_type == "response.completed":
             response_obj = event.get("response")
@@ -1660,7 +1920,7 @@ def response_events_to_chat_stream_chunks(
                 output = response_obj.get("output")
                 if isinstance(output, list):
                     for item in output:
-                        item_type, call_id, _ = _validated_responses_stream_output_item(
+                        item_type, call_id, name, arguments = _validated_responses_stream_output_item(
                             item,
                             function_name_from_response_item=function_name_from_response_item,
                         )
@@ -1672,6 +1932,12 @@ def response_events_to_chat_stream_chunks(
                                     "unpaired_tool_call",
                                     "Cannot translate a completed function call that was never paired with a stream item.",
                                 )
+                            if state["id"] != call_id or state["name"] != name:
+                                raise UnsupportedProtocolTranslationError(
+                                    "unpaired_tool_call",
+                                    "Cannot translate terminal function-call output with conflicting identity.",
+                                )
+                            append_final_arguments(state, arguments or "", "terminal function-call output")
                     finish_reason = "tool_calls" if any(
                         isinstance(item, Mapping) and item.get("type") == "function_call"
                         for item in output
@@ -1723,6 +1989,34 @@ class ResponsesToChatStreamConverter:
             "choices": [{"index": 0, "delta": dict(delta), "finish_reason": finish_reason}],
         }
 
+    def _final_argument_chunks(
+        self,
+        state: dict[str, Any],
+        final_arguments: str,
+        label: str,
+    ) -> list[dict[str, Any]]:
+        if not state["emitted_header"]:
+            raise UnsupportedProtocolTranslationError(
+                "unpaired_tool_call",
+                f"Cannot translate {label} arguments without a paired function-call stream item.",
+            )
+        suffix = _function_argument_suffix(state["arguments"], final_arguments, label)
+        if not suffix:
+            return []
+        state["arguments"] += suffix
+        return [
+            self._chunk(
+                {
+                    "tool_calls": [
+                        {
+                            "index": state["index"],
+                            "function": {"arguments": suffix},
+                        }
+                    ]
+                }
+            )
+        ]
+
     def chunks_for_event(self, event: Mapping[str, Any]) -> list[dict[str, Any]]:
         event_type = event.get("type")
         if event_type in {"response.failed", "response.incomplete", "error"}:
@@ -1750,40 +2044,27 @@ class ResponsesToChatStreamConverter:
             return []
         if event_type == "response.output_item.added":
             item = event.get("item")
-            if not isinstance(item, Mapping):
-                raise UnsupportedProtocolTranslationError(
-                    "unsupported_protocol_semantics",
-                    "Cannot translate a non-object Responses stream output item.",
-                )
-            if item.get("type") == "message":
-                if item.get("content") is not None:
-                    responses_content_to_chat_content(item.get("content"))
+            item_type, call_id, name, arguments = _validated_responses_stream_output_item(item)
+            if item_type == "message":
                 return []
-            if item.get("type") != "function_call":
-                raise UnsupportedProtocolTranslationError(
-                    "unsupported_protocol_semantics",
-                    f"Cannot translate Responses stream output item type {item.get('type')!r} to Chat Completions.",
-                )
             item_id = item.get("id") or item.get("call_id") or ""
             state = self._tool_state(str(item_id))
-            call_id = item.get("call_id")
-            if not isinstance(call_id, str) or not call_id:
+            if state["id"] and state["id"] != call_id:
                 raise UnsupportedProtocolTranslationError(
                     "unpaired_tool_call",
-                    "Cannot translate a function-call stream item without a non-empty call_id.",
+                    "Cannot translate conflicting function-call ids for one Responses stream item.",
                 )
-            name = item.get("name")
-            if not isinstance(name, str) or not name:
+            if state["name"] and state["name"] != name:
                 raise UnsupportedProtocolTranslationError(
                     "unsupported_protocol_semantics",
-                    "Cannot translate a function-call stream item without a non-empty name.",
+                    "Cannot translate conflicting function names for one Responses stream item.",
                 )
             state["id"] = call_id
             state["name"] = name
             if not (state["id"] and state["name"] and not state["emitted_header"]):
-                return []
+                return self._final_argument_chunks(state, arguments or "", "function-call item")
             state["emitted_header"] = True
-            return [
+            chunks = [
                 self._chunk(
                     {
                         "tool_calls": [
@@ -1797,10 +2078,17 @@ class ResponsesToChatStreamConverter:
                     }
                 )
             ]
+            chunks.extend(self._final_argument_chunks(state, arguments or "", "function-call item"))
+            return chunks
         if event_type == "response.function_call_arguments.delta":
             item_id = str(event.get("item_id") or "")
             state = self._tool_state(item_id)
             delta_args = event.get("delta")
+            if delta_args is not None and not isinstance(delta_args, str):
+                raise UnsupportedProtocolTranslationError(
+                    "unsupported_protocol_semantics",
+                    "Cannot translate non-string function-call argument delta.",
+                )
             if not (isinstance(delta_args, str) and delta_args):
                 return []
             if not state["emitted_header"]:
@@ -1815,13 +2103,14 @@ class ResponsesToChatStreamConverter:
                         "Cannot translate function-call arguments without a paired function name.",
                     )
                 state["emitted_header"] = True
+                state["arguments"] += delta_args
                 return [
                     self._chunk(
                         {
                             "tool_calls": [
-                                    {
-                                        "index": state["index"],
-                                        "id": state["id"],
+                                {
+                                    "index": state["index"],
+                                    "id": state["id"],
                                     "type": "function",
                                     "function": {"name": state["name"], "arguments": delta_args},
                                 }
@@ -1829,6 +2118,7 @@ class ResponsesToChatStreamConverter:
                         }
                     )
                 ]
+            state["arguments"] += delta_args
             return [
                 self._chunk(
                     {
@@ -1841,9 +2131,24 @@ class ResponsesToChatStreamConverter:
                     }
                 )
             ]
+        if event_type == "response.function_call_arguments.done":
+            item_id = str(event.get("item_id") or "")
+            state = self.tool_states.get(item_id)
+            arguments = event.get("arguments")
+            if not isinstance(arguments, str):
+                raise UnsupportedProtocolTranslationError(
+                    "unsupported_protocol_semantics",
+                    "Cannot translate non-string final function-call arguments.",
+                )
+            if state is None:
+                raise UnsupportedProtocolTranslationError(
+                    "unpaired_tool_call",
+                    "Cannot translate final function-call arguments without a paired stream item.",
+                )
+            return self._final_argument_chunks(state, arguments, "function-call done")
         if event_type == "response.output_item.done":
             item = event.get("item")
-            item_type, call_id, _ = _validated_responses_stream_output_item(item)
+            item_type, call_id, name, arguments = _validated_responses_stream_output_item(item)
             if item_type == "function_call":
                 item_id = str(item.get("id") or call_id or "")
                 state = self.tool_states.get(item_id)
@@ -1852,16 +2157,22 @@ class ResponsesToChatStreamConverter:
                         "unpaired_tool_call",
                         "Cannot translate a completed function call that was never paired with a stream item.",
                     )
+                if state["id"] != call_id or state["name"] != name:
+                    raise UnsupportedProtocolTranslationError(
+                        "unpaired_tool_call",
+                        "Cannot translate a completed function call with conflicting identity.",
+                    )
+                return self._final_argument_chunks(state, arguments or "", "completed function-call item")
             return []
         if event_type == "response.completed":
-            self.completed = True
             finish_reason = "stop"
+            chunks: list[dict[str, Any]] = []
             response_obj = event.get("response")
             if isinstance(response_obj, Mapping):
                 output = response_obj.get("output")
                 if isinstance(output, list):
                     for item in output:
-                        item_type, call_id, _ = _validated_responses_stream_output_item(item)
+                        item_type, call_id, name, arguments = _validated_responses_stream_output_item(item)
                         if item_type == "function_call":
                             item_id = str(item.get("id") or call_id or "")
                             state = self.tool_states.get(item_id)
@@ -1870,9 +2181,23 @@ class ResponsesToChatStreamConverter:
                                     "unpaired_tool_call",
                                     "Cannot translate a completed function call that was never paired with a stream item.",
                                 )
+                            if state["id"] != call_id or state["name"] != name:
+                                raise UnsupportedProtocolTranslationError(
+                                    "unpaired_tool_call",
+                                    "Cannot translate terminal function-call output with conflicting identity.",
+                                )
+                            chunks.extend(
+                                self._final_argument_chunks(
+                                    state,
+                                    arguments or "",
+                                    "terminal function-call output",
+                                )
+                            )
                     if any(isinstance(item, Mapping) and item.get("type") == "function_call" for item in output):
                         finish_reason = "tool_calls"
-            return [self._chunk({}, finish_reason=finish_reason)]
+            self.completed = True
+            chunks.append(self._chunk({}, finish_reason=finish_reason))
+            return chunks
         return []
 
 
@@ -2060,6 +2385,7 @@ class ChatToResponsesStreamConverter:
         return self._complete_events()
 
     def events_for_chunk(self, chunk: Mapping[str, Any]) -> list[dict[str, Any]]:
+        _validate_chat_stream_choices(chunk)
         if isinstance(chunk.get("model"), str):
             self.model = chunk.get("model")
         events: list[dict[str, Any]] = []
@@ -2071,7 +2397,7 @@ class ChatToResponsesStreamConverter:
                 continue
             delta = choice.get("delta")
             if isinstance(delta, Mapping):
-                _raise_for_unsupported_chat_message_semantics(delta)
+                _validate_chat_stream_source(delta)
                 content = delta.get("content")
                 if isinstance(content, str) and content:
                     self.text_parts.append(content)
@@ -2103,6 +2429,11 @@ class ChatToResponsesStreamConverter:
                                 "unsupported_protocol_semantics",
                                 "Cannot translate a non-object assistant tool-call stream delta.",
                             )
+                        _require_supported_fields(
+                            tool_call,
+                            {"index", "id", "type", "function"},
+                            "Chat Completions assistant tool-call stream delta",
+                        )
                         tool_type = tool_call.get("type")
                         if tool_type not in (None, "function"):
                             raise UnsupportedProtocolTranslationError(
@@ -2110,19 +2441,55 @@ class ChatToResponsesStreamConverter:
                                 f"Cannot translate assistant tool type {tool_type!r} to Responses stream events.",
                             )
                         raw_index = tool_call.get("index", fallback_index)
-                        index = raw_index if isinstance(raw_index, int) else fallback_index
+                        if not isinstance(raw_index, int):
+                            raise UnsupportedProtocolTranslationError(
+                                "unsupported_protocol_semantics",
+                                "Cannot translate a non-integer assistant tool-call stream index.",
+                            )
+                        index = raw_index
                         state = self._tool_state(index)
                         call_id = tool_call.get("id")
-                        if isinstance(call_id, str) and call_id and not state["call_id"]:
-                            state["call_id"] = call_id
+                        if call_id is not None:
+                            if not isinstance(call_id, str):
+                                raise UnsupportedProtocolTranslationError(
+                                    "unpaired_tool_call",
+                                    "Cannot translate a tool-call stream delta with an invalid id.",
+                                )
+                            if call_id:
+                                if state["call_id"] and state["call_id"] != call_id:
+                                    raise UnsupportedProtocolTranslationError(
+                                        "unpaired_tool_call",
+                                        "Cannot translate conflicting tool-call ids for one stream index.",
+                                    )
+                                state["call_id"] = call_id
                         function = tool_call.get("function")
                         argument_delta: str | None = None
+                        if function is not None and not isinstance(function, Mapping):
+                            raise UnsupportedProtocolTranslationError(
+                                "unsupported_protocol_semantics",
+                                "Cannot translate a non-object assistant function-call stream delta.",
+                            )
                         if isinstance(function, Mapping):
+                            _require_supported_fields(
+                                function,
+                                {"name", "arguments"},
+                                "Chat Completions assistant function-call stream delta",
+                            )
                             name = function.get("name")
-                            if isinstance(name, str) and name and not state["name"]:
+                            if name is not None:
+                                if not isinstance(name, str) or not name:
+                                    raise UnsupportedProtocolTranslationError(
+                                        "unsupported_protocol_semantics",
+                                        "Cannot translate an invalid assistant function name in a stream delta.",
+                                    )
+                                if state["name"] and state["name"] != name:
+                                    raise UnsupportedProtocolTranslationError(
+                                        "unsupported_protocol_semantics",
+                                        "Cannot translate conflicting function names for one stream index.",
+                                    )
                                 state["name"] = name
-                            arguments = function.get("arguments")
-                            if isinstance(arguments, str) and arguments:
+                            arguments = _function_arguments(function, "Chat Completions function-call stream")
+                            if arguments:
                                 state["arguments"].append(arguments)
                                 argument_delta = arguments
                         events.extend(self._tool_added_events(state))
@@ -2232,14 +2599,22 @@ def response_body_to_response_sse_events(
     collect_text_fragments: CollectTextFragments = _default_collect_text_fragments,
 ) -> list[dict[str, Any]]:
     payload = json.loads(body.decode("utf-8-sig"))
-    if not isinstance(payload, dict) or isinstance(payload.get("error"), (str, Mapping)):
+    if not isinstance(payload, dict):
         return []
 
     response = dict(payload)
     response_id = response.get("id") if isinstance(response.get("id"), str) else f"resp_{uuid.uuid4().hex[:12]}"
     response["id"] = response_id
     response.setdefault("object", "response")
-    response.setdefault("status", "completed")
+    status = response.get("status")
+    if status is None:
+        status = "failed" if response.get("error") is not None else "completed"
+    if status not in {"completed", "incomplete", "failed"}:
+        raise UnsupportedProtocolTranslationError(
+            "unsupported_protocol_semantics",
+            f"Cannot synthesize a terminal Responses stream from body status {status!r}.",
+        )
+    response["status"] = status
     output = response.get("output")
     output_items = output if isinstance(output, list) else []
     model_value = response.get("model")
@@ -2254,9 +2629,12 @@ def response_body_to_response_sse_events(
 
     for output_index, raw_item in enumerate(output_items):
         if not isinstance(raw_item, Mapping):
-            continue
+            raise UnsupportedProtocolTranslationError(
+                "unsupported_protocol_semantics",
+                "Cannot synthesize Responses stream events for a non-object output item.",
+            )
         item = dict(raw_item)
-        item_type = item.get("type")
+        item_type, _, _, arguments = _validated_responses_stream_output_item(item)
         item_id = item.get("id") if isinstance(item.get("id"), str) else f"item_{output_index}"
         item["id"] = item_id
         if item_type == "message":
@@ -2321,8 +2699,7 @@ def response_body_to_response_sse_events(
                     "item": in_progress_item,
                 }
             )
-            arguments = item.get("arguments")
-            if isinstance(arguments, str) and arguments:
+            if arguments:
                 events.append(
                     {
                         "type": "response.function_call_arguments.delta",
@@ -2337,7 +2714,7 @@ def response_body_to_response_sse_events(
                         "type": "response.function_call_arguments.done",
                         "output_index": output_index,
                         "item_id": item_id,
-                        "arguments": arguments if isinstance(arguments, str) else "",
+                        "arguments": arguments or "",
                     },
                     {
                         "type": "response.output_item.done",
@@ -2347,10 +2724,14 @@ def response_body_to_response_sse_events(
                 ]
             )
 
-    response["status"] = "completed"
     if model_value is not None:
         response["model"] = model_value
-    events.append({"type": "response.completed", "response": response})
+    terminal_event_type = {
+        "completed": "response.completed",
+        "incomplete": "response.incomplete",
+        "failed": "response.failed",
+    }[status]
+    events.append({"type": terminal_event_type, "response": response})
     return events
 
 

--- a/src-python/protocol_translation.py
+++ b/src-python/protocol_translation.py
@@ -83,6 +83,27 @@ def _raise_for_unsupported_chat_message_semantics(message: Mapping[str, Any]) ->
             )
 
 
+def _require_supported_chat_message_fields(message: Mapping[str, Any], label: str) -> None:
+    role = message.get("role")
+    allowed_by_role = {
+        "system": {"role", "content"},
+        "user": {"role", "content"},
+        "assistant": {
+            "role",
+            "content",
+            "tool_calls",
+            "refusal",
+            "audio",
+            "annotations",
+            "reasoning",
+            "reasoning_content",
+        },
+        "tool": {"role", "content", "tool_call_id"},
+    }
+    _require_supported_fields(message, allowed_by_role.get(role, {"role", "content"}), label)
+    _raise_for_unsupported_chat_message_semantics(message)
+
+
 def _require_supported_fields(value: Mapping[str, Any], allowed: set[str], label: str) -> None:
     unsupported = sorted(str(key) for key in value.keys() if key not in allowed)
     if unsupported:
@@ -275,6 +296,25 @@ def responses_request_to_chat_completion_body(body: bytes) -> bytes:
     payload = json.loads(body.decode("utf-8-sig"))
     if not isinstance(payload, dict):
         return body
+    _require_supported_fields(
+        payload,
+        {
+            "model",
+            "input",
+            "instructions",
+            "tools",
+            "tool_choice",
+            "stream",
+            "temperature",
+            "top_p",
+            "presence_penalty",
+            "frequency_penalty",
+            "parallel_tool_calls",
+            "max_output_tokens",
+            "reasoning",
+        },
+        "Responses request",
+    )
     if payload.get("reasoning") is not None:
         raise UnsupportedProtocolTranslationError(
             "unsupported_protocol_semantics",
@@ -380,18 +420,33 @@ def chat_messages_to_responses_input(
                 "unsupported_protocol_semantics",
                 "Cannot translate a non-object Chat Completions message.",
             )
-        _raise_for_unsupported_chat_message_semantics(message)
+        _require_supported_chat_message_fields(message, "Chat Completions message")
         role = message.get("role")
         if role == "system":
             content = message.get("content")
-            text = content if isinstance(content, str) else chat_content_text(content)
+            if content is not None and not isinstance(content, str):
+                raise UnsupportedProtocolTranslationError(
+                    "unsupported_protocol_semantics",
+                    "Cannot translate non-text Chat Completions system content to Responses instructions.",
+                )
+            text = content if isinstance(content, str) else ""
             if text:
                 instructions_parts.append(text)
             continue
         tool_calls = message.get("tool_calls")
+        if role == "assistant" and tool_calls is not None and not isinstance(tool_calls, list):
+            raise UnsupportedProtocolTranslationError(
+                "unsupported_protocol_semantics",
+                "Cannot translate a non-list assistant tool_calls payload.",
+            )
         if isinstance(tool_calls, list) and role == "assistant":
             content = message.get("content")
-            text = content if isinstance(content, str) else chat_content_text(content)
+            if content is not None and not isinstance(content, str):
+                raise UnsupportedProtocolTranslationError(
+                    "unsupported_protocol_semantics",
+                    "Cannot translate non-text assistant content alongside tool calls.",
+                )
+            text = content if isinstance(content, str) else ""
             if text:
                 input_items.append(
                     {
@@ -406,6 +461,11 @@ def chat_messages_to_responses_input(
                         "unsupported_protocol_semantics",
                         "Cannot translate a non-object assistant tool call.",
                     )
+                _require_supported_fields(
+                    tool_call,
+                    {"id", "type", "function"},
+                    "Chat Completions assistant tool call",
+                )
                 tool_type = tool_call.get("type")
                 if tool_type not in (None, "function"):
                     raise UnsupportedProtocolTranslationError(
@@ -418,6 +478,11 @@ def chat_messages_to_responses_input(
                         "unsupported_protocol_semantics",
                         "Cannot translate an assistant tool call without a function payload.",
                     )
+                _require_supported_fields(
+                    function,
+                    {"name", "arguments"},
+                    "Chat Completions assistant function call",
+                )
                 name = function.get("name")
                 if not isinstance(name, str) or not name:
                     raise UnsupportedProtocolTranslationError(
@@ -448,7 +513,12 @@ def chat_messages_to_responses_input(
                     "Cannot translate a tool result without a non-empty tool_call_id.",
                 )
             content = message.get("content")
-            output = content if isinstance(content, str) else chat_content_text(content)
+            if content is not None and not isinstance(content, str):
+                raise UnsupportedProtocolTranslationError(
+                    "unsupported_protocol_semantics",
+                    "Cannot translate non-text Chat Completions tool result content to Responses.",
+                )
+            output = content if isinstance(content, str) else ""
             input_items.append(
                 {
                     "type": "function_call_output",
@@ -552,10 +622,36 @@ def chat_completions_request_to_responses_body(
     payload = json.loads(body.decode("utf-8-sig"))
     if not isinstance(payload, dict):
         return body
+    _require_supported_fields(
+        payload,
+        {
+            "model",
+            "messages",
+            "tools",
+            "tool_choice",
+            "stream",
+            "temperature",
+            "top_p",
+            "presence_penalty",
+            "frequency_penalty",
+            "parallel_tool_calls",
+            "max_tokens",
+            "max_output_tokens",
+            "reasoning",
+            "reasoning_effort",
+            "n",
+        },
+        "Chat Completions request",
+    )
     if payload.get("reasoning") is not None or payload.get("reasoning_effort") is not None:
         raise UnsupportedProtocolTranslationError(
             "unsupported_protocol_semantics",
             "Cannot translate Chat Completions reasoning controls to Responses without a proven equivalent.",
+        )
+    if "n" in payload and payload.get("n") not in (None, 1):
+        raise UnsupportedProtocolTranslationError(
+            "unsupported_protocol_semantics",
+            "Cannot translate multiple Chat Completions choices to a single Responses result.",
         )
 
     instructions, input_items = chat_messages_to_responses_input(
@@ -712,9 +808,20 @@ def chat_completion_to_response_body(
     incomplete_details: dict[str, str] | None = None
     choices = payload.get("choices")
     if isinstance(choices, list):
+        if len(choices) > 1:
+            raise UnsupportedProtocolTranslationError(
+                "unsupported_protocol_semantics",
+                "Cannot translate multiple Chat Completions choices to a single Responses result.",
+            )
         for index, choice in enumerate(choices):
             if not isinstance(choice, dict):
                 continue
+            choice_index = choice.get("index", index)
+            if choice_index not in (None, 0):
+                raise UnsupportedProtocolTranslationError(
+                    "unsupported_protocol_semantics",
+                    f"Cannot translate Chat Completions choice index {choice_index!r} to a single Responses result.",
+                )
             finish_reason = choice.get("finish_reason")
             if finish_reason == "length":
                 incomplete_details = {"reason": "max_output_tokens"}
@@ -726,6 +833,7 @@ def chat_completion_to_response_body(
             message = choice.get("message")
             if not isinstance(message, dict):
                 continue
+            _require_supported_chat_message_fields(message, "Chat Completions response message")
             tool_outputs = _chat_completion_tool_outputs(
                 message,
                 chat_content_text=chat_content_text,
@@ -919,6 +1027,7 @@ def chat_completion_body_to_stream_chunks(body: bytes) -> list[dict[str, Any]]:
         message = choice.get("message")
         if not isinstance(message, Mapping):
             continue
+        _require_supported_chat_message_fields(message, "Chat Completions response message")
         content = message.get("content")
         if isinstance(content, str) and content:
             chunks.append(
@@ -938,12 +1047,28 @@ def chat_completion_body_to_stream_chunks(body: bytes) -> list[dict[str, Any]]:
                         "unsupported_protocol_semantics",
                         "Cannot translate a non-object assistant tool call into Chat Completions chunks.",
                     )
+                _require_supported_fields(
+                    tool_call,
+                    {"id", "type", "function", "index"},
+                    "Chat Completions assistant tool call",
+                )
+                tool_type = tool_call.get("type")
+                if tool_type not in (None, "function"):
+                    raise UnsupportedProtocolTranslationError(
+                        "unsupported_protocol_semantics",
+                        f"Cannot translate assistant tool type {tool_type!r} into Chat Completions chunks.",
+                    )
                 function = tool_call.get("function")
                 if not isinstance(function, Mapping):
                     raise UnsupportedProtocolTranslationError(
                         "unsupported_protocol_semantics",
                         "Cannot translate an assistant tool call without a function payload into Chat Completions chunks.",
                     )
+                _require_supported_fields(
+                    function,
+                    {"name", "arguments"},
+                    "Chat Completions assistant function call",
+                )
                 name = function.get("name")
                 if not isinstance(name, str) or not name:
                     raise UnsupportedProtocolTranslationError(

--- a/src-python/protocol_translation.py
+++ b/src-python/protocol_translation.py
@@ -102,6 +102,12 @@ def _require_supported_chat_message_fields(message: Mapping[str, Any], label: st
     }
     _require_supported_fields(message, allowed_by_role.get(role, {"role", "content"}), label)
     _raise_for_unsupported_chat_message_semantics(message)
+    content = message.get("content")
+    if content is not None and not isinstance(content, (str, list)):
+        raise UnsupportedProtocolTranslationError(
+            "unsupported_protocol_semantics",
+            f"Cannot translate a non-string, non-list {label} content value.",
+        )
 
 
 def _require_supported_fields(value: Mapping[str, Any], allowed: set[str], label: str) -> None:
@@ -150,8 +156,13 @@ def _validate_function_tool_fields(value: Mapping[str, Any], allowed: set[str], 
 def responses_content_to_chat_content(value: Any) -> str | list[dict[str, Any]]:
     if isinstance(value, str):
         return value
-    if not isinstance(value, list):
+    if value is None:
         return ""
+    if not isinstance(value, list):
+        raise UnsupportedProtocolTranslationError(
+            "unsupported_protocol_semantics",
+            "Cannot translate a non-string, non-list Responses content value.",
+        )
 
     parts: list[dict[str, Any]] = []
     text_fragments: list[str] = []
@@ -207,8 +218,13 @@ def responses_content_to_chat_content(value: Any) -> str | list[dict[str, Any]]:
 def responses_input_to_chat_messages(value: Any) -> list[dict[str, Any]]:
     if isinstance(value, str):
         return [{"role": "user", "content": value}]
-    if not isinstance(value, list):
+    if value is None:
         return []
+    if not isinstance(value, list):
+        raise UnsupportedProtocolTranslationError(
+            "unsupported_protocol_semantics",
+            "Cannot translate a non-string, non-list Responses input payload.",
+        )
 
     messages: list[dict[str, Any]] = []
     for item in value:
@@ -291,8 +307,13 @@ def responses_input_to_chat_messages(value: Any) -> list[dict[str, Any]]:
 
 
 def responses_tools_to_chat_tools(value: Any) -> list[dict[str, Any]]:
-    if not isinstance(value, list):
+    if value is None:
         return []
+    if not isinstance(value, list):
+        raise UnsupportedProtocolTranslationError(
+            "unsupported_protocol_semantics",
+            "Cannot translate a non-list Responses tools payload.",
+        )
     tools: list[dict[str, Any]] = []
     for item in value:
         if not isinstance(item, dict) or item.get("type") != "function":
@@ -373,6 +394,18 @@ def responses_request_to_chat_completion_body(body: bytes) -> bytes:
             "unsupported_protocol_semantics",
             "Cannot translate Responses reasoning controls to Chat Completions without a proven equivalent.",
         )
+    if "input" in payload and not isinstance(payload["input"], (str, list)):
+        raise UnsupportedProtocolTranslationError(
+            "unsupported_protocol_semantics",
+            "Cannot translate a present non-string, non-list Responses input payload.",
+        )
+    if "instructions" in payload and payload["instructions"] is not None and not isinstance(
+        payload["instructions"], str
+    ):
+        raise UnsupportedProtocolTranslationError(
+            "unsupported_protocol_semantics",
+            "Cannot translate a present non-string Responses instructions payload.",
+        )
 
     messages: list[dict[str, Any]] = []
     instructions = payload.get("instructions")
@@ -411,8 +444,13 @@ def responses_request_to_chat_completion_body(body: bytes) -> bytes:
 def chat_content_to_responses_content(value: Any) -> list[dict[str, Any]]:
     if isinstance(value, str):
         return [{"type": "input_text", "text": value}]
-    if not isinstance(value, list):
+    if value is None:
         return []
+    if not isinstance(value, list):
+        raise UnsupportedProtocolTranslationError(
+            "unsupported_protocol_semantics",
+            "Cannot translate a non-string, non-list Chat Completions content value.",
+        )
     parts: list[dict[str, Any]] = []
     for fragment in value:
         if not isinstance(fragment, dict):
@@ -462,8 +500,13 @@ def chat_messages_to_responses_input(
     *,
     chat_content_text: ChatContentText = _default_chat_content_text,
 ) -> tuple[str | None, list[dict[str, Any]]]:
-    if not isinstance(messages, list):
+    if messages is None:
         return None, []
+    if not isinstance(messages, list):
+        raise UnsupportedProtocolTranslationError(
+            "unsupported_protocol_semantics",
+            "Cannot translate a non-list Chat Completions messages payload.",
+        )
 
     instructions_parts: list[str] = []
     input_items: list[dict[str, Any]] = []
@@ -611,8 +654,13 @@ def chat_messages_to_responses_input(
 
 
 def chat_tools_to_responses_tools(value: Any) -> list[dict[str, Any]]:
-    if not isinstance(value, list):
+    if value is None:
         return []
+    if not isinstance(value, list):
+        raise UnsupportedProtocolTranslationError(
+            "unsupported_protocol_semantics",
+            "Cannot translate a non-list Chat Completions tools payload.",
+        )
     tools: list[dict[str, Any]] = []
     for item in value:
         if not isinstance(item, dict) or item.get("type") != "function":
@@ -714,6 +762,11 @@ def chat_completions_request_to_responses_body(
         raise UnsupportedProtocolTranslationError(
             "unsupported_protocol_semantics",
             "Cannot translate multiple Chat Completions choices to a single Responses result.",
+        )
+    if "messages" in payload and not isinstance(payload["messages"], list):
+        raise UnsupportedProtocolTranslationError(
+            "unsupported_protocol_semantics",
+            "Cannot translate a present non-list Chat Completions messages payload.",
         )
 
     instructions, input_items = chat_messages_to_responses_input(
@@ -876,6 +929,12 @@ def chat_completion_to_response_body(
             separators=(",", ":"),
         ).encode("utf-8")
 
+    if "choices" in payload and not isinstance(payload["choices"], list):
+        raise UnsupportedProtocolTranslationError(
+            "unsupported_protocol_semantics",
+            "Cannot translate a present non-list Chat Completions choices payload.",
+        )
+
     output: list[dict[str, Any]] = []
     incomplete_details: dict[str, str] | None = None
     choices = payload.get("choices")
@@ -887,7 +946,10 @@ def chat_completion_to_response_body(
             )
         for index, choice in enumerate(choices):
             if not isinstance(choice, dict):
-                continue
+                raise UnsupportedProtocolTranslationError(
+                    "unsupported_protocol_semantics",
+                    "Cannot translate a non-object Chat Completions response choice.",
+                )
             choice_index = choice.get("index", index)
             if choice_index not in (None, 0):
                 raise UnsupportedProtocolTranslationError(
@@ -904,7 +966,10 @@ def chat_completion_to_response_body(
                 )
             message = choice.get("message")
             if not isinstance(message, dict):
-                continue
+                raise UnsupportedProtocolTranslationError(
+                    "unsupported_protocol_semantics",
+                    "Cannot translate a Chat Completions response choice without an object message.",
+                )
             _require_supported_chat_message_fields(message, "Chat Completions response message")
             tool_outputs = _chat_completion_tool_outputs(
                 message,
@@ -985,6 +1050,11 @@ def response_body_to_chat_completion_body(
     )
     if has_error_signal:
         return error_body(payload)
+    if "output" in payload and not isinstance(output, list):
+        raise UnsupportedProtocolTranslationError(
+            "unsupported_protocol_semantics",
+            "Cannot translate a present non-list Responses output payload.",
+        )
 
     text_parts: list[str] = []
     tool_calls: list[dict[str, Any]] = []
@@ -1085,6 +1155,11 @@ def chat_completion_body_to_stream_chunks(body: bytes) -> list[dict[str, Any]]:
     payload = json.loads(body.decode("utf-8-sig"))
     if not isinstance(payload, dict):
         return []
+    if "choices" in payload and not isinstance(payload["choices"], list):
+        raise UnsupportedProtocolTranslationError(
+            "unsupported_protocol_semantics",
+            "Cannot synthesize Chat Completions chunks from a present non-list choices payload.",
+        )
 
     response_id = payload.get("id") if isinstance(payload.get("id"), str) else f"chatcmpl_{uuid.uuid4().hex[:12]}"
     model = payload.get("model")
@@ -1103,12 +1178,18 @@ def chat_completion_body_to_stream_chunks(body: bytes) -> list[dict[str, Any]]:
 
     for fallback_index, choice in enumerate(choices):
         if not isinstance(choice, Mapping):
-            continue
+            raise UnsupportedProtocolTranslationError(
+                "unsupported_protocol_semantics",
+                "Cannot synthesize Chat Completions chunks for a non-object response choice.",
+            )
         index = choice.get("index")
         index = index if isinstance(index, int) else fallback_index
         message = choice.get("message")
         if not isinstance(message, Mapping):
-            continue
+            raise UnsupportedProtocolTranslationError(
+                "unsupported_protocol_semantics",
+                "Cannot synthesize Chat Completions chunks for a response choice without an object message.",
+            )
         _require_supported_chat_message_fields(message, "Chat Completions response message")
         content = message.get("content")
         if isinstance(content, str) and content:
@@ -1239,6 +1320,33 @@ def _validate_chat_stream_choices(chunk: Mapping[str, Any]) -> None:
         )
 
 
+def _is_chat_stream_usage_only_chunk(chunk: Mapping[str, Any]) -> bool:
+    return chunk.get("choices") == [] and "usage" in chunk
+
+
+def _validate_chat_stream_terminal_order(chunks: list[Mapping[str, Any] | str]) -> None:
+    terminal_seen = False
+    for chunk in chunks:
+        if chunk == "[DONE]":
+            terminal_seen = True
+            continue
+        if not isinstance(chunk, Mapping):
+            continue
+        _validate_chat_stream_choices(chunk)
+        if terminal_seen:
+            if _is_chat_stream_usage_only_chunk(chunk):
+                continue
+            raise UnsupportedProtocolTranslationError(
+                "unsupported_protocol_semantics",
+                "Cannot translate Chat Completions stream semantics after a terminal chunk.",
+            )
+        choices = chunk.get("choices")
+        if not isinstance(choices, list) or not choices:
+            continue
+        if choices[0].get("finish_reason") is not None:
+            terminal_seen = True
+
+
 def _validate_chat_stream_source(source: Mapping[str, Any]) -> None:
     _require_supported_fields(
         source,
@@ -1274,9 +1382,7 @@ def chat_stream_chunks_to_response_events(
     next_output_index = 0
     message_output_index: int | None = None
 
-    for chunk in chunks:
-        if isinstance(chunk, Mapping):
-            _validate_chat_stream_choices(chunk)
+    _validate_chat_stream_terminal_order(chunks)
 
     for chunk in chunks:
         if not isinstance(chunk, Mapping):
@@ -1650,12 +1756,31 @@ def _function_argument_suffix(current: str, final: str, label: str) -> str:
     )
 
 
+def _validate_responses_stream_terminal_order(events: list[Mapping[str, Any] | str]) -> None:
+    terminal_seen = False
+    for event in events:
+        if event == "[DONE]":
+            terminal_seen = True
+            continue
+        if not isinstance(event, Mapping):
+            continue
+        event_type = event.get("type")
+        if terminal_seen:
+            raise UnsupportedProtocolTranslationError(
+                "unsupported_protocol_semantics",
+                "Cannot translate Responses stream semantics after a terminal event.",
+            )
+        if event_type in {"response.completed", "response.failed", "response.incomplete", "error"}:
+            terminal_seen = True
+
+
 def response_events_to_chat_stream_chunks(
-    events: list[Mapping[str, Any]],
+    events: list[Mapping[str, Any] | str],
     *,
     require_completed: bool = False,
     function_name_from_response_item: FunctionNameFromResponseItem = _default_function_name_from_response_item,
 ) -> list[dict[str, Any]]:
+    _validate_responses_stream_terminal_order(events)
     if require_completed and not responses_events_have_completed(events):
         raise UpstreamStreamIncompleteError("Responses stream ended before response.completed")
 
@@ -1918,6 +2043,11 @@ def response_events_to_chat_stream_chunks(
             response_obj = event.get("response")
             if isinstance(response_obj, Mapping):
                 output = response_obj.get("output")
+                if "output" in response_obj and not isinstance(output, list):
+                    raise UnsupportedProtocolTranslationError(
+                        "unsupported_protocol_semantics",
+                        "Cannot translate a terminal Responses event with a non-list output payload.",
+                    )
                 if isinstance(output, list):
                     for item in output:
                         item_type, call_id, name, arguments = _validated_responses_stream_output_item(
@@ -2019,6 +2149,11 @@ class ResponsesToChatStreamConverter:
 
     def chunks_for_event(self, event: Mapping[str, Any]) -> list[dict[str, Any]]:
         event_type = event.get("type")
+        if self.completed:
+            raise UnsupportedProtocolTranslationError(
+                "unsupported_protocol_semantics",
+                "Cannot translate Responses stream semantics after a terminal event.",
+            )
         if event_type in {"response.failed", "response.incomplete", "error"}:
             raise UnsupportedProtocolTranslationError(
                 "upstream_response_failed",
@@ -2170,6 +2305,11 @@ class ResponsesToChatStreamConverter:
             response_obj = event.get("response")
             if isinstance(response_obj, Mapping):
                 output = response_obj.get("output")
+                if "output" in response_obj and not isinstance(output, list):
+                    raise UnsupportedProtocolTranslationError(
+                        "unsupported_protocol_semantics",
+                        "Cannot translate a terminal Responses event with a non-list output payload.",
+                    )
                 if isinstance(output, list):
                     for item in output:
                         item_type, call_id, name, arguments = _validated_responses_stream_output_item(item)
@@ -2386,10 +2526,17 @@ class ChatToResponsesStreamConverter:
 
     def events_for_chunk(self, chunk: Mapping[str, Any]) -> list[dict[str, Any]]:
         _validate_chat_stream_choices(chunk)
+        choices = chunk.get("choices")
+        if self.completed:
+            if _is_chat_stream_usage_only_chunk(chunk):
+                return []
+            raise UnsupportedProtocolTranslationError(
+                "unsupported_protocol_semantics",
+                "Cannot translate Chat Completions stream semantics after a terminal chunk.",
+            )
         if isinstance(chunk.get("model"), str):
             self.model = chunk.get("model")
         events: list[dict[str, Any]] = []
-        choices = chunk.get("choices")
         if not isinstance(choices, list):
             return events
         for choice in choices:
@@ -2616,6 +2763,11 @@ def response_body_to_response_sse_events(
         )
     response["status"] = status
     output = response.get("output")
+    if "output" in response and not isinstance(output, list):
+        raise UnsupportedProtocolTranslationError(
+            "unsupported_protocol_semantics",
+            "Cannot synthesize Responses stream events from a present non-list output payload.",
+        )
     output_items = output if isinstance(output, list) else []
     model_value = response.get("model")
 

--- a/src-python/protocol_translation.py
+++ b/src-python/protocol_translation.py
@@ -4,6 +4,13 @@ The Gateway owns routing, transport, retries, and Codex-specific semantic
 repair.  This module owns only the protocol shapes used at that boundary.
 Optional callbacks keep the few Gateway-owned naming and repair policies out of
 the translation implementation while preserving existing behavior.
+
+Only the documented lossless subset crosses this seam: text without
+annotations, URL-backed images (including detail), and paired function calls.
+The longstanding developer-to-system/instructions text compatibility mapping
+remains for third-party Chat endpoints. Other semantic items—including new
+content fields—raise ``UnsupportedProtocolTranslationError`` instead of being
+dropped or rewritten.
 """
 
 from __future__ import annotations
@@ -24,6 +31,14 @@ UsageFromResponse = Callable[[Mapping[str, Any]], Mapping[str, Any] | None]
 
 class UpstreamStreamIncompleteError(RuntimeError):
     """Raised when an upstream stream ends without a terminal event."""
+
+
+class UnsupportedProtocolTranslationError(ValueError):
+    """Raised when a wire shape cannot cross the protocol seam losslessly."""
+
+    def __init__(self, code: str, detail: str):
+        self.code = code
+        super().__init__(detail)
 
 
 def _default_collect_text_fragments(value: Any) -> list[str]:
@@ -58,6 +73,25 @@ def _default_usage_from_response(response: Mapping[str, Any]) -> Mapping[str, An
     return usage if isinstance(usage, Mapping) else None
 
 
+def _raise_for_unsupported_chat_message_semantics(message: Mapping[str, Any]) -> None:
+    for field in ("refusal", "audio", "annotations", "reasoning", "reasoning_content"):
+        value = message.get(field)
+        if value not in (None, "", [], {}):
+            raise UnsupportedProtocolTranslationError(
+                "unsupported_protocol_semantics",
+                f"Cannot translate Chat Completions message field {field!r} to Responses without losing it.",
+            )
+
+
+def _require_supported_fields(value: Mapping[str, Any], allowed: set[str], label: str) -> None:
+    unsupported = sorted(str(key) for key in value.keys() if key not in allowed)
+    if unsupported:
+        raise UnsupportedProtocolTranslationError(
+            "unsupported_protocol_semantics",
+            f"Cannot translate {label} fields without losing them: {', '.join(unsupported)}.",
+        )
+
+
 def responses_content_to_chat_content(value: Any) -> str | list[dict[str, Any]]:
     if isinstance(value, str):
         return value
@@ -69,20 +103,46 @@ def responses_content_to_chat_content(value: Any) -> str | list[dict[str, Any]]:
     has_image = False
     for part in value:
         if not isinstance(part, Mapping):
-            continue
+            raise UnsupportedProtocolTranslationError(
+                "unsupported_protocol_semantics",
+                "Cannot translate a non-object Responses content part.",
+            )
         part_type = part.get("type")
         if part_type in {"input_text", "output_text", "text"} and isinstance(part.get("text"), str):
+            _require_supported_fields(part, {"type", "text", "annotations"}, "Responses text content part")
+            annotations = part.get("annotations")
+            if annotations not in (None, []):
+                raise UnsupportedProtocolTranslationError(
+                    "unsupported_protocol_semantics",
+                    "Cannot translate Responses text annotations to Chat Completions without losing them.",
+                )
             text = part["text"]
             text_fragments.append(text)
             parts.append({"type": "text", "text": text})
             continue
         if part_type == "input_image" and isinstance(part.get("image_url"), str):
+            _require_supported_fields(part, {"type", "image_url", "detail"}, "Responses image content part")
             has_image = True
-            parts.append({"type": "image_url", "image_url": {"url": part["image_url"]}})
+            image_url: dict[str, str] = {"url": part["image_url"]}
+            detail = part.get("detail")
+            if isinstance(detail, str):
+                image_url["detail"] = detail
+            elif detail is not None:
+                raise UnsupportedProtocolTranslationError(
+                    "unsupported_protocol_semantics",
+                    "Cannot translate a non-string Responses image detail value.",
+                )
+            parts.append({"type": "image_url", "image_url": image_url})
             continue
         if part_type == "input_image" and isinstance(part.get("file_id"), str):
-            has_image = True
-            parts.append({"type": "text", "text": f"[Image file: {part['file_id']}]"})
+            raise UnsupportedProtocolTranslationError(
+                "unsupported_protocol_semantics",
+                "Cannot translate a Responses image file reference to Chat Completions without changing it to text.",
+            )
+        raise UnsupportedProtocolTranslationError(
+            "unsupported_protocol_semantics",
+            f"Cannot translate Responses content part type {part_type!r} to Chat Completions.",
+        )
 
     if has_image:
         return parts or [{"type": "text", "text": ""}]
@@ -98,21 +158,35 @@ def responses_input_to_chat_messages(value: Any) -> list[dict[str, Any]]:
     messages: list[dict[str, Any]] = []
     for item in value:
         if not isinstance(item, dict):
-            continue
+            raise UnsupportedProtocolTranslationError(
+                "unsupported_protocol_semantics",
+                "Cannot translate a non-object Responses input item.",
+            )
         item_type = item.get("type")
         if item_type == "message" or (item_type is None and ("role" in item or "content" in item)):
             role = item.get("role")
             if role == "developer":
                 role = "system"
-            else:
-                role = role if role in {"system", "user", "assistant"} else "user"
+            elif role not in {"system", "user", "assistant"}:
+                raise UnsupportedProtocolTranslationError(
+                    "unsupported_protocol_semantics",
+                    f"Cannot translate Responses message role {role!r} to Chat Completions.",
+                )
             messages.append({"role": role, "content": responses_content_to_chat_content(item.get("content"))})
             continue
         if item_type == "function_call":
             call_id = item.get("call_id")
             name = item.get("name")
-            if not isinstance(call_id, str) or not isinstance(name, str):
-                continue
+            if not isinstance(call_id, str) or not call_id:
+                raise UnsupportedProtocolTranslationError(
+                    "unpaired_tool_call",
+                    "Cannot translate a function call without a non-empty call_id.",
+                )
+            if not isinstance(name, str) or not name:
+                raise UnsupportedProtocolTranslationError(
+                    "unsupported_protocol_semantics",
+                    "Cannot translate a function call without a non-empty name.",
+                )
             arguments = item.get("arguments")
             if not isinstance(arguments, str):
                 arguments = json.dumps(arguments if arguments is not None else {}, ensure_ascii=True, separators=(",", ":"))
@@ -132,11 +206,19 @@ def responses_input_to_chat_messages(value: Any) -> list[dict[str, Any]]:
             continue
         if item_type == "function_call_output":
             call_id = item.get("call_id")
-            if not isinstance(call_id, str):
-                continue
+            if not isinstance(call_id, str) or not call_id:
+                raise UnsupportedProtocolTranslationError(
+                    "unpaired_tool_call",
+                    "Cannot translate a function result without a non-empty call_id.",
+                )
             output = item.get("output")
             content = output if isinstance(output, str) else json.dumps(output, ensure_ascii=True, separators=(",", ":"))
             messages.append({"role": "tool", "tool_call_id": call_id, "content": content})
+            continue
+        raise UnsupportedProtocolTranslationError(
+            "unsupported_protocol_semantics",
+            f"Cannot translate Responses input item type {item_type!r} to Chat Completions.",
+        )
     return messages
 
 
@@ -146,10 +228,17 @@ def responses_tools_to_chat_tools(value: Any) -> list[dict[str, Any]]:
     tools: list[dict[str, Any]] = []
     for item in value:
         if not isinstance(item, dict) or item.get("type") != "function":
-            continue
+            tool_type = item.get("type") if isinstance(item, Mapping) else type(item).__name__
+            raise UnsupportedProtocolTranslationError(
+                "unsupported_protocol_semantics",
+                f"Cannot translate Responses tool type {tool_type!r} to Chat Completions.",
+            )
         name = item.get("name")
         if not isinstance(name, str) or not name:
-            continue
+            raise UnsupportedProtocolTranslationError(
+                "unsupported_protocol_semantics",
+                "Cannot translate a Responses function tool without a non-empty name.",
+            )
         function: dict[str, Any] = {"name": name}
         description = item.get("description")
         if isinstance(description, str):
@@ -157,16 +246,28 @@ def responses_tools_to_chat_tools(value: Any) -> list[dict[str, Any]]:
         parameters = item.get("parameters")
         if isinstance(parameters, dict):
             function["parameters"] = parameters
+        strict = item.get("strict")
+        if isinstance(strict, bool):
+            function["strict"] = strict
         tools.append({"type": "function", "function": function})
     return tools
 
 
 def responses_tool_choice_to_chat_tool_choice(value: Any) -> Any:
-    if not isinstance(value, dict) or value.get("type") != "function":
+    if value is None or isinstance(value, str):
         return value
+    if not isinstance(value, dict) or value.get("type") != "function":
+        choice_type = value.get("type") if isinstance(value, Mapping) else type(value).__name__
+        raise UnsupportedProtocolTranslationError(
+            "unsupported_protocol_semantics",
+            f"Cannot translate Responses tool_choice type {choice_type!r} to Chat Completions.",
+        )
     name = value.get("name")
     if not isinstance(name, str) or not name:
-        return value
+        raise UnsupportedProtocolTranslationError(
+            "unsupported_protocol_semantics",
+            "Cannot translate a Responses function tool_choice without a non-empty name.",
+        )
     return {"type": "function", "function": {"name": name}}
 
 
@@ -174,6 +275,11 @@ def responses_request_to_chat_completion_body(body: bytes) -> bytes:
     payload = json.loads(body.decode("utf-8-sig"))
     if not isinstance(payload, dict):
         return body
+    if payload.get("reasoning") is not None:
+        raise UnsupportedProtocolTranslationError(
+            "unsupported_protocol_semantics",
+            "Cannot translate Responses reasoning controls to Chat Completions without a proven equivalent.",
+        )
 
     messages: list[dict[str, Any]] = []
     instructions = payload.get("instructions")
@@ -217,13 +323,44 @@ def chat_content_to_responses_content(value: Any) -> list[dict[str, Any]]:
     parts: list[dict[str, Any]] = []
     for fragment in value:
         if not isinstance(fragment, dict):
-            continue
+            raise UnsupportedProtocolTranslationError(
+                "unsupported_protocol_semantics",
+                "Cannot translate a non-object Chat Completions content part.",
+            )
         if fragment.get("type") == "text" and isinstance(fragment.get("text"), str):
+            _require_supported_fields(fragment, {"type", "text", "annotations"}, "Chat Completions text content part")
+            annotations = fragment.get("annotations")
+            if annotations not in (None, []):
+                raise UnsupportedProtocolTranslationError(
+                    "unsupported_protocol_semantics",
+                    "Cannot translate Chat Completions text annotations to Responses without losing them.",
+                )
             parts.append({"type": "input_text", "text": fragment["text"]})
         elif fragment.get("type") == "image_url" and isinstance(fragment.get("image_url"), dict):
+            _require_supported_fields(fragment, {"type", "image_url"}, "Chat Completions image content part")
+            _require_supported_fields(fragment["image_url"], {"url", "detail"}, "Chat Completions image URL")
             url = fragment["image_url"].get("url")
             if isinstance(url, str):
-                parts.append({"type": "input_image", "image_url": url})
+                part: dict[str, str] = {"type": "input_image", "image_url": url}
+                detail = fragment["image_url"].get("detail")
+                if isinstance(detail, str):
+                    part["detail"] = detail
+                elif detail is not None:
+                    raise UnsupportedProtocolTranslationError(
+                        "unsupported_protocol_semantics",
+                        "Cannot translate a non-string Chat Completions image detail value.",
+                    )
+                parts.append(part)
+                continue
+            raise UnsupportedProtocolTranslationError(
+                "unsupported_protocol_semantics",
+                "Cannot translate a Chat Completions image without a URL.",
+            )
+        else:
+            raise UnsupportedProtocolTranslationError(
+                "unsupported_protocol_semantics",
+                f"Cannot translate Chat Completions content part type {fragment.get('type')!r} to Responses.",
+            )
     return parts
 
 
@@ -239,7 +376,11 @@ def chat_messages_to_responses_input(
     input_items: list[dict[str, Any]] = []
     for message in messages:
         if not isinstance(message, dict):
-            continue
+            raise UnsupportedProtocolTranslationError(
+                "unsupported_protocol_semantics",
+                "Cannot translate a non-object Chat Completions message.",
+            )
+        _raise_for_unsupported_chat_message_semantics(message)
         role = message.get("role")
         if role == "system":
             content = message.get("content")
@@ -261,14 +402,34 @@ def chat_messages_to_responses_input(
                 )
             for tool_call in tool_calls:
                 if not isinstance(tool_call, dict):
-                    continue
+                    raise UnsupportedProtocolTranslationError(
+                        "unsupported_protocol_semantics",
+                        "Cannot translate a non-object assistant tool call.",
+                    )
+                tool_type = tool_call.get("type")
+                if tool_type not in (None, "function"):
+                    raise UnsupportedProtocolTranslationError(
+                        "unsupported_protocol_semantics",
+                        f"Cannot translate assistant tool type {tool_type!r} to Responses.",
+                    )
                 function = tool_call.get("function")
                 if not isinstance(function, dict):
-                    continue
+                    raise UnsupportedProtocolTranslationError(
+                        "unsupported_protocol_semantics",
+                        "Cannot translate an assistant tool call without a function payload.",
+                    )
                 name = function.get("name")
                 if not isinstance(name, str) or not name:
-                    continue
-                call_id = tool_call.get("id") or f"call_{uuid.uuid4().hex[:12]}"
+                    raise UnsupportedProtocolTranslationError(
+                        "unsupported_protocol_semantics",
+                        "Cannot translate an assistant tool call without a non-empty function name.",
+                    )
+                call_id = tool_call.get("id")
+                if not isinstance(call_id, str) or not call_id:
+                    raise UnsupportedProtocolTranslationError(
+                        "unpaired_tool_call",
+                        "Cannot translate an assistant tool call without a non-empty id.",
+                    )
                 arguments = function.get("arguments")
                 input_items.append(
                     {
@@ -280,7 +441,12 @@ def chat_messages_to_responses_input(
                 )
             continue
         if role == "tool":
-            call_id = message.get("tool_call_id") or f"call_{uuid.uuid4().hex[:12]}"
+            call_id = message.get("tool_call_id")
+            if not isinstance(call_id, str) or not call_id:
+                raise UnsupportedProtocolTranslationError(
+                    "unpaired_tool_call",
+                    "Cannot translate a tool result without a non-empty tool_call_id.",
+                )
             content = message.get("content")
             output = content if isinstance(content, str) else chat_content_text(content)
             input_items.append(
@@ -292,7 +458,12 @@ def chat_messages_to_responses_input(
             )
             continue
 
-        response_role = role if role in {"user", "assistant"} else "user"
+        if role not in {"user", "assistant"}:
+            raise UnsupportedProtocolTranslationError(
+                "unsupported_protocol_semantics",
+                f"Cannot translate Chat Completions message role {role!r} to Responses.",
+            )
+        response_role = role
         content_parts = chat_content_to_responses_content(message.get("content"))
         if not content_parts:
             content_parts = [{"type": "input_text", "text": ""}]
@@ -322,13 +493,23 @@ def chat_tools_to_responses_tools(value: Any) -> list[dict[str, Any]]:
     tools: list[dict[str, Any]] = []
     for item in value:
         if not isinstance(item, dict) or item.get("type") != "function":
-            continue
+            tool_type = item.get("type") if isinstance(item, Mapping) else type(item).__name__
+            raise UnsupportedProtocolTranslationError(
+                "unsupported_protocol_semantics",
+                f"Cannot translate Chat Completions tool type {tool_type!r} to Responses.",
+            )
         function = item.get("function")
         if not isinstance(function, dict):
-            continue
+            raise UnsupportedProtocolTranslationError(
+                "unsupported_protocol_semantics",
+                "Cannot translate a Chat Completions function tool without a function payload.",
+            )
         name = function.get("name")
         if not isinstance(name, str) or not name:
-            continue
+            raise UnsupportedProtocolTranslationError(
+                "unsupported_protocol_semantics",
+                "Cannot translate a Chat Completions function tool without a non-empty name.",
+            )
         tool: dict[str, Any] = {"type": "function", "name": name}
         description = function.get("description")
         if isinstance(description, str):
@@ -346,11 +527,21 @@ def chat_tools_to_responses_tools(value: Any) -> list[dict[str, Any]]:
 def chat_tool_choice_to_responses_tool_choice(value: Any) -> Any:
     if isinstance(value, str):
         return value
-    if isinstance(value, dict) and value.get("type") == "function":
-        function = value.get("function")
-        if isinstance(function, dict) and isinstance(function.get("name"), str):
-            return {"type": "function", "name": function["name"]}
-    return value
+    if value is None:
+        return value
+    if not isinstance(value, dict) or value.get("type") != "function":
+        choice_type = value.get("type") if isinstance(value, Mapping) else type(value).__name__
+        raise UnsupportedProtocolTranslationError(
+            "unsupported_protocol_semantics",
+            f"Cannot translate Chat Completions tool_choice type {choice_type!r} to Responses.",
+        )
+    function = value.get("function")
+    if not isinstance(function, dict) or not isinstance(function.get("name"), str) or not function["name"]:
+        raise UnsupportedProtocolTranslationError(
+            "unsupported_protocol_semantics",
+            "Cannot translate a Chat Completions function tool_choice without a non-empty name.",
+        )
+    return {"type": "function", "name": function["name"]}
 
 
 def chat_completions_request_to_responses_body(
@@ -361,6 +552,11 @@ def chat_completions_request_to_responses_body(
     payload = json.loads(body.decode("utf-8-sig"))
     if not isinstance(payload, dict):
         return body
+    if payload.get("reasoning") is not None or payload.get("reasoning_effort") is not None:
+        raise UnsupportedProtocolTranslationError(
+            "unsupported_protocol_semantics",
+            "Cannot translate Chat Completions reasoning controls to Responses without a proven equivalent.",
+        )
 
     instructions, input_items = chat_messages_to_responses_input(
         payload.get("messages"),
@@ -400,7 +596,15 @@ def _chat_completion_message_output(
     *,
     chat_content_text: ChatContentText,
 ) -> dict[str, Any] | None:
+    _raise_for_unsupported_chat_message_semantics(message)
     content = message.get("content")
+    if isinstance(content, list):
+        content_parts = chat_content_to_responses_content(content)
+        if any(part.get("type") != "input_text" for part in content_parts):
+            raise UnsupportedProtocolTranslationError(
+                "unsupported_protocol_semantics",
+                "Cannot translate non-text Chat Completions response content to Responses without losing it.",
+            )
     text = content if isinstance(content, str) else chat_content_text(content)
     if not text:
         return None
@@ -421,6 +625,11 @@ def _chat_completion_tool_outputs(
 ) -> list[dict[str, Any]]:
     tool_calls = message.get("tool_calls")
     if not isinstance(tool_calls, list):
+        if tool_calls is not None:
+            raise UnsupportedProtocolTranslationError(
+                "unsupported_protocol_semantics",
+                "Cannot translate a non-list Chat Completions tool_calls payload.",
+            )
         content = message.get("content")
         text = content if isinstance(content, str) else chat_content_text(content)
         return xmlish_tool_outputs(text) if text and xmlish_tool_outputs is not None else []
@@ -428,16 +637,34 @@ def _chat_completion_tool_outputs(
     output: list[dict[str, Any]] = []
     for tool_call in tool_calls:
         if not isinstance(tool_call, dict):
-            continue
+            raise UnsupportedProtocolTranslationError(
+                "unsupported_protocol_semantics",
+                "Cannot translate a non-object assistant tool call.",
+            )
+        tool_type = tool_call.get("type")
+        if tool_type not in (None, "function"):
+            raise UnsupportedProtocolTranslationError(
+                "unsupported_protocol_semantics",
+                f"Cannot translate assistant tool type {tool_type!r} to Responses.",
+            )
         function = tool_call.get("function")
         if not isinstance(function, dict):
-            continue
+            raise UnsupportedProtocolTranslationError(
+                "unsupported_protocol_semantics",
+                "Cannot translate an assistant tool call without a function payload.",
+            )
         name = function.get("name")
         if not isinstance(name, str) or not name:
-            continue
+            raise UnsupportedProtocolTranslationError(
+                "unsupported_protocol_semantics",
+                "Cannot translate an assistant tool call without a non-empty function name.",
+            )
         call_id = tool_call.get("id")
         if not isinstance(call_id, str) or not call_id:
-            call_id = f"call_{uuid.uuid4().hex[:12]}"
+            raise UnsupportedProtocolTranslationError(
+                "unpaired_tool_call",
+                "Cannot translate an assistant tool call without a non-empty id.",
+            )
         arguments = function.get("arguments")
         output.append(
             {
@@ -464,12 +691,38 @@ def chat_completion_to_response_body(
     if not isinstance(payload, dict):
         return body
 
+    upstream_error = payload.get("error")
+    if upstream_error is not None:
+        error = dict(upstream_error) if isinstance(upstream_error, Mapping) else {"message": str(upstream_error)}
+        error.setdefault("type", "upstream_error")
+        return json.dumps(
+            {
+                "id": payload.get("id") if isinstance(payload.get("id"), str) else f"resp_{uuid.uuid4().hex[:12]}",
+                "object": "response",
+                "status": "failed",
+                "model": payload.get("model"),
+                "output": [],
+                "error": error,
+            },
+            ensure_ascii=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+
     output: list[dict[str, Any]] = []
+    incomplete_details: dict[str, str] | None = None
     choices = payload.get("choices")
     if isinstance(choices, list):
         for index, choice in enumerate(choices):
             if not isinstance(choice, dict):
                 continue
+            finish_reason = choice.get("finish_reason")
+            if finish_reason == "length":
+                incomplete_details = {"reason": "max_output_tokens"}
+            elif finish_reason not in (None, "stop", "tool_calls"):
+                raise UnsupportedProtocolTranslationError(
+                    "unsupported_protocol_semantics",
+                    f"Cannot translate Chat Completions finish_reason {finish_reason!r} to Responses.",
+                )
             message = choice.get("message")
             if not isinstance(message, dict):
                 continue
@@ -478,7 +731,9 @@ def chat_completion_to_response_body(
                 chat_content_text=chat_content_text,
                 xmlish_tool_outputs=xmlish_tool_outputs,
             )
-            if tool_outputs:
+            if tool_outputs and not isinstance(message.get("tool_calls"), list):
+                # Gateway compatibility: XML-ish tool markup represents the
+                # tool call itself, not assistant text to relay separately.
                 output.extend(tool_outputs)
                 continue
             message_output = _chat_completion_message_output(
@@ -488,14 +743,17 @@ def chat_completion_to_response_body(
             )
             if message_output is not None:
                 output.append(message_output)
+            output.extend(tool_outputs)
 
     response_payload: dict[str, Any] = {
         "id": payload.get("id") if isinstance(payload.get("id"), str) else f"resp_{uuid.uuid4().hex[:12]}",
         "object": "response",
-        "status": "completed",
+        "status": "incomplete" if incomplete_details is not None else "completed",
         "model": payload.get("model"),
         "output": output,
     }
+    if incomplete_details is not None:
+        response_payload["incomplete_details"] = incomplete_details
     if "usage" in payload:
         response_payload["usage"] = payload["usage"]
 
@@ -545,7 +803,7 @@ def response_body_to_chat_completion_body(
         or isinstance(payload.get("detail"), str)
         or payload.get("status") in {"failed", "incomplete"}
     )
-    if has_error_signal and (not isinstance(output, list) or not output):
+    if has_error_signal:
         return error_body(payload)
 
     text_parts: list[str] = []
@@ -553,30 +811,61 @@ def response_body_to_chat_completion_body(
     if isinstance(output, list):
         for item in output:
             if not isinstance(item, dict):
-                continue
+                raise UnsupportedProtocolTranslationError(
+                    "unsupported_protocol_semantics",
+                    "Cannot translate a non-object Responses output item.",
+                )
             if item.get("type") == "message":
                 content = item.get("content")
+                role = item.get("role")
+                if role not in (None, "assistant"):
+                    raise UnsupportedProtocolTranslationError(
+                        "unsupported_protocol_semantics",
+                        f"Cannot translate Responses output message role {role!r} to Chat Completions.",
+                    )
                 if isinstance(content, list):
+                    responses_content_to_chat_content(content)
                     for part in content:
                         if isinstance(part, dict) and part.get("type") in ("output_text", "text"):
                             text = part.get("text")
                             if isinstance(text, str):
                                 text_parts.append(text)
+                elif isinstance(content, str):
+                    text_parts.append(content)
+                elif content is not None:
+                    raise UnsupportedProtocolTranslationError(
+                        "unsupported_protocol_semantics",
+                        "Cannot translate a non-text Responses output message content value.",
+                    )
             elif item.get("type") == "function_call":
-                call_id = item.get("call_id") or item.get("id") or f"call_{uuid.uuid4().hex[:12]}"
+                call_id = item.get("call_id")
+                if not isinstance(call_id, str) or not call_id:
+                    raise UnsupportedProtocolTranslationError(
+                        "unpaired_tool_call",
+                        "Cannot translate a function call without a non-empty call_id.",
+                    )
                 name = function_name_from_response_item(item)
                 arguments = item.get("arguments")
-                if isinstance(name, str) and name:
-                    tool_calls.append(
-                        {
-                            "id": call_id,
-                            "type": "function",
-                            "function": {
-                                "name": name,
-                                "arguments": arguments if isinstance(arguments, str) else "",
-                            },
-                        }
+                if not isinstance(name, str) or not name:
+                    raise UnsupportedProtocolTranslationError(
+                        "unsupported_protocol_semantics",
+                        "Cannot translate a function call without a non-empty name.",
                     )
+                tool_calls.append(
+                    {
+                        "id": call_id,
+                        "type": "function",
+                        "function": {
+                            "name": name,
+                            "arguments": arguments if isinstance(arguments, str) else "",
+                        },
+                    }
+                )
+            else:
+                raise UnsupportedProtocolTranslationError(
+                    "unsupported_protocol_semantics",
+                    f"Cannot translate Responses output item type {item.get('type')!r} to Chat Completions.",
+                )
 
     message: dict[str, Any] = {"role": "assistant", "content": "".join(text_parts) or None}
     if tool_calls:
@@ -645,16 +934,30 @@ def chat_completion_body_to_stream_chunks(body: bytes) -> list[dict[str, Any]]:
         if isinstance(tool_calls, list):
             for fallback_tool_index, tool_call in enumerate(tool_calls):
                 if not isinstance(tool_call, Mapping):
-                    continue
+                    raise UnsupportedProtocolTranslationError(
+                        "unsupported_protocol_semantics",
+                        "Cannot translate a non-object assistant tool call into Chat Completions chunks.",
+                    )
                 function = tool_call.get("function")
                 if not isinstance(function, Mapping):
-                    continue
+                    raise UnsupportedProtocolTranslationError(
+                        "unsupported_protocol_semantics",
+                        "Cannot translate an assistant tool call without a function payload into Chat Completions chunks.",
+                    )
                 name = function.get("name")
                 if not isinstance(name, str) or not name:
-                    continue
+                    raise UnsupportedProtocolTranslationError(
+                        "unsupported_protocol_semantics",
+                        "Cannot translate an assistant tool call without a non-empty function name into Chat Completions chunks.",
+                    )
                 tool_index = tool_call.get("index")
                 tool_index = tool_index if isinstance(tool_index, int) else fallback_tool_index
-                call_id = tool_call.get("id") if isinstance(tool_call.get("id"), str) else f"call_{uuid.uuid4().hex[:12]}"
+                call_id = tool_call.get("id")
+                if not isinstance(call_id, str) or not call_id:
+                    raise UnsupportedProtocolTranslationError(
+                        "unpaired_tool_call",
+                        "Cannot translate an assistant tool call without a non-empty id into Chat Completions chunks.",
+                    )
                 arguments = function.get("arguments") if isinstance(function.get("arguments"), str) else ""
                 chunks.append(
                     {
@@ -710,6 +1013,7 @@ def chat_stream_chunks_to_response_events(
     events: list[dict[str, Any]] = []
     text_parts: list[str] = []
     finished = False
+    incomplete_details: dict[str, str] | None = None
     response_id = f"resp_{uuid.uuid4().hex[:12]}"
     model: str | None = None
 
@@ -776,22 +1080,50 @@ def chat_stream_chunks_to_response_events(
         for choice in choices:
             if not isinstance(choice, dict):
                 continue
-            if choice.get("finish_reason") is not None:
+            finish_reason = choice.get("finish_reason")
+            if finish_reason is not None:
                 finished = True
+                if finish_reason == "length":
+                    incomplete_details = {"reason": "max_output_tokens"}
+                elif finish_reason not in {"stop", "tool_calls"}:
+                    raise UnsupportedProtocolTranslationError(
+                        "unsupported_protocol_semantics",
+                        f"Cannot translate Chat Completions finish_reason {finish_reason!r} to Responses stream events.",
+                    )
             delta = choice.get("delta")
             message = choice.get("message")
             source = delta if isinstance(delta, dict) else message if isinstance(message, dict) else None
             if not isinstance(source, dict):
                 continue
+            _raise_for_unsupported_chat_message_semantics(source)
             content = source.get("content")
             if isinstance(content, str) and content:
                 text_parts.append(content)
+            elif content is not None:
+                raise UnsupportedProtocolTranslationError(
+                    "unsupported_protocol_semantics",
+                    "Cannot translate non-text Chat Completions stream content to Responses without losing it.",
+                )
             tool_calls = source.get("tool_calls")
-            if not isinstance(tool_calls, list):
+            if tool_calls is None:
                 continue
+            if not isinstance(tool_calls, list):
+                raise UnsupportedProtocolTranslationError(
+                    "unsupported_protocol_semantics",
+                    "Cannot translate a non-list Chat Completions stream tool_calls payload.",
+                )
             for fallback_index, tool_call in enumerate(tool_calls):
                 if not isinstance(tool_call, dict):
-                    continue
+                    raise UnsupportedProtocolTranslationError(
+                        "unsupported_protocol_semantics",
+                        "Cannot translate a non-object assistant tool-call stream delta.",
+                    )
+                tool_type = tool_call.get("type")
+                if tool_type not in (None, "function"):
+                    raise UnsupportedProtocolTranslationError(
+                        "unsupported_protocol_semantics",
+                        f"Cannot translate assistant tool type {tool_type!r} to Responses stream events.",
+                    )
                 raw_index = tool_call.get("index", fallback_index)
                 index = raw_index if isinstance(raw_index, int) else fallback_index
                 state = state_for(index)
@@ -804,8 +1136,6 @@ def chat_stream_chunks_to_response_events(
                     name = function.get("name")
                     if isinstance(name, str) and name and not state["name"]:
                         state["name"] = normalize_function_name(name)
-                    if state["name"] and not state["call_id"]:
-                        state["call_id"] = f"call_{uuid.uuid4().hex[:12]}"
                     arguments = function.get("arguments")
                     if isinstance(arguments, str) and arguments:
                         state["arguments"].append(arguments)
@@ -830,9 +1160,17 @@ def chat_stream_chunks_to_response_events(
     text = "".join(text_parts)
     extracted_xmlish_tool_outputs = xmlish_tool_outputs(text) if text and xmlish_tool_outputs is not None else []
     for state in sorted(states.values(), key=lambda item: item["output_index"]):
+        if not state["call_id"]:
+            raise UnsupportedProtocolTranslationError(
+                "unpaired_tool_call",
+                "Cannot translate a terminal assistant tool call without a non-empty id.",
+            )
+        if not state["name"]:
+            raise UnsupportedProtocolTranslationError(
+                "unsupported_protocol_semantics",
+                "Cannot translate a terminal assistant tool call without a non-empty function name.",
+            )
         maybe_emit_added(state)
-        if not state["added"]:
-            continue
         arguments = "".join(state["arguments"])
         item = {
             "id": state["item_id"],
@@ -924,17 +1262,59 @@ def chat_stream_chunks_to_response_events(
     completed_response: dict[str, Any] = {
         "id": response_id,
         "object": "response",
-        "status": "completed",
+        "status": "incomplete" if incomplete_details is not None else "completed",
         "output": output,
     }
+    if incomplete_details is not None:
+        completed_response["incomplete_details"] = incomplete_details
     if model:
         completed_response["model"] = model
-    events.append({"type": "response.completed", "response": completed_response})
+    events.append(
+        {
+            "type": "response.incomplete" if incomplete_details is not None else "response.completed",
+            "response": completed_response,
+        }
+    )
     return events
 
 
 def responses_events_have_completed(events: list[Mapping[str, Any]]) -> bool:
     return any(isinstance(event, Mapping) and event.get("type") == "response.completed" for event in events)
+
+
+def _validated_responses_stream_output_item(
+    item: Any,
+    *,
+    function_name_from_response_item: FunctionNameFromResponseItem = _default_function_name_from_response_item,
+) -> tuple[str, str | None, str | None]:
+    if not isinstance(item, Mapping):
+        raise UnsupportedProtocolTranslationError(
+            "unsupported_protocol_semantics",
+            "Cannot translate a non-object Responses stream output item.",
+        )
+    item_type = item.get("type")
+    if item_type == "message":
+        if item.get("content") is not None:
+            responses_content_to_chat_content(item.get("content"))
+        return "message", None, None
+    if item_type != "function_call":
+        raise UnsupportedProtocolTranslationError(
+            "unsupported_protocol_semantics",
+            f"Cannot translate Responses stream output item type {item_type!r} to Chat Completions.",
+        )
+    call_id = item.get("call_id")
+    if not isinstance(call_id, str) or not call_id:
+        raise UnsupportedProtocolTranslationError(
+            "unpaired_tool_call",
+            "Cannot translate a function-call stream item without a non-empty call_id.",
+        )
+    name = function_name_from_response_item(item)
+    if not isinstance(name, str) or not name:
+        raise UnsupportedProtocolTranslationError(
+            "unsupported_protocol_semantics",
+            "Cannot translate a function-call stream item without a non-empty name.",
+        )
+    return "function_call", call_id, name
 
 
 def response_events_to_chat_stream_chunks(
@@ -968,6 +1348,11 @@ def response_events_to_chat_stream_chunks(
         if not isinstance(event, Mapping):
             continue
         event_type = event.get("type")
+        if event_type in {"response.failed", "response.incomplete", "error"}:
+            raise UnsupportedProtocolTranslationError(
+                "upstream_response_failed",
+                f"Cannot translate terminal Responses stream event {event_type!r} as a successful Chat Completions stream.",
+            )
         if event_type == "response.created":
             response_obj = event.get("response")
             if isinstance(response_obj, Mapping):
@@ -996,14 +1381,90 @@ def response_events_to_chat_stream_chunks(
                     }
                 )
             continue
+        if event_type in {"response.content_part.added", "response.content_part.done"}:
+            part = event.get("part")
+            if not isinstance(part, Mapping):
+                raise UnsupportedProtocolTranslationError(
+                    "unsupported_protocol_semantics",
+                    "Cannot translate a Responses stream content-part event without an object part.",
+                )
+            responses_content_to_chat_content([part])
+            continue
         if event_type == "response.output_item.added":
             item = event.get("item")
-            if isinstance(item, Mapping) and item.get("type") == "function_call":
-                item_id = item.get("id") or item.get("call_id") or ""
-                state = tool_state(str(item_id))
-                state["id"] = item.get("call_id") or state["id"]
-                state["name"] = function_name_from_response_item(item) or state["name"]
-                if state["id"] and state["name"] and not state["emitted_header"]:
+            if not isinstance(item, Mapping):
+                raise UnsupportedProtocolTranslationError(
+                    "unsupported_protocol_semantics",
+                    "Cannot translate a non-object Responses stream output item.",
+                )
+            if item.get("type") == "message":
+                if item.get("content") is not None:
+                    responses_content_to_chat_content(item.get("content"))
+                continue
+            if item.get("type") != "function_call":
+                raise UnsupportedProtocolTranslationError(
+                    "unsupported_protocol_semantics",
+                    f"Cannot translate Responses stream output item type {item.get('type')!r} to Chat Completions.",
+                )
+            item_id = item.get("id") or item.get("call_id") or ""
+            state = tool_state(str(item_id))
+            call_id = item.get("call_id")
+            if not isinstance(call_id, str) or not call_id:
+                raise UnsupportedProtocolTranslationError(
+                    "unpaired_tool_call",
+                    "Cannot translate a function-call stream item without a non-empty call_id.",
+                )
+            name = function_name_from_response_item(item)
+            if not isinstance(name, str) or not name:
+                raise UnsupportedProtocolTranslationError(
+                    "unsupported_protocol_semantics",
+                    "Cannot translate a function-call stream item without a non-empty name.",
+                )
+            state["id"] = call_id
+            state["name"] = name
+            if state["id"] and state["name"] and not state["emitted_header"]:
+                chunks.append(
+                    {
+                        "id": response_id or f"chatcmpl_{uuid.uuid4().hex[:12]}",
+                        "object": "chat.completion.chunk",
+                        "created": int(time.time()),
+                        "model": model,
+                        "choices": [
+                            {
+                                "index": 0,
+                                "delta": {
+                                    "tool_calls": [
+                                        {
+                                            "index": state["index"],
+                                            "id": state["id"],
+                                            "type": "function",
+                                            "function": {"name": state["name"], "arguments": ""},
+                                        }
+                                    ]
+                                },
+                                "finish_reason": None,
+                            }
+                        ],
+                    }
+                )
+                state["emitted_header"] = True
+            continue
+        if event_type == "response.function_call_arguments.delta":
+            item_id = event.get("item_id") or ""
+            state = tool_state(str(item_id))
+            delta_args = event.get("delta")
+            if isinstance(delta_args, str) and delta_args:
+                if not state["emitted_header"]:
+                    if not state["id"]:
+                        raise UnsupportedProtocolTranslationError(
+                            "unpaired_tool_call",
+                            "Cannot translate function-call arguments without a paired non-empty call_id.",
+                        )
+                    if not state["name"]:
+                        raise UnsupportedProtocolTranslationError(
+                            "unsupported_protocol_semantics",
+                            "Cannot translate function-call arguments without a paired function name.",
+                        )
                     chunks.append(
                         {
                             "id": response_id or f"chatcmpl_{uuid.uuid4().hex[:12]}",
@@ -1018,38 +1479,6 @@ def response_events_to_chat_stream_chunks(
                                             {
                                                 "index": state["index"],
                                                 "id": state["id"],
-                                                "type": "function",
-                                                "function": {"name": state["name"], "arguments": ""},
-                                            }
-                                        ]
-                                    },
-                                    "finish_reason": None,
-                                }
-                            ],
-                        }
-                    )
-                    state["emitted_header"] = True
-            continue
-        if event_type == "response.function_call_arguments.delta":
-            item_id = event.get("item_id") or ""
-            state = tool_state(str(item_id))
-            delta_args = event.get("delta")
-            if isinstance(delta_args, str) and delta_args:
-                if not state["emitted_header"]:
-                    chunks.append(
-                        {
-                            "id": response_id or f"chatcmpl_{uuid.uuid4().hex[:12]}",
-                            "object": "chat.completion.chunk",
-                            "created": int(time.time()),
-                            "model": model,
-                            "choices": [
-                                {
-                                    "index": 0,
-                                    "delta": {
-                                        "tool_calls": [
-                                            {
-                                                "index": state["index"],
-                                                "id": state["id"] or f"call_{uuid.uuid4().hex[:12]}",
                                                 "type": "function",
                                                 "function": {"name": state["name"], "arguments": delta_args},
                                             }
@@ -1085,11 +1514,39 @@ def response_events_to_chat_stream_chunks(
                         }
                     )
             continue
+        if event_type == "response.output_item.done":
+            item = event.get("item")
+            item_type, call_id, _ = _validated_responses_stream_output_item(
+                item,
+                function_name_from_response_item=function_name_from_response_item,
+            )
+            if item_type == "function_call":
+                item_id = str(item.get("id") or call_id or "")
+                state = tool_states.get(item_id)
+                if state is None or not state["emitted_header"]:
+                    raise UnsupportedProtocolTranslationError(
+                        "unpaired_tool_call",
+                        "Cannot translate a completed function call that was never paired with a stream item.",
+                    )
+            continue
         if event_type == "response.completed":
             response_obj = event.get("response")
             if isinstance(response_obj, Mapping):
                 output = response_obj.get("output")
                 if isinstance(output, list):
+                    for item in output:
+                        item_type, call_id, _ = _validated_responses_stream_output_item(
+                            item,
+                            function_name_from_response_item=function_name_from_response_item,
+                        )
+                        if item_type == "function_call":
+                            item_id = str(item.get("id") or call_id or "")
+                            state = tool_states.get(item_id)
+                            if state is None or not state["emitted_header"]:
+                                raise UnsupportedProtocolTranslationError(
+                                    "unpaired_tool_call",
+                                    "Cannot translate a completed function call that was never paired with a stream item.",
+                                )
                     finish_reason = "tool_calls" if any(
                         isinstance(item, Mapping) and item.get("type") == "function_call"
                         for item in output
@@ -1143,6 +1600,11 @@ class ResponsesToChatStreamConverter:
 
     def chunks_for_event(self, event: Mapping[str, Any]) -> list[dict[str, Any]]:
         event_type = event.get("type")
+        if event_type in {"response.failed", "response.incomplete", "error"}:
+            raise UnsupportedProtocolTranslationError(
+                "upstream_response_failed",
+                f"Cannot translate terminal Responses stream event {event_type!r} as a successful Chat Completions stream.",
+            )
         if event_type == "response.created":
             response_obj = event.get("response")
             if isinstance(response_obj, Mapping):
@@ -1152,14 +1614,47 @@ class ResponsesToChatStreamConverter:
         if event_type == "response.output_text.delta":
             delta_text = event.get("delta")
             return [self._chunk({"content": delta_text})] if isinstance(delta_text, str) and delta_text else []
+        if event_type in {"response.content_part.added", "response.content_part.done"}:
+            part = event.get("part")
+            if not isinstance(part, Mapping):
+                raise UnsupportedProtocolTranslationError(
+                    "unsupported_protocol_semantics",
+                    "Cannot translate a Responses stream content-part event without an object part.",
+                )
+            responses_content_to_chat_content([part])
+            return []
         if event_type == "response.output_item.added":
             item = event.get("item")
-            if not (isinstance(item, Mapping) and item.get("type") == "function_call"):
+            if not isinstance(item, Mapping):
+                raise UnsupportedProtocolTranslationError(
+                    "unsupported_protocol_semantics",
+                    "Cannot translate a non-object Responses stream output item.",
+                )
+            if item.get("type") == "message":
+                if item.get("content") is not None:
+                    responses_content_to_chat_content(item.get("content"))
                 return []
+            if item.get("type") != "function_call":
+                raise UnsupportedProtocolTranslationError(
+                    "unsupported_protocol_semantics",
+                    f"Cannot translate Responses stream output item type {item.get('type')!r} to Chat Completions.",
+                )
             item_id = item.get("id") or item.get("call_id") or ""
             state = self._tool_state(str(item_id))
-            state["id"] = item.get("call_id") or state["id"]
-            state["name"] = item.get("name") or state["name"]
+            call_id = item.get("call_id")
+            if not isinstance(call_id, str) or not call_id:
+                raise UnsupportedProtocolTranslationError(
+                    "unpaired_tool_call",
+                    "Cannot translate a function-call stream item without a non-empty call_id.",
+                )
+            name = item.get("name")
+            if not isinstance(name, str) or not name:
+                raise UnsupportedProtocolTranslationError(
+                    "unsupported_protocol_semantics",
+                    "Cannot translate a function-call stream item without a non-empty name.",
+                )
+            state["id"] = call_id
+            state["name"] = name
             if not (state["id"] and state["name"] and not state["emitted_header"]):
                 return []
             state["emitted_header"] = True
@@ -1184,15 +1679,24 @@ class ResponsesToChatStreamConverter:
             if not (isinstance(delta_args, str) and delta_args):
                 return []
             if not state["emitted_header"]:
+                if not state["id"]:
+                    raise UnsupportedProtocolTranslationError(
+                        "unpaired_tool_call",
+                        "Cannot translate function-call arguments without a paired non-empty call_id.",
+                    )
+                if not state["name"]:
+                    raise UnsupportedProtocolTranslationError(
+                        "unsupported_protocol_semantics",
+                        "Cannot translate function-call arguments without a paired function name.",
+                    )
                 state["emitted_header"] = True
-                call_id = state["id"] or f"call_{uuid.uuid4().hex[:12]}"
                 return [
                     self._chunk(
                         {
                             "tool_calls": [
-                                {
-                                    "index": state["index"],
-                                    "id": call_id,
+                                    {
+                                        "index": state["index"],
+                                        "id": state["id"],
                                     "type": "function",
                                     "function": {"name": state["name"], "arguments": delta_args},
                                 }
@@ -1212,17 +1716,37 @@ class ResponsesToChatStreamConverter:
                     }
                 )
             ]
+        if event_type == "response.output_item.done":
+            item = event.get("item")
+            item_type, call_id, _ = _validated_responses_stream_output_item(item)
+            if item_type == "function_call":
+                item_id = str(item.get("id") or call_id or "")
+                state = self.tool_states.get(item_id)
+                if state is None or not state["emitted_header"]:
+                    raise UnsupportedProtocolTranslationError(
+                        "unpaired_tool_call",
+                        "Cannot translate a completed function call that was never paired with a stream item.",
+                    )
+            return []
         if event_type == "response.completed":
             self.completed = True
             finish_reason = "stop"
             response_obj = event.get("response")
             if isinstance(response_obj, Mapping):
                 output = response_obj.get("output")
-                if isinstance(output, list) and any(
-                    isinstance(item, Mapping) and item.get("type") == "function_call"
-                    for item in output
-                ):
-                    finish_reason = "tool_calls"
+                if isinstance(output, list):
+                    for item in output:
+                        item_type, call_id, _ = _validated_responses_stream_output_item(item)
+                        if item_type == "function_call":
+                            item_id = str(item.get("id") or call_id or "")
+                            state = self.tool_states.get(item_id)
+                            if state is None or not state["emitted_header"]:
+                                raise UnsupportedProtocolTranslationError(
+                                    "unpaired_tool_call",
+                                    "Cannot translate a completed function call that was never paired with a stream item.",
+                                )
+                    if any(isinstance(item, Mapping) and item.get("type") == "function_call" for item in output):
+                        finish_reason = "tool_calls"
             return [self._chunk({}, finish_reason=finish_reason)]
         return []
 
@@ -1329,15 +1853,25 @@ class ChatToResponsesStreamConverter:
         state["added"] = True
         return events
 
-    def _complete_events(self) -> list[dict[str, Any]]:
+    def _complete_events(self, *, incomplete: bool = False) -> list[dict[str, Any]]:
         if self.completed:
             return []
         self.completed = True
         events = self._created_events()
         output_by_index: dict[int, dict[str, Any]] = {}
         for state in sorted(self.tool_states.values(), key=lambda item: item["output_index"]):
+            if not state["call_id"]:
+                raise UnsupportedProtocolTranslationError(
+                    "unpaired_tool_call",
+                    "Cannot translate a terminal assistant tool call without a non-empty id.",
+                )
+            if not state["name"]:
+                raise UnsupportedProtocolTranslationError(
+                    "unsupported_protocol_semantics",
+                    "Cannot translate a terminal assistant tool call without a non-empty function name.",
+                )
             events.extend(self._tool_added_events(state))
-            if not state["added"] or state["done"]:
+            if state["done"]:
                 continue
             arguments = "".join(state["arguments"])
             item = {
@@ -1385,18 +1919,16 @@ class ChatToResponsesStreamConverter:
             )
             output_by_index[output_index] = item
         output = [item for _, item in sorted(output_by_index.items(), key=lambda pair: pair[0])]
-        events.append(
-            {
-                "type": "response.completed",
-                "response": {
-                    "id": self.response_id,
-                    "object": "response",
-                    "status": "completed",
-                    "model": self.model,
-                    "output": output,
-                },
-            }
-        )
+        response = {
+            "id": self.response_id,
+            "object": "response",
+            "status": "incomplete" if incomplete else "completed",
+            "model": self.model,
+            "output": output,
+        }
+        if incomplete:
+            response["incomplete_details"] = {"reason": "max_output_tokens"}
+        events.append({"type": "response.incomplete" if incomplete else "response.completed", "response": response})
         return events
 
     def events_for_done(self) -> list[dict[str, Any]]:
@@ -1414,6 +1946,7 @@ class ChatToResponsesStreamConverter:
                 continue
             delta = choice.get("delta")
             if isinstance(delta, Mapping):
+                _raise_for_unsupported_chat_message_semantics(delta)
                 content = delta.get("content")
                 if isinstance(content, str) and content:
                     self.text_parts.append(content)
@@ -1427,11 +1960,30 @@ class ChatToResponsesStreamConverter:
                             "delta": content,
                         }
                     )
+                elif content is not None:
+                    raise UnsupportedProtocolTranslationError(
+                        "unsupported_protocol_semantics",
+                        "Cannot translate non-text Chat Completions stream content to Responses without losing it.",
+                    )
                 tool_calls = delta.get("tool_calls")
-                if isinstance(tool_calls, list):
+                if tool_calls is not None:
+                    if not isinstance(tool_calls, list):
+                        raise UnsupportedProtocolTranslationError(
+                            "unsupported_protocol_semantics",
+                            "Cannot translate a non-list Chat Completions stream tool_calls payload.",
+                        )
                     for fallback_index, tool_call in enumerate(tool_calls):
                         if not isinstance(tool_call, Mapping):
-                            continue
+                            raise UnsupportedProtocolTranslationError(
+                                "unsupported_protocol_semantics",
+                                "Cannot translate a non-object assistant tool-call stream delta.",
+                            )
+                        tool_type = tool_call.get("type")
+                        if tool_type not in (None, "function"):
+                            raise UnsupportedProtocolTranslationError(
+                                "unsupported_protocol_semantics",
+                                f"Cannot translate assistant tool type {tool_type!r} to Responses stream events.",
+                            )
                         raw_index = tool_call.get("index", fallback_index)
                         index = raw_index if isinstance(raw_index, int) else fallback_index
                         state = self._tool_state(index)
@@ -1458,7 +2010,15 @@ class ChatToResponsesStreamConverter:
                                     "delta": argument_delta,
                                 }
                             )
-            if choice.get("finish_reason") is not None:
+            finish_reason = choice.get("finish_reason")
+            if finish_reason == "length":
+                events.extend(self._complete_events(incomplete=True))
+            elif finish_reason is not None:
+                if finish_reason not in {"stop", "tool_calls"}:
+                    raise UnsupportedProtocolTranslationError(
+                        "unsupported_protocol_semantics",
+                        f"Cannot translate Chat Completions finish_reason {finish_reason!r} to Responses stream events.",
+                    )
                 events.extend(self._complete_events())
         return events
 
@@ -1674,6 +2234,7 @@ __all__ = [
     for entrypoint in (
         ChatToResponsesStreamConverter,
         ResponsesToChatStreamConverter,
+        UnsupportedProtocolTranslationError,
         UpstreamStreamIncompleteError,
         chat_completion_body_to_stream_chunks,
         chat_completion_error_body,

--- a/tests/test_chat_completions_gateway.py
+++ b/tests/test_chat_completions_gateway.py
@@ -642,7 +642,15 @@ class ResponseEventsToChatStreamTests(unittest.TestCase):
                 "response": {
                     "id": "resp_2",
                     "model": "gpt-5.5",
-                    "output": [{"type": "function_call", "id": "fc_call_1", "call_id": "call_1", "name": "get_weather", "arguments": '{}'}],
+                    "output": [
+                        {
+                            "type": "function_call",
+                            "id": "fc_call_1",
+                            "call_id": "call_1",
+                            "name": "get_weather",
+                            "arguments": '{"city":"NYC"}',
+                        }
+                    ],
                 },
             },
         ]
@@ -3605,6 +3613,32 @@ class ChatCompletionsEndpointTests(unittest.TestCase):
         self.assertIn(b'"error":"OSError"', written)
         self.assertIn(b'"codexhub_error"', written)
         self.assertIn(b'"code":"upstream.transport"', written)
+
+    def test_post_responses_streaming_preserves_buffered_incomplete_terminal(self):
+        body = json.dumps({
+            "model": "gpt-5.5",
+            "input": "Hello",
+            "stream": True,
+        }).encode("utf-8")
+        handler = self._make_handler(body, path="/v1/responses")
+        upstream_body = json.dumps(
+            {
+                "id": "resp_incomplete",
+                "object": "response",
+                "status": "incomplete",
+                "model": "gpt-5.5",
+                "output": [],
+                "incomplete_details": {"reason": "max_output_tokens"},
+            }
+        ).encode("utf-8")
+
+        with patch("codex_proxy._official_urlopen", return_value=_FakeJsonResponse(upstream_body)):
+            CodexProxyHandler.do_POST(handler)
+
+        written = b"".join(handler.wfile.writes)
+        self.assertIn(b"event: response.incomplete", written)
+        self.assertIn(b'"status":"incomplete"', written)
+        self.assertNotIn(b"event: response.completed", written)
 
     def test_auto_upstream_format_uses_responses_when_responses_succeeds(self):
         policy = codex_proxy.load_policy(codex_proxy.POLICY_PATH)

--- a/tests/test_chat_completions_gateway.py
+++ b/tests/test_chat_completions_gateway.py
@@ -492,13 +492,12 @@ class ChatToolChoiceTests(unittest.TestCase):
 
 
 class ChatToolsToResponsesTests(unittest.TestCase):
-    def test_filters_non_function_tools(self):
-        result = _chat_tools_to_responses_tools([
-            {"type": "function", "function": {"name": "foo"}},
-            {"type": "other"},
-        ])
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0]["name"], "foo")
+    def test_rejects_non_function_tools_that_cannot_cross_the_protocol_seam(self):
+        with self.assertRaises(ValueError):
+            _chat_tools_to_responses_tools([
+                {"type": "function", "function": {"name": "foo"}},
+                {"type": "other"},
+            ])
 
 
 class ResponseBodyToChatTests(unittest.TestCase):
@@ -924,6 +923,28 @@ class ChatCompletionsEndpointTests(unittest.TestCase):
         self.assertEqual(result["choices"][0]["message"]["content"], "Hi there!")
         self.assertEqual(result["choices"][0]["finish_reason"], "stop")
         self.assertEqual(handler._fake.status, 200)
+
+    def test_post_chat_completions_rejects_unsupported_upstream_response_semantics(self):
+        body = json.dumps({
+            "model": "gpt-5.5",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "stream": False,
+        }).encode("utf-8")
+        handler = self._make_handler(body)
+        upstream_body = json.dumps({
+            "id": "resp_reasoning",
+            "object": "response",
+            "status": "completed",
+            "model": "gpt-5.5",
+            "output": [{"type": "reasoning", "summary": [{"type": "summary_text", "text": "private"}]}],
+        }).encode("utf-8")
+
+        with patch("codex_proxy._official_urlopen", return_value=_FakeJsonResponse(upstream_body)):
+            CodexProxyHandler.do_POST(handler)
+
+        result = json.loads(b"".join(handler.wfile.writes))
+        self.assertEqual(handler._fake.status, 502)
+        self.assertEqual(result["error"]["type"], "unsupported_protocol_semantics")
 
     def test_post_chat_completions_events_use_proxy_request_kind(self):
         body = json.dumps({

--- a/tests/test_protocol_translation.py
+++ b/tests/test_protocol_translation.py
@@ -160,6 +160,100 @@ class ProtocolTranslationTests(unittest.TestCase):
 
             self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
 
+    def test_unmapped_request_message_and_tool_fields_fail_closed(self):
+        responses_payload = {
+            "model": "example-model",
+            "input": [{"type": "message", "role": "user", "content": "Hello"}],
+            "future_semantic_field": {"must": "not disappear"},
+        }
+        chat_payload = {
+            "model": "example-model",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "future_semantic_field": {"must": "not disappear"},
+        }
+        for convert, payload in (
+            (protocol_translation.responses_request_to_chat_completion_body, responses_payload),
+            (protocol_translation.chat_completions_request_to_responses_body, chat_payload),
+        ):
+            with self.subTest(convert=convert.__name__), self.assertRaises(
+                protocol_translation.UnsupportedProtocolTranslationError
+            ) as raised:
+                convert(json.dumps(payload).encode("utf-8"))
+
+            self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
+
+        lossy_chat_messages = (
+            {"role": "system", "content": [{"type": "file", "file_id": "file_123"}]},
+            {"role": "tool", "tool_call_id": "call_123", "content": [{"type": "file", "file_id": "file_123"}]},
+            {"role": "user", "name": "unmapped-name", "content": "Hello"},
+            {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "Call it", "annotations": [{"type": "url_citation"}]}],
+                "tool_calls": [
+                    {"id": "call_123", "type": "function", "function": {"name": "lookup", "arguments": "{}"}}
+                ],
+            },
+        )
+        for message in lossy_chat_messages:
+            with self.subTest(message=message), self.assertRaises(
+                protocol_translation.UnsupportedProtocolTranslationError
+            ) as raised:
+                protocol_translation.chat_completions_request_to_responses_body(
+                    json.dumps({"model": "example-model", "messages": [message]}).encode("utf-8")
+                )
+
+            self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
+
+    def test_non_reversible_chat_choice_semantics_fail_closed(self):
+        with self.assertRaises(protocol_translation.UnsupportedProtocolTranslationError) as raised:
+            protocol_translation.chat_completions_request_to_responses_body(
+                json.dumps(
+                    {"model": "example-model", "messages": [{"role": "user", "content": "Hello"}], "n": 2}
+                ).encode("utf-8")
+            )
+        self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
+
+        body = json.dumps(
+            {
+                "id": "chatcmpl_choices",
+                "model": "example-model",
+                "choices": [
+                    {"index": 0, "message": {"role": "assistant", "content": "A"}, "finish_reason": "stop"},
+                    {"index": 1, "message": {"role": "assistant", "content": "B"}, "finish_reason": "stop"},
+                ],
+            }
+        ).encode("utf-8")
+        with self.assertRaises(protocol_translation.UnsupportedProtocolTranslationError) as raised:
+            protocol_translation.chat_completion_to_response_body(body)
+        self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
+
+    def test_chat_completion_chunking_rejects_lossy_message_semantics(self):
+        for message in (
+            {"role": "assistant", "content": None, "refusal": "I cannot help with that."},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {"id": "call_123", "type": "custom", "function": {"name": "apply_patch", "arguments": "{}"}}
+                ],
+            },
+            {"role": "assistant", "content": "Hello", "future_semantic_field": {"id": "future"}},
+        ):
+            with self.subTest(message=message), self.assertRaises(
+                protocol_translation.UnsupportedProtocolTranslationError
+            ) as raised:
+                protocol_translation.chat_completion_body_to_stream_chunks(
+                    json.dumps(
+                        {
+                            "id": "chatcmpl_123",
+                            "model": "example-model",
+                            "choices": [{"index": 0, "message": message, "finish_reason": "stop"}],
+                        }
+                    ).encode("utf-8")
+                )
+
+            self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
+
     def test_responses_semantic_items_without_chat_equivalents_fail_closed(self):
         payloads = {
             "reasoning": {

--- a/tests/test_protocol_translation.py
+++ b/tests/test_protocol_translation.py
@@ -5,6 +5,269 @@ import protocol_translation
 
 
 class ProtocolTranslationTests(unittest.TestCase):
+    def test_chat_history_with_missing_tool_ids_fails_closed(self):
+        for message in (
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{"type": "function", "function": {"name": "get_weather", "arguments": "{}"}}],
+            },
+            {"role": "tool", "content": "Sunny"},
+        ):
+            with self.subTest(message=message), self.assertRaises(
+                protocol_translation.UnsupportedProtocolTranslationError
+            ) as raised:
+                protocol_translation.chat_completions_request_to_responses_body(
+                    json.dumps({"model": "example-model", "messages": [message]}).encode("utf-8")
+                )
+
+            self.assertEqual(raised.exception.code, "unpaired_tool_call")
+
+    def test_responses_history_with_missing_tool_ids_fails_closed(self):
+        for item in (
+            {"type": "function_call", "name": "get_weather", "arguments": "{}"},
+            {"type": "function_call_output", "output": "Sunny"},
+        ):
+            with self.subTest(item=item), self.assertRaises(
+                protocol_translation.UnsupportedProtocolTranslationError
+            ) as raised:
+                protocol_translation.responses_request_to_chat_completion_body(
+                    json.dumps({"model": "example-model", "input": [item]}).encode("utf-8")
+                )
+
+            self.assertEqual(raised.exception.code, "unpaired_tool_call")
+
+    def test_response_bodies_with_missing_tool_ids_fail_closed(self):
+        responses_body = json.dumps(
+            {
+                "id": "resp_123",
+                "model": "example-model",
+                "output": [{"type": "function_call", "name": "get_weather", "arguments": "{}"}],
+            }
+        ).encode("utf-8")
+        chat_body = json.dumps(
+            {
+                "id": "chatcmpl_123",
+                "model": "example-model",
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": None,
+                            "tool_calls": [
+                                {"type": "function", "function": {"name": "get_weather", "arguments": "{}"}}
+                            ],
+                        }
+                    }
+                ],
+            }
+        ).encode("utf-8")
+
+        for convert, body in (
+            (protocol_translation.response_body_to_chat_completion_body, responses_body),
+            (protocol_translation.chat_completion_to_response_body, chat_body),
+        ):
+            with self.subTest(convert=convert.__name__), self.assertRaises(
+                protocol_translation.UnsupportedProtocolTranslationError
+            ) as raised:
+                convert(body)
+
+            self.assertEqual(raised.exception.code, "unpaired_tool_call")
+
+    def test_chat_completion_chunking_with_missing_tool_id_fails_closed(self):
+        body = json.dumps(
+            {
+                "id": "chatcmpl_123",
+                "model": "example-model",
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": None,
+                            "tool_calls": [
+                                {"type": "function", "function": {"name": "get_weather", "arguments": "{}"}}
+                            ],
+                        },
+                        "finish_reason": "tool_calls",
+                    }
+                ],
+            }
+        ).encode("utf-8")
+
+        with self.assertRaises(protocol_translation.UnsupportedProtocolTranslationError) as raised:
+            protocol_translation.chat_completion_body_to_stream_chunks(body)
+
+        self.assertEqual(raised.exception.code, "unpaired_tool_call")
+
+    def test_responses_content_with_annotations_fails_closed(self):
+        body = json.dumps(
+            {
+                "model": "example-model",
+                "input": [
+                    {
+                        "type": "message",
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "input_text",
+                                "text": "See the citation.",
+                                "annotations": [{"type": "url_citation", "url": "https://example.test"}],
+                            }
+                        ],
+                    }
+                ],
+            }
+        ).encode("utf-8")
+
+        with self.assertRaises(protocol_translation.UnsupportedProtocolTranslationError) as raised:
+            protocol_translation.responses_request_to_chat_completion_body(body)
+
+        self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
+
+    def test_unknown_content_fields_fail_closed_in_both_request_directions(self):
+        responses_body = json.dumps(
+            {
+                "model": "example-model",
+                "input": [
+                    {
+                        "type": "message",
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": "Hello", "future_metadata": {"id": "future"}}],
+                    }
+                ],
+            }
+        ).encode("utf-8")
+        chat_body = json.dumps(
+            {
+                "model": "example-model",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [{"type": "text", "text": "Hello", "future_metadata": {"id": "future"}}],
+                    }
+                ],
+            }
+        ).encode("utf-8")
+
+        for convert, body in (
+            (protocol_translation.responses_request_to_chat_completion_body, responses_body),
+            (protocol_translation.chat_completions_request_to_responses_body, chat_body),
+        ):
+            with self.subTest(convert=convert.__name__), self.assertRaises(
+                protocol_translation.UnsupportedProtocolTranslationError
+            ) as raised:
+                convert(body)
+
+            self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
+
+    def test_responses_semantic_items_without_chat_equivalents_fail_closed(self):
+        payloads = {
+            "reasoning": {
+                "input": [{"type": "reasoning", "summary": [{"type": "summary_text", "text": "private"}]}]
+            },
+            "refusal": {
+                "input": [
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [{"type": "refusal", "refusal": "I cannot help with that."}],
+                    }
+                ]
+            },
+            "search": {"input": [{"type": "web_search_call", "status": "completed", "action": {"query": "Codex"}}]},
+            "custom_tool": {
+                "input": [
+                    {"type": "custom_tool_call", "call_id": "call_patch", "name": "apply_patch", "input": "*** Begin Patch"}
+                ]
+            },
+            "file": {
+                "input": [
+                    {
+                        "type": "message",
+                        "role": "user",
+                        "content": [{"type": "input_file", "file_id": "file_123"}],
+                    }
+                ]
+            },
+            "audio": {
+                "input": [
+                    {
+                        "type": "message",
+                        "role": "user",
+                        "content": [{"type": "input_audio", "input_audio": {"data": "abc", "format": "wav"}}],
+                    }
+                ]
+            },
+            "unknown": {"input": [{"type": "future_semantic_item", "value": "must not disappear"}]},
+        }
+
+        for semantic, payload in payloads.items():
+            with self.subTest(semantic=semantic), self.assertRaises(
+                protocol_translation.UnsupportedProtocolTranslationError
+            ) as raised:
+                protocol_translation.responses_request_to_chat_completion_body(
+                    json.dumps({"model": "example-model", **payload}).encode("utf-8")
+                )
+
+            self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
+
+    def test_chat_semantic_fields_without_responses_equivalents_fail_closed(self):
+        payloads = {
+            "reasoning": {
+                "reasoning_effort": "high",
+                "messages": [{"role": "user", "content": "Hello"}],
+            },
+            "refusal": {
+                "messages": [{"role": "assistant", "content": None, "refusal": "I cannot help with that."}],
+            },
+            "search": {
+                "messages": [{"role": "user", "content": "Search the web."}],
+                "tools": [{"type": "web_search"}],
+            },
+            "custom_tool": {
+                "messages": [{"role": "user", "content": "Apply a patch."}],
+                "tools": [{"type": "custom", "name": "apply_patch"}],
+            },
+            "file": {
+                "messages": [{"role": "user", "content": [{"type": "file", "file_id": "file_123"}]}],
+            },
+            "audio": {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [{"type": "input_audio", "input_audio": {"data": "abc", "format": "wav"}}],
+                    }
+                ],
+            },
+            "annotations": {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": "See this.",
+                                "annotations": [{"type": "url_citation", "url": "https://example.test"}],
+                            }
+                        ],
+                    }
+                ],
+            },
+            "unknown": {
+                "messages": [{"role": "user", "content": [{"type": "future_content", "value": "must not disappear"}]}],
+            },
+        }
+
+        for semantic, payload in payloads.items():
+            with self.subTest(semantic=semantic), self.assertRaises(
+                protocol_translation.UnsupportedProtocolTranslationError
+            ) as raised:
+                protocol_translation.chat_completions_request_to_responses_body(
+                    json.dumps({"model": "example-model", **payload}).encode("utf-8")
+                )
+
+            self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
+
     def test_chat_request_translates_to_responses(self):
         body = json.dumps(
             {
@@ -34,6 +297,113 @@ class ProtocolTranslationTests(unittest.TestCase):
         self.assertEqual(translated["tools"][0]["name"], "get_weather")
         self.assertEqual(translated["tool_choice"], {"type": "function", "name": "get_weather"})
 
+    def test_function_tool_strictness_is_preserved_between_request_formats(self):
+        responses_body = json.dumps(
+            {
+                "model": "example-model",
+                "input": "Hello",
+                "tools": [
+                    {
+                        "type": "function",
+                        "name": "get_weather",
+                        "parameters": {"type": "object", "properties": {}},
+                        "strict": True,
+                    }
+                ],
+            }
+        ).encode("utf-8")
+
+        chat_payload = json.loads(protocol_translation.responses_request_to_chat_completion_body(responses_body))
+        self.assertTrue(chat_payload["tools"][0]["function"]["strict"])
+
+        round_tripped = json.loads(
+            protocol_translation.chat_completions_request_to_responses_body(json.dumps(chat_payload).encode("utf-8"))
+        )
+        self.assertTrue(round_tripped["tools"][0]["strict"])
+
+    def test_url_image_detail_round_trips_between_request_formats(self):
+        responses_body = json.dumps(
+            {
+                "model": "example-model",
+                "input": [
+                    {
+                        "type": "message",
+                        "role": "user",
+                        "content": [
+                            {"type": "input_text", "text": "Describe this image."},
+                            {"type": "input_image", "image_url": "https://example.test/image.png", "detail": "high"},
+                        ],
+                    }
+                ],
+            }
+        ).encode("utf-8")
+
+        chat_payload = json.loads(protocol_translation.responses_request_to_chat_completion_body(responses_body))
+        image_part = chat_payload["messages"][0]["content"][1]
+        self.assertEqual(image_part, {"type": "image_url", "image_url": {"url": "https://example.test/image.png", "detail": "high"}})
+
+        round_tripped = json.loads(
+            protocol_translation.chat_completions_request_to_responses_body(json.dumps(chat_payload).encode("utf-8"))
+        )
+        self.assertEqual(
+            round_tripped["input"][0]["content"][1],
+            {"type": "input_image", "image_url": "https://example.test/image.png", "detail": "high"},
+        )
+
+    def test_responses_non_function_tools_fail_closed(self):
+        for tool_type in ("web_search_preview", "file_search", "custom"):
+            with self.subTest(tool_type=tool_type), self.assertRaises(
+                protocol_translation.UnsupportedProtocolTranslationError
+            ) as raised:
+                protocol_translation.responses_request_to_chat_completion_body(
+                    json.dumps(
+                        {
+                            "model": "example-model",
+                            "input": "Hello",
+                            "tools": [{"type": tool_type}],
+                        }
+                    ).encode("utf-8")
+                )
+
+            self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
+
+    def test_non_function_tool_choices_fail_closed(self):
+        responses_body = json.dumps(
+            {"model": "example-model", "input": "Hello", "tool_choice": {"type": "custom", "name": "apply_patch"}}
+        ).encode("utf-8")
+        chat_body = json.dumps(
+            {
+                "model": "example-model",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "tool_choice": {"type": "custom", "name": "apply_patch"},
+            }
+        ).encode("utf-8")
+
+        for convert, body in (
+            (protocol_translation.responses_request_to_chat_completion_body, responses_body),
+            (protocol_translation.chat_completions_request_to_responses_body, chat_body),
+        ):
+            with self.subTest(convert=convert.__name__), self.assertRaises(
+                protocol_translation.UnsupportedProtocolTranslationError
+            ) as raised:
+                convert(body)
+
+            self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
+
+    def test_responses_reasoning_controls_fail_closed(self):
+        with self.assertRaises(protocol_translation.UnsupportedProtocolTranslationError) as raised:
+            protocol_translation.responses_request_to_chat_completion_body(
+                json.dumps(
+                    {
+                        "model": "example-model",
+                        "input": "Hello",
+                        "reasoning": {"effort": "high"},
+                    }
+                ).encode("utf-8")
+            )
+
+        self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
+
     def test_responses_body_translates_to_chat_completion(self):
         body = json.dumps(
             {
@@ -62,6 +432,176 @@ class ProtocolTranslationTests(unittest.TestCase):
         self.assertEqual(choice["message"]["tool_calls"][0]["id"], "call_weather")
         self.assertEqual(choice["message"]["tool_calls"][0]["function"]["name"], "get_weather")
         self.assertEqual(choice["finish_reason"], "tool_calls")
+
+    def test_failed_or_incomplete_responses_body_is_never_translated_as_success(self):
+        for status in ("failed", "incomplete"):
+            with self.subTest(status=status):
+                translated = json.loads(
+                    protocol_translation.response_body_to_chat_completion_body(
+                        json.dumps(
+                            {
+                                "id": "resp_123",
+                                "model": "example-model",
+                                "status": status,
+                                "output": [
+                                    {
+                                        "type": "message",
+                                        "role": "assistant",
+                                        "content": [{"type": "output_text", "text": "Partial", "annotations": []}],
+                                    }
+                                ],
+                            }
+                        ).encode("utf-8")
+                    )
+                )
+
+                self.assertIn("error", translated)
+                self.assertNotIn("choices", translated)
+
+    def test_response_output_semantics_without_chat_equivalents_fail_closed(self):
+        outputs = {
+            "reasoning": {"type": "reasoning", "summary": [{"type": "summary_text", "text": "private"}]},
+            "refusal": {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "refusal", "refusal": "I cannot help with that."}],
+            },
+            "search": {"type": "web_search_call", "status": "completed", "action": {"query": "Codex"}},
+            "custom_tool": {"type": "custom_tool_call", "call_id": "call_patch", "name": "apply_patch", "input": "*** Begin Patch"},
+            "file": {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "input_file", "file_id": "file_123"}],
+            },
+            "audio": {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_audio", "audio": {"data": "abc", "format": "wav"}}],
+            },
+            "annotations": {
+                "type": "message",
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "output_text",
+                        "text": "See this.",
+                        "annotations": [{"type": "url_citation", "url": "https://example.test"}],
+                    }
+                ],
+            },
+            "unknown": {"type": "future_output", "value": "must not disappear"},
+        }
+
+        for semantic, output in outputs.items():
+            with self.subTest(semantic=semantic), self.assertRaises(
+                protocol_translation.UnsupportedProtocolTranslationError
+            ) as raised:
+                protocol_translation.response_body_to_chat_completion_body(
+                    json.dumps({"id": "resp_123", "model": "example-model", "status": "completed", "output": [output]}).encode(
+                        "utf-8"
+                    )
+                )
+
+            self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
+
+    def test_chat_response_preserves_text_and_function_call_together(self):
+        translated = json.loads(
+            protocol_translation.chat_completion_to_response_body(
+                json.dumps(
+                    {
+                        "id": "chatcmpl_123",
+                        "model": "example-model",
+                        "choices": [
+                            {
+                                "message": {
+                                    "role": "assistant",
+                                    "content": "I will check that.",
+                                    "tool_calls": [
+                                        {
+                                            "id": "call_weather",
+                                            "type": "function",
+                                            "function": {"name": "get_weather", "arguments": '{"city":"Shanghai"}'},
+                                        }
+                                    ],
+                                },
+                                "finish_reason": "tool_calls",
+                            }
+                        ],
+                    }
+                ).encode("utf-8")
+            )
+        )
+
+        self.assertEqual([item["type"] for item in translated["output"]], ["message", "function_call"])
+        self.assertEqual(translated["output"][0]["content"][0]["text"], "I will check that.")
+        self.assertEqual(translated["output"][1]["call_id"], "call_weather")
+
+    def test_chat_response_semantics_without_responses_equivalents_fail_closed(self):
+        messages = {
+            "reasoning": {"role": "assistant", "content": None, "reasoning_content": "private"},
+            "refusal": {"role": "assistant", "content": None, "refusal": "I cannot help with that."},
+            "search": {"role": "assistant", "content": None, "tool_calls": [{"type": "web_search"}]},
+            "custom_tool": {"role": "assistant", "content": None, "tool_calls": [{"type": "custom", "name": "apply_patch"}]},
+            "file": {"role": "assistant", "content": [{"type": "file", "file_id": "file_123"}]},
+            "audio": {"role": "assistant", "content": None, "audio": {"data": "abc", "format": "wav"}},
+            "annotations": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "See this.",
+                        "annotations": [{"type": "url_citation", "url": "https://example.test"}],
+                    }
+                ],
+            },
+            "unknown": {"role": "assistant", "content": [{"type": "future_content", "value": "must not disappear"}]},
+        }
+
+        for semantic, message in messages.items():
+            with self.subTest(semantic=semantic), self.assertRaises(
+                protocol_translation.UnsupportedProtocolTranslationError
+            ) as raised:
+                protocol_translation.chat_completion_to_response_body(
+                    json.dumps({"id": "chatcmpl_123", "model": "example-model", "choices": [{"message": message}]}).encode(
+                        "utf-8"
+                    )
+                )
+
+            self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
+
+    def test_chat_response_failure_and_length_states_are_preserved(self):
+        failed = json.loads(
+            protocol_translation.chat_completion_to_response_body(
+                json.dumps(
+                    {
+                        "id": "chatcmpl_failed",
+                        "model": "example-model",
+                        "error": {"message": "upstream rejected the request", "type": "invalid_request_error", "code": "bad_input"},
+                    }
+                ).encode("utf-8")
+            )
+        )
+        self.assertEqual(failed["status"], "failed")
+        self.assertEqual(failed["error"]["code"], "bad_input")
+
+        incomplete = json.loads(
+            protocol_translation.chat_completion_to_response_body(
+                json.dumps(
+                    {
+                        "id": "chatcmpl_length",
+                        "model": "example-model",
+                        "choices": [
+                            {
+                                "message": {"role": "assistant", "content": "Partial"},
+                                "finish_reason": "length",
+                            }
+                        ],
+                    }
+                ).encode("utf-8")
+            )
+        )
+        self.assertEqual(incomplete["status"], "incomplete")
+        self.assertEqual(incomplete["incomplete_details"], {"reason": "max_output_tokens"})
 
     def test_chat_stream_translates_to_responses_events(self):
         chunks = [
@@ -113,6 +653,92 @@ class ProtocolTranslationTests(unittest.TestCase):
         self.assertEqual(events[-1]["type"], "response.completed")
         self.assertEqual(events[-1]["response"]["output"][0]["arguments"], '{"city":"Shanghai"}')
 
+    def test_chat_stream_with_terminal_tool_call_missing_id_fails_closed(self):
+        chunk = {
+            "choices": [
+                {
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "function": {"name": "get_weather", "arguments": "{}"},
+                            }
+                        ]
+                    },
+                    "finish_reason": "tool_calls",
+                }
+            ]
+        }
+
+        with self.assertRaises(protocol_translation.UnsupportedProtocolTranslationError) as raised:
+            protocol_translation.chat_stream_chunks_to_response_events([chunk])
+        self.assertEqual(raised.exception.code, "unpaired_tool_call")
+
+        converter = protocol_translation.ChatToResponsesStreamConverter()
+        with self.assertRaises(protocol_translation.UnsupportedProtocolTranslationError) as raised:
+            converter.events_for_chunk(chunk)
+        self.assertEqual(raised.exception.code, "unpaired_tool_call")
+
+    def test_chat_length_stream_maps_to_responses_incomplete_event(self):
+        chunk = {"choices": [{"delta": {"content": "Partial"}, "finish_reason": "length"}]}
+
+        events = protocol_translation.chat_stream_chunks_to_response_events([chunk])
+        self.assertEqual(events[-1]["type"], "response.incomplete")
+        self.assertEqual(events[-1]["response"]["status"], "incomplete")
+        self.assertEqual(events[-1]["response"]["incomplete_details"], {"reason": "max_output_tokens"})
+
+        converter = protocol_translation.ChatToResponsesStreamConverter()
+        stateful_events = converter.events_for_chunk(chunk)
+        self.assertEqual(stateful_events[-1]["type"], "response.incomplete")
+        self.assertEqual(stateful_events[-1]["response"]["status"], "incomplete")
+
+    def test_chat_stream_custom_tool_delta_fails_closed(self):
+        chunk = {
+            "choices": [
+                {
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "id": "call_patch",
+                                "type": "custom",
+                                "function": {"name": "apply_patch", "arguments": "*** Begin Patch"},
+                            }
+                        ]
+                    },
+                    "finish_reason": "tool_calls",
+                }
+            ]
+        }
+
+        with self.assertRaises(protocol_translation.UnsupportedProtocolTranslationError) as raised:
+            protocol_translation.chat_stream_chunks_to_response_events([chunk])
+        self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
+
+        converter = protocol_translation.ChatToResponsesStreamConverter()
+        with self.assertRaises(protocol_translation.UnsupportedProtocolTranslationError) as raised:
+            converter.events_for_chunk(chunk)
+        self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
+
+    def test_chat_stream_non_text_content_fails_closed(self):
+        chunk = {
+            "choices": [
+                {
+                    "delta": {"content": [{"type": "file", "file_id": "file_123"}]},
+                    "finish_reason": "stop",
+                }
+            ]
+        }
+
+        with self.assertRaises(protocol_translation.UnsupportedProtocolTranslationError) as raised:
+            protocol_translation.chat_stream_chunks_to_response_events([chunk])
+        self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
+
+        converter = protocol_translation.ChatToResponsesStreamConverter()
+        with self.assertRaises(protocol_translation.UnsupportedProtocolTranslationError) as raised:
+            converter.events_for_chunk(chunk)
+        self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
+
     def test_responses_stream_translates_to_chat_chunks(self):
         events = [
             {"type": "response.created", "response": {"id": "resp_123", "model": "example-model"}},
@@ -127,6 +753,149 @@ class ProtocolTranslationTests(unittest.TestCase):
         self.assertEqual(chunks[1]["choices"][0]["delta"]["content"], "Hello")
         self.assertEqual(chunks[2]["choices"][0]["delta"]["content"], " world")
         self.assertEqual(chunks[-1]["choices"][0]["finish_reason"], "stop")
+
+    def test_responses_stream_with_function_call_missing_id_fails_closed(self):
+        events = [
+            {"type": "response.created", "response": {"id": "resp_123", "model": "example-model"}},
+            {
+                "type": "response.output_item.added",
+                "output_index": 0,
+                "item": {
+                    "id": "fc_weather",
+                    "type": "function_call",
+                    "status": "in_progress",
+                    "name": "get_weather",
+                    "arguments": "",
+                },
+            },
+        ]
+
+        with self.assertRaises(protocol_translation.UnsupportedProtocolTranslationError) as raised:
+            protocol_translation.response_events_to_chat_stream_chunks(events)
+        self.assertEqual(raised.exception.code, "unpaired_tool_call")
+
+        converter = protocol_translation.ResponsesToChatStreamConverter()
+        converter.chunks_for_event(events[0])
+        with self.assertRaises(protocol_translation.UnsupportedProtocolTranslationError) as raised:
+            converter.chunks_for_event(events[1])
+        self.assertEqual(raised.exception.code, "unpaired_tool_call")
+
+    def test_responses_function_argument_delta_without_paired_call_fails_closed(self):
+        events = [
+            {"type": "response.created", "response": {"id": "resp_123", "model": "example-model"}},
+            {
+                "type": "response.function_call_arguments.delta",
+                "item_id": "fc_weather",
+                "output_index": 0,
+                "delta": "{}",
+            },
+        ]
+
+        with self.assertRaises(protocol_translation.UnsupportedProtocolTranslationError) as raised:
+            protocol_translation.response_events_to_chat_stream_chunks(events)
+        self.assertEqual(raised.exception.code, "unpaired_tool_call")
+
+        converter = protocol_translation.ResponsesToChatStreamConverter()
+        converter.chunks_for_event(events[0])
+        with self.assertRaises(protocol_translation.UnsupportedProtocolTranslationError) as raised:
+            converter.chunks_for_event(events[1])
+        self.assertEqual(raised.exception.code, "unpaired_tool_call")
+
+    def test_responses_failed_or_incomplete_stream_fails_closed_for_chat(self):
+        for terminal_type in ("response.failed", "response.incomplete"):
+            events = [
+                {"type": "response.created", "response": {"id": "resp_123", "model": "example-model"}},
+                {"type": terminal_type, "response": {"id": "resp_123", "status": terminal_type.removeprefix("response.")}},
+            ]
+
+            with self.subTest(terminal_type=terminal_type), self.assertRaises(
+                protocol_translation.UnsupportedProtocolTranslationError
+            ) as raised:
+                protocol_translation.response_events_to_chat_stream_chunks(events)
+            self.assertEqual(raised.exception.code, "upstream_response_failed")
+
+            converter = protocol_translation.ResponsesToChatStreamConverter()
+            converter.chunks_for_event(events[0])
+            with self.assertRaises(protocol_translation.UnsupportedProtocolTranslationError) as raised:
+                converter.chunks_for_event(events[1])
+            self.assertEqual(raised.exception.code, "upstream_response_failed")
+
+    def test_stream_reasoning_semantics_fail_closed_in_both_directions(self):
+        for event_type in ("response.output_item.added", "response.output_item.done"):
+            response_events = [
+                {"type": "response.created", "response": {"id": "resp_123", "model": "example-model"}},
+                {
+                    "type": event_type,
+                    "output_index": 0,
+                    "item": {"id": "rs_123", "type": "reasoning", "status": "in_progress", "summary": []},
+                },
+            ]
+            with self.subTest(event_type=event_type), self.assertRaises(
+                protocol_translation.UnsupportedProtocolTranslationError
+            ) as raised:
+                protocol_translation.response_events_to_chat_stream_chunks(response_events)
+            self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
+
+            responses_to_chat = protocol_translation.ResponsesToChatStreamConverter()
+            responses_to_chat.chunks_for_event(response_events[0])
+            with self.assertRaises(protocol_translation.UnsupportedProtocolTranslationError) as raised:
+                responses_to_chat.chunks_for_event(response_events[1])
+            self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
+
+        chat_chunk = {"choices": [{"delta": {"reasoning_content": "private"}, "finish_reason": "stop"}]}
+        with self.assertRaises(protocol_translation.UnsupportedProtocolTranslationError) as raised:
+            protocol_translation.chat_stream_chunks_to_response_events([chat_chunk])
+        self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
+
+        chat_to_responses = protocol_translation.ChatToResponsesStreamConverter()
+        with self.assertRaises(protocol_translation.UnsupportedProtocolTranslationError) as raised:
+            chat_to_responses.events_for_chunk(chat_chunk)
+        self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
+
+    def test_stream_refusal_content_part_fails_closed_for_chat(self):
+        events = [
+            {"type": "response.created", "response": {"id": "resp_123", "model": "example-model"}},
+            {
+                "type": "response.content_part.added",
+                "output_index": 0,
+                "item_id": "msg_123",
+                "content_index": 0,
+                "part": {"type": "refusal", "refusal": "I cannot help with that."},
+            },
+        ]
+
+        with self.assertRaises(protocol_translation.UnsupportedProtocolTranslationError) as raised:
+            protocol_translation.response_events_to_chat_stream_chunks(events)
+        self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
+
+        converter = protocol_translation.ResponsesToChatStreamConverter()
+        converter.chunks_for_event(events[0])
+        with self.assertRaises(protocol_translation.UnsupportedProtocolTranslationError) as raised:
+            converter.chunks_for_event(events[1])
+        self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
+
+    def test_responses_completed_stream_with_unknown_output_fails_closed_for_chat(self):
+        events = [
+            {"type": "response.created", "response": {"id": "resp_123", "model": "example-model"}},
+            {
+                "type": "response.completed",
+                "response": {
+                    "id": "resp_123",
+                    "status": "completed",
+                    "output": [{"type": "future_output", "value": "must not disappear"}],
+                },
+            },
+        ]
+
+        with self.assertRaises(protocol_translation.UnsupportedProtocolTranslationError) as raised:
+            protocol_translation.response_events_to_chat_stream_chunks(events)
+        self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
+
+        converter = protocol_translation.ResponsesToChatStreamConverter()
+        converter.chunks_for_event(events[0])
+        with self.assertRaises(protocol_translation.UnsupportedProtocolTranslationError) as raised:
+            converter.chunks_for_event(events[1])
+        self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
 
     def test_stateful_stream_converters_emit_terminal_protocol_events(self):
         chat_to_responses = protocol_translation.ChatToResponsesStreamConverter()

--- a/tests/test_protocol_translation.py
+++ b/tests/test_protocol_translation.py
@@ -254,6 +254,146 @@ class ProtocolTranslationTests(unittest.TestCase):
 
             self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
 
+    def test_structured_request_items_and_tools_reject_unknown_fields(self):
+        responses_payloads = (
+            {
+                "input": [
+                    {"type": "message", "role": "user", "content": "Hello", "future": {"id": "message"}}
+                ]
+            },
+            {
+                "input": [
+                    {
+                        "type": "function_call",
+                        "call_id": "call_123",
+                        "name": "lookup",
+                        "arguments": "{}",
+                        "future": {"id": "call"},
+                    }
+                ]
+            },
+            {
+                "input": "Hello",
+                "tools": [
+                    {
+                        "type": "function",
+                        "name": "lookup",
+                        "parameters": {"type": "object"},
+                        "future": {"id": "tool"},
+                    }
+                ],
+            },
+        )
+        for payload in responses_payloads:
+            with self.subTest(direction="responses_to_chat", payload=payload), self.assertRaises(
+                protocol_translation.UnsupportedProtocolTranslationError
+            ) as raised:
+                protocol_translation.responses_request_to_chat_completion_body(
+                    json.dumps({"model": "example-model", **payload}).encode("utf-8")
+                )
+            self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
+
+        chat_payloads = (
+            {
+                "messages": [{"role": "user", "content": "Hello"}],
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {"name": "lookup", "parameters": {"type": "object"}},
+                        "future": {"id": "tool"},
+                    }
+                ],
+            },
+            {
+                "messages": [{"role": "user", "content": "Hello"}],
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "lookup",
+                            "parameters": {"type": "object"},
+                            "future": {"id": "function"},
+                        },
+                    }
+                ],
+            },
+            {
+                "messages": [
+                    {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "call_123",
+                                "type": "function",
+                                "function": {"name": "lookup", "arguments": {"query": "Codex"}},
+                            }
+                        ],
+                    }
+                ]
+            },
+        )
+        for payload in chat_payloads:
+            with self.subTest(direction="chat_to_responses", payload=payload), self.assertRaises(
+                protocol_translation.UnsupportedProtocolTranslationError
+            ) as raised:
+                protocol_translation.chat_completions_request_to_responses_body(
+                    json.dumps({"model": "example-model", **payload}).encode("utf-8")
+                )
+            self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
+
+    def test_non_string_function_arguments_fail_closed_in_body_converters(self):
+        chat_body = json.dumps(
+            {
+                "id": "chatcmpl_123",
+                "model": "example-model",
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": None,
+                            "tool_calls": [
+                                {
+                                    "id": "call_123",
+                                    "type": "function",
+                                    "function": {"name": "lookup", "arguments": {"query": "Codex"}},
+                                }
+                            ],
+                        },
+                        "finish_reason": "tool_calls",
+                    }
+                ],
+            }
+        ).encode("utf-8")
+        responses_body = json.dumps(
+            {
+                "id": "resp_123",
+                "status": "completed",
+                "model": "example-model",
+                "output": [
+                    {
+                        "id": "fc_123",
+                        "type": "function_call",
+                        "status": "completed",
+                        "call_id": "call_123",
+                        "name": "lookup",
+                        "arguments": {"query": "Codex"},
+                    }
+                ],
+            }
+        ).encode("utf-8")
+
+        for convert, body in (
+            (protocol_translation.chat_completion_to_response_body, chat_body),
+            (protocol_translation.chat_completion_body_to_stream_chunks, chat_body),
+            (protocol_translation.response_body_to_chat_completion_body, responses_body),
+        ):
+            with self.subTest(convert=convert.__name__), self.assertRaises(
+                protocol_translation.UnsupportedProtocolTranslationError
+            ) as raised:
+                convert(body)
+            self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
+
     def test_responses_semantic_items_without_chat_equivalents_fail_closed(self):
         payloads = {
             "reasoning": {
@@ -833,6 +973,104 @@ class ProtocolTranslationTests(unittest.TestCase):
             converter.events_for_chunk(chunk)
         self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
 
+    def test_chat_stream_rejects_multiple_or_nonzero_choices_before_translation(self):
+        chunks = (
+            {
+                "choices": [
+                    {"index": 0, "delta": {"content": "A"}, "finish_reason": "stop"},
+                    {"index": 1, "delta": {"content": "B"}, "finish_reason": "stop"},
+                ]
+            },
+            {"choices": [{"index": 1, "delta": {"content": "B"}, "finish_reason": "stop"}]},
+            {"choices": [{"index": None, "delta": {"content": "B"}, "finish_reason": "stop"}]},
+            {"choices": {"index": 0, "delta": {"content": "A"}}},
+        )
+        for chunk in chunks:
+            with self.subTest(mode="batch", chunk=chunk), self.assertRaises(
+                protocol_translation.UnsupportedProtocolTranslationError
+            ) as raised:
+                protocol_translation.chat_stream_chunks_to_response_events([chunk])
+            self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
+
+            converter = protocol_translation.ChatToResponsesStreamConverter()
+            with self.subTest(mode="incremental", chunk=chunk), self.assertRaises(
+                protocol_translation.UnsupportedProtocolTranslationError
+            ) as raised:
+                converter.events_for_chunk(chunk)
+            self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
+            self.assertFalse(converter.created)
+            self.assertFalse(converter.completed)
+            self.assertEqual(converter.text_parts, [])
+
+    def test_chat_stream_rejects_unknown_tool_fields_and_non_string_arguments(self):
+        tool_calls = (
+            {
+                "index": 0,
+                "id": "call_123",
+                "type": "function",
+                "function": {"name": "lookup", "arguments": "{}"},
+                "future": {"id": "tool"},
+            },
+            {
+                "index": 0,
+                "id": "call_123",
+                "type": "function",
+                "function": {"name": "lookup", "arguments": {"query": "Codex"}},
+            },
+        )
+        for tool_call in tool_calls:
+            chunk = {
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {"tool_calls": [tool_call]},
+                        "finish_reason": "tool_calls",
+                    }
+                ]
+            }
+            with self.subTest(mode="batch", tool_call=tool_call), self.assertRaises(
+                protocol_translation.UnsupportedProtocolTranslationError
+            ) as raised:
+                protocol_translation.chat_stream_chunks_to_response_events([chunk])
+            self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
+
+            converter = protocol_translation.ChatToResponsesStreamConverter()
+            with self.subTest(mode="incremental", tool_call=tool_call), self.assertRaises(
+                protocol_translation.UnsupportedProtocolTranslationError
+            ) as raised:
+                converter.events_for_chunk(chunk)
+            self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
+
+    def test_chat_stream_preserves_text_and_structured_tool_call(self):
+        chunks = [
+            {"choices": [{"index": 0, "delta": {"content": "I will check."}, "finish_reason": None}]},
+            {
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "id": "call_123",
+                                    "type": "function",
+                                    "function": {"name": "lookup", "arguments": "{}"},
+                                }
+                            ]
+                        },
+                        "finish_reason": "tool_calls",
+                    }
+                ]
+            },
+        ]
+
+        events = protocol_translation.chat_stream_chunks_to_response_events(chunks)
+
+        completed = events[-1]["response"]
+        self.assertEqual([item["type"] for item in completed["output"]], ["message", "function_call"])
+        self.assertEqual(completed["output"][0]["content"][0]["text"], "I will check.")
+        self.assertEqual(completed["output"][1]["call_id"], "call_123")
+
     def test_responses_stream_translates_to_chat_chunks(self):
         events = [
             {"type": "response.created", "response": {"id": "resp_123", "model": "example-model"}},
@@ -894,6 +1132,101 @@ class ProtocolTranslationTests(unittest.TestCase):
         with self.assertRaises(protocol_translation.UnsupportedProtocolTranslationError) as raised:
             converter.chunks_for_event(events[1])
         self.assertEqual(raised.exception.code, "unpaired_tool_call")
+
+    def test_responses_stream_preserves_final_function_arguments_without_deltas(self):
+        item = {
+            "id": "fc_123",
+            "type": "function_call",
+            "status": "completed",
+            "call_id": "call_123",
+            "name": "lookup",
+            "arguments": '{"query":"Codex"}',
+        }
+        prefix = [
+            {"type": "response.created", "response": {"id": "resp_123", "model": "example-model"}},
+            {
+                "type": "response.output_item.added",
+                "output_index": 0,
+                "item": {**item, "status": "in_progress", "arguments": ""},
+            },
+        ]
+        endings = (
+            [
+                {
+                    "type": "response.function_call_arguments.done",
+                    "item_id": "fc_123",
+                    "output_index": 0,
+                    "arguments": item["arguments"],
+                },
+                {"type": "response.output_item.done", "output_index": 0, "item": item},
+            ],
+            [{"type": "response.output_item.done", "output_index": 0, "item": item}],
+        )
+        terminal = {
+            "type": "response.completed",
+            "response": {"id": "resp_123", "status": "completed", "output": [item]},
+        }
+
+        def streamed_arguments(chunks):
+            return "".join(
+                tool_call.get("function", {}).get("arguments", "")
+                for chunk in chunks
+                for choice in chunk.get("choices", [])
+                for tool_call in choice.get("delta", {}).get("tool_calls", [])
+            )
+
+        for ending in endings:
+            events = [*prefix, *ending, terminal]
+            with self.subTest(mode="batch", ending=ending):
+                chunks = protocol_translation.response_events_to_chat_stream_chunks(events)
+                self.assertEqual(streamed_arguments(chunks), item["arguments"])
+
+            converter = protocol_translation.ResponsesToChatStreamConverter()
+            chunks = []
+            for event in events:
+                chunks.extend(converter.chunks_for_event(event))
+            with self.subTest(mode="incremental", ending=ending):
+                self.assertEqual(streamed_arguments(chunks), item["arguments"])
+
+    def test_responses_stream_rejects_disagreeing_function_argument_final(self):
+        prefix = [
+            {"type": "response.created", "response": {"id": "resp_123", "model": "example-model"}},
+            {
+                "type": "response.output_item.added",
+                "output_index": 0,
+                "item": {
+                    "id": "fc_123",
+                    "type": "function_call",
+                    "status": "in_progress",
+                    "call_id": "call_123",
+                    "name": "lookup",
+                    "arguments": "",
+                },
+            },
+            {
+                "type": "response.function_call_arguments.delta",
+                "item_id": "fc_123",
+                "output_index": 0,
+                "delta": '{"query":',
+            },
+        ]
+        done = {
+            "type": "response.function_call_arguments.done",
+            "item_id": "fc_123",
+            "output_index": 0,
+            "arguments": '{"other":"value"}',
+        }
+
+        with self.assertRaises(protocol_translation.UnsupportedProtocolTranslationError) as raised:
+            protocol_translation.response_events_to_chat_stream_chunks([*prefix, done])
+        self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
+
+        converter = protocol_translation.ResponsesToChatStreamConverter()
+        for event in prefix:
+            converter.chunks_for_event(event)
+        with self.assertRaises(protocol_translation.UnsupportedProtocolTranslationError) as raised:
+            converter.chunks_for_event(done)
+        self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
 
     def test_responses_failed_or_incomplete_stream_fails_closed_for_chat(self):
         for terminal_type in ("response.failed", "response.incomplete"):
@@ -990,6 +1323,39 @@ class ProtocolTranslationTests(unittest.TestCase):
         with self.assertRaises(protocol_translation.UnsupportedProtocolTranslationError) as raised:
             converter.chunks_for_event(events[1])
         self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
+
+    def test_response_body_to_sse_preserves_incomplete_and_failed_terminals(self):
+        payloads = (
+            (
+                {
+                    "id": "resp_incomplete",
+                    "object": "response",
+                    "status": "incomplete",
+                    "output": [],
+                    "incomplete_details": {"reason": "max_output_tokens"},
+                },
+                "response.incomplete",
+            ),
+            (
+                {
+                    "id": "resp_failed",
+                    "object": "response",
+                    "status": "failed",
+                    "output": [],
+                    "error": {"code": "provider_error", "message": "provider failed"},
+                },
+                "response.failed",
+            ),
+        )
+
+        for payload, terminal_type in payloads:
+            with self.subTest(status=payload["status"]):
+                events = protocol_translation.response_body_to_response_sse_events(
+                    json.dumps(payload).encode("utf-8")
+                )
+                self.assertEqual(events[-1]["type"], terminal_type)
+                self.assertEqual(events[-1]["response"]["status"], payload["status"])
+                self.assertNotIn("response.completed", [event["type"] for event in events])
 
     def test_stateful_stream_converters_emit_terminal_protocol_events(self):
         chat_to_responses = protocol_translation.ChatToResponsesStreamConverter()

--- a/tests/test_protocol_translation.py
+++ b/tests/test_protocol_translation.py
@@ -293,6 +293,57 @@ class ProtocolTranslationTests(unittest.TestCase):
                 )
             self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
 
+    def test_request_semantic_containers_reject_present_invalid_types(self):
+        cases = (
+            (
+                protocol_translation.responses_request_to_chat_completion_body,
+                {"model": "example-model", "input": {"role": "user", "content": "Hello"}},
+            ),
+            (
+                protocol_translation.responses_request_to_chat_completion_body,
+                {
+                    "model": "example-model",
+                    "input": [{"type": "message", "role": "user", "content": {"text": "Hello"}}],
+                },
+            ),
+            (
+                protocol_translation.responses_request_to_chat_completion_body,
+                {"model": "example-model", "input": "Hello", "instructions": {"text": "Be concise."}},
+            ),
+            (
+                protocol_translation.chat_completions_request_to_responses_body,
+                {"model": "example-model", "messages": {"role": "user", "content": "Hello"}},
+            ),
+            (
+                protocol_translation.chat_completions_request_to_responses_body,
+                {
+                    "model": "example-model",
+                    "messages": [{"role": "user", "content": {"text": "Hello"}}],
+                },
+            ),
+            (
+                protocol_translation.responses_request_to_chat_completion_body,
+                {"model": "example-model", "input": "Hello", "tools": {"type": "function"}},
+            ),
+            (
+                protocol_translation.chat_completions_request_to_responses_body,
+                {
+                    "model": "example-model",
+                    "messages": [{"role": "user", "content": "Hello"}],
+                    "tools": {"type": "function"},
+                },
+            ),
+        )
+
+        for convert, payload in cases:
+            with self.subTest(convert=convert.__name__, payload=payload), self.assertRaises(
+                protocol_translation.UnsupportedProtocolTranslationError
+            ) as raised:
+                convert(json.dumps(payload).encode("utf-8"))
+
+            self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
+
+    def test_structured_chat_request_items_and_tools_reject_unknown_fields(self):
         chat_payloads = (
             {
                 "messages": [{"role": "user", "content": "Hello"}],
@@ -393,6 +444,153 @@ class ProtocolTranslationTests(unittest.TestCase):
             ) as raised:
                 convert(body)
             self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
+
+    def test_response_semantic_containers_reject_present_invalid_types(self):
+        chat_body = json.dumps(
+            {
+                "id": "chatcmpl_123",
+                "model": "example-model",
+                "choices": {"index": 0, "message": {"role": "assistant", "content": "Hello"}},
+            }
+        ).encode("utf-8")
+        responses_body = json.dumps(
+            {
+                "id": "resp_123",
+                "status": "completed",
+                "model": "example-model",
+                "output": {"type": "message", "role": "assistant", "content": []},
+            }
+        ).encode("utf-8")
+
+        for convert, body in (
+            (protocol_translation.chat_completion_to_response_body, chat_body),
+            (protocol_translation.chat_completion_body_to_stream_chunks, chat_body),
+            (protocol_translation.response_body_to_chat_completion_body, responses_body),
+            (protocol_translation.response_body_to_response_sse_events, responses_body),
+        ):
+            with self.subTest(convert=convert.__name__), self.assertRaises(
+                protocol_translation.UnsupportedProtocolTranslationError
+            ) as raised:
+                convert(body)
+
+            self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
+
+    def test_response_message_content_rejects_present_invalid_container_types(self):
+        chat_body = json.dumps(
+            {
+                "id": "chatcmpl_123",
+                "model": "example-model",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": {"text": "Hello"}},
+                        "finish_reason": "stop",
+                    }
+                ],
+            }
+        ).encode("utf-8")
+        responses_body = json.dumps(
+            {
+                "id": "resp_123",
+                "status": "completed",
+                "model": "example-model",
+                "output": [
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": {"type": "output_text", "text": "Hello"},
+                    }
+                ],
+            }
+        ).encode("utf-8")
+
+        for convert, body in (
+            (protocol_translation.chat_completion_to_response_body, chat_body),
+            (protocol_translation.chat_completion_body_to_stream_chunks, chat_body),
+            (protocol_translation.response_body_to_chat_completion_body, responses_body),
+            (protocol_translation.response_body_to_response_sse_events, responses_body),
+        ):
+            with self.subTest(convert=convert.__name__), self.assertRaises(
+                protocol_translation.UnsupportedProtocolTranslationError
+            ) as raised:
+                convert(body)
+
+            self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
+
+    def test_chat_response_choice_and_message_reject_invalid_container_types(self):
+        payloads = (
+            {
+                "id": "chatcmpl_123",
+                "model": "example-model",
+                "choices": [[]],
+            },
+            {
+                "id": "chatcmpl_123",
+                "model": "example-model",
+                "choices": [{"index": 0, "message": [], "finish_reason": "stop"}],
+            },
+        )
+
+        for payload in payloads:
+            body = json.dumps(payload).encode("utf-8")
+            for convert in (
+                protocol_translation.chat_completion_to_response_body,
+                protocol_translation.chat_completion_body_to_stream_chunks,
+            ):
+                with self.subTest(convert=convert.__name__, payload=payload), self.assertRaises(
+                    protocol_translation.UnsupportedProtocolTranslationError
+                ) as raised:
+                    convert(body)
+
+                self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
+
+    def test_valid_empty_containers_and_assistant_null_content_remain_supported(self):
+        responses_request = json.loads(
+            protocol_translation.responses_request_to_chat_completion_body(
+                json.dumps({"model": "example-model", "input": [], "tools": []}).encode("utf-8")
+            )
+        )
+        self.assertEqual(responses_request["messages"], [{"role": "user", "content": ""}])
+        self.assertNotIn("tools", responses_request)
+
+        chat_request = json.loads(
+            protocol_translation.chat_completions_request_to_responses_body(
+                json.dumps({"model": "example-model", "messages": [], "tools": []}).encode("utf-8")
+            )
+        )
+        self.assertEqual(
+            chat_request["input"],
+            [{"type": "message", "role": "user", "content": [{"type": "input_text", "text": ""}]}],
+        )
+        self.assertNotIn("tools", chat_request)
+
+        empty_chat_body = json.loads(
+            protocol_translation.chat_completion_to_response_body(
+                json.dumps({"id": "chatcmpl_empty", "model": "example-model", "choices": []}).encode("utf-8")
+            )
+        )
+        self.assertEqual(empty_chat_body["output"], [])
+
+        empty_responses_body = json.loads(
+            protocol_translation.response_body_to_chat_completion_body(
+                json.dumps(
+                    {"id": "resp_empty", "status": "completed", "model": "example-model", "output": []}
+                ).encode("utf-8")
+            )
+        )
+        self.assertIsNone(empty_responses_body["choices"][0]["message"]["content"])
+
+        assistant_null = json.loads(
+            protocol_translation.chat_completions_request_to_responses_body(
+                json.dumps(
+                    {
+                        "model": "example-model",
+                        "messages": [{"role": "assistant", "content": None}],
+                    }
+                ).encode("utf-8")
+            )
+        )
+        self.assertEqual(assistant_null["input"][0]["role"], "assistant")
 
     def test_responses_semantic_items_without_chat_equivalents_fail_closed(self):
         payloads = {
@@ -1002,6 +1200,45 @@ class ProtocolTranslationTests(unittest.TestCase):
             self.assertFalse(converter.completed)
             self.assertEqual(converter.text_parts, [])
 
+    def test_chat_stream_rejects_semantic_chunks_after_terminal(self):
+        terminal_chunk = {
+            "choices": [{"index": 0, "delta": {"content": "A"}, "finish_reason": "stop"}]
+        }
+        late_chunk = {
+            "choices": [{"index": 0, "delta": {"content": "B"}, "finish_reason": None}]
+        }
+
+        with self.assertRaises(protocol_translation.UnsupportedProtocolTranslationError) as raised:
+            protocol_translation.chat_stream_chunks_to_response_events([terminal_chunk, late_chunk])
+        self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
+
+        converter = protocol_translation.ChatToResponsesStreamConverter()
+        terminal_events = converter.events_for_chunk(terminal_chunk)
+        self.assertEqual(terminal_events[-1]["type"], "response.completed")
+        with self.assertRaises(protocol_translation.UnsupportedProtocolTranslationError) as raised:
+            converter.events_for_chunk(late_chunk)
+        self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
+
+    def test_chat_stream_allows_nonsemantic_framing_after_terminal(self):
+        terminal_chunk = {
+            "choices": [{"index": 0, "delta": {"content": "A"}, "finish_reason": "stop"}]
+        }
+        usage_chunk = {
+            "choices": [],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        }
+
+        events = protocol_translation.chat_stream_chunks_to_response_events(
+            [terminal_chunk, usage_chunk, "[DONE]"]
+        )
+        self.assertEqual(events[-1]["type"], "response.completed")
+        self.assertEqual(events[-1]["response"]["output"][0]["content"][0]["text"], "A")
+
+        converter = protocol_translation.ChatToResponsesStreamConverter()
+        converter.events_for_chunk(terminal_chunk)
+        self.assertEqual(converter.events_for_chunk(usage_chunk), [])
+        self.assertEqual(converter.events_for_done(), [])
+
     def test_chat_stream_rejects_unknown_tool_fields_and_non_string_arguments(self):
         tool_calls = (
             {
@@ -1084,6 +1321,63 @@ class ProtocolTranslationTests(unittest.TestCase):
         self.assertEqual(chunks[0]["choices"][0]["delta"], {"role": "assistant"})
         self.assertEqual(chunks[1]["choices"][0]["delta"]["content"], "Hello")
         self.assertEqual(chunks[2]["choices"][0]["delta"]["content"], " world")
+        self.assertEqual(chunks[-1]["choices"][0]["finish_reason"], "stop")
+
+    def test_responses_stream_rejects_semantic_events_after_terminal(self):
+        created = {"type": "response.created", "response": {"id": "resp_123", "model": "example-model"}}
+        terminal = {
+            "type": "response.completed",
+            "response": {"id": "resp_123", "status": "completed", "output": []},
+        }
+        late_delta = {
+            "type": "response.output_text.delta",
+            "output_index": 0,
+            "item_id": "msg_123",
+            "content_index": 0,
+            "delta": "late",
+        }
+
+        with self.assertRaises(protocol_translation.UnsupportedProtocolTranslationError) as raised:
+            protocol_translation.response_events_to_chat_stream_chunks([created, terminal, late_delta])
+        self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
+
+        converter = protocol_translation.ResponsesToChatStreamConverter()
+        converter.chunks_for_event(created)
+        terminal_chunks = converter.chunks_for_event(terminal)
+        self.assertEqual(terminal_chunks[-1]["choices"][0]["finish_reason"], "stop")
+        with self.assertRaises(protocol_translation.UnsupportedProtocolTranslationError) as raised:
+            converter.chunks_for_event(late_delta)
+        self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
+
+    def test_responses_stream_rejects_invalid_terminal_output_container(self):
+        terminal = {
+            "type": "response.completed",
+            "response": {
+                "id": "resp_123",
+                "status": "completed",
+                "output": {"type": "message", "role": "assistant", "content": []},
+            },
+        }
+
+        with self.assertRaises(protocol_translation.UnsupportedProtocolTranslationError) as raised:
+            protocol_translation.response_events_to_chat_stream_chunks([terminal])
+        self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
+
+        converter = protocol_translation.ResponsesToChatStreamConverter()
+        with self.assertRaises(protocol_translation.UnsupportedProtocolTranslationError) as raised:
+            converter.chunks_for_event(terminal)
+        self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
+
+    def test_responses_stream_allows_done_framing_after_terminal(self):
+        created = {"type": "response.created", "response": {"id": "resp_123", "model": "example-model"}}
+        terminal = {
+            "type": "response.completed",
+            "response": {"id": "resp_123", "status": "completed", "output": []},
+        }
+
+        chunks = protocol_translation.response_events_to_chat_stream_chunks(
+            [created, terminal, "[DONE]"]
+        )
         self.assertEqual(chunks[-1]["choices"][0]["finish_reason"], "stop")
 
     def test_responses_stream_with_function_call_missing_id_fails_closed(self):

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -6251,7 +6251,7 @@ class RoutingTests(unittest.TestCase):
         self.assertEqual(done["item"]["arguments"], "{\"message\":\"hi\"}")
         self.assertEqual(completed["response"]["output"][0]["call_id"], "call_spawn")
 
-    def test_chat_tool_call_chunks_generate_call_id_when_upstream_omits_it(self):
+    def test_chat_tool_call_chunks_fail_closed_when_upstream_omits_id(self):
         chunks = [
             {
                 "choices": [
@@ -6286,14 +6286,10 @@ class RoutingTests(unittest.TestCase):
             "[DONE]",
         ]
 
-        events = _chat_stream_chunks_to_response_events(chunks)
+        with self.assertRaises(codex_proxy.UpstreamProtocolTranslationError) as raised:
+            _chat_stream_chunks_to_response_events(chunks)
 
-        done = next(event for event in events if event["type"] == "response.output_item.done")
-        completed = next(event for event in events if event["type"] == "response.completed")
-        self.assertTrue(done["item"]["call_id"].startswith("call_"))
-        self.assertEqual(done["item"]["name"], "multi_agent_v1__spawn_agent")
-        self.assertEqual(json.loads(done["item"]["arguments"])["message"], "hi")
-        self.assertEqual(completed["response"]["output"][0]["call_id"], done["item"]["call_id"])
+        self.assertEqual(raised.exception.cause.code, "unpaired_tool_call")
 
     def test_chat_tool_call_chunks_drop_text_message_when_tool_call_present(self):
         chunks = [

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -6291,7 +6291,7 @@ class RoutingTests(unittest.TestCase):
 
         self.assertEqual(raised.exception.cause.code, "unpaired_tool_call")
 
-    def test_chat_tool_call_chunks_drop_text_message_when_tool_call_present(self):
+    def test_chat_tool_call_chunks_preserve_text_message_when_tool_call_present(self):
         chunks = [
             {
                 "choices": [
@@ -6347,10 +6347,13 @@ class RoutingTests(unittest.TestCase):
         completed = next(event for event in events if event["type"] == "response.completed")
 
         self.assertTrue(any(event["type"] == "response.output_item.done" for event in events))
-        self.assertFalse(any(event["type"] == "response.output_text.delta" for event in events))
-        self.assertEqual(len(completed["response"]["output"]), 1)
-        self.assertEqual(completed["response"]["output"][0]["type"], "function_call")
-        self.assertEqual(completed["response"]["output"][0]["name"], "mcp__node_repl__js")
+        self.assertTrue(any(event["type"] == "response.output_text.delta" for event in events))
+        self.assertEqual(
+            [item["type"] for item in completed["response"]["output"]],
+            ["message", "function_call"],
+        )
+        self.assertEqual(completed["response"]["output"][0]["content"][0]["text"], "I'll read the plan first.")
+        self.assertEqual(completed["response"]["output"][1]["name"], "mcp__node_repl__js")
 
     def test_chat_stream_pipeline_preserves_node_repl_dot_alias_tool_call(self):
         chunks = [
@@ -6414,10 +6417,16 @@ class RoutingTests(unittest.TestCase):
         self.assertEqual(done["item"]["namespace"], "mcp__node_repl")
         self.assertEqual(done["item"]["name"], "js")
         self.assertEqual(json.loads(done["item"]["arguments"]), {"code": "readPlan()"})
-        self.assertEqual(completed["response"]["output"][0]["type"], "function_call")
-        self.assertEqual(completed["response"]["output"][0]["namespace"], "mcp__node_repl")
-        self.assertEqual(completed["response"]["output"][0]["name"], "js")
-        self.assertFalse(any(event.get("item", {}).get("type") == "message" for event in events if isinstance(event.get("item"), dict)))
+        completed_call = next(item for item in completed["response"]["output"] if item["type"] == "function_call")
+        self.assertEqual(completed_call["namespace"], "mcp__node_repl")
+        self.assertEqual(completed_call["name"], "js")
+        self.assertTrue(
+            any(
+                event.get("item", {}).get("type") == "message"
+                for event in events
+                if isinstance(event.get("item"), dict)
+            )
+        )
 
     def test_chat_stream_pipeline_preserves_multi_agent_dot_alias_tool_call(self):
         chunks = [


### PR DESCRIPTION
## Summary

- preserve the reversible Responses/Chat subset: plain text, URL-backed images including `detail`, strict function schemas, paired function calls/results, and text plus tool calls
- fail closed with typed protocol errors when semantic data has no proven reversible mapping
- remove random fallback IDs from structured assistant tool calls/results and require stable pairing IDs in bodies, history, and streams
- map unsupported upstream response semantics to explicit 502 Gateway errors while keeping client-side unsupported request shapes as 400 errors

## Behavior changed

- rejects missing or empty `call_id`, initial tool-call `id`, and `tool_call_id` values instead of inventing an unpairable ID; a later empty stream ID remains a no-op only after a valid ID established the pairing
- rejects unknown fields on request messages, function calls, tools, tool choices, response items, and stream items
- rejects non-string structured function arguments rather than rewriting them to `""` or JSON text
- rejects present invalid semantic containers for Responses `input`/`output`, Chat `messages`/`choices`, both `tools` shapes, instructions, message content, response choices, and body-to-SSE reconstruction; absent fields, valid empty lists, and compatible assistant null content retain existing behavior
- rejects multiple, malformed, or nonzero-index Chat alternatives before either batch or incremental translation mutates state
- rejects semantic Chat chunks or Responses events after a terminal frame in both batch and incremental converters while allowing Chat usage-only framing and parser-level `[DONE]`
- preserves assistant text and structured function calls as separate ordered Responses output items
- reconciles Responses argument deltas with `arguments.done`, `output_item.done`, and terminal full arguments; emits only a verified missing suffix and rejects disagreement
- preserves Chat `length` and buffered Responses `incomplete`/`failed` terminal states, including handler-level JSON-to-SSE synthesis
- preserves URL image `detail` and function-tool `strict`

## Explicit unsupported cases

The seam returns `unsupported_protocol_semantics`, `unpaired_tool_call`, or `upstream_response_failed` for non-reversible reasoning, refusal, search, custom-tool, file, audio, non-empty annotation, unknown content/item/field, invalid semantic container, non-function tool/tool-choice, alternative-choice, post-terminal semantic data, argument-type/disagreement, unsupported finish-state, and missing pairing-ID shapes.

## Compatibility limits

- the longstanding third-party developer-to-system/instructions textual compatibility mapping remains documented in `src-python/protocol_translation.py`
- the existing XML-ish third-party tool-markup fallback remains a compatibility boundary: it creates and exposes the initial call ID for markup it recognizes; it does not replace a missing ID on a structured call/result
- `docs/superpowers/plans/2026-07-09-post-0.1.2-issue-closeout.md` Task C2 remains accurate and is cited as the existing Issue #26 compatibility/acceptance artifact; no documentation correction was needed
- no retry, upstream transport, downstream-disconnect, concurrency, telemetry-analyzer, or RoutePlan policy was changed
- exact implementation base: `origin/dev@4b55cca647291f57b191176663310f983d1ae388`

## Verification

- `python -m pytest tests/test_protocol_translation.py tests/test_chat_completions_gateway.py tests/test_routing.py` — 527 passed
- `python -m pytest` — 886 passed, 1 skipped
- `python scripts/report_quality_gates.py` — exit 0, report-only; parse errors 0 (existing advisory findings reported)
- `git diff --check` — clean

## Review evidence

- Orchestrator review on `523659ad` identified five reproducible Spec failures; all five have focused batch/incremental/body/handler regressions and fixes in `f802a466`
- Orchestrator final review on `f802a466` identified invalid-container and post-terminal fail-open boundaries; both directions and all four batch/incremental stream modes have focused regressions and fixes in `9e764778`
- completed local Standards checklist: only the protocol seam and focused tests changed; no documented-standard breach or routing/retry policy change
- completed local Issue-spec checklist: structured unknowns/types/containers, alternative choices, post-terminal guards, mixed text/tool output, final argument reconciliation, terminal states, missing IDs, third-party documentation, hotset, and required gates all pass
- earlier independent reviewer calls suffered platform `task systemError` / stream disconnect; their preserved concrete tests and both later Orchestrator review rounds are incorporated. Orchestrator final merge review remains required.

Closes #26