### PR TITLE
fix: semantic Provider dirty detection for reverted edits (#84)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
     "dev": "vite --host 127.0.0.1",
     "build": "tsc && vite build",
     "test:ui-contract": "node --test scripts/ui-contract.test.mjs",
+    "test:provider-comparison": "node --test scripts/provider-comparison.test.mjs",
     "preview": "vite preview --host 127.0.0.1"
   },
   "dependencies": {

--- a/frontend/scripts/provider-comparison.test.mjs
+++ b/frontend/scripts/provider-comparison.test.mjs
@@ -1,0 +1,190 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { readFile } from "node:fs/promises";
+import ts from "typescript";
+
+const comparisonPath = new URL("../src/lib/providerComparison.ts", import.meta.url);
+const endpointPath = new URL("../src/lib/providerEndpoint.ts", import.meta.url);
+const modelPath = new URL("../src/lib/providerModel.ts", import.meta.url);
+const typesPath = new URL("../src/lib/types.ts", import.meta.url);
+
+const [comparisonSource, endpointSource, modelSource, typesSource] = await Promise.all([
+  readFile(comparisonPath, "utf8"),
+  readFile(endpointPath, "utf8"),
+  readFile(modelPath, "utf8"),
+  readFile(typesPath, "utf8"),
+]);
+
+// Strip imports and exports, then combine all sources for evaluation.
+// providerEndpoint imports i18n and tauri at runtime but none of those
+// functions are called during comparison - only normalizeProviderEndpointSelection
+// and normalizeModel are invoked, which are pure and dependency-free.
+// Strip ALL import lines (including type imports and multi-line) from every source.
+function stripImports(source) {
+  return source.replace(/^\s*import[\s\S]*?;\s*$/gm, "");
+}
+
+const combinedSource = [
+  typesSource
+    .replace(/export (interface|type) /g, "declare $1 ")
+    .replace(/export function/g, "function"),
+  stripImports(endpointSource)
+    .replace(/export function/g, "function")
+    .replace(/export \{[^}]+\}/g, ""),
+  stripImports(modelSource)
+    .replace(/export function/g, "function"),
+  stripImports(comparisonSource)
+    .replace(/export function/g, "function")
+    .replace(/export \{[^}]+\}/g, ""),
+].join("\n\n");
+
+const jsOutput = ts.transpileModule(combinedSource, {
+  compilerOptions: {
+    module: ts.ModuleKind.CommonJS,
+    target: ts.ScriptTarget.ES2022,
+    strict: false,
+  },
+}).outputText;
+
+const moduleExports = {};
+// Provide a mock require for any residual dependencies (none are called
+// during comparison — normalizeProviderEndpointSelection and normalizeModel
+// are pure and dependency-free).
+const mockRequire = () => ({ t: () => "" });
+const wrappedModule = new Function(
+  "exports",
+  "require",
+  jsOutput + "\nexports.normalizeProviderForComparison = normalizeProviderForComparison; exports.isProviderDirty = isProviderDirty;",
+);
+wrappedModule(moduleExports, mockRequire);
+const { isProviderDirty, normalizeProviderForComparison } = moduleExports;
+
+function makeModel(overrides = {}) {
+  return {
+    id: "model-a",
+    display_name: "Model A",
+    upstream_model: "model-a",
+    enabled: true,
+    context_window: null,
+    input_modalities: ["text"],
+    supported_reasoning_levels: [],
+    default_reasoning_level: null,
+    ...overrides,
+  };
+}
+
+function makeProvider(overrides = {}) {
+  return {
+    id: "prov-1",
+    name: "Test Provider",
+    base_url: "https://example.com",
+    api_key: null,
+    upstream_format: "responses",
+    available_upstream_formats: [],
+    tool_protocol: "auto",
+    enabled: true,
+    models: [makeModel()],
+    ...overrides,
+  };
+}
+
+test("toggle revert: disabling then re-enabling a model does not produce dirty state", () => {
+  const baseline = makeProvider();
+  const draftDisabled = makeProvider({
+    models: [makeModel({ enabled: false })],
+  });
+  const draftReverted = makeProvider({
+    models: [makeModel({ enabled: true })],
+  });
+  assert.ok(isProviderDirty(baseline, draftDisabled), "disabling a model should be dirty");
+  assert.ok(!isProviderDirty(baseline, draftReverted), "re-enabling the model should not be dirty");
+});
+
+test("text-field revert: changing and restoring display_name does not produce dirty state", () => {
+  const baseline = makeProvider();
+  const draftChanged = makeProvider({
+    models: [makeModel({ display_name: "Changed" })],
+  });
+  const draftReverted = makeProvider({
+    models: [makeModel({ display_name: "Model A" })],
+  });
+  assert.ok(isProviderDirty(baseline, draftChanged), "changing display_name should be dirty");
+  assert.ok(!isProviderDirty(baseline, draftReverted), "restoring display_name should not be dirty");
+});
+
+test("optional/default fields: omitted fields equal their persisted default equivalents", () => {
+  const baselineWithOmitted = {
+    id: "prov-1",
+    name: "Test Provider",
+    base_url: "https://example.com",
+    enabled: true,
+    models: [{
+      id: "model-a",
+      display_name: "Model A",
+      upstream_model: "model-a",
+      enabled: true,
+    }],
+  };
+  const draftWithDefaults = {
+    id: "prov-1",
+    name: "Test Provider",
+    base_url: "https://example.com",
+    enabled: true,
+    models: [{
+      id: "model-a",
+      display_name: "Model A",
+      upstream_model: "model-a",
+      enabled: true,
+      context_window: null,
+      input_modalities: ["text"],
+      supported_reasoning_levels: [],
+      default_reasoning_level: null,
+    }],
+  };
+  assert.ok(
+    !isProviderDirty(baselineWithOmitted, draftWithDefaults),
+    "omitted optional fields should equal their normalized defaults",
+  );
+});
+
+test("meaningful reorder: swapping model order produces dirty state", () => {
+  const baseline = makeProvider({
+    models: [makeModel({ id: "a", display_name: "A" }), makeModel({ id: "b", display_name: "B" })],
+  });
+  const draftReordered = makeProvider({
+    models: [makeModel({ id: "b", display_name: "B" }), makeModel({ id: "a", display_name: "A" })],
+  });
+  assert.ok(isProviderDirty(baseline, draftReordered), "reordering models should be dirty");
+});
+
+test("normalizeProviderForComparison normalizes nested models", () => {
+  const provider = {
+    id: "prov-1",
+    name: "Test Provider",
+    base_url: "https://example.com",
+    enabled: true,
+    models: [{
+      id: "model-a",
+      enabled: true,
+    }],
+  };
+  const normalized = normalizeProviderForComparison(provider);
+  assert.equal(normalized.models[0].context_window, null);
+  assert.deepEqual(normalized.models[0].input_modalities, ["text"]);
+  assert.deepEqual(normalized.models[0].supported_reasoning_levels, []);
+  assert.equal(normalized.models[0].default_reasoning_level, null);
+  assert.equal(normalized.upstream_format, "responses");
+  assert.equal(normalized.tool_protocol, "auto");
+});
+
+test("provider-level field changes are dirty", () => {
+  const baseline = makeProvider();
+  const draft = makeProvider({ name: "Changed Name" });
+  assert.ok(isProviderDirty(baseline, draft), "changing provider name should be dirty");
+});
+
+test("null vs undefined api_key are equal", () => {
+  const baseline = makeProvider({ api_key: undefined });
+  const draft = makeProvider({ api_key: null });
+  assert.ok(!isProviderDirty(baseline, draft), "undefined and null api_key should be equal");
+});

--- a/frontend/scripts/provider-comparison.test.mjs
+++ b/frontend/scripts/provider-comparison.test.mjs
@@ -147,12 +147,100 @@ test("optional/default fields: omitted fields equal their persisted default equi
   );
 });
 
-test("meaningful reorder: swapping model order produces dirty state", () => {
+test("semantic comparison ignores key insertion order at every object depth", () => {
+  const baseline = {
+    id: "prov-1",
+    name: "Test Provider",
+    base_url: "https://example.com",
+    enabled: true,
+    models: [{
+      id: "model-a",
+      display_name: "Model A",
+      upstream_model: "model-a",
+      enabled: true,
+      pricing: {
+        input_per_million: 1,
+        cached_input_per_million: 0.5,
+        output_per_million: 2,
+        currency: "USD",
+        source: "catalog",
+        estimate: false,
+      },
+      metadata_provenance: {
+        source: "catalog",
+        source_url: "https://example.com/catalog",
+        fetched_at: "2026-07-14T00:00:00Z",
+        confidence: "high",
+      },
+    }],
+  };
+  const draft = {
+    models: [{
+      metadata_provenance: {
+        confidence: "high",
+        fetched_at: "2026-07-14T00:00:00Z",
+        source_url: "https://example.com/catalog",
+        source: "catalog",
+      },
+      pricing: {
+        estimate: false,
+        source: "catalog",
+        currency: "USD",
+        output_per_million: 2,
+        cached_input_per_million: 0.5,
+        input_per_million: 1,
+      },
+      enabled: true,
+      upstream_model: "model-a",
+      display_name: "Model A",
+      id: "model-a",
+    }],
+    enabled: true,
+    base_url: "https://example.com",
+    name: "Test Provider",
+    id: "prov-1",
+  };
+  assert.ok(!isProviderDirty(baseline, draft), "key insertion order should not produce dirty state");
+});
+
+test("omitted model codex and Gateway flags equal their persisted true defaults", () => {
   const baseline = makeProvider({
-    models: [makeModel({ id: "a", display_name: "A" }), makeModel({ id: "b", display_name: "B" })],
+    models: [makeModel({ codex_enabled: undefined, gateway_exported: undefined })],
+  });
+  const draft = makeProvider({
+    models: [makeModel({ codex_enabled: true, gateway_exported: true })],
+  });
+  assert.ok(!isProviderDirty(baseline, draft), "omitted persisted-true flags should compare equal to true");
+});
+
+test("restoring visible model order ignores redundant sort_order metadata", () => {
+  const baseline = makeProvider({
+    models: [
+      makeModel({ id: "a", display_name: "A", sort_order: null }),
+      makeModel({ id: "b", display_name: "B" }),
+    ],
+  });
+  const draftRestored = makeProvider({
+    models: [
+      makeModel({ id: "a", display_name: "A", sort_order: 1 }),
+      makeModel({ id: "b", display_name: "B", sort_order: 2 }),
+    ],
+  });
+  assert.ok(!isProviderDirty(baseline, draftRestored), "redundant sequential sort_order should not be dirty");
+});
+
+test("actual model reorder remains dirty after sort_order canonicalization", () => {
+  const baseline = makeProvider({
+    models: [
+      makeModel({ id: "a", display_name: "A", sort_order: null }),
+      makeModel({ id: "b", display_name: "B" }),
+    ],
   });
   const draftReordered = makeProvider({
-    models: [makeModel({ id: "b", display_name: "B" }), makeModel({ id: "a", display_name: "A" })],
+    models: [
+      makeModel({ id: "b", display_name: "B", sort_order: 1 }),
+      makeModel({ id: "a", display_name: "A", sort_order: 2 }),
+    ],
   });
   assert.ok(isProviderDirty(baseline, draftReordered), "reordering models should be dirty");
 });

--- a/frontend/scripts/ui-contract.test.mjs
+++ b/frontend/scripts/ui-contract.test.mjs
@@ -1850,8 +1850,9 @@ test("provider endpoint probe persists detected formats and selects the recommen
   assert.match(catalogActionsSource, /const saved = await api\.saveProviders\(nextProviders\);/);
   assert.match(catalogActionsSource, /updateToast\(toastId, \{[\s\S]*providers\.probeCompleted/);
   assert.match(providerDetail, /const normalizedProvider = useMemo\(\(\) => normalizeProviderEndpointSelection\(provider\), \[provider\]\);/);
-  assert.match(providerDetail, /const dirty = JSON\.stringify\(draft\) !== JSON\.stringify\(normalizedProvider\);/);
-  assert.doesNotMatch(providerDetail, /const dirty = JSON\.stringify\(draft\) !== JSON\.stringify\(provider\);/);
+  assert.match(providerDetail, /const dirty = isProviderDirty\(normalizedProvider, draft\);/);
+  assert.doesNotMatch(providerDetail, /JSON\.stringify\(draft\)/);
+  assert.match(providerEditorSource, /import \{ isProviderDirty \} from "\.\.\/\.\.\/lib\/providerComparison";/);
   assert.match(providerDetail, /setDraft\(\(current\) => applyProviderProbeResult\(current, result\)\);/);
   assert.match(providerDetail, /current\.id === provider\.id[\s\S]*available_upstream_formats: availableFormats/);
   assert.doesNotMatch(providerDetail, /const upstreamFormat = normalizedEndpointFormat\(provider\.upstream_format\);/);

--- a/frontend/src/components/providers/ProviderEditor.tsx
+++ b/frontend/src/components/providers/ProviderEditor.tsx
@@ -19,6 +19,7 @@ import {
 } from "../../lib/providerEndpoint";
 import { endpointSelectionOptions, type AddProviderForm, type InlineTestState } from "../../lib/providerForm";
 import { normalizeModel } from "../../lib/providerModel";
+import { isProviderDirty } from "../../lib/providerComparison";
 import { cx, displayModel, renumberModels } from "../../lib/format";
 import { api, messageFromError } from "../../lib/tauri";
 import type { Model, Provider, ToolProtocol, UpstreamFormat, UpstreamFormatProbeResult } from "../../lib/types";
@@ -53,7 +54,7 @@ export function ProviderDetail({
   const normalizedProvider = useMemo(() => normalizeProviderEndpointSelection(provider), [provider]);
   const [draft, setDraft] = useState(() => normalizedProvider);
   const [endpointTestState, setEndpointTestState] = useState<InlineTestState>("idle");
-  const dirty = JSON.stringify(draft) !== JSON.stringify(normalizedProvider);
+  const dirty = isProviderDirty(normalizedProvider, draft);
 
   useEffect(() => {
     setDraft(normalizedProvider);

--- a/frontend/src/lib/providerComparison.ts
+++ b/frontend/src/lib/providerComparison.ts
@@ -1,0 +1,60 @@
+import type { Model, Provider } from "./types";
+import { normalizeProviderEndpointSelection } from "./providerEndpoint";
+import { normalizeModel } from "./providerModel";
+
+/**
+ * Normalize a Provider for semantic comparison. Both the persisted baseline
+ * and the working draft pass through this boundary so that omitted fields and
+ * their persisted default equivalents compare as equal. Model array ordering
+ * is preserved because it carries priority.
+ */
+export function normalizeProviderForComparison(provider: Provider): Provider {
+  const endpointNormalized = normalizeProviderEndpointSelection(provider);
+  return {
+    ...endpointNormalized,
+    api_key: endpointNormalized.api_key ?? null,
+    tool_surface_strategy: endpointNormalized.tool_surface_strategy ?? null,
+    reports_cached_input_tokens: endpointNormalized.reports_cached_input_tokens ?? null,
+    display_prefix: endpointNormalized.display_prefix ?? null,
+    sort_order: endpointNormalized.sort_order ?? null,
+    locked: endpointNormalized.locked ?? false,
+    models: endpointNormalized.models.map(normalizeModelForComparison),
+  };
+}
+
+/**
+ * Returns true when the draft has a material, persistable configuration
+ * difference from the persisted baseline. Omitted fields, default
+ * equivalents, and normalization side-effects do not produce dirty state.
+ * Model ordering is meaningful and a reorder does produce dirty state.
+ */
+export function isProviderDirty(baseline: Provider, draft: Provider): boolean {
+  return serializeProvider(baseline) !== serializeProvider(draft);
+}
+
+function normalizeModelForComparison(model: Model): Model {
+  const normalized = normalizeModel(model);
+  return {
+    ...normalized,
+    display_name: normalized.display_name ?? null,
+    upstream_model: normalized.upstream_model ?? null,
+    tool_surface_strategy: normalized.tool_surface_strategy ?? null,
+    source_kind: normalized.source_kind ?? null,
+    locked: normalized.locked ?? false,
+    codex_enabled: normalized.codex_enabled ?? false,
+    gateway_exported: normalized.gateway_exported ?? false,
+    max_context_window: normalized.max_context_window ?? null,
+    effective_source: normalized.effective_source ?? null,
+    max_source: normalized.max_source ?? null,
+    confidence: normalized.confidence ?? null,
+    verified_at: normalized.verified_at ?? null,
+    max_output_tokens: normalized.max_output_tokens ?? null,
+    sort_order: normalized.sort_order ?? null,
+    pricing: normalized.pricing ?? null,
+    metadata_provenance: normalized.metadata_provenance ?? null,
+  };
+}
+
+function serializeProvider(provider: Provider): string {
+  return JSON.stringify(normalizeProviderForComparison(provider));
+}

--- a/frontend/src/lib/providerComparison.ts
+++ b/frontend/src/lib/providerComparison.ts
@@ -18,7 +18,7 @@ export function normalizeProviderForComparison(provider: Provider): Provider {
     display_prefix: endpointNormalized.display_prefix ?? null,
     sort_order: endpointNormalized.sort_order ?? null,
     locked: endpointNormalized.locked ?? false,
-    models: endpointNormalized.models.map(normalizeModelForComparison),
+    models: endpointNormalized.models.map((model, index) => normalizeModelForComparison(model, index)),
   };
 }
 
@@ -32,7 +32,7 @@ export function isProviderDirty(baseline: Provider, draft: Provider): boolean {
   return serializeProvider(baseline) !== serializeProvider(draft);
 }
 
-function normalizeModelForComparison(model: Model): Model {
+function normalizeModelForComparison(model: Model, index: number): Model {
   const normalized = normalizeModel(model);
   return {
     ...normalized,
@@ -41,20 +41,44 @@ function normalizeModelForComparison(model: Model): Model {
     tool_surface_strategy: normalized.tool_surface_strategy ?? null,
     source_kind: normalized.source_kind ?? null,
     locked: normalized.locked ?? false,
-    codex_enabled: normalized.codex_enabled ?? false,
-    gateway_exported: normalized.gateway_exported ?? false,
+    codex_enabled: normalized.codex_enabled ?? true,
+    gateway_exported: normalized.gateway_exported ?? true,
     max_context_window: normalized.max_context_window ?? null,
     effective_source: normalized.effective_source ?? null,
     max_source: normalized.max_source ?? null,
     confidence: normalized.confidence ?? null,
     verified_at: normalized.verified_at ?? null,
     max_output_tokens: normalized.max_output_tokens ?? null,
-    sort_order: normalized.sort_order ?? null,
+    sort_order: index + 1,
     pricing: normalized.pricing ?? null,
     metadata_provenance: normalized.metadata_provenance ?? null,
   };
 }
 
 function serializeProvider(provider: Provider): string {
-  return JSON.stringify(normalizeProviderForComparison(provider));
+  return JSON.stringify(canonicalizeForSerialization(normalizeProviderForComparison(provider)));
+}
+
+/**
+ * JSON stringification preserves insertion order for object keys. Canonicalize
+ * every object before comparison so equivalent persisted data has one stable
+ * representation, while keeping array order because model priority is meaningful.
+ */
+function canonicalizeForSerialization(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => item === undefined ? null : canonicalizeForSerialization(item));
+  }
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+
+  const source = value as Record<string, unknown>;
+  const canonical: Record<string, unknown> = {};
+  for (const key of Object.keys(source).sort()) {
+    const nestedValue = source[key];
+    if (nestedValue !== undefined) {
+      canonical[key] = canonicalizeForSerialization(nestedValue);
+    }
+  }
+  return canonical;
 }


### PR DESCRIPTION
## Semantic Provider dirty detection (#84)

### Problem

Provider dirty state compared raw object representations. Reverting a visible edit could leave normalized defaults or reordered object keys in the draft, keeping Save enabled and incorrectly triggering the unsaved-changes navigation dialog.

### Solution

- Add one canonical Provider comparison boundary used by Save/navigation dirty state.
- Normalize persisted baseline and draft, including nested models.
- Canonicalize object-key order recursively while preserving model array order.
- Treat omitted model defaults as their persisted equivalents, including `codex_enabled=true` and `gateway_exported=true`.
- Ignore redundant sequential `sort_order` metadata while retaining actual model reorder differences.

### Changes

- `frontend/src/lib/providerComparison.ts`: semantic normalization and stable serialization.
- `frontend/src/components/providers/ProviderEditor.tsx`: use the canonical dirty-state boundary.
- `frontend/scripts/provider-comparison.test.mjs`: ten regressions covering visible reverts, defaults, key order, restored sort metadata, and real reorder.
- `frontend/scripts/ui-contract.test.mjs` and `frontend/package.json`: comparison contract wiring.

### Verification

- Provider comparison: 10/10 passed.
- UI contract: 132/132 passed.
- Frontend build: passed.
- `git diff --check`: passed.
- Report-only quality gate: passed without a new blocking finding.
- GitHub CI: Python, frontend/UI, Rust normal, Rust debug, Clippy, and release flavor all passed.

### Non-goals

Provider persistence schema, model-priority semantics, Gateway/routing/protocol behavior, and unrelated settings UI.

Closes #84