### PR TITLE
diagnostics: retain Official lease disposition on reset

### DIFF
--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -141,6 +141,30 @@ OFFICIAL_TCP_KEEPALIVE_IDLE_MS = 5000
 OFFICIAL_TCP_KEEPALIVE_INTERVAL_MS = 5000
 OFFICIAL_HTTP_POOLS: dict[str, Any] = {}
 OFFICIAL_HTTP_POOLS_LOCK = threading.Lock()
+_OFFICIAL_ATTEMPT_CONNECTION_STATE = threading.local()
+
+
+def _reset_official_attempt_connection_disposition() -> None:
+    """Clear the per-thread lease label before a new Official pool request."""
+
+    _OFFICIAL_ATTEMPT_CONNECTION_STATE.disposition = "unobserved"
+
+
+def _set_official_attempt_connection_disposition(disposition: str) -> None:
+    if disposition in {"new", "reused"}:
+        _OFFICIAL_ATTEMPT_CONNECTION_STATE.disposition = disposition
+
+
+def _official_attempt_connection_disposition() -> str:
+    disposition = getattr(_OFFICIAL_ATTEMPT_CONNECTION_STATE, "disposition", "unobserved")
+    return disposition if disposition in {"new", "reused"} else "unobserved"
+
+
+def _clear_official_attempt_connection_disposition() -> None:
+    try:
+        del _OFFICIAL_ATTEMPT_CONNECTION_STATE.disposition
+    except AttributeError:
+        pass
 
 
 def _official_socket_options() -> list[tuple[int, int, int]]:
@@ -198,6 +222,7 @@ class _OfficialHTTPSConnectionPool(urllib3.connectionpool.HTTPSConnectionPool):
             connection._codexhub_diagnostic_connection_disposition = disposition
         except Exception:
             pass
+        _set_official_attempt_connection_disposition(disposition)
         return connection
 
     def _put_conn(self, connection: Any) -> None:
@@ -371,6 +396,7 @@ def _stdlib_transport_error(exc: BaseException) -> BaseException:
 def _official_urlopen(request: Request, *, timeout: float) -> Any:
     manager = _official_pool_manager(request.full_url)
     headers = {key: value for key, value in request.header_items() if key.lower() != "connection"}
+    _reset_official_attempt_connection_disposition()
     try:
         response = manager.request(
             request.get_method(),
@@ -386,7 +412,15 @@ def _official_urlopen(request: Request, *, timeout: float) -> Any:
         )
     except urllib3.exceptions.HTTPError as exc:
         translated = _stdlib_transport_error(exc)
+        disposition = _official_attempt_connection_disposition()
+        if disposition != "unobserved":
+            try:
+                setattr(translated, "_codexhub_diagnostic_connection_disposition", disposition)
+            except Exception:
+                pass
         raise translated from exc
+    finally:
+        _clear_official_attempt_connection_disposition()
 
     pooled_response = _OfficialPooledResponse(response)
     if response.status >= 400:
@@ -1441,6 +1475,16 @@ def _diagnostic_response_metadata(response: Any) -> tuple[Any, Any]:
 def _diagnostic_connection_disposition(response: Any) -> str:
     try:
         disposition = getattr(response, "connection_disposition", "unobserved")
+    except Exception:
+        return "unobserved"
+    return disposition if disposition in {"new", "reused"} else "unobserved"
+
+
+def _diagnostic_error_connection_disposition(exc: BaseException) -> str:
+    """Read only the safe lease label attached to an Official transport error."""
+
+    try:
+        disposition = getattr(exc, "_codexhub_diagnostic_connection_disposition", "unobserved")
     except Exception:
         return "unobserved"
     return disposition if disposition in {"new", "reused"} else "unobserved"
@@ -10844,6 +10888,7 @@ def _open_upstream_response(
             return response
         except (HTTPError, IncompleteRead, OSError, URLError) as exc:
             elapsed_ms = int(max(0.0, time.monotonic() - attempt_started_at) * 1000)
+            connection_disposition = _diagnostic_error_connection_disposition(exc)
             try:
                 failure_phase = transport_failure_phase(exc)
             except Exception:
@@ -10871,7 +10916,7 @@ def _open_upstream_response(
                     elapsed_ms=elapsed_ms,
                     outcome="error",
                     failure_phase=failure_phase,
-                    connection_disposition="unobserved",
+                    connection_disposition=connection_disposition,
                     provider=upstream_name,
                     model=diagnostic_model,
                 )
@@ -10891,7 +10936,7 @@ def _open_upstream_response(
                 elapsed_ms=elapsed_ms,
                 outcome="error",
                 failure_phase=failure_phase,
-                connection_disposition="unobserved",
+                connection_disposition=connection_disposition,
                 provider=upstream_name,
                 model=diagnostic_model,
             )

--- a/tests/test_official_proxy_path_localization.py
+++ b/tests/test_official_proxy_path_localization.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+import tempfile
+from unittest import TestCase
+from unittest.mock import patch
+from urllib.request import Request
+
+import codex_proxy
+import diagnostic_recorder
+
+
+class _Connection:
+    def __init__(self) -> None:
+        self.sock = object()
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _ResettingProxyManager:
+    def __init__(self, pool: object) -> None:
+        self._pool = pool
+        self.calls = 0
+
+    def request(self, *_args: object, **_kwargs: object) -> object:
+        self.calls += 1
+        self._pool._get_conn()
+        raise codex_proxy.urllib3.exceptions.ProtocolError(
+            "fixture proxy reset",
+            ConnectionResetError("fixture proxy reset"),
+        )
+
+
+class _RouteManager:
+    def __init__(self) -> None:
+        self.pool_classes_by_scheme: dict[str, object] = {}
+
+
+class _StreamBodyResetResponse:
+    status = 200
+    headers = {"Content-Type": "text/event-stream"}
+
+    def __init__(self) -> None:
+        self._line_sent = False
+
+    def readline(self) -> bytes:
+        if not self._line_sent:
+            self._line_sent = True
+            return b"data: {}\n\n"
+        raise ConnectionResetError("fixture proxy reset")
+
+
+class OfficialProxyPathLocalizationTests(TestCase):
+    def _rolling_records(self, root: Path) -> list[dict[str, object]]:
+        rolling = root / "diagnostics" / "rolling"
+        return [
+            json.loads(line)
+            for path in rolling.glob("*.jsonl")
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if line
+        ]
+
+    def test_proxy_reset_before_headers_retains_connection_disposition(self) -> None:
+        """A pre-header proxy reset retains whether its pool lease was fresh or reused."""
+
+        for released_at, expected in ((None, "new"), (99.0, "reused")):
+            with self.subTest(expected=expected):
+                root = Path(self.enterContext(tempfile.TemporaryDirectory()))
+                recorder = diagnostic_recorder.DiagnosticRecorder(root)
+                self.addCleanup(recorder.shutdown, 1)
+                request = Request("https://example.test/v1/responses", data=b"{}", method="POST")
+                pool = object.__new__(codex_proxy._OfficialHTTPSConnectionPool)
+                pool.proxy = object()
+                connection = _Connection()
+                if released_at is not None:
+                    connection._codexhub_released_at = released_at
+                manager = _ResettingProxyManager(pool)
+
+                with (
+                    patch.object(
+                        codex_proxy.urllib3.connectionpool.HTTPSConnectionPool,
+                        "_get_conn",
+                        return_value=connection,
+                    ),
+                    patch("codex_proxy.time.monotonic", return_value=100.0),
+                    patch("codex_proxy._official_pool_manager", return_value=manager),
+                    patch.object(codex_proxy, "GATEWAY_DIAGNOSTIC_RECORDER", recorder),
+                ):
+                    with self.assertRaises(ConnectionResetError):
+                        codex_proxy._open_upstream_response(
+                            request,
+                            upstream_name="official",
+                            upstream_format="responses",
+                            timeout=1,
+                            event_context={"request_id": "private-request", "model": "openai/gpt-5.6-terra"},
+                            max_attempts=1,
+                        )
+
+                self.assertTrue(recorder.flush(3))
+                records = self._rolling_records(root)
+                kinds = [record["kind"] for record in records]
+                attempts = [record for record in records if record["kind"] == "upstream_attempt"]
+
+                self.assertNotIn("upstream_headers", kinds)
+                self.assertEqual(len(attempts), 1)
+                self.assertEqual(attempts[0]["connection_disposition"], expected)
+                self.assertNotIn("private-request", json.dumps(records))
+
+    def test_pre_header_proxy_reset_respects_the_fixed_gateway_retry_budget(self) -> None:
+        request = Request("https://example.test/v1/responses", data=b"{}", method="POST")
+        pool = object.__new__(codex_proxy._OfficialHTTPSConnectionPool)
+        pool.proxy = object()
+        connection = _Connection()
+        manager = _ResettingProxyManager(pool)
+
+        with (
+            patch.object(
+                codex_proxy.urllib3.connectionpool.HTTPSConnectionPool,
+                "_get_conn",
+                return_value=connection,
+            ),
+            patch("codex_proxy._official_pool_manager", return_value=manager),
+            patch("codex_proxy.time.sleep") as sleep,
+            patch("codex_proxy.write_proxy_event") as write_event,
+        ):
+            with self.assertRaises(ConnectionResetError):
+                codex_proxy._open_upstream_response(
+                    request,
+                    upstream_name="official",
+                    upstream_format="responses",
+                    timeout=1,
+                    event_context={"request_id": "private-request"},
+                    max_attempts=3,
+                )
+
+        retries = [call for call in write_event.call_args_list if call.args and call.args[0] == "upstream_retry"]
+        self.assertEqual(manager.calls, 3)
+        self.assertEqual(len(retries), 2)
+        self.assertEqual(sleep.call_count, 2)
+
+    def test_official_proxy_selection_distinguishes_bypass_explicit_and_registry_routes(self) -> None:
+        target = "https://example.test/v1/responses"
+        explicit_proxy = "http://explicit-proxy.invalid"
+        registry_proxy = "http://registry-proxy.invalid"
+
+        with (
+            patch("codex_proxy.sys.platform", "win32"),
+            patch("codex_proxy.getproxies", return_value={"https": explicit_proxy}),
+            patch("codex_proxy.getproxies_registry") as registry,
+            patch("codex_proxy.proxy_bypass", return_value=True),
+        ):
+            self.assertIsNone(codex_proxy._official_proxy_url(target))
+        registry.assert_not_called()
+
+        with (
+            patch("codex_proxy.sys.platform", "win32"),
+            patch("codex_proxy.getproxies", return_value={"https": explicit_proxy}),
+            patch("codex_proxy.getproxies_registry") as registry,
+            patch("codex_proxy.proxy_bypass", return_value=False),
+        ):
+            self.assertEqual(codex_proxy._official_proxy_url(target), explicit_proxy)
+        registry.assert_not_called()
+
+        with (
+            patch("codex_proxy.sys.platform", "win32"),
+            patch("codex_proxy.getproxies", return_value={"no": "localhost"}),
+            patch("codex_proxy.getproxies_registry", return_value={"https": registry_proxy}),
+            patch("codex_proxy.proxy_bypass", return_value=False),
+        ):
+            self.assertEqual(codex_proxy._official_proxy_url(target), registry_proxy)
+
+    def test_direct_and_registry_derived_routes_use_separate_pool_managers(self) -> None:
+        direct_manager = _RouteManager()
+        proxy_manager = _RouteManager()
+        with (
+            patch.object(codex_proxy, "OFFICIAL_HTTP_POOLS", {}),
+            patch(
+                "codex_proxy._official_proxy_url",
+                side_effect=[None, "http://registry-proxy.invalid"],
+            ),
+            patch("codex_proxy.urllib3.ProxyManager", return_value=proxy_manager) as make_proxy_manager,
+            patch("codex_proxy.urllib3.PoolManager", return_value=direct_manager) as make_direct_manager,
+        ):
+            direct = codex_proxy._official_pool_manager("https://example.test/v1/responses")
+            proxied = codex_proxy._official_pool_manager("https://example.test/v1/responses")
+
+        self.assertIs(direct, direct_manager)
+        self.assertIs(proxied, proxy_manager)
+        self.assertIsNot(direct, proxied)
+        make_proxy_manager.assert_called_once()
+        make_direct_manager.assert_called_once()
+        self.assertIs(proxy_manager.pool_classes_by_scheme["https"], codex_proxy._OfficialHTTPSConnectionPool)
+        self.assertIs(direct_manager.pool_classes_by_scheme["https"], codex_proxy._OfficialHTTPSConnectionPool)
+
+    def test_proxy_reset_during_stream_body_is_ordered_after_headers_and_never_retried(self) -> None:
+        root = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        recorder = diagnostic_recorder.DiagnosticRecorder(root)
+        self.addCleanup(recorder.shutdown, 1)
+        response = _StreamBodyResetResponse()
+        handler = object.__new__(codex_proxy.CodexProxyHandler)
+        handler.close_connection = False
+        handler.send_response = lambda _status: None
+        handler.send_header = lambda _key, _value: None
+        handler.end_headers = lambda: None
+        handler.wfile = io.BytesIO()
+        recorder.observe_upstream_headers("private-request", status=200, headers=response.headers)
+
+        with patch.object(codex_proxy, "GATEWAY_DIAGNOSTIC_RECORDER", recorder):
+            status = handler._relay_official_passthrough_sse_response(
+                response,
+                "official",
+                request_id="private-request",
+            )
+
+        self.assertTrue(recorder.flush(3))
+        records = self._rolling_records(root)
+        kinds = [record["kind"] for record in records]
+
+        self.assertEqual(status, 502)
+        self.assertTrue(handler.close_connection)
+        self.assertLess(kinds.index("upstream_headers"), kinds.index("sse_first"))
+        self.assertLess(kinds.index("sse_first"), kinds.index("upstream_close"))
+        self.assertNotIn("retry", kinds)
+        rendered = json.dumps(records)
+        self.assertNotIn("private-request", rendered)
+        self.assertNotIn("fixture proxy reset", rendered)


### PR DESCRIPTION
## Summary

Diagnostic-only replacement for superseded PR #128. Refs #114.

This branch cherry-picks only `f9d06bb834095f3b508d4400e34bdcc96ff526f7` onto current `dev`.

## Exact dev-facing scope

- `src-python/codex_proxy.py`
- `tests/test_official_proxy_path_localization.py`

The deterministic stable patch ID matches `f9d06bb`; no historical manual-capture, A/B, replay, evidence, routing, script, or documentation files are included.

The change preserves the sanitized `new`/`reused` Official pool-lease disposition across an upstream failure before response headers. It changes no proxy selection or precedence, pooling, retry, timeout, SSE relay, downstream, UI, or shared-system behavior.

## Classification boundary

The result remains a strong registry-derived proxy-route association only. It does not establish unsafe automatic-proxy precedence, pool reuse, retry budget, or CodexHub as the first physical reset.

## Preserved verification

- Targeted proxy-path tests: 18 passed, including 2 subtests.
- Full Python suite: 1,146 passed, 1 skipped, 264 subtests.
- Report-only quality gates completed with baseline findings only.
- Diff hygiene passed.

Replacement GitHub CI is authoritative. No local full-suite rerun or formal review was performed for this mechanical split.