### PR TITLE
Fix official model planner metadata catalog

### DIFF
--- a/config/official_model_catalog_metadata.json
+++ b/config/official_model_catalog_metadata.json
@@ -10,35 +10,40 @@
       "prefer_websockets": true,
       "tool_mode": "code_mode_only",
       "multi_agent_version": "v2",
-      "use_responses_lite": true,
-      "comp_hash": "3000",
-      "supports_search_tool": true
+      "use_responses_lite": true
     },
     "gpt-5.6-terra": {
       "prefer_websockets": true,
       "tool_mode": "code_mode_only",
       "multi_agent_version": "v2",
-      "use_responses_lite": true,
-      "comp_hash": "3000",
-      "supports_search_tool": true
+      "use_responses_lite": true
     },
     "gpt-5.6-luna": {
       "prefer_websockets": true,
       "tool_mode": "code_mode_only",
       "multi_agent_version": "v1",
-      "use_responses_lite": true,
-      "comp_hash": "3000",
-      "supports_search_tool": true
+      "use_responses_lite": true
     },
     "gpt-5.5": {
       "prefer_websockets": true,
       "tool_mode": null,
       "multi_agent_version": null,
-      "use_responses_lite": false,
-      "context_window": 272000,
-      "max_context_window": 272000,
-      "comp_hash": "2911",
-      "supports_search_tool": true
+      "use_responses_lite": false
+    },
+    "gpt-5.4": {
+      "prefer_websockets": true,
+      "tool_mode": null,
+      "multi_agent_version": null,
+      "use_responses_lite": false
+    },
+    "gpt-5.4-mini": {
+      "prefer_websockets": true,
+      "tool_mode": null,
+      "multi_agent_version": null,
+      "use_responses_lite": false
+    },
+    "gpt-5.3-codex-spark": {
+      "use_responses_lite": false
     }
   }
 }

--- a/config/official_model_catalog_metadata.json
+++ b/config/official_model_catalog_metadata.json
@@ -1,0 +1,44 @@
+{
+  "schema_version": 1,
+  "source": {
+    "repository": "openai/codex",
+    "revision": "b24aa20107f365a1d0f06de9e0b28df5c516c7dd",
+    "path": "codex-rs/models-manager/models.json"
+  },
+  "models": {
+    "gpt-5.6-sol": {
+      "prefer_websockets": true,
+      "tool_mode": "code_mode_only",
+      "multi_agent_version": "v2",
+      "use_responses_lite": true,
+      "comp_hash": "3000",
+      "supports_search_tool": true
+    },
+    "gpt-5.6-terra": {
+      "prefer_websockets": true,
+      "tool_mode": "code_mode_only",
+      "multi_agent_version": "v2",
+      "use_responses_lite": true,
+      "comp_hash": "3000",
+      "supports_search_tool": true
+    },
+    "gpt-5.6-luna": {
+      "prefer_websockets": true,
+      "tool_mode": "code_mode_only",
+      "multi_agent_version": "v1",
+      "use_responses_lite": true,
+      "comp_hash": "3000",
+      "supports_search_tool": true
+    },
+    "gpt-5.5": {
+      "prefer_websockets": true,
+      "tool_mode": null,
+      "multi_agent_version": null,
+      "use_responses_lite": false,
+      "context_window": 272000,
+      "max_context_window": 272000,
+      "comp_hash": "2911",
+      "supports_search_tool": true
+    }
+  }
+}

--- a/src-python/catalog_sync.py
+++ b/src-python/catalog_sync.py
@@ -155,7 +155,7 @@ MINIMAL_OFFICIAL_MODEL: dict[str, Any] = {
     "experimental_supported_tools": [],
     "input_modalities": ["text"],
     "supports_search_tool": True,
-    "use_responses_lite": True,
+    "use_responses_lite": False,
 }
 
 OFFICIAL_FAST_SERVICE_TIERS: list[dict[str, str]] = [
@@ -255,19 +255,34 @@ PINNED_OFFICIAL_MODEL_IDS = (
     "gpt-5.6-terra",
     "gpt-5.6-luna",
     "gpt-5.5",
+    "gpt-5.4",
+    "gpt-5.4-mini",
+    "gpt-5.3-codex-spark",
 )
-PINNED_OFFICIAL_MODEL_COMMON_FIELDS = (
+PINNED_OFFICIAL_CODE_MODE_MULTI_AGENT_VERSIONS = {
+    "gpt-5.6-sol": "v2",
+    "gpt-5.6-terra": "v2",
+    "gpt-5.6-luna": "v1",
+}
+PINNED_OFFICIAL_LEGACY_MODEL_IDS = (
+    "gpt-5.5",
+    "gpt-5.4",
+    "gpt-5.4-mini",
+)
+PINNED_OFFICIAL_PLANNER_FIELD_SET = (
     "prefer_websockets",
     "tool_mode",
     "multi_agent_version",
     "use_responses_lite",
-    "comp_hash",
-    "supports_search_tool",
 )
-PINNED_OFFICIAL_MODEL_LIMIT_FIELDS = (
-    "context_window",
-    "max_context_window",
-)
+PINNED_OFFICIAL_MODEL_FIELD_SETS = {
+    **{
+        slug: PINNED_OFFICIAL_PLANNER_FIELD_SET
+        for slug in PINNED_OFFICIAL_CODE_MODE_MULTI_AGENT_VERSIONS
+    },
+    **{slug: PINNED_OFFICIAL_PLANNER_FIELD_SET for slug in PINNED_OFFICIAL_LEGACY_MODEL_IDS},
+    "gpt-5.3-codex-spark": ("use_responses_lite",),
+}
 
 
 def load_pinned_official_catalog_metadata(
@@ -288,27 +303,28 @@ def load_pinned_official_catalog_metadata(
         metadata = models.get(slug)
         if not isinstance(metadata, dict):
             raise ValueError(f"official catalog metadata for {slug} is invalid")
-        required_fields = set(PINNED_OFFICIAL_MODEL_COMMON_FIELDS)
-        if slug == "gpt-5.5":
-            required_fields.update(PINNED_OFFICIAL_MODEL_LIMIT_FIELDS)
-        if set(metadata) != required_fields:
+        if set(metadata) != set(PINNED_OFFICIAL_MODEL_FIELD_SETS[slug]):
             raise ValueError(f"official catalog metadata for {slug} has an invalid field set")
-        if not isinstance(metadata["prefer_websockets"], bool):
-            raise ValueError(f"official catalog metadata for {slug} has an invalid websocket flag")
-        if metadata["tool_mode"] not in (None, "code_mode_only"):
-            raise ValueError(f"official catalog metadata for {slug} has an invalid tool mode")
-        if metadata["multi_agent_version"] not in (None, "v1", "v2"):
-            raise ValueError(f"official catalog metadata for {slug} has an invalid multi-agent version")
-        if not isinstance(metadata["use_responses_lite"], bool):
+        if slug in PINNED_OFFICIAL_CODE_MODE_MULTI_AGENT_VERSIONS:
+            if metadata["prefer_websockets"] is not True:
+                raise ValueError(f"official catalog metadata for {slug} has an invalid websocket flag")
+            if metadata["tool_mode"] != "code_mode_only":
+                raise ValueError(f"official catalog metadata for {slug} has an invalid tool mode")
+            if metadata["multi_agent_version"] != PINNED_OFFICIAL_CODE_MODE_MULTI_AGENT_VERSIONS[slug]:
+                raise ValueError(f"official catalog metadata for {slug} has an invalid multi-agent version")
+            if metadata["use_responses_lite"] is not True:
+                raise ValueError(f"official catalog metadata for {slug} has an invalid Responses Lite flag")
+        elif slug in PINNED_OFFICIAL_LEGACY_MODEL_IDS:
+            if metadata["prefer_websockets"] is not True:
+                raise ValueError(f"official catalog metadata for {slug} has an invalid websocket flag")
+            if metadata["tool_mode"] is not None:
+                raise ValueError(f"official catalog metadata for {slug} has an invalid tool mode")
+            if metadata["multi_agent_version"] is not None:
+                raise ValueError(f"official catalog metadata for {slug} has an invalid multi-agent version")
+            if metadata["use_responses_lite"] is not False:
+                raise ValueError(f"official catalog metadata for {slug} has an invalid Responses Lite flag")
+        elif metadata["use_responses_lite"] is not False:
             raise ValueError(f"official catalog metadata for {slug} has an invalid Responses Lite flag")
-        if not isinstance(metadata["supports_search_tool"], bool):
-            raise ValueError(f"official catalog metadata for {slug} has an invalid search-tool flag")
-        if not isinstance(metadata["comp_hash"], str) or not metadata["comp_hash"]:
-            raise ValueError(f"official catalog metadata for {slug} has an invalid compatibility hash")
-        if slug == "gpt-5.5":
-            for field in PINNED_OFFICIAL_MODEL_LIMIT_FIELDS:
-                if not isinstance(metadata[field], int) or isinstance(metadata[field], bool) or metadata[field] <= 0:
-                    raise ValueError(f"official catalog metadata for {slug} has an invalid {field}")
         validated[slug] = deepcopy(metadata)
     return validated
 
@@ -671,6 +687,11 @@ def apply_pinned_official_catalog_metadata(model: dict[str, Any], slug: str) -> 
         model.update(deepcopy(metadata))
 
 
+def normalize_official_responses_lite_opt_in(model: dict[str, Any]) -> None:
+    if not isinstance(model.get("use_responses_lite"), bool):
+        model["use_responses_lite"] = False
+
+
 def official_proxy_alias(slug: str) -> str:
     return f"{OFFICIAL_PROXY_PROVIDER_ALIAS}/{slug}"
 
@@ -729,6 +750,7 @@ def build_official_proxy_model(slug: str, official_by_slug: dict[str, dict[str, 
     model["display_name"] = official_short_display_name(slug, model, policy)
     if source_model is None:
         apply_official_model_defaults(model, slug)
+    normalize_official_responses_lite_opt_in(model)
     apply_pinned_official_catalog_metadata(model, slug)
     limits = RESOLVED_MODEL_LIMITS.get(("openai", slug))
     live_context = model.get("context_window")

--- a/src-python/catalog_sync.py
+++ b/src-python/catalog_sync.py
@@ -61,6 +61,7 @@ GENERATED_STATE_PATH = RUNTIME_MODEL_CATALOG_DIR / "codex-proxy-state.json"
 SETTINGS_PATH = RUNTIME_CODEX_DIR / "proxy" / "settings.json"
 RESOLVED_MODEL_LIMITS_PATH = REPO_ROOT / "config" / "resolved_model_limits.json"
 RESOLVED_MODEL_LIMITS = load_resolved_model_limits(RESOLVED_MODEL_LIMITS_PATH)
+OFFICIAL_CATALOG_METADATA_PATH = REPO_ROOT / "config" / "official_model_catalog_metadata.json"
 
 OLLAMA_MODELS_URL = "https://ollama.com/v1/models"
 OLLAMA_SHOW_URL = "https://ollama.com/api/show"
@@ -249,6 +250,70 @@ REASONING_LEVEL_DESCRIPTIONS = {
 }
 THIRD_PARTY_REASONING_LEVEL_ORDER = ("low", "medium", "high", "xhigh", "max")
 THIRD_PARTY_REASONING_LEVELS = set(THIRD_PARTY_REASONING_LEVEL_ORDER)
+PINNED_OFFICIAL_MODEL_IDS = (
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna",
+    "gpt-5.5",
+)
+PINNED_OFFICIAL_MODEL_COMMON_FIELDS = (
+    "prefer_websockets",
+    "tool_mode",
+    "multi_agent_version",
+    "use_responses_lite",
+    "comp_hash",
+    "supports_search_tool",
+)
+PINNED_OFFICIAL_MODEL_LIMIT_FIELDS = (
+    "context_window",
+    "max_context_window",
+)
+
+
+def load_pinned_official_catalog_metadata(
+    path: Path = OFFICIAL_CATALOG_METADATA_PATH,
+) -> dict[str, dict[str, Any]]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError(f"official catalog metadata is unreadable: {error}") from error
+    if payload.get("schema_version") != 1:
+        raise ValueError("official catalog metadata has an unsupported schema")
+    models = payload.get("models")
+    if not isinstance(models, dict) or set(models) != set(PINNED_OFFICIAL_MODEL_IDS):
+        raise ValueError("official catalog metadata has an incomplete model set")
+
+    validated: dict[str, dict[str, Any]] = {}
+    for slug in PINNED_OFFICIAL_MODEL_IDS:
+        metadata = models.get(slug)
+        if not isinstance(metadata, dict):
+            raise ValueError(f"official catalog metadata for {slug} is invalid")
+        required_fields = set(PINNED_OFFICIAL_MODEL_COMMON_FIELDS)
+        if slug == "gpt-5.5":
+            required_fields.update(PINNED_OFFICIAL_MODEL_LIMIT_FIELDS)
+        if set(metadata) != required_fields:
+            raise ValueError(f"official catalog metadata for {slug} has an invalid field set")
+        if not isinstance(metadata["prefer_websockets"], bool):
+            raise ValueError(f"official catalog metadata for {slug} has an invalid websocket flag")
+        if metadata["tool_mode"] not in (None, "code_mode_only"):
+            raise ValueError(f"official catalog metadata for {slug} has an invalid tool mode")
+        if metadata["multi_agent_version"] not in (None, "v1", "v2"):
+            raise ValueError(f"official catalog metadata for {slug} has an invalid multi-agent version")
+        if not isinstance(metadata["use_responses_lite"], bool):
+            raise ValueError(f"official catalog metadata for {slug} has an invalid Responses Lite flag")
+        if not isinstance(metadata["supports_search_tool"], bool):
+            raise ValueError(f"official catalog metadata for {slug} has an invalid search-tool flag")
+        if not isinstance(metadata["comp_hash"], str) or not metadata["comp_hash"]:
+            raise ValueError(f"official catalog metadata for {slug} has an invalid compatibility hash")
+        if slug == "gpt-5.5":
+            for field in PINNED_OFFICIAL_MODEL_LIMIT_FIELDS:
+                if not isinstance(metadata[field], int) or isinstance(metadata[field], bool) or metadata[field] <= 0:
+                    raise ValueError(f"official catalog metadata for {slug} has an invalid {field}")
+        validated[slug] = deepcopy(metadata)
+    return validated
+
+
+PINNED_OFFICIAL_CATALOG_METADATA = load_pinned_official_catalog_metadata()
 
 
 def sanitize_third_party_reasoning_levels(value: Any) -> list[dict[str, str]]:
@@ -600,6 +665,12 @@ def apply_official_model_defaults(model: dict[str, Any], slug: str) -> None:
         model[key] = deepcopy(value)
 
 
+def apply_pinned_official_catalog_metadata(model: dict[str, Any], slug: str) -> None:
+    metadata = PINNED_OFFICIAL_CATALOG_METADATA.get(slug)
+    if metadata is not None:
+        model.update(deepcopy(metadata))
+
+
 def official_proxy_alias(slug: str) -> str:
     return f"{OFFICIAL_PROXY_PROVIDER_ALIAS}/{slug}"
 
@@ -658,6 +729,7 @@ def build_official_proxy_model(slug: str, official_by_slug: dict[str, dict[str, 
     model["display_name"] = official_short_display_name(slug, model, policy)
     if source_model is None:
         apply_official_model_defaults(model, slug)
+    apply_pinned_official_catalog_metadata(model, slug)
     limits = RESOLVED_MODEL_LIMITS.get(("openai", slug))
     live_context = model.get("context_window")
     apply_resolved_model_limits(model, limits)

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -5,13 +5,13 @@ use crate::{
 use reqwest::blocking::Client;
 use reqwest::header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE};
 use serde::Deserialize;
-use serde_json::{json, Value};
+use serde_json::{json, Map, Value};
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdout, Command, Stdio};
-use std::sync::mpsc;
+use std::sync::{mpsc, OnceLock};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
@@ -21,6 +21,26 @@ const CODEX_APP_SERVER_MODEL_LIST_TIMEOUT: Duration = Duration::from_secs(8);
 const GENERATED_CATALOG_FILE: &str = "codexhub-model-catalog.json";
 const LEGACY_GENERATED_CATALOG_FILE: &str = "codex-proxy-official-ollama.json";
 const RESOLVED_MODEL_LIMITS_JSON: &str = include_str!("../../config/resolved_model_limits.json");
+const OFFICIAL_CATALOG_METADATA_JSON: &str =
+    include_str!("../../config/official_model_catalog_metadata.json");
+const PINNED_OFFICIAL_MODEL_IDS: &[&str] = &[
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna",
+    "gpt-5.5",
+];
+const PINNED_OFFICIAL_MODEL_COMMON_FIELDS: &[&str] = &[
+    "prefer_websockets",
+    "tool_mode",
+    "multi_agent_version",
+    "use_responses_lite",
+    "comp_hash",
+    "supports_search_tool",
+];
+const PINNED_OFFICIAL_MODEL_LIMIT_FIELDS: &[&str] =
+    &["context_window", "max_context_window"];
+static PINNED_OFFICIAL_CATALOG_METADATA: OnceLock<Result<HashMap<String, Map<String, Value>>, String>> =
+    OnceLock::new();
 const RESPONSE_ENDPOINT_SUFFIXES: &[&str] = &["/responses", "/response"];
 const KNOWN_PROVIDER_ENDPOINT_SUFFIXES: &[&str] = &[
     "/chat/completions",
@@ -546,6 +566,7 @@ fn subscription_models_from_payload(
         let Some(mut model) = subscription_model_from_item(item) else {
             continue;
         };
+        apply_pinned_official_catalog_metadata_to_seed(&mut model)?;
         if let Some(&position) = positions.get(&model.slug) {
             let existing: &OfficialSubscriptionModel = &output[position];
             let enabled = existing.enabled || model.enabled;
@@ -569,6 +590,136 @@ fn subscription_models_from_payload(
         }
     }
     Ok(output)
+}
+
+fn apply_pinned_official_catalog_metadata_to_seed(
+    model: &mut OfficialSubscriptionModel,
+) -> Result<(), String> {
+    let Some(metadata) = pinned_official_catalog_metadata()?.get(&model.slug) else {
+        return Ok(());
+    };
+    let raw = model
+        .raw
+        .as_object_mut()
+        .ok_or_else(|| format!("official model {} has invalid raw metadata", model.slug))?;
+    for (key, value) in metadata {
+        raw.insert(key.clone(), value.clone());
+    }
+    Ok(())
+}
+
+fn pinned_official_catalog_metadata() -> Result<&'static HashMap<String, Map<String, Value>>, String> {
+    PINNED_OFFICIAL_CATALOG_METADATA
+        .get_or_init(parse_pinned_official_catalog_metadata)
+        .as_ref()
+        .map_err(|error| error.clone())
+}
+
+fn parse_pinned_official_catalog_metadata() -> Result<HashMap<String, Map<String, Value>>, String> {
+    let document: Value = serde_json::from_str(OFFICIAL_CATALOG_METADATA_JSON)
+        .map_err(|error| format!("official catalog metadata is unreadable: {error}"))?;
+    if document.get("schema_version") != Some(&json!(1)) {
+        return Err("official catalog metadata has an unsupported schema".to_string());
+    }
+    let models = document
+        .get("models")
+        .and_then(Value::as_object)
+        .ok_or_else(|| "official catalog metadata has no model map".to_string())?;
+    if models.len() != PINNED_OFFICIAL_MODEL_IDS.len()
+        || PINNED_OFFICIAL_MODEL_IDS
+            .iter()
+            .any(|slug| !models.contains_key(*slug))
+    {
+        return Err("official catalog metadata has an incomplete model set".to_string());
+    }
+
+    let mut output = HashMap::new();
+    for slug in PINNED_OFFICIAL_MODEL_IDS {
+        let metadata = models
+            .get(*slug)
+            .and_then(Value::as_object)
+            .ok_or_else(|| format!("official catalog metadata for {slug} is invalid"))?;
+        validate_pinned_official_catalog_metadata(slug, metadata)?;
+        output.insert((*slug).to_string(), metadata.clone());
+    }
+    Ok(output)
+}
+
+fn validate_pinned_official_catalog_metadata(
+    slug: &str,
+    metadata: &Map<String, Value>,
+) -> Result<(), String> {
+    let mut required_fields = PINNED_OFFICIAL_MODEL_COMMON_FIELDS.to_vec();
+    if slug == "gpt-5.5" {
+        required_fields.extend_from_slice(PINNED_OFFICIAL_MODEL_LIMIT_FIELDS);
+    }
+    if metadata.len() != required_fields.len()
+        || required_fields.iter().any(|field| !metadata.contains_key(*field))
+    {
+        return Err(format!(
+            "official catalog metadata for {slug} has an invalid field set"
+        ));
+    }
+    if !metadata
+        .get("prefer_websockets")
+        .and_then(Value::as_bool)
+        .is_some()
+    {
+        return Err(format!(
+            "official catalog metadata for {slug} has an invalid websocket flag"
+        ));
+    }
+    let valid_tool_mode = match metadata.get("tool_mode") {
+        Some(Value::Null) => true,
+        Some(Value::String(value)) => value == "code_mode_only",
+        _ => false,
+    };
+    if !valid_tool_mode {
+        return Err(format!(
+            "official catalog metadata for {slug} has an invalid tool mode"
+        ));
+    }
+    let valid_multi_agent_version = match metadata.get("multi_agent_version") {
+        Some(Value::Null) => true,
+        Some(Value::String(value)) => value == "v1" || value == "v2",
+        _ => false,
+    };
+    if !valid_multi_agent_version {
+        return Err(format!(
+            "official catalog metadata for {slug} has an invalid multi-agent version"
+        ));
+    }
+    for field in ["use_responses_lite", "supports_search_tool"] {
+        if metadata.get(field).and_then(Value::as_bool).is_none() {
+            return Err(format!(
+                "official catalog metadata for {slug} has an invalid {field} flag"
+            ));
+        }
+    }
+    if !metadata
+        .get("comp_hash")
+        .and_then(Value::as_str)
+        .is_some_and(|value| !value.is_empty())
+    {
+        return Err(format!(
+            "official catalog metadata for {slug} has an invalid compatibility hash"
+        ));
+    }
+    if slug == "gpt-5.5" {
+        for field in PINNED_OFFICIAL_MODEL_LIMIT_FIELDS {
+            if metadata
+                .get(*field)
+                .and_then(Value::as_u64)
+                .filter(|value| *value > 0)
+                .is_none()
+            {
+                return Err(format!(
+                    "official catalog metadata for {slug} has an invalid {field}"
+                ));
+            }
+        }
+    }
+    Ok(())
 }
 
 fn subscription_model_from_item(item: &Value) -> Option<OfficialSubscriptionModel> {
@@ -2376,7 +2527,7 @@ mod tests {
                     ],
                     "defaultReasoningEffort": "low",
                     "multi_agent_version": "v2",
-                    "tool_mode": "native",
+                    "tool_mode": "code_mode_only",
                     "model_messages": {"upgrade": "Use Sol"},
                     "skills_instructions": "Official skills contract",
                     "web_search_tool_type": "text",
@@ -2384,7 +2535,7 @@ mod tests {
                     "availability": {"plan": "plus"},
                     "upgrade": "gpt-5.7-sol",
                     "upgradeInfo": {"message": "Upgrade available"},
-                    "comp_hash": "sol-compat-hash"
+                    "comp_hash": "3000"
                 }
             ]
         }))
@@ -2400,7 +2551,7 @@ mod tests {
         assert_eq!(sol["display_name"], "5.6 Sol");
         assert_eq!(sol["context_window"], 400000);
         assert_eq!(sol["multi_agent_version"], "v2");
-        assert_eq!(sol["tool_mode"], "native");
+        assert_eq!(sol["tool_mode"], "code_mode_only");
         assert_eq!(sol["model_messages"]["upgrade"], "Use Sol");
         assert_eq!(sol["skills_instructions"], "Official skills contract");
         assert_eq!(sol["web_search_tool_type"], "text");
@@ -2408,7 +2559,7 @@ mod tests {
         assert_eq!(sol["availability"]["plan"], "plus");
         assert_eq!(sol["upgrade"], "gpt-5.7-sol");
         assert_eq!(sol["upgradeInfo"]["message"], "Upgrade available");
-        assert_eq!(sol["comp_hash"], "sol-compat-hash");
+        assert_eq!(sol["comp_hash"], "3000");
         let terra_efforts = terra["supported_reasoning_levels"]
             .as_array()
             .unwrap()
@@ -2429,6 +2580,47 @@ mod tests {
             sol_efforts,
             ["low", "medium", "high", "xhigh", "max", "ultra"]
         );
+    }
+
+    #[test]
+    fn subscription_seed_backfills_pinned_official_planner_metadata_per_model() {
+        let subscription_models = subscription_models_from_payload(&json!({
+            "data": [
+                {"id": "gpt-5.6-sol", "model": "gpt-5.6-sol"},
+                {"id": "gpt-5.6-terra", "model": "gpt-5.6-terra"},
+                {"id": "gpt-5.6-luna", "model": "gpt-5.6-luna"},
+                {
+                    "id": "gpt-5.5",
+                    "model": "gpt-5.5",
+                    "use_responses_lite": true,
+                    "tool_mode": "code_mode_only",
+                    "multi_agent_version": "v2"
+                }
+            ]
+        }))
+        .expect("subscription models");
+        let seeds = subscription_models
+            .iter()
+            .map(super::official_subscription_seed_model)
+            .collect::<Vec<_>>();
+
+        for (index, version) in [(0, "v2"), (1, "v2"), (2, "v1")] {
+            assert_eq!(seeds[index]["tool_mode"], "code_mode_only");
+            assert_eq!(seeds[index]["multi_agent_version"], version);
+            assert_eq!(seeds[index]["prefer_websockets"], true);
+            assert_eq!(seeds[index]["use_responses_lite"], true);
+        }
+
+        let gpt_55 = &seeds[3];
+        assert!(gpt_55.get("tool_mode").is_some());
+        assert!(gpt_55["tool_mode"].is_null());
+        assert!(gpt_55.get("multi_agent_version").is_some());
+        assert!(gpt_55["multi_agent_version"].is_null());
+        assert_eq!(gpt_55["prefer_websockets"], true);
+        assert_eq!(gpt_55["use_responses_lite"], false);
+        assert_eq!(gpt_55["context_window"], 272000);
+        assert_eq!(gpt_55["max_context_window"], 272000);
+        assert_eq!(gpt_55["comp_hash"], "2911");
     }
 
     #[test]

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -39,7 +39,9 @@ const PINNED_OFFICIAL_MODEL_COMMON_FIELDS: &[&str] = &[
 ];
 const PINNED_OFFICIAL_MODEL_LIMIT_FIELDS: &[&str] =
     &["context_window", "max_context_window"];
-static PINNED_OFFICIAL_CATALOG_METADATA: OnceLock<Result<HashMap<String, Map<String, Value>>, String>> =
+type PinnedOfficialCatalogMetadata = HashMap<String, Map<String, Value>>;
+type PinnedOfficialCatalogMetadataResult = Result<PinnedOfficialCatalogMetadata, String>;
+static PINNED_OFFICIAL_CATALOG_METADATA: OnceLock<PinnedOfficialCatalogMetadataResult> =
     OnceLock::new();
 const RESPONSE_ENDPOINT_SUFFIXES: &[&str] = &["/responses", "/response"];
 const KNOWN_PROVIDER_ENDPOINT_SUFFIXES: &[&str] = &[
@@ -608,14 +610,14 @@ fn apply_pinned_official_catalog_metadata_to_seed(
     Ok(())
 }
 
-fn pinned_official_catalog_metadata() -> Result<&'static HashMap<String, Map<String, Value>>, String> {
+fn pinned_official_catalog_metadata() -> Result<&'static PinnedOfficialCatalogMetadata, String> {
     PINNED_OFFICIAL_CATALOG_METADATA
         .get_or_init(parse_pinned_official_catalog_metadata)
         .as_ref()
         .map_err(|error| error.clone())
 }
 
-fn parse_pinned_official_catalog_metadata() -> Result<HashMap<String, Map<String, Value>>, String> {
+fn parse_pinned_official_catalog_metadata() -> PinnedOfficialCatalogMetadataResult {
     let document: Value = serde_json::from_str(OFFICIAL_CATALOG_METADATA_JSON)
         .map_err(|error| format!("official catalog metadata is unreadable: {error}"))?;
     if document.get("schema_version") != Some(&json!(1)) {

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -28,17 +28,17 @@ const PINNED_OFFICIAL_MODEL_IDS: &[&str] = &[
     "gpt-5.6-terra",
     "gpt-5.6-luna",
     "gpt-5.5",
+    "gpt-5.4",
+    "gpt-5.4-mini",
+    "gpt-5.3-codex-spark",
 ];
-const PINNED_OFFICIAL_MODEL_COMMON_FIELDS: &[&str] = &[
+const PINNED_OFFICIAL_PLANNER_FIELDS: &[&str] = &[
     "prefer_websockets",
     "tool_mode",
     "multi_agent_version",
     "use_responses_lite",
-    "comp_hash",
-    "supports_search_tool",
 ];
-const PINNED_OFFICIAL_MODEL_LIMIT_FIELDS: &[&str] =
-    &["context_window", "max_context_window"];
+const PINNED_OFFICIAL_LITE_ONLY_FIELDS: &[&str] = &["use_responses_lite"];
 type PinnedOfficialCatalogMetadata = HashMap<String, Map<String, Value>>;
 type PinnedOfficialCatalogMetadataResult = Result<PinnedOfficialCatalogMetadata, String>;
 static PINNED_OFFICIAL_CATALOG_METADATA: OnceLock<PinnedOfficialCatalogMetadataResult> =
@@ -597,17 +597,28 @@ fn subscription_models_from_payload(
 fn apply_pinned_official_catalog_metadata_to_seed(
     model: &mut OfficialSubscriptionModel,
 ) -> Result<(), String> {
-    let Some(metadata) = pinned_official_catalog_metadata()?.get(&model.slug) else {
-        return Ok(());
-    };
+    let metadata = pinned_official_catalog_metadata()?.get(&model.slug);
     let raw = model
         .raw
         .as_object_mut()
         .ok_or_else(|| format!("official model {} has invalid raw metadata", model.slug))?;
-    for (key, value) in metadata {
-        raw.insert(key.clone(), value.clone());
+    ensure_responses_lite_opt_in(raw);
+    if let Some(metadata) = metadata {
+        for (key, value) in metadata {
+            raw.insert(key.clone(), value.clone());
+        }
     }
     Ok(())
+}
+
+fn ensure_responses_lite_opt_in(metadata: &mut Map<String, Value>) {
+    if metadata
+        .get("use_responses_lite")
+        .and_then(Value::as_bool)
+        .is_none()
+    {
+        metadata.insert("use_responses_lite".to_string(), json!(false));
+    }
 }
 
 fn pinned_official_catalog_metadata() -> Result<&'static PinnedOfficialCatalogMetadata, String> {
@@ -651,10 +662,13 @@ fn validate_pinned_official_catalog_metadata(
     slug: &str,
     metadata: &Map<String, Value>,
 ) -> Result<(), String> {
-    let mut required_fields = PINNED_OFFICIAL_MODEL_COMMON_FIELDS.to_vec();
-    if slug == "gpt-5.5" {
-        required_fields.extend_from_slice(PINNED_OFFICIAL_MODEL_LIMIT_FIELDS);
-    }
+    let required_fields = if pinned_official_code_mode_multi_agent_version(slug).is_some()
+        || is_pinned_official_legacy_model(slug)
+    {
+        PINNED_OFFICIAL_PLANNER_FIELDS
+    } else {
+        PINNED_OFFICIAL_LITE_ONLY_FIELDS
+    };
     if metadata.len() != required_fields.len()
         || required_fields.iter().any(|field| !metadata.contains_key(*field))
     {
@@ -662,66 +676,94 @@ fn validate_pinned_official_catalog_metadata(
             "official catalog metadata for {slug} has an invalid field set"
         ));
     }
-    if !metadata
-        .get("prefer_websockets")
-        .and_then(Value::as_bool)
-        .is_some()
+    if let Some(expected_multi_agent_version) = pinned_official_code_mode_multi_agent_version(slug)
     {
-        return Err(format!(
-            "official catalog metadata for {slug} has an invalid websocket flag"
-        ));
-    }
-    let valid_tool_mode = match metadata.get("tool_mode") {
-        Some(Value::Null) => true,
-        Some(Value::String(value)) => value == "code_mode_only",
-        _ => false,
-    };
-    if !valid_tool_mode {
-        return Err(format!(
-            "official catalog metadata for {slug} has an invalid tool mode"
-        ));
-    }
-    let valid_multi_agent_version = match metadata.get("multi_agent_version") {
-        Some(Value::Null) => true,
-        Some(Value::String(value)) => value == "v1" || value == "v2",
-        _ => false,
-    };
-    if !valid_multi_agent_version {
-        return Err(format!(
-            "official catalog metadata for {slug} has an invalid multi-agent version"
-        ));
-    }
-    for field in ["use_responses_lite", "supports_search_tool"] {
-        if metadata.get(field).and_then(Value::as_bool).is_none() {
+        if metadata
+            .get("prefer_websockets")
+            .and_then(Value::as_bool)
+            != Some(true)
+        {
             return Err(format!(
-                "official catalog metadata for {slug} has an invalid {field} flag"
+                "official catalog metadata for {slug} has an invalid websocket flag"
             ));
         }
-    }
-    if !metadata
-        .get("comp_hash")
-        .and_then(Value::as_str)
-        .is_some_and(|value| !value.is_empty())
+        if metadata.get("tool_mode").and_then(Value::as_str) != Some("code_mode_only") {
+            return Err(format!(
+                "official catalog metadata for {slug} has an invalid tool mode"
+            ));
+        }
+        if metadata
+            .get("multi_agent_version")
+            .and_then(Value::as_str)
+            != Some(expected_multi_agent_version)
+        {
+            return Err(format!(
+                "official catalog metadata for {slug} has an invalid multi-agent version"
+            ));
+        }
+        if metadata
+            .get("use_responses_lite")
+            .and_then(Value::as_bool)
+            != Some(true)
+        {
+            return Err(format!(
+                "official catalog metadata for {slug} has an invalid Responses Lite flag"
+            ));
+        }
+    } else if is_pinned_official_legacy_model(slug) {
+        if metadata
+            .get("prefer_websockets")
+            .and_then(Value::as_bool)
+            != Some(true)
+        {
+            return Err(format!(
+                "official catalog metadata for {slug} has an invalid websocket flag"
+            ));
+        }
+        if !metadata.get("tool_mode").is_some_and(Value::is_null) {
+            return Err(format!(
+                "official catalog metadata for {slug} has an invalid tool mode"
+            ));
+        }
+        if !metadata
+            .get("multi_agent_version")
+            .is_some_and(Value::is_null)
+        {
+            return Err(format!(
+                "official catalog metadata for {slug} has an invalid multi-agent version"
+            ));
+        }
+        if metadata
+            .get("use_responses_lite")
+            .and_then(Value::as_bool)
+            != Some(false)
+        {
+            return Err(format!(
+                "official catalog metadata for {slug} has an invalid Responses Lite flag"
+            ));
+        }
+    } else if metadata
+        .get("use_responses_lite")
+        .and_then(Value::as_bool)
+        != Some(false)
     {
         return Err(format!(
-            "official catalog metadata for {slug} has an invalid compatibility hash"
+            "official catalog metadata for {slug} has an invalid Responses Lite flag"
         ));
     }
-    if slug == "gpt-5.5" {
-        for field in PINNED_OFFICIAL_MODEL_LIMIT_FIELDS {
-            if metadata
-                .get(*field)
-                .and_then(Value::as_u64)
-                .filter(|value| *value > 0)
-                .is_none()
-            {
-                return Err(format!(
-                    "official catalog metadata for {slug} has an invalid {field}"
-                ));
-            }
-        }
-    }
     Ok(())
+}
+
+fn pinned_official_code_mode_multi_agent_version(slug: &str) -> Option<&'static str> {
+    match slug {
+        "gpt-5.6-sol" | "gpt-5.6-terra" => Some("v2"),
+        "gpt-5.6-luna" => Some("v1"),
+        _ => None,
+    }
+}
+
+fn is_pinned_official_legacy_model(slug: &str) -> bool {
+    matches!(slug, "gpt-5.5" | "gpt-5.4" | "gpt-5.4-mini")
 }
 
 fn subscription_model_from_item(item: &Value) -> Option<OfficialSubscriptionModel> {
@@ -927,6 +969,7 @@ fn write_official_subscription_seed(
 
 fn official_subscription_seed_model(model: &OfficialSubscriptionModel) -> Value {
     let mut payload = model.raw.as_object().cloned().unwrap_or_default();
+    ensure_responses_lite_opt_in(&mut payload);
     payload.insert("slug".to_string(), json!(model.slug));
     payload
         .entry("display_name".to_string())
@@ -2597,6 +2640,31 @@ mod tests {
                     "use_responses_lite": true,
                     "tool_mode": "code_mode_only",
                     "multi_agent_version": "v2"
+                },
+                {
+                    "id": "gpt-5.4",
+                    "model": "gpt-5.4",
+                    "use_responses_lite": true,
+                    "tool_mode": "code_mode_only",
+                    "multi_agent_version": "v2"
+                },
+                {
+                    "id": "gpt-5.4-mini",
+                    "model": "gpt-5.4-mini",
+                    "use_responses_lite": true,
+                    "tool_mode": "code_mode_only",
+                    "multi_agent_version": "v2"
+                },
+                {
+                    "id": "gpt-5.3-codex-spark",
+                    "model": "gpt-5.3-codex-spark",
+                    "use_responses_lite": true
+                },
+                {"id": "gpt-sparse", "model": "gpt-sparse"},
+                {
+                    "id": "gpt-explicit-lite",
+                    "model": "gpt-explicit-lite",
+                    "use_responses_lite": true
                 }
             ]
         }))
@@ -2613,16 +2681,22 @@ mod tests {
             assert_eq!(seeds[index]["use_responses_lite"], true);
         }
 
-        let gpt_55 = &seeds[3];
-        assert!(gpt_55.get("tool_mode").is_some());
-        assert!(gpt_55["tool_mode"].is_null());
-        assert!(gpt_55.get("multi_agent_version").is_some());
-        assert!(gpt_55["multi_agent_version"].is_null());
-        assert_eq!(gpt_55["prefer_websockets"], true);
-        assert_eq!(gpt_55["use_responses_lite"], false);
-        assert_eq!(gpt_55["context_window"], 272000);
-        assert_eq!(gpt_55["max_context_window"], 272000);
-        assert_eq!(gpt_55["comp_hash"], "2911");
+        for legacy_model in &seeds[3..6] {
+            assert!(legacy_model.get("tool_mode").is_some());
+            assert!(legacy_model["tool_mode"].is_null());
+            assert!(legacy_model.get("multi_agent_version").is_some());
+            assert!(legacy_model["multi_agent_version"].is_null());
+            assert_eq!(legacy_model["prefer_websockets"], true);
+            assert_eq!(legacy_model["use_responses_lite"], false);
+        }
+
+        for sparse_model in [&seeds[6], &seeds[7]] {
+            assert_eq!(sparse_model["use_responses_lite"], false);
+            assert!(sparse_model.get("prefer_websockets").is_none());
+            assert!(sparse_model.get("tool_mode").is_none());
+            assert!(sparse_model.get("multi_agent_version").is_none());
+        }
+        assert_eq!(seeds[8]["use_responses_lite"], true);
     }
 
     #[test]

--- a/src-tauri/src/proxy.rs
+++ b/src-tauri/src/proxy.rs
@@ -2208,6 +2208,19 @@ time.sleep(10)
             }
         }
 
+        let config_source = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .join("config")
+            .join("official_model_catalog_metadata.json");
+        let config_target = repo_root.join("config");
+        fs::create_dir_all(&config_target).unwrap();
+        fs::copy(
+            config_source,
+            config_target.join("official_model_catalog_metadata.json"),
+        )
+        .unwrap();
+
         repo_root
     }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -29,6 +29,7 @@
     "createUpdaterArtifacts": true,
     "resources": {
       "../config/*.toml": "config",
+      "../config/official_model_catalog_metadata.json": "config/official_model_catalog_metadata.json",
       "../config/resolved_model_limits.json": "config/resolved_model_limits.json",
       "../src-python/*.py": "src-python",
       "../src-python/vendor/*.whl": "src-python/vendor",

--- a/tests/test_catalog_sync.py
+++ b/tests/test_catalog_sync.py
@@ -317,9 +317,32 @@ class CatalogSyncTests(unittest.TestCase):
                 "slug": "gpt-5.5",
                 "display_name": "GPT-5.5",
                 "use_responses_lite": True,
+                "prefer_websockets": False,
                 "tool_mode": "code_mode_only",
                 "multi_agent_version": "v2",
             },
+            {
+                "slug": "gpt-5.4",
+                "display_name": "GPT-5.4",
+                "use_responses_lite": True,
+                "prefer_websockets": False,
+                "tool_mode": "code_mode_only",
+                "multi_agent_version": "v2",
+            },
+            {
+                "slug": "gpt-5.4-mini",
+                "display_name": "GPT-5.4-Mini",
+                "use_responses_lite": True,
+                "prefer_websockets": False,
+                "tool_mode": "code_mode_only",
+                "multi_agent_version": "v2",
+            },
+            {
+                "slug": "gpt-5.3-codex-spark",
+                "display_name": "GPT-5.3-Codex-Spark",
+                "use_responses_lite": True,
+            },
+            {"slug": "gpt-sparse", "display_name": "GPT-Sparse"},
         ]
 
         catalog = build_codex_catalog(official, [], self.policy, "0.144.0")
@@ -336,20 +359,24 @@ class CatalogSyncTests(unittest.TestCase):
                 self.assertEqual(model["multi_agent_version"], multi_agent_version)
                 self.assertIs(model["prefer_websockets"], True)
                 self.assertIs(model["use_responses_lite"], True)
-                self.assertEqual(model["comp_hash"], "3000")
-                self.assertIs(model["supports_search_tool"], True)
 
-        gpt_55 = by_slug["gpt-5.5"]
-        self.assertIn("tool_mode", gpt_55)
-        self.assertIsNone(gpt_55["tool_mode"])
-        self.assertIn("multi_agent_version", gpt_55)
-        self.assertIsNone(gpt_55["multi_agent_version"])
-        self.assertIs(gpt_55["prefer_websockets"], True)
-        self.assertIs(gpt_55["use_responses_lite"], False)
-        self.assertEqual(gpt_55["context_window"], 272000)
-        self.assertEqual(gpt_55["max_context_window"], 272000)
-        self.assertEqual(gpt_55["comp_hash"], "2911")
-        self.assertIs(gpt_55["supports_search_tool"], True)
+        for slug in ("gpt-5.5", "gpt-5.4", "gpt-5.4-mini"):
+            with self.subTest(slug=slug):
+                model = by_slug[slug]
+                self.assertIn("tool_mode", model)
+                self.assertIsNone(model["tool_mode"])
+                self.assertIn("multi_agent_version", model)
+                self.assertIsNone(model["multi_agent_version"])
+                self.assertIs(model["prefer_websockets"], True)
+                self.assertIs(model["use_responses_lite"], False)
+
+        for slug in ("gpt-5.3-codex-spark", "gpt-sparse"):
+            with self.subTest(slug=slug):
+                model = by_slug[slug]
+                self.assertIs(model["use_responses_lite"], False)
+                self.assertNotIn("prefer_websockets", model)
+                self.assertNotIn("tool_mode", model)
+                self.assertNotIn("multi_agent_version", model)
 
     def test_minimal_official_catalog_uses_pinned_planner_metadata(self):
         policy = CatalogPolicy(
@@ -361,6 +388,10 @@ class CatalogSyncTests(unittest.TestCase):
                 "gpt-5.6-terra",
                 "gpt-5.6-luna",
                 "gpt-5.5",
+                "gpt-5.4",
+                "gpt-5.4-mini",
+                "gpt-5.3-codex-spark",
+                "gpt-sparse",
             ),
             allowed_ollama_cloud_models=(),
         )
@@ -374,6 +405,18 @@ class CatalogSyncTests(unittest.TestCase):
         self.assertIs(by_slug["gpt-5.5"]["use_responses_lite"], False)
         self.assertIsNone(by_slug["gpt-5.5"]["tool_mode"])
         self.assertIsNone(by_slug["gpt-5.5"]["multi_agent_version"])
+        for slug in ("gpt-5.4", "gpt-5.4-mini"):
+            with self.subTest(slug=slug):
+                self.assertIs(by_slug[slug]["use_responses_lite"], False)
+                self.assertIs(by_slug[slug]["prefer_websockets"], True)
+                self.assertIsNone(by_slug[slug]["tool_mode"])
+                self.assertIsNone(by_slug[slug]["multi_agent_version"])
+        for slug in ("gpt-5.3-codex-spark", "gpt-sparse"):
+            with self.subTest(slug=slug):
+                self.assertIs(by_slug[slug]["use_responses_lite"], False)
+                self.assertNotIn("prefer_websockets", by_slug[slug])
+                self.assertNotIn("tool_mode", by_slug[slug])
+                self.assertNotIn("multi_agent_version", by_slug[slug])
 
     def test_pinned_official_catalog_metadata_rejects_an_incomplete_model_set(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -535,8 +578,8 @@ class CatalogSyncTests(unittest.TestCase):
         catalog = build_codex_catalog([], [], policy, "0.142.0")
         by_slug = {model["slug"]: model for model in catalog["models"]}
 
-        self.assertEqual(by_slug["gpt-5.5"]["context_window"], 272000)
-        self.assertEqual(by_slug["gpt-5.5"]["max_context_window"], 272000)
+        self.assertEqual(by_slug["gpt-5.5"]["context_window"], 258400)
+        self.assertEqual(by_slug["gpt-5.5"]["max_context_window"], 258400)
         self.assertEqual(catalog_sync.OFFICIAL_MODEL_DEFAULTS["gpt-5.5-fast"]["context_window"], 258400)
         self.assertEqual(catalog_sync.OFFICIAL_MODEL_DEFAULTS["gpt-5.5-fast"]["max_context_window"], 258400)
         self.assertEqual(by_slug["gpt-5.5"]["additional_speed_tiers"], ["fast"])

--- a/tests/test_catalog_sync.py
+++ b/tests/test_catalog_sync.py
@@ -274,7 +274,7 @@ class CatalogSyncTests(unittest.TestCase):
                     {"effort": "ultra", "description": "Ultra"},
                 ],
                 "multi_agent_version": "v2",
-                "tool_mode": "native",
+                "tool_mode": "code_mode_only",
                 "model_messages": {"upgrade": "Use Sol"},
                 "skills_instructions": "Official skills contract",
                 "web_search_tool_type": "text",
@@ -282,7 +282,7 @@ class CatalogSyncTests(unittest.TestCase):
                 "availability": {"plan": "plus"},
                 "upgrade": "gpt-5.7-sol",
                 "upgrade_info": {"message": "Upgrade available"},
-                "comp_hash": "sol-compat-hash",
+                "comp_hash": "3000",
             }
         ]
 
@@ -307,6 +307,91 @@ class CatalogSyncTests(unittest.TestCase):
                 "upstream_model": "gpt-5.6-sol",
             },
         )
+
+    def test_official_catalog_backfills_pinned_planner_metadata_per_model(self):
+        official = [
+            {"slug": "gpt-5.6-sol", "display_name": "GPT-5.6-Sol"},
+            {"slug": "gpt-5.6-terra", "display_name": "GPT-5.6-Terra"},
+            {"slug": "gpt-5.6-luna", "display_name": "GPT-5.6-Luna"},
+            {
+                "slug": "gpt-5.5",
+                "display_name": "GPT-5.5",
+                "use_responses_lite": True,
+                "tool_mode": "code_mode_only",
+                "multi_agent_version": "v2",
+            },
+        ]
+
+        catalog = build_codex_catalog(official, [], self.policy, "0.144.0")
+        by_slug = {model["slug"]: model for model in catalog["models"]}
+
+        for slug, multi_agent_version in (
+            ("gpt-5.6-sol", "v2"),
+            ("gpt-5.6-terra", "v2"),
+            ("gpt-5.6-luna", "v1"),
+        ):
+            with self.subTest(slug=slug):
+                model = by_slug[slug]
+                self.assertEqual(model["tool_mode"], "code_mode_only")
+                self.assertEqual(model["multi_agent_version"], multi_agent_version)
+                self.assertIs(model["prefer_websockets"], True)
+                self.assertIs(model["use_responses_lite"], True)
+                self.assertEqual(model["comp_hash"], "3000")
+                self.assertIs(model["supports_search_tool"], True)
+
+        gpt_55 = by_slug["gpt-5.5"]
+        self.assertIn("tool_mode", gpt_55)
+        self.assertIsNone(gpt_55["tool_mode"])
+        self.assertIn("multi_agent_version", gpt_55)
+        self.assertIsNone(gpt_55["multi_agent_version"])
+        self.assertIs(gpt_55["prefer_websockets"], True)
+        self.assertIs(gpt_55["use_responses_lite"], False)
+        self.assertEqual(gpt_55["context_window"], 272000)
+        self.assertEqual(gpt_55["max_context_window"], 272000)
+        self.assertEqual(gpt_55["comp_hash"], "2911")
+        self.assertIs(gpt_55["supports_search_tool"], True)
+
+    def test_minimal_official_catalog_uses_pinned_planner_metadata(self):
+        policy = CatalogPolicy(
+            denied_models=set(),
+            denied_substrings=set(),
+            display_names={},
+            official_models=(
+                "gpt-5.6-sol",
+                "gpt-5.6-terra",
+                "gpt-5.6-luna",
+                "gpt-5.5",
+            ),
+            allowed_ollama_cloud_models=(),
+        )
+
+        catalog = build_codex_catalog([], [], policy, "0.144.0")
+        by_slug = {model["slug"]: model for model in catalog["models"]}
+
+        self.assertEqual(by_slug["gpt-5.6-sol"]["multi_agent_version"], "v2")
+        self.assertEqual(by_slug["gpt-5.6-terra"]["multi_agent_version"], "v2")
+        self.assertEqual(by_slug["gpt-5.6-luna"]["multi_agent_version"], "v1")
+        self.assertIs(by_slug["gpt-5.5"]["use_responses_lite"], False)
+        self.assertIsNone(by_slug["gpt-5.5"]["tool_mode"])
+        self.assertIsNone(by_slug["gpt-5.5"]["multi_agent_version"])
+
+    def test_pinned_official_catalog_metadata_rejects_an_incomplete_model_set(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "official-models.json"
+            path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "models": {
+                            "gpt-5.6-sol": {},
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ValueError, "incomplete model set"):
+                catalog_sync.load_pinned_official_catalog_metadata(path)
 
     def test_official_alias_duplicates_collapse_to_fresh_bare_record(self):
         official = [
@@ -450,8 +535,8 @@ class CatalogSyncTests(unittest.TestCase):
         catalog = build_codex_catalog([], [], policy, "0.142.0")
         by_slug = {model["slug"]: model for model in catalog["models"]}
 
-        self.assertEqual(by_slug["gpt-5.5"]["context_window"], 258400)
-        self.assertEqual(by_slug["gpt-5.5"]["max_context_window"], 258400)
+        self.assertEqual(by_slug["gpt-5.5"]["context_window"], 272000)
+        self.assertEqual(by_slug["gpt-5.5"]["max_context_window"], 272000)
         self.assertEqual(catalog_sync.OFFICIAL_MODEL_DEFAULTS["gpt-5.5-fast"]["context_window"], 258400)
         self.assertEqual(catalog_sync.OFFICIAL_MODEL_DEFAULTS["gpt-5.5-fast"]["max_context_window"], 258400)
         self.assertEqual(by_slug["gpt-5.5"]["additional_speed_tiers"], ["fast"])


### PR DESCRIPTION

## Scope

- Preserve the accepted seven-model official catalog matrix through the Rust subscription seed and Python generated catalog.
- `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna` retain `use_responses_lite=true`, `prefer_websockets=true`, `tool_mode=code_mode_only`, and exact V2/V2/V1 multi-agent metadata.
- `gpt-5.5`, `gpt-5.4`, and `gpt-5.4-mini` retain `use_responses_lite=false`, `prefer_websockets=true`, and intentionally null planner fields.
- `gpt-5.3-codex-spark`, sparse, and unknown Official entries fail safe to non-Lite and do not receive invented 5.6 planner fields. Explicit boolean opt-in values are preserved.
- This delta does not change context-window or compaction metadata; #124 remains out of scope.

## Evidence

- Red-before: the prior four-model fixture left 5.4/5.4-mini on a 5.6 planner shape and left Spark/sparse entries Lite-enabled.
- Focused Python catalog projection: `45 passed`, `17 subtests passed`.
- Focused Rust projection test was attempted but this Worker image has no `cargo`; CI is the Rust verification authority for this delta.
- PR CI passed: Python, frontend, Release flavor contract, Rust clippy, Rust normal tests, and Rust debug tests.
- `git diff --check` passed.
- The prior candidate full suite remains the single recorded full-suite run and was not rerun for this review delta.

## Remaining #106 gate

After merge and a new Debug build, the Orchestrator will run the seven-model CLI matrix plus Desktop Code Mode discovery, native `list_threads`, and one native `send_message_to_thread` callback. Those manual behavior gates remain outstanding.

## Boundaries

No Gateway transport/retry/SSE, Task state/database, credentials, routing, shared Desktop configuration, or #124 context-window/compaction work changed.

Refs #106
