### PR TITLE
feat: add normal and debug build flavors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,8 +63,16 @@ jobs:
         run: npm run test:ui-contract
 
   rust-tests:
-    name: Rust tests
+    name: Rust tests (${{ matrix.flavor }})
     runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        flavor:
+          - normal
+          - debug
+    env:
+      CODEXHUB_BUILD_FLAVOR: ${{ matrix.flavor }}
     defaults:
       run:
         working-directory: src-tauri
@@ -92,7 +100,58 @@ jobs:
           Set-Content -Path resources/python/.ci-placeholder -Value ''
 
       - name: Run cargo tests
-        run: cargo test --locked
+        run: |
+          if ("${{ matrix.flavor }}" -eq "debug") {
+            cargo test --locked --features debug-diagnostics
+          } else {
+            cargo test --locked
+          }
+
+      - name: Build release-optimized flavor
+        run: |
+          if ("${{ matrix.flavor }}" -eq "debug") {
+            cargo build --release --locked --features debug-diagnostics
+          } else {
+            cargo build --release --locked
+          }
+
+  release-flavor-contract:
+    name: Release flavor contract
+    runs-on: windows-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Verify normal default and debug parity
+        shell: pwsh
+        run: |
+          $normalDefault = & scripts/build-windows-portable.ps1 -DryRun | ConvertFrom-Json
+          $normal = & scripts/build-windows-portable.ps1 -Flavor normal -DryRun | ConvertFrom-Json
+          $debug = & scripts/build-windows-portable.ps1 -Flavor debug -DryRun | ConvertFrom-Json
+          if ($normalDefault.flavor -ne "normal") { throw "Omitted -Flavor must produce normal." }
+          if ($normal.version -ne $debug.version -or $normal.source_revision -ne $debug.source_revision) {
+            throw "Normal and debug must come from the same version and source revision."
+          }
+          if ($normal.generated_config.productName -ne $debug.generated_config.productName -or
+              $normal.generated_config.identifier -ne $debug.generated_config.identifier -or
+              $normal.generated_config.title -ne $debug.generated_config.title) {
+            throw "Normal and debug must preserve one application identity."
+          }
+          if ($normal.updater_manifest -ne "latest.json" -or $debug.updater_manifest -ne "latest-debug.json") {
+            throw "Flavor updater manifests are not selected correctly."
+          }
+          if ($normal.installer_name -eq $debug.installer_name -or -not $debug.debug_diagnostics_enabled) {
+            throw "Debug artifact identity or diagnostic capability is missing."
+          }
+          $replacement = & scripts/Test-BuildFlavorReplacement.ps1 -DryRun | ConvertFrom-Json
+          if (($replacement.sequence -join ",") -ne "normal,debug,normal") {
+            throw "The same-version replacement sequence is not normal -> debug -> normal."
+          }
+          if ($replacement.application_identity.identifier -ne $normal.generated_config.identifier -or
+              $replacement.runtime.gateway_port -ne $normal.generated_config.gatewayPort -or
+              $replacement.runtime.expected_gateway_owner_count -ne 1) {
+            throw "Flavor replacement no longer preserves one application and Gateway owner."
+          }
 
   rust-clippy:
     name: Rust clippy

--- a/README.md
+++ b/README.md
@@ -60,13 +60,43 @@ The desktop app and Gateway have independent lifecycles. Closing the window hide
 
 Release installers include the runtime required for normal use. Normal users do not need to install Python, Node.js, or Rust separately. Source development still requires local Node.js, Rust/Tauri tooling, and Python.
 
-## Release And Beta Channels
+## Normal And Debug Build Flavors
 
-CodexHub release uses frontend port `1420`, bridge port `1421`, Gateway port `9099`, and `%USERPROFILE%\.codex` by default.
+Each release tag produces two release-optimized CodexHub artifacts from the same commit and semantic version:
 
-CodexHub Beta uses frontend port `1430`, bridge port `1431`, Gateway port `9109`, and `%USERPROFILE%\.codexhub-beta\codex-home` by default. Beta does not take over the release Codex config on first launch.
+- `normal` is the default build. It retains the existing `latest.json` update contract and `CodexHub_<version>_x64-setup.exe` installer name.
+- `debug` is selected explicitly at build time and enables diagnostic capability code. It uses `latest-debug.json` and `CodexHub_<version>_debug_x64-setup.exe`, so its updater cannot silently switch to `normal`.
 
-Client routing state is target-based: `Official`, `Release`, or `Beta`. If a target is managed by the other channel, the current app displays `Managed by Release` or `Managed by Beta` and requires explicit takeover confirmation before rewriting it.
+Both flavors share the same application identifier, installed application, ports (`1420`/`1421`/`9099`), `%USERPROFILE%\.codex` runtime home, settings, and Gateway owner. They are not separate products or Rust/Tauri development builds. Installing one flavor over the other at the same version replaces the installed app while preserving supported runtime data; do not run them as side-by-side installations.
+
+The build scripts reject unsupported flavor names before compilation. Use the normal default or select debug explicitly:
+
+```powershell
+# Portable build plans (no compilation)
+.\scripts\build-windows-portable.ps1 -DryRun
+.\scripts\build-windows-portable.ps1 -Flavor debug -DryRun
+
+# Signed, release-optimized installer builds
+.\scripts\build-windows-release.ps1 -Flavor normal
+.\scripts\build-windows-release.ps1 -Flavor debug
+```
+
+Both installer artifacts and both manifests belong to the same GitHub Release tag. Debug manifests declare their flavor and artifact name; a mismatch is rejected before download/install. A normal manifest without flavor metadata remains accepted only when it points to the historical normal artifact name, preserving installed normal-user update compatibility.
+
+For a packaged same-version replacement smoke, first inspect the contract, then run the explicit installer sequence only in a dedicated Windows test environment with a known settings fixture:
+
+```powershell
+.\scripts\Test-BuildFlavorReplacement.ps1 -DryRun
+.\scripts\Test-BuildFlavorReplacement.ps1 `
+  -Version 0.1.4 `
+  -NormalInstaller .\CodexHub_0.1.4_x64-setup.exe `
+  -DebugInstaller .\CodexHub_0.1.4_debug_x64-setup.exe `
+  -SettingsPath "$env:USERPROFILE\.codex\proxy\settings.json" `
+  -InstalledExe 'C:\path\to\CodexHub.exe' `
+  -RunInstall -LaunchAfterInstall
+```
+
+The smoke proves normal → debug → normal replacement preserves the supplied settings file and observes exactly one Gateway listener. It is intentionally opt-in because it runs signed installers.
 
 ## Usage
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -60,13 +60,43 @@ CodexHub Desktop App
 
 发布版安装包随附普通使用所需的运行时；普通用户不需要额外安装 Python、Node.js 或 Rust。从源码开发时仍需要本机具备 Node.js、Rust/Tauri 工具链和 Python 运行环境。
 
-## Release 与 Beta 通道
+## Normal 与 Debug 构建风味
 
-CodexHub 正式版默认使用前端端口 `1420`、桥接端口 `1421`、Gateway 端口 `9099`，并使用 `%USERPROFILE%\.codex`。
+每个发布 tag 都会从同一个提交和同一个语义版本产出两个经过 release 优化的 CodexHub 构建：
 
-CodexHub Beta 默认使用前端端口 `1430`、桥接端口 `1431`、Gateway 端口 `9109`，并使用 `%USERPROFILE%\.codexhub-beta\codex-home`。Beta 不会在首次启动时自动接管正式版 Codex 配置。
+- `normal` 是默认构建，保留现有 `latest.json` 更新契约和 `CodexHub_<version>_x64-setup.exe` 安装包名称。
+- `debug` 必须在构建时显式选择，并启用诊断能力代码。它使用 `latest-debug.json` 和 `CodexHub_<version>_debug_x64-setup.exe`，因此自动更新不会悄悄切回 `normal`。
 
-客户端路由状态以目标配置为准：`Official`、`Release` 或 `Beta`。当某个目标由另一个通道管理时，当前 App 会显示 `Managed by Release` 或 `Managed by Beta`，需要显式确认后才会接管。
+两个风味使用同一个应用标识、安装应用、端口（`1420`/`1421`/`9099`）、`%USERPROFILE%\.codex` 运行目录、设置和 Gateway 所有者。它们不是两个产品，也不是 Rust/Tauri 的开发构建。同一版本安装一个风味覆盖另一个风味时，会替换已安装应用并保留受支持的运行时数据；不要并排运行两个风味。
+
+构建脚本会在编译前拒绝不受支持的风味名称。可以使用默认的 normal，或显式选择 debug：
+
+```powershell
+# Portable 构建计划（不编译）
+.\scripts\build-windows-portable.ps1 -DryRun
+.\scripts\build-windows-portable.ps1 -Flavor debug -DryRun
+
+# 已签名、release 优化的安装包构建
+.\scripts\build-windows-release.ps1 -Flavor normal
+.\scripts\build-windows-release.ps1 -Flavor debug
+```
+
+两个安装包和两个 manifest 属于同一个 GitHub Release tag。Debug manifest 会声明风味和产物名称；不匹配会在下载和安装前被拒绝。没有风味元数据的 normal manifest 只会在其指向历史 normal 产物名称时被接受，以保持已安装 normal 用户的更新兼容性。
+
+如需验证同版本替换，请先查看契约，再只在专用 Windows 测试环境中执行显式安装包序列，并提供已知的设置文件：
+
+```powershell
+.\scripts\Test-BuildFlavorReplacement.ps1 -DryRun
+.\scripts\Test-BuildFlavorReplacement.ps1 `
+  -Version 0.1.4 `
+  -NormalInstaller .\CodexHub_0.1.4_x64-setup.exe `
+  -DebugInstaller .\CodexHub_0.1.4_debug_x64-setup.exe `
+  -SettingsPath "$env:USERPROFILE\.codex\proxy\settings.json" `
+  -InstalledExe 'C:\path\to\CodexHub.exe' `
+  -RunInstall -LaunchAfterInstall
+```
+
+该 smoke 会验证 normal → debug → normal 替换保持指定设置文件不变，并且观察到恰好一个 Gateway 监听者。因为它会运行已签名安装包，所以必须显式执行。
 
 ## 使用说明
 

--- a/config/build-flavors.json
+++ b/config/build-flavors.json
@@ -1,5 +1,5 @@
 {
-  "stable": {
+  "normal": {
     "productName": "CodexHub",
     "executableBaseName": "CodexHub",
     "identifier": "com.codexhub.app",
@@ -13,28 +13,30 @@
     "updaterEndpoint": "https://github.com/NOirBRight/CodexHub/releases/latest/download/latest.json",
     "updaterManifestName": "latest.json",
     "releaseAssetPrefix": "CodexHub",
+    "releaseAssetSuffix": "",
     "autostartTaskName": "CodexHubProxy",
     "macosLabel": "com.codexhub.proxy",
     "macosPlistFile": "com.codexhub.proxy.plist",
     "linuxServiceFile": "codexhub-proxy.service"
   },
-  "beta": {
-    "productName": "CodexHub Beta",
-    "executableBaseName": "CodexHubBeta",
-    "identifier": "com.codexhub.beta",
-    "windowTitle": "CodexHub Beta",
-    "frontendPort": 1430,
-    "bridgePort": 1431,
-    "gatewayPort": 9109,
-    "routingOwner": "beta",
-    "defaultCodexHome": ".codexhub-beta",
+  "debug": {
+    "productName": "CodexHub",
+    "executableBaseName": "CodexHub",
+    "identifier": "com.codexhub.app",
+    "windowTitle": "CodexHub",
+    "frontendPort": 1420,
+    "bridgePort": 1421,
+    "gatewayPort": 9099,
+    "routingOwner": "release",
+    "defaultCodexHome": ".codex",
     "codexTargetHome": ".codex",
-    "updaterEndpoint": "https://github.com/NOirBRight/CodexHub/releases/download/beta/latest-beta.json",
-    "updaterManifestName": "latest-beta.json",
-    "releaseAssetPrefix": "CodexHubBeta",
-    "autostartTaskName": "CodexHubBetaProxy",
-    "macosLabel": "com.codexhub.beta.proxy",
-    "macosPlistFile": "com.codexhub.beta.proxy.plist",
-    "linuxServiceFile": "codexhub-beta-proxy.service"
+    "updaterEndpoint": "https://github.com/NOirBRight/CodexHub/releases/latest/download/latest-debug.json",
+    "updaterManifestName": "latest-debug.json",
+    "releaseAssetPrefix": "CodexHub",
+    "releaseAssetSuffix": "_debug",
+    "autostartTaskName": "CodexHubProxy",
+    "macosLabel": "com.codexhub.proxy",
+    "macosPlistFile": "com.codexhub.proxy.plist",
+    "linuxServiceFile": "codexhub-proxy.service"
   }
 }

--- a/frontend/scripts/ui-contract.test.mjs
+++ b/frontend/scripts/ui-contract.test.mjs
@@ -482,7 +482,7 @@ test("Windows release build vendors a pinned Python runtime", async () => {
   assert.match(prepareScript, /src-python\\codex_proxy\.py/);
 });
 
-test("release build scripts support stable and beta flavor configuration", async () => {
+test("release build scripts support normal and debug flavor configuration", async () => {
   const [buildScript, packageSource, viteSource] = await Promise.all([
     readFile(buildWindowsReleasePath, "utf8"),
     readFile(new URL("../package.json", import.meta.url), "utf8"),
@@ -491,36 +491,42 @@ test("release build scripts support stable and beta flavor configuration", async
   const packageJson = JSON.parse(packageSource);
   const flavorManifest = JSON.parse(await readFile(new URL("../../config/build-flavors.json", import.meta.url), "utf8"));
 
-  assert.deepEqual(Object.keys(flavorManifest).sort(), ["beta", "stable"]);
-  assert.equal(flavorManifest.stable.productName, "CodexHub");
-  assert.equal(flavorManifest.stable.identifier, "com.codexhub.app");
-  assert.equal(flavorManifest.stable.frontendPort, 1420);
-  assert.equal(flavorManifest.stable.bridgePort, 1421);
-  assert.equal(flavorManifest.stable.gatewayPort, 9099);
-  assert.equal(flavorManifest.stable.routingOwner, "release");
-  assert.equal(flavorManifest.beta.productName, "CodexHub Beta");
-  assert.equal(flavorManifest.beta.identifier, "com.codexhub.beta");
-  assert.equal(flavorManifest.beta.frontendPort, 1430);
-  assert.equal(flavorManifest.beta.bridgePort, 1431);
-  assert.equal(flavorManifest.beta.gatewayPort, 9109);
-  assert.equal(flavorManifest.beta.routingOwner, "beta");
-  assert.equal(flavorManifest.beta.updaterManifestName, "latest-beta.json");
-  assert.match(buildScript, /ValidateSet\("stable",\s*"beta"\)/);
+  assert.deepEqual(Object.keys(flavorManifest).sort(), ["debug", "normal"]);
+  assert.equal(flavorManifest.normal.productName, "CodexHub");
+  assert.equal(flavorManifest.normal.identifier, "com.codexhub.app");
+  assert.equal(flavorManifest.normal.frontendPort, 1420);
+  assert.equal(flavorManifest.normal.bridgePort, 1421);
+  assert.equal(flavorManifest.normal.gatewayPort, 9099);
+  assert.equal(flavorManifest.normal.routingOwner, "release");
+  assert.equal(flavorManifest.debug.productName, flavorManifest.normal.productName);
+  assert.equal(flavorManifest.debug.identifier, flavorManifest.normal.identifier);
+  assert.equal(flavorManifest.debug.frontendPort, flavorManifest.normal.frontendPort);
+  assert.equal(flavorManifest.debug.bridgePort, flavorManifest.normal.bridgePort);
+  assert.equal(flavorManifest.debug.gatewayPort, flavorManifest.normal.gatewayPort);
+  assert.equal(flavorManifest.debug.routingOwner, flavorManifest.normal.routingOwner);
+  assert.equal(flavorManifest.normal.updaterManifestName, "latest.json");
+  assert.equal(flavorManifest.debug.updaterManifestName, "latest-debug.json");
+  assert.equal(flavorManifest.normal.releaseAssetSuffix, "");
+  assert.equal(flavorManifest.debug.releaseAssetSuffix, "_debug");
+  assert.match(buildScript, /ValidateSet\("normal",\s*"debug"\)/);
   assert.match(buildScript, /Build-TauriConfig\.ps1/);
   assert.match(buildScript, /CODEXHUB_BUILD_FLAVOR/);
+  assert.match(buildScript, /debug-diagnostics/);
+  assert.match(buildScript, /CARGO_TARGET_DIR/);
   assert.match(buildScript, /CODEXHUB_FRONTEND_PORT/);
-  assert.match(buildScript, /cargo tauri build --config \$generatedTauriConfigPath --bundles nsis --ci/);
+  assert.match(buildScript, /cargo @tauriBuildArgs/);
   assert.match(buildScript, /releaseAssetPrefix/);
+  assert.match(buildScript, /Get-ReleaseArtifactName/);
+  assert.match(buildScript, /Get-ReleaseManifestName/);
   assert.match(buildScript, /\$installerNameCandidates = \[System\.Collections\.Generic\.List\[string\]\]::new\(\)/);
   assert.match(buildScript, /foreach \(\$nameCandidate in @\(\s*\$assetPrefix,\s*\$productName,\s*\(\$productName -replace "\\s\+", ""\),\s*\(\$productName -replace "\\s\+", "_"\)\s*\)\)/s);
-  assert.match(buildScript, /\$installerName = "\{0\}_\{1\}_x64-setup\.exe" -f \$nameCandidate, \$version/);
   assert.match(buildScript, /Remove-Item -LiteralPath \$artifactPath -Force -ErrorAction SilentlyContinue/);
   assert.match(buildScript, /Remove-Item -LiteralPath "\$artifactPath\.sig" -Force -ErrorAction SilentlyContinue/);
   assert.match(buildScript, /\$expectedCandidateList = \(\$installerNameCandidates \| ForEach-Object \{ "\$_ \(\+ \.sig\)" \}\) -join ", "/);
   assert.match(buildScript, /\$resolvedInstaller = foreach \(\$installerName in \$installerNameCandidates\)/);
   assert.match(buildScript, /Move-Item -LiteralPath \$resolvedInstaller\.InstallerPath -Destination \$installerPath -Force/);
   assert.match(buildScript, /Move-Item -LiteralPath \$resolvedInstaller\.SignaturePath -Destination \$signaturePath -Force/);
-  assert.match(buildScript, /throw "Expected NSIS installer\/signature pair was not generated for flavor '\$Flavor'\. Looked for: \$expectedCandidateList"/);
+  assert.match(buildScript, /Expected NSIS installer\/signature pair was not generated for flavor/);
   assert.match(buildScript, /\$manifestName = \[System\.IO\.Path\]::GetFileName\(\$manifestPath\)/);
   assert.match(buildScript, /throw "Generated \$manifestName failed validation: \$manifestPath"/);
   assert.doesNotMatch(buildScript, /if \(\(-not \(Test-Path -LiteralPath \$installerPath -PathType Leaf\)\) -or \(-not \(Test-Path -LiteralPath \$signaturePath -PathType Leaf\)\)\) \{/);
@@ -716,16 +722,25 @@ test("gateway empty states are localized outside the static contract", async () 
   assert.match(usageSource, /t\("usage\.pendingData"\)/);
 });
 
-test("Beta empty usage state explains isolated Gateway telemetry", async () => {
-  const [gatewaySource, enSource, zhSource] = await Promise.all([
+test("debug builds expose a localized diagnostics badge without changing Gateway telemetry", async () => {
+  const [gatewaySource, runtimeSource, typesSource, enSource, zhSource] = await Promise.all([
     readFile(gatewayPagePath, "utf8"),
+    readFile(runtimeBarPath, "utf8"),
+    readFile(typesPath, "utf8"),
     readFile(enLocalePath, "utf8"),
     readFile(zhLocalePath, "utf8"),
   ]);
 
-  assert.match(gatewaySource, /appFlavor\?\.flavor === "beta"[\s\S]*t\("gateway\.betaUsageIsolated"\)/);
-  assert.match(enSource, /betaUsageIsolated: "Beta uses isolated Gateway usage data/);
-  assert.match(zhSource, /betaUsageIsolated: "Beta 使用独立的 Gateway 用量数据/);
+  assert.match(typesSource, /export type BuildFlavor = "normal" \| "debug"/);
+  assert.match(typesSource, /export interface BuildInfo/);
+  assert.match(typesSource, /diagnostics_enabled: boolean/);
+  assert.match(runtimeSource, /appFlavor\?\.build\.flavor === "debug"/);
+  assert.match(runtimeSource, /appFlavor\.build\.diagnostics_enabled/);
+  assert.match(runtimeSource, /t\("runtime\.debugDiagnostics"\)/);
+  assert.match(enSource, /debugDiagnostics: "Debug diagnostics"/);
+  assert.match(zhSource, /debugDiagnostics: "调试诊断"/);
+  assert.doesNotMatch(gatewaySource, /appFlavor\?\.flavor === "beta"/);
+  assert.doesNotMatch(gatewaySource, /gateway\.betaUsageIsolated/);
 });
 
 test("gateway page is wired to real usage and client backend APIs", async () => {
@@ -2615,7 +2630,8 @@ test("Windows portable build uses the Tauri custom protocol pipeline", async () 
   const portableScript = await readFile(buildWindowsPortablePath, "utf8");
 
   assert.match(portableScript, /Prepare-PythonRuntime\.ps1/);
-  assert.match(portableScript, /cargo tauri build --config \$generatedTauriConfigPath --no-bundle --ci/);
+  assert.match(portableScript, /\$tauriBuildArgs = @\("tauri", "build", "--config", \$generatedTauriConfigPath, "--no-bundle", "--ci"\)/);
+  assert.match(portableScript, /& cargo @tauriBuildArgs/);
   assert.doesNotMatch(portableScript, /cargo build --release/);
 });
 
@@ -2809,19 +2825,27 @@ test("app updater has an opt-in E2E script for virtual release detection and ins
   assert.match(script, /windows-x86_64-nsis/);
   assert.match(appUpdatesSource, /CODEXHUB_UPDATE_E2E_ENDPOINT/);
   assert.match(appUpdatesSource, /CODEXHUB_UPDATE_E2E_SKIP_INSTALL/);
+  assert.match(appUpdatesSource, /configured_updater_endpoints/);
+  assert.match(appUpdatesSource, /validate_checked_update/);
+  assert.match(appUpdatesSource, /update\.raw_json/);
+  assert.doesNotMatch(appUpdatesSource, /validate_configured_flavor_manifest/);
+  assert.match(appUpdatesSource, /validate_flavor_manifest/);
+  assert.match(appUpdatesSource, /codexhub_flavor/);
   assert.match(appUpdatesSource, /app\.updater_builder\(\)/);
-  assert.match(appUpdatesSource, /builder[\s\S]*\.endpoints\(vec!\[endpoint\]\)/);
+  assert.match(appUpdatesSource, /\.endpoints\(endpoints\)/);
   assert.match(appUpdatesSource, /cfg\(debug_assertions\)/);
 });
 
-test("app update e2e script supports beta manifest and bridge ports", async () => {
+test("app update e2e script supports normal and debug manifests", async () => {
   const script = await readFile(appUpdateE2ePath, "utf8");
 
-  assert.match(script, /ValidateSet\("stable",\s*"beta"\)/);
-  assert.match(script, /latest-beta\.json/);
-  assert.match(script, /CodexHubBeta_/);
-  assert.match(script, /1421/);
-  assert.match(script, /1431/);
+  assert.match(script, /ValidateSet\("normal",\s*"debug"\)/);
+  assert.match(script, /Get-ReleaseManifestName/);
+  assert.match(script, /Get-ReleaseArtifactName/);
+  assert.match(script, /Get-FlavorTargetRoot/);
+  assert.match(script, /codexhub_flavor = \$Flavor/);
+  assert.match(script, /flavorConfig\.bridgePort/);
+  assert.doesNotMatch(script, /latest-beta\.json/);
 });
 
 test("settings drawer places version updates at the bottom and keeps backdrop blur", async () => {

--- a/frontend/src/components/RuntimeBar.tsx
+++ b/frontend/src/components/RuntimeBar.tsx
@@ -51,9 +51,9 @@ export function RuntimeBar({
         <span className="truncate text-base font-semibold text-ink">
           {appFlavor?.product_name ?? "CodexHub"}
         </span>
-        {appFlavor?.flavor === "beta" ? (
+        {appFlavor?.build.flavor === "debug" && appFlavor.build.diagnostics_enabled ? (
           <span className="rounded-control border border-amber-300 bg-amber-50 px-1.5 py-0.5 text-[10px] font-semibold text-amber-800">
-            Beta
+            {t("runtime.debugDiagnostics")}
           </span>
         ) : null}
       </div>

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -58,6 +58,7 @@ const enUS = {
   },
   runtime: {
     closeToTray: "Close to tray",
+    debugDiagnostics: "Debug diagnostics",
     gatewayHint: "Gateway is the local OpenAI-compatible server in front of Hub",
     maximizeOrRestore: "Maximize or restore",
     minimize: "Minimize",

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -58,6 +58,7 @@ const zhCN = {
   },
   runtime: {
     closeToTray: "最小化到托盘",
+    debugDiagnostics: "调试诊断",
     gatewayHint: "Gateway 是 Hub 前面的本地 OpenAI 兼容服务",
     maximizeOrRestore: "最大化或还原",
     minimize: "最小化",

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -110,11 +110,18 @@ export interface AppVersionInfo {
   current_version: string;
 }
 
-export type RuntimeFlavor = "stable" | "beta";
+export type BuildFlavor = "normal" | "debug";
 export type RoutingOwner = "official" | "release" | "beta" | "unknown_external";
 
+export interface BuildInfo {
+  semantic_version: string;
+  flavor: BuildFlavor;
+  source_revision: string;
+  diagnostics_enabled: boolean;
+}
+
 export interface AppFlavorInfo {
-  flavor: RuntimeFlavor;
+  build: BuildInfo;
   routing_owner: RoutingOwner;
   product_name: string;
   bridge_port: number;

--- a/frontend/src/pages/GatewayPage.tsx
+++ b/frontend/src/pages/GatewayPage.tsx
@@ -570,12 +570,7 @@ function GatewayPageImpl({
         <StackedUsageChartShell
           events={usageEvents}
           onWindowChange={onUsageWindowChange}
-          pendingMessage={
-            pending?.usage ??
-            (appFlavor?.flavor === "beta"
-              ? t("gateway.betaUsageIsolated")
-              : t("gateway.pendingUsage"))
-          }
+          pendingMessage={pending?.usage ?? t("gateway.pendingUsage")}
           providers={providers}
           summary={usageSummary}
           telemetryStatus={usageStatus}

--- a/scripts/Build-TauriConfig.ps1
+++ b/scripts/Build-TauriConfig.ps1
@@ -1,7 +1,7 @@
 [CmdletBinding()]
 param(
-    [ValidateSet("stable", "beta")]
-    [string]$Flavor = "stable",
+    [ValidateSet("normal", "debug")]
+    [string]$Flavor = "normal",
     [string]$RepoRoot = (Split-Path -Parent $PSScriptRoot),
     [string]$OutputRoot = ""
 )

--- a/scripts/New-ReleaseChannelPlan.ps1
+++ b/scripts/New-ReleaseChannelPlan.ps1
@@ -1,8 +1,7 @@
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory = $true)]
-    [ValidateSet("stable", "beta")]
-    [string]$Flavor,
+    [ValidateSet("normal", "debug")]
+    [string]$Flavor = "normal",
     [Parameter(Mandatory = $true)]
     [string]$Version,
     [string]$Commit = "HEAD",
@@ -28,58 +27,40 @@ function Resolve-GitCommit([string]$Ref) {
 
 $commitSha = Resolve-GitCommit $Commit
 $mainSha = Resolve-GitCommit "main"
-$devSha = Resolve-GitCommit "dev"
-Assert-ReleaseChannelVersion -Flavor $Flavor -Version $Version
+Assert-ReleaseFlavorVersion -Flavor $Flavor -Version $Version
 
-if ($Flavor -eq "beta") {
-    & git -C $RepoRoot merge-base --is-ancestor $commitSha $devSha
-    if ($LASTEXITCODE -ne 0) {
-        throw "Beta publication requires a commit on or ancestor of dev."
-    }
-    $assetPrefix = "CodexHubBeta"
-    $installer = "${assetPrefix}_${Version}_x64-setup.exe"
-    $plan = [ordered]@{
-        flavor = "beta"
-        version = $Version
-        commit = $commitSha
-        dry_run = $true
-        manifest = [ordered]@{
-            name = "latest-beta.json"
-            asset_url = "https://github.com/NOirBRight/CodexHub/releases/download/v$Version/$installer"
-        }
-        immutable_release = [ordered]@{
-            tag = "v$Version"
-            prerelease = $true
-            assets = @($installer, "$installer.sig")
-        }
-        channel_release = [ordered]@{
-            tag = "beta"
-            prerelease = $true
-            assets = @("latest-beta.json")
-        }
-    }
+if ($commitSha -ne $mainSha) {
+    throw "Normal and debug publication requires the exact main commit."
 }
-else {
-    if ($commitSha -ne $mainSha) {
-        throw "Stable publication requires the exact main commit; dev must never publish Stable."
+
+$normalInstaller = Get-ReleaseArtifactName -Flavor "normal" -Version $Version
+$debugInstaller = Get-ReleaseArtifactName -Flavor "debug" -Version $Version
+$normalManifest = Get-ReleaseManifestName -Flavor "normal"
+$debugManifest = Get-ReleaseManifestName -Flavor "debug"
+$selectedInstaller = Get-ReleaseArtifactName -Flavor $Flavor -Version $Version
+$selectedManifest = Get-ReleaseManifestName -Flavor $Flavor
+$plan = [ordered]@{
+    flavor = $Flavor
+    version = $Version
+    commit = $commitSha
+    dry_run = $true
+    manifest = [ordered]@{
+        name = $selectedManifest
+        asset_url = "https://github.com/NOirBRight/CodexHub/releases/download/v$Version/$selectedInstaller"
     }
-    $installer = "CodexHub_${Version}_x64-setup.exe"
-    $plan = [ordered]@{
-        flavor = "stable"
-        version = $Version
-        commit = $commitSha
-        dry_run = $true
-        manifest = [ordered]@{
-            name = "latest.json"
-            asset_url = "https://github.com/NOirBRight/CodexHub/releases/download/v$Version/$installer"
-        }
-        immutable_release = [ordered]@{
-            tag = "v$Version"
-            prerelease = $false
-            assets = @($installer, "$installer.sig", "latest.json")
-        }
-        channel_release = $null
+    immutable_release = [ordered]@{
+        tag = "v$Version"
+        prerelease = $false
+        assets = @(
+            $normalInstaller,
+            "$normalInstaller.sig",
+            $normalManifest,
+            $debugInstaller,
+            "$debugInstaller.sig",
+            $debugManifest
+        )
     }
+    channel_release = $null
 }
 
 $plan | ConvertTo-Json -Depth 8 -Compress

--- a/scripts/ReleaseChannel.ps1
+++ b/scripts/ReleaseChannel.ps1
@@ -1,8 +1,8 @@
-function Assert-ReleaseChannelVersion {
+function Assert-ReleaseFlavorVersion {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
-        [ValidateSet("stable", "beta")]
+        [ValidateSet("normal", "debug")]
         [string]$Flavor,
         [Parameter(Mandatory = $true)]
         [string]$Version
@@ -16,10 +16,51 @@ function Assert-ReleaseChannelVersion {
     }
 
     $hasPrerelease = $Matches.ContainsKey("prerelease") -and -not [string]::IsNullOrEmpty($Matches["prerelease"])
-    if ($Flavor -eq "stable" -and $hasPrerelease) {
-        throw "Stable release requires a version without a prerelease suffix."
+    if ($hasPrerelease) {
+        throw "Normal and debug release flavors require a version without a prerelease suffix."
     }
-    if ($Flavor -eq "beta" -and -not $hasPrerelease) {
-        throw "Beta release requires a prerelease version."
+}
+
+function Get-ReleaseArtifactName {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateSet("normal", "debug")]
+        [string]$Flavor,
+        [Parameter(Mandatory = $true)]
+        [string]$Version
+    )
+
+    $suffix = if ($Flavor -eq "debug") { "_debug" } else { "" }
+    return "CodexHub_${Version}${suffix}_x64-setup.exe"
+}
+
+function Get-ReleaseManifestName {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateSet("normal", "debug")]
+        [string]$Flavor
+    )
+
+    if ($Flavor -eq "debug") {
+        return "latest-debug.json"
     }
+    return "latest.json"
+}
+
+function Get-FlavorTargetRoot {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$TauriDir,
+        [Parameter(Mandatory = $true)]
+        [ValidateSet("normal", "debug")]
+        [string]$Flavor
+    )
+
+    if ($Flavor -eq "debug") {
+        return Join-Path $TauriDir "target\build-flavors\debug"
+    }
+    return Join-Path $TauriDir "target"
 }

--- a/scripts/Test-BuildFlavorReplacement.ps1
+++ b/scripts/Test-BuildFlavorReplacement.ps1
@@ -1,0 +1,172 @@
+[CmdletBinding()]
+param(
+    [string]$RepoRoot = (Split-Path -Parent $PSScriptRoot),
+    [string]$Version = "",
+    [string]$NormalInstaller = "",
+    [string]$DebugInstaller = "",
+    [string]$SettingsPath = "",
+    [string]$InstalledExe = "",
+    [switch]$RunInstall,
+    [switch]$LaunchAfterInstall,
+    [switch]$DryRun
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+if ($RunInstall -and $DryRun) {
+    throw "-RunInstall and -DryRun cannot be used together."
+}
+if ($LaunchAfterInstall -and -not $RunInstall) {
+    throw "-LaunchAfterInstall requires -RunInstall."
+}
+
+. (Join-Path $PSScriptRoot "ReleaseChannel.ps1")
+
+$flavorManifestPath = Join-Path $RepoRoot "config\build-flavors.json"
+$tauriConfigPath = Join-Path $RepoRoot "src-tauri\tauri.conf.json"
+$flavorManifest = Get-Content -Raw -LiteralPath $flavorManifestPath | ConvertFrom-Json
+$tauriConfig = Get-Content -Raw -LiteralPath $tauriConfigPath | ConvertFrom-Json
+$normal = $flavorManifest.normal
+$debug = $flavorManifest.debug
+if ($null -eq $normal -or $null -eq $debug) {
+    throw "Build flavor manifest must define both normal and debug."
+}
+
+if ([string]::IsNullOrWhiteSpace($Version)) {
+    $Version = [string]$tauriConfig.version
+}
+Assert-ReleaseFlavorVersion -Flavor normal -Version $Version
+Assert-ReleaseFlavorVersion -Flavor debug -Version $Version
+
+$sharedIdentityKeys = @(
+    "productName",
+    "executableBaseName",
+    "identifier",
+    "windowTitle",
+    "frontendPort",
+    "bridgePort",
+    "gatewayPort",
+    "routingOwner",
+    "defaultCodexHome",
+    "codexTargetHome",
+    "autostartTaskName",
+    "macosLabel",
+    "macosPlistFile",
+    "linuxServiceFile"
+)
+foreach ($key in $sharedIdentityKeys) {
+    if ([string]$normal.$key -ne [string]$debug.$key) {
+        throw "normal and debug must share $key for same-version replacement."
+    }
+}
+
+$normalInstallerName = Get-ReleaseArtifactName -Flavor normal -Version $Version
+$debugInstallerName = Get-ReleaseArtifactName -Flavor debug -Version $Version
+$sequence = @(
+    [pscustomobject]@{ Flavor = "normal"; InstallerName = $normalInstallerName },
+    [pscustomobject]@{ Flavor = "debug"; InstallerName = $debugInstallerName },
+    [pscustomobject]@{ Flavor = "normal"; InstallerName = $normalInstallerName }
+)
+
+$plan = [ordered]@{
+    version = $Version
+    sequence = @($sequence | ForEach-Object { $_.Flavor })
+    normal_installer = $normalInstallerName
+    debug_installer = $debugInstallerName
+    application_identity = [ordered]@{
+        product_name = [string]$normal.productName
+        identifier = [string]$normal.identifier
+        executable = "{0}.exe" -f ([string]$normal.executableBaseName)
+    }
+    runtime = [ordered]@{
+        home = [string]$normal.defaultCodexHome
+        routing_owner = [string]$normal.routingOwner
+        gateway_port = [int]$normal.gatewayPort
+        expected_gateway_owner_count = 1
+    }
+}
+
+if ($DryRun) {
+    $plan | ConvertTo-Json -Depth 8 -Compress
+    return
+}
+
+if (-not $RunInstall) {
+    Write-Host "Replacement contract verified. Use -RunInstall in a dedicated Windows test environment to exercise the installer sequence."
+    return
+}
+
+if ([string]::IsNullOrWhiteSpace($NormalInstaller) -or [string]::IsNullOrWhiteSpace($DebugInstaller)) {
+    throw "-RunInstall requires both -NormalInstaller and -DebugInstaller."
+}
+if ([string]::IsNullOrWhiteSpace($SettingsPath) -or -not (Test-Path -LiteralPath $SettingsPath -PathType Leaf)) {
+    throw "-RunInstall requires an existing -SettingsPath to prove supported settings survive replacement."
+}
+if ($LaunchAfterInstall -and ([string]::IsNullOrWhiteSpace($InstalledExe) -or -not (Test-Path -LiteralPath $InstalledExe -PathType Leaf))) {
+    throw "-LaunchAfterInstall requires an existing -InstalledExe."
+}
+
+function Assert-InstallerPath {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+        [Parameter(Mandatory = $true)]
+        [string]$ExpectedName
+    )
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        throw "Installer was not found: $Path"
+    }
+    if ((Split-Path -Leaf $Path) -ne $ExpectedName) {
+        throw "Installer name mismatch: expected $ExpectedName, got $(Split-Path -Leaf $Path)."
+    }
+}
+
+function Get-SettingsHash {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    return (Get-FileHash -Algorithm SHA256 -LiteralPath $Path).Hash.ToLowerInvariant()
+}
+
+function Assert-OneGatewayOwner {
+    param([Parameter(Mandatory = $true)][int]$Port)
+
+    $owners = @(
+        Get-NetTCPConnection -State Listen -LocalPort $Port -ErrorAction SilentlyContinue |
+            Select-Object -ExpandProperty OwningProcess -Unique
+    )
+    if ($owners.Count -ne 1) {
+        throw "Expected exactly one Gateway owner on port $Port, found $($owners -join ', ')."
+    }
+}
+
+Assert-InstallerPath -Path $NormalInstaller -ExpectedName $normalInstallerName
+Assert-InstallerPath -Path $DebugInstaller -ExpectedName $debugInstallerName
+$settingsHash = Get-SettingsHash -Path $SettingsPath
+$installerPaths = @{ normal = $NormalInstaller; debug = $DebugInstaller }
+
+foreach ($step in $sequence) {
+    & $installerPaths[$step.Flavor] /S
+    if ($LASTEXITCODE -ne 0) {
+        throw "Installer replacement failed for $($step.Flavor) with exit code $LASTEXITCODE."
+    }
+    if ((Get-SettingsHash -Path $SettingsPath) -ne $settingsHash) {
+        throw "Supported settings changed while replacing with $($step.Flavor)."
+    }
+
+    if ($LaunchAfterInstall) {
+        $process = Start-Process -FilePath (Resolve-Path -LiteralPath $InstalledExe).Path -PassThru -WindowStyle Hidden
+        try {
+            Start-Sleep -Milliseconds 750
+            Assert-OneGatewayOwner -Port ([int]$normal.gatewayPort)
+        }
+        finally {
+            if (-not $process.HasExited) {
+                Stop-Process -Id $process.Id -Force
+            }
+        }
+    }
+}
+
+Write-Host "Normal -> debug -> normal same-version replacement preserved settings and kept exactly one Gateway owner."

--- a/scripts/Test-ReleaseManifest.ps1
+++ b/scripts/Test-ReleaseManifest.ps1
@@ -1,7 +1,7 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $true)]
-    [ValidateSet("stable", "beta")]
+    [ValidateSet("normal", "debug")]
     [string]$Flavor,
     [Parameter(Mandatory = $true)]
     [string]$Version,
@@ -17,7 +17,7 @@ $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
 . (Join-Path $PSScriptRoot "ReleaseChannel.ps1")
 
-Assert-ReleaseChannelVersion -Flavor $Flavor -Version $Version
+Assert-ReleaseFlavorVersion -Flavor $Flavor -Version $Version
 
 foreach ($path in @($ManifestPath, $InstallerPath, $SignaturePath)) {
     if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
@@ -27,9 +27,8 @@ foreach ($path in @($ManifestPath, $InstallerPath, $SignaturePath)) {
 
 $manifestName = [System.IO.Path]::GetFileName($ManifestPath)
 $installerName = [System.IO.Path]::GetFileName($InstallerPath)
-$expectedManifestName = if ($Flavor -eq "beta") { "latest-beta.json" } else { "latest.json" }
-$expectedPrefix = if ($Flavor -eq "beta") { "CodexHubBeta" } else { "CodexHub" }
-$expectedInstallerName = "${expectedPrefix}_${Version}_x64-setup.exe"
+$expectedManifestName = Get-ReleaseManifestName -Flavor $Flavor
+$expectedInstallerName = Get-ReleaseArtifactName -Flavor $Flavor -Version $Version
 
 if ($manifestName -ne $expectedManifestName) {
     throw "$Flavor release manifest must be named $expectedManifestName."
@@ -45,6 +44,9 @@ $platform = $manifest.platforms."windows-x86_64"
 $signature = (Get-Content -Raw -LiteralPath $SignaturePath).Trim()
 if ($manifest.version -ne $Version) {
     throw "Manifest version does not match $Version."
+}
+if ($manifest.codexhub_flavor -ne $Flavor) {
+    throw "Manifest flavor does not match $Flavor."
 }
 if ([string]::IsNullOrWhiteSpace($signature) -or $platform.signature -ne $signature) {
     throw "Manifest signature does not match the paired signature artifact."

--- a/scripts/build-windows-portable.ps1
+++ b/scripts/build-windows-portable.ps1
@@ -1,8 +1,7 @@
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory = $true)]
-    [ValidateSet("stable", "beta")]
-    [string]$Flavor,
+    [ValidateSet("normal", "debug")]
+    [string]$Flavor = "normal",
     [string]$OutputRoot = "",
     [string]$RepoRoot = (Split-Path -Parent $PSScriptRoot),
     [switch]$DryRun
@@ -28,7 +27,8 @@ $generatedTauriConfigPath = (& (Join-Path $PSScriptRoot "Build-TauriConfig.ps1")
 $generatedTauriConfig = Get-Content -Raw -LiteralPath $generatedTauriConfigPath | ConvertFrom-Json
 $version = [string]$generatedTauriConfig.version
 . (Join-Path $PSScriptRoot "ReleaseChannel.ps1")
-Assert-ReleaseChannelVersion -Flavor $Flavor -Version $version
+Assert-ReleaseFlavorVersion -Flavor $Flavor -Version $version
+$targetRoot = Get-FlavorTargetRoot -TauriDir $tauriDir -Flavor $Flavor
 
 $generatedEndpoint = [string]$generatedTauriConfig.plugins.updater.endpoints[0]
 if (
@@ -40,12 +40,14 @@ if (
     throw "Generated Tauri config does not match the requested $Flavor flavor."
 }
 
-$commit = (& git -C $repoRoot rev-parse --short=8 HEAD).Trim()
-if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($commit)) {
+$sourceRevision = (& git -C $repoRoot rev-parse HEAD).Trim()
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($sourceRevision)) {
     throw "Unable to resolve portable build commit."
 }
+$commit = $sourceRevision.Substring(0, [Math]::Min(8, $sourceRevision.Length))
 $portableExecutable = "{0}.exe" -f ([string]$flavorConfig.executableBaseName)
-$portableName = "{0}_{1}_portable_{2}" -f ([string]$flavorConfig.releaseAssetPrefix), $version, $commit
+$releaseAssetSuffix = [string]$flavorConfig.releaseAssetSuffix
+$portableName = "{0}_{1}{2}_portable_{3}" -f ([string]$flavorConfig.releaseAssetPrefix), $version, $releaseAssetSuffix, $commit
 $portableDir = Join-Path $OutputRoot $portableName
 $portableZip = "$portableDir.zip"
 
@@ -53,12 +55,19 @@ if ($DryRun) {
     [ordered]@{
         flavor = $Flavor
         version = $version
+        source_revision = $sourceRevision
         executable = $portableExecutable
         portable_name = $portableName
+        installer_name = (Get-ReleaseArtifactName -Flavor $Flavor -Version $version)
+        updater_manifest = (Get-ReleaseManifestName -Flavor $Flavor)
+        release_optimized = $true
+        debug_diagnostics_enabled = ($Flavor -eq "debug")
         generated_config = [ordered]@{
             productName = [string]$generatedTauriConfig.productName
             identifier = [string]$generatedTauriConfig.identifier
             title = [string]$generatedTauriConfig.app.windows[0].title
+            bridgePort = [int]$flavorConfig.bridgePort
+            gatewayPort = [int]$flavorConfig.gatewayPort
             updaterEndpoint = $generatedEndpoint
         }
     } | ConvertTo-Json -Depth 4 -Compress
@@ -90,11 +99,17 @@ finally {
 }
 
 $previousBuildFlavor = $env:CODEXHUB_BUILD_FLAVOR
+$previousCargoTarget = $env:CARGO_TARGET_DIR
 try {
     $env:CODEXHUB_BUILD_FLAVOR = $Flavor
+    $env:CARGO_TARGET_DIR = $targetRoot
     Push-Location $tauriDir
     try {
-        & cargo tauri build --config $generatedTauriConfigPath --no-bundle --ci
+        $tauriBuildArgs = @("tauri", "build", "--config", $generatedTauriConfigPath, "--no-bundle", "--ci")
+        if ($Flavor -eq "debug") {
+            $tauriBuildArgs += @("--features", "debug-diagnostics")
+        }
+        & cargo @tauriBuildArgs
         if ($LASTEXITCODE -ne 0) {
             throw "Tauri portable build failed with exit code $LASTEXITCODE."
         }
@@ -110,6 +125,12 @@ finally {
     else {
         $env:CODEXHUB_BUILD_FLAVOR = $previousBuildFlavor
     }
+    if ($null -eq $previousCargoTarget) {
+        Remove-Item Env:\CARGO_TARGET_DIR -ErrorAction SilentlyContinue
+    }
+    else {
+        $env:CARGO_TARGET_DIR = $previousCargoTarget
+    }
 }
 
 if (Test-Path -LiteralPath $portableDir) {
@@ -120,9 +141,9 @@ if (Test-Path -LiteralPath $portableZip) {
 }
 New-Item -ItemType Directory -Force -Path $portableDir | Out-Null
 
-Copy-Item -LiteralPath (Join-Path $tauriDir "target\release\codexhub.exe") -Destination (Join-Path $portableDir $portableExecutable)
+Copy-Item -LiteralPath (Join-Path $targetRoot "release\codexhub.exe") -Destination (Join-Path $portableDir $portableExecutable)
 foreach ($resource in @("config", "src-python", "python")) {
-    Copy-Item -LiteralPath (Join-Path $tauriDir "target\release\$resource") -Destination $portableDir -Recurse
+    Copy-Item -LiteralPath (Join-Path $targetRoot "release\$resource") -Destination $portableDir -Recurse
 }
 Compress-Archive -Path (Join-Path $portableDir "*") -DestinationPath $portableZip -CompressionLevel Optimal
 

--- a/scripts/build-windows-release.ps1
+++ b/scripts/build-windows-release.ps1
@@ -1,7 +1,7 @@
 [CmdletBinding()]
 param(
-    [ValidateSet("stable", "beta")]
-    [string]$Flavor = "stable",
+    [ValidateSet("normal", "debug")]
+    [string]$Flavor = "normal",
     [string]$PrivateKeyPath = (Join-Path $env:USERPROFILE ".codexhub\codexhub-updater.key"),
     [string]$PrivateKeyPassword = $env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD,
     [string]$ReleaseBaseUrl = "",
@@ -24,6 +24,7 @@ if ($null -eq $flavorConfig) {
 }
 $generatedTauriConfigPath = (& (Join-Path $PSScriptRoot "Build-TauriConfig.ps1") -Flavor $Flavor -RepoRoot $repoRoot).Trim()
 $tauriConfigPath = $generatedTauriConfigPath
+. (Join-Path $PSScriptRoot "ReleaseChannel.ps1")
 
 if (-not (Test-Path -LiteralPath $PrivateKeyPath -PathType Leaf)) {
     throw "Updater private key was not found: $PrivateKeyPath"
@@ -32,12 +33,14 @@ if (-not (Test-Path -LiteralPath $PrivateKeyPath -PathType Leaf)) {
 $tauriConfig = Get-Content -Raw -LiteralPath $tauriConfigPath | ConvertFrom-Json
 $productName = [string]$tauriConfig.productName
 $version = [string]$tauriConfig.version
+Assert-ReleaseFlavorVersion -Flavor $Flavor -Version $version
 if ([string]::IsNullOrWhiteSpace($ReleaseBaseUrl)) {
     $ReleaseBaseUrl = "https://github.com/NOirBRight/CodexHub/releases/download/v$version"
 }
-$bundleDir = Join-Path $tauriDir "target\release\bundle\nsis"
+$targetRoot = Get-FlavorTargetRoot -TauriDir $tauriDir -Flavor $Flavor
+$bundleDir = Join-Path $targetRoot "release\bundle\nsis"
 $assetPrefix = [string]$flavorConfig.releaseAssetPrefix
-$canonicalInstallerName = "{0}_{1}_x64-setup.exe" -f $assetPrefix, $version
+$canonicalInstallerName = Get-ReleaseArtifactName -Flavor $Flavor -Version $version
 
 $installerNameCandidates = [System.Collections.Generic.List[string]]::new()
 foreach ($nameCandidate in @(
@@ -100,6 +103,7 @@ $previousSigningKey = $env:TAURI_SIGNING_PRIVATE_KEY
 $previousSigningPassword = $env:TAURI_SIGNING_PRIVATE_KEY_PASSWORD
 $previousBuildFlavor = $env:CODEXHUB_BUILD_FLAVOR
 $previousTauriConfig = $env:TAURI_CONFIG
+$previousCargoTarget = $env:CARGO_TARGET_DIR
 
 try {
     $env:TAURI_SIGNING_PRIVATE_KEY = (Resolve-Path -LiteralPath $PrivateKeyPath).Path
@@ -111,6 +115,7 @@ try {
     }
     $env:CODEXHUB_BUILD_FLAVOR = $Flavor
     $env:TAURI_CONFIG = $generatedTauriConfigPath
+    $env:CARGO_TARGET_DIR = $targetRoot
 
     if (Test-Path -LiteralPath $bundleDir -PathType Container) {
         foreach ($installerName in $installerNameCandidates) {
@@ -122,7 +127,11 @@ try {
 
     Push-Location $tauriDir
     try {
-        & cargo tauri build --config $generatedTauriConfigPath --bundles nsis --ci
+        $tauriBuildArgs = @("tauri", "build", "--config", $generatedTauriConfigPath, "--bundles", "nsis", "--ci")
+        if ($Flavor -eq "debug") {
+            $tauriBuildArgs += @("--features", "debug-diagnostics")
+        }
+        & cargo @tauriBuildArgs
         if ($LASTEXITCODE -ne 0) {
             throw "Tauri Windows release build failed with exit code $LASTEXITCODE."
         }
@@ -158,6 +167,13 @@ finally {
     }
     else {
         $env:TAURI_CONFIG = $previousTauriConfig
+    }
+
+    if ($null -eq $previousCargoTarget) {
+        Remove-Item Env:\CARGO_TARGET_DIR -ErrorAction SilentlyContinue
+    }
+    else {
+        $env:CARGO_TARGET_DIR = $previousCargoTarget
     }
 }
 
@@ -209,8 +225,14 @@ if ([string]::IsNullOrWhiteSpace($Notes)) {
 }
 
 $releaseBaseUrl = $ReleaseBaseUrl.TrimEnd("/")
+$sourceRevision = (& git -C $repoRoot rev-parse HEAD).Trim()
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($sourceRevision)) {
+    throw "Unable to resolve release build commit."
+}
 $manifest = [ordered]@{
     version = $version
+    codexhub_flavor = $Flavor
+    codexhub_source_revision = $sourceRevision
     notes = $Notes
     pub_date = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ", [Globalization.CultureInfo]::InvariantCulture)
     platforms = [ordered]@{
@@ -221,7 +243,7 @@ $manifest = [ordered]@{
     }
 }
 
-$manifestPath = Join-Path $bundleDir ([string]$flavorConfig.updaterManifestName)
+$manifestPath = Join-Path $bundleDir (Get-ReleaseManifestName -Flavor $Flavor)
 $manifestName = [System.IO.Path]::GetFileName($manifestPath)
 $manifestJson = $manifest | ConvertTo-Json -Depth 8
 $utf8NoBom = New-Object System.Text.UTF8Encoding $false

--- a/scripts/e2e-app-update.ps1
+++ b/scripts/e2e-app-update.ps1
@@ -1,7 +1,7 @@
 [CmdletBinding()]
 param(
-    [ValidateSet("stable", "beta")]
-    [string]$Flavor = "stable",
+    [ValidateSet("normal", "debug")]
+    [string]$Flavor = "normal",
     [int]$Port = 18765,
     [string]$BridgeUrl = "",
     [string]$AppExe = "",
@@ -11,6 +11,8 @@ param(
     [string]$CurrentVersion = "",
     [string]$NextVersion = "",
     [switch]$Launch,
+    [switch]$BuildApp,
+    [switch]$ShowAppBuildPlan,
     [switch]$Install,
     [switch]$DownloadOnly,
     [switch]$KeepAlive,
@@ -20,17 +22,55 @@ param(
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
 
+if ($BuildApp -and -not $Launch) {
+    throw "-BuildApp requires -Launch."
+}
+if ($BuildApp -and -not [string]::IsNullOrWhiteSpace($AppExe)) {
+    throw "-BuildApp uses the default flavor executable path; omit -AppExe."
+}
+
 $repoRoot = Split-Path -Parent $PSScriptRoot
+. (Join-Path $PSScriptRoot "ReleaseChannel.ps1")
+$preparePythonRuntimePath = Join-Path $PSScriptRoot "Prepare-PythonRuntime.ps1"
 $flavorManifest = Get-Content -Raw -LiteralPath (Join-Path $repoRoot "config\build-flavors.json") | ConvertFrom-Json
 $flavorConfig = $flavorManifest.$Flavor
-# Stable defaults remain latest.json / CodexHub_ / 1421; beta defaults remain latest-beta.json / CodexHubBeta_ / 1431.
 if ($null -eq $flavorConfig) {
     throw "Unknown update E2E flavor: $Flavor"
 }
+$targetRoot = Get-FlavorTargetRoot -TauriDir (Join-Path $repoRoot "src-tauri") -Flavor $Flavor
 if ([string]::IsNullOrWhiteSpace($BridgeUrl)) {
     $BridgeUrl = "http://127.0.0.1:$($flavorConfig.bridgePort)/api/invoke"
 }
 $tauriConfigPath = Join-Path $repoRoot "src-tauri\tauri.conf.json"
+
+function Get-AppBuildPlan {
+    $cargoArgs = [System.Collections.Generic.List[string]]@("build", "--locked")
+    if ($Flavor -eq "debug") {
+        $cargoArgs.Add("--features")
+        $cargoArgs.Add("debug-diagnostics")
+    }
+
+    $appExecutable = Join-Path $targetRoot "debug\codexhub.exe"
+    return [pscustomobject][ordered]@{
+        flavor = $Flavor
+        working_directory = Join-Path $repoRoot "src-tauri"
+        target_root = $targetRoot
+        app_executable = $appExecutable
+        prepare_python_runtime = $preparePythonRuntimePath
+        environment = [ordered]@{
+            CODEXHUB_BUILD_FLAVOR = $Flavor
+            CARGO_TARGET_DIR = $targetRoot
+        }
+        cargo_args = $cargoArgs.ToArray()
+        command = "cargo $($cargoArgs -join ' ')"
+    }
+}
+
+$script:AppBuildPlan = Get-AppBuildPlan
+if ($ShowAppBuildPlan) {
+    $script:AppBuildPlan | ConvertTo-Json -Depth 8 -Compress
+    exit 0
+}
 
 function Get-TauriVersion {
     $config = Get-Content -Raw -LiteralPath $tauriConfigPath | ConvertFrom-Json
@@ -53,18 +93,15 @@ function Get-ReleaseAsset {
         return (Resolve-Path -LiteralPath $InstallerPath).Path
     }
 
-    $bundleDir = Join-Path $repoRoot "src-tauri\target\release\bundle\nsis"
-    $assetPrefix = [string]$flavorConfig.releaseAssetPrefix
-    $candidate = Get-ChildItem -LiteralPath $bundleDir -Filter "${assetPrefix}_*_x64-setup.exe" -ErrorAction SilentlyContinue |
-        Sort-Object LastWriteTime |
-        Select-Object -Last 1
-
-    if ($null -ne $candidate) {
-        return $candidate.FullName
+    $bundleDir = Join-Path $targetRoot "release\bundle\nsis"
+    $expectedInstallerName = Get-ReleaseArtifactName -Flavor $Flavor -Version $NextVersion
+    $candidate = Join-Path $bundleDir $expectedInstallerName
+    if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+        return $candidate
     }
 
     if ($AllowDummy) {
-        $dummy = Join-Path $ReleaseRoot "${assetPrefix}_${NextVersion}_x64-setup.exe"
+        $dummy = Join-Path $ReleaseRoot (Get-ReleaseArtifactName -Flavor $Flavor -Version $NextVersion)
         [System.IO.File]::WriteAllText($dummy, "virtual CodexHub update asset")
         return $dummy
     }
@@ -99,6 +136,7 @@ function Write-VirtualRelease {
 
     $manifest = [ordered]@{
         version = $NextVersion
+        codexhub_flavor = $Flavor
         notes = "virtual CodexHub update`n- E2E detection path`n- E2E install path"
         pub_date = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ", [Globalization.CultureInfo]::InvariantCulture)
         platforms = [ordered]@{
@@ -113,7 +151,7 @@ function Write-VirtualRelease {
         }
     }
 
-    $manifestName = [string]$flavorConfig.updaterManifestName
+    $manifestName = Get-ReleaseManifestName -Flavor $Flavor
     $manifestPath = Join-Path $ReleaseRoot $manifestName
     $json = $manifest | ConvertTo-Json -Depth 8
     $utf8NoBom = New-Object System.Text.UTF8Encoding $false
@@ -223,11 +261,14 @@ function Wait-InstallStatusPhase {
 }
 
 function Start-AppForE2E([string]$Endpoint) {
+    if ($BuildApp) {
+        Build-AppForE2E -Plan $script:AppBuildPlan
+    }
     if ([string]::IsNullOrWhiteSpace($AppExe)) {
-        $script:AppExe = Join-Path $repoRoot "src-tauri\target\debug\codexhub.exe"
+        $script:AppExe = $script:AppBuildPlan.app_executable
     }
     if (-not (Test-Path -LiteralPath $AppExe -PathType Leaf)) {
-        throw "App executable not found: $AppExe. Build a debug app first with 'cargo build' in src-tauri."
+        throw "App executable not found: $AppExe. Run this script with -Launch -BuildApp, or inspect -ShowAppBuildPlan for the exact flavor build command."
     }
 
     $info = [System.Diagnostics.ProcessStartInfo]::new()
@@ -240,6 +281,50 @@ function Start-AppForE2E([string]$Endpoint) {
     [System.Diagnostics.Process]::Start($info)
 }
 
+function Build-AppForE2E {
+    param([Parameter(Mandatory = $true)]$Plan)
+
+    & $Plan.prepare_python_runtime -RepoRoot $repoRoot
+    if ($LASTEXITCODE -ne 0) {
+        throw "Python runtime preparation failed with exit code $LASTEXITCODE."
+    }
+
+    $previousBuildFlavor = $env:CODEXHUB_BUILD_FLAVOR
+    $previousCargoTarget = $env:CARGO_TARGET_DIR
+    try {
+        $env:CODEXHUB_BUILD_FLAVOR = [string]$Plan.environment.CODEXHUB_BUILD_FLAVOR
+        $env:CARGO_TARGET_DIR = [string]$Plan.environment.CARGO_TARGET_DIR
+        Push-Location $Plan.working_directory
+        try {
+            & cargo @($Plan.cargo_args)
+            if ($LASTEXITCODE -ne 0) {
+                throw "Flavor E2E app build failed with exit code $LASTEXITCODE."
+            }
+        }
+        finally {
+            Pop-Location
+        }
+    }
+    finally {
+        if ($null -eq $previousBuildFlavor) {
+            Remove-Item Env:\CODEXHUB_BUILD_FLAVOR -ErrorAction SilentlyContinue
+        }
+        else {
+            $env:CODEXHUB_BUILD_FLAVOR = $previousBuildFlavor
+        }
+        if ($null -eq $previousCargoTarget) {
+            Remove-Item Env:\CARGO_TARGET_DIR -ErrorAction SilentlyContinue
+        }
+        else {
+            $env:CARGO_TARGET_DIR = $previousCargoTarget
+        }
+    }
+
+    if (-not (Test-Path -LiteralPath $Plan.app_executable -PathType Leaf)) {
+        throw "Flavor E2E app build did not produce the expected executable: $($Plan.app_executable)"
+    }
+}
+
 if ([string]::IsNullOrWhiteSpace($CurrentVersion)) {
     $CurrentVersion = Get-TauriVersion
 }
@@ -248,7 +333,7 @@ if ([string]::IsNullOrWhiteSpace($NextVersion)) {
 }
 
 $manifestPath = Write-VirtualRelease
-$manifestName = [string]$flavorConfig.updaterManifestName
+$manifestName = Get-ReleaseManifestName -Flavor $Flavor
 $manifestUrl = "http://127.0.0.1:$Port/$manifestName"
 Write-Host "Virtual release manifest: $manifestPath"
 Write-Host "Virtual release endpoint: $manifestUrl"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,6 +6,9 @@ authors = ["CodexHub"]
 license = "MIT"
 edition = "2021"
 
+[features]
+debug-diagnostics = []
+
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
 

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,6 +1,52 @@
+use std::process::Command;
+
 fn main() {
-    let flavor = std::env::var("CODEXHUB_BUILD_FLAVOR").unwrap_or_else(|_| "stable".to_string());
-    println!("cargo:rustc-env=CODEXHUB_BUILD_FLAVOR={flavor}");
     println!("cargo:rerun-if-env-changed=CODEXHUB_BUILD_FLAVOR");
+    println!("cargo:rerun-if-env-changed=CARGO_FEATURE_DEBUG_DIAGNOSTICS");
+    println!("cargo:rerun-if-env-changed=GITHUB_SHA");
+    println!("cargo:rerun-if-changed=../.git/HEAD");
+
+    let flavor = std::env::var("CODEXHUB_BUILD_FLAVOR")
+        .unwrap_or_else(|_| "normal".to_string())
+        .trim()
+        .to_ascii_lowercase();
+    if !matches!(flavor.as_str(), "normal" | "debug") {
+        panic!("CODEXHUB_BUILD_FLAVOR must be normal or debug, got {flavor:?}");
+    }
+
+    let diagnostics_enabled = std::env::var_os("CARGO_FEATURE_DEBUG_DIAGNOSTICS").is_some();
+    if (flavor == "debug") != diagnostics_enabled {
+        panic!(
+            "CODEXHUB_BUILD_FLAVOR={flavor} must {} the debug-diagnostics Cargo feature",
+            if flavor == "debug" { "enable" } else { "not enable" }
+        );
+    }
+
+    println!("cargo:rustc-env=CODEXHUB_BUILD_FLAVOR={flavor}");
+    println!(
+        "cargo:rustc-env=CODEXHUB_SOURCE_REVISION={}",
+        source_revision()
+    );
     tauri_build::build()
+}
+
+fn source_revision() -> String {
+    if let Some(revision) = std::env::var("GITHUB_SHA")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+    {
+        return revision;
+    }
+
+    Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir("..")
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "unknown".to_string())
 }

--- a/src-tauri/src/app_flavor.rs
+++ b/src-tauri/src/app_flavor.rs
@@ -1,3 +1,4 @@
+use crate::build_info::{self, BuildFlavor, BuildInfo};
 use serde::Serialize;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -10,6 +11,8 @@ pub enum RoutingOwner {
     UnknownExternal,
 }
 
+/// Legacy runtime-routing identities retained only to decode existing target ownership.
+/// New build flavors are defined by `build_info::BuildFlavor` and always use `Stable`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum RuntimeFlavor {
@@ -19,7 +22,7 @@ pub enum RuntimeFlavor {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct AppFlavorInfo {
-    pub flavor: RuntimeFlavor,
+    pub build: BuildInfo,
     pub routing_owner: RoutingOwner,
     pub product_name: &'static str,
     pub bridge_port: u16,
@@ -32,11 +35,29 @@ pub struct AppFlavorInfo {
 }
 
 pub fn current() -> RuntimeFlavor {
-    RuntimeFlavor::from_name(option_env!("CODEXHUB_BUILD_FLAVOR").unwrap_or("stable"))
+    runtime_flavor_for_build(build_info::current().flavor)
 }
 
 pub fn current_info() -> AppFlavorInfo {
-    current().info()
+    let build = build_info::current();
+    let runtime = runtime_flavor_for_build(build.flavor);
+    let codex_target_owner = crate::runtime_paths::codex_target_home_dir()
+        .ok()
+        .and_then(|home| std::fs::read_to_string(home.join("config.toml")).ok())
+        .as_deref()
+        .and_then(crate::config::codex_overlay_owner);
+    AppFlavorInfo {
+        build,
+        routing_owner: runtime.routing_owner(),
+        product_name: runtime.product_name(),
+        bridge_port: runtime.bridge_port(),
+        gateway_port: runtime.gateway_port(),
+        default_codex_home_suffix: runtime.default_codex_home_suffix(),
+        runtime_home_suffix: runtime.runtime_home_suffix(),
+        codex_target_home_suffix: runtime.codex_target_home_suffix(),
+        codex_target_owner,
+        codex_takeover_required: runtime.codex_takeover_required(codex_target_owner),
+    }
 }
 
 pub fn default_gateway_port() -> u16 {
@@ -47,34 +68,11 @@ pub fn bridge_addr() -> String {
     format!("127.0.0.1:{}", current().bridge_port())
 }
 
+fn runtime_flavor_for_build(_flavor: BuildFlavor) -> RuntimeFlavor {
+    RuntimeFlavor::Stable
+}
+
 impl RuntimeFlavor {
-    pub fn from_name(value: &str) -> Self {
-        match value.trim().to_ascii_lowercase().as_str() {
-            "beta" => Self::Beta,
-            _ => Self::Stable,
-        }
-    }
-
-    pub fn info(self) -> AppFlavorInfo {
-        let codex_target_owner = crate::runtime_paths::codex_target_home_dir()
-            .ok()
-            .and_then(|home| std::fs::read_to_string(home.join("config.toml")).ok())
-            .as_deref()
-            .and_then(crate::config::codex_overlay_owner);
-        AppFlavorInfo {
-            flavor: self,
-            routing_owner: self.routing_owner(),
-            product_name: self.product_name(),
-            bridge_port: self.bridge_port(),
-            gateway_port: self.gateway_port(),
-            default_codex_home_suffix: self.default_codex_home_suffix(),
-            runtime_home_suffix: self.runtime_home_suffix(),
-            codex_target_home_suffix: self.codex_target_home_suffix(),
-            codex_target_owner,
-            codex_takeover_required: self.codex_takeover_required(codex_target_owner),
-        }
-    }
-
     pub fn routing_owner(self) -> RoutingOwner {
         match self {
             Self::Stable => RoutingOwner::Release,
@@ -161,17 +159,21 @@ mod tests {
     use super::*;
 
     #[test]
-    fn stable_defaults_match_existing_ports_and_identity() {
-        let flavor = RuntimeFlavor::Stable;
-        assert_eq!(flavor.routing_owner(), RoutingOwner::Release);
-        assert_eq!(flavor.product_name(), "CodexHub");
-        assert_eq!(flavor.bridge_port(), 1421);
-        assert_eq!(flavor.gateway_port(), 9099);
-        assert_eq!(flavor.autostart_task_name(), "CodexHubProxy");
+    fn normal_and_debug_builds_share_the_existing_runtime_identity() {
+        for build_flavor in [BuildFlavor::Normal, BuildFlavor::Debug] {
+            let runtime = runtime_flavor_for_build(build_flavor);
+            assert_eq!(runtime, RuntimeFlavor::Stable);
+            assert_eq!(runtime.routing_owner(), RoutingOwner::Release);
+            assert_eq!(runtime.product_name(), "CodexHub");
+            assert_eq!(runtime.bridge_port(), 1421);
+            assert_eq!(runtime.gateway_port(), 9099);
+            assert_eq!(runtime.runtime_home_suffix(), ".codex");
+            assert_eq!(runtime.autostart_task_name(), "CodexHubProxy");
+        }
     }
 
     #[test]
-    fn beta_defaults_are_isolated_from_stable() {
+    fn legacy_beta_runtime_metadata_remains_decodable_for_existing_targets() {
         let flavor = RuntimeFlavor::Beta;
         assert_eq!(flavor.routing_owner(), RoutingOwner::Beta);
         assert_eq!(flavor.product_name(), "CodexHub Beta");
@@ -185,16 +187,19 @@ mod tests {
     }
 
     #[test]
-    fn beta_runtime_home_is_separate_but_codex_target_stays_real() {
+    fn legacy_beta_runtime_home_is_separate_but_codex_target_stays_real() {
         let flavor = RuntimeFlavor::Beta;
 
         assert_eq!(flavor.runtime_home_suffix(), ".codexhub-beta");
         assert_eq!(flavor.codex_target_home_suffix(), ".codex");
-        assert_ne!(flavor.runtime_home_suffix(), flavor.codex_target_home_suffix());
+        assert_ne!(
+            flavor.runtime_home_suffix(),
+            flavor.codex_target_home_suffix()
+        );
     }
 
     #[test]
-    fn beta_frontend_takeover_state_includes_unowned_and_official_targets() {
+    fn legacy_beta_frontend_takeover_state_includes_unowned_and_official_targets() {
         assert!(RuntimeFlavor::Beta.codex_takeover_required(None));
         assert!(RuntimeFlavor::Beta.codex_takeover_required(Some(RoutingOwner::Official)));
         assert!(!RuntimeFlavor::Beta.codex_takeover_required(Some(RoutingOwner::Beta)));

--- a/src-tauri/src/app_updates.rs
+++ b/src-tauri/src/app_updates.rs
@@ -1,4 +1,7 @@
-use crate::{runtime_paths, safe_file};
+use crate::{
+    build_info::{self, BuildFlavor},
+    runtime_paths, safe_file,
+};
 use serde::{Deserialize, Serialize};
 use std::{
     fs,
@@ -7,7 +10,7 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 use tauri::AppHandle;
-use tauri_plugin_updater::{Error as UpdaterError, Updater, UpdaterExt};
+use tauri_plugin_updater::{Error as UpdaterError, Update, Updater, UpdaterExt};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AppVersionInfo {
@@ -67,6 +70,20 @@ struct UpdateCandidate {
     date: Option<String>,
 }
 
+#[derive(Debug, Deserialize)]
+struct FlavorUpdateManifest {
+    version: String,
+    #[serde(default)]
+    codexhub_flavor: Option<BuildFlavor>,
+    platforms: std::collections::BTreeMap<String, FlavorUpdatePlatform>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FlavorUpdatePlatform {
+    signature: String,
+    url: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 struct PendingUpdate {
     target_version: String,
@@ -84,20 +101,19 @@ pub fn get_app_version(app: AppHandle) -> AppVersionInfo {
 pub async fn check_app_update(app: AppHandle) -> Result<AppUpdateStatus, String> {
     let current = current_version(&app);
     let checked_at = checked_at_now();
-    let update = updater(&app, "check for updates")?
-        .check()
-        .await
-        .map(|update| {
-            update.map(|update| UpdateCandidate {
+    let flavor = build_info::current().flavor;
+    let update = match updater(&app, "check for updates")?.check().await {
+        Ok(Some(update)) => {
+            validate_checked_update(&update, flavor)?;
+            Ok(Some(UpdateCandidate {
                 version: update.version.clone(),
                 notes: update.body.clone(),
                 date: update.date.as_ref().map(ToString::to_string),
-            })
-        });
-
-    if update_feed_is_missing(&update).await {
-        return Ok(no_update_status(current, checked_at));
-    }
+            }))
+        }
+        Ok(None) => Ok(None),
+        Err(error) => Err(error),
+    };
 
     status_from_update_check(current, checked_at, update)
 }
@@ -163,29 +179,172 @@ fn version_info(current_version: impl Into<String>) -> AppVersionInfo {
     }
 }
 
-#[cfg(debug_assertions)]
 fn updater(app: &AppHandle, action: &str) -> Result<Updater, String> {
-    let mut builder = app.updater_builder();
-    if let Ok(endpoint) = std::env::var("CODEXHUB_UPDATE_E2E_ENDPOINT") {
-        let endpoint = endpoint.trim();
-        if !endpoint.is_empty() {
-            let endpoint = endpoint
-                .parse()
-                .map_err(|error| operation_error(action, error))?;
-            builder = builder
-                .endpoints(vec![endpoint])
-                .map_err(|error| operation_error(action, error))?;
-        }
-    }
-    builder
+    let endpoints = configured_updater_endpoints()?;
+    app.updater_builder()
+        .endpoints(endpoints)
+        .map_err(|error| operation_error(action, error))?
         .build()
         .map_err(|error| updater_setup_error(action, error))
 }
 
-#[cfg(not(debug_assertions))]
-fn updater(app: &AppHandle, action: &str) -> Result<Updater, String> {
-    app.updater()
-        .map_err(|error| updater_setup_error(action, error))
+fn configured_updater_endpoints() -> Result<Vec<reqwest::Url>, String> {
+    #[cfg(debug_assertions)]
+    if let Some(endpoint) =
+        std::env::var_os("CODEXHUB_UPDATE_E2E_ENDPOINT").filter(|value| !value.is_empty())
+    {
+        let endpoint = endpoint.to_string_lossy().trim().to_string();
+        return endpoint
+            .parse()
+            .map(|endpoint| vec![endpoint])
+            .map_err(|error| operation_error("configure update endpoint", error));
+    }
+
+    build_info::current()
+        .flavor
+        .updater_endpoint()
+        .parse()
+        .map(|endpoint| vec![endpoint])
+        .map_err(|error| operation_error("configure update endpoint", error))
+}
+
+async fn checked_update(app: &AppHandle, action: &str) -> Result<Option<Update>, String> {
+    match updater(app, action)?.check().await {
+        Ok(update) => Ok(update),
+        Err(UpdaterError::ReleaseNotFound) => Ok(None),
+        Err(error) => Err(operation_error(action, error)),
+    }
+}
+
+fn parse_flavor_manifest(
+    manifest: &str,
+    expected_flavor: BuildFlavor,
+) -> Result<FlavorUpdateManifest, String> {
+    serde_json::from_str(manifest).map_err(|error| {
+        format!(
+            "Rejected {} update manifest: invalid JSON or flavor metadata: {error}",
+            expected_flavor.as_str()
+        )
+    })
+}
+
+#[cfg(test)]
+fn validate_flavor_manifest(manifest: &str, expected_flavor: BuildFlavor) -> Result<(), String> {
+    let manifest = parse_flavor_manifest(manifest, expected_flavor)?;
+    validate_flavor_manifest_data(&manifest, expected_flavor)
+}
+
+fn validate_flavor_manifest_data(
+    manifest: &FlavorUpdateManifest,
+    expected_flavor: BuildFlavor,
+) -> Result<(), String> {
+    let version = manifest.version.trim();
+    if version.is_empty() {
+        return Err(format!(
+            "Rejected {} update manifest: version is empty.",
+            expected_flavor.as_str()
+        ));
+    }
+
+    match manifest.codexhub_flavor {
+        Some(actual_flavor) if actual_flavor == expected_flavor => {}
+        Some(actual_flavor) => {
+            return Err(format!(
+                "Rejected {} update manifest: manifest declares {}.",
+                expected_flavor.as_str(),
+                actual_flavor.as_str()
+            ));
+        }
+        None if expected_flavor.accepts_legacy_flavorless_manifest() => {}
+        None => {
+            return Err(format!(
+                "Rejected {} update manifest: codexhub_flavor is required.",
+                expected_flavor.as_str()
+            ));
+        }
+    }
+
+    let platform = manifest.platforms.get("windows-x86_64").ok_or_else(|| {
+        format!(
+            "Rejected {} update manifest: windows-x86_64 artifact is missing.",
+            expected_flavor.as_str()
+        )
+    })?;
+    if platform.signature.trim().is_empty() {
+        return Err(format!(
+            "Rejected {} update manifest: artifact signature is empty.",
+            expected_flavor.as_str()
+        ));
+    }
+
+    let url: reqwest::Url = platform.url.parse().map_err(|error| {
+        format!(
+            "Rejected {} update manifest: artifact URL is invalid: {error}",
+            expected_flavor.as_str()
+        )
+    })?;
+    let expected_name = expected_flavor.installer_name(version);
+    if !url.path().ends_with(&format!("/{expected_name}")) {
+        return Err(format!(
+            "Rejected {} update manifest: expected artifact {expected_name}, got {}.",
+            expected_flavor.as_str(),
+            url.path()
+        ));
+    }
+
+    Ok(())
+}
+
+fn validate_checked_update(update: &Update, expected_flavor: BuildFlavor) -> Result<(), String> {
+    let raw_manifest = serde_json::to_string(&update.raw_json).map_err(|error| {
+        format!(
+            "Rejected {} update manifest: unable to encode updater response: {error}",
+            expected_flavor.as_str()
+        )
+    })?;
+    validate_checked_update_payload(
+        &raw_manifest,
+        &update.version,
+        update.download_url.as_str(),
+        expected_flavor,
+    )
+}
+
+fn validate_checked_update_payload(
+    raw_manifest: &str,
+    selected_version: &str,
+    selected_download_url: &str,
+    expected_flavor: BuildFlavor,
+) -> Result<(), String> {
+    let manifest = parse_flavor_manifest(raw_manifest, expected_flavor)?;
+    validate_flavor_manifest_data(&manifest, expected_flavor)?;
+
+    let manifest_version = manifest.version.trim();
+    if manifest_version != selected_version.trim() {
+        return Err(format!(
+            "Rejected {} update: updater selected version {}, but its checked manifest declares {}.",
+            expected_flavor.as_str(),
+            selected_version,
+            manifest.version
+        ));
+    }
+
+    let selected_url: reqwest::Url = selected_download_url.parse().map_err(|error| {
+        format!(
+            "Rejected {} update: updater selected an invalid artifact URL: {error}",
+            expected_flavor.as_str()
+        )
+    })?;
+    let expected_name = expected_flavor.installer_name(manifest_version);
+    if !selected_url.path().ends_with(&format!("/{expected_name}")) {
+        return Err(format!(
+            "Rejected {} update: updater selected {}, expected {expected_name}.",
+            expected_flavor.as_str(),
+            selected_url.path()
+        ));
+    }
+
+    Ok(())
 }
 
 fn no_update_status(
@@ -235,17 +394,14 @@ fn status_from_update_check(
 
 async fn run_app_update_install(app: AppHandle) -> Result<(), String> {
     let current = current_version(&app);
-    let Some(update) = updater(&app, "install update")?
-        .check()
-        .await
-        .map_err(|error| operation_error("install update", error))?
-    else {
+    let Some(update) = checked_update(&app, "install update").await? else {
         set_install_status(install_status_idle_with_message(
             current,
             "CodexHub is already up to date.",
         ));
         return Ok(());
     };
+    validate_checked_update(&update, build_info::current().flavor)?;
 
     let target = update.version.clone();
     set_install_status(AppUpdateInstallStatus {
@@ -491,45 +647,6 @@ fn parse_semver_triplet(version: &str) -> Option<(u64, u64, u64)> {
     Some((major, minor, patch))
 }
 
-async fn update_feed_is_missing(update: &Result<Option<UpdateCandidate>, UpdaterError>) -> bool {
-    let Err(error) = update else {
-        return false;
-    };
-    if matches!(error, UpdaterError::ReleaseNotFound) {
-        return true;
-    }
-    let Some(url) = update_error_url(error) else {
-        return false;
-    };
-    if !is_github_latest_update_manifest_url(&url) {
-        return false;
-    }
-    update_manifest_returns_not_found(&url).await
-}
-
-fn update_error_url(error: &UpdaterError) -> Option<String> {
-    match error {
-        UpdaterError::Reqwest(error) => error.url().map(ToString::to_string),
-        _ => None,
-    }
-}
-
-fn is_github_latest_update_manifest_url(url: &str) -> bool {
-    url.starts_with("https://github.com/") && url.contains("/releases/latest/download/latest.json")
-}
-
-async fn update_manifest_returns_not_found(url: &str) -> bool {
-    let Ok(response) = reqwest::Client::new()
-        .get(url)
-        .header(reqwest::header::ACCEPT, "application/json")
-        .send()
-        .await
-    else {
-        return false;
-    };
-    response.status() == reqwest::StatusCode::NOT_FOUND
-}
-
 fn operation_error(action: &str, error: impl std::fmt::Display) -> String {
     format!("Failed to {action}: {error}")
 }
@@ -629,16 +746,97 @@ mod tests {
     }
 
     #[test]
-    fn missing_feed_probe_is_limited_to_github_latest_update_manifests() {
-        assert!(is_github_latest_update_manifest_url(
-            "https://github.com/NOirBRight/CodexHub/releases/latest/download/latest.json",
-        ));
-        assert!(!is_github_latest_update_manifest_url(
-            "https://github.com/NOirBRight/CodexHub/releases/download/v0.1.0/latest.json",
-        ));
-        assert!(!is_github_latest_update_manifest_url(
-            "https://example.com/releases/latest/download/latest.json",
-        ));
+    fn normal_manifest_keeps_flavorless_latest_json_backward_compatibility() {
+        let manifest = flavor_manifest(
+            None,
+            "0.1.5",
+            "https://github.com/NOirBRight/CodexHub/releases/download/v0.1.5/CodexHub_0.1.5_x64-setup.exe",
+        );
+
+        assert_eq!(
+            validate_flavor_manifest(&manifest, BuildFlavor::Normal),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn debug_manifest_requires_matching_flavor_metadata_and_artifact_name() {
+        let manifest = flavor_manifest(
+            Some("debug"),
+            "0.1.5",
+            "https://github.com/NOirBRight/CodexHub/releases/download/v0.1.5/CodexHub_0.1.5_debug_x64-setup.exe",
+        );
+
+        assert_eq!(
+            validate_flavor_manifest(&manifest, BuildFlavor::Debug),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn updater_rejects_cross_flavor_manifest_before_download() {
+        let manifest = flavor_manifest(
+            Some("normal"),
+            "0.1.5",
+            "https://github.com/NOirBRight/CodexHub/releases/download/v0.1.5/CodexHub_0.1.5_x64-setup.exe",
+        );
+
+        let error = validate_flavor_manifest(&manifest, BuildFlavor::Debug)
+            .expect_err("debug must reject a normal manifest");
+
+        assert!(error.contains("manifest declares normal"));
+    }
+
+    #[test]
+    fn updater_rejects_mismatched_artifact_even_when_flavor_metadata_matches() {
+        let manifest = flavor_manifest(
+            Some("debug"),
+            "0.1.5",
+            "https://github.com/NOirBRight/CodexHub/releases/download/v0.1.5/CodexHub_0.1.5_x64-setup.exe",
+        );
+
+        let error = validate_flavor_manifest(&manifest, BuildFlavor::Debug)
+            .expect_err("debug must reject a normal installer artifact");
+
+        assert!(error.contains("expected artifact CodexHub_0.1.5_debug_x64-setup.exe"));
+    }
+
+    #[test]
+    fn updater_binds_the_checked_manifest_to_the_selected_download_artifact() {
+        let manifest = flavor_manifest(
+            Some("debug"),
+            "0.1.5",
+            "https://github.com/NOirBRight/CodexHub/releases/download/v0.1.5/CodexHub_0.1.5_debug_x64-setup.exe",
+        );
+
+        let error = validate_checked_update_payload(
+            &manifest,
+            "0.1.5",
+            "https://github.com/NOirBRight/CodexHub/releases/download/v0.1.5/CodexHub_0.1.5_x64-setup.exe",
+            BuildFlavor::Debug,
+        )
+        .expect_err("debug must reject a checked update that selects the normal artifact");
+
+        assert!(error.contains("updater selected"));
+    }
+
+    #[test]
+    fn normal_checked_update_keeps_flavorless_latest_json_compatibility() {
+        let manifest = flavor_manifest(
+            None,
+            "0.1.5",
+            "https://github.com/NOirBRight/CodexHub/releases/download/v0.1.5/CodexHub_0.1.5_x64-setup.exe",
+        );
+
+        assert_eq!(
+            validate_checked_update_payload(
+                &manifest,
+                "0.1.5",
+                "https://github.com/NOirBRight/CodexHub/releases/download/v0.1.5/CodexHub_0.1.5_x64-setup.exe",
+                BuildFlavor::Normal,
+            ),
+            Ok(())
+        );
     }
 
     #[test]
@@ -763,6 +961,22 @@ mod tests {
     #[test]
     fn checked_at_now_is_unix_timestamp_string() {
         assert!(checked_at_now().starts_with("unix:"));
+    }
+
+    fn flavor_manifest(flavor: Option<&str>, version: &str, url: &str) -> String {
+        let mut manifest = serde_json::json!({
+            "version": version,
+            "platforms": {
+                "windows-x86_64": {
+                    "signature": "signed-value",
+                    "url": url,
+                }
+            }
+        });
+        if let Some(flavor) = flavor {
+            manifest["codexhub_flavor"] = serde_json::Value::String(flavor.to_string());
+        }
+        serde_json::to_string(&manifest).expect("serialize flavor manifest")
     }
 
     fn stale_lock_path(path: &std::path::Path) -> std::path::PathBuf {

--- a/src-tauri/src/build_info.rs
+++ b/src-tauri/src/build_info.rs
@@ -1,0 +1,121 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BuildFlavor {
+    Normal,
+    Debug,
+}
+
+impl BuildFlavor {
+    pub fn from_name(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "normal" => Some(Self::Normal),
+            "debug" => Some(Self::Debug),
+            _ => None,
+        }
+    }
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Normal => "normal",
+            Self::Debug => "debug",
+        }
+    }
+
+    pub const fn diagnostics_enabled(self) -> bool {
+        matches!(self, Self::Debug)
+    }
+
+    pub const fn updater_manifest_name(self) -> &'static str {
+        match self {
+            Self::Normal => "latest.json",
+            Self::Debug => "latest-debug.json",
+        }
+    }
+
+    pub fn updater_endpoint(self) -> String {
+        format!(
+            "https://github.com/NOirBRight/CodexHub/releases/latest/download/{}",
+            self.updater_manifest_name()
+        )
+    }
+
+    pub fn installer_name(self, version: &str) -> String {
+        match self {
+            Self::Normal => format!("CodexHub_{version}_x64-setup.exe"),
+            Self::Debug => format!("CodexHub_{version}_debug_x64-setup.exe"),
+        }
+    }
+
+    pub const fn accepts_legacy_flavorless_manifest(self) -> bool {
+        matches!(self, Self::Normal)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct BuildInfo {
+    pub semantic_version: &'static str,
+    pub flavor: BuildFlavor,
+    pub source_revision: &'static str,
+    pub diagnostics_enabled: bool,
+}
+
+pub fn current() -> BuildInfo {
+    let flavor = BuildFlavor::from_name(option_env!("CODEXHUB_BUILD_FLAVOR").unwrap_or("normal"))
+        .expect("build.rs must provide a valid CodexHub build flavor");
+    let diagnostics_enabled = cfg!(feature = "debug-diagnostics");
+    assert_eq!(
+        flavor.diagnostics_enabled(),
+        diagnostics_enabled,
+        "CodexHub build flavor and debug-diagnostics feature must agree"
+    );
+
+    BuildInfo {
+        semantic_version: env!("CARGO_PKG_VERSION"),
+        flavor,
+        source_revision: option_env!("CODEXHUB_SOURCE_REVISION").unwrap_or("unknown"),
+        diagnostics_enabled,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flavor_parser_accepts_only_supported_compile_time_values() {
+        assert_eq!(BuildFlavor::from_name("normal"), Some(BuildFlavor::Normal));
+        assert_eq!(BuildFlavor::from_name(" DEBUG "), Some(BuildFlavor::Debug));
+        assert_eq!(BuildFlavor::from_name("stable"), None);
+        assert_eq!(BuildFlavor::from_name("beta"), None);
+    }
+
+    #[test]
+    fn artifact_and_manifest_identity_is_flavor_specific_without_changing_semver() {
+        let version = "0.2.0";
+
+        assert_eq!(BuildFlavor::Normal.updater_manifest_name(), "latest.json");
+        assert_eq!(
+            BuildFlavor::Debug.updater_manifest_name(),
+            "latest-debug.json"
+        );
+        assert_eq!(
+            BuildFlavor::Normal.installer_name(version),
+            "CodexHub_0.2.0_x64-setup.exe"
+        );
+        assert_eq!(
+            BuildFlavor::Debug.installer_name(version),
+            "CodexHub_0.2.0_debug_x64-setup.exe"
+        );
+    }
+
+    #[test]
+    fn current_build_info_reports_one_semver_and_matching_diagnostic_capability() {
+        let info = current();
+
+        assert_eq!(info.semantic_version, env!("CARGO_PKG_VERSION"));
+        assert!(!info.source_revision.is_empty());
+        assert_eq!(info.flavor.diagnostics_enabled(), info.diagnostics_enabled);
+    }
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3,6 +3,7 @@
 mod app_flavor;
 mod app_updates;
 mod autostart;
+mod build_info;
 mod catalog;
 mod cli;
 mod config;

--- a/src-tauri/src/web_bridge.rs
+++ b/src-tauri/src/web_bridge.rs
@@ -254,9 +254,14 @@ fn dispatch(request: InvokeRequest, app: Option<AppHandle>) -> Result<Value, Str
         "switch_mode" => {
             let mode = string_arg(&request.args, "mode")?;
             let auto_sync = bool_arg(&request.args, "autoSync")?;
-            let force_takeover = optional_bool_arg(&request.args, &["forceTakeover", "force_takeover"])
-                .unwrap_or(false);
-            to_value(config::switch_mode_with_takeover(&mode, auto_sync, force_takeover))
+            let force_takeover =
+                optional_bool_arg(&request.args, &["forceTakeover", "force_takeover"])
+                    .unwrap_or(false);
+            to_value(config::switch_mode_with_takeover(
+                &mode,
+                auto_sync,
+                force_takeover,
+            ))
         }
         "start_proxy" => to_value(proxy::start()),
         "stop_proxy" => to_value(proxy::stop()),
@@ -528,9 +533,7 @@ fn dispatch(request: InvokeRequest, app: Option<AppHandle>) -> Result<Value, Str
                 target_unified,
             ))
         }
-        "get_conversation_sync_status" => {
-            to_value(history::preflight_unified_history(false, None))
-        }
+        "get_conversation_sync_status" => to_value(history::preflight_unified_history(false, None)),
         "sync_conversation_history" => {
             let target_provider = request.args.get("targetProvider").and_then(Value::as_str);
             to_value(history::preflight_unified_history(
@@ -539,8 +542,8 @@ fn dispatch(request: InvokeRequest, app: Option<AppHandle>) -> Result<Value, Str
             ))
         }
         "diagnose_conversation_history" => {
-            let _full_scan = optional_bool_arg(&request.args, &["fullScan", "full_scan"])
-                .unwrap_or(true);
+            let _full_scan =
+                optional_bool_arg(&request.args, &["fullScan", "full_scan"]).unwrap_or(true);
             to_value(history::preflight_unified_history(false, None))
         }
         "sync_catalog" => to_value(catalog::sync_catalog()),
@@ -805,7 +808,7 @@ mod tests {
     }
 
     #[test]
-    fn get_app_flavor_returns_runtime_metadata() {
+    fn get_app_flavor_returns_build_and_runtime_metadata() {
         let response = handle_request(
             BridgeRequest {
                 method: "POST".to_string(),
@@ -822,8 +825,16 @@ mod tests {
         .expect("invoke");
 
         assert_eq!(response.status, 200);
-        let text = String::from_utf8_lossy(&response.body);
-        assert!(text.contains("\"product_name\":\"CodexHub\""));
-        assert!(text.contains("\"gateway_port\":9099"));
+        let body: serde_json::Value = serde_json::from_slice(&response.body).expect("json body");
+        let value = &body["value"];
+        assert_eq!(value["product_name"], "CodexHub");
+        assert_eq!(value["gateway_port"], 9099);
+        let build = crate::build_info::current();
+        assert_eq!(value["build"]["semantic_version"], build.semantic_version);
+        assert_eq!(value["build"]["flavor"], build.flavor.as_str());
+        assert_eq!(
+            value["build"]["diagnostics_enabled"],
+            build.diagnostics_enabled
+        );
     }
 }

--- a/tests/test_release_channel_scripts.py
+++ b/tests/test_release_channel_scripts.py
@@ -19,7 +19,7 @@ def test_official_transport_wheel_is_pinned_and_packaged():
     assert tauri["bundle"]["resources"]["../src-python/vendor/*.whl"] == "src-python/vendor"
 
 
-def test_stable_release_version_is_consistent_across_manifests():
+def test_release_version_is_consistent_across_manifests():
     expected = "0.1.4"
     tauri = json.loads((ROOT / "src-tauri" / "tauri.conf.json").read_text(encoding="utf-8"))
     cargo = tomllib.loads((ROOT / "src-tauri" / "Cargo.toml").read_text(encoding="utf-8"))
@@ -57,15 +57,44 @@ def test_v014_audit_records_reconciliation_and_display_contract():
         assert evidence in audit
 
 
-def test_portable_uses_flavor_executable_base_name():
+def test_flavors_share_application_identity_and_split_only_update_artifacts():
     flavors = json.loads((ROOT / "config" / "build-flavors.json").read_text(encoding="utf-8"))
+
+    assert sorted(flavors) == ["debug", "normal"]
+    for key in (
+        "productName",
+        "executableBaseName",
+        "identifier",
+        "windowTitle",
+        "frontendPort",
+        "bridgePort",
+        "gatewayPort",
+        "routingOwner",
+        "defaultCodexHome",
+        "codexTargetHome",
+        "autostartTaskName",
+        "macosLabel",
+        "macosPlistFile",
+        "linuxServiceFile",
+    ):
+        assert flavors["normal"][key] == flavors["debug"][key]
+
+    assert flavors["normal"]["updaterManifestName"] == "latest.json"
+    assert flavors["debug"]["updaterManifestName"] == "latest-debug.json"
+    assert flavors["normal"]["releaseAssetSuffix"] == ""
+    assert flavors["debug"]["releaseAssetSuffix"] == "_debug"
+
+
+def test_portable_uses_one_executable_name_and_flavor_specific_archives():
     script = (ROOT / "scripts" / "build-windows-portable.ps1").read_text(encoding="utf-8-sig")
 
-    assert flavors["stable"]["executableBaseName"] == "CodexHub"
-    assert flavors["beta"]["executableBaseName"] == "CodexHubBeta"
+    assert '[ValidateSet("normal", "debug")]' in script
+    assert '[string]$Flavor = "normal"' in script
     assert '$portableExecutable = "{0}.exe" -f ([string]$flavorConfig.executableBaseName)' in script
-    assert 'Join-Path $portableDir $portableExecutable' in script
-    assert 'Join-Path $tauriDir "target\\release\\codexhub.exe"' in script
+    assert '$portableName = "{0}_{1}{2}_portable_{3}"' in script
+    assert "debug-diagnostics" in script
+    assert "CARGO_TARGET_DIR" in script
+    assert 'Join-Path $targetRoot "release\\codexhub.exe"' in script
 
 
 def _portable_fixture(tmp_path: Path, version: str) -> Path:
@@ -86,17 +115,30 @@ def _portable_fixture(tmp_path: Path, version: str) -> Path:
     return repo
 
 
-def _portable(repo: Path, flavor: str) -> subprocess.CompletedProcess[str]:
+def _portable(repo: Path, flavor: str | None = None) -> subprocess.CompletedProcess[str]:
+    args = [
+        "powershell",
+        "-NoProfile",
+        "-File",
+        str(ROOT / "scripts" / "build-windows-portable.ps1"),
+    ]
+    if flavor is not None:
+        args.extend(["-Flavor", flavor])
+    args.extend(["-RepoRoot", str(repo), "-DryRun"])
+    return subprocess.run(args, text=True, capture_output=True)
+
+
+def _replacement(repo: Path, version: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         [
             "powershell",
             "-NoProfile",
             "-File",
-            str(ROOT / "scripts" / "build-windows-portable.ps1"),
-            "-Flavor",
-            flavor,
+            str(ROOT / "scripts" / "Test-BuildFlavorReplacement.ps1"),
             "-RepoRoot",
             str(repo),
+            "-Version",
+            version,
             "-DryRun",
         ],
         text=True,
@@ -104,92 +146,138 @@ def _portable(repo: Path, flavor: str) -> subprocess.CompletedProcess[str]:
     )
 
 
-def test_portable_dry_run_validates_generated_beta_config_and_output_name(tmp_path):
-    repo = _portable_fixture(tmp_path, "0.1.5-beta.1")
+def test_portable_dry_runs_default_to_normal_and_keep_source_version_parity(tmp_path):
+    repo = _portable_fixture(tmp_path, "0.1.5")
 
-    result = _portable(repo, "beta")
+    default_normal = _portable(repo)
+    explicit_normal = _portable(repo, "normal")
+    debug = _portable(repo, "debug")
+
+    assert default_normal.returncode == 0, default_normal.stderr
+    assert explicit_normal.returncode == 0, explicit_normal.stderr
+    assert debug.returncode == 0, debug.stderr
+    default_plan = json.loads(default_normal.stdout)
+    normal_plan = json.loads(explicit_normal.stdout)
+    debug_plan = json.loads(debug.stdout)
+    assert default_plan["flavor"] == "normal"
+    assert normal_plan["version"] == debug_plan["version"] == "0.1.5"
+    assert normal_plan["source_revision"] == debug_plan["source_revision"]
+    assert normal_plan["executable"] == debug_plan["executable"] == "CodexHub.exe"
+    assert normal_plan["portable_name"].startswith("CodexHub_0.1.5_portable_")
+    assert debug_plan["portable_name"].startswith("CodexHub_0.1.5_debug_portable_")
+    assert normal_plan["installer_name"] == "CodexHub_0.1.5_x64-setup.exe"
+    assert debug_plan["installer_name"] == "CodexHub_0.1.5_debug_x64-setup.exe"
+    assert normal_plan["updater_manifest"] == "latest.json"
+    assert debug_plan["updater_manifest"] == "latest-debug.json"
+    assert normal_plan["release_optimized"] is True
+    assert debug_plan["release_optimized"] is True
+    assert normal_plan["debug_diagnostics_enabled"] is False
+    assert debug_plan["debug_diagnostics_enabled"] is True
+    assert normal_plan["generated_config"]["productName"] == debug_plan["generated_config"]["productName"]
+    assert normal_plan["generated_config"]["identifier"] == debug_plan["generated_config"]["identifier"]
+    assert normal_plan["generated_config"]["title"] == debug_plan["generated_config"]["title"]
+    assert normal_plan["generated_config"]["bridgePort"] == debug_plan["generated_config"]["bridgePort"] == 1421
+    assert normal_plan["generated_config"]["gatewayPort"] == debug_plan["generated_config"]["gatewayPort"] == 9099
+    assert normal_plan["generated_config"]["updaterEndpoint"].endswith("/latest.json")
+    assert debug_plan["generated_config"]["updaterEndpoint"].endswith("/latest-debug.json")
+
+
+def test_replacement_smoke_contract_uses_one_identity_and_gateway_owner(tmp_path):
+    repo = _portable_fixture(tmp_path, "0.1.5")
+
+    result = _replacement(repo, "0.1.5")
 
     assert result.returncode == 0, result.stderr
     plan = json.loads(result.stdout)
-    assert plan["flavor"] == "beta"
-    assert plan["version"] == "0.1.5-beta.1"
-    assert plan["executable"] == "CodexHubBeta.exe"
-    assert plan["portable_name"].startswith("CodexHubBeta_0.1.5-beta.1_portable_")
-    assert plan["generated_config"] == {
-        "productName": "CodexHub Beta",
-        "identifier": "com.codexhub.beta",
-        "title": "CodexHub Beta",
-        "updaterEndpoint": "https://github.com/NOirBRight/CodexHub/releases/download/beta/latest-beta.json",
+    assert plan["version"] == "0.1.5"
+    assert plan["sequence"] == ["normal", "debug", "normal"]
+    assert plan["normal_installer"] == "CodexHub_0.1.5_x64-setup.exe"
+    assert plan["debug_installer"] == "CodexHub_0.1.5_debug_x64-setup.exe"
+    assert plan["application_identity"] == {
+        "product_name": "CodexHub",
+        "identifier": "com.codexhub.app",
+        "executable": "CodexHub.exe",
+    }
+    assert plan["runtime"] == {
+        "home": ".codex",
+        "routing_owner": "release",
+        "gateway_port": 9099,
+        "expected_gateway_owner_count": 1,
     }
 
 
-def test_portable_dry_run_rejects_beta_version_for_stable(tmp_path):
-    repo = _portable_fixture(tmp_path, "0.1.5-beta.1")
-
-    result = _portable(repo, "stable")
-
-    assert result.returncode != 0
-    assert "Stable" in result.stderr
-    assert "prerelease" in result.stderr
-
-
-def test_portable_dry_run_validates_stable_executable_name(tmp_path):
-    repo = _portable_fixture(tmp_path, "0.1.5")
-
-    result = _portable(repo, "stable")
-
-    assert result.returncode == 0, result.stderr
-    plan = json.loads(result.stdout)
-    assert plan["executable"] == "CodexHub.exe"
-    assert plan["portable_name"].startswith("CodexHub_0.1.5_portable_")
-    assert plan["generated_config"]["productName"] == "CodexHub"
-
-
-def test_portable_dry_run_rejects_stable_version_for_beta(tmp_path):
-    repo = _portable_fixture(tmp_path, "0.1.5")
-
-    result = _portable(repo, "beta")
-
-    assert result.returncode != 0
-    assert "Beta" in result.stderr
-    assert "prerelease" in result.stderr
-
-
-def test_portable_requires_explicit_flavor(tmp_path):
+def test_replacement_smoke_requires_explicit_installer_inputs(tmp_path):
     repo = _portable_fixture(tmp_path, "0.1.5")
 
     result = subprocess.run(
         [
             "powershell",
-            "-NonInteractive",
             "-NoProfile",
             "-File",
-            str(ROOT / "scripts" / "build-windows-portable.ps1"),
+            str(ROOT / "scripts" / "Test-BuildFlavorReplacement.ps1"),
             "-RepoRoot",
             str(repo),
-            "-DryRun",
+            "-Version",
+            "0.1.5",
+            "-RunInstall",
         ],
         text=True,
         capture_output=True,
     )
 
     assert result.returncode != 0
+    assert "requires both -NormalInstaller and -DebugInstaller" in result.stderr
+
+    script = (ROOT / "scripts" / "Test-BuildFlavorReplacement.ps1").read_text(encoding="utf-8")
+    assert "if ($owners.Count -ne 1)" in script
+    assert "Expected exactly one Gateway owner" in script
+
+
+def _update_e2e_app_build_plan(flavor: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            "powershell",
+            "-NoProfile",
+            "-File",
+            str(ROOT / "scripts" / "e2e-app-update.ps1"),
+            "-Flavor",
+            flavor,
+            "-ShowAppBuildPlan",
+        ],
+        text=True,
+        capture_output=True,
+    )
+
+
+def test_debug_update_e2e_build_plan_produces_its_default_flavor_path():
+    result = _update_e2e_app_build_plan("debug")
+
+    assert result.returncode == 0, result.stderr
+    plan = json.loads(result.stdout)
+    target_root = ROOT / "src-tauri" / "target" / "build-flavors" / "debug"
+    assert plan["flavor"] == "debug"
+    assert Path(plan["target_root"]).resolve() == target_root.resolve()
+    assert Path(plan["app_executable"]).resolve() == (target_root / "debug" / "codexhub.exe").resolve()
+    assert Path(plan["prepare_python_runtime"]).resolve() == (ROOT / "scripts" / "Prepare-PythonRuntime.ps1").resolve()
+    assert plan["environment"] == {
+        "CODEXHUB_BUILD_FLAVOR": "debug",
+        "CARGO_TARGET_DIR": str(target_root),
+    }
+    assert plan["cargo_args"] == ["build", "--locked", "--features", "debug-diagnostics"]
+    assert plan["command"] == "cargo build --locked --features debug-diagnostics"
+
+    script = (ROOT / "scripts" / "e2e-app-update.ps1").read_text(encoding="utf-8-sig")
+    assert "& $Plan.prepare_python_runtime -RepoRoot $repoRoot" in script
+    assert "Python runtime preparation failed with exit code $LASTEXITCODE." in script
+
+
+def test_portable_rejects_invalid_flavor_before_building(tmp_path):
+    repo = _portable_fixture(tmp_path, "0.1.5")
+
+    result = _portable(repo, "invalid")
+
+    assert result.returncode != 0
     assert "Flavor" in result.stderr
-
-
-def test_beta_portable_asset_prefix_is_distinct():
-    flavors = json.loads((ROOT / "config" / "build-flavors.json").read_text(encoding="utf-8"))
-
-    assert flavors["stable"]["releaseAssetPrefix"] == "CodexHub"
-    assert flavors["beta"]["releaseAssetPrefix"] == "CodexHubBeta"
-
-
-def test_flavor_manifest_separates_beta_runtime_from_codex_target():
-    flavors = json.loads((ROOT / "config" / "build-flavors.json").read_text(encoding="utf-8"))
-    assert flavors["stable"]["defaultCodexHome"] == ".codex"
-    assert flavors["stable"]["codexTargetHome"] == ".codex"
-    assert flavors["beta"]["defaultCodexHome"] == ".codexhub-beta"
-    assert flavors["beta"]["codexTargetHome"] == ".codex"
 
 
 def _git(repo: Path, *args: str) -> str:
@@ -236,85 +324,59 @@ def _plan(repo: Path, flavor: str, version: str, commit: str) -> subprocess.Comp
     )
 
 
-def test_beta_dry_run_plans_immutable_assets_and_pointer_manifest(tmp_path):
-    repo, _, dev_commit = _release_repo(tmp_path)
+def test_release_plan_places_both_flavors_in_one_immutable_release(tmp_path):
+    repo, main_commit, _ = _release_repo(tmp_path)
 
-    result = _plan(repo, "beta", "0.1.4-beta.1", dev_commit)
+    result = _plan(repo, "debug", "0.1.5", main_commit)
 
     assert result.returncode == 0, result.stderr
     plan = json.loads(result.stdout)
-    assert plan["immutable_release"]["tag"] == "v0.1.4-beta.1"
-    assert plan["immutable_release"]["prerelease"] is True
-    assert plan["immutable_release"]["assets"] == [
-        "CodexHubBeta_0.1.4-beta.1_x64-setup.exe",
-        "CodexHubBeta_0.1.4-beta.1_x64-setup.exe.sig",
-    ]
-    assert plan["channel_release"] == {
-        "tag": "beta",
-        "prerelease": True,
-        "assets": ["latest-beta.json"],
+    assert plan["flavor"] == "debug"
+    assert plan["manifest"] == {
+        "name": "latest-debug.json",
+        "asset_url": "https://github.com/NOirBRight/CodexHub/releases/download/v0.1.5/CodexHub_0.1.5_debug_x64-setup.exe",
     }
-    assert "latest.json" not in json.dumps(plan)
+    assert plan["immutable_release"] == {
+        "tag": "v0.1.5",
+        "prerelease": False,
+        "assets": [
+            "CodexHub_0.1.5_x64-setup.exe",
+            "CodexHub_0.1.5_x64-setup.exe.sig",
+            "latest.json",
+            "CodexHub_0.1.5_debug_x64-setup.exe",
+            "CodexHub_0.1.5_debug_x64-setup.exe.sig",
+            "latest-debug.json",
+        ],
+    }
+    assert plan["channel_release"] is None
 
 
-def test_beta_gate_rejects_stable_version(tmp_path):
-    repo, _, dev_commit = _release_repo(tmp_path)
-    result = _plan(repo, "beta", "0.1.4", dev_commit)
-    assert result.returncode != 0
-    assert "prerelease version" in result.stderr
-
-
-def test_beta_gate_accepts_next_version_prerelease_via_shared_semver_validator(tmp_path):
-    repo, _, dev_commit = _release_repo(tmp_path)
-
-    result = _plan(repo, "beta", "0.1.5-beta.1", dev_commit)
-
-    assert result.returncode == 0, result.stderr
-    assert json.loads(result.stdout)["version"] == "0.1.5-beta.1"
-
-
-def test_semver_accepts_alphanumeric_prerelease_starting_with_zero(tmp_path):
-    repo, _, dev_commit = _release_repo(tmp_path)
-
-    result = _plan(repo, "beta", "1.2.3-0alpha", dev_commit)
-
-    assert result.returncode == 0, result.stderr
-    assert json.loads(result.stdout)["version"] == "1.2.3-0alpha"
-
-
-def test_semver_rejects_numeric_prerelease_with_leading_zero(tmp_path):
-    repo, _, dev_commit = _release_repo(tmp_path)
-
-    result = _plan(repo, "beta", "1.2.3-01", dev_commit)
-
-    assert result.returncode != 0
-    assert "valid SemVer" in result.stderr
-
-
-def test_semver_rejects_trailing_line_feed(tmp_path):
-    repo, _, dev_commit = _release_repo(tmp_path)
-
-    result = _plan(repo, "beta", "1.2.3-beta.1\n", dev_commit)
-
-    assert result.returncode != 0
-    assert "valid SemVer" in result.stderr
-
-
-def test_stable_gate_requires_exact_main_and_stable_version(tmp_path):
+def test_release_plan_rejects_prerelease_versions_and_non_main_commits(tmp_path):
     repo, main_commit, dev_commit = _release_repo(tmp_path)
 
-    accepted = _plan(repo, "stable", "0.1.4", main_commit)
-    rejected = _plan(repo, "stable", "0.1.4", dev_commit)
+    prerelease = _plan(repo, "normal", "0.1.5-beta.1", main_commit)
+    wrong_commit = _plan(repo, "debug", "0.1.5", dev_commit)
 
-    assert accepted.returncode == 0, accepted.stderr
-    assert rejected.returncode != 0
-    assert "exact main commit" in rejected.stderr
+    assert prerelease.returncode != 0
+    assert "prerelease suffix" in prerelease.stderr
+    assert wrong_commit.returncode != 0
+    assert "exact main commit" in wrong_commit.stderr
 
 
-def test_release_builder_points_beta_manifest_to_immutable_tag():
+def test_release_builder_uses_release_optimized_flavor_features_and_immutable_urls():
     script = (ROOT / "scripts" / "build-windows-release.ps1").read_text(encoding="utf-8-sig")
+
+    assert '[ValidateSet("normal", "debug")]' in script
+    assert "Get-ReleaseArtifactName" in script
+    assert "Get-FlavorTargetRoot" in script
+    assert "debug-diagnostics" in script
+    assert "CARGO_TARGET_DIR" in script
+    assert '"--bundles", "nsis", "--ci"' in script
+    assert "--debug" not in script
     assert 'releases/download/v$version' in script
-    assert 'releases/download/beta"' not in script
+    assert 'releases/download/beta' not in script
+    assert "codexhub_flavor = $Flavor" in script
+    assert "codexhub_source_revision = $sourceRevision" in script
 
 
 def _validate_manifest(
@@ -346,75 +408,67 @@ def _validate_manifest(
     )
 
 
-def test_beta_manifest_validator_requires_immutable_asset_url_and_pair(tmp_path):
-    version = "0.1.4-beta.4"
-    installer = tmp_path / f"CodexHubBeta_{version}_x64-setup.exe"
+def _manifest_payload(flavor: str, version: str, installer: Path) -> dict:
+    return {
+        "version": version,
+        "codexhub_flavor": flavor,
+        "platforms": {
+            "windows-x86_64": {
+                "signature": "signed-value",
+                "url": f"https://github.com/NOirBRight/CodexHub/releases/download/v{version}/{installer.name}",
+            }
+        },
+    }
+
+
+def test_debug_manifest_validator_requires_matching_flavor_and_artifact_pair(tmp_path):
+    version = "0.1.5"
+    installer = tmp_path / f"CodexHub_{version}_debug_x64-setup.exe"
     signature = Path(f"{installer}.sig")
-    manifest = tmp_path / "latest-beta.json"
+    manifest = tmp_path / "latest-debug.json"
     installer.write_bytes(b"installer")
     signature.write_text("signed-value", encoding="utf-8")
-    manifest.write_text(
-        json.dumps(
-            {
-                "version": version,
-                "platforms": {
-                    "windows-x86_64": {
-                        "signature": "signed-value",
-                        "url": f"https://github.com/NOirBRight/CodexHub/releases/download/v{version}/{installer.name}",
-                    }
-                },
-            }
-        ),
-        encoding="utf-8",
-    )
-
-    accepted = _validate_manifest("beta", version, manifest, installer, signature)
-    payload = json.loads(manifest.read_text(encoding="utf-8"))
-    payload["platforms"]["windows-x86_64"]["url"] = (
-        f"https://github.com/NOirBRight/CodexHub/releases/download/beta/{installer.name}"
-    )
+    payload = _manifest_payload("debug", version, installer)
     manifest.write_text(json.dumps(payload), encoding="utf-8")
-    rejected = _validate_manifest("beta", version, manifest, installer, signature)
+
+    accepted = _validate_manifest("debug", version, manifest, installer, signature)
+    payload["codexhub_flavor"] = "normal"
+    manifest.write_text(json.dumps(payload), encoding="utf-8")
+    rejected = _validate_manifest("debug", version, manifest, installer, signature)
 
     assert accepted.returncode == 0, accepted.stderr
     assert rejected.returncode != 0
-    assert "immutable version tag" in rejected.stderr
+    assert "Manifest flavor" in rejected.stderr
 
 
-def test_release_scripts_share_generic_semver_channel_validation():
-    plan_script = (ROOT / "scripts" / "New-ReleaseChannelPlan.ps1").read_text(encoding="utf-8-sig")
-    manifest_script = (ROOT / "scripts" / "Test-ReleaseManifest.ps1").read_text(encoding="utf-8-sig")
-
-    for script in (plan_script, manifest_script):
-        assert '. (Join-Path $PSScriptRoot "ReleaseChannel.ps1")' in script
-        assert "Assert-ReleaseChannelVersion" in script
-        assert "0\\.1\\.4" not in script
-
-
-def test_stable_manifest_gate_rejects_prerelease_version(tmp_path):
-    version = "0.1.5-beta.1"
+def test_normal_manifest_validator_preserves_latest_json_name_and_rejects_debug_artifact(tmp_path):
+    version = "0.1.5"
     installer = tmp_path / f"CodexHub_{version}_x64-setup.exe"
     signature = Path(f"{installer}.sig")
     manifest = tmp_path / "latest.json"
     installer.write_bytes(b"installer")
     signature.write_text("signed-value", encoding="utf-8")
-    manifest.write_text(
-        json.dumps(
-            {
-                "version": version,
-                "platforms": {
-                    "windows-x86_64": {
-                        "signature": "signed-value",
-                        "url": f"https://github.com/NOirBRight/CodexHub/releases/download/v{version}/{installer.name}",
-                    }
-                },
-            }
-        ),
-        encoding="utf-8",
-    )
+    payload = _manifest_payload("normal", version, installer)
+    manifest.write_text(json.dumps(payload), encoding="utf-8")
 
-    result = _validate_manifest("stable", version, manifest, installer, signature)
+    accepted = _validate_manifest("normal", version, manifest, installer, signature)
+    debug_installer = tmp_path / f"CodexHub_{version}_debug_x64-setup.exe"
+    debug_installer.write_bytes(b"installer")
+    rejected = _validate_manifest("normal", version, manifest, debug_installer, signature)
 
-    assert result.returncode != 0
-    assert "Stable" in result.stderr
-    assert "prerelease" in result.stderr
+    assert accepted.returncode == 0, accepted.stderr
+    assert rejected.returncode != 0
+    assert "normal installer" in rejected.stderr.lower()
+
+
+def test_release_scripts_share_flavor_validation_helpers():
+    plan_script = (ROOT / "scripts" / "New-ReleaseChannelPlan.ps1").read_text(encoding="utf-8-sig")
+    manifest_script = (ROOT / "scripts" / "Test-ReleaseManifest.ps1").read_text(encoding="utf-8-sig")
+    helpers = (ROOT / "scripts" / "ReleaseChannel.ps1").read_text(encoding="utf-8-sig")
+
+    for script in (plan_script, manifest_script):
+        assert '. (Join-Path $PSScriptRoot "ReleaseChannel.ps1")' in script
+        assert "Assert-ReleaseFlavorVersion" in script
+    assert "Get-ReleaseArtifactName" in helpers
+    assert "Get-ReleaseManifestName" in helpers
+    assert "Get-FlavorTargetRoot" in helpers


### PR DESCRIPTION
## Summary
- add compile-time `normal` (default) and explicit `debug` flavors with one SemVer, application identity, runtime home, and Gateway owner
- publish flavor-specific updater manifests/artifacts while preserving normal `latest.json` compatibility and rejecting mismatched checked-update payloads before download
- add debug-only build badge, release/portable/E2E automation, CI coverage, documentation, and opt-in same-version replacement smoke coverage

## Validation
- `python -m pytest -q` (1032 passed, 1 skipped, 244 subtests)
- `npm run test:ui-contract` and `npm run build`
- `cargo test --locked` and `cargo test --locked --features debug-diagnostics` (285 each)
- release-optimized normal/debug builds, `cargo clippy --locked --all-targets -- -D warnings`
- flavor manifest/replacement dry-runs, plus real Python runtime preparation and debug E2E target build
- `python scripts/report_quality_gates.py` (report-only)

The packaged installer replacement smoke is deliberately opt-in for a disposable Windows installation environment; its dry-run contract is covered in CI.

Closes #116