### PR TITLE
feat: add bounded Gateway event writer

### DIFF
--- a/src-python/bounded_event_writer.py
+++ b/src-python/bounded_event_writer.py
@@ -11,6 +11,7 @@ from collections import deque
 from dataclasses import dataclass, field
 import errno
 import json
+import math
 from pathlib import Path
 import threading
 import time
@@ -20,6 +21,10 @@ import weakref
 
 WriterOutcome = Literal["drained", "timeout", "failed"]
 WriterShutdownState = Literal["running", "stopping", "stopped"]
+
+
+class _RecordTooLarge(ValueError):
+    """Raised when bounded admission proves a record cannot fit in the queue."""
 
 
 class EventSink(Protocol):
@@ -299,6 +304,9 @@ class BoundedEventWriter:
         self._shutdown_state: WriterShutdownState = "running"
         self._worker: threading.Thread | None = None
         self._writer_generation = 0
+        # A crash with retained backlog gets exactly one automatic replacement.
+        # A successful write resets this guard for a later, independent crash.
+        self._automatic_restart_used = False
         self._rotation_target_sequence: int | None = None
         self._sink_ownership: Literal["weak", "strong"]
         self._claim_sink_ownership()
@@ -306,8 +314,27 @@ class BoundedEventWriter:
     def enqueue(self, record: Mapping[str, Any]) -> bool:
         """Attempt a non-blocking in-memory enqueue of one sanitized record."""
 
+        with self._condition:
+            if self._shutdown_state != "running":
+                self._dropped_records += 1
+                self._condition.notify_all()
+                return False
+            if self._pending_records >= self._max_records:
+                self._record_overflow_locked(byte_count=0)
+                self._condition.notify_all()
+                return False
+            admission_limit = self._max_bytes
+
         try:
-            data = _serialize_record(record)
+            data = _serialize_record(record, max_bytes=admission_limit)
+        except _RecordTooLarge:
+            with self._condition:
+                if self._shutdown_state == "running":
+                    self._record_overflow_locked(byte_count=0)
+                else:
+                    self._dropped_records += 1
+                self._condition.notify_all()
+            return False
         except Exception:
             with self._condition:
                 self._record_failure_locked("serialization_rejected", record_count=1, byte_count=0)
@@ -322,10 +349,7 @@ class BoundedEventWriter:
                 self._condition.notify_all()
                 return False
             if self._pending_records >= self._max_records or self._pending_bytes + byte_count > self._max_bytes:
-                self._dropped_records += 1
-                self._dropped_bytes += byte_count
-                self._pending_recovery.overflow_records += 1
-                self._pending_recovery.overflow_bytes += byte_count
+                self._record_overflow_locked(byte_count=byte_count)
                 self._condition.notify_all()
                 return False
 
@@ -486,6 +510,7 @@ class BoundedEventWriter:
     def _writer_loop(self) -> None:
         current_worker = threading.current_thread()
         inflight: Sequence[_QueuedRecord] = ()
+        writer_crashed = False
         try:
             while True:
                 with self._condition:
@@ -521,6 +546,7 @@ class BoundedEventWriter:
                 with self._condition:
                     self._complete_batch_locked(inflight)
                     self._written_records += len(inflight)
+                    self._automatic_restart_used = False
                     recovery = self._pending_recovery.snapshot() if self._pending_recovery.has_data() else None
                     self._recovery_inflight = recovery is not None
                     self._condition.notify_all()
@@ -529,6 +555,7 @@ class BoundedEventWriter:
                 if recovery is not None:
                     self._emit_recovery(recovery)
         except BaseException:
+            writer_crashed = True
             with self._condition:
                 if inflight:
                     self._complete_batch_locked(inflight)
@@ -545,6 +572,9 @@ class BoundedEventWriter:
             with self._condition:
                 if self._worker is current_worker:
                     self._worker = None
+                if writer_crashed and self._queue and not self._automatic_restart_used:
+                    self._automatic_restart_used = True
+                    self._ensure_worker_locked()
                 if self._shutdown_state == "stopping" and self._pending_records == 0:
                     self._shutdown_state = "stopped"
                     release_sink_ownership = True
@@ -619,6 +649,12 @@ class BoundedEventWriter:
         if include_recovery:
             self._pending_recovery.add_failure(category, record_count)
 
+    def _record_overflow_locked(self, *, byte_count: int) -> None:
+        self._dropped_records += 1
+        self._dropped_bytes += byte_count
+        self._pending_recovery.overflow_records += 1
+        self._pending_recovery.overflow_bytes += byte_count
+
     def _status_locked(self) -> BoundedEventWriterStatus:
         return BoundedEventWriterStatus(
             queued_records=self._pending_records,
@@ -638,11 +674,153 @@ class BoundedEventWriter:
         )
 
 
-def _serialize_record(record: Mapping[str, Any]) -> bytes:
+def _serialize_record(record: Mapping[str, Any], *, max_bytes: int | None = None) -> bytes:
     if not isinstance(record, Mapping):
         raise TypeError("event record must be a mapping")
+    if max_bytes is not None:
+        _admit_record_size(record, max_bytes)
     text = json.dumps(dict(record), ensure_ascii=True, separators=(",", ":"))
-    return text.encode("utf-8") + b"\n"
+    data = text.encode("utf-8") + b"\n"
+    if max_bytes is not None and len(data) > max_bytes:
+        # The admission pass is deliberately conservative. Keep this fallback
+        # so a future serializer change cannot violate the request-path bound.
+        raise _RecordTooLarge("serialized event exceeds bounded admission")
+    return data
+
+
+def _admit_record_size(record: Mapping[str, Any], max_bytes: int) -> None:
+    """Prove a JSONL record fits before allocating its serialized snapshot.
+
+    ``json.dumps`` can allocate a string proportional to arbitrary request
+    content. This pass measures exactly the JSON shape emitted by the writer
+    and stops as soon as the configured byte budget is exhausted. It performs
+    no JSON encoding or mapping snapshot until the record is known to fit.
+    """
+
+    if max_bytes < 3:
+        raise _RecordTooLarge("JSONL record cannot fit in bounded admission")
+    budget = _JsonSizeBudget(max_bytes - 1)
+    _measure_json_mapping(record, budget, set())
+
+
+class _JsonSizeBudget:
+    def __init__(self, remaining: int) -> None:
+        self.remaining = remaining
+
+    def consume(self, byte_count: int) -> None:
+        if byte_count > self.remaining:
+            raise _RecordTooLarge("JSON record exceeds bounded admission")
+        self.remaining -= byte_count
+
+
+def _measure_json_mapping(value: Mapping[Any, Any], budget: _JsonSizeBudget, active: set[int]) -> None:
+    identity = id(value)
+    if identity in active:
+        raise ValueError("circular event mapping")
+    active.add(identity)
+    try:
+        budget.consume(1)
+        first = True
+        for key in value:
+            if not first:
+                budget.consume(1)
+            first = False
+            _measure_json_key(key, budget)
+            budget.consume(1)
+            _measure_json_value(value[key], budget, active)
+        budget.consume(1)
+    finally:
+        active.remove(identity)
+
+
+def _measure_json_sequence(value: list[Any] | tuple[Any, ...], budget: _JsonSizeBudget, active: set[int]) -> None:
+    identity = id(value)
+    if identity in active:
+        raise ValueError("circular event sequence")
+    active.add(identity)
+    try:
+        budget.consume(1)
+        first = True
+        for item in value:
+            if not first:
+                budget.consume(1)
+            first = False
+            _measure_json_value(item, budget, active)
+        budget.consume(1)
+    finally:
+        active.remove(identity)
+
+
+def _measure_json_value(value: Any, budget: _JsonSizeBudget, active: set[int]) -> None:
+    if value is None:
+        budget.consume(4)
+    elif isinstance(value, bool):
+        budget.consume(4 if value else 5)
+    elif isinstance(value, str):
+        _measure_json_string(value, budget)
+    elif isinstance(value, int):
+        _measure_json_integer(value, budget)
+    elif isinstance(value, float):
+        _measure_json_float(value, budget)
+    elif isinstance(value, dict):
+        _measure_json_mapping(value, budget, active)
+    elif isinstance(value, (list, tuple)):
+        _measure_json_sequence(value, budget, active)
+    else:
+        raise TypeError("event record contains a non-JSON value")
+
+
+def _measure_json_key(key: Any, budget: _JsonSizeBudget) -> None:
+    if isinstance(key, str):
+        _measure_json_string(key, budget)
+    elif key is None:
+        budget.consume(6)
+    elif isinstance(key, bool):
+        budget.consume(6 if key else 7)
+    elif isinstance(key, int):
+        _measure_json_integer(key, budget, quoted=True)
+    elif isinstance(key, float):
+        _measure_json_float(key, budget, quoted=True)
+    else:
+        raise TypeError("event record contains a non-JSON key")
+
+
+def _measure_json_string(value: str, budget: _JsonSizeBudget) -> None:
+    budget.consume(2)
+    for character in value:
+        code_point = ord(character)
+        if character in {'"', "\\"}:
+            budget.consume(2)
+        elif character in {"\b", "\t", "\n", "\f", "\r"}:
+            budget.consume(2)
+        elif code_point < 0x20:
+            budget.consume(6)
+        elif code_point <= 0x7F:
+            budget.consume(1)
+        elif code_point <= 0xFFFF:
+            budget.consume(6)
+        else:
+            budget.consume(12)
+
+
+def _measure_json_integer(value: int, budget: _JsonSizeBudget, *, quoted: bool = False) -> None:
+    sign = 1 if value < 0 else 0
+    digit_upper_bound = 1 if value == 0 else (value.bit_length() * 30_103) // 100_000 + 2
+    rendered_upper_bound = sign + digit_upper_bound
+    if rendered_upper_bound > budget.remaining + 2:
+        raise _RecordTooLarge("integer exceeds bounded admission")
+    rendered_size = len(str(value))
+    budget.consume(rendered_size + (2 if quoted else 0))
+
+
+def _measure_json_float(value: float, budget: _JsonSizeBudget, *, quoted: bool = False) -> None:
+    if math.isnan(value):
+        rendered_size = 3
+    elif math.isinf(value):
+        rendered_size = 9 if value < 0 else 8
+    else:
+        rendered_size = len(float.__repr__(value))
+    budget.consume(rendered_size + (2 if quoted else 0))
 
 
 def _default_recovery_record(summary: RecoverySummary) -> Mapping[str, Any]:

--- a/src-python/bounded_event_writer.py
+++ b/src-python/bounded_event_writer.py
@@ -1,0 +1,664 @@
+"""Bounded, non-blocking JSONL event writing.
+
+Callers hand this module already-sanitized mappings. ``enqueue`` serializes a
+snapshot in memory and never opens, writes, flushes, rotates, or waits on a
+sink. One background writer owns batching, sink failures, and JSONL recovery.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+import errno
+import json
+from pathlib import Path
+import threading
+import time
+from typing import Any, BinaryIO, Callable, Deque, Literal, Mapping, Protocol, Sequence
+import weakref
+
+
+WriterOutcome = Literal["drained", "timeout", "failed"]
+WriterShutdownState = Literal["running", "stopping", "stopped"]
+
+
+class EventSink(Protocol):
+    """The writer-facing sink seam.
+
+    Implementations receive complete JSONL records, each ending in exactly one
+    newline. They may raise when storage is unavailable; those errors are
+    contained by :class:`BoundedEventWriter`.
+    """
+
+    def append(self, records: Sequence[bytes]) -> None:
+        """Append complete serialized records in their supplied order."""
+
+
+@dataclass(frozen=True)
+class RecoverySummary:
+    """Bounded, content-free telemetry about recovered writer pressure."""
+
+    overflow_records: int
+    overflow_bytes: int
+    failed_records: int
+    failure_count: int
+    failure_category_counts: tuple[tuple[str, int], ...]
+
+    @property
+    def failure_categories(self) -> tuple[str, ...]:
+        return tuple(category for category, _count in self.failure_category_counts)
+
+
+RecoveryRecordFactory = Callable[[RecoverySummary], Mapping[str, Any]]
+RotationOperation = Callable[[], None]
+
+
+@dataclass(frozen=True)
+class BoundedEventWriterStatus:
+    """Sanitized observable state for a writer.
+
+    Counts describe accepted telemetry records only. Recovery records generated
+    by the writer are exposed separately and never reveal record content or a
+    raw sink path.
+    """
+
+    queued_records: int
+    queued_bytes: int
+    accepted_records: int
+    written_records: int
+    dropped_records: int
+    dropped_bytes: int
+    failure_count: int
+    last_failure_category: str | None
+    last_failure_time: float | None
+    recovery_events_written: int
+    recovery_pending: bool
+    shutdown_state: WriterShutdownState
+    writer_alive: bool
+    writer_generation: int
+
+
+@dataclass(frozen=True)
+class BoundedEventWriterResult:
+    """Result of a bounded flush or shutdown operation."""
+
+    outcome: WriterOutcome
+    status: BoundedEventWriterStatus
+
+    @property
+    def completed(self) -> bool:
+        return self.outcome == "drained"
+
+
+@dataclass(frozen=True)
+class _QueuedRecord:
+    sequence: int
+    data: bytes
+
+    @property
+    def byte_count(self) -> int:
+        return len(self.data)
+
+
+@dataclass
+class _PendingRecovery:
+    overflow_records: int = 0
+    overflow_bytes: int = 0
+    failed_records: int = 0
+    failure_count: int = 0
+    failure_categories: dict[str, int] = field(default_factory=dict)
+
+    def has_data(self) -> bool:
+        return any(
+            (
+                self.overflow_records,
+                self.overflow_bytes,
+                self.failed_records,
+                self.failure_count,
+            )
+        )
+
+    def snapshot(self) -> RecoverySummary:
+        return RecoverySummary(
+            overflow_records=self.overflow_records,
+            overflow_bytes=self.overflow_bytes,
+            failed_records=self.failed_records,
+            failure_count=self.failure_count,
+            failure_category_counts=tuple(sorted(self.failure_categories.items())),
+        )
+
+    def subtract(self, summary: RecoverySummary) -> None:
+        self.overflow_records = max(0, self.overflow_records - summary.overflow_records)
+        self.overflow_bytes = max(0, self.overflow_bytes - summary.overflow_bytes)
+        self.failed_records = max(0, self.failed_records - summary.failed_records)
+        self.failure_count = max(0, self.failure_count - summary.failure_count)
+        for category, count in summary.failure_category_counts:
+            remaining = self.failure_categories.get(category, 0) - count
+            if remaining > 0:
+                self.failure_categories[category] = remaining
+            else:
+                self.failure_categories.pop(category, None)
+
+    def add_failure(self, category: str, record_count: int) -> None:
+        self.failed_records += record_count
+        self.failure_count += 1
+        # Failure categories are fixed, short labels chosen by this module.
+        # Keep the aggregation itself bounded even if a future category changes.
+        if category in self.failure_categories or len(self.failure_categories) < 8:
+            self.failure_categories[category] = self.failure_categories.get(category, 0) + 1
+
+
+class JsonlFileSink:
+    """Append complete JSONL records while repairing a previous partial tail.
+
+    The sink deliberately opens a file only from the writer thread. If storage
+    fails midway through a record, the next append discards that unterminated
+    tail before accepting more records, so a partial serialization is never
+    exposed as a valid JSONL line.
+    """
+
+    _TAIL_SCAN_BYTES = 64 * 1024
+
+    def __init__(
+        self,
+        path: Path,
+        *,
+        open_file: Callable[[Path, str], BinaryIO] | None = None,
+    ) -> None:
+        self._path = path
+        self._identity_path = path.expanduser().resolve()
+        self._open_file = open_file or self._default_open_file
+        self._lock = threading.Lock()
+
+    def __hash__(self) -> int:
+        return hash(self._identity_path)
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, JsonlFileSink) and self._identity_path == other._identity_path
+
+    @staticmethod
+    def _default_open_file(path: Path, mode: str) -> BinaryIO:
+        return path.open(mode)
+
+    def append(self, records: Sequence[bytes]) -> None:
+        if not records:
+            return
+        if any(not record.endswith(b"\n") or b"\n" in record[:-1] for record in records):
+            raise ValueError("event sink requires complete one-line JSONL records")
+
+        payload = b"".join(records)
+        with self._lock:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            with self._open_file(self._path, "a+b") as handle:
+                self._repair_partial_tail(handle)
+                self._write_all(handle, payload)
+                handle.flush()
+
+    @classmethod
+    def _repair_partial_tail(cls, handle: BinaryIO) -> None:
+        handle.seek(0, 2)
+        end = handle.tell()
+        if end == 0:
+            return
+
+        handle.seek(end - 1)
+        if handle.read(1) == b"\n":
+            return
+
+        cursor = end
+        while cursor:
+            start = max(0, cursor - cls._TAIL_SCAN_BYTES)
+            handle.seek(start)
+            chunk = handle.read(cursor - start)
+            newline = chunk.rfind(b"\n")
+            if newline >= 0:
+                handle.seek(start + newline + 1)
+                handle.truncate()
+                handle.flush()
+                return
+            cursor = start
+
+        handle.seek(0)
+        handle.truncate()
+        handle.flush()
+
+    @staticmethod
+    def _write_all(handle: BinaryIO, payload: bytes) -> None:
+        offset = 0
+        while offset < len(payload):
+            written = handle.write(payload[offset:])
+            if not isinstance(written, int) or written <= 0:
+                raise OSError("event sink made no write progress")
+            offset += written
+
+
+class BoundedEventWriter:
+    """Own a bounded event queue and exactly one background writer lifecycle.
+
+    ``enqueue`` is safe for concurrent request threads: it performs only
+    in-memory serialization and lock-protected queue bookkeeping. The sink,
+    batching, partial-write cleanup, failure isolation, and aggregate recovery
+    telemetry all stay behind this module's interface.
+    """
+
+    _sink_owners_lock = threading.Lock()
+    _weak_sink_owners: weakref.WeakKeyDictionary[Any, Any] = weakref.WeakKeyDictionary()
+    _strong_sink_owners: dict[int, Any] = {}
+
+    def __init__(
+        self,
+        sink: EventSink,
+        *,
+        max_records: int,
+        max_bytes: int,
+        batch_max_records: int = 128,
+        batch_max_bytes: int = 256 * 1024,
+        recovery_record_factory: RecoveryRecordFactory | None = None,
+        clock: Callable[[], float] = time.time,
+        thread_name: str = "bounded-event-writer",
+    ) -> None:
+        if max_records < 1:
+            raise ValueError("max_records must be positive")
+        if max_bytes < 1:
+            raise ValueError("max_bytes must be positive")
+        if batch_max_records < 1:
+            raise ValueError("batch_max_records must be positive")
+        if batch_max_bytes < 1:
+            raise ValueError("batch_max_bytes must be positive")
+
+        self._sink = sink
+        self._max_records = max_records
+        self._max_bytes = max_bytes
+        self._batch_max_records = batch_max_records
+        self._batch_max_bytes = batch_max_bytes
+        self._recovery_record_factory = recovery_record_factory or _default_recovery_record
+        self._clock = clock
+        self._thread_name = thread_name
+
+        self._condition = threading.Condition(threading.RLock())
+        self._queue: Deque[_QueuedRecord] = deque()
+        # Pending counts include a batch currently being written. This keeps the
+        # configured bounds strict even while storage is slow.
+        self._pending_records = 0
+        self._pending_bytes = 0
+        self._next_sequence = 1
+        self._completed_sequence = 0
+
+        self._accepted_records = 0
+        self._written_records = 0
+        self._dropped_records = 0
+        self._dropped_bytes = 0
+        self._failure_count = 0
+        self._last_failure_category: str | None = None
+        self._last_failure_time: float | None = None
+        self._recovery_events_written = 0
+        self._pending_recovery = _PendingRecovery()
+        self._recovery_inflight = False
+        self._unresolved_failure = False
+
+        self._shutdown_state: WriterShutdownState = "running"
+        self._worker: threading.Thread | None = None
+        self._writer_generation = 0
+        self._rotation_target_sequence: int | None = None
+        self._sink_ownership: Literal["weak", "strong"]
+        self._claim_sink_ownership()
+
+    def enqueue(self, record: Mapping[str, Any]) -> bool:
+        """Attempt a non-blocking in-memory enqueue of one sanitized record."""
+
+        try:
+            data = _serialize_record(record)
+        except Exception:
+            with self._condition:
+                self._record_failure_locked("serialization_rejected", record_count=1, byte_count=0)
+                self._condition.notify_all()
+            return False
+
+        byte_count = len(data)
+        with self._condition:
+            if self._shutdown_state != "running":
+                self._dropped_records += 1
+                self._dropped_bytes += byte_count
+                self._condition.notify_all()
+                return False
+            if self._pending_records >= self._max_records or self._pending_bytes + byte_count > self._max_bytes:
+                self._dropped_records += 1
+                self._dropped_bytes += byte_count
+                self._pending_recovery.overflow_records += 1
+                self._pending_recovery.overflow_bytes += byte_count
+                self._condition.notify_all()
+                return False
+
+            queued = _QueuedRecord(sequence=self._next_sequence, data=data)
+            self._next_sequence += 1
+            self._queue.append(queued)
+            self._pending_records += 1
+            self._pending_bytes += byte_count
+            self._accepted_records += 1
+            self._ensure_worker_locked()
+            self._condition.notify_all()
+            return True
+
+    def status(self) -> BoundedEventWriterStatus:
+        """Return only sanitized counters and lifecycle state."""
+
+        with self._condition:
+            return self._status_locked()
+
+    def flush(self, timeout: float = 5.0) -> BoundedEventWriterResult:
+        """Boundedly process records accepted before this call."""
+
+        with self._condition:
+            target_sequence = self._next_sequence - 1
+            self._ensure_worker_locked()
+            self._condition.notify_all()
+        return self._wait_for(target_sequence, timeout)
+
+    def rotate(self, operation: RotationOperation, timeout: float = 5.0) -> BoundedEventWriterResult:
+        """Fence sink writes around a caller-owned, bounded rotation operation.
+
+        The caller owns the rotation policy and its file changes. This module
+        drains records accepted before the fence, holds later records in memory
+        without blocking their enqueuers, then releases them only after the
+        supplied operation returns.
+        """
+
+        with self._condition:
+            if self._shutdown_state != "running" or self._rotation_target_sequence is not None:
+                return BoundedEventWriterResult("failed", self._status_locked())
+            target_sequence = self._next_sequence - 1
+            self._rotation_target_sequence = target_sequence
+            self._ensure_worker_locked()
+            self._condition.notify_all()
+
+        fenced = self._wait_for(target_sequence, timeout)
+        if fenced.outcome == "timeout":
+            with self._condition:
+                self._rotation_target_sequence = None
+                self._condition.notify_all()
+            return fenced
+
+        try:
+            operation()
+        except BaseException:
+            with self._condition:
+                self._record_failure_locked("rotation_failed", record_count=0, byte_count=0)
+                self._rotation_target_sequence = None
+                self._condition.notify_all()
+                return self._result_locked()
+
+        with self._condition:
+            self._rotation_target_sequence = None
+            self._condition.notify_all()
+            return self._result_locked()
+
+    def shutdown(self, timeout: float = 5.0) -> BoundedEventWriterResult:
+        """Reject later enqueues and boundedly drain records accepted so far."""
+
+        with self._condition:
+            if self._shutdown_state == "running":
+                self._shutdown_state = "stopping"
+            target_sequence = self._next_sequence - 1
+            self._ensure_worker_locked()
+            self._condition.notify_all()
+
+        result = self._wait_for(target_sequence, timeout)
+        if result.outcome == "timeout":
+            return result
+
+        deadline = time.monotonic() + max(0.0, timeout)
+        with self._condition:
+            worker = self._worker
+            self._condition.notify_all()
+        if worker is not None and worker is not threading.current_thread():
+            worker.join(max(0.0, deadline - time.monotonic()))
+
+        release_sink_ownership = False
+        with self._condition:
+            if worker is not None and worker.is_alive():
+                return BoundedEventWriterResult("timeout", self._status_locked())
+            if self._pending_records == 0:
+                self._shutdown_state = "stopped"
+                release_sink_ownership = True
+            result = self._result_locked()
+        if release_sink_ownership:
+            self._release_sink_ownership()
+        return result
+
+    def _wait_for(self, target_sequence: int, timeout: float) -> BoundedEventWriterResult:
+        deadline = time.monotonic() + max(0.0, timeout)
+        with self._condition:
+            while self._completed_sequence < target_sequence or self._recovery_inflight:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return BoundedEventWriterResult("timeout", self._status_locked())
+                self._condition.wait(remaining)
+            return self._result_locked()
+
+    def _result_locked(self) -> BoundedEventWriterResult:
+        outcome: WriterOutcome = "failed" if self._unresolved_failure else "drained"
+        return BoundedEventWriterResult(outcome, self._status_locked())
+
+    def _ensure_worker_locked(self) -> None:
+        if self._shutdown_state not in {"running", "stopping"}:
+            return
+        if self._worker is not None and self._worker.is_alive():
+            return
+        if not self._queue:
+            return
+        try:
+            worker = threading.Thread(target=self._writer_loop, name=self._thread_name, daemon=True)
+            self._worker = worker
+            self._writer_generation += 1
+            worker.start()
+        except Exception:
+            self._worker = None
+            self._record_failure_locked("writer_start_failed", record_count=0, byte_count=0)
+
+    def _claim_sink_ownership(self) -> None:
+        with self._sink_owners_lock:
+            try:
+                existing = self._weak_sink_owners.get(self._sink)
+            except TypeError:
+                existing = self._strong_sink_owners.get(id(self._sink))
+                ownership = "strong"
+            else:
+                ownership = "weak"
+            if existing is not None and existing._shutdown_state != "stopped":
+                raise ValueError("an active BoundedEventWriter already owns this sink")
+            if ownership == "weak":
+                self._weak_sink_owners[self._sink] = self
+            else:
+                self._strong_sink_owners[id(self._sink)] = self
+            self._sink_ownership = ownership
+
+    def _release_sink_ownership(self) -> None:
+        with self._sink_owners_lock:
+            if self._sink_ownership == "weak":
+                try:
+                    if self._weak_sink_owners.get(self._sink) is self:
+                        del self._weak_sink_owners[self._sink]
+                except TypeError:
+                    return
+            elif self._strong_sink_owners.get(id(self._sink)) is self:
+                self._strong_sink_owners.pop(id(self._sink), None)
+
+    def _writer_loop(self) -> None:
+        current_worker = threading.current_thread()
+        inflight: Sequence[_QueuedRecord] = ()
+        try:
+            while True:
+                with self._condition:
+                    while not self._queue:
+                        if self._shutdown_state == "stopping":
+                            return
+                        self._condition.wait()
+                    while (
+                        self._rotation_target_sequence is not None
+                        and self._queue[0].sequence > self._rotation_target_sequence
+                    ):
+                        self._condition.wait()
+                        if not self._queue:
+                            break
+                    if not self._queue:
+                        continue
+                    inflight = self._take_batch_locked()
+
+                try:
+                    self._sink.append([record.data for record in inflight])
+                except Exception as exc:
+                    with self._condition:
+                        self._complete_batch_locked(inflight)
+                        self._record_failure_locked(
+                            _failure_category(exc),
+                            record_count=len(inflight),
+                            byte_count=sum(record.byte_count for record in inflight),
+                        )
+                        self._condition.notify_all()
+                    inflight = ()
+                    continue
+
+                with self._condition:
+                    self._complete_batch_locked(inflight)
+                    self._written_records += len(inflight)
+                    recovery = self._pending_recovery.snapshot() if self._pending_recovery.has_data() else None
+                    self._recovery_inflight = recovery is not None
+                    self._condition.notify_all()
+                inflight = ()
+
+                if recovery is not None:
+                    self._emit_recovery(recovery)
+        except BaseException:
+            with self._condition:
+                if inflight:
+                    self._complete_batch_locked(inflight)
+                    self._record_failure_locked(
+                        "writer_crash",
+                        record_count=len(inflight),
+                        byte_count=sum(record.byte_count for record in inflight),
+                    )
+                else:
+                    self._record_failure_locked("writer_crash", record_count=0, byte_count=0)
+                self._condition.notify_all()
+        finally:
+            release_sink_ownership = False
+            with self._condition:
+                if self._worker is current_worker:
+                    self._worker = None
+                if self._shutdown_state == "stopping" and self._pending_records == 0:
+                    self._shutdown_state = "stopped"
+                    release_sink_ownership = True
+                self._condition.notify_all()
+            if release_sink_ownership:
+                self._release_sink_ownership()
+
+    def _take_batch_locked(self) -> list[_QueuedRecord]:
+        batch: list[_QueuedRecord] = []
+        batch_bytes = 0
+        while self._queue and len(batch) < self._batch_max_records:
+            next_record = self._queue[0]
+            if (
+                self._rotation_target_sequence is not None
+                and next_record.sequence > self._rotation_target_sequence
+            ):
+                break
+            if batch and batch_bytes + next_record.byte_count > self._batch_max_bytes:
+                break
+            batch.append(self._queue.popleft())
+            batch_bytes += next_record.byte_count
+        return batch
+
+    def _complete_batch_locked(self, batch: Sequence[_QueuedRecord]) -> None:
+        if not batch:
+            return
+        self._pending_records -= len(batch)
+        self._pending_bytes -= sum(record.byte_count for record in batch)
+        self._completed_sequence = max(self._completed_sequence, batch[-1].sequence)
+
+    def _emit_recovery(self, summary: RecoverySummary) -> None:
+        try:
+            recovery_record = self._recovery_record_factory(summary)
+            self._sink.append([_serialize_record(recovery_record)])
+        except BaseException:
+            with self._condition:
+                # Do not feed this failure back into the same aggregate. The
+                # original summary remains pending and can be retried after a
+                # future normal write succeeds.
+                self._record_failure_locked(
+                    "recovery_emit_failed",
+                    record_count=0,
+                    byte_count=0,
+                    include_recovery=False,
+                )
+                self._recovery_inflight = False
+                self._condition.notify_all()
+            return
+
+        with self._condition:
+            self._pending_recovery.subtract(summary)
+            self._recovery_events_written += 1
+            if not self._pending_recovery.has_data():
+                self._unresolved_failure = False
+            self._recovery_inflight = False
+            self._condition.notify_all()
+
+    def _record_failure_locked(
+        self,
+        category: str,
+        *,
+        record_count: int,
+        byte_count: int,
+        include_recovery: bool = True,
+    ) -> None:
+        self._dropped_records += record_count
+        self._dropped_bytes += byte_count
+        self._failure_count += 1
+        self._last_failure_category = category
+        self._last_failure_time = self._clock()
+        self._unresolved_failure = True
+        if include_recovery:
+            self._pending_recovery.add_failure(category, record_count)
+
+    def _status_locked(self) -> BoundedEventWriterStatus:
+        return BoundedEventWriterStatus(
+            queued_records=self._pending_records,
+            queued_bytes=self._pending_bytes,
+            accepted_records=self._accepted_records,
+            written_records=self._written_records,
+            dropped_records=self._dropped_records,
+            dropped_bytes=self._dropped_bytes,
+            failure_count=self._failure_count,
+            last_failure_category=self._last_failure_category,
+            last_failure_time=self._last_failure_time,
+            recovery_events_written=self._recovery_events_written,
+            recovery_pending=self._pending_recovery.has_data() or self._recovery_inflight,
+            shutdown_state=self._shutdown_state,
+            writer_alive=self._worker is not None and self._worker.is_alive(),
+            writer_generation=self._writer_generation,
+        )
+
+
+def _serialize_record(record: Mapping[str, Any]) -> bytes:
+    if not isinstance(record, Mapping):
+        raise TypeError("event record must be a mapping")
+    text = json.dumps(dict(record), ensure_ascii=True, separators=(",", ":"))
+    return text.encode("utf-8") + b"\n"
+
+
+def _default_recovery_record(summary: RecoverySummary) -> Mapping[str, Any]:
+    return {
+        "event": "telemetry_writer_recovered",
+        "overflow_records": summary.overflow_records,
+        "overflow_bytes": summary.overflow_bytes,
+        "failed_records": summary.failed_records,
+        "failure_count": summary.failure_count,
+        "failure_categories": list(summary.failure_categories),
+    }
+
+
+def _failure_category(error: Exception) -> str:
+    if isinstance(error, PermissionError):
+        return "permission_denied"
+    if isinstance(error, OSError) and error.errno in {errno.ENOSPC, errno.EDQUOT}:
+        return "disk_full"
+    return "sink_error"

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -118,6 +118,7 @@ from websocket_transport import (
     write_frame,
 )
 import proxy_telemetry
+import bounded_event_writer
 
 try:
     import zstandard
@@ -648,13 +649,40 @@ RUNTIME_CODEX_DIR = _runtime_codex_dir()
 RUNTIME_PROXY_DIR = RUNTIME_CODEX_DIR / "proxy"
 PROXY_EVENT_LOG_PATH = RUNTIME_PROXY_DIR / "codex-proxy-events.jsonl"
 PROXY_TEXT_LOG_PATH = RUNTIME_PROXY_DIR / "codex-proxy.log"
-PROXY_EVENT_LOG_LOCK = threading.Lock()
+# Both limits apply to serialized Gateway telemetry still awaiting a sink write,
+# including an in-flight batch, so slow storage cannot grow request memory.
 PROXY_EVENT_QUEUE_MAXSIZE = _env_positive_int("CODEX_PROXY_EVENT_QUEUE_MAXSIZE", 4096)
-PROXY_EVENT_QUEUE: queue.Queue[dict[str, Any]] = queue.Queue(maxsize=PROXY_EVENT_QUEUE_MAXSIZE)
-PROXY_EVENT_WRITER_LOCK = threading.Lock()
-PROXY_EVENT_WRITER_THREAD: threading.Thread | None = None
-PROXY_EVENT_DROPPED_COUNT = 0
-PROXY_EVENT_DROPPED_LOCK = threading.Lock()
+GATEWAY_EVENT_QUEUE_MAX_BYTES = _env_positive_int("CODEX_PROXY_EVENT_QUEUE_MAX_BYTES", 4 * 1024 * 1024)
+
+
+def _gateway_event_writer_recovery_record(
+    summary: bounded_event_writer.RecoverySummary,
+) -> Mapping[str, Any]:
+    return proxy_telemetry.prepare_event_payload(
+        "telemetry_writer_recovered",
+        {
+            "overflow_records": summary.overflow_records,
+            "overflow_bytes": summary.overflow_bytes,
+            "failed_records": summary.failed_records,
+            "failure_count": summary.failure_count,
+            "failure_categories": list(summary.failure_categories),
+        },
+        RUNTIME_CODEX_DIR,
+    )
+
+
+_previous_gateway_event_writer = globals().get("GATEWAY_EVENT_WRITER")
+if isinstance(_previous_gateway_event_writer, bounded_event_writer.BoundedEventWriter):
+    _previous_gateway_event_writer.shutdown(timeout=1.0)
+
+
+GATEWAY_EVENT_WRITER = bounded_event_writer.BoundedEventWriter(
+    bounded_event_writer.JsonlFileSink(PROXY_EVENT_LOG_PATH),
+    max_records=PROXY_EVENT_QUEUE_MAXSIZE,
+    max_bytes=GATEWAY_EVENT_QUEUE_MAX_BYTES,
+    recovery_record_factory=_gateway_event_writer_recovery_record,
+    thread_name="codex-gateway-event-writer",
+)
 DEFAULT_UPSTREAM_TIMEOUT_SECONDS = 300
 DEFAULT_TRANSPORT_SSE_IDLE_TIMEOUT_SECONDS = 600.0
 DEFAULT_MODEL_EVENT_SSE_IDLE_TIMEOUT_SECONDS = 300.0
@@ -1353,59 +1381,12 @@ def write_proxy_event(event: str, **fields: Any) -> None:
     _enqueue_proxy_event_payload(payload)
 
 
-def _enqueue_proxy_event_payload(payload: dict[str, Any]) -> bool:
-    global PROXY_EVENT_DROPPED_COUNT
-    _ensure_proxy_event_writer_started()
-    try:
-        PROXY_EVENT_QUEUE.put_nowait(payload)
-        return True
-    except queue.Full:
-        with PROXY_EVENT_DROPPED_LOCK:
-            PROXY_EVENT_DROPPED_COUNT += 1
-        return False
-
-
-def _ensure_proxy_event_writer_started() -> None:
-    global PROXY_EVENT_WRITER_THREAD
-    with PROXY_EVENT_WRITER_LOCK:
-        if PROXY_EVENT_WRITER_THREAD is not None and PROXY_EVENT_WRITER_THREAD.is_alive():
-            return
-        PROXY_EVENT_WRITER_THREAD = threading.Thread(
-            target=_proxy_event_writer_loop,
-            name="codex-proxy-event-writer",
-            daemon=True,
-        )
-        PROXY_EVENT_WRITER_THREAD.start()
-
-
-def _proxy_event_writer_loop() -> None:
-    while True:
-        payload = PROXY_EVENT_QUEUE.get()
-        try:
-            _write_proxy_event_payload_to_log(payload)
-        finally:
-            PROXY_EVENT_QUEUE.task_done()
-
-
-def _write_proxy_event_payload_to_log(payload: Mapping[str, Any]) -> None:
-    line = json.dumps(payload, ensure_ascii=True, separators=(",", ":"))
-    try:
-        with PROXY_EVENT_LOG_LOCK:
-            PROXY_EVENT_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
-            with PROXY_EVENT_LOG_PATH.open("a", encoding="utf-8") as handle:
-                handle.write(line + "\n")
-                handle.flush()
-    except OSError as exc:
-        logger.warning("failed to write proxy event log: %s", type(exc).__name__)
+def _enqueue_proxy_event_payload(payload: Mapping[str, Any]) -> bool:
+    return GATEWAY_EVENT_WRITER.enqueue(payload)
 
 
 def flush_proxy_event_writer(timeout: float = 5.0) -> bool:
-    deadline = time.monotonic() + max(0.0, timeout)
-    while PROXY_EVENT_QUEUE.unfinished_tasks:
-        if time.monotonic() >= deadline:
-            return False
-        time.sleep(0.01)
-    return True
+    return GATEWAY_EVENT_WRITER.flush(timeout).completed
 
 
 def _usage_int(value: Any) -> int | None:

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -651,8 +651,9 @@ PROXY_EVENT_LOG_PATH = RUNTIME_PROXY_DIR / "codex-proxy-events.jsonl"
 PROXY_TEXT_LOG_PATH = RUNTIME_PROXY_DIR / "codex-proxy.log"
 # Both limits apply to serialized Gateway telemetry still awaiting a sink write,
 # including an in-flight batch, so slow storage cannot grow request memory.
-PROXY_EVENT_QUEUE_MAXSIZE = _env_positive_int("CODEX_PROXY_EVENT_QUEUE_MAXSIZE", 4096)
-GATEWAY_EVENT_QUEUE_MAX_BYTES = _env_positive_int("CODEX_PROXY_EVENT_QUEUE_MAX_BYTES", 4 * 1024 * 1024)
+GATEWAY_EVENT_QUEUE_MAX_RECORDS = _env_positive_int("CODEX_GATEWAY_EVENT_QUEUE_MAX_RECORDS", 4096)
+GATEWAY_EVENT_QUEUE_MAX_BYTES = _env_positive_int("CODEX_GATEWAY_EVENT_QUEUE_MAX_BYTES", 4 * 1024 * 1024)
+GATEWAY_EVENT_WRITER_SHUTDOWN_TIMEOUT_SECONDS = 5.0
 
 
 def _gateway_event_writer_recovery_record(
@@ -678,7 +679,7 @@ if isinstance(_previous_gateway_event_writer, bounded_event_writer.BoundedEventW
 
 GATEWAY_EVENT_WRITER = bounded_event_writer.BoundedEventWriter(
     bounded_event_writer.JsonlFileSink(PROXY_EVENT_LOG_PATH),
-    max_records=PROXY_EVENT_QUEUE_MAXSIZE,
+    max_records=GATEWAY_EVENT_QUEUE_MAX_RECORDS,
     max_bytes=GATEWAY_EVENT_QUEUE_MAX_BYTES,
     recovery_record_factory=_gateway_event_writer_recovery_record,
     thread_name="codex-gateway-event-writer",
@@ -1378,10 +1379,10 @@ def gateway_transparent_vision_proxy_enabled() -> bool:
 
 def write_proxy_event(event: str, **fields: Any) -> None:
     payload = proxy_telemetry.prepare_event_payload(event, fields, RUNTIME_CODEX_DIR)
-    _enqueue_proxy_event_payload(payload)
+    _enqueue_gateway_event_payload(payload)
 
 
-def _enqueue_proxy_event_payload(payload: Mapping[str, Any]) -> bool:
+def _enqueue_gateway_event_payload(payload: Mapping[str, Any]) -> bool:
     return GATEWAY_EVENT_WRITER.enqueue(payload)
 
 
@@ -14217,7 +14218,14 @@ def run_server(host: str, port: int) -> None:
     )
     server = ThreadingHTTPServer((host, port), CodexProxyHandler)
     logger.info("serving Codex proxy on %s:%s", host, port)
-    server.serve_forever()
+    try:
+        server.serve_forever()
+    finally:
+        writer_result = GATEWAY_EVENT_WRITER.shutdown(
+            timeout=GATEWAY_EVENT_WRITER_SHUTDOWN_TIMEOUT_SECONDS,
+        )
+        if not writer_result.completed:
+            logger.warning("Gateway event writer shutdown ended with %s", writer_result.outcome)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/test_bounded_event_writer.py
+++ b/tests/test_bounded_event_writer.py
@@ -10,6 +10,7 @@ import threading
 import time
 from typing import Sequence
 from unittest import TestCase
+from unittest.mock import patch
 
 from bounded_event_writer import BoundedEventWriter, JsonlFileSink
 
@@ -82,16 +83,22 @@ class FailingSink(RecordingSink):
         super().append(records)
 
 
-class CrashOnceSink(RecordingSink):
+class CrashWithRetainedBacklogSink(RecordingSink):
     def __init__(self) -> None:
         super().__init__()
+        self.crash_entered = threading.Event()
+        self.release_crash = threading.Event()
+        self.replacement_wrote = threading.Event()
         self._crash_once = True
 
     def append(self, records: Sequence[bytes]) -> None:
         if self._crash_once:
             self._crash_once = False
+            self.crash_entered.set()
+            self.release_crash.wait(3)
             raise WriterCrash()
         super().append(records)
+        self.replacement_wrote.set()
 
 
 class AggregateFailureSink(BlockingSink):
@@ -165,6 +172,35 @@ class BoundedEventWriterTests(TestCase):
         self.assertEqual(byte_writer.status().dropped_bytes, second_size)
         byte_sink.release.set()
         self.assertTrue(byte_writer.flush(1).completed)
+
+    def test_oversized_single_record_is_rejected_before_full_json_serialization(self) -> None:
+        sink = RecordingSink()
+        writer = self._writer(sink, max_records=8, max_bytes=128)
+        oversized = {"event": "oversized", "payload": "x" * 1_000_000}
+
+        with patch("bounded_event_writer.json.dumps", wraps=json.dumps) as dumps:
+            self.assertFalse(writer.enqueue(oversized))
+
+        self.assertEqual(dumps.call_count, 0)
+        status = writer.status()
+        self.assertEqual(status.queued_records, 0)
+        self.assertEqual(status.dropped_records, 1)
+        self.assertEqual(status.dropped_bytes, 0)
+        self.assertTrue(status.recovery_pending)
+
+    def test_bounded_admission_preserves_escaped_json_record_bytes(self) -> None:
+        record = {
+            "event": "escaped",
+            "value": '"\\\n\x01\u00e9\U0001f600',
+            "nested": [None, True, False, -12, float("nan")],
+        }
+        expected = json.dumps(record, ensure_ascii=True, separators=(",", ":")).encode("utf-8") + b"\n"
+        sink = RecordingSink()
+        writer = self._writer(sink, max_records=8, max_bytes=len(expected))
+
+        self.assertTrue(writer.enqueue(record))
+        self.assertTrue(writer.flush(1).completed)
+        self.assertEqual(sink.batches, [[expected]])
 
     def test_accepted_records_keep_fifo_order_and_batch_after_slow_write(self) -> None:
         sink = BlockingSink()
@@ -376,19 +412,19 @@ class BoundedEventWriterTests(TestCase):
             records = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
             self.assertEqual([record["event"] for record in records], ["after-repair", "telemetry_writer_recovered"])
 
-    def test_writer_crash_is_recovered_by_one_new_writer_lifecycle(self) -> None:
-        sink = CrashOnceSink()
+    def test_writer_crash_restarts_once_and_drains_retained_backlog_without_followup_calls(self) -> None:
+        sink = CrashWithRetainedBacklogSink()
         writer = self._writer(sink)
         self.assertTrue(writer.enqueue({"event": "crash"}))
-        self.assertEqual(writer.flush(1).outcome, "failed")
-        self.assertFalse(writer.status().writer_alive)
+        self.assertTrue(sink.crash_entered.wait(1))
+        self.assertTrue(writer.enqueue({"event": "retained"}))
+        sink.release_crash.set()
 
-        self.assertTrue(writer.enqueue({"event": "after-crash"}))
-        self.assertTrue(writer.flush(1).completed)
-        self.assertGreaterEqual(writer.status().writer_generation, 2)
+        self.assertTrue(sink.replacement_wrote.wait(1))
+        self.assertEqual(writer.status().writer_generation, 2)
         self.assertEqual(
             [record["event"] for record in sink.records()],
-            ["after-crash", "telemetry_writer_recovered"],
+            ["retained", "telemetry_writer_recovered"],
         )
 
     def test_shutdown_drains_or_times_out_without_hanging(self) -> None:

--- a/tests/test_bounded_event_writer.py
+++ b/tests/test_bounded_event_writer.py
@@ -1,0 +1,409 @@
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import Mapping
+import errno
+import json
+from pathlib import Path
+import tempfile
+import threading
+import time
+from typing import Sequence
+from unittest import TestCase
+
+from bounded_event_writer import BoundedEventWriter, JsonlFileSink
+
+
+class WriterCrash(BaseException):
+    pass
+
+
+class RecursionErrorMapping(Mapping[str, object]):
+    def __iter__(self):
+        raise RecursionError("recursive mapping")
+
+    def __len__(self) -> int:
+        return 1
+
+    def __getitem__(self, key: str) -> object:
+        return "unused"
+
+
+class RecordingSink:
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self.batches: list[list[bytes]] = []
+        self.active_writes = 0
+        self.max_active_writes = 0
+
+    def append(self, records: Sequence[bytes]) -> None:
+        with self._lock:
+            self.active_writes += 1
+            self.max_active_writes = max(self.max_active_writes, self.active_writes)
+        try:
+            with self._lock:
+                self.batches.append(list(records))
+        finally:
+            with self._lock:
+                self.active_writes -= 1
+
+    def records(self) -> list[dict[str, object]]:
+        with self._lock:
+            return [json.loads(record) for batch in self.batches for record in batch]
+
+
+class BlockingSink(RecordingSink):
+    def __init__(self) -> None:
+        super().__init__()
+        self.entered = threading.Event()
+        self.release = threading.Event()
+        self._block_once = True
+
+    def append(self, records: Sequence[bytes]) -> None:
+        should_block = False
+        with self._lock:
+            if self._block_once:
+                self._block_once = False
+                should_block = True
+        if should_block:
+            self.entered.set()
+            self.release.wait(3)
+        super().append(records)
+
+
+class FailingSink(RecordingSink):
+    def __init__(self, errors: Sequence[Exception]) -> None:
+        super().__init__()
+        self._errors: deque[Exception] = deque(errors)
+
+    def append(self, records: Sequence[bytes]) -> None:
+        if self._errors:
+            raise self._errors.popleft()
+        super().append(records)
+
+
+class CrashOnceSink(RecordingSink):
+    def __init__(self) -> None:
+        super().__init__()
+        self._crash_once = True
+
+    def append(self, records: Sequence[bytes]) -> None:
+        if self._crash_once:
+            self._crash_once = False
+            raise WriterCrash()
+        super().append(records)
+
+
+class AggregateFailureSink(BlockingSink):
+    def __init__(self) -> None:
+        super().__init__()
+        self.recovery_attempts = 0
+
+    def append(self, records: Sequence[bytes]) -> None:
+        if any(json.loads(record).get("event") == "telemetry_writer_recovered" for record in records):
+            self.recovery_attempts += 1
+            raise OSError(errno.ENOSPC, "disk full")
+        super().append(records)
+
+
+class PartialWriteHandle:
+    def __init__(self, handle, state: dict[str, bool]) -> None:
+        self._handle = handle
+        self._state = state
+
+    def __enter__(self):
+        self._handle.__enter__()
+        return self
+
+    def __exit__(self, *args):
+        return self._handle.__exit__(*args)
+
+    def __getattr__(self, name: str):
+        return getattr(self._handle, name)
+
+    def write(self, data: bytes) -> int:
+        if self._state["fail_once"]:
+            self._state["fail_once"] = False
+            count = max(1, len(data) // 2)
+            self._handle.write(data[:count])
+            self._handle.flush()
+            raise OSError(errno.ENOSPC, "disk full")
+        return self._handle.write(data)
+
+
+class BoundedEventWriterTests(TestCase):
+    def _writer(self, sink, **kwargs) -> BoundedEventWriter:
+        kwargs.setdefault("max_records", 64)
+        kwargs.setdefault("max_bytes", 64 * 1024)
+        writer = BoundedEventWriter(sink, **kwargs)
+        self.addCleanup(writer.shutdown, 1)
+        return writer
+
+    def test_bounds_record_and_serialized_byte_capacity(self) -> None:
+        count_sink = BlockingSink()
+        count_writer = self._writer(count_sink, max_records=2, max_bytes=4096)
+        self.assertTrue(count_writer.enqueue({"event": "first"}))
+        self.assertTrue(count_sink.entered.wait(1))
+        self.assertTrue(count_writer.enqueue({"event": "second"}))
+        self.assertFalse(count_writer.enqueue({"event": "third"}))
+        self.assertEqual(count_writer.status().queued_records, 2)
+        self.assertEqual(count_writer.status().dropped_records, 1)
+        count_sink.release.set()
+        self.assertTrue(count_writer.flush(1).completed)
+        self.assertEqual(count_writer.status().recovery_events_written, 1)
+
+        byte_sink = BlockingSink()
+        first = {"event": "first", "payload": "a" * 32}
+        second = {"event": "second", "payload": "b" * 32}
+        first_size = len(json.dumps(first, ensure_ascii=True, separators=(",", ":")).encode("utf-8")) + 1
+        second_size = len(json.dumps(second, ensure_ascii=True, separators=(",", ":")).encode("utf-8")) + 1
+        byte_writer = self._writer(byte_sink, max_records=8, max_bytes=first_size + second_size - 1)
+        self.assertTrue(byte_writer.enqueue(first))
+        self.assertTrue(byte_sink.entered.wait(1))
+        self.assertFalse(byte_writer.enqueue(second))
+        self.assertEqual(byte_writer.status().queued_bytes, first_size)
+        self.assertEqual(byte_writer.status().dropped_bytes, second_size)
+        byte_sink.release.set()
+        self.assertTrue(byte_writer.flush(1).completed)
+
+    def test_accepted_records_keep_fifo_order_and_batch_after_slow_write(self) -> None:
+        sink = BlockingSink()
+        writer = self._writer(sink, batch_max_records=2, batch_max_bytes=4096)
+        self.assertTrue(writer.enqueue({"event": "one"}))
+        self.assertTrue(sink.entered.wait(1))
+        self.assertTrue(writer.enqueue({"event": "two"}))
+        self.assertTrue(writer.enqueue({"event": "three"}))
+
+        sink.release.set()
+        self.assertTrue(writer.flush(1).completed)
+
+        self.assertEqual([record["event"] for record in sink.records()], ["one", "two", "three"])
+        self.assertEqual([len(batch) for batch in sink.batches], [1, 2])
+
+    def test_concurrent_producers_use_one_writer_and_complete_jsonl_records(self) -> None:
+        sink = RecordingSink()
+        writer = self._writer(sink, max_records=512, max_bytes=512 * 1024, batch_max_records=32)
+        producer_count = 8
+        records_per_producer = 25
+        barrier = threading.Barrier(producer_count)
+        accepted: list[bool] = []
+        accepted_lock = threading.Lock()
+
+        def produce(producer: int) -> None:
+            barrier.wait()
+            local = [writer.enqueue({"event": "request", "producer": producer, "index": index}) for index in range(records_per_producer)]
+            with accepted_lock:
+                accepted.extend(local)
+
+        threads = [threading.Thread(target=produce, args=(producer,)) for producer in range(producer_count)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(2)
+
+        self.assertTrue(all(accepted))
+        self.assertEqual(len(accepted), producer_count * records_per_producer)
+        self.assertTrue(writer.flush(3).completed)
+        records = sink.records()
+        self.assertEqual(len(records), producer_count * records_per_producer)
+        self.assertEqual(
+            {(record["producer"], record["index"]) for record in records},
+            {(producer, index) for producer in range(producer_count) for index in range(records_per_producer)},
+        )
+        self.assertEqual(sink.max_active_writes, 1)
+
+    def test_a_sink_has_one_active_writer_and_can_be_reclaimed_after_shutdown(self) -> None:
+        sink = RecordingSink()
+        writer = self._writer(sink)
+        with self.assertRaisesRegex(ValueError, "already owns this sink"):
+            BoundedEventWriter(sink, max_records=64, max_bytes=64 * 1024)
+
+        self.assertTrue(writer.shutdown(1).completed)
+        replacement = self._writer(sink)
+        self.assertTrue(replacement.enqueue({"event": "replacement"}))
+        self.assertTrue(replacement.flush(1).completed)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "shared-events.jsonl"
+            file_writer = self._writer(JsonlFileSink(path))
+            with self.assertRaisesRegex(ValueError, "already owns this sink"):
+                BoundedEventWriter(JsonlFileSink(path), max_records=64, max_bytes=64 * 1024)
+            self.assertTrue(file_writer.shutdown(1).completed)
+
+    def test_rotation_fence_holds_later_records_while_caller_policy_runs(self) -> None:
+        sink = RecordingSink()
+        writer = self._writer(sink)
+        self.assertTrue(writer.enqueue({"event": "before-rotation"}))
+        rotation_entered = threading.Event()
+        release_rotation = threading.Event()
+        results = []
+
+        def rotate() -> None:
+            rotation_entered.set()
+            release_rotation.wait(1)
+
+        rotation_thread = threading.Thread(target=lambda: results.append(writer.rotate(rotate, 1)))
+        rotation_thread.start()
+        self.assertTrue(rotation_entered.wait(1))
+        self.assertTrue(writer.enqueue({"event": "after-rotation"}))
+        self.assertEqual([record["event"] for record in sink.records()], ["before-rotation"])
+        self.assertEqual(writer.status().queued_records, 1)
+
+        release_rotation.set()
+        rotation_thread.join(1)
+        self.assertFalse(rotation_thread.is_alive())
+        self.assertEqual(len(results), 1)
+        self.assertTrue(results[0].completed)
+        self.assertTrue(writer.flush(1).completed)
+        self.assertEqual(
+            [record["event"] for record in sink.records()],
+            ["before-rotation", "after-rotation"],
+        )
+
+    def test_overflow_recovery_is_aggregate_and_never_recursively_enqueued(self) -> None:
+        sink = AggregateFailureSink()
+        writer = self._writer(sink, max_records=1, max_bytes=4096)
+        self.assertTrue(writer.enqueue({"event": "accepted"}))
+        self.assertTrue(sink.entered.wait(1))
+        self.assertFalse(writer.enqueue({"event": "dropped"}))
+
+        sink.release.set()
+        result = writer.flush(1)
+
+        self.assertEqual(result.outcome, "failed")
+        self.assertEqual(sink.recovery_attempts, 1)
+        self.assertEqual([record["event"] for record in sink.records()], ["accepted"])
+        status = writer.status()
+        self.assertEqual(status.accepted_records, 1)
+        self.assertEqual(status.dropped_records, 1)
+        self.assertTrue(status.recovery_pending)
+        stopped = writer.shutdown(1)
+        self.assertEqual(stopped.outcome, "failed")
+        self.assertEqual(stopped.status.shutdown_state, "stopped")
+
+    def test_slow_sink_does_not_block_enqueue_and_flush_times_out_boundedly(self) -> None:
+        sink = BlockingSink()
+        writer = self._writer(sink)
+        started = time.monotonic()
+        self.assertTrue(writer.enqueue({"event": "slow"}))
+        self.assertLess(time.monotonic() - started, 0.2)
+        self.assertTrue(sink.entered.wait(1))
+
+        result = writer.flush(0.02)
+        self.assertEqual(result.outcome, "timeout")
+        sink.release.set()
+        self.assertTrue(writer.flush(1).completed)
+
+    def test_permission_and_disk_full_failures_are_contained_and_recover(self) -> None:
+        for error, expected_category in (
+            (PermissionError("denied"), "permission_denied"),
+            (OSError(errno.ENOSPC, "disk full"), "disk_full"),
+        ):
+            with self.subTest(expected_category=expected_category):
+                sink = FailingSink([error])
+                writer = self._writer(sink, clock=lambda: 123.0)
+                self.assertTrue(writer.enqueue({"event": "will-fail"}))
+                self.assertEqual(writer.flush(1).outcome, "failed")
+                failed = writer.status()
+                self.assertEqual(failed.last_failure_category, expected_category)
+                self.assertEqual(failed.last_failure_time, 123.0)
+                self.assertEqual(failed.dropped_records, 1)
+
+                self.assertTrue(writer.enqueue({"event": "recovered"}))
+                self.assertTrue(writer.flush(1).completed)
+                events = [record["event"] for record in sink.records()]
+                self.assertEqual(events, ["recovered", "telemetry_writer_recovered"])
+
+    def test_serialization_rejection_and_repeated_sink_failures_recover_without_new_workers(self) -> None:
+        serialization_sink = RecordingSink()
+        serialization_writer = self._writer(serialization_sink)
+        self.assertFalse(serialization_writer.enqueue({"event": "bad", "value": object()}))
+        self.assertEqual(serialization_writer.flush(0).outcome, "failed")
+        self.assertTrue(serialization_writer.enqueue({"event": "after-serialization"}))
+        self.assertTrue(serialization_writer.flush(1).completed)
+        self.assertEqual(
+            [record["event"] for record in serialization_sink.records()],
+            ["after-serialization", "telemetry_writer_recovered"],
+        )
+
+        recursive_sink = RecordingSink()
+        recursive_writer = self._writer(recursive_sink)
+        self.assertFalse(recursive_writer.enqueue(RecursionErrorMapping()))
+        self.assertEqual(recursive_writer.status().last_failure_category, "serialization_rejected")
+
+        nonfinite_sink = RecordingSink()
+        nonfinite_writer = self._writer(nonfinite_sink)
+        self.assertTrue(nonfinite_writer.enqueue({"event": "nonfinite", "value": float("nan")}))
+        self.assertTrue(nonfinite_writer.flush(1).completed)
+        self.assertIn(b'"value":NaN', nonfinite_sink.batches[0][0])
+
+        sink = FailingSink([OSError(errno.EIO, "first"), OSError(errno.EIO, "second")])
+        writer = self._writer(sink, batch_max_records=1)
+        self.assertTrue(writer.enqueue({"event": "first"}))
+        self.assertTrue(writer.enqueue({"event": "second"}))
+        self.assertEqual(writer.flush(1).outcome, "failed")
+        self.assertTrue(writer.enqueue({"event": "after-failures"}))
+        self.assertTrue(writer.flush(1).completed)
+        self.assertEqual(writer.status().writer_generation, 1)
+        self.assertEqual(
+            [record["event"] for record in sink.records()],
+            ["after-failures", "telemetry_writer_recovered"],
+        )
+
+    def test_partial_disk_write_is_repaired_before_future_complete_jsonl_records(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "events.jsonl"
+            state = {"fail_once": True}
+
+            def open_file(open_path: Path, mode: str):
+                handle = open_path.open(mode)
+                if state["fail_once"]:
+                    return PartialWriteHandle(handle, state)
+                return handle
+
+            writer = self._writer(
+                JsonlFileSink(path, open_file=open_file),
+                recovery_record_factory=lambda summary: {
+                    "event": "telemetry_writer_recovered",
+                    "failed_records": summary.failed_records,
+                },
+            )
+            self.assertTrue(writer.enqueue({"event": "partial"}))
+            self.assertEqual(writer.flush(1).outcome, "failed")
+            self.assertTrue(writer.enqueue({"event": "after-repair"}))
+            self.assertTrue(writer.flush(1).completed)
+
+            records = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+            self.assertEqual([record["event"] for record in records], ["after-repair", "telemetry_writer_recovered"])
+
+    def test_writer_crash_is_recovered_by_one_new_writer_lifecycle(self) -> None:
+        sink = CrashOnceSink()
+        writer = self._writer(sink)
+        self.assertTrue(writer.enqueue({"event": "crash"}))
+        self.assertEqual(writer.flush(1).outcome, "failed")
+        self.assertFalse(writer.status().writer_alive)
+
+        self.assertTrue(writer.enqueue({"event": "after-crash"}))
+        self.assertTrue(writer.flush(1).completed)
+        self.assertGreaterEqual(writer.status().writer_generation, 2)
+        self.assertEqual(
+            [record["event"] for record in sink.records()],
+            ["after-crash", "telemetry_writer_recovered"],
+        )
+
+    def test_shutdown_drains_or_times_out_without_hanging(self) -> None:
+        normal_sink = RecordingSink()
+        normal_writer = self._writer(normal_sink)
+        self.assertTrue(normal_writer.enqueue({"event": "before-stop"}))
+        result = normal_writer.shutdown(1)
+        self.assertTrue(result.completed)
+        self.assertEqual(result.status.shutdown_state, "stopped")
+        self.assertFalse(normal_writer.enqueue({"event": "after-stop"}))
+
+        slow_sink = BlockingSink()
+        slow_writer = self._writer(slow_sink)
+        self.assertTrue(slow_writer.enqueue({"event": "slow-stop"}))
+        self.assertTrue(slow_sink.entered.wait(1))
+        self.assertEqual(slow_writer.shutdown(0.02).outcome, "timeout")
+        slow_sink.release.set()
+        self.assertTrue(slow_writer.shutdown(1).completed)

--- a/tests/test_proxy_event_logging.py
+++ b/tests/test_proxy_event_logging.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import importlib
 import json
 import os
-import queue
 import sqlite3
 import stat
 import tempfile
@@ -532,21 +531,14 @@ class ProxyEventLoggingTests(TestCase):
             finally:
                 importlib.reload(codex_proxy)
 
-    def test_proxy_event_writer_queue_is_bounded_and_drops_without_blocking(self):
+    def test_gateway_event_writer_delegates_payloads_to_the_bounded_writer(self):
         payloads = [
             {"event": "request_start", "request_id": "req-one"},
             {"event": "request_complete", "request_id": "req-two"},
         ]
-        original_queue = codex_proxy.PROXY_EVENT_QUEUE
-        original_dropped = codex_proxy.PROXY_EVENT_DROPPED_COUNT
-        try:
-            codex_proxy.PROXY_EVENT_QUEUE = queue.Queue(maxsize=1)
-            codex_proxy.PROXY_EVENT_DROPPED_COUNT = 0
-            with patch("codex_proxy._ensure_proxy_event_writer_started"):
-                self.assertTrue(codex_proxy._enqueue_proxy_event_payload(payloads[0]))
-                self.assertFalse(codex_proxy._enqueue_proxy_event_payload(payloads[1]))
-            self.assertEqual(codex_proxy.PROXY_EVENT_QUEUE.qsize(), 1)
-            self.assertEqual(codex_proxy.PROXY_EVENT_DROPPED_COUNT, 1)
-        finally:
-            codex_proxy.PROXY_EVENT_QUEUE = original_queue
-            codex_proxy.PROXY_EVENT_DROPPED_COUNT = original_dropped
+        with patch.object(codex_proxy.GATEWAY_EVENT_WRITER, "enqueue", side_effect=[True, False]) as enqueue:
+            self.assertTrue(codex_proxy._enqueue_proxy_event_payload(payloads[0]))
+            self.assertFalse(codex_proxy._enqueue_proxy_event_payload(payloads[1]))
+
+        self.assertEqual(enqueue.call_args_list[0].args, (payloads[0],))
+        self.assertEqual(enqueue.call_args_list[1].args, (payloads[1],))

--- a/tests/test_proxy_event_logging.py
+++ b/tests/test_proxy_event_logging.py
@@ -537,8 +537,8 @@ class ProxyEventLoggingTests(TestCase):
             {"event": "request_complete", "request_id": "req-two"},
         ]
         with patch.object(codex_proxy.GATEWAY_EVENT_WRITER, "enqueue", side_effect=[True, False]) as enqueue:
-            self.assertTrue(codex_proxy._enqueue_proxy_event_payload(payloads[0]))
-            self.assertFalse(codex_proxy._enqueue_proxy_event_payload(payloads[1]))
+            self.assertTrue(codex_proxy._enqueue_gateway_event_payload(payloads[0]))
+            self.assertFalse(codex_proxy._enqueue_gateway_event_payload(payloads[1]))
 
         self.assertEqual(enqueue.call_args_list[0].args, (payloads[0],))
         self.assertEqual(enqueue.call_args_list[1].args, (payloads[1],))

--- a/tests/test_proxy_shutdown.py
+++ b/tests/test_proxy_shutdown.py
@@ -1,11 +1,36 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
+import tempfile
 import threading
 from http.client import HTTPConnection
 from http.server import ThreadingHTTPServer
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
 
+import codex_proxy
 from codex_proxy import CodexProxyHandler
+
+
+def _run_server_with_event_writer_result(writer_result):
+    server = Mock()
+    writer = Mock()
+    writer.shutdown.return_value = writer_result
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with (
+            patch.object(codex_proxy, "PROXY_TEXT_LOG_PATH", Path(tmpdir) / "proxy.log"),
+            patch.object(codex_proxy.logging, "basicConfig"),
+            patch.object(codex_proxy.logging, "FileHandler"),
+            patch.object(codex_proxy.logging, "StreamHandler"),
+            patch.object(codex_proxy, "ThreadingHTTPServer", return_value=server),
+            patch.object(codex_proxy, "GATEWAY_EVENT_WRITER", writer),
+            patch.object(codex_proxy.logger, "warning") as warning,
+        ):
+            codex_proxy.run_server("127.0.0.1", 8080)
+
+    return server, writer, warning
 
 
 def test_shutdown_endpoint_stops_server() -> None:
@@ -31,3 +56,27 @@ def test_shutdown_endpoint_stops_server() -> None:
             server.shutdown()
         server.server_close()
         thread.join(timeout=2)
+
+
+def test_run_server_drains_the_event_writer_when_the_server_exits() -> None:
+    server, writer, warning = _run_server_with_event_writer_result(
+        SimpleNamespace(completed=True, outcome="drained"),
+    )
+
+    server.serve_forever.assert_called_once_with()
+    writer.shutdown.assert_called_once_with(
+        timeout=codex_proxy.GATEWAY_EVENT_WRITER_SHUTDOWN_TIMEOUT_SECONDS,
+    )
+    warning.assert_not_called()
+
+
+def test_run_server_reports_a_bounded_event_writer_shutdown_timeout() -> None:
+    _server, writer, warning = _run_server_with_event_writer_result(
+        SimpleNamespace(completed=False, outcome="timeout"),
+    )
+
+    writer.shutdown.assert_called_once_with(
+        timeout=codex_proxy.GATEWAY_EVENT_WRITER_SHUTDOWN_TIMEOUT_SECONDS,
+    )
+    warning.assert_called_once()
+    assert "timeout" in warning.call_args.args[1:]


### PR DESCRIPTION
## Summary

- Add a reusable bounded JSONL event writer for Gateway telemetry with FIFO batching, per-sink ownership, bounded recovery aggregation, and rotation coordination.
- Route existing Gateway event logging through the writer without changing successful event bodies.
- Address review blockers: retained backlog automatically receives one replacement writer after a crash; oversized records are rejected before full JSON encoding; and normal `run_server()` exit boundedly drains or times out the writer.

## Validation

- Focused writer, telemetry, shutdown, and routing suites — 445 passed, 99 subtests
- `python -m pytest -q` — 1054 passed, 1 skipped, 246 subtests
- `python scripts/report_quality_gates.py` — report-only baseline; no new bounded-writer findings
- Final Standards + Spec two-axis review — no findings

Closes #6