### PR TITLE
Document risk-tiered verification policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Single-context layout — one `CONTEXT.md` + `docs/adr/` at the repo root. See `
 
 ### CI and manual verification
 
-Use GitHub Actions PR checks for `dev` and `main`; when unavailable, run the documented fallback commands. See `docs/agents/ci.md`.
+Classify work as fast, standard, or strict and select local checks from `docs/agents/verification-policy.md`. GitHub Actions remains the final PR gate for `dev` and `main`; when unavailable, run the documented fallback commands in `docs/agents/ci.md`.
 
 ### User feedback
 

--- a/docs/agents/ci.md
+++ b/docs/agents/ci.md
@@ -1,6 +1,6 @@
 # CI and manual verification
 
-GitHub Actions runs the required PR validation for branches targeting `dev` and `main`.
+GitHub Actions runs the required PR validation for branches targeting `dev` and `main`. Local candidate checks are selected by `docs/agents/verification-policy.md`; they do not duplicate every CI job by default.
 
 ## CI jobs
 
@@ -11,9 +11,9 @@ GitHub Actions runs the required PR validation for branches targeting `dev` and 
 
 The Rust jobs create a temporary `src-tauri/resources/python/.ci-placeholder` file during CI because Tauri's resource glob requires at least one runtime Python resource file. The placeholder is not committed.
 
-## Manual fallback
+## Full manual fallback
 
-Use these commands when GitHub Actions is unavailable or before opening a PR:
+Use all of these commands when GitHub Actions is unavailable and the change must be integrated. Before opening a normal PR, run only the local suites selected by the verification policy:
 
 ```powershell
 python -m pytest -q

--- a/docs/agents/verification-policy.md
+++ b/docs/agents/verification-policy.md
@@ -1,0 +1,63 @@
+# Risk-tiered verification policy
+
+GitHub Issues own observable product acceptance. This repository owns the
+engineering verification matrix below. Skills and agents select and execute
+these rules; they must not add hidden acceptance gates.
+
+## Classes
+
+| Class | Use for | Local candidate gate | Review |
+|---|---|---|---|
+| `fast` | Documentation, copy, metadata, isolated UI, or small deterministic logic with no shared lifecycle/public contract | Targeted checks and `git diff --check`; no local full suite | One direct Orchestrator scope/acceptance check |
+| `standard` | Reversible feature or bug contained to one clear boundary | Targeted checks during development, then one relevant full suite from the matrix below | One Orchestrator-owned Standards/Spec review |
+| `strict` | Protocol, routing, transport, auth, permissions, persistence/migration, release/update/install, security/privacy, concurrency/cancellation, or nondeterministic runtime evidence | Targeted checks, one relevant full suite, and only Issue-required harness/manual evidence | One Orchestrator-owned Standards/Spec review; later review is delta-only |
+
+Choose the highest applicable class. Before expanding a `fast` or `standard`
+task across a public/persisted contract, shared lifecycle, security boundary,
+or another subsystem, record an architecture decision in the Issue and upgrade
+the class. File count alone does not determine risk.
+
+## Relevant full-suite matrix
+
+Run targeted tests freely while implementing. At the candidate commit,
+`standard` and `strict` work runs each relevant suite once:
+
+| Changed boundary | Relevant local full suite |
+|---|---|
+| Python Gateway, routing, protocol translation, analyzers, Python configuration, or Python test infrastructure | `python -m pytest -q` |
+| Frontend source, UI contracts, frontend configuration, or frontend dependencies | `npm run build` and `npm run test:ui-contract` in `frontend/` |
+| Tauri/Rust commands, Gateway lifecycle, configuration, packaging code, Rust dependencies, or Rust test infrastructure | `cargo test --locked` and `cargo clippy --locked --all-targets -- -D warnings` in `src-tauri/` |
+| Shared frontend/Tauri command or persisted-settings contract | Frontend and Rust suites |
+| Shared Python/Rust Gateway, process-lifecycle, catalog, packaging, updater, release, or installer boundary | Every suite touched by the contract; release instructions may add an explicit build matrix |
+
+Documentation-only changes need link/content inspection and diff hygiene, not a
+language full suite. A `fast` isolated UI or pure-logic change still runs the
+narrow compile/test command that proves its acceptance, but does not duplicate
+the repository's complete language suite locally.
+
+After review fixes, run affected targeted checks and rely on CI. Repeat a local
+full suite only when the delta crosses a new row of this matrix. Do not rerun a
+full suite merely because a reviewer re-read the same candidate.
+
+## Manual and runtime evidence
+
+Manual/Desktop/live-provider evidence is required only when the Issue names an
+observable behavior that deterministic tests cannot prove. Record the exact
+variable, bound, success/failure cues, and sanitized artifact before running.
+One clean run does not create a new acceptance gate. Retry only for a new
+hypothesis or materially changed environment.
+
+`python scripts/report_quality_gates.py` is always report-only. Run it once when
+changed Python, TypeScript/TSX, or Rust source is in its scan scope; findings do
+not block PR, merge, or release under the current policy.
+
+## CI authority
+
+GitHub Actions runs all four repository jobs for every PR to `dev` or `main`
+regardless of local verification class. Local risk selection reduces duplicate
+work; it does not weaken CI. When CI is unavailable and a merge must proceed,
+reproduce the full fallback in `docs/agents/ci.md`.
+
+Existing active work migrates incrementally: retain already completed full
+suites and formal reviews, do not restart a Worker, and verify only later
+deltas unless they cross a new matrix boundary.


### PR DESCRIPTION
## Summary

- define fast, standard, and strict local verification classes
- map Python, frontend, Rust, and cross-boundary changes to relevant local suites
- keep all four GitHub Actions jobs as the final PR gate
- keep report-quality tooling non-blocking and make review-fix verification delta-only

## Verification

- direct Fast-class scope and acceptance review
- markdown references exist
- git diff --check

This PR changes repository policy documentation only; it does not change CI jobs or product behavior.