### PR TITLE
fix: accept native apply_patch history ids

### DIFF
--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -7640,6 +7640,7 @@ APPLY_PATCH_CUSTOM_TOOL_HISTORY_CALL_FIELDS = frozenset(
 APPLY_PATCH_CUSTOM_TOOL_HISTORY_OUTPUT_FIELDS = frozenset(
     {"type", "call_id", "output"}
 )
+APPLY_PATCH_CUSTOM_TOOL_HISTORY_NATIVE_FIELDS = frozenset({"id"})
 
 
 class _ApplyPatchAdapterFailure(ValueError):
@@ -7792,6 +7793,20 @@ def _raise_apply_patch_history_adapter_failure(
     )
 
 
+def _has_exact_apply_patch_custom_tool_history_fields(
+    item: Mapping[str, Any],
+    required_fields: frozenset[str],
+) -> bool:
+    fields = set(item)
+    if fields == required_fields:
+        return True
+    return (
+        fields == required_fields | APPLY_PATCH_CUSTOM_TOOL_HISTORY_NATIVE_FIELDS
+        and isinstance(item.get("id"), str)
+        and bool(item["id"])
+    )
+
+
 def _adapt_apply_patch_custom_tool_history(
     input_items: list[Any],
     *,
@@ -7825,7 +7840,10 @@ def _adapt_apply_patch_custom_tool_history(
         call_id = raw_item.get("call_id")
         if _is_apply_patch_custom_tool_call(raw_item):
             if (
-                set(raw_item) != APPLY_PATCH_CUSTOM_TOOL_HISTORY_CALL_FIELDS
+                not _has_exact_apply_patch_custom_tool_history_fields(
+                    raw_item,
+                    APPLY_PATCH_CUSTOM_TOOL_HISTORY_CALL_FIELDS,
+                )
                 or raw_item.get("status") != "completed"
                 or not isinstance(call_id, str)
                 or not call_id
@@ -7858,7 +7876,10 @@ def _adapt_apply_patch_custom_tool_history(
 
         if item_type == "custom_tool_call_output":
             if isinstance(call_id, str) and call_id in pending_call_ids:
-                if set(raw_item) != APPLY_PATCH_CUSTOM_TOOL_HISTORY_OUTPUT_FIELDS:
+                if not _has_exact_apply_patch_custom_tool_history_fields(
+                    raw_item,
+                    APPLY_PATCH_CUSTOM_TOOL_HISTORY_OUTPUT_FIELDS,
+                ):
                     _raise_apply_patch_history_adapter_failure(event_context)
                 pending_call_ids.remove(call_id)
                 rewritten_items.append(

--- a/tests/fixtures/glm_apply_patch_history_native_ids.json
+++ b/tests/fixtures/glm_apply_patch_history_native_ids.json
@@ -1,0 +1,51 @@
+{
+  "fixture_schema": "codexhub-glm-apply-patch-history-native-ids/v1",
+  "sanitized": true,
+  "source": "Sanitized structural reproduction of the #105 regression addendum; not a raw request capture.",
+  "model": "glm-5.2",
+  "input": [
+    {
+      "type": "message",
+      "role": "developer",
+      "content": "<sanitized-history-before-pair>"
+    },
+    {
+      "id": "ctc_sanitized_apply_patch",
+      "type": "custom_tool_call",
+      "status": "completed",
+      "call_id": "call_sanitized_apply_patch",
+      "name": "apply_patch",
+      "input": "*** Begin Patch\n*** Update File: SANITIZED_TARGET\n@@\n-OLD\n+NEW\n*** End Patch\n"
+    },
+    {
+      "id": "ctco_sanitized_apply_patch",
+      "type": "custom_tool_call_output",
+      "call_id": "call_sanitized_apply_patch",
+      "output": "<sanitized-success>"
+    },
+    {
+      "type": "message",
+      "role": "user",
+      "content": "<sanitized-continuation>"
+    }
+  ],
+  "tools": [
+    {
+      "type": "custom",
+      "name": "apply_patch"
+    }
+  ],
+  "expected_apply_patch_function_history": [
+    {
+      "type": "function_call",
+      "call_id": "call_sanitized_apply_patch",
+      "name": "apply_patch",
+      "arguments": "{\"patch\":\"*** Begin Patch\\n*** Update File: SANITIZED_TARGET\\n@@\\n-OLD\\n+NEW\\n*** End Patch\\n\"}"
+    },
+    {
+      "type": "function_call_output",
+      "call_id": "call_sanitized_apply_patch",
+      "output": "<sanitized-success>"
+    }
+  ]
+}

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -43,6 +43,11 @@ def _load_glm_apply_patch_retry_fixture():
     return json.loads(fixture_path.read_text(encoding="utf-8"))
 
 
+def _load_glm_apply_patch_history_native_ids_fixture():
+    fixture_path = Path(__file__).parent / "fixtures" / "glm_apply_patch_history_native_ids.json"
+    return json.loads(fixture_path.read_text(encoding="utf-8"))
+
+
 class FakeWFile:
     def __init__(self, fail_on_write=None):
         self.writes = []
@@ -8650,6 +8655,43 @@ class RoutingTests(unittest.TestCase):
             {"type": "function_call_output", "call_id": "call_apply_patch", "output": patch_result},
         )
 
+    def test_responses_structured_provider_adapts_native_id_apply_patch_history_fixture(self):
+        fixture = _load_glm_apply_patch_history_native_ids_fixture()
+        transformed = compatible_request_body(
+            json.dumps(
+                {
+                    "model": fixture["model"],
+                    "input": fixture["input"],
+                    "tools": fixture["tools"],
+                },
+                ensure_ascii=True,
+            ).encode("utf-8"),
+            {
+                "name": "ollama_cloud",
+                "upstream_format": "responses",
+                "tool_protocol": "responses_structured",
+            },
+            event_context={"request_id": "<sanitized-request-id>"},
+            inject_codex_tools=False,
+        )
+        payload = json.loads(transformed)
+
+        self.assertEqual(payload["input"][0], fixture["input"][0])
+        self.assertEqual(payload["input"][1:3], fixture["expected_apply_patch_function_history"])
+        self.assertEqual(payload["input"][3], fixture["input"][3])
+        self.assertNotIn("id", payload["input"][1])
+        self.assertNotIn("id", payload["input"][2])
+        history_events = [
+            call.kwargs
+            for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] == "third_party_apply_patch_freeform_history_adapter"
+        ]
+        self.assertEqual(len(history_events), 1)
+        self.assertEqual(history_events[0]["outcome"], "adapted")
+        self.assertEqual(history_events[0]["count"], 1)
+        for forbidden in ("id", "call_id", "name", "input", "output", "patch", "arguments"):
+            self.assertNotIn(forbidden, history_events[0])
+
     def test_responses_structured_provider_preserves_body_originated_apply_patch_continuation(self):
         fixture = _load_glm_apply_patch_retry_fixture()
         function_item = {
@@ -8778,7 +8820,17 @@ class RoutingTests(unittest.TestCase):
             "output": "Success. Updated target.txt",
         }
         malformed_histories = (
-            ("unexpected_call_field", [{**custom_call, "id": "fc_call_patch"}, custom_output]),
+            ("unexpected_call_field", [{**custom_call, "unexpected": "field"}, custom_output]),
+            (
+                "native_call_id_with_unexpected_field",
+                [{**custom_call, "id": "ctc_sanitized_apply_patch", "unexpected": "field"}, custom_output],
+            ),
+            ("non_string_call_item_id", [{**custom_call, "id": 1}, custom_output]),
+            ("empty_output_item_id", [custom_call, {**custom_output, "id": ""}]),
+            (
+                "native_output_id_with_unexpected_field",
+                [custom_call, {**custom_output, "id": "ctco_sanitized_apply_patch", "unexpected": "field"}],
+            ),
             ("missing_completed_status", [{key: value for key, value in custom_call.items() if key != "status"}, custom_output]),
             ("empty_patch", [{**custom_call, "input": "  "}, custom_output]),
             ("unexpected_output_field", [custom_call, {**custom_output, "status": "completed"}]),


### PR DESCRIPTION
## Summary
- Accept the current Codex Desktop native `id` metadata on an exact completed `apply_patch` custom-tool history pair.
- Discard only that recognized native metadata while preserving `call_id`, ordering, paired output, and sanitized telemetry.
- Add a sanitized structural regression fixture plus malformed-ID and arbitrary-extra-field coverage.

## Root cause
The inverse history adapter treated native `id` fields as arbitrary extras and rejected the retained history locally before the GLM request could run.

## Validation
- `python -m pytest -q tests/test_routing.py -k apply_patch`
- `python -m pytest -q`
- `python scripts/report_quality_gates.py` (report-only)

## Scope
No routing, retry, provider selection, fallback, advertised tool schema, permission behavior, or #84 Provider code changed. The retained #84 Worker was not retried, per instruction.

Refs #105