### PR TITLE
Fix fallback catalog and bound Issue #106 lifecycle evidence

### DIFF
--- a/config/catalog_policy.toml
+++ b/config/catalog_policy.toml
@@ -6,6 +6,9 @@ ollama_cloud_base_url = "https://ollama.com/v1"
 [visibility]
 auto_include_ollama_cloud = false
 official_models = [
+  "gpt-5.6-sol",
+  "gpt-5.6-terra",
+  "gpt-5.6-luna",
   "gpt-5.5",
   "gpt-5.4",
   "gpt-5.4-mini",
@@ -65,6 +68,9 @@ denied_models = [
 denied_substrings = ["embedding"]
 
 [display_names]
+"gpt-5.6-sol" = "GPT-5.6 Sol"
+"gpt-5.6-terra" = "GPT-5.6 Terra"
+"gpt-5.6-luna" = "GPT-5.6 Luna"
 "gpt-5.5" = "GPT-5.5"
 "gpt-5.5-fast" = "GPT-5.5 Fast"
 "gpt-5.4" = "GPT-5.4"

--- a/docs/evidence/issue-106/README.md
+++ b/docs/evidence/issue-106/README.md
@@ -18,7 +18,8 @@ python scripts/run_issue_106_task_lifecycle.py --scenario red
 The runner creates a fresh task-owned `CODEX_HOME` for each run, writes its
 catalog and overlay only there, disables nonessential plugin services, removes
 provider-key environment variables from its child process, and uses native
-`thread/delete` before removing that temporary home. It emits only sanitized
+`thread/delete`, client-pipe close, and app-server shutdown before removing
+that temporary home. It emits only sanitized
 counts, states, and binding fields: no local paths, prompts, task identifiers,
 session identifiers, credentials, or gateway token values.
 
@@ -37,9 +38,10 @@ about a visual `Custom` or `Light` label.
 
 `green` exercises create, list, bootstrap, read, rename, explicit full binding
 and permission preflight, resume, normal continuation without a binding
-override, read replay, native delete, and temporary-home cleanup against a
-catalog-listed external model. `--repeat 2` is the supported repeated-run leak
-check.
+override, read replay, native delete, client-pipe close, task-owned app-server
+shutdown, and temporary-home cleanup against a catalog-listed external model.
+It defaults to,
+and requires, at least two runs for the repeated-run leak check.
 
 `red` uses a deliberately unlisted model identifier. The current App CLI
 accepts both create and message requests, persists input-only no-output turns,

--- a/docs/evidence/issue-106/README.md
+++ b/docs/evidence/issue-106/README.md
@@ -38,11 +38,17 @@ links those probes to post-worktree Task materialization. Accordingly, this
 change adds evidence coverage only and deliberately leaves CodexHub product
 behavior unchanged.
 
-The verifier reads the known CodexHub configuration/catalog/proxy boundary
-sources and fails if they gain either the named global MCP or a generic
-`mcp_servers` configuration surface. That source check is deliberately narrow:
-it supports the ownership boundary, not a claim about the official client's
-internal implementation.
+The verifier reads the known CodexHub configuration, catalog, Gateway, and
+app-server-probe boundary source modules. It fails if they gain either the
+named global MCP or a generic `mcp_servers` configuration surface, and it
+requires the bounded model and usage probe launch sites to remain present.
+That source check is deliberately narrow: it supports the ownership boundary,
+not a claim about the official client's internal implementation or a proven
+causal link to Task materialization.
+
+The retained JSON has a closed schema: it requires source provenance, rejects
+unknown fields, and checks strings for local paths, Task/session identifiers,
+and credential-shaped material without echoing their values in mismatches.
 
 The official Task read surface was available for an existing materialized Task.
 A new create replay and repeated process-leak run were intentionally not run:

--- a/docs/evidence/issue-106/README.md
+++ b/docs/evidence/issue-106/README.md
@@ -58,7 +58,8 @@ residual is documented in
 If a create or turn request instead rejects, the runner calls it
 `atomic_rejection` only when it retains a numeric JSON-RPC error code and a
 subsequent `thread/read` proves zero persisted turns. A rejected create without
-a readable Task, or any nonempty/error-imprecise readback, is
+a readable Task, a rejected turn without readable Task state, or any
+nonempty/error-imprecise readback is
 `unverified_rejection`.
 
 | Contract area | Status | Exact evidence boundary |

--- a/docs/evidence/issue-106/README.md
+++ b/docs/evidence/issue-106/README.md
@@ -1,0 +1,59 @@
+# Issue #106 task-creation evidence
+
+This directory records a sanitized, deterministic replay of the observed
+Task-creation A/B boundary. It is not a live Task creator and it does not
+modify Codex configuration, native Task state, worktrees, or any internal
+Codex database.
+
+Run the replay from the repository root:
+
+```powershell
+python scripts/check_codex_task_creation_lifecycle.py
+```
+
+The verifier also includes negative controls. Each must fail visibly:
+
+```powershell
+python scripts/check_codex_task_creation_lifecycle.py --replay-case materialize-red
+python scripts/check_codex_task_creation_lifecycle.py --replay-case unmaterialize-green
+python scripts/check_codex_task_creation_lifecycle.py --replay-case fail-git-preflight
+python scripts/check_codex_task_creation_lifecycle.py --replay-case skip-cleanup
+python scripts/check_codex_task_creation_lifecycle.py --replay-case identifier-leak
+```
+
+## Retained boundary
+
+The red case reached client-placeholder and worktree provisioning, but no
+rollout/session materialized. Native Task listing therefore had no task to
+read, message, rename, archive, or delete. The green case materialized after
+the optional global `openaiDeveloperDocs` MCP was disabled, completed in
+10.146 seconds, and passed create/read/message plus the requested full-access
+preflight.
+
+Read-only inspection establishes that CodexHub's configuration overlay manages
+only the model-provider/catalog surface; it does not configure global MCP
+servers or expose the native Task lifecycle. CodexHub does start bounded
+external app-server probes for model and usage reads, but no committed path
+links those probes to post-worktree Task materialization. Accordingly, this
+change adds evidence coverage only and deliberately leaves CodexHub product
+behavior unchanged.
+
+The verifier reads the known CodexHub configuration/catalog/proxy boundary
+sources and fails if they gain either the named global MCP or a generic
+`mcp_servers` configuration surface. That source check is deliberately narrow:
+it supports the ownership boundary, not a claim about the official client's
+internal implementation.
+
+The official Task read surface was available for an existing materialized Task.
+A new create replay and repeated process-leak run were intentionally not run:
+they would create replacement Tasks and require Orchestrator approval.
+The retained successful GitHub preflight is structurally checked by the replay;
+it does not create or inspect another worktree.
+
+## Cleanup boundary
+
+Two clean orphan worktrees were removable. One failed placeholder left an empty
+directory until the official client releases its handle. Supported archive and
+delete operations rejected the placeholder because no real session existed.
+No internal Codex database was edited. The precise upstream report is in
+[official-client-half-created-task-defect.md](official-client-half-created-task-defect.md).

--- a/docs/evidence/issue-106/README.md
+++ b/docs/evidence/issue-106/README.md
@@ -1,10 +1,10 @@
 # Issue #106 task-creation evidence
 
-This directory contains both the retained historical fixture and the authorized
-isolated App CLI replay used to separate CodexHub catalog ownership from native
-Task lifecycle ownership.
+This directory separates the current isolated App CLI controls from a retained
+historical fixture. Neither substitutes for the unresolved end-to-end Issue
+#106 acceptance contract.
 
-## Deterministic isolated replay
+## Current isolated controls
 
 Run these commands from the repository root while the local CodexHub Gateway is
 active:
@@ -15,66 +15,87 @@ python scripts/run_issue_106_task_lifecycle.py --scenario green --repeat 2
 python scripts/run_issue_106_task_lifecycle.py --scenario red
 ```
 
-The runner creates a fresh task-owned `CODEX_HOME` for each run, writes its
-catalog and overlay only there, disables nonessential plugin services, removes
-provider-key environment variables from its child process, and uses native
-`thread/delete`, client-pipe close, and app-server shutdown before removing
-that temporary home. It emits only sanitized
-counts, states, and binding fields: no local paths, prompts, task identifiers,
-session identifiers, credentials, or gateway token values.
+The runner creates a fresh task-owned `CODEX_HOME` for every run, writes its
+catalog and overlay only there, removes provider-key environment variables from
+its child process, and uses native `thread/delete`, client-pipe close, and
+app-server shutdown before removing that temporary home. Its result contains
+only sanitized counts, states, and binding fields; it does not emit local paths,
+Task or session identifiers, credentials, gateway token values, or raw rollout
+contents.
 
-`compare` is the official/disconnected versus CodexHub/connected catalog
-control. The fresh official control has no copied authentication, so it is a
-catalog control rather than a valid official-rollout control. It confirms that
-the App CLI itself knows the requested current official model and `max` effort.
-The connected control then verifies that CodexHub preserves that binding in its
-isolated catalog.
+`compare` is an account and catalog control only. It makes fresh disconnected
+and CodexHub-connected `model/list` calls and confirms the requested official
+model and `max` effort are listed in both isolated catalogs, while the external
+model is listed only when connected. It does not call `thread/start`,
+`turn/start`, `thread/read`, or an official remote lifecycle. The official
+remote full-lifecycle A/B remains an unrun external gate.
 
-A separate authenticated native App Task control validated the requested
-official full binding, read/rename sequence, normal continuation, and supported
-archive cleanup without retaining any Task identifier. The native Task API does
-not expose the Desktop's presentation label, so this evidence makes no claim
-about a visual `Custom` or `Light` label.
+`green` creates one connected native Task with a catalog-listed external model,
+completes its bootstrap turn, reads back the retained non-archived Task, and
+then proves that it is present in `thread/list` before rename or deletion. The
+App server does not list this Task while its first turn is in flight, so the
+runner makes no in-flight-list claim. It then full-binds, resumes, performs an
+ordinary continuation, reads replay, and deletes natively. The only binding
+transition it verifies is the same external custom-provider model from `low`
+bootstrap effort to `max` effort. Its resume assertion requires the persisted
+model, `modelProvider: custom`, `max` effort, `never` approval, and full-access
+sandbox values. It does not verify a different explicit Worker model/reasoning
+transition, an official remote lifecycle, or a Desktop `Custom`/`Light`
+presentation label.
 
-`green` exercises create, list, bootstrap, read, rename, explicit full binding
-and permission preflight, resume, normal continuation without a binding
-override, read replay, native delete, client-pipe close, task-owned app-server
-shutdown, and temporary-home cleanup against a catalog-listed external model.
-It defaults to,
-and requires, at least two runs for the repeated-run leak check.
+The full-bind preflight is deliberately metadata-only: it sends the requested
+approval and sandbox policy values, but does not exercise filesystem or network
+access. `green` requires two isolated runs. Its repeated cleanup result covers
+only native Task deletion, the task-owned client pipe, task-owned app-server,
+and task-owned temporary home. It does not cover remote-control enrollment,
+shared configuration, global client worktrees, or client-placeholder cleanup.
 
-`red` uses a deliberately unlisted model identifier. The current App CLI
-accepts both create and message requests, persists input-only no-output turns,
-and then leaves a normal continuation without a usable rollout. Native cleanup
-still succeeds. That is an upstream atomicity defect, documented in
+`red` uses a deliberately unlisted sentinel model. The current App CLI accepts
+both create and first-turn requests, persists an input-only no-output turn, and
+then leaves an ordinary continuation without a usable rollout. That upstream
+residual is documented in
 [official-app-server-non-atomic-model-binding.md](official-app-server-non-atomic-model-binding.md).
-Before the catalog fix, the requested Luna binding was absent from the connected
-fallback catalog and exercised this same invalid-binding boundary. The sentinel
-keeps that red control deterministic after Luna becomes correctly listed.
+If a create or turn request instead rejects, the runner calls it
+`atomic_rejection` only when it retains a numeric JSON-RPC error code and a
+subsequent `thread/read` proves zero persisted turns. A rejected create without
+a readable Task, or any nonempty/error-imprecise readback, is
+`unverified_rejection`.
 
-## CodexHub-owned fix
+| Contract area | Status | Exact evidence boundary |
+| --- | --- | --- |
+| CodexHub fallback catalog lists current requested official bindings and effort | Covered | Fresh isolated catalog policy and catalog regression test |
+| Connected external-model create/read/rename/same-model full-bind/continue/delete | Covered, partial | Active `thread/list` assertion and replay require the persisted `custom` provider |
+| Low-cost bootstrap to a different explicit Worker model/reasoning binding | Unrun external gate | The current live runner deliberately uses the same external model |
+| Official remote full-lifecycle A/B | Unrun external gate | `compare` is account/catalog/model-list only |
+| Permission policy acceptance | Partial | Metadata-only policy fields; no filesystem or network access exercise |
+| Unlisted-model request atomicity | Reproduced upstream residual | Accepted input-only turn and unusable continuation; rejected paths are classified conservatively |
+| Repeated cleanup | Covered, task-owned only | Native Task/client-pipe/app-server/temporary-home cleanup; not remote-control, worktree, or placeholder cleanup |
+
+## CodexHub-owned correction
 
 The fallback catalog policy had stopped listing the current official Sol, Terra,
 and Luna bindings when no runtime subscription seed was available. The App
 could therefore accept a full binding that CodexHub had not advertised. The
-policy now includes those bindings, and the catalog regression test verifies
-the Terra `max` binding plus resolved context limits in a fresh-home fallback.
+policy now includes those bindings, and the catalog regression test verifies the
+Terra `max` binding plus resolved context limits in a fresh-home fallback.
 
-CodexHub does not create native Tasks, own the App CLI's rollout persistence,
-or configure global MCP servers. The isolated runner deliberately does not
-attempt a client-side workaround for the upstream non-atomic behavior.
+CodexHub does not create native Tasks, own App CLI rollout persistence, or
+configure global MCP servers. The isolated runner deliberately does not attempt
+a client-side workaround for the upstream non-atomic behavior.
 
 ## Retained historical fixture
 
-The original sanitized fixture remains a structural record of the earlier
-sidebar placeholder observation. It does not create a live Task:
+The original sanitized fixture remains a structural record of an earlier
+sidebar-placeholder observation. It does not create a live Task:
 
 ```powershell
 python scripts/check_codex_task_creation_lifecycle.py
 ```
 
-Its negative controls remain deterministic and fail visibly. The fixture has a
-closed schema and rejects local paths, Task/session identifiers, and
-credential-shaped strings without echoing them in mismatches. The earlier
-placeholder report is retained in
+The fixture does not validate active Task listing, an official remote lifecycle,
+access exercise, remote-control enrollment, repeated-run cleanup, client
+placeholder cleanup, or worktree cleanup. Its negative controls remain
+deterministic and fail visibly. The fixture has a closed schema and rejects
+local paths, Task/session identifiers, and credential-shaped strings without
+echoing them in mismatches. The earlier placeholder report is retained in
 [official-client-half-created-task-defect.md](official-client-half-created-task-defect.md).

--- a/docs/evidence/issue-106/README.md
+++ b/docs/evidence/issue-106/README.md
@@ -1,65 +1,78 @@
 # Issue #106 task-creation evidence
 
-This directory records a sanitized, deterministic replay of the observed
-Task-creation A/B boundary. It is not a live Task creator and it does not
-modify Codex configuration, native Task state, worktrees, or any internal
-Codex database.
+This directory contains both the retained historical fixture and the authorized
+isolated App CLI replay used to separate CodexHub catalog ownership from native
+Task lifecycle ownership.
 
-Run the replay from the repository root:
+## Deterministic isolated replay
+
+Run these commands from the repository root while the local CodexHub Gateway is
+active:
+
+```powershell
+python scripts/run_issue_106_task_lifecycle.py --scenario compare
+python scripts/run_issue_106_task_lifecycle.py --scenario green --repeat 2
+python scripts/run_issue_106_task_lifecycle.py --scenario red
+```
+
+The runner creates a fresh task-owned `CODEX_HOME` for each run, writes its
+catalog and overlay only there, disables nonessential plugin services, removes
+provider-key environment variables from its child process, and uses native
+`thread/delete` before removing that temporary home. It emits only sanitized
+counts, states, and binding fields: no local paths, prompts, task identifiers,
+session identifiers, credentials, or gateway token values.
+
+`compare` is the official/disconnected versus CodexHub/connected catalog
+control. The fresh official control has no copied authentication, so it is a
+catalog control rather than a valid official-rollout control. It confirms that
+the App CLI itself knows the requested current official model and `max` effort.
+The connected control then verifies that CodexHub preserves that binding in its
+isolated catalog.
+
+A separate authenticated native App Task control validated the requested
+official full binding, read/rename sequence, normal continuation, and supported
+archive cleanup without retaining any Task identifier. The native Task API does
+not expose the Desktop's presentation label, so this evidence makes no claim
+about a visual `Custom` or `Light` label.
+
+`green` exercises create, list, bootstrap, read, rename, explicit full binding
+and permission preflight, resume, normal continuation without a binding
+override, read replay, native delete, and temporary-home cleanup against a
+catalog-listed external model. `--repeat 2` is the supported repeated-run leak
+check.
+
+`red` uses a deliberately unlisted model identifier. The current App CLI
+accepts both create and message requests, persists input-only no-output turns,
+and then leaves a normal continuation without a usable rollout. Native cleanup
+still succeeds. That is an upstream atomicity defect, documented in
+[official-app-server-non-atomic-model-binding.md](official-app-server-non-atomic-model-binding.md).
+Before the catalog fix, the requested Luna binding was absent from the connected
+fallback catalog and exercised this same invalid-binding boundary. The sentinel
+keeps that red control deterministic after Luna becomes correctly listed.
+
+## CodexHub-owned fix
+
+The fallback catalog policy had stopped listing the current official Sol, Terra,
+and Luna bindings when no runtime subscription seed was available. The App
+could therefore accept a full binding that CodexHub had not advertised. The
+policy now includes those bindings, and the catalog regression test verifies
+the Terra `max` binding plus resolved context limits in a fresh-home fallback.
+
+CodexHub does not create native Tasks, own the App CLI's rollout persistence,
+or configure global MCP servers. The isolated runner deliberately does not
+attempt a client-side workaround for the upstream non-atomic behavior.
+
+## Retained historical fixture
+
+The original sanitized fixture remains a structural record of the earlier
+sidebar placeholder observation. It does not create a live Task:
 
 ```powershell
 python scripts/check_codex_task_creation_lifecycle.py
 ```
 
-The verifier also includes negative controls. Each must fail visibly:
-
-```powershell
-python scripts/check_codex_task_creation_lifecycle.py --replay-case materialize-red
-python scripts/check_codex_task_creation_lifecycle.py --replay-case unmaterialize-green
-python scripts/check_codex_task_creation_lifecycle.py --replay-case fail-git-preflight
-python scripts/check_codex_task_creation_lifecycle.py --replay-case skip-cleanup
-python scripts/check_codex_task_creation_lifecycle.py --replay-case identifier-leak
-```
-
-## Retained boundary
-
-The red case reached client-placeholder and worktree provisioning, but no
-rollout/session materialized. Native Task listing therefore had no task to
-read, message, rename, archive, or delete. The green case materialized after
-the optional global `openaiDeveloperDocs` MCP was disabled, completed in
-10.146 seconds, and passed create/read/message plus the requested full-access
-preflight.
-
-Read-only inspection establishes that CodexHub's configuration overlay manages
-only the model-provider/catalog surface; it does not configure global MCP
-servers or expose the native Task lifecycle. CodexHub does start bounded
-external app-server probes for model and usage reads, but no committed path
-links those probes to post-worktree Task materialization. Accordingly, this
-change adds evidence coverage only and deliberately leaves CodexHub product
-behavior unchanged.
-
-The verifier reads the known CodexHub configuration, catalog, Gateway, and
-app-server-probe boundary source modules. It fails if they gain either the
-named global MCP or a generic `mcp_servers` configuration surface, and it
-requires the bounded model and usage probe launch sites to remain present.
-That source check is deliberately narrow: it supports the ownership boundary,
-not a claim about the official client's internal implementation or a proven
-causal link to Task materialization.
-
-The retained JSON has a closed schema: it requires source provenance, rejects
-unknown fields, and checks strings for local paths, Task/session identifiers,
-and credential-shaped material without echoing their values in mismatches.
-
-The official Task read surface was available for an existing materialized Task.
-A new create replay and repeated process-leak run were intentionally not run:
-they would create replacement Tasks and require Orchestrator approval.
-The retained successful GitHub preflight is structurally checked by the replay;
-it does not create or inspect another worktree.
-
-## Cleanup boundary
-
-Two clean orphan worktrees were removable. One failed placeholder left an empty
-directory until the official client releases its handle. Supported archive and
-delete operations rejected the placeholder because no real session existed.
-No internal Codex database was edited. The precise upstream report is in
+Its negative controls remain deterministic and fail visibly. The fixture has a
+closed schema and rejects local paths, Task/session identifiers, and
+credential-shaped strings without echoing them in mismatches. The earlier
+placeholder report is retained in
 [official-client-half-created-task-defect.md](official-client-half-created-task-defect.md).

--- a/docs/evidence/issue-106/official-app-server-non-atomic-model-binding.md
+++ b/docs/evidence/issue-106/official-app-server-non-atomic-model-binding.md
@@ -1,0 +1,53 @@
+# Upstream report: app-server accepts an unavailable model binding non-atomically
+
+## Summary
+
+The App-managed `app-server` accepts `thread/start` and `turn/start` for a
+model absent from its own `model/list` result. It then persists an input-only,
+no-output turn instead of rejecting the unavailable binding atomically. A
+normal continuation without a model override has no usable rollout.
+
+## Safe reproduction
+
+1. Start the App CLI with a fresh, isolated `CODEX_HOME`; do not copy an auth
+   file or change any shared configuration.
+2. Configure an isolated custom-provider catalog that omits a chosen sentinel
+   model identifier, then confirm the omission through `model/list`.
+3. Call `thread/start` with that identifier, followed by `turn/start` with the
+   same identifier.
+4. After a bounded wait, call `thread/read`.
+5. Resume by thread identifier and start one ordinary continuation without a
+   model override, then read again. Finally call native `thread/delete`.
+
+The repository runner provides that exact sequence without exposing identifiers
+or credentials:
+
+```powershell
+python scripts/run_issue_106_task_lifecycle.py --scenario red
+```
+
+## Observed result
+
+- Both creation and first-turn requests are accepted although the model is not
+  advertised.
+- The first persisted turn contains only its input item and no agent output.
+- The App reports either an in-progress active thread or a completed turn with
+  a system error, depending on client timing; neither state has a usable
+  rollout.
+- The normal continuation likewise persists no agent output.
+- Native deletion succeeds, so cleanup is possible only after the invalid
+  persistent state has already been created.
+
+## Expected result
+
+Model binding validation should happen before any persistent Task/turn state is
+created. An unavailable model must produce a deterministic `thread/start` or
+`turn/start` error with no rollout, input-only turn, or continuation target.
+
+## Product boundary
+
+CodexHub's proven responsibility is to advertise current supported official
+bindings consistently in its fallback catalog. That catalog defect is fixed in
+this change. CodexHub does not own App CLI request acceptance, native Task
+persistence, or rollout cleanup, and it should not edit client-internal data or
+invent a deletion workaround for this behavior.

--- a/docs/evidence/issue-106/official-app-server-non-atomic-model-binding.md
+++ b/docs/evidence/issue-106/official-app-server-non-atomic-model-binding.md
@@ -3,9 +3,10 @@
 ## Summary
 
 The App-managed `app-server` accepts `thread/start` and `turn/start` for a
-model absent from its own `model/list` result. It then persists an input-only,
-no-output turn instead of rejecting the unavailable binding atomically. A
-normal continuation without a model override has no usable rollout.
+model absent from the connected isolated catalog returned by its own
+`model/list` result. It then persists an input-only, no-output turn instead of
+rejecting the unavailable binding atomically. A normal continuation without a
+model override has no usable rollout.
 
 ## Safe reproduction
 
@@ -43,6 +44,24 @@ python scripts/run_issue_106_task_lifecycle.py --scenario red
 Model binding validation should happen before any persistent Task/turn state is
 created. An unavailable model must produce a deterministic `thread/start` or
 `turn/start` error with no rollout, input-only turn, or continuation target.
+
+## Rejection classification
+
+The runner does not assume that every request rejection is atomic. It reports
+`atomic_rejection` only when a numeric JSON-RPC error code is captured and a
+subsequent `thread/read` shows zero persisted turns. A rejected create with no
+readable Task, a nonempty readback, or an error without a numeric code is an
+`unverified_rejection`. The observed residual described above is the accepted,
+non-atomic path rather than a rejection path.
+
+## Scope limits
+
+This reproduction covers the connected isolated custom-provider catalog path.
+It does not establish an official remote full lifecycle A/B, a low-cost
+bootstrap followed by a different explicit Worker model/reasoning binding, a
+filesystem or network access exercise, or a Desktop presentation label. The
+separate `compare` control is account/catalog/model-list only and leaves the
+official remote full-lifecycle control unrun.
 
 ## Product boundary
 

--- a/docs/evidence/issue-106/official-app-server-non-atomic-model-binding.md
+++ b/docs/evidence/issue-106/official-app-server-non-atomic-model-binding.md
@@ -50,9 +50,10 @@ created. An unavailable model must produce a deterministic `thread/start` or
 The runner does not assume that every request rejection is atomic. It reports
 `atomic_rejection` only when a numeric JSON-RPC error code is captured and a
 subsequent `thread/read` shows zero persisted turns. A rejected create with no
-readable Task, a nonempty readback, or an error without a numeric code is an
-`unverified_rejection`. The observed residual described above is the accepted,
-non-atomic path rather than a rejection path.
+readable Task, a rejected turn with unavailable Task readback, a nonempty
+readback, or an error without a numeric code is an `unverified_rejection`. The
+observed residual described above is the accepted, non-atomic path rather than
+a rejection path.
 
 ## Scope limits
 

--- a/docs/evidence/issue-106/official-client-half-created-task-defect.md
+++ b/docs/evidence/issue-106/official-client-half-created-task-defect.md
@@ -1,0 +1,59 @@
+# Upstream report: failed Task creation leaves an unmanageable sidebar stub
+
+## Summary
+
+When a new sidebar-visible, worktree-backed Task times out during startup, the
+official client can leave a visible client placeholder and a provisioned
+worktree without materializing a rollout/session. The resulting object is not
+a native Task and cannot be managed or removed through the supported Task API.
+
+## Preconditions
+
+- A global optional MCP server delays `thread/start` initialization past the
+  client materialization timeout.
+- Create one new worktree-backed Task. Do not retry the creation after timeout;
+  retries create additional ambiguous placeholders.
+
+## Observed result
+
+1. Worktree setup and a client-side placeholder complete.
+2. No rollout/session materializes.
+3. Native Task listing omits the placeholder.
+4. Read, message, and rename have no usable Task target; archive and supported
+   CLI deletion reject the placeholder because no real session exists.
+5. Clean orphan worktrees can be removed independently, but a failed
+   placeholder can retain an empty client-held directory until the client
+   releases its file handle.
+
+## Expected result
+
+Task creation should be atomic from the sidebar's perspective: either a native
+Task/rollout is materialized and returned, or the client deterministically
+removes the placeholder and any provisioned worktree. If cleanup is deferred,
+the sidebar should expose a supported retry/cancel action and retain enough
+state for that action to succeed.
+
+## Impact
+
+The sidebar can show duplicate-looking or permanent `New task` cards that do
+not correspond to any native Task. Operators cannot archive or delete them
+through supported interfaces, and repeated retries risk accumulating orphan
+worktrees.
+
+## Scope and safety boundary
+
+The A/B isolated the startup delay to an optional global MCP server; disabling
+that server made a short bootstrap materialize in about ten seconds and pass
+the requested full-access preflight. CodexHub does run bounded external
+app-server probes for model and usage reads, but no committed path proves that
+those probes start or break this MCP, or that they control native Task
+persistence. CodexHub does not manage this MCP server or the native Task
+persistence lifecycle. No credentials, system proxy, official binary, global
+configuration (beyond the reversible diagnostic A/B), protocol translation, or
+internal Codex database should be changed to work around this defect.
+
+## Requested fix
+
+Provide an official client-side rollback path for a Task that has acquired a
+client placeholder or worktree but has no rollout/session, including removal of
+the sidebar card and deterministic release/removal of its worktree directory.

--- a/docs/evidence/issue-106/official-client-half-created-task-defect.md
+++ b/docs/evidence/issue-106/official-client-half-created-task-defect.md
@@ -42,15 +42,19 @@ worktrees.
 
 ## Scope and safety boundary
 
-The A/B isolated the startup delay to an optional global MCP server; disabling
-that server made a short bootstrap materialize in about ten seconds and pass
-the requested full-access preflight. CodexHub does run bounded external
-app-server probes for model and usage reads, but no committed path proves that
-those probes start or break this MCP, or that they control native Task
-persistence. CodexHub does not manage this MCP server or the native Task
-persistence lifecycle. No credentials, system proxy, official binary, global
-configuration (beyond the reversible diagnostic A/B), protocol translation, or
-internal Codex database should be changed to work around this defect.
+This is a retained historical incident report, not a current live-control
+replay. Its fixture verifier validates only sanitized structural facts; it does
+not create a live Task or establish active Task listing, remote-control
+enrollment, worktree/placeholder cleanup, or repeated-run leak coverage. The
+historical A/B isolated the startup delay to an optional global MCP server; the
+reported full-access preflight was policy metadata, not a filesystem or network
+access exercise. CodexHub does run bounded external app-server probes for model
+and usage reads, but no committed path proves that those probes start or break
+this MCP, or that they control native Task persistence. CodexHub does not manage
+this MCP server or the native Task persistence lifecycle. No credentials, system
+proxy, official binary, global configuration (beyond the reversible diagnostic
+A/B), protocol translation, or internal Codex database should be changed to
+work around this defect.
 
 ## Requested fix
 

--- a/docs/evidence/issue-106/task-creation-lifecycle.json
+++ b/docs/evidence/issue-106/task-creation-lifecycle.json
@@ -8,7 +8,7 @@
       "repository_inspection": "read_only",
       "live_task_creation": "not_authorized"
     },
-    "conclusion_limit": "This fixture verifies the retained structural facts. It is not a live Task-create replay and does not establish a repeated-run process-leak result."
+    "conclusion_limit": "This fixture only verifies retained historical structural facts. It is not a live Task-create, active-Task-list, or official remote lifecycle replay, and it does not establish access, remote-control, worktree/placeholder, or repeated-run leak coverage."
   },
   "product_boundary": {
     "codexhub_manages_global_mcp": false,

--- a/docs/evidence/issue-106/task-creation-lifecycle.json
+++ b/docs/evidence/issue-106/task-creation-lifecycle.json
@@ -1,0 +1,70 @@
+{
+  "schema_version": 1,
+  "capture_kind": "sanitized_task_creation_ab_evidence",
+  "source": {
+    "evidence_type": "observed A/B plus read-only repository inspection",
+    "conclusion_limit": "This fixture verifies the retained structural facts. It is not a live Task-create replay and does not establish a repeated-run process-leak result."
+  },
+  "product_boundary": {
+    "codexhub_manages_global_mcp": false,
+    "codexhub_has_bounded_app_server_model_probes": true,
+    "codexhub_exposes_native_task_lifecycle": false,
+    "proven_link_from_model_probes_to_task_materialization": false,
+    "product_behavior_changed": false
+  },
+  "red_case": {
+    "classification": "half_created",
+    "client_placeholder_created": true,
+    "worktree_provisioned": true,
+    "rollout_materialized": false,
+    "native_task_listing_contains_placeholder": false,
+    "client_timeout_exceeded": true,
+    "supported_task_operations": {
+      "read": "unavailable_no_session",
+      "message": "unavailable_no_session",
+      "rename": "unavailable_no_session",
+      "archive": "rejected_no_session",
+      "delete": "rejected_no_session"
+    }
+  },
+  "green_case": {
+    "bootstrap": {
+      "global_openai_developer_docs_mcp_enabled": false,
+      "profile": "short_low_cost"
+    },
+    "materialized": true,
+    "materialization_seconds": 10.146,
+    "lifecycle": {
+      "create": "passed",
+      "read": "passed",
+      "message": "passed"
+    },
+    "permission_preflight": {
+      "filesystem": "unrestricted",
+      "network": "enabled",
+      "approval": "never"
+    },
+    "git_preflight": "passed"
+  },
+  "official_remote_control": {
+    "read_existing_materialized_task": "available",
+    "create_replay": "not_run_without_orchestrator_approval"
+  },
+  "cleanup_observation": {
+    "clean_orphan_worktrees_removed": 2,
+    "client_held_empty_directory": true,
+    "official_client_handle_release_required": true,
+    "internal_codex_database_edited": false
+  },
+  "leak_detection": {
+    "repeated_task_creation_runs": 0,
+    "app_server_processes": "not_run_without_orchestrator_approval",
+    "claim": "no_repeated_run_no_leak_claim"
+  },
+  "sanitization": {
+    "contains_credentials": false,
+    "contains_local_paths": false,
+    "contains_prompts_or_messages": false,
+    "contains_task_or_session_identifiers": false
+  }
+}

--- a/docs/evidence/issue-106/task-creation-lifecycle.json
+++ b/docs/evidence/issue-106/task-creation-lifecycle.json
@@ -3,11 +3,20 @@
   "capture_kind": "sanitized_task_creation_ab_evidence",
   "source": {
     "evidence_type": "observed A/B plus read-only repository inspection",
+    "provenance": {
+      "observation_basis": "orchestrator_observed_ab",
+      "repository_inspection": "read_only",
+      "live_task_creation": "not_authorized"
+    },
     "conclusion_limit": "This fixture verifies the retained structural facts. It is not a live Task-create replay and does not establish a repeated-run process-leak result."
   },
   "product_boundary": {
     "codexhub_manages_global_mcp": false,
     "codexhub_has_bounded_app_server_model_probes": true,
+    "bounded_app_server_probe_sources": [
+      "src-tauri/src/models.rs",
+      "src-tauri/src/openai_usage.rs"
+    ],
     "codexhub_exposes_native_task_lifecycle": false,
     "proven_link_from_model_probes_to_task_materialization": false,
     "product_behavior_changed": false

--- a/scripts/check_codex_task_creation_lifecycle.py
+++ b/scripts/check_codex_task_creation_lifecycle.py
@@ -381,7 +381,7 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.replay_case == "identity":
         print("Task creation A/B: half_created -> materialized")
-        print("Live remote create replay: not run without Orchestrator approval")
+        print("Historical fixture only; live replay is isolated in the Issue #106 lifecycle runner")
         print("TASK_CREATION_LIFECYCLE_COMPLETE")
         return 0
 

--- a/scripts/check_codex_task_creation_lifecycle.py
+++ b/scripts/check_codex_task_creation_lifecycle.py
@@ -1,8 +1,9 @@
-"""Replay the sanitized Issue #106 task-creation A/B lifecycle contract.
+"""Verify the retained sanitized Issue #106 historical fixture.
 
 This is deliberately a fixture verifier, not a Task creator. It must never
 create a Codex Task, modify global Codex configuration, or inspect internal
-Codex databases. A live create replay requires explicit Orchestrator approval.
+Codex databases. The separate isolated lifecycle runner owns the authorized
+live controls; this fixture does not establish their coverage.
 """
 
 from __future__ import annotations
@@ -63,8 +64,9 @@ EVIDENCE_SCHEMA: dict[str, Any] = {
             "live_task_creation": "not_authorized",
         },
         "conclusion_limit": (
-            "This fixture verifies the retained structural facts. It is not a live Task-create replay "
-            "and does not establish a repeated-run process-leak result."
+            "This fixture only verifies retained historical structural facts. It is not a live Task-create, "
+            "active-Task-list, or official remote lifecycle replay, and it does not establish access, "
+            "remote-control, worktree/placeholder, or repeated-run leak coverage."
         ),
     },
     "product_boundary": {

--- a/scripts/check_codex_task_creation_lifecycle.py
+++ b/scripts/check_codex_task_creation_lifecycle.py
@@ -371,26 +371,35 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 1
 
-    replay = deepcopy(evidence)
-    apply_replay_case(replay, args.replay_case)
-    mismatches = validate_evidence(replay)
-    if mismatches:
+    original_mismatches = validate_evidence(evidence)
+    if original_mismatches:
         print(
-            "TASK_CREATION_LIFECYCLE_MISMATCH: " + " | ".join(mismatches),
+            "TASK_CREATION_LIFECYCLE_MISMATCH: " + " | ".join(original_mismatches),
             file=sys.stderr,
         )
         return 1
-    if args.replay_case != "identity":
+
+    if args.replay_case == "identity":
+        print("Task creation A/B: half_created -> materialized")
+        print("Live remote create replay: not run without Orchestrator approval")
+        print("TASK_CREATION_LIFECYCLE_COMPLETE")
+        return 0
+
+    replay = deepcopy(evidence)
+    apply_replay_case(replay, args.replay_case)
+    replay_mismatches = validate_evidence(replay)
+    if replay_mismatches:
         print(
-            f"NEGATIVE_REPLAY_CONTROL_DID_NOT_FAIL: {args.replay_case}",
+            "TASK_CREATION_LIFECYCLE_MISMATCH: " + " | ".join(replay_mismatches),
             file=sys.stderr,
         )
-        return 2
+        return 1
 
-    print("Task creation A/B: half_created -> materialized")
-    print("Live remote create replay: not run without Orchestrator approval")
-    print("TASK_CREATION_LIFECYCLE_COMPLETE")
-    return 0
+    print(
+        f"NEGATIVE_REPLAY_CONTROL_DID_NOT_FAIL: {args.replay_case}",
+        file=sys.stderr,
+    )
+    return 2
 
 
 if __name__ == "__main__":

--- a/scripts/check_codex_task_creation_lifecycle.py
+++ b/scripts/check_codex_task_creation_lifecycle.py
@@ -1,0 +1,332 @@
+"""Replay the sanitized Issue #106 task-creation A/B lifecycle contract.
+
+This is deliberately a fixture verifier, not a Task creator. It must never
+create a Codex Task, modify global Codex configuration, or inspect internal
+Codex databases. A live create replay requires explicit Orchestrator approval.
+"""
+
+from __future__ import annotations
+
+import argparse
+from copy import deepcopy
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_EVIDENCE_PATH = REPO_ROOT / "docs" / "evidence" / "issue-106" / "task-creation-lifecycle.json"
+OWNERSHIP_BOUNDARY_PATHS = (
+    Path("src-python/config_overlay.py"),
+    Path("src-python/catalog_sync.py"),
+    Path("src-tauri/src/catalog.rs"),
+    Path("src-tauri/src/config.rs"),
+    Path("src-tauri/src/proxy.rs"),
+)
+GLOBAL_MCP_CONFIGURATION_TOKENS = ("openaideveloperdocs", "mcp_servers")
+FORBIDDEN_KEYS = {
+    "api_key",
+    "authorization",
+    "client_thread_id",
+    "cwd",
+    "session_id",
+    "task_id",
+    "thread_id",
+    "worktree_path",
+}
+EXPECTED_SANITIZATION = {
+    "contains_credentials": False,
+    "contains_local_paths": False,
+    "contains_prompts_or_messages": False,
+    "contains_task_or_session_identifiers": False,
+}
+
+
+def _mapping(value: Any, label: str, mismatches: list[str]) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    mismatches.append(f"{label} must be an object")
+    return {}
+
+
+def _value(mapping: dict[str, Any], key: str, label: str, mismatches: list[str]) -> Any:
+    if key in mapping:
+        return mapping[key]
+    mismatches.append(f"{label}.{key} is missing")
+    return None
+
+
+def _expect_equal(actual: Any, expected: Any, label: str, mismatches: list[str]) -> None:
+    if actual != expected:
+        mismatches.append(f"{label} did not match the expected contract")
+
+
+def _forbidden_key_paths(value: Any, prefix: str = "$") -> list[str]:
+    if isinstance(value, dict):
+        found: list[str] = []
+        for key, child in value.items():
+            child_path = f"{prefix}.{key}"
+            if key in FORBIDDEN_KEYS:
+                found.append(child_path)
+            found.extend(_forbidden_key_paths(child, child_path))
+        return found
+    if isinstance(value, list):
+        return [
+            path
+            for index, child in enumerate(value)
+            for path in _forbidden_key_paths(child, f"{prefix}[{index}]")
+        ]
+    return []
+
+
+def validate_owned_boundary_sources(repo_root: Path = REPO_ROOT) -> list[str]:
+    """Check that the known CodexHub ownership boundary has not gained MCP config."""
+
+    mismatches: list[str] = []
+    for relative_path in OWNERSHIP_BOUNDARY_PATHS:
+        path = repo_root / relative_path
+        try:
+            source = path.read_text(encoding="utf-8").lower()
+        except OSError as error:
+            mismatches.append(f"ownership boundary source unavailable: {relative_path}: {error}")
+            continue
+        for token in GLOBAL_MCP_CONFIGURATION_TOKENS:
+            if token in source:
+                mismatches.append(f"ownership boundary source configures global MCP token {token!r}: {relative_path}")
+    return mismatches
+
+
+def validate_evidence(evidence: Any) -> list[str]:
+    """Return every replay-contract mismatch without exposing fixture values."""
+
+    mismatches: list[str] = []
+    root = _mapping(evidence, "evidence", mismatches)
+    _expect_equal(_value(root, "schema_version", "evidence", mismatches), 1, "schema_version", mismatches)
+    _expect_equal(
+        _value(root, "capture_kind", "evidence", mismatches),
+        "sanitized_task_creation_ab_evidence",
+        "capture_kind",
+        mismatches,
+    )
+
+    product_boundary = _mapping(_value(root, "product_boundary", "evidence", mismatches), "product_boundary", mismatches)
+    _expect_equal(
+        _value(product_boundary, "codexhub_manages_global_mcp", "product_boundary", mismatches),
+        False,
+        "product_boundary.codexhub_manages_global_mcp",
+        mismatches,
+    )
+    _expect_equal(
+        _value(product_boundary, "codexhub_has_bounded_app_server_model_probes", "product_boundary", mismatches),
+        True,
+        "product_boundary.codexhub_has_bounded_app_server_model_probes",
+        mismatches,
+    )
+    _expect_equal(
+        _value(product_boundary, "codexhub_exposes_native_task_lifecycle", "product_boundary", mismatches),
+        False,
+        "product_boundary.codexhub_exposes_native_task_lifecycle",
+        mismatches,
+    )
+    _expect_equal(
+        _value(product_boundary, "proven_link_from_model_probes_to_task_materialization", "product_boundary", mismatches),
+        False,
+        "product_boundary.proven_link_from_model_probes_to_task_materialization",
+        mismatches,
+    )
+    _expect_equal(
+        _value(product_boundary, "product_behavior_changed", "product_boundary", mismatches),
+        False,
+        "product_boundary.product_behavior_changed",
+        mismatches,
+    )
+
+    red = _mapping(_value(root, "red_case", "evidence", mismatches), "red_case", mismatches)
+    for key, expected in {
+        "classification": "half_created",
+        "client_placeholder_created": True,
+        "worktree_provisioned": True,
+        "rollout_materialized": False,
+        "native_task_listing_contains_placeholder": False,
+        "client_timeout_exceeded": True,
+    }.items():
+        _expect_equal(_value(red, key, "red_case", mismatches), expected, f"red_case.{key}", mismatches)
+    red_operations = _mapping(
+        _value(red, "supported_task_operations", "red_case", mismatches),
+        "red_case.supported_task_operations",
+        mismatches,
+    )
+    for operation, expected in {
+        "read": "unavailable_no_session",
+        "message": "unavailable_no_session",
+        "rename": "unavailable_no_session",
+        "archive": "rejected_no_session",
+        "delete": "rejected_no_session",
+    }.items():
+        _expect_equal(
+            _value(red_operations, operation, "red_case.supported_task_operations", mismatches),
+            expected,
+            f"red_case.supported_task_operations.{operation}",
+            mismatches,
+        )
+
+    green = _mapping(_value(root, "green_case", "evidence", mismatches), "green_case", mismatches)
+    _expect_equal(_value(green, "materialized", "green_case", mismatches), True, "green_case.materialized", mismatches)
+    materialization_seconds = _value(green, "materialization_seconds", "green_case", mismatches)
+    if not isinstance(materialization_seconds, (int, float)) or isinstance(materialization_seconds, bool):
+        mismatches.append("green_case.materialization_seconds must be numeric")
+    elif not 0 < materialization_seconds <= 15:
+        mismatches.append("green_case.materialization_seconds must be within the bounded bootstrap window")
+    green_bootstrap = _mapping(_value(green, "bootstrap", "green_case", mismatches), "green_case.bootstrap", mismatches)
+    _expect_equal(
+        _value(green_bootstrap, "global_openai_developer_docs_mcp_enabled", "green_case.bootstrap", mismatches),
+        False,
+        "green_case.bootstrap.global_openai_developer_docs_mcp_enabled",
+        mismatches,
+    )
+    green_lifecycle = _mapping(_value(green, "lifecycle", "green_case", mismatches), "green_case.lifecycle", mismatches)
+    for operation in ("create", "read", "message"):
+        _expect_equal(
+            _value(green_lifecycle, operation, "green_case.lifecycle", mismatches),
+            "passed",
+            f"green_case.lifecycle.{operation}",
+            mismatches,
+        )
+    _expect_equal(
+        _value(green, "permission_preflight", "green_case", mismatches),
+        {"filesystem": "unrestricted", "network": "enabled", "approval": "never"},
+        "green_case.permission_preflight",
+        mismatches,
+    )
+    _expect_equal(
+        _value(green, "git_preflight", "green_case", mismatches),
+        "passed",
+        "green_case.git_preflight",
+        mismatches,
+    )
+
+    remote_control = _mapping(
+        _value(root, "official_remote_control", "evidence", mismatches),
+        "official_remote_control",
+        mismatches,
+    )
+    _expect_equal(
+        _value(remote_control, "read_existing_materialized_task", "official_remote_control", mismatches),
+        "available",
+        "official_remote_control.read_existing_materialized_task",
+        mismatches,
+    )
+    _expect_equal(
+        _value(remote_control, "create_replay", "official_remote_control", mismatches),
+        "not_run_without_orchestrator_approval",
+        "official_remote_control.create_replay",
+        mismatches,
+    )
+
+    cleanup = _mapping(
+        _value(root, "cleanup_observation", "evidence", mismatches), "cleanup_observation", mismatches
+    )
+    for key, expected in {
+        "clean_orphan_worktrees_removed": 2,
+        "client_held_empty_directory": True,
+        "official_client_handle_release_required": True,
+        "internal_codex_database_edited": False,
+    }.items():
+        _expect_equal(_value(cleanup, key, "cleanup_observation", mismatches), expected, f"cleanup_observation.{key}", mismatches)
+
+    leak_detection = _mapping(
+        _value(root, "leak_detection", "evidence", mismatches), "leak_detection", mismatches
+    )
+    _expect_equal(
+        _value(leak_detection, "repeated_task_creation_runs", "leak_detection", mismatches),
+        0,
+        "leak_detection.repeated_task_creation_runs",
+        mismatches,
+    )
+    _expect_equal(
+        _value(leak_detection, "app_server_processes", "leak_detection", mismatches),
+        "not_run_without_orchestrator_approval",
+        "leak_detection.app_server_processes",
+        mismatches,
+    )
+    _expect_equal(
+        _value(leak_detection, "claim", "leak_detection", mismatches),
+        "no_repeated_run_no_leak_claim",
+        "leak_detection.claim",
+        mismatches,
+    )
+
+    sanitization = _value(root, "sanitization", "evidence", mismatches)
+    _expect_equal(sanitization, EXPECTED_SANITIZATION, "sanitization", mismatches)
+    for path in _forbidden_key_paths(root):
+        mismatches.append(f"sanitization forbids identifier or secret key at {path}")
+    mismatches.extend(validate_owned_boundary_sources())
+    return mismatches
+
+
+def apply_replay_case(evidence: dict[str, Any], replay_case: str) -> None:
+    if replay_case == "identity":
+        return
+    if replay_case == "materialize-red":
+        evidence["red_case"]["rollout_materialized"] = True
+        return
+    if replay_case == "unmaterialize-green":
+        evidence["green_case"]["materialized"] = False
+        return
+    if replay_case == "fail-git-preflight":
+        evidence["green_case"]["git_preflight"] = "failed"
+        return
+    if replay_case == "skip-cleanup":
+        evidence["cleanup_observation"]["clean_orphan_worktrees_removed"] = 1
+        return
+    if replay_case == "identifier-leak":
+        evidence["red_case"]["task_id"] = "forbidden"
+        return
+    raise ValueError(f"unknown replay case: {replay_case}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--evidence", type=Path, default=DEFAULT_EVIDENCE_PATH)
+    parser.add_argument(
+        "--replay-case",
+        choices=(
+            "identity",
+            "materialize-red",
+            "unmaterialize-green",
+            "fail-git-preflight",
+            "skip-cleanup",
+            "identifier-leak",
+        ),
+        default="identity",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        evidence = json.loads(args.evidence.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        print("TASK_CREATION_LIFECYCLE_MISMATCH: unable to read sanitized evidence", file=sys.stderr)
+        return 1
+    if not isinstance(evidence, dict):
+        print("TASK_CREATION_LIFECYCLE_MISMATCH: evidence root must be an object", file=sys.stderr)
+        return 1
+
+    replay = deepcopy(evidence)
+    apply_replay_case(replay, args.replay_case)
+    mismatches = validate_evidence(replay)
+    if mismatches:
+        print("TASK_CREATION_LIFECYCLE_MISMATCH: " + " | ".join(mismatches), file=sys.stderr)
+        return 1
+    if args.replay_case != "identity":
+        print(f"NEGATIVE_REPLAY_CONTROL_DID_NOT_FAIL: {args.replay_case}", file=sys.stderr)
+        return 2
+
+    print("Task creation A/B: half_created -> materialized")
+    print("Live remote create replay: not run without Orchestrator approval")
+    print("TASK_CREATION_LIFECYCLE_COMPLETE")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_codex_task_creation_lifecycle.py
+++ b/scripts/check_codex_task_creation_lifecycle.py
@@ -28,19 +28,18 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_EVIDENCE_PATH = (
     REPO_ROOT / "docs" / "evidence" / "issue-106" / "task-creation-lifecycle.json"
 )
+APP_SERVER_PROBE_MARKERS = {
+    Path("src-tauri/src/models.rs"): 'args(["app-server", "--stdio"])',
+    Path("src-tauri/src/openai_usage.rs"): 'args(["app-server", "--stdio"])',
+}
 OWNERSHIP_BOUNDARY_PATHS = (
     Path("src-python/config_overlay.py"),
     Path("src-python/catalog_sync.py"),
     Path("src-tauri/src/catalog.rs"),
     Path("src-tauri/src/config.rs"),
     Path("src-tauri/src/proxy.rs"),
-    Path("src-tauri/src/models.rs"),
-    Path("src-tauri/src/openai_usage.rs"),
+    *APP_SERVER_PROBE_MARKERS,
 )
-APP_SERVER_PROBE_MARKERS = {
-    Path("src-tauri/src/models.rs"): 'args(["app-server", "--stdio"])',
-    Path("src-tauri/src/openai_usage.rs"): 'args(["app-server", "--stdio"])',
-}
 GLOBAL_MCP_CONFIGURATION_TOKENS = ("openaideveloperdocs", "mcp_servers")
 FORBIDDEN_KEYS = {
     "api_key",
@@ -160,7 +159,8 @@ TASK_OR_SESSION_IDENTIFIER_PATTERN = re.compile(
     re.IGNORECASE,
 )
 CREDENTIAL_SHAPE_PATTERN = re.compile(
-    r"(?:\b(?:sk|ghp|gho|github_pat)_[a-z0-9_-]+\b|\bbearer\s+\S+|"
+    r"(?:\b(?:sk(?:[-_][a-z0-9][a-z0-9_-]*)+|ghp_[a-z0-9_-]+|gho_[a-z0-9_-]+|"
+    r"github_pat_[a-z0-9_-]+)\b|\bbearer\s+\S+|"
     r"\b(?:api[_ -]?key|authorization|credential|secret|password|token)\b)",
     re.IGNORECASE,
 )
@@ -191,7 +191,7 @@ def _require_exact_fields(
 def _expect_equal(
     actual: Any, expected: Any, label: str, mismatches: list[str]
 ) -> None:
-    if actual != expected:
+    if type(actual) is not type(expected) or actual != expected:
         mismatches.append(f"{label} did not match the expected contract")
 
 

--- a/scripts/check_codex_task_creation_lifecycle.py
+++ b/scripts/check_codex_task_creation_lifecycle.py
@@ -11,19 +11,36 @@ import argparse
 from copy import deepcopy
 import json
 from pathlib import Path
+import re
 import sys
 from typing import Any
 
 
+class NumberRange:
+    """A numeric schema leaf with an exclusive lower and inclusive upper bound."""
+
+    def __init__(self, minimum: float, maximum: float) -> None:
+        self.minimum = minimum
+        self.maximum = maximum
+
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
-DEFAULT_EVIDENCE_PATH = REPO_ROOT / "docs" / "evidence" / "issue-106" / "task-creation-lifecycle.json"
+DEFAULT_EVIDENCE_PATH = (
+    REPO_ROOT / "docs" / "evidence" / "issue-106" / "task-creation-lifecycle.json"
+)
 OWNERSHIP_BOUNDARY_PATHS = (
     Path("src-python/config_overlay.py"),
     Path("src-python/catalog_sync.py"),
     Path("src-tauri/src/catalog.rs"),
     Path("src-tauri/src/config.rs"),
     Path("src-tauri/src/proxy.rs"),
+    Path("src-tauri/src/models.rs"),
+    Path("src-tauri/src/openai_usage.rs"),
 )
+APP_SERVER_PROBE_MARKERS = {
+    Path("src-tauri/src/models.rs"): 'args(["app-server", "--stdio"])',
+    Path("src-tauri/src/openai_usage.rs"): 'args(["app-server", "--stdio"])',
+}
 GLOBAL_MCP_CONFIGURATION_TOKENS = ("openaideveloperdocs", "mcp_servers")
 FORBIDDEN_KEYS = {
     "api_key",
@@ -35,233 +52,269 @@ FORBIDDEN_KEYS = {
     "thread_id",
     "worktree_path",
 }
-EXPECTED_SANITIZATION = {
-    "contains_credentials": False,
-    "contains_local_paths": False,
-    "contains_prompts_or_messages": False,
-    "contains_task_or_session_identifiers": False,
-}
 
-
-def _mapping(value: Any, label: str, mismatches: list[str]) -> dict[str, Any]:
-    if isinstance(value, dict):
-        return value
-    mismatches.append(f"{label} must be an object")
-    return {}
-
-
-def _value(mapping: dict[str, Any], key: str, label: str, mismatches: list[str]) -> Any:
-    if key in mapping:
-        return mapping[key]
-    mismatches.append(f"{label}.{key} is missing")
-    return None
-
-
-def _expect_equal(actual: Any, expected: Any, label: str, mismatches: list[str]) -> None:
-    if actual != expected:
-        mismatches.append(f"{label} did not match the expected contract")
-
-
-def _forbidden_key_paths(value: Any, prefix: str = "$") -> list[str]:
-    if isinstance(value, dict):
-        found: list[str] = []
-        for key, child in value.items():
-            child_path = f"{prefix}.{key}"
-            if key in FORBIDDEN_KEYS:
-                found.append(child_path)
-            found.extend(_forbidden_key_paths(child, child_path))
-        return found
-    if isinstance(value, list):
-        return [
-            path
-            for index, child in enumerate(value)
-            for path in _forbidden_key_paths(child, f"{prefix}[{index}]")
-        ]
-    return []
-
-
-def validate_owned_boundary_sources(repo_root: Path = REPO_ROOT) -> list[str]:
-    """Check that the known CodexHub ownership boundary has not gained MCP config."""
-
-    mismatches: list[str] = []
-    for relative_path in OWNERSHIP_BOUNDARY_PATHS:
-        path = repo_root / relative_path
-        try:
-            source = path.read_text(encoding="utf-8").lower()
-        except OSError as error:
-            mismatches.append(f"ownership boundary source unavailable: {relative_path}: {error}")
-            continue
-        for token in GLOBAL_MCP_CONFIGURATION_TOKENS:
-            if token in source:
-                mismatches.append(f"ownership boundary source configures global MCP token {token!r}: {relative_path}")
-    return mismatches
-
-
-def validate_evidence(evidence: Any) -> list[str]:
-    """Return every replay-contract mismatch without exposing fixture values."""
-
-    mismatches: list[str] = []
-    root = _mapping(evidence, "evidence", mismatches)
-    _expect_equal(_value(root, "schema_version", "evidence", mismatches), 1, "schema_version", mismatches)
-    _expect_equal(
-        _value(root, "capture_kind", "evidence", mismatches),
-        "sanitized_task_creation_ab_evidence",
-        "capture_kind",
-        mismatches,
-    )
-
-    product_boundary = _mapping(_value(root, "product_boundary", "evidence", mismatches), "product_boundary", mismatches)
-    _expect_equal(
-        _value(product_boundary, "codexhub_manages_global_mcp", "product_boundary", mismatches),
-        False,
-        "product_boundary.codexhub_manages_global_mcp",
-        mismatches,
-    )
-    _expect_equal(
-        _value(product_boundary, "codexhub_has_bounded_app_server_model_probes", "product_boundary", mismatches),
-        True,
-        "product_boundary.codexhub_has_bounded_app_server_model_probes",
-        mismatches,
-    )
-    _expect_equal(
-        _value(product_boundary, "codexhub_exposes_native_task_lifecycle", "product_boundary", mismatches),
-        False,
-        "product_boundary.codexhub_exposes_native_task_lifecycle",
-        mismatches,
-    )
-    _expect_equal(
-        _value(product_boundary, "proven_link_from_model_probes_to_task_materialization", "product_boundary", mismatches),
-        False,
-        "product_boundary.proven_link_from_model_probes_to_task_materialization",
-        mismatches,
-    )
-    _expect_equal(
-        _value(product_boundary, "product_behavior_changed", "product_boundary", mismatches),
-        False,
-        "product_boundary.product_behavior_changed",
-        mismatches,
-    )
-
-    red = _mapping(_value(root, "red_case", "evidence", mismatches), "red_case", mismatches)
-    for key, expected in {
+EVIDENCE_SCHEMA: dict[str, Any] = {
+    "schema_version": 1,
+    "capture_kind": "sanitized_task_creation_ab_evidence",
+    "source": {
+        "evidence_type": "observed A/B plus read-only repository inspection",
+        "provenance": {
+            "observation_basis": "orchestrator_observed_ab",
+            "repository_inspection": "read_only",
+            "live_task_creation": "not_authorized",
+        },
+        "conclusion_limit": (
+            "This fixture verifies the retained structural facts. It is not a live Task-create replay "
+            "and does not establish a repeated-run process-leak result."
+        ),
+    },
+    "product_boundary": {
+        "codexhub_manages_global_mcp": False,
+        "codexhub_has_bounded_app_server_model_probes": True,
+        "bounded_app_server_probe_sources": [
+            "src-tauri/src/models.rs",
+            "src-tauri/src/openai_usage.rs",
+        ],
+        "codexhub_exposes_native_task_lifecycle": False,
+        "proven_link_from_model_probes_to_task_materialization": False,
+        "product_behavior_changed": False,
+    },
+    "red_case": {
         "classification": "half_created",
         "client_placeholder_created": True,
         "worktree_provisioned": True,
         "rollout_materialized": False,
         "native_task_listing_contains_placeholder": False,
         "client_timeout_exceeded": True,
-    }.items():
-        _expect_equal(_value(red, key, "red_case", mismatches), expected, f"red_case.{key}", mismatches)
-    red_operations = _mapping(
-        _value(red, "supported_task_operations", "red_case", mismatches),
-        "red_case.supported_task_operations",
-        mismatches,
-    )
-    for operation, expected in {
-        "read": "unavailable_no_session",
-        "message": "unavailable_no_session",
-        "rename": "unavailable_no_session",
-        "archive": "rejected_no_session",
-        "delete": "rejected_no_session",
-    }.items():
-        _expect_equal(
-            _value(red_operations, operation, "red_case.supported_task_operations", mismatches),
-            expected,
-            f"red_case.supported_task_operations.{operation}",
-            mismatches,
-        )
-
-    green = _mapping(_value(root, "green_case", "evidence", mismatches), "green_case", mismatches)
-    _expect_equal(_value(green, "materialized", "green_case", mismatches), True, "green_case.materialized", mismatches)
-    materialization_seconds = _value(green, "materialization_seconds", "green_case", mismatches)
-    if not isinstance(materialization_seconds, (int, float)) or isinstance(materialization_seconds, bool):
-        mismatches.append("green_case.materialization_seconds must be numeric")
-    elif not 0 < materialization_seconds <= 15:
-        mismatches.append("green_case.materialization_seconds must be within the bounded bootstrap window")
-    green_bootstrap = _mapping(_value(green, "bootstrap", "green_case", mismatches), "green_case.bootstrap", mismatches)
-    _expect_equal(
-        _value(green_bootstrap, "global_openai_developer_docs_mcp_enabled", "green_case.bootstrap", mismatches),
-        False,
-        "green_case.bootstrap.global_openai_developer_docs_mcp_enabled",
-        mismatches,
-    )
-    green_lifecycle = _mapping(_value(green, "lifecycle", "green_case", mismatches), "green_case.lifecycle", mismatches)
-    for operation in ("create", "read", "message"):
-        _expect_equal(
-            _value(green_lifecycle, operation, "green_case.lifecycle", mismatches),
-            "passed",
-            f"green_case.lifecycle.{operation}",
-            mismatches,
-        )
-    _expect_equal(
-        _value(green, "permission_preflight", "green_case", mismatches),
-        {"filesystem": "unrestricted", "network": "enabled", "approval": "never"},
-        "green_case.permission_preflight",
-        mismatches,
-    )
-    _expect_equal(
-        _value(green, "git_preflight", "green_case", mismatches),
-        "passed",
-        "green_case.git_preflight",
-        mismatches,
-    )
-
-    remote_control = _mapping(
-        _value(root, "official_remote_control", "evidence", mismatches),
-        "official_remote_control",
-        mismatches,
-    )
-    _expect_equal(
-        _value(remote_control, "read_existing_materialized_task", "official_remote_control", mismatches),
-        "available",
-        "official_remote_control.read_existing_materialized_task",
-        mismatches,
-    )
-    _expect_equal(
-        _value(remote_control, "create_replay", "official_remote_control", mismatches),
-        "not_run_without_orchestrator_approval",
-        "official_remote_control.create_replay",
-        mismatches,
-    )
-
-    cleanup = _mapping(
-        _value(root, "cleanup_observation", "evidence", mismatches), "cleanup_observation", mismatches
-    )
-    for key, expected in {
+        "supported_task_operations": {
+            "read": "unavailable_no_session",
+            "message": "unavailable_no_session",
+            "rename": "unavailable_no_session",
+            "archive": "rejected_no_session",
+            "delete": "rejected_no_session",
+        },
+    },
+    "green_case": {
+        "bootstrap": {
+            "global_openai_developer_docs_mcp_enabled": False,
+            "profile": "short_low_cost",
+        },
+        "materialized": True,
+        "materialization_seconds": NumberRange(0, 15),
+        "lifecycle": {
+            "create": "passed",
+            "read": "passed",
+            "message": "passed",
+        },
+        "permission_preflight": {
+            "filesystem": "unrestricted",
+            "network": "enabled",
+            "approval": "never",
+        },
+        "git_preflight": "passed",
+    },
+    "official_remote_control": {
+        "read_existing_materialized_task": "available",
+        "create_replay": "not_run_without_orchestrator_approval",
+    },
+    "cleanup_observation": {
         "clean_orphan_worktrees_removed": 2,
         "client_held_empty_directory": True,
         "official_client_handle_release_required": True,
         "internal_codex_database_edited": False,
-    }.items():
-        _expect_equal(_value(cleanup, key, "cleanup_observation", mismatches), expected, f"cleanup_observation.{key}", mismatches)
+    },
+    "leak_detection": {
+        "repeated_task_creation_runs": 0,
+        "app_server_processes": "not_run_without_orchestrator_approval",
+        "claim": "no_repeated_run_no_leak_claim",
+    },
+    "sanitization": {
+        "contains_credentials": False,
+        "contains_local_paths": False,
+        "contains_prompts_or_messages": False,
+        "contains_task_or_session_identifiers": False,
+    },
+}
 
-    leak_detection = _mapping(
-        _value(root, "leak_detection", "evidence", mismatches), "leak_detection", mismatches
-    )
-    _expect_equal(
-        _value(leak_detection, "repeated_task_creation_runs", "leak_detection", mismatches),
-        0,
-        "leak_detection.repeated_task_creation_runs",
-        mismatches,
-    )
-    _expect_equal(
-        _value(leak_detection, "app_server_processes", "leak_detection", mismatches),
-        "not_run_without_orchestrator_approval",
-        "leak_detection.app_server_processes",
-        mismatches,
-    )
-    _expect_equal(
-        _value(leak_detection, "claim", "leak_detection", mismatches),
-        "no_repeated_run_no_leak_claim",
-        "leak_detection.claim",
-        mismatches,
+
+def _schema_field_names(schema: Any) -> frozenset[str]:
+    if not isinstance(schema, dict):
+        return frozenset()
+    return frozenset(schema).union(
+        *(_schema_field_names(child) for child in schema.values())
     )
 
-    sanitization = _value(root, "sanitization", "evidence", mismatches)
-    _expect_equal(sanitization, EXPECTED_SANITIZATION, "sanitization", mismatches)
-    for path in _forbidden_key_paths(root):
-        mismatches.append(f"sanitization forbids identifier or secret key at {path}")
-    mismatches.extend(validate_owned_boundary_sources())
+
+ALLOWED_EVIDENCE_FIELD_NAMES = _schema_field_names(EVIDENCE_SCHEMA)
+WINDOWS_LOCAL_PATH_PATTERN = re.compile(
+    r"(?:\b[a-z]:[\\/]|\\\\[^\\/\r\n]+[\\/]|%(?:userprofile|appdata|localappdata|home)%)",
+    re.IGNORECASE,
+)
+POSIX_LOCAL_PATH_PATTERN = re.compile(
+    r"(?<![A-Za-z0-9_.-])/(?:users|home|tmp|var|private|mnt)(?:/|$)",
+    re.IGNORECASE,
+)
+TASK_OR_SESSION_IDENTIFIER_PATTERN = re.compile(
+    r"(?:\b(?:client[_-]?thread|task|thread|session|rollout)(?:[_-]?id)?[-_:]?[0-9a-f]{8,}\b|"
+    r"\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b)",
+    re.IGNORECASE,
+)
+CREDENTIAL_SHAPE_PATTERN = re.compile(
+    r"(?:\b(?:sk|ghp|gho|github_pat)_[a-z0-9_-]+\b|\bbearer\s+\S+|"
+    r"\b(?:api[_ -]?key|authorization|credential|secret|password|token)\b)",
+    re.IGNORECASE,
+)
+
+
+def _require_object(
+    value: Any, label: str, mismatches: list[str]
+) -> dict[str, Any] | None:
+    if isinstance(value, dict):
+        return value
+    mismatches.append(f"{label} must be an object")
+    return None
+
+
+def _require_exact_fields(
+    mapping: dict[str, Any],
+    expected_fields: frozenset[str],
+    label: str,
+    mismatches: list[str],
+) -> None:
+    missing_fields = sorted(expected_fields - mapping.keys())
+    if missing_fields:
+        mismatches.append(f"{label} has missing fields: {', '.join(missing_fields)}")
+    if set(mapping) - expected_fields:
+        mismatches.append(f"{label} has unexpected fields")
+
+
+def _expect_equal(
+    actual: Any, expected: Any, label: str, mismatches: list[str]
+) -> None:
+    if actual != expected:
+        mismatches.append(f"{label} did not match the expected contract")
+
+
+def _schema_child_label(label: str, key: str) -> str:
+    return key if label == "evidence" else f"{label}.{key}"
+
+
+def _validate_schema(
+    value: Any, schema: Any, label: str, mismatches: list[str]
+) -> None:
+    if isinstance(schema, dict):
+        mapping = _require_object(value, label, mismatches)
+        if mapping is None:
+            return
+        _require_exact_fields(mapping, frozenset(schema), label, mismatches)
+        for key, child_schema in schema.items():
+            if key in mapping:
+                _validate_schema(
+                    mapping[key],
+                    child_schema,
+                    _schema_child_label(label, key),
+                    mismatches,
+                )
+        return
+
+    if isinstance(schema, NumberRange):
+        if not isinstance(value, (int, float)) or isinstance(value, bool):
+            mismatches.append(f"{label} must be numeric")
+        elif not schema.minimum < value <= schema.maximum:
+            mismatches.append(f"{label} must be within the bounded bootstrap window")
+        return
+
+    _expect_equal(value, schema, label, mismatches)
+
+
+def _safe_child_path(prefix: str, key: object) -> str:
+    if isinstance(key, str) and key in ALLOWED_EVIDENCE_FIELD_NAMES:
+        return f"{prefix}.{key}"
+    return f"{prefix}.<unexpected>"
+
+
+def _forbidden_key_count(value: Any) -> int:
+    if isinstance(value, dict):
+        found = 0
+        for key, child in value.items():
+            if isinstance(key, str) and key.casefold() in FORBIDDEN_KEYS:
+                found += 1
+            found += _forbidden_key_count(child)
+        return found
+    if isinstance(value, list):
+        return sum(_forbidden_key_count(child) for child in value)
+    return 0
+
+
+def _unsafe_string_mismatches(value: Any, prefix: str = "$") -> list[str]:
+    if isinstance(value, dict):
+        return [
+            mismatch
+            for key, child in value.items()
+            for mismatch in _unsafe_string_mismatches(
+                child, _safe_child_path(prefix, key)
+            )
+        ]
+    if isinstance(value, list):
+        return [
+            mismatch
+            for index, child in enumerate(value)
+            for mismatch in _unsafe_string_mismatches(child, f"{prefix}[{index}]")
+        ]
+    if not isinstance(value, str):
+        return []
+
+    mismatches: list[str] = []
+    if WINDOWS_LOCAL_PATH_PATTERN.search(value) or POSIX_LOCAL_PATH_PATTERN.search(
+        value
+    ):
+        mismatches.append(f"unsafe local path string at {prefix}")
+    if TASK_OR_SESSION_IDENTIFIER_PATTERN.search(value):
+        mismatches.append(f"unsafe task or session identifier string at {prefix}")
+    if CREDENTIAL_SHAPE_PATTERN.search(value):
+        mismatches.append(f"unsafe credential-like string at {prefix}")
+    return mismatches
+
+
+def validate_owned_boundary_sources(repo_root: Path = REPO_ROOT) -> list[str]:
+    """Check the bounded CodexHub source boundary without exposing host paths."""
+
+    mismatches: list[str] = []
+    for relative_path in OWNERSHIP_BOUNDARY_PATHS:
+        path = repo_root / relative_path
+        try:
+            source = path.read_text(encoding="utf-8").lower()
+        except OSError:
+            mismatches.append(
+                f"ownership boundary source unavailable: {relative_path.as_posix()}"
+            )
+            continue
+        for token in GLOBAL_MCP_CONFIGURATION_TOKENS:
+            if token in source:
+                mismatches.append(
+                    "ownership boundary source configures global MCP token "
+                    f"{token!r}: {relative_path.as_posix()}"
+                )
+        marker = APP_SERVER_PROBE_MARKERS.get(relative_path)
+        if marker is not None and marker.lower() not in source:
+            mismatches.append(
+                "ownership boundary source missing bounded app-server probe: "
+                f"{relative_path.as_posix()}"
+            )
+    return mismatches
+
+
+def validate_evidence(
+    evidence: Any, repo_root: Path = REPO_ROOT
+) -> list[str]:
+    """Return every contract mismatch without exposing untrusted fixture values."""
+
+    mismatches: list[str] = []
+    _validate_schema(evidence, EVIDENCE_SCHEMA, "evidence", mismatches)
+    if _forbidden_key_count(evidence):
+        mismatches.append("sanitization forbids sensitive field names")
+    mismatches.extend(_unsafe_string_mismatches(evidence))
+    mismatches.extend(validate_owned_boundary_sources(repo_root))
     return mismatches
 
 
@@ -306,20 +359,32 @@ def main(argv: list[str] | None = None) -> int:
     try:
         evidence = json.loads(args.evidence.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
-        print("TASK_CREATION_LIFECYCLE_MISMATCH: unable to read sanitized evidence", file=sys.stderr)
+        print(
+            "TASK_CREATION_LIFECYCLE_MISMATCH: unable to read sanitized evidence",
+            file=sys.stderr,
+        )
         return 1
     if not isinstance(evidence, dict):
-        print("TASK_CREATION_LIFECYCLE_MISMATCH: evidence root must be an object", file=sys.stderr)
+        print(
+            "TASK_CREATION_LIFECYCLE_MISMATCH: evidence root must be an object",
+            file=sys.stderr,
+        )
         return 1
 
     replay = deepcopy(evidence)
     apply_replay_case(replay, args.replay_case)
     mismatches = validate_evidence(replay)
     if mismatches:
-        print("TASK_CREATION_LIFECYCLE_MISMATCH: " + " | ".join(mismatches), file=sys.stderr)
+        print(
+            "TASK_CREATION_LIFECYCLE_MISMATCH: " + " | ".join(mismatches),
+            file=sys.stderr,
+        )
         return 1
     if args.replay_case != "identity":
-        print(f"NEGATIVE_REPLAY_CONTROL_DID_NOT_FAIL: {args.replay_case}", file=sys.stderr)
+        print(
+            f"NEGATIVE_REPLAY_CONTROL_DID_NOT_FAIL: {args.replay_case}",
+            file=sys.stderr,
+        )
         return 2
 
     print("Task creation A/B: half_created -> materialized")

--- a/scripts/run_issue_106_task_lifecycle.py
+++ b/scripts/run_issue_106_task_lifecycle.py
@@ -166,9 +166,13 @@ class JsonRpcClient:
             self._responses[message_id] = message
 
     def close(self) -> None:
-        if self._process.stdin is not None:
-            self._process.stdin.close()
-        self._reader.join(timeout=1)
+        try:
+            if self._process.stdin is not None and not self._process.stdin.closed:
+                self._process.stdin.close()
+        except OSError as error:
+            raise AppServerFailure("app_server_client_close_failed") from error
+        finally:
+            self._reader.join(timeout=1)
 
 
 def response_result(response: dict[str, Any], operation: str) -> dict[str, Any]:
@@ -180,7 +184,7 @@ def response_result(response: dict[str, Any], operation: str) -> dict[str, Any]:
     return result
 
 
-def resolve_app_codex(explicit: str | None) -> Path:
+def resolve_issue106_app_codex(explicit: str | None) -> Path:
     if explicit:
         candidate = Path(explicit).expanduser().resolve()
         if candidate.is_file():
@@ -248,7 +252,7 @@ def isolated_environment(home: Path) -> dict[str, str]:
     return environment
 
 
-def run_checked(command: list[str], environment: dict[str, str]) -> None:
+def run_issue106_setup_command(command: list[str], environment: dict[str, str]) -> None:
     try:
         completed = subprocess.run(
             command,
@@ -271,7 +275,7 @@ def prepare_connected_home(
     gateway_base_url: str,
     gateway_key: str | None,
 ) -> None:
-    run_checked(
+    run_issue106_setup_command(
         [sys.executable, str(REPO_ROOT / "src-python" / "catalog_sync.py"), "--sync"],
         environment,
     )
@@ -292,10 +296,10 @@ def prepare_connected_home(
     ]
     if gateway_key:
         overlay_command.extend(("--gateway-key", gateway_key))
-    run_checked(overlay_command, environment)
+    run_issue106_setup_command(overlay_command, environment)
 
 
-def start_app_server(
+def start_issue106_app_server(
     codex_command: Path, home: Path, environment: dict[str, str]
 ) -> subprocess.Popen[str]:
     command = [str(codex_command), "app-server"]
@@ -321,20 +325,55 @@ def start_app_server(
         raise AppServerFailure("app_server_start_failed") from error
 
 
-def stop_app_server(process: subprocess.Popen[str]) -> None:
-    if process.stdin is not None and not process.stdin.closed:
-        process.stdin.close()
+def stop_issue106_app_server(process: subprocess.Popen[str]) -> None:
+    pipe_close_failed = False
+    process_stopped = False
     try:
-        process.wait(timeout=5)
-    except subprocess.TimeoutExpired:
-        process.terminate()
+        if process.stdin is not None and not process.stdin.closed:
+            try:
+                process.stdin.close()
+            except OSError:
+                pipe_close_failed = True
         try:
             process.wait(timeout=5)
-        except subprocess.TimeoutExpired:
-            process.kill()
-            process.wait(timeout=5)
-    if process.stdout is not None:
-        process.stdout.close()
+            process_stopped = True
+        except (OSError, subprocess.TimeoutExpired):
+            pass
+        if not process_stopped:
+            try:
+                process.terminate()
+            except OSError:
+                pass
+            try:
+                process.wait(timeout=5)
+                process_stopped = True
+            except (OSError, subprocess.TimeoutExpired):
+                pass
+        if not process_stopped:
+            try:
+                process.kill()
+            except OSError:
+                pass
+            try:
+                process.wait(timeout=5)
+                process_stopped = True
+            except (OSError, subprocess.TimeoutExpired):
+                pass
+        if not process_stopped:
+            try:
+                process_stopped = process.poll() is not None
+            except OSError:
+                process_stopped = False
+    finally:
+        if process.stdout is not None:
+            try:
+                process.stdout.close()
+            except OSError:
+                pipe_close_failed = True
+    if not process_stopped:
+        raise AppServerFailure("app_server_cleanup_failed")
+    if pipe_close_failed:
+        raise AppServerFailure("app_server_pipe_close_failed")
 
 
 def initialize(client: JsonRpcClient, timeout: float) -> None:
@@ -359,7 +398,9 @@ def initialize(client: JsonRpcClient, timeout: float) -> None:
     client.notify("initialized")
 
 
-def read_model_list(client: JsonRpcClient, timeout: float) -> list[dict[str, Any]]:
+def read_issue106_model_list(
+    client: JsonRpcClient, timeout: float
+) -> list[dict[str, Any]]:
     result = response_result(client.request("model/list", {"limit": 100}, timeout), "model_list")
     models = result.get("data")
     if not isinstance(models, list):
@@ -386,20 +427,48 @@ def model_efforts(model: dict[str, Any]) -> set[str]:
 
 
 def catalog_summary(
-    models: list[dict[str, Any]], requested_official_model: str
+    models: list[dict[str, Any]],
+    requested_official_model: str,
+    external_model: str | None = None,
 ) -> dict[str, Any]:
     ids = {model_id(model) for model in models}
     requested = next(
         (model for model in models if model_id(model) == requested_official_model),
         None,
     )
-    return {
+    summary: dict[str, Any] = {
         "modelCount": len(models),
         "requestedOfficialModelListed": requested_official_model in ids,
         "requestedOfficialModelSupportsMax": bool(
             requested is not None and "max" in model_efforts(requested)
         ),
     }
+    if external_model is not None:
+        summary["externalModelListed"] = external_model in ids
+    return summary
+
+
+def assert_catalog_comparison(
+    official_disconnected: dict[str, Any], codexhub_connected: dict[str, Any]
+) -> None:
+    for snapshot in (official_disconnected, codexhub_connected):
+        if snapshot.get("account") != {
+            "authenticated": False,
+            "requiresOpenaiAuth": True,
+        }:
+            raise AppServerFailure("isolated_catalog_control_not_disconnected")
+        catalog = snapshot.get("catalog")
+        if not isinstance(catalog, dict) or not (
+            catalog.get("requestedOfficialModelListed") is True
+            and catalog.get("requestedOfficialModelSupportsMax") is True
+        ):
+            raise AppServerFailure("requested_official_binding_not_listed")
+    official_catalog = official_disconnected["catalog"]
+    connected_catalog = codexhub_connected["catalog"]
+    if official_catalog.get("externalModelListed") is not False:
+        raise AppServerFailure("external_model_present_in_official_catalog")
+    if connected_catalog.get("externalModelListed") is not True:
+        raise AppServerFailure("external_model_missing_from_connected_catalog")
 
 
 def read_account_summary(client: JsonRpcClient, timeout: float) -> dict[str, bool]:
@@ -524,6 +593,44 @@ def thread_list_contains(
     return any(isinstance(thread, dict) and thread.get("id") == thread_id for thread in threads)
 
 
+def start_issue106_custom_thread(
+    client: JsonRpcClient,
+    workspace: Path,
+    model: str,
+    timeout: float,
+    operation: str,
+) -> str:
+    started = response_result(
+        client.request(
+            "thread/start",
+            {
+                "cwd": str(workspace),
+                "model": model,
+                "modelProvider": "custom",
+                "approvalPolicy": "never",
+                "sandbox": "danger-full-access",
+                "ephemeral": False,
+            },
+            timeout,
+        ),
+        operation,
+    )
+    return get_thread_id(get_thread(started, operation), operation)
+
+
+def cleanup_issue106_thread(
+    client: JsonRpcClient, thread_id: str, timeout: float
+) -> str:
+    try:
+        response_result(
+            client.request("thread/delete", {"threadId": thread_id}, timeout),
+            "thread_delete",
+        )
+        return "failed" if thread_list_contains(client, thread_id, timeout) else "passed"
+    except (AppServerFailure, TimeoutError):
+        return "failed"
+
+
 def binding_summary(result: dict[str, Any]) -> dict[str, Any]:
     return {
         "model": result.get("model"),
@@ -562,7 +669,7 @@ def run_green_lifecycle(
     requested_official_model: str,
 ) -> dict[str, Any]:
     stages: list[str] = ["list"]
-    models = read_model_list(client, timeout)
+    models = read_issue106_model_list(client, timeout)
     model_ids = {model_id(model) for model in models}
     if external_model not in model_ids:
         raise AppServerFailure("external_model_not_listed")
@@ -579,22 +686,9 @@ def run_green_lifecycle(
     result: dict[str, Any] | None = None
     try:
         stages.append("create")
-        started = response_result(
-            client.request(
-                "thread/start",
-                {
-                    "cwd": str(workspace),
-                    "model": external_model,
-                    "modelProvider": "custom",
-                    "approvalPolicy": "never",
-                    "sandbox": "danger-full-access",
-                    "ephemeral": False,
-                },
-                timeout,
-            ),
-            "thread_start",
+        thread_id = start_issue106_custom_thread(
+            client, workspace, external_model, timeout, "thread_start"
         )
-        thread_id = get_thread_id(get_thread(started, "thread_start"), "thread_start")
 
         stages.append("bootstrap")
         bootstrap_turn = turn_started(
@@ -666,18 +760,7 @@ def run_green_lifecycle(
         }
     finally:
         if thread_id is not None:
-            try:
-                response_result(
-                    client.request("thread/delete", {"threadId": thread_id}, 10),
-                    "thread_delete",
-                )
-                native_cleanup = (
-                    "failed"
-                    if thread_list_contains(client, thread_id, 10)
-                    else "passed"
-                )
-            except (AppServerFailure, TimeoutError):
-                native_cleanup = "failed"
+            native_cleanup = cleanup_issue106_thread(client, thread_id, 10)
         if result is not None:
             result["nativeCleanup"] = native_cleanup
     if native_cleanup != "passed":
@@ -722,11 +805,11 @@ def red_continuation(
     try:
         wait_for_turn(client, thread_id, turn_id, timeout)
     except (AppServerFailure, TimeoutError):
-        snapshot = thread_snapshot(client, thread_id, timeout)
-        if snapshot["assistantOutputTurns"] == 0:
-            return {"status": "no_usable_rollout", "snapshot": snapshot}
-        return {"status": "unexpected_output", "snapshot": snapshot}
-    return {"status": "unexpected_turn_completion"}
+        pass
+    snapshot = thread_snapshot(client, thread_id, timeout)
+    if snapshot["assistantOutputTurns"] == 0:
+        return {"status": "no_usable_rollout", "snapshot": snapshot}
+    return {"status": "unexpected_output", "snapshot": snapshot}
 
 
 def run_red_missing_model(
@@ -736,7 +819,7 @@ def run_red_missing_model(
     red_timeout: float,
     red_model: str,
 ) -> dict[str, Any]:
-    models = read_model_list(client, timeout)
+    models = read_issue106_model_list(client, timeout)
     if red_model in {model_id(model) for model in models}:
         raise AppServerFailure("red_model_is_listed")
     workspace = home / "red-workspace"
@@ -746,20 +829,8 @@ def run_red_missing_model(
     result: dict[str, Any] | None = None
     try:
         try:
-            started = response_result(
-                client.request(
-                    "thread/start",
-                    {
-                        "cwd": str(workspace),
-                        "model": red_model,
-                        "modelProvider": "custom",
-                        "approvalPolicy": "never",
-                        "sandbox": "danger-full-access",
-                        "ephemeral": False,
-                    },
-                    timeout,
-                ),
-                "red_thread_start",
+            thread_id = start_issue106_custom_thread(
+                client, workspace, red_model, timeout, "red_thread_start"
             )
         except AppServerRequestRejected:
             result = {
@@ -767,72 +838,66 @@ def run_red_missing_model(
                 "stages": ["list", "create_rejected"],
             }
             native_cleanup = "not_needed"
-            return result
-        thread_id = get_thread_id(get_thread(started, "red_thread_start"), "red_thread_start")
-        try:
-            turn_id = turn_started(
-                client,
-                thread_id,
-                BOOTSTRAP_INPUT,
-                timeout,
-                model=red_model,
-                effort="low",
-            )
-        except AppServerRequestRejected:
-            result = {
-                "outcome": "atomic_rejection",
-                "stages": ["list", "create", "turn_start_rejected"],
-            }
-            return result
-        try:
-            wait_for_turn(client, thread_id, turn_id, red_timeout)
-        except (AppServerFailure, TimeoutError):
-            snapshot = thread_snapshot(client, thread_id, timeout)
-            initial_state = classify_red_snapshot(snapshot)
-            continuation = red_continuation(
-                client, thread_id, min(red_timeout, 20.0)
-            )
-            if (
-                initial_state
-                in {"in_progress_without_output", "failed_without_output"}
-                and continuation["status"]
-                in {"resume_rejected", "turn_rejected", "no_usable_rollout"}
-            ):
-                outcome = "non_atomic_missing_model"
+        else:
+            if thread_id is None:
+                raise AppServerFailure("red_thread_start_missing_thread_id")
+            try:
+                turn_id = turn_started(
+                    client,
+                    thread_id,
+                    BOOTSTRAP_INPUT,
+                    timeout,
+                    model=red_model,
+                    effort="low",
+                )
+            except AppServerRequestRejected:
+                result = {
+                    "outcome": "atomic_rejection",
+                    "stages": ["list", "create", "turn_start_rejected"],
+                }
             else:
-                outcome = "unexpected_missing_model_state"
-            result = {
-                "outcome": outcome,
-                "stages": [
-                    "list",
-                    "create",
-                    "turn_start",
-                    "bounded_wait",
-                    "read",
-                    "continue_without_binding_override",
-                ],
-                "initialState": initial_state,
-                "snapshot": snapshot,
-                "continuation": continuation,
-            }
-            return result
-        result = {
-            "outcome": "unexpected_turn_completion",
-            "stages": ["list", "create", "turn_start", "turn_completed"],
-        }
-        return result
+                try:
+                    wait_for_turn(client, thread_id, turn_id, red_timeout)
+                except (AppServerFailure, TimeoutError):
+                    pass
+                snapshot = thread_snapshot(client, thread_id, timeout)
+                initial_state = classify_red_snapshot(snapshot)
+                continuation = red_continuation(
+                    client, thread_id, min(red_timeout, 20.0)
+                )
+                if (
+                    initial_state
+                    in {"in_progress_without_output", "failed_without_output"}
+                    and continuation["status"]
+                    in {"resume_rejected", "turn_rejected", "no_usable_rollout"}
+                ):
+                    outcome = "non_atomic_missing_model"
+                else:
+                    outcome = "unexpected_missing_model_state"
+                result = {
+                    "outcome": outcome,
+                    "stages": [
+                        "list",
+                        "create",
+                        "turn_start",
+                        "bounded_wait",
+                        "read",
+                        "continue_without_binding_override",
+                    ],
+                    "initialState": initial_state,
+                    "snapshot": snapshot,
+                    "continuation": continuation,
+                }
     finally:
         if thread_id is not None:
-            try:
-                response_result(
-                    client.request("thread/delete", {"threadId": thread_id}, 10),
-                    "thread_delete",
-                )
-                native_cleanup = "passed"
-            except (AppServerFailure, TimeoutError):
-                native_cleanup = "failed"
+            native_cleanup = cleanup_issue106_thread(client, thread_id, 10)
         if result is not None:
             result["nativeCleanup"] = native_cleanup
+    if native_cleanup not in {"passed", "not_needed"}:
+        raise AppServerFailure("native_cleanup_failed")
+    if result is None:
+        raise AppServerFailure("red_lifecycle_missing_result")
+    return result
 
 
 def with_isolated_client(
@@ -847,26 +912,46 @@ def with_isolated_client(
     environment = isolated_environment(home)
     process: subprocess.Popen[str] | None = None
     client: JsonRpcClient | None = None
+    client_close_cleanup = "not_started"
+    app_server_cleanup = "not_started"
     temporary_cleanup = "not_started"
     result: dict[str, Any] | None = None
     try:
         if connected:
             prepare_connected_home(home, environment, gateway_base_url, gateway_key)
-        process = start_app_server(codex_command, home, environment)
+        process = start_issue106_app_server(codex_command, home, environment)
         client = JsonRpcClient(process)
         result = action(client, home)
     finally:
-        if client is not None:
-            client.close()
-        if process is not None:
-            stop_app_server(process)
         try:
-            remove_temporary_home(home)
-            temporary_cleanup = "passed"
-        except AppServerFailure:
-            temporary_cleanup = "failed"
+            if client is not None:
+                try:
+                    client.close()
+                    client_close_cleanup = "passed"
+                except AppServerFailure:
+                    client_close_cleanup = "failed"
+        finally:
+            try:
+                if process is not None:
+                    try:
+                        stop_issue106_app_server(process)
+                        app_server_cleanup = "passed"
+                    except AppServerFailure:
+                        app_server_cleanup = "failed"
+            finally:
+                try:
+                    remove_temporary_home(home)
+                    temporary_cleanup = "passed"
+                except AppServerFailure:
+                    temporary_cleanup = "failed"
         if result is not None:
+            result["clientClose"] = client_close_cleanup
+            result["appServerCleanup"] = app_server_cleanup
             result["temporaryHomeCleanup"] = temporary_cleanup
+    if client_close_cleanup != "passed":
+        raise AppServerFailure("app_server_client_close_failed")
+    if app_server_cleanup != "passed":
+        raise AppServerFailure("app_server_cleanup_failed")
     if temporary_cleanup != "passed":
         raise AppServerFailure("temporary_home_cleanup_failed")
     if result is None:
@@ -880,6 +965,7 @@ def run_catalog_comparison(
     gateway_key: str | None,
     timeout: float,
     requested_official_model: str,
+    external_model: str,
 ) -> dict[str, Any]:
     def inspect(connected: bool) -> dict[str, Any]:
         def action(client: JsonRpcClient, _home: Path) -> dict[str, Any]:
@@ -887,7 +973,9 @@ def run_catalog_comparison(
             return {
                 "account": read_account_summary(client, timeout),
                 "catalog": catalog_summary(
-                    read_model_list(client, timeout), requested_official_model
+                    read_issue106_model_list(client, timeout),
+                    requested_official_model,
+                    external_model,
                 ),
             }
 
@@ -899,7 +987,24 @@ def run_catalog_comparison(
             action=action,
         )
 
-    return {"officialDisconnected": inspect(False), "codexHubConnected": inspect(True)}
+    official_disconnected = inspect(False)
+    codexhub_connected = inspect(True)
+    assert_catalog_comparison(official_disconnected, codexhub_connected)
+    return {
+        "outcome": "passed",
+        "officialDisconnected": official_disconnected,
+        "codexHubConnected": codexhub_connected,
+    }
+
+
+def is_clean_issue106_green_run(run: dict[str, Any]) -> bool:
+    return (
+        run.get("outcome") == "passed"
+        and run.get("nativeCleanup") == "passed"
+        and run.get("clientClose") == "passed"
+        and run.get("appServerCleanup") == "passed"
+        and run.get("temporaryHomeCleanup") == "passed"
+    )
 
 
 def run_repeated_green_lifecycle(
@@ -911,6 +1016,8 @@ def run_repeated_green_lifecycle(
     requested_official_model: str,
     repeat: int,
 ) -> dict[str, Any]:
+    if repeat < 2:
+        raise AppServerFailure("repeated_green_runs_required")
     runs: list[dict[str, Any]] = []
     for _ in range(repeat):
         def action(client: JsonRpcClient, home: Path) -> dict[str, Any]:
@@ -928,8 +1035,12 @@ def run_repeated_green_lifecycle(
                 action=action,
             )
         )
+    repeated_cleanup = (
+        "passed" if all(is_clean_issue106_green_run(run) for run in runs) else "failed"
+    )
     return {
-        "outcome": "passed" if all(run.get("outcome") == "passed" for run in runs) else "failed",
+        "outcome": "passed" if repeated_cleanup == "passed" else "failed",
+        "repeatedRunCleanup": repeated_cleanup,
         "runs": runs,
     }
 
@@ -970,17 +1081,19 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--external-model", default="glm-5.2")
     parser.add_argument("--requested-official-model", default="gpt-5.6-terra")
     parser.add_argument("--red-model", default="codexhub-issue106-missing-model")
-    parser.add_argument("--repeat", type=int, default=1)
+    parser.add_argument("--repeat", type=int, default=2)
     args = parser.parse_args(argv)
     if args.timeout <= 0 or args.red_timeout <= 0 or args.repeat < 1:
         parser.error("timeout values must be positive and repeat must be at least one")
+    if args.scenario == "green" and args.repeat < 2:
+        parser.error("green requires at least two isolated runs")
     return args
 
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     try:
-        codex_command = resolve_app_codex(args.codex)
+        codex_command = resolve_issue106_app_codex(args.codex)
         if args.scenario == "compare":
             result = run_catalog_comparison(
                 codex_command,
@@ -988,6 +1101,7 @@ def main(argv: list[str] | None = None) -> int:
                 args.gateway_key,
                 args.timeout,
                 args.requested_official_model,
+                args.external_model,
             )
         elif args.scenario == "green":
             result = run_repeated_green_lifecycle(

--- a/scripts/run_issue_106_task_lifecycle.py
+++ b/scripts/run_issue_106_task_lifecycle.py
@@ -177,7 +177,17 @@ class JsonRpcClient:
 
 def response_result(response: dict[str, Any], operation: str) -> dict[str, Any]:
     if "error" in response:
-        raise AppServerRequestRejected(operation)
+        error = response["error"]
+        details: dict[str, Any] = {"errorKind": "json_rpc"}
+        if isinstance(error, dict):
+            code = error.get("code")
+            if isinstance(code, int) and not isinstance(code, bool):
+                details["errorCode"] = code
+            else:
+                details["errorKind"] = "json_rpc_without_numeric_code"
+        else:
+            details["errorKind"] = "invalid_json_rpc_error"
+        raise AppServerRequestRejected(operation, details)
     result = response.get("result")
     if not isinstance(result, dict):
         raise AppServerFailure(f"{operation}_invalid_result")
@@ -593,6 +603,27 @@ def thread_list_contains(
     return any(isinstance(thread, dict) and thread.get("id") == thread_id for thread in threads)
 
 
+def rejection_summary(rejection: AppServerRequestRejected) -> dict[str, Any]:
+    summary: dict[str, Any] = {"operation": rejection.operation}
+    if rejection.details is not None:
+        summary.update(rejection.details)
+    return summary
+
+
+def verified_atomic_turn_rejection(
+    rejection: AppServerRequestRejected, snapshot: dict[str, Any]
+) -> bool:
+    return (
+        isinstance(rejection.details, dict)
+        and isinstance(rejection.details.get("errorCode"), int)
+        and not isinstance(rejection.details.get("errorCode"), bool)
+        and snapshot["turnCount"] == 0
+        and snapshot["turnStatuses"] == []
+        and snapshot["turnItemCounts"] == []
+        and snapshot["assistantOutputTurns"] == 0
+    )
+
+
 def start_issue106_custom_thread(
     client: JsonRpcClient,
     workspace: Path,
@@ -661,6 +692,11 @@ def assert_green_snapshot(snapshot: dict[str, Any], expected_turn_count: int) ->
         raise AppServerFailure("thread_replay_missing_assistant_output")
 
 
+def assert_live_task_for_list(snapshot: dict[str, Any]) -> None:
+    if snapshot["threadStatus"] not in {"active", "idle"}:
+        raise AppServerFailure("thread_not_live_for_list")
+
+
 def run_green_lifecycle(
     client: JsonRpcClient,
     home: Path,
@@ -668,7 +704,7 @@ def run_green_lifecycle(
     external_model: str,
     requested_official_model: str,
 ) -> dict[str, Any]:
-    stages: list[str] = ["list"]
+    stages: list[str] = ["catalog_list"]
     models = read_issue106_model_list(client, timeout)
     model_ids = {model_id(model) for model in models}
     if external_model not in model_ids:
@@ -704,6 +740,11 @@ def run_green_lifecycle(
         stages.append("read")
         bootstrap_snapshot = thread_snapshot(client, thread_id, timeout)
         assert_green_snapshot(bootstrap_snapshot, 1)
+        assert_live_task_for_list(bootstrap_snapshot)
+
+        stages.append("list_active")
+        if not thread_list_contains(client, thread_id, timeout):
+            raise AppServerFailure("active_thread_missing_from_list")
 
         stages.append("rename")
         response_result(
@@ -715,7 +756,7 @@ def run_green_lifecycle(
             "thread_name_set",
         )
 
-        stages.append("full_binding_permission_preflight")
+        stages.append("same_model_max_metadata_preflight")
         full_turn = turn_started(
             client,
             thread_id,
@@ -735,6 +776,7 @@ def run_green_lifecycle(
         binding = binding_summary(resumed)
         if (
             binding["model"] != external_model
+            or binding["modelProvider"] != "custom"
             or binding["reasoningEffort"] != "max"
             or binding["approvalPolicy"] != "never"
             or not is_danger_full_access(binding["sandbox"])
@@ -755,6 +797,16 @@ def run_green_lifecycle(
             "stages": stages,
             "catalog": catalog,
             "binding": binding,
+            "bindingTransition": {
+                "bootstrapAndFullModelSame": True,
+                "bootstrapEffort": "low",
+                "fullEffort": "max",
+            },
+            "activeTaskListControl": {
+                "outcome": "passed",
+                "threadStatus": bootstrap_snapshot["threadStatus"],
+            },
+            "preflightClassification": "metadata_only",
             "bootstrap": bootstrap_snapshot,
             "replay": replay_snapshot,
         }
@@ -832,10 +884,12 @@ def run_red_missing_model(
             thread_id = start_issue106_custom_thread(
                 client, workspace, red_model, timeout, "red_thread_start"
             )
-        except AppServerRequestRejected:
+        except AppServerRequestRejected as rejection:
             result = {
-                "outcome": "atomic_rejection",
-                "stages": ["list", "create_rejected"],
+                "outcome": "unverified_rejection",
+                "stages": ["catalog_list", "create_rejected"],
+                "rejection": rejection_summary(rejection),
+                "rejectionClassification": "thread_read_unavailable_without_thread_id",
             }
             native_cleanup = "not_needed"
         else:
@@ -850,10 +904,28 @@ def run_red_missing_model(
                     model=red_model,
                     effort="low",
                 )
-            except AppServerRequestRejected:
+            except AppServerRequestRejected as rejection:
+                rejected_snapshot = thread_snapshot(client, thread_id, timeout)
+                atomic_rejection = verified_atomic_turn_rejection(
+                    rejection, rejected_snapshot
+                )
                 result = {
-                    "outcome": "atomic_rejection",
-                    "stages": ["list", "create", "turn_start_rejected"],
+                    "outcome": "atomic_rejection"
+                    if atomic_rejection
+                    else "unverified_rejection",
+                    "stages": [
+                        "catalog_list",
+                        "create",
+                        "turn_start_rejected",
+                        "read_rejection",
+                    ],
+                    "rejection": rejection_summary(rejection),
+                    "rejectionClassification": (
+                        "thread_read_empty_with_json_rpc_error"
+                        if atomic_rejection
+                        else "thread_read_not_empty_or_error_not_precise"
+                    ),
+                    "threadRead": rejected_snapshot,
                 }
             else:
                 try:
@@ -877,7 +949,7 @@ def run_red_missing_model(
                 result = {
                     "outcome": outcome,
                     "stages": [
-                        "list",
+                        "catalog_list",
                         "create",
                         "turn_start",
                         "bounded_wait",
@@ -992,6 +1064,8 @@ def run_catalog_comparison(
     assert_catalog_comparison(official_disconnected, codexhub_connected)
     return {
         "outcome": "passed",
+        "controlScope": "catalog_and_account_only",
+        "officialRemoteLifecycle": "unrun_external_gate",
         "officialDisconnected": official_disconnected,
         "codexHubConnected": codexhub_connected,
     }

--- a/scripts/run_issue_106_task_lifecycle.py
+++ b/scripts/run_issue_106_task_lifecycle.py
@@ -1,0 +1,1028 @@
+"""Exercise the Issue #106 Task lifecycle through an isolated App CLI session.
+
+The runner uses only the App-managed ``codex app-server`` API.  Every run has
+its own temporary ``CODEX_HOME`` and its own config/catalog overlay; it never
+reads or changes the user's Desktop configuration, auth files, or internal
+Codex databases.  The connected scenarios require a running local CodexHub
+Gateway, while the catalog comparison can run disconnected.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections import deque
+import json
+import os
+from pathlib import Path
+import queue
+import shutil
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from typing import Any, Callable
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TEMP_HOME_PREFIX = "codexhub-issue106-task-lifecycle-"
+DISABLED_APP_SERVER_SERVICES = ("plugins", "remote_plugin", "plugin_sharing")
+SENSITIVE_ENVIRONMENT_NAMES = (
+    "ANTHROPIC_API_KEY",
+    "OLLAMA_API_KEY",
+    "OPENAI_API_KEY",
+)
+BOOTSTRAP_INPUT = "Reply exactly READY. Do not use tools."
+PREFLIGHT_INPUT = "Reply exactly PREFLIGHT_DONE. Do not use tools."
+CONTINUATION_INPUT = "Reply exactly CONTINUED. Do not use tools."
+SAFE_THREAD_NAME = "Issue 106 isolated lifecycle"
+
+
+class AppServerFailure(RuntimeError):
+    """A sanitized app-server failure; do not retain raw server error text."""
+
+    def __init__(self, operation: str, details: dict[str, Any] | None = None) -> None:
+        super().__init__(operation)
+        self.operation = operation
+        self.details = details
+
+
+class AppServerRequestRejected(AppServerFailure):
+    """A completed JSON-RPC error response, distinct from transport failure."""
+
+
+class JsonRpcClient:
+    def __init__(self, process: subprocess.Popen[str]) -> None:
+        self._process = process
+        self._lines: queue.Queue[str | None] = queue.Queue()
+        self._reader = threading.Thread(target=self._read_stdout, daemon=True)
+        self._reader.start()
+        self._next_id = 1
+        self._notifications: deque[dict[str, Any]] = deque()
+        self._responses: dict[int, dict[str, Any]] = {}
+
+    def _read_stdout(self) -> None:
+        assert self._process.stdout is not None
+        for line in self._process.stdout:
+            self._lines.put(line)
+        self._lines.put(None)
+
+    def _write(self, payload: dict[str, Any]) -> None:
+        if self._process.stdin is None:
+            raise AppServerFailure("app_server_stdin_closed")
+        self._process.stdin.write(json.dumps(payload, separators=(",", ":")) + "\n")
+        self._process.stdin.flush()
+
+    def notify(self, method: str, params: dict[str, Any] | None = None) -> None:
+        payload: dict[str, Any] = {"jsonrpc": "2.0", "method": method}
+        if params is not None:
+            payload["params"] = params
+        self._write(payload)
+
+    def request(
+        self, method: str, params: dict[str, Any], timeout: float
+    ) -> dict[str, Any]:
+        request_id = self._next_id
+        self._next_id += 1
+        self._write(
+            {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "method": method,
+                "params": params,
+            }
+        )
+        return self._wait_for_response(request_id, timeout, method)
+
+    def _wait_for_response(
+        self, request_id: int, timeout: float, operation: str
+    ) -> dict[str, Any]:
+        cached = self._responses.pop(request_id, None)
+        if cached is not None:
+            return cached
+
+        deadline = time.monotonic() + timeout
+        while True:
+            message = self._next_message(deadline, operation)
+            if message.get("id") == request_id and not isinstance(
+                message.get("method"), str
+            ):
+                return message
+            self._store_unmatched(message)
+
+    def wait_for_notification(
+        self,
+        predicate: Callable[[dict[str, Any]], bool],
+        timeout: float,
+        operation: str,
+    ) -> dict[str, Any]:
+        for notification in tuple(self._notifications):
+            if predicate(notification):
+                self._notifications.remove(notification)
+                return notification
+
+        deadline = time.monotonic() + timeout
+        while True:
+            message = self._next_message(deadline, operation)
+            if isinstance(message.get("method"), str) and predicate(message):
+                return message
+            self._store_unmatched(message)
+
+    def _next_message(self, deadline: float, operation: str) -> dict[str, Any]:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError(operation)
+        try:
+            line = self._lines.get(timeout=remaining)
+        except queue.Empty as error:
+            raise TimeoutError(operation) from error
+        if line is None:
+            raise AppServerFailure("app_server_exited")
+        try:
+            message = json.loads(line)
+        except json.JSONDecodeError as error:
+            raise AppServerFailure("app_server_invalid_json") from error
+        if not isinstance(message, dict):
+            raise AppServerFailure("app_server_invalid_message")
+        return message
+
+    def _store_unmatched(self, message: dict[str, Any]) -> None:
+        method = message.get("method")
+        message_id = message.get("id")
+        if isinstance(method, str) and isinstance(message_id, int):
+            self._write(
+                {
+                    "jsonrpc": "2.0",
+                    "id": message_id,
+                    "error": {
+                        "code": -32601,
+                        "message": "issue-106 lifecycle runner does not service callbacks",
+                    },
+                }
+            )
+        elif isinstance(method, str):
+            self._notifications.append(message)
+        elif isinstance(message_id, int):
+            self._responses[message_id] = message
+
+    def close(self) -> None:
+        if self._process.stdin is not None:
+            self._process.stdin.close()
+        self._reader.join(timeout=1)
+
+
+def response_result(response: dict[str, Any], operation: str) -> dict[str, Any]:
+    if "error" in response:
+        raise AppServerRequestRejected(operation)
+    result = response.get("result")
+    if not isinstance(result, dict):
+        raise AppServerFailure(f"{operation}_invalid_result")
+    return result
+
+
+def resolve_app_codex(explicit: str | None) -> Path:
+    if explicit:
+        candidate = Path(explicit).expanduser().resolve()
+        if candidate.is_file():
+            return candidate
+        raise AppServerFailure("app_cli_not_found")
+
+    local_app_data = os.environ.get("LOCALAPPDATA")
+    if local_app_data:
+        root = Path(local_app_data) / "OpenAI" / "Codex" / "bin"
+        candidates = sorted(
+            (path for path in root.glob("*/codex.exe") if path.is_file()),
+            key=lambda path: path.stat().st_mtime_ns,
+            reverse=True,
+        )
+        if candidates:
+            return candidates[0]
+
+    fallback = shutil.which("codex.exe") or shutil.which("codex.cmd") or shutil.which("codex")
+    if fallback:
+        return Path(fallback).resolve()
+    raise AppServerFailure("app_cli_not_found")
+
+
+def is_task_owned_temporary_home(home: Path) -> bool:
+    try:
+        resolved_home = home.resolve()
+        temporary_root = Path(tempfile.gettempdir()).resolve()
+        return (
+            resolved_home.parent == temporary_root
+            and resolved_home.name.startswith(TEMP_HOME_PREFIX)
+        )
+    except OSError:
+        return False
+
+
+def create_temporary_home() -> Path:
+    home = Path(tempfile.mkdtemp(prefix=TEMP_HOME_PREFIX))
+    if not is_task_owned_temporary_home(home):
+        raise AppServerFailure("temporary_home_outside_task_scope")
+    return home
+
+
+def remove_temporary_home(home: Path) -> None:
+    if not is_task_owned_temporary_home(home):
+        raise AppServerFailure("temporary_home_outside_task_scope")
+    last_error: OSError | None = None
+    for _ in range(10):
+        try:
+            shutil.rmtree(home)
+            return
+        except FileNotFoundError:
+            return
+        except OSError as error:
+            last_error = error
+            time.sleep(0.25)
+    raise AppServerFailure("temporary_home_cleanup_failed") from last_error
+
+
+def isolated_environment(home: Path) -> dict[str, str]:
+    environment = os.environ.copy()
+    environment["CODEX_HOME"] = str(home)
+    environment.pop("CODEX_CONFIG", None)
+    for name in SENSITIVE_ENVIRONMENT_NAMES:
+        environment.pop(name, None)
+    return environment
+
+
+def run_checked(command: list[str], environment: dict[str, str]) -> None:
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=REPO_ROOT,
+            env=environment,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as error:
+        raise AppServerFailure("isolated_configuration_setup_failed") from error
+    if completed.returncode != 0:
+        raise AppServerFailure("isolated_configuration_setup_failed")
+
+
+def prepare_connected_home(
+    home: Path,
+    environment: dict[str, str],
+    gateway_base_url: str,
+    gateway_key: str | None,
+) -> None:
+    run_checked(
+        [sys.executable, str(REPO_ROOT / "src-python" / "catalog_sync.py"), "--sync"],
+        environment,
+    )
+    overlay_command = [
+        sys.executable,
+        str(REPO_ROOT / "src-python" / "config_overlay.py"),
+        "apply",
+        "--config",
+        str(home / "config.toml"),
+        "--backup",
+        str(home / "proxy" / "config.toml.backup"),
+        "--catalog",
+        str(home / "model-catalogs" / "codexhub-model-catalog.json"),
+        "--base-url",
+        gateway_base_url,
+        "--owner",
+        "release",
+    ]
+    if gateway_key:
+        overlay_command.extend(("--gateway-key", gateway_key))
+    run_checked(overlay_command, environment)
+
+
+def start_app_server(
+    codex_command: Path, home: Path, environment: dict[str, str]
+) -> subprocess.Popen[str]:
+    command = [str(codex_command), "app-server"]
+    for service in DISABLED_APP_SERVER_SERVICES:
+        command.extend(("--disable", service))
+    command.append("--stdio")
+    creationflags = subprocess.CREATE_NO_WINDOW if os.name == "nt" else 0
+    try:
+        return subprocess.Popen(
+            command,
+            cwd=home,
+            env=environment,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            bufsize=1,
+            creationflags=creationflags,
+        )
+    except OSError as error:
+        raise AppServerFailure("app_server_start_failed") from error
+
+
+def stop_app_server(process: subprocess.Popen[str]) -> None:
+    if process.stdin is not None and not process.stdin.closed:
+        process.stdin.close()
+    try:
+        process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        process.terminate()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=5)
+    if process.stdout is not None:
+        process.stdout.close()
+
+
+def initialize(client: JsonRpcClient, timeout: float) -> None:
+    response_result(
+        client.request(
+            "initialize",
+            {
+                "clientInfo": {
+                    "name": "codexhub-issue106-lifecycle",
+                    "version": "1",
+                },
+                "capabilities": {
+                    "experimentalApi": True,
+                    "requestAttestation": False,
+                    "optOutNotificationMethods": [],
+                },
+            },
+            timeout,
+        ),
+        "initialize",
+    )
+    client.notify("initialized")
+
+
+def read_model_list(client: JsonRpcClient, timeout: float) -> list[dict[str, Any]]:
+    result = response_result(client.request("model/list", {"limit": 100}, timeout), "model_list")
+    models = result.get("data")
+    if not isinstance(models, list):
+        raise AppServerFailure("model_list_invalid_data")
+    return [model for model in models if isinstance(model, dict)]
+
+
+def model_id(model: dict[str, Any]) -> str:
+    return str(model.get("model") or model.get("id") or "").strip()
+
+
+def model_efforts(model: dict[str, Any]) -> set[str]:
+    raw_efforts = model.get("supportedReasoningEfforts") or model.get(
+        "supported_reasoning_levels"
+    )
+    if not isinstance(raw_efforts, list):
+        return set()
+    return {
+        str(item.get("reasoningEffort") or item.get("effort") or "").strip()
+        for item in raw_efforts
+        if isinstance(item, dict)
+        and str(item.get("reasoningEffort") or item.get("effort") or "").strip()
+    }
+
+
+def catalog_summary(
+    models: list[dict[str, Any]], requested_official_model: str
+) -> dict[str, Any]:
+    ids = {model_id(model) for model in models}
+    requested = next(
+        (model for model in models if model_id(model) == requested_official_model),
+        None,
+    )
+    return {
+        "modelCount": len(models),
+        "requestedOfficialModelListed": requested_official_model in ids,
+        "requestedOfficialModelSupportsMax": bool(
+            requested is not None and "max" in model_efforts(requested)
+        ),
+    }
+
+
+def read_account_summary(client: JsonRpcClient, timeout: float) -> dict[str, bool]:
+    result = response_result(client.request("account/read", {}, timeout), "account_read")
+    return {
+        "authenticated": result.get("account") is not None,
+        "requiresOpenaiAuth": result.get("requiresOpenaiAuth") is True,
+    }
+
+
+def get_thread(result: dict[str, Any], operation: str) -> dict[str, Any]:
+    thread = result.get("thread")
+    if not isinstance(thread, dict):
+        raise AppServerFailure(f"{operation}_missing_thread")
+    return thread
+
+
+def get_thread_id(thread: dict[str, Any], operation: str) -> str:
+    thread_id = thread.get("id")
+    if not isinstance(thread_id, str) or not thread_id:
+        raise AppServerFailure(f"{operation}_missing_thread_id")
+    return thread_id
+
+
+def get_turn_id(result: dict[str, Any], operation: str) -> str:
+    turn = result.get("turn")
+    turn_id = turn.get("id") if isinstance(turn, dict) else None
+    if not isinstance(turn_id, str) or not turn_id:
+        raise AppServerFailure(f"{operation}_missing_turn_id")
+    return turn_id
+
+
+def turn_started(
+    client: JsonRpcClient,
+    thread_id: str,
+    text: str,
+    timeout: float,
+    *,
+    model: str | None = None,
+    effort: str | None = None,
+    permission_preflight: bool = False,
+) -> str:
+    params: dict[str, Any] = {
+        "threadId": thread_id,
+        "input": [{"type": "text", "text": text}],
+    }
+    if model is not None:
+        params["model"] = model
+    if effort is not None:
+        params["effort"] = effort
+    if permission_preflight:
+        params["approvalPolicy"] = "never"
+        params["sandboxPolicy"] = {"type": "dangerFullAccess"}
+    result = response_result(client.request("turn/start", params, timeout), "turn_start")
+    return get_turn_id(result, "turn_start")
+
+
+def wait_for_turn(
+    client: JsonRpcClient, thread_id: str, turn_id: str, timeout: float
+) -> dict[str, Any]:
+    notification = client.wait_for_notification(
+        lambda item: (
+            item.get("method") == "turn/completed"
+            and isinstance(item.get("params"), dict)
+            and item["params"].get("threadId") == thread_id
+            and isinstance(item["params"].get("turn"), dict)
+            and item["params"]["turn"].get("id") == turn_id
+        ),
+        timeout,
+        "turn_completed",
+    )
+    turn = notification["params"]["turn"]
+    if turn.get("status") != "completed":
+        raise AppServerFailure("turn_not_completed")
+    return turn
+
+
+def thread_snapshot(client: JsonRpcClient, thread_id: str, timeout: float) -> dict[str, Any]:
+    result = response_result(
+        client.request("thread/read", {"threadId": thread_id, "includeTurns": True}, timeout),
+        "thread_read",
+    )
+    thread = get_thread(result, "thread_read")
+    turns = thread.get("turns")
+    if not isinstance(turns, list):
+        raise AppServerFailure("thread_read_missing_turns")
+    status = thread.get("status")
+    return {
+        "threadStatus": status.get("type") if isinstance(status, dict) else None,
+        "turnCount": len(turns),
+        "turnStatuses": [
+            turn.get("status") if isinstance(turn, dict) else None for turn in turns
+        ],
+        "turnItemCounts": [
+            len(turn.get("items", [])) if isinstance(turn, dict) else None
+            for turn in turns
+        ],
+        "assistantOutputTurns": sum(
+            1
+            for turn in turns
+            if isinstance(turn, dict)
+            and any(
+                isinstance(item, dict)
+                and (
+                    item.get("role") == "assistant"
+                    or item.get("type") in {"agent_message", "agentMessage"}
+                )
+                for item in turn.get("items", [])
+                if isinstance(turn.get("items", []), list)
+            )
+        ),
+    }
+
+
+def thread_list_contains(
+    client: JsonRpcClient, thread_id: str, timeout: float
+) -> bool:
+    result = response_result(client.request("thread/list", {}, timeout), "thread_list")
+    threads = result.get("data")
+    if not isinstance(threads, list):
+        raise AppServerFailure("thread_list_invalid_data")
+    return any(isinstance(thread, dict) and thread.get("id") == thread_id for thread in threads)
+
+
+def binding_summary(result: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "model": result.get("model"),
+        "modelProvider": result.get("modelProvider"),
+        "reasoningEffort": result.get("reasoningEffort"),
+        "approvalPolicy": result.get("approvalPolicy"),
+        "sandbox": result.get("sandbox"),
+    }
+
+
+def is_danger_full_access(value: object) -> bool:
+    return value == "danger-full-access" or (
+        isinstance(value, dict) and value.get("type") == "dangerFullAccess"
+    )
+
+
+def assert_green_snapshot(snapshot: dict[str, Any], expected_turn_count: int) -> None:
+    if snapshot["turnCount"] != expected_turn_count:
+        raise AppServerFailure("thread_replay_turn_count_mismatch")
+    if snapshot["turnStatuses"] != ["completed"] * expected_turn_count:
+        raise AppServerFailure("thread_replay_turn_status_mismatch")
+    if any(
+        not isinstance(count, int) or count < 2
+        for count in snapshot["turnItemCounts"]
+    ):
+        raise AppServerFailure("thread_replay_missing_output")
+    if snapshot["assistantOutputTurns"] != expected_turn_count:
+        raise AppServerFailure("thread_replay_missing_assistant_output")
+
+
+def run_green_lifecycle(
+    client: JsonRpcClient,
+    home: Path,
+    timeout: float,
+    external_model: str,
+    requested_official_model: str,
+) -> dict[str, Any]:
+    stages: list[str] = ["list"]
+    models = read_model_list(client, timeout)
+    model_ids = {model_id(model) for model in models}
+    if external_model not in model_ids:
+        raise AppServerFailure("external_model_not_listed")
+    catalog = catalog_summary(models, requested_official_model)
+    if not catalog["requestedOfficialModelListed"] or not catalog[
+        "requestedOfficialModelSupportsMax"
+    ]:
+        raise AppServerFailure("requested_official_binding_not_listed")
+
+    workspace = home / "workspace"
+    workspace.mkdir()
+    thread_id: str | None = None
+    native_cleanup = "not_started"
+    result: dict[str, Any] | None = None
+    try:
+        stages.append("create")
+        started = response_result(
+            client.request(
+                "thread/start",
+                {
+                    "cwd": str(workspace),
+                    "model": external_model,
+                    "modelProvider": "custom",
+                    "approvalPolicy": "never",
+                    "sandbox": "danger-full-access",
+                    "ephemeral": False,
+                },
+                timeout,
+            ),
+            "thread_start",
+        )
+        thread_id = get_thread_id(get_thread(started, "thread_start"), "thread_start")
+
+        stages.append("bootstrap")
+        bootstrap_turn = turn_started(
+            client,
+            thread_id,
+            BOOTSTRAP_INPUT,
+            timeout,
+            model=external_model,
+            effort="low",
+        )
+        wait_for_turn(client, thread_id, bootstrap_turn, timeout)
+
+        stages.append("read")
+        bootstrap_snapshot = thread_snapshot(client, thread_id, timeout)
+        assert_green_snapshot(bootstrap_snapshot, 1)
+
+        stages.append("rename")
+        response_result(
+            client.request(
+                "thread/name/set",
+                {"threadId": thread_id, "name": SAFE_THREAD_NAME},
+                timeout,
+            ),
+            "thread_name_set",
+        )
+
+        stages.append("full_binding_permission_preflight")
+        full_turn = turn_started(
+            client,
+            thread_id,
+            PREFLIGHT_INPUT,
+            timeout,
+            model=external_model,
+            effort="max",
+            permission_preflight=True,
+        )
+        wait_for_turn(client, thread_id, full_turn, timeout)
+
+        stages.append("resume")
+        resumed = response_result(
+            client.request("thread/resume", {"threadId": thread_id}, timeout),
+            "thread_resume",
+        )
+        binding = binding_summary(resumed)
+        if (
+            binding["model"] != external_model
+            or binding["reasoningEffort"] != "max"
+            or binding["approvalPolicy"] != "never"
+            or not is_danger_full_access(binding["sandbox"])
+        ):
+            raise AppServerFailure("full_binding_not_replayed", binding)
+
+        stages.append("continue")
+        continuation_turn = turn_started(
+            client, thread_id, CONTINUATION_INPUT, timeout
+        )
+        wait_for_turn(client, thread_id, continuation_turn, timeout)
+
+        stages.append("read_replay")
+        replay_snapshot = thread_snapshot(client, thread_id, timeout)
+        assert_green_snapshot(replay_snapshot, 3)
+        result = {
+            "outcome": "passed",
+            "stages": stages,
+            "catalog": catalog,
+            "binding": binding,
+            "bootstrap": bootstrap_snapshot,
+            "replay": replay_snapshot,
+        }
+    finally:
+        if thread_id is not None:
+            try:
+                response_result(
+                    client.request("thread/delete", {"threadId": thread_id}, 10),
+                    "thread_delete",
+                )
+                native_cleanup = (
+                    "failed"
+                    if thread_list_contains(client, thread_id, 10)
+                    else "passed"
+                )
+            except (AppServerFailure, TimeoutError):
+                native_cleanup = "failed"
+        if result is not None:
+            result["nativeCleanup"] = native_cleanup
+    if native_cleanup != "passed":
+        raise AppServerFailure("native_cleanup_failed")
+    if result is None:
+        raise AppServerFailure("green_lifecycle_missing_result")
+    return result
+
+
+def classify_red_snapshot(snapshot: dict[str, Any]) -> str:
+    if (
+        snapshot["threadStatus"] == "active"
+        and snapshot["turnStatuses"] == ["inProgress"]
+        and snapshot["turnItemCounts"] == [1]
+        and snapshot["assistantOutputTurns"] == 0
+    ):
+        return "in_progress_without_output"
+    if (
+        snapshot["threadStatus"] == "systemError"
+        and snapshot["turnStatuses"] == ["completed"]
+        and snapshot["turnItemCounts"] == [1]
+        and snapshot["assistantOutputTurns"] == 0
+    ):
+        return "failed_without_output"
+    return "unexpected_missing_model_state"
+
+
+def red_continuation(
+    client: JsonRpcClient, thread_id: str, timeout: float
+) -> dict[str, Any]:
+    try:
+        response_result(
+            client.request("thread/resume", {"threadId": thread_id}, timeout),
+            "red_thread_resume",
+        )
+    except (AppServerFailure, TimeoutError):
+        return {"status": "resume_rejected"}
+    try:
+        turn_id = turn_started(client, thread_id, CONTINUATION_INPUT, timeout)
+    except (AppServerFailure, TimeoutError):
+        return {"status": "turn_rejected"}
+    try:
+        wait_for_turn(client, thread_id, turn_id, timeout)
+    except (AppServerFailure, TimeoutError):
+        snapshot = thread_snapshot(client, thread_id, timeout)
+        if snapshot["assistantOutputTurns"] == 0:
+            return {"status": "no_usable_rollout", "snapshot": snapshot}
+        return {"status": "unexpected_output", "snapshot": snapshot}
+    return {"status": "unexpected_turn_completion"}
+
+
+def run_red_missing_model(
+    client: JsonRpcClient,
+    home: Path,
+    timeout: float,
+    red_timeout: float,
+    red_model: str,
+) -> dict[str, Any]:
+    models = read_model_list(client, timeout)
+    if red_model in {model_id(model) for model in models}:
+        raise AppServerFailure("red_model_is_listed")
+    workspace = home / "red-workspace"
+    workspace.mkdir()
+    thread_id: str | None = None
+    native_cleanup = "not_started"
+    result: dict[str, Any] | None = None
+    try:
+        try:
+            started = response_result(
+                client.request(
+                    "thread/start",
+                    {
+                        "cwd": str(workspace),
+                        "model": red_model,
+                        "modelProvider": "custom",
+                        "approvalPolicy": "never",
+                        "sandbox": "danger-full-access",
+                        "ephemeral": False,
+                    },
+                    timeout,
+                ),
+                "red_thread_start",
+            )
+        except AppServerRequestRejected:
+            result = {
+                "outcome": "atomic_rejection",
+                "stages": ["list", "create_rejected"],
+            }
+            native_cleanup = "not_needed"
+            return result
+        thread_id = get_thread_id(get_thread(started, "red_thread_start"), "red_thread_start")
+        try:
+            turn_id = turn_started(
+                client,
+                thread_id,
+                BOOTSTRAP_INPUT,
+                timeout,
+                model=red_model,
+                effort="low",
+            )
+        except AppServerRequestRejected:
+            result = {
+                "outcome": "atomic_rejection",
+                "stages": ["list", "create", "turn_start_rejected"],
+            }
+            return result
+        try:
+            wait_for_turn(client, thread_id, turn_id, red_timeout)
+        except (AppServerFailure, TimeoutError):
+            snapshot = thread_snapshot(client, thread_id, timeout)
+            initial_state = classify_red_snapshot(snapshot)
+            continuation = red_continuation(
+                client, thread_id, min(red_timeout, 20.0)
+            )
+            if (
+                initial_state
+                in {"in_progress_without_output", "failed_without_output"}
+                and continuation["status"]
+                in {"resume_rejected", "turn_rejected", "no_usable_rollout"}
+            ):
+                outcome = "non_atomic_missing_model"
+            else:
+                outcome = "unexpected_missing_model_state"
+            result = {
+                "outcome": outcome,
+                "stages": [
+                    "list",
+                    "create",
+                    "turn_start",
+                    "bounded_wait",
+                    "read",
+                    "continue_without_binding_override",
+                ],
+                "initialState": initial_state,
+                "snapshot": snapshot,
+                "continuation": continuation,
+            }
+            return result
+        result = {
+            "outcome": "unexpected_turn_completion",
+            "stages": ["list", "create", "turn_start", "turn_completed"],
+        }
+        return result
+    finally:
+        if thread_id is not None:
+            try:
+                response_result(
+                    client.request("thread/delete", {"threadId": thread_id}, 10),
+                    "thread_delete",
+                )
+                native_cleanup = "passed"
+            except (AppServerFailure, TimeoutError):
+                native_cleanup = "failed"
+        if result is not None:
+            result["nativeCleanup"] = native_cleanup
+
+
+def with_isolated_client(
+    *,
+    codex_command: Path,
+    connected: bool,
+    gateway_base_url: str,
+    gateway_key: str | None,
+    action: Callable[[JsonRpcClient, Path], dict[str, Any]],
+) -> dict[str, Any]:
+    home = create_temporary_home()
+    environment = isolated_environment(home)
+    process: subprocess.Popen[str] | None = None
+    client: JsonRpcClient | None = None
+    temporary_cleanup = "not_started"
+    result: dict[str, Any] | None = None
+    try:
+        if connected:
+            prepare_connected_home(home, environment, gateway_base_url, gateway_key)
+        process = start_app_server(codex_command, home, environment)
+        client = JsonRpcClient(process)
+        result = action(client, home)
+    finally:
+        if client is not None:
+            client.close()
+        if process is not None:
+            stop_app_server(process)
+        try:
+            remove_temporary_home(home)
+            temporary_cleanup = "passed"
+        except AppServerFailure:
+            temporary_cleanup = "failed"
+        if result is not None:
+            result["temporaryHomeCleanup"] = temporary_cleanup
+    if temporary_cleanup != "passed":
+        raise AppServerFailure("temporary_home_cleanup_failed")
+    if result is None:
+        raise AppServerFailure("isolated_run_missing_result")
+    return result
+
+
+def run_catalog_comparison(
+    codex_command: Path,
+    gateway_base_url: str,
+    gateway_key: str | None,
+    timeout: float,
+    requested_official_model: str,
+) -> dict[str, Any]:
+    def inspect(connected: bool) -> dict[str, Any]:
+        def action(client: JsonRpcClient, _home: Path) -> dict[str, Any]:
+            initialize(client, timeout)
+            return {
+                "account": read_account_summary(client, timeout),
+                "catalog": catalog_summary(
+                    read_model_list(client, timeout), requested_official_model
+                ),
+            }
+
+        return with_isolated_client(
+            codex_command=codex_command,
+            connected=connected,
+            gateway_base_url=gateway_base_url,
+            gateway_key=gateway_key,
+            action=action,
+        )
+
+    return {"officialDisconnected": inspect(False), "codexHubConnected": inspect(True)}
+
+
+def run_repeated_green_lifecycle(
+    codex_command: Path,
+    gateway_base_url: str,
+    gateway_key: str | None,
+    timeout: float,
+    external_model: str,
+    requested_official_model: str,
+    repeat: int,
+) -> dict[str, Any]:
+    runs: list[dict[str, Any]] = []
+    for _ in range(repeat):
+        def action(client: JsonRpcClient, home: Path) -> dict[str, Any]:
+            initialize(client, timeout)
+            return run_green_lifecycle(
+                client, home, timeout, external_model, requested_official_model
+            )
+
+        runs.append(
+            with_isolated_client(
+                codex_command=codex_command,
+                connected=True,
+                gateway_base_url=gateway_base_url,
+                gateway_key=gateway_key,
+                action=action,
+            )
+        )
+    return {
+        "outcome": "passed" if all(run.get("outcome") == "passed" for run in runs) else "failed",
+        "runs": runs,
+    }
+
+
+def run_red_scenario(
+    codex_command: Path,
+    gateway_base_url: str,
+    gateway_key: str | None,
+    timeout: float,
+    red_timeout: float,
+    red_model: str,
+) -> dict[str, Any]:
+    def action(client: JsonRpcClient, home: Path) -> dict[str, Any]:
+        initialize(client, timeout)
+        return run_red_missing_model(client, home, timeout, red_timeout, red_model)
+
+    return with_isolated_client(
+        codex_command=codex_command,
+        connected=True,
+        gateway_base_url=gateway_base_url,
+        gateway_key=gateway_key,
+        action=action,
+    )
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--codex", help="Path to the App-managed Codex CLI")
+    parser.add_argument(
+        "--scenario",
+        choices=("compare", "green", "red"),
+        default="compare",
+    )
+    parser.add_argument("--gateway-base-url", default="http://127.0.0.1:9099")
+    parser.add_argument("--gateway-key")
+    parser.add_argument("--timeout", type=float, default=60.0)
+    parser.add_argument("--red-timeout", type=float, default=30.0)
+    parser.add_argument("--external-model", default="glm-5.2")
+    parser.add_argument("--requested-official-model", default="gpt-5.6-terra")
+    parser.add_argument("--red-model", default="codexhub-issue106-missing-model")
+    parser.add_argument("--repeat", type=int, default=1)
+    args = parser.parse_args(argv)
+    if args.timeout <= 0 or args.red_timeout <= 0 or args.repeat < 1:
+        parser.error("timeout values must be positive and repeat must be at least one")
+    return args
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        codex_command = resolve_app_codex(args.codex)
+        if args.scenario == "compare":
+            result = run_catalog_comparison(
+                codex_command,
+                args.gateway_base_url,
+                args.gateway_key,
+                args.timeout,
+                args.requested_official_model,
+            )
+        elif args.scenario == "green":
+            result = run_repeated_green_lifecycle(
+                codex_command,
+                args.gateway_base_url,
+                args.gateway_key,
+                args.timeout,
+                args.external_model,
+                args.requested_official_model,
+                args.repeat,
+            )
+        else:
+            result = run_red_scenario(
+                codex_command,
+                args.gateway_base_url,
+                args.gateway_key,
+                args.timeout,
+                args.red_timeout,
+                args.red_model,
+            )
+    except AppServerFailure as error:
+        payload: dict[str, Any] = {"failure": error.operation, "outcome": "failed"}
+        if error.details is not None:
+            payload["details"] = error.details
+        print(json.dumps(payload, sort_keys=True))
+        return 1
+    except TimeoutError as error:
+        print(json.dumps({"failure": str(error), "outcome": "failed"}, sort_keys=True))
+        return 1
+
+    print(json.dumps(result, sort_keys=True))
+    if args.scenario == "red":
+        return 0 if result.get("outcome") == "non_atomic_missing_model" else 1
+    return 0 if result.get("outcome", "passed") == "passed" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_issue_106_task_lifecycle.py
+++ b/scripts/run_issue_106_task_lifecycle.py
@@ -905,28 +905,42 @@ def run_red_missing_model(
                     effort="low",
                 )
             except AppServerRequestRejected as rejection:
-                rejected_snapshot = thread_snapshot(client, thread_id, timeout)
-                atomic_rejection = verified_atomic_turn_rejection(
-                    rejection, rejected_snapshot
-                )
-                result = {
-                    "outcome": "atomic_rejection"
-                    if atomic_rejection
-                    else "unverified_rejection",
-                    "stages": [
-                        "catalog_list",
-                        "create",
-                        "turn_start_rejected",
-                        "read_rejection",
-                    ],
-                    "rejection": rejection_summary(rejection),
-                    "rejectionClassification": (
-                        "thread_read_empty_with_json_rpc_error"
+                try:
+                    rejected_snapshot = thread_snapshot(client, thread_id, timeout)
+                except (AppServerFailure, TimeoutError):
+                    result = {
+                        "outcome": "unverified_rejection",
+                        "stages": [
+                            "catalog_list",
+                            "create",
+                            "turn_start_rejected",
+                            "read_rejection_failed",
+                        ],
+                        "rejection": rejection_summary(rejection),
+                        "rejectionClassification": "thread_read_unavailable_after_turn_rejection",
+                    }
+                else:
+                    atomic_rejection = verified_atomic_turn_rejection(
+                        rejection, rejected_snapshot
+                    )
+                    result = {
+                        "outcome": "atomic_rejection"
                         if atomic_rejection
-                        else "thread_read_not_empty_or_error_not_precise"
-                    ),
-                    "threadRead": rejected_snapshot,
-                }
+                        else "unverified_rejection",
+                        "stages": [
+                            "catalog_list",
+                            "create",
+                            "turn_start_rejected",
+                            "read_rejection",
+                        ],
+                        "rejection": rejection_summary(rejection),
+                        "rejectionClassification": (
+                            "thread_read_empty_with_json_rpc_error"
+                            if atomic_rejection
+                            else "thread_read_not_empty_or_error_not_precise"
+                        ),
+                        "threadRead": rejected_snapshot,
+                    }
             else:
                 try:
                     wait_for_turn(client, thread_id, turn_id, red_timeout)

--- a/tests/test_catalog_sync.py
+++ b/tests/test_catalog_sync.py
@@ -481,6 +481,24 @@ class CatalogSyncTests(unittest.TestCase):
             ):
                 self.assertIn(required_key, by_slug[model_id])
 
+    def test_policy_fallback_lists_current_official_bindings_without_a_runtime_seed(self):
+        policy = catalog_sync.load_policy(catalog_sync.POLICY_PATH)
+
+        catalog = build_codex_catalog([], [], policy, "0.144.0")
+        by_slug = {model["slug"]: model for model in catalog["models"]}
+
+        self.assertEqual(
+            [model_id for model_id in ("gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna") if model_id in by_slug],
+            ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"],
+        )
+        self.assertEqual(by_slug["gpt-5.6-terra"]["display_name"], "5.6 Terra")
+        self.assertEqual(by_slug["gpt-5.6-terra"]["context_window"], 353400)
+        self.assertEqual(by_slug["gpt-5.6-terra"]["max_context_window"], 1050000)
+        self.assertIn(
+            "max",
+            [entry["effort"] for entry in by_slug["gpt-5.6-terra"]["supported_reasoning_levels"]],
+        )
+
     def test_build_catalog_preserves_fallback_metadata_for_ollama_models(self):
         fallback_models = [
             {

--- a/tests/test_issue_106_app_server_lifecycle.py
+++ b/tests/test_issue_106_app_server_lifecycle.py
@@ -28,14 +28,129 @@ class BrokenPipeProcess:
 
 
 def snapshot(
-    thread_status: str, turn_statuses: list[str], turn_item_counts: list[int]
+    thread_status: str,
+    turn_statuses: list[str],
+    turn_item_counts: list[int],
+    *,
+    assistant_outputs: int = 0,
 ) -> dict[str, object]:
     return {
         "threadStatus": thread_status,
+        "turnCount": len(turn_statuses),
         "turnStatuses": turn_statuses,
         "turnItemCounts": turn_item_counts,
-        "assistantOutputTurns": 0,
+        "assistantOutputTurns": assistant_outputs,
     }
+
+
+def run_green_fixture(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, model_provider: str = "custom"
+) -> tuple[dict[str, object], list[dict[str, object]], list[str]]:
+    snapshots = iter(
+        [
+            snapshot("idle", ["completed"], [2], assistant_outputs=1),
+            snapshot(
+                "idle",
+                ["completed", "completed", "completed"],
+                [2, 2, 2],
+                assistant_outputs=3,
+            ),
+        ]
+    )
+    turn_ids = iter(("bootstrap", "full", "continuation"))
+    turn_options: list[dict[str, object]] = []
+    listed_threads: list[str] = []
+
+    class GreenClient:
+        def request(
+            self, method: str, params: dict[str, object], timeout: float
+        ) -> dict[str, object]:
+            del params, timeout
+            if method == "thread/resume":
+                return {
+                    "result": {
+                        "model": "external-model",
+                        "modelProvider": model_provider,
+                        "reasoningEffort": "max",
+                        "approvalPolicy": "never",
+                        "sandbox": {"type": "dangerFullAccess"},
+                    }
+                }
+            return {"result": {}}
+
+    monkeypatch.setattr(
+        RUNNER,
+        "read_issue106_model_list",
+        lambda *_args: [
+            {"id": "external-model"},
+            {
+                "id": "official-model",
+                "supportedReasoningEfforts": [{"reasoningEffort": "max"}],
+            },
+        ],
+    )
+    monkeypatch.setattr(
+        RUNNER,
+        "start_issue106_custom_thread",
+        lambda *_args: "synthetic-thread",
+    )
+
+    def start_turn(*_args: object, **options: object) -> str:
+        turn_options.append(options)
+        return next(turn_ids)
+
+    monkeypatch.setattr(RUNNER, "turn_started", start_turn)
+    monkeypatch.setattr(
+        RUNNER,
+        "wait_for_turn",
+        lambda *_args, **_kwargs: {"status": "completed"},
+    )
+    monkeypatch.setattr(RUNNER, "thread_snapshot", lambda *_args: next(snapshots))
+
+    def list_contains(_client: object, thread_id: str, _timeout: float) -> bool:
+        listed_threads.append(thread_id)
+        return True
+
+    monkeypatch.setattr(RUNNER, "thread_list_contains", list_contains)
+    monkeypatch.setattr(RUNNER, "cleanup_issue106_thread", lambda *_args: "passed")
+
+    result = RUNNER.run_green_lifecycle(
+        GreenClient(),
+        tmp_path,
+        timeout=1,
+        external_model="external-model",
+        requested_official_model="official-model",
+    )
+    return result, turn_options, listed_threads
+
+
+def run_red_turn_rejection_fixture(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    rejected_snapshot: dict[str, object],
+    rejection_details: dict[str, object],
+) -> dict[str, object]:
+    monkeypatch.setattr(RUNNER, "read_issue106_model_list", lambda *_args: [])
+    monkeypatch.setattr(
+        RUNNER,
+        "start_issue106_custom_thread",
+        lambda *_args: "synthetic-thread",
+    )
+
+    def reject_turn(*_args: object, **_kwargs: object) -> str:
+        raise RUNNER.AppServerRequestRejected("turn_start", rejection_details)
+
+    monkeypatch.setattr(RUNNER, "turn_started", reject_turn)
+    monkeypatch.setattr(RUNNER, "thread_snapshot", lambda *_args: rejected_snapshot)
+    monkeypatch.setattr(RUNNER, "cleanup_issue106_thread", lambda *_args: "passed")
+
+    return RUNNER.run_red_missing_model(
+        object(),
+        tmp_path,
+        timeout=1,
+        red_timeout=1,
+        red_model="unlisted-model",
+    )
 
 
 @pytest.mark.parametrize(
@@ -115,6 +230,50 @@ def test_catalog_comparison_requires_fresh_official_and_connected_controls() -> 
     connected["catalog"]["externalModelListed"] = False
     with pytest.raises(RUNNER.AppServerFailure, match="external_model_missing"):
         RUNNER.assert_catalog_comparison(official, connected)
+
+
+def test_catalog_comparison_labels_the_official_lifecycle_as_unrun(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    controls = iter(
+        [
+            {
+                "account": {"authenticated": False, "requiresOpenaiAuth": True},
+                "catalog": {
+                    "modelCount": 7,
+                    "requestedOfficialModelListed": True,
+                    "requestedOfficialModelSupportsMax": True,
+                    "externalModelListed": False,
+                },
+            },
+            {
+                "account": {"authenticated": False, "requiresOpenaiAuth": True},
+                "catalog": {
+                    "modelCount": 29,
+                    "requestedOfficialModelListed": True,
+                    "requestedOfficialModelSupportsMax": True,
+                    "externalModelListed": True,
+                },
+            },
+        ]
+    )
+    monkeypatch.setattr(
+        RUNNER,
+        "with_isolated_client",
+        lambda **_kwargs: next(controls),
+    )
+
+    result = RUNNER.run_catalog_comparison(
+        Path("codex"),
+        "http://127.0.0.1:9099",
+        None,
+        timeout=1,
+        requested_official_model="official-model",
+        external_model="external-model",
+    )
+
+    assert result["controlScope"] == "catalog_and_account_only"
+    assert result["officialRemoteLifecycle"] == "unrun_external_gate"
 
 
 def test_repeated_green_result_requires_every_cleanup_boundary() -> None:
@@ -267,6 +426,98 @@ def test_red_control_reads_completed_system_error_before_classifying(
     assert result["continuation"]["status"] == "no_usable_rollout"
 
 
+def test_green_scope_records_active_list_same_model_and_metadata_preflight(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    result, turn_options, listed_threads = run_green_fixture(monkeypatch, tmp_path)
+
+    assert result["activeTaskListControl"] == {
+        "outcome": "passed",
+        "threadStatus": "idle",
+    }
+    assert result["preflightClassification"] == "metadata_only"
+    assert result["bindingTransition"] == {
+        "bootstrapAndFullModelSame": True,
+        "bootstrapEffort": "low",
+        "fullEffort": "max",
+    }
+    assert result["binding"]["modelProvider"] == "custom"
+    assert "list_active" in result["stages"]
+    assert result["stages"].index("read") < result["stages"].index("list_active")
+    assert result["stages"].index("list_active") < result["stages"].index("rename")
+    assert listed_threads == ["synthetic-thread"]
+    assert turn_options[1] == {
+        "model": "external-model",
+        "effort": "max",
+        "permission_preflight": True,
+    }
+
+
+def test_green_rejects_a_resume_that_falls_back_from_the_custom_provider(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    with pytest.raises(RUNNER.AppServerFailure, match="full_binding_not_replayed"):
+        run_green_fixture(monkeypatch, tmp_path, model_provider="fallback")
+
+
+def test_turn_rejection_is_atomic_only_after_empty_thread_read_and_error_code(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    result = run_red_turn_rejection_fixture(
+        monkeypatch,
+        tmp_path,
+        snapshot("idle", [], []),
+        {"errorKind": "json_rpc", "errorCode": -32602},
+    )
+
+    assert result["outcome"] == "atomic_rejection"
+    assert result["rejection"] == {
+        "operation": "turn_start",
+        "errorKind": "json_rpc",
+        "errorCode": -32602,
+    }
+    assert result["rejectionClassification"] == "thread_read_empty_with_json_rpc_error"
+    assert result["threadRead"]["turnCount"] == 0
+
+
+def test_turn_rejection_with_a_persisted_turn_is_unverified(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    result = run_red_turn_rejection_fixture(
+        monkeypatch,
+        tmp_path,
+        snapshot("systemError", ["completed"], [1]),
+        {"errorKind": "json_rpc", "errorCode": -32602},
+    )
+
+    assert result["outcome"] == "unverified_rejection"
+    assert result["rejectionClassification"] == "thread_read_not_empty_or_error_not_precise"
+
+
+def test_create_rejection_without_a_task_read_is_unverified(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(RUNNER, "read_issue106_model_list", lambda *_args: [])
+
+    def reject_create(*_args: object, **_kwargs: object) -> str:
+        raise RUNNER.AppServerRequestRejected(
+            "red_thread_start", {"errorKind": "json_rpc", "errorCode": -32602}
+        )
+
+    monkeypatch.setattr(RUNNER, "start_issue106_custom_thread", reject_create)
+
+    result = RUNNER.run_red_missing_model(
+        object(),
+        tmp_path,
+        timeout=1,
+        red_timeout=1,
+        red_model="unlisted-model",
+    )
+
+    assert result["outcome"] == "unverified_rejection"
+    assert result["rejectionClassification"] == "thread_read_unavailable_without_thread_id"
+
+
 def test_green_defaults_to_two_runs_and_rejects_a_single_run() -> None:
     assert RUNNER.parse_args(["--scenario", "green"]).repeat == 2
 
@@ -275,8 +526,10 @@ def test_green_defaults_to_two_runs_and_rejects_a_single_run() -> None:
 
 
 def test_json_rpc_error_is_distinct_from_an_app_server_transport_failure() -> None:
-    with pytest.raises(RUNNER.AppServerRequestRejected):
+    with pytest.raises(RUNNER.AppServerRequestRejected) as raised:
         RUNNER.response_result({"error": {"code": -1}}, "thread_start")
+
+    assert raised.value.details == {"errorKind": "json_rpc", "errorCode": -1}
 
 
 def test_temporary_home_guard_allows_only_this_runner_immediate_temp_children() -> None:

--- a/tests/test_issue_106_app_server_lifecycle.py
+++ b/tests/test_issue_106_app_server_lifecycle.py
@@ -14,6 +14,19 @@ RUNNER = importlib.util.module_from_spec(RUNNER_SPEC)
 RUNNER_SPEC.loader.exec_module(RUNNER)
 
 
+class BrokenPipeStdin:
+    closed = False
+
+    def close(self) -> None:
+        self.closed = True
+        raise BrokenPipeError
+
+
+class BrokenPipeProcess:
+    stdin = BrokenPipeStdin()
+    stdout: tuple[str, ...] = ()
+
+
 def snapshot(
     thread_status: str, turn_statuses: list[str], turn_item_counts: list[int]
 ) -> dict[str, object]:
@@ -75,6 +88,190 @@ def test_catalog_summary_does_not_retain_model_identifiers() -> None:
         "requestedOfficialModelListed": True,
         "requestedOfficialModelSupportsMax": True,
     }
+
+
+def test_catalog_comparison_requires_fresh_official_and_connected_controls() -> None:
+    official = {
+        "account": {"authenticated": False, "requiresOpenaiAuth": True},
+        "catalog": {
+            "modelCount": 7,
+            "requestedOfficialModelListed": True,
+            "requestedOfficialModelSupportsMax": True,
+            "externalModelListed": False,
+        },
+    }
+    connected = {
+        "account": {"authenticated": False, "requiresOpenaiAuth": True},
+        "catalog": {
+            "modelCount": 29,
+            "requestedOfficialModelListed": True,
+            "requestedOfficialModelSupportsMax": True,
+            "externalModelListed": True,
+        },
+    }
+
+    RUNNER.assert_catalog_comparison(official, connected)
+
+    connected["catalog"]["externalModelListed"] = False
+    with pytest.raises(RUNNER.AppServerFailure, match="external_model_missing"):
+        RUNNER.assert_catalog_comparison(official, connected)
+
+
+def test_repeated_green_result_requires_every_cleanup_boundary() -> None:
+    run = {
+        "outcome": "passed",
+        "nativeCleanup": "passed",
+        "clientClose": "passed",
+        "appServerCleanup": "passed",
+        "temporaryHomeCleanup": "passed",
+    }
+
+    assert RUNNER.is_clean_issue106_green_run(run)
+
+    run["appServerCleanup"] = "failed"
+    assert not RUNNER.is_clean_issue106_green_run(run)
+
+
+def test_client_close_sanitizes_a_broken_pipe() -> None:
+    client = RUNNER.JsonRpcClient(BrokenPipeProcess())
+
+    with pytest.raises(RUNNER.AppServerFailure, match="app_server_client_close_failed"):
+        client.close()
+
+
+def test_app_server_stop_finishes_shutdown_after_broken_pipe_failures() -> None:
+    events: list[str] = []
+
+    class FailingInput:
+        closed = False
+
+        def close(self) -> None:
+            self.closed = True
+            events.append("stdin")
+            raise BrokenPipeError
+
+    class FailingOutput:
+        def close(self) -> None:
+            events.append("stdout")
+            raise OSError
+
+    class Process:
+        stdin = FailingInput()
+        stdout = FailingOutput()
+        waits = 0
+
+        def wait(self, timeout: float) -> int:
+            del timeout
+            self.waits += 1
+            events.append("wait")
+            if self.waits == 1:
+                raise RUNNER.subprocess.TimeoutExpired("app-server", 5)
+            return 0
+
+        def terminate(self) -> None:
+            events.append("terminate")
+
+        def kill(self) -> None:
+            events.append("kill")
+
+        def poll(self) -> int:
+            return 0
+
+    with pytest.raises(RUNNER.AppServerFailure, match="app_server_pipe_close_failed"):
+        RUNNER.stop_issue106_app_server(Process())
+
+    assert events == ["stdin", "wait", "terminate", "wait", "stdout"]
+
+
+def test_isolated_teardown_runs_after_a_client_close_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    events: list[str] = []
+    home = tmp_path / "issue106-home"
+    home.mkdir()
+
+    class FailingClient:
+        def close(self) -> None:
+            events.append("client")
+            raise RUNNER.AppServerFailure("app_server_client_close_failed")
+
+    monkeypatch.setattr(RUNNER, "create_temporary_home", lambda: home)
+    monkeypatch.setattr(RUNNER, "start_issue106_app_server", lambda *_args: object())
+    monkeypatch.setattr(RUNNER, "JsonRpcClient", lambda _process: FailingClient())
+    monkeypatch.setattr(
+        RUNNER,
+        "stop_issue106_app_server",
+        lambda _process: events.append("app-server"),
+    )
+    monkeypatch.setattr(
+        RUNNER,
+        "remove_temporary_home",
+        lambda _home: events.append("temporary-home"),
+    )
+
+    with pytest.raises(RUNNER.AppServerFailure, match="app_server_client_close_failed"):
+        RUNNER.with_isolated_client(
+            codex_command=Path("codex"),
+            connected=False,
+            gateway_base_url="http://127.0.0.1:9099",
+            gateway_key=None,
+            action=lambda _client, _home: {"outcome": "passed"},
+        )
+
+    assert events == ["client", "app-server", "temporary-home"]
+
+
+def test_red_control_reads_completed_system_error_before_classifying(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    snapshots = iter(
+        [
+            snapshot("systemError", ["completed"], [1]),
+            snapshot("systemError", ["completed", "completed"], [1, 1]),
+        ]
+    )
+    turn_ids = iter(("first-turn", "continuation-turn"))
+
+    class ResumableClient:
+        def request(
+            self, method: str, params: dict[str, object], timeout: float
+        ) -> dict[str, object]:
+            del method, params, timeout
+            return {"result": {}}
+
+    monkeypatch.setattr(RUNNER, "read_issue106_model_list", lambda *_args: [])
+    monkeypatch.setattr(
+        RUNNER,
+        "start_issue106_custom_thread",
+        lambda *_args: "red-thread",
+    )
+    monkeypatch.setattr(RUNNER, "turn_started", lambda *_args, **_kwargs: next(turn_ids))
+    monkeypatch.setattr(
+        RUNNER,
+        "wait_for_turn",
+        lambda *_args, **_kwargs: {"status": "completed"},
+    )
+    monkeypatch.setattr(RUNNER, "thread_snapshot", lambda *_args: next(snapshots))
+    monkeypatch.setattr(RUNNER, "cleanup_issue106_thread", lambda *_args: "passed")
+
+    result = RUNNER.run_red_missing_model(
+        ResumableClient(),
+        tmp_path,
+        timeout=1,
+        red_timeout=1,
+        red_model="unlisted-model",
+    )
+
+    assert result["outcome"] == "non_atomic_missing_model"
+    assert result["initialState"] == "failed_without_output"
+    assert result["continuation"]["status"] == "no_usable_rollout"
+
+
+def test_green_defaults_to_two_runs_and_rejects_a_single_run() -> None:
+    assert RUNNER.parse_args(["--scenario", "green"]).repeat == 2
+
+    with pytest.raises(SystemExit):
+        RUNNER.parse_args(["--scenario", "green", "--repeat", "1"])
 
 
 def test_json_rpc_error_is_distinct_from_an_app_server_transport_failure() -> None:

--- a/tests/test_issue_106_app_server_lifecycle.py
+++ b/tests/test_issue_106_app_server_lifecycle.py
@@ -1,0 +1,91 @@
+import importlib.util
+from pathlib import Path
+import tempfile
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+RUNNER_PATH = ROOT / "scripts" / "run_issue_106_task_lifecycle.py"
+RUNNER_SPEC = importlib.util.spec_from_file_location("issue_106_lifecycle_runner", RUNNER_PATH)
+assert RUNNER_SPEC is not None
+assert RUNNER_SPEC.loader is not None
+RUNNER = importlib.util.module_from_spec(RUNNER_SPEC)
+RUNNER_SPEC.loader.exec_module(RUNNER)
+
+
+def snapshot(
+    thread_status: str, turn_statuses: list[str], turn_item_counts: list[int]
+) -> dict[str, object]:
+    return {
+        "threadStatus": thread_status,
+        "turnStatuses": turn_statuses,
+        "turnItemCounts": turn_item_counts,
+        "assistantOutputTurns": 0,
+    }
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("danger-full-access", True),
+        ({"type": "dangerFullAccess"}, True),
+        ({"type": "workspaceWrite"}, False),
+        (None, False),
+    ],
+)
+def test_full_access_binding_accepts_only_supported_app_server_encodings(
+    value: object, expected: bool
+) -> None:
+    assert RUNNER.is_danger_full_access(value) is expected
+
+
+def test_red_classifier_preserves_both_observed_no_output_states() -> None:
+    assert (
+        RUNNER.classify_red_snapshot(snapshot("active", ["inProgress"], [1]))
+        == "in_progress_without_output"
+    )
+    assert (
+        RUNNER.classify_red_snapshot(snapshot("systemError", ["completed"], [1]))
+        == "failed_without_output"
+    )
+
+
+def test_red_classifier_rejects_a_turn_that_has_any_agent_output() -> None:
+    value = snapshot("systemError", ["completed"], [1])
+    value["assistantOutputTurns"] = 1
+
+    assert RUNNER.classify_red_snapshot(value) == "unexpected_missing_model_state"
+
+
+def test_catalog_summary_does_not_retain_model_identifiers() -> None:
+    summary = RUNNER.catalog_summary(
+        [
+            {
+                "id": "gpt-5.6-terra",
+                "supportedReasoningEfforts": [{"reasoningEffort": "max"}],
+            },
+            {"id": "glm-5.2"},
+        ],
+        "gpt-5.6-terra",
+    )
+
+    assert summary == {
+        "modelCount": 2,
+        "requestedOfficialModelListed": True,
+        "requestedOfficialModelSupportsMax": True,
+    }
+
+
+def test_json_rpc_error_is_distinct_from_an_app_server_transport_failure() -> None:
+    with pytest.raises(RUNNER.AppServerRequestRejected):
+        RUNNER.response_result({"error": {"code": -1}}, "thread_start")
+
+
+def test_temporary_home_guard_allows_only_this_runner_immediate_temp_children() -> None:
+    temporary_root = Path(tempfile.gettempdir())
+    safe = temporary_root / f"{RUNNER.TEMP_HOME_PREFIX}synthetic"
+
+    assert RUNNER.is_task_owned_temporary_home(safe)
+    assert not RUNNER.is_task_owned_temporary_home(temporary_root / "unrelated")
+    assert not RUNNER.is_task_owned_temporary_home(safe / "nested")

--- a/tests/test_issue_106_app_server_lifecycle.py
+++ b/tests/test_issue_106_app_server_lifecycle.py
@@ -127,7 +127,7 @@ def run_green_fixture(
 def run_red_turn_rejection_fixture(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
-    rejected_snapshot: dict[str, object],
+    rejected_snapshot: dict[str, object] | BaseException,
     rejection_details: dict[str, object],
 ) -> dict[str, object]:
     monkeypatch.setattr(RUNNER, "read_issue106_model_list", lambda *_args: [])
@@ -141,7 +141,12 @@ def run_red_turn_rejection_fixture(
         raise RUNNER.AppServerRequestRejected("turn_start", rejection_details)
 
     monkeypatch.setattr(RUNNER, "turn_started", reject_turn)
-    monkeypatch.setattr(RUNNER, "thread_snapshot", lambda *_args: rejected_snapshot)
+    def read_rejection(*_args: object) -> dict[str, object]:
+        if isinstance(rejected_snapshot, BaseException):
+            raise rejected_snapshot
+        return rejected_snapshot
+
+    monkeypatch.setattr(RUNNER, "thread_snapshot", read_rejection)
     monkeypatch.setattr(RUNNER, "cleanup_issue106_thread", lambda *_args: "passed")
 
     return RUNNER.run_red_missing_model(
@@ -492,6 +497,24 @@ def test_turn_rejection_with_a_persisted_turn_is_unverified(
 
     assert result["outcome"] == "unverified_rejection"
     assert result["rejectionClassification"] == "thread_read_not_empty_or_error_not_precise"
+
+
+def test_turn_rejection_with_an_unreadable_task_is_unverified(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    result = run_red_turn_rejection_fixture(
+        monkeypatch,
+        tmp_path,
+        RUNNER.AppServerFailure("thread_read_failed"),
+        {"errorKind": "json_rpc", "errorCode": -32602},
+    )
+
+    assert result["outcome"] == "unverified_rejection"
+    assert (
+        result["rejectionClassification"]
+        == "thread_read_unavailable_after_turn_rejection"
+    )
+    assert "threadRead" not in result
 
 
 def test_create_rejection_without_a_task_read_is_unverified(

--- a/tests/test_issue_106_task_creation_lifecycle.py
+++ b/tests/test_issue_106_task_creation_lifecycle.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+import importlib.util
 import json
 import subprocess
 import sys
@@ -9,6 +11,11 @@ import pytest
 ROOT = Path(__file__).resolve().parents[1]
 EVIDENCE = ROOT / "docs" / "evidence" / "issue-106" / "task-creation-lifecycle.json"
 REPLAY_SCRIPT = ROOT / "scripts" / "check_codex_task_creation_lifecycle.py"
+CHECKER_SPEC = importlib.util.spec_from_file_location("issue_106_lifecycle_checker", REPLAY_SCRIPT)
+assert CHECKER_SPEC is not None
+assert CHECKER_SPEC.loader is not None
+CHECKER = importlib.util.module_from_spec(CHECKER_SPEC)
+CHECKER_SPEC.loader.exec_module(CHECKER)
 
 
 def run_replay(case: str) -> subprocess.CompletedProcess[str]:
@@ -21,54 +28,59 @@ def run_replay(case: str) -> subprocess.CompletedProcess[str]:
     )
 
 
-def walk_keys(value: object) -> set[str]:
-    if isinstance(value, dict):
-        return set(value) | set().union(*(walk_keys(item) for item in value.values()))
-    if isinstance(value, list):
-        return set().union(*(walk_keys(item) for item in value)) if value else set()
-    return set()
+def read_evidence() -> dict[str, object]:
+    return json.loads(EVIDENCE.read_text(encoding="utf-8"))
 
 
-def test_task_creation_evidence_covers_red_green_boundary_without_private_identifiers() -> None:
+def test_task_creation_evidence_matches_the_strict_sanitized_contract() -> None:
     evidence = json.loads(EVIDENCE.read_text(encoding="utf-8"))
 
-    assert evidence["schema_version"] == 1
-    assert evidence["capture_kind"] == "sanitized_task_creation_ab_evidence"
-    assert evidence["product_boundary"] == {
-        "codexhub_manages_global_mcp": False,
-        "codexhub_has_bounded_app_server_model_probes": True,
-        "codexhub_exposes_native_task_lifecycle": False,
-        "proven_link_from_model_probes_to_task_materialization": False,
-        "product_behavior_changed": False,
-    }
-    assert evidence["red_case"]["classification"] == "half_created"
-    assert evidence["red_case"]["worktree_provisioned"] is True
-    assert evidence["red_case"]["rollout_materialized"] is False
-    assert evidence["green_case"]["materialized"] is True
-    assert evidence["green_case"]["permission_preflight"] == {
-        "filesystem": "unrestricted",
-        "network": "enabled",
-        "approval": "never",
-    }
-    assert evidence["green_case"]["git_preflight"] == "passed"
-    assert evidence["cleanup_observation"]["clean_orphan_worktrees_removed"] == 2
-    assert evidence["cleanup_observation"]["client_held_empty_directory"] is True
-    assert evidence["sanitization"] == {
-        "contains_credentials": False,
-        "contains_local_paths": False,
-        "contains_prompts_or_messages": False,
-        "contains_task_or_session_identifiers": False,
-    }
-    assert not {
-        "authorization",
-        "api_key",
-        "client_thread_id",
-        "cwd",
-        "session_id",
-        "task_id",
-        "thread_id",
-        "worktree_path",
-    } & walk_keys(evidence)
+    assert CHECKER.validate_evidence(evidence, repo_root=ROOT) == []
+
+
+def test_task_creation_evidence_requires_a_provenance_source() -> None:
+    evidence = read_evidence()
+    del evidence["source"]
+
+    mismatches = CHECKER.validate_evidence(evidence, repo_root=ROOT)
+
+    assert "evidence has missing fields: source" in mismatches
+
+
+def test_task_creation_evidence_rejects_unknown_and_unsafe_source_values() -> None:
+    evidence = read_evidence()
+    source = evidence["source"]
+    assert isinstance(source, dict)
+    source["notes"] = r"C:\Synthetic\Private\path\rollout-019f0000"
+    source["credential"] = "synthetic-secret-value"
+    source["evidence_type"] = r"C:\Synthetic\Private\path\rollout-019f0000"
+    source["conclusion_limit"] = "synthetic-secret-value"
+
+    mismatches = CHECKER.validate_evidence(evidence, repo_root=ROOT)
+    rendered = " | ".join(mismatches)
+
+    assert "source has unexpected fields" in mismatches
+    assert "unsafe local path string at $.source.<unexpected>" in mismatches
+    assert "unsafe task or session identifier string at $.source.<unexpected>" in mismatches
+    assert "unsafe credential-like string at $.source.<unexpected>" in mismatches
+    assert "unsafe local path string at $.source.evidence_type" in mismatches
+    assert "unsafe credential-like string at $.source.conclusion_limit" in mismatches
+    assert r"C:\Synthetic\Private\path\rollout-019f0000" not in rendered
+    assert "synthetic-secret-value" not in rendered
+
+
+def test_task_creation_evidence_reports_unavailable_boundary_sources_without_local_paths(tmp_path: Path) -> None:
+    mismatches = CHECKER.validate_evidence(read_evidence(), repo_root=tmp_path)
+    rendered = " | ".join(mismatches)
+
+    assert "ownership boundary source unavailable: src-python/config_overlay.py" in mismatches
+    assert str(tmp_path) not in rendered
+
+
+def test_task_creation_boundary_guard_covers_bounded_app_server_probe_sites() -> None:
+    assert Path("src-tauri/src/models.rs") in CHECKER.OWNERSHIP_BOUNDARY_PATHS
+    assert Path("src-tauri/src/openai_usage.rs") in CHECKER.OWNERSHIP_BOUNDARY_PATHS
+    assert CHECKER.validate_owned_boundary_sources(ROOT) == []
 
 
 def test_task_creation_identity_replay_passes() -> None:

--- a/tests/test_issue_106_task_creation_lifecycle.py
+++ b/tests/test_issue_106_task_creation_lifecycle.py
@@ -1,0 +1,89 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+EVIDENCE = ROOT / "docs" / "evidence" / "issue-106" / "task-creation-lifecycle.json"
+REPLAY_SCRIPT = ROOT / "scripts" / "check_codex_task_creation_lifecycle.py"
+
+
+def run_replay(case: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(REPLAY_SCRIPT), "--replay-case", case],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def walk_keys(value: object) -> set[str]:
+    if isinstance(value, dict):
+        return set(value) | set().union(*(walk_keys(item) for item in value.values()))
+    if isinstance(value, list):
+        return set().union(*(walk_keys(item) for item in value)) if value else set()
+    return set()
+
+
+def test_task_creation_evidence_covers_red_green_boundary_without_private_identifiers() -> None:
+    evidence = json.loads(EVIDENCE.read_text(encoding="utf-8"))
+
+    assert evidence["schema_version"] == 1
+    assert evidence["capture_kind"] == "sanitized_task_creation_ab_evidence"
+    assert evidence["product_boundary"] == {
+        "codexhub_manages_global_mcp": False,
+        "codexhub_has_bounded_app_server_model_probes": True,
+        "codexhub_exposes_native_task_lifecycle": False,
+        "proven_link_from_model_probes_to_task_materialization": False,
+        "product_behavior_changed": False,
+    }
+    assert evidence["red_case"]["classification"] == "half_created"
+    assert evidence["red_case"]["worktree_provisioned"] is True
+    assert evidence["red_case"]["rollout_materialized"] is False
+    assert evidence["green_case"]["materialized"] is True
+    assert evidence["green_case"]["permission_preflight"] == {
+        "filesystem": "unrestricted",
+        "network": "enabled",
+        "approval": "never",
+    }
+    assert evidence["green_case"]["git_preflight"] == "passed"
+    assert evidence["cleanup_observation"]["clean_orphan_worktrees_removed"] == 2
+    assert evidence["cleanup_observation"]["client_held_empty_directory"] is True
+    assert evidence["sanitization"] == {
+        "contains_credentials": False,
+        "contains_local_paths": False,
+        "contains_prompts_or_messages": False,
+        "contains_task_or_session_identifiers": False,
+    }
+    assert not {
+        "authorization",
+        "api_key",
+        "client_thread_id",
+        "cwd",
+        "session_id",
+        "task_id",
+        "thread_id",
+        "worktree_path",
+    } & walk_keys(evidence)
+
+
+def test_task_creation_identity_replay_passes() -> None:
+    result = run_replay("identity")
+
+    assert result.returncode == 0, result.stderr
+    assert "TASK_CREATION_LIFECYCLE_COMPLETE" in result.stdout
+
+
+@pytest.mark.parametrize(
+    "case",
+    ["materialize-red", "unmaterialize-green", "fail-git-preflight", "skip-cleanup", "identifier-leak"],
+)
+def test_task_creation_negative_replays_fail_visibly(case: str) -> None:
+    result = run_replay(case)
+
+    assert result.returncode == 1
+    assert "TASK_CREATION_LIFECYCLE_MISMATCH:" in result.stderr

--- a/tests/test_issue_106_task_creation_lifecycle.py
+++ b/tests/test_issue_106_task_creation_lifecycle.py
@@ -18,9 +18,14 @@ CHECKER = importlib.util.module_from_spec(CHECKER_SPEC)
 CHECKER_SPEC.loader.exec_module(CHECKER)
 
 
-def run_replay(case: str) -> subprocess.CompletedProcess[str]:
+def run_replay(
+    case: str, evidence_path: Path | None = None
+) -> subprocess.CompletedProcess[str]:
+    command = [sys.executable, str(REPLAY_SCRIPT), "--replay-case", case]
+    if evidence_path is not None:
+        command.extend(("--evidence", str(evidence_path)))
     return subprocess.run(
-        [sys.executable, str(REPLAY_SCRIPT), "--replay-case", case],
+        command,
         cwd=ROOT,
         check=False,
         capture_output=True,
@@ -121,6 +126,24 @@ def test_task_creation_identity_replay_passes() -> None:
 
     assert result.returncode == 0, result.stderr
     assert "TASK_CREATION_LIFECYCLE_COMPLETE" in result.stdout
+
+
+def test_task_creation_malformed_nested_fixture_fails_without_a_traceback(tmp_path: Path) -> None:
+    evidence = read_evidence()
+    evidence["red_case"] = []
+    malformed_evidence = tmp_path / "malformed-task-creation-evidence.json"
+    malformed_evidence.write_text(json.dumps(evidence), encoding="utf-8")
+
+    result = run_replay("materialize-red", malformed_evidence)
+    rendered = result.stdout + result.stderr
+
+    assert result.returncode == 1
+    assert "TASK_CREATION_LIFECYCLE_MISMATCH: red_case must be an object" in result.stderr
+    assert "Traceback" not in rendered
+    assert str(ROOT) not in rendered
+    assert str(malformed_evidence) not in rendered
+    assert not CHECKER.WINDOWS_LOCAL_PATH_PATTERN.search(rendered)
+    assert not CHECKER.POSIX_LOCAL_PATH_PATTERN.search(rendered)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_issue_106_task_creation_lifecycle.py
+++ b/tests/test_issue_106_task_creation_lifecycle.py
@@ -69,6 +69,39 @@ def test_task_creation_evidence_rejects_unknown_and_unsafe_source_values() -> No
     assert "synthetic-secret-value" not in rendered
 
 
+def test_task_creation_evidence_rejects_json_scalar_type_aliases() -> None:
+    evidence = read_evidence()
+    evidence["schema_version"] = True
+    product_boundary = evidence["product_boundary"]
+    assert isinstance(product_boundary, dict)
+    product_boundary["codexhub_manages_global_mcp"] = 0
+    green_case = evidence["green_case"]
+    assert isinstance(green_case, dict)
+    green_case["materialized"] = 1
+
+    mismatches = CHECKER.validate_evidence(evidence, repo_root=ROOT)
+
+    assert "schema_version did not match the expected contract" in mismatches
+    assert "product_boundary.codexhub_manages_global_mcp did not match the expected contract" in mismatches
+    assert "green_case.materialized did not match the expected contract" in mismatches
+
+
+@pytest.mark.parametrize("credential_shape", ["sk-abcdefghijklmnop", "sk-proj-abcdefghijklmnop"])
+def test_task_creation_evidence_rejects_common_openai_credential_shapes(
+    credential_shape: str,
+) -> None:
+    evidence = read_evidence()
+    source = evidence["source"]
+    assert isinstance(source, dict)
+    source["evidence_type"] = credential_shape
+
+    mismatches = CHECKER.validate_evidence(evidence, repo_root=ROOT)
+    rendered = " | ".join(mismatches)
+
+    assert "unsafe credential-like string at $.source.evidence_type" in mismatches
+    assert credential_shape not in rendered
+
+
 def test_task_creation_evidence_reports_unavailable_boundary_sources_without_local_paths(tmp_path: Path) -> None:
     mismatches = CHECKER.validate_evidence(read_evidence(), repo_root=tmp_path)
     rendered = " | ".join(mismatches)


### PR DESCRIPTION
## CodexHub-owned correction

- Fix the stale fallback catalog so the current requested official bindings and supported efforts are present in a fresh isolated catalog.
- Cover the fallback policy with catalog regression tests.
- Keep the official app-server persistence defect outside CodexHub: no client-side repair, transport/retry/SSE change, or internal-state mutation is introduced.

## Live isolated evidence (partial)

- `compare` passed as an account/catalog/model-list control. The fresh official/disconnected and CodexHub/connected catalogs list the requested official binding with `max` effort; the external model is listed only when connected. It executes no Task lifecycle, so the official remote full-lifecycle A/B is an unrun external gate.
- `green --repeat 2` passed two connected external-model create -> bootstrap -> read -> retained Task list -> rename -> full-bind -> resume -> continue -> replay -> delete runs, with native Task, client-pipe, app-server, and temporary-home cleanup. The full binding is the same external custom-provider model from low bootstrap effort to max effort; readback asserts `modelProvider: custom`.
- The full-bind permission preflight is explicitly metadata-only. It asserts requested policy fields but does not perform filesystem or network access.
- `red` reproduced the official app-server residual: an unlisted model is accepted, an input-only turn persists without agent output, and an ordinary continuation has no usable rollout. Rejected paths are called atomic only after a numeric JSON-RPC error and a zero-turn `thread/read`; all other rejected paths are unverified.

## Requirement matrix

| Requirement | State | Boundary |
| --- | --- | --- |
| Current official fallback bindings/efforts in isolated catalog | Covered | CodexHub-owned catalog policy |
| Connected external-model same-model lifecycle | Covered, partial | Two live runs; retained Task list and custom-provider resume assertion |
| Low bootstrap -> different explicit Worker model/reasoning | Unrun external gate | Current green flow intentionally uses the same external model |
| Official remote full lifecycle A/B | Unrun external gate | `compare` is catalog/account/model-list only |
| Permission access exercise | Partial | Metadata-only policy preflight |
| Unlisted-model request atomicity | Reproduced upstream residual | Input-only turn and unusable continuation remain |
| Cleanup beyond task-owned native resources | Unrun | No remote-control, shared-config, worktree, or placeholder cleanup claim |

## Remaining upstream blocker

CodexHub's stale fallback catalog is fixed and covered. The official app-server can still accept an unlisted model, persist an input-only turn without a rollout, and make normal continuation unusable. That residual is upstream-owned and remains unresolved. Issue #106 stays open because its broader atomic-send/continuation acceptance is not satisfied.

## Scope

No shared/global configuration, credentials, internal Codex state, transport/retry/SSE behavior, protocol routing, global client worktrees, or client-side repair changed.

Refs #106