### PR TITLE
fix: restore Official context budget cache authority

### DIFF
--- a/src-python/catalog_sync.py
+++ b/src-python/catalog_sync.py
@@ -32,6 +32,8 @@ from providers_config import (
 )
 from model_limits import (
     CURRENT_DIRECT_OFFICIAL_SOURCE,
+    DEGRADED_LAST_KNOWN_OFFICIAL_SOURCE,
+    FRESH_DIRECT_OFFICIAL_CACHE_AUTHORITY_SOURCE,
     OfficialContextBudget,
     apply_resolved_model_limits,
     load_resolved_model_limits,
@@ -54,6 +56,7 @@ def _runtime_codex_dir() -> Path:
 RUNTIME_CODEX_DIR = _runtime_codex_dir()
 BUNDLED_MODEL_CATALOG_DIR = REPO_ROOT / "model-catalogs"
 RUNTIME_MODEL_CATALOG_DIR = RUNTIME_CODEX_DIR / "model-catalogs"
+DIRECT_OFFICIAL_MODELS_CACHE_PATH = RUNTIME_CODEX_DIR / "models_cache.json"
 
 POLICY_PATH = REPO_ROOT / "config" / "catalog_policy.toml"
 OFFICIAL_SEED_PATH = BUNDLED_MODEL_CATALOG_DIR / "openai-plus-ollama-cloud.json"
@@ -75,6 +78,7 @@ OLLAMA_SHOW_URL = "https://ollama.com/api/show"
 DEFAULT_CLIENT_VERSION = "0.142.0"
 OLLAMA_PRIORITY_BASE = 100
 DIRECT_OFFICIAL_CONTEXT_MAX_AGE_SECONDS = 12 * 60 * 60
+DIRECT_OFFICIAL_CACHE_STATUS_SOURCE = "direct_official_cache"
 OFFICIAL_PROXY_PROVIDER_ALIAS = "openai"
 
 
@@ -370,6 +374,7 @@ def catalog_cache_dependency_paths() -> tuple[Path, ...]:
         POLICY_PATH,
         OFFICIAL_SEED_PATH,
         RUNTIME_OFFICIAL_SEED_PATH,
+        DIRECT_OFFICIAL_MODELS_CACHE_PATH,
         OLLAMA_FALLBACK_PATH,
         SETTINGS_PATH,
         DEFAULT_PROVIDERS_PATH,
@@ -495,6 +500,219 @@ def load_official_seed_snapshot(
     return OfficialSeedSnapshot(models=[], source="missing", context_freshness="missing")
 
 
+@dataclass(frozen=True)
+class DirectOfficialCacheAuthority:
+    """Sanitized numeric evidence joined to one current Official model list."""
+
+    context_by_slug: dict[str, dict[str, int]]
+    source: str
+    freshness: str
+
+
+def _unavailable_direct_official_cache_authority(
+    freshness: str,
+) -> DirectOfficialCacheAuthority:
+    return DirectOfficialCacheAuthority(
+        context_by_slug={},
+        source=DIRECT_OFFICIAL_CACHE_STATUS_SOURCE,
+        freshness=freshness,
+    )
+
+
+def _nonempty_string(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _direct_official_model_identity(model: Any) -> str | None:
+    if not isinstance(model, dict):
+        return None
+    identities: list[str] = []
+    for key in ("slug", "model", "id"):
+        if key not in model:
+            continue
+        value = model.get(key)
+        if not _nonempty_string(value):
+            return None
+        slug = canonical_model_id(value)
+        if slug.startswith("openai/gpt-"):
+            slug = slug.removeprefix("openai/")
+        if not slug.startswith("gpt-"):
+            return None
+        identities.append(slug)
+    if not identities or len(set(identities)) != 1:
+        return None
+    return identities[0]
+
+
+def _direct_official_model_index(
+    models: Iterable[dict[str, Any]],
+) -> dict[str, dict[str, Any]] | None:
+    indexed: dict[str, dict[str, Any]] = {}
+    for model in models:
+        slug = _direct_official_model_identity(model)
+        if slug is None or slug in indexed:
+            return None
+        indexed[slug] = model
+    return indexed
+
+
+def _positive_context_int(value: Any) -> int | None:
+    return value if isinstance(value, int) and not isinstance(value, bool) and value > 0 else None
+
+
+def _validated_cache_context_values(model: dict[str, Any]) -> dict[str, int] | None:
+    raw_context = model.get("context_window")
+    raw_max_context = model.get("max_context_window")
+    raw_effective_percent = model.get("effective_context_window_percent")
+    if all(value is None for value in (raw_context, raw_max_context, raw_effective_percent)):
+        return {}
+
+    context_window = _positive_context_int(raw_context)
+    max_context_window = _positive_context_int(raw_max_context)
+    effective_percent = _positive_context_int(raw_effective_percent)
+    if (
+        context_window is None
+        or max_context_window is None
+        or max_context_window < context_window
+        or effective_percent is None
+        or effective_percent > 100
+    ):
+        return None
+
+    values = {
+        "context_window": context_window,
+        "max_context_window": max_context_window,
+        "effective_context_window_percent": effective_percent,
+    }
+    if "auto_compact_token_limit" in model:
+        auto_compact_token_limit = _positive_context_int(model.get("auto_compact_token_limit"))
+        if auto_compact_token_limit is None:
+            return None
+        values["auto_compact_token_limit"] = auto_compact_token_limit
+    return values
+
+
+def _load_stable_json_object(path: Path) -> dict[str, Any] | None:
+    """Read one stable view of an atomically published cache file.
+
+    Native Codex writes this cache as a replacement.  If its metadata changes
+    while it is read, discard the observation rather than accepting a mixed
+    write.  Deliberately return no error detail so diagnostics never expose a
+    local path or cache contents.
+    """
+
+    try:
+        if not path.is_file() or path.is_symlink():
+            return None
+        before = path.stat()
+        text = path.read_text(encoding="utf-8-sig")
+        after = path.stat()
+    except (OSError, UnicodeError):
+        return None
+    if (before.st_size, before.st_mtime_ns) != (after.st_size, after.st_mtime_ns):
+        return None
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def load_fresh_direct_official_cache_authority(
+    snapshot: OfficialSeedSnapshot,
+    cache_path: Path = DIRECT_OFFICIAL_MODELS_CACHE_PATH,
+    *,
+    now_timestamp: float | None = None,
+) -> DirectOfficialCacheAuthority:
+    """Return only numeric Direct-cache evidence proven safe for this list.
+
+    The cache is never a bundled fallback: it is usable solely alongside a
+    fresh current app-server model list whose visible model identities agree
+    with the cache.  ETag/configuration markers prove provenance internally
+    and are intentionally omitted from the returned authority.
+    """
+
+    if (
+        snapshot.source != CURRENT_DIRECT_OFFICIAL_SOURCE
+        or snapshot.context_freshness != "fresh"
+    ):
+        return _unavailable_direct_official_cache_authority(snapshot.context_freshness)
+
+    payload = _load_stable_json_object(cache_path)
+    if payload is None:
+        return _unavailable_direct_official_cache_authority("missing")
+    freshness = _direct_catalog_context_freshness(payload, now_timestamp)
+    if freshness != "fresh":
+        return _unavailable_direct_official_cache_authority(freshness)
+    if not _nonempty_string(payload.get("etag")) or not _nonempty_string(
+        payload.get("client_version")
+    ):
+        return _unavailable_direct_official_cache_authority("missing")
+
+    cache_models = payload.get("models")
+    if not isinstance(cache_models, list):
+        return _unavailable_direct_official_cache_authority("missing")
+    current_by_slug = _direct_official_model_index(snapshot.models)
+    cache_by_slug = _direct_official_model_index(
+        [model for model in cache_models if isinstance(model, dict)]
+    )
+    if current_by_slug is None or cache_by_slug is None or not current_by_slug:
+        return _unavailable_direct_official_cache_authority("contradictory")
+    if len(cache_models) != len(cache_by_slug) or not set(current_by_slug).issubset(cache_by_slug):
+        return _unavailable_direct_official_cache_authority("contradictory")
+
+    context_by_slug: dict[str, dict[str, int]] = {}
+    for slug in current_by_slug:
+        cached_model = cache_by_slug[slug]
+        if not _nonempty_string(cached_model.get("comp_hash")):
+            return _unavailable_direct_official_cache_authority("missing")
+        values = _validated_cache_context_values(cached_model)
+        if values is None:
+            return _unavailable_direct_official_cache_authority("contradictory")
+        if values:
+            context_by_slug[slug] = values
+
+    if not context_by_slug:
+        return _unavailable_direct_official_cache_authority("missing")
+    return DirectOfficialCacheAuthority(
+        context_by_slug=context_by_slug,
+        source=FRESH_DIRECT_OFFICIAL_CACHE_AUTHORITY_SOURCE,
+        freshness="fresh",
+    )
+
+
+def _previous_official_context_budget_is_safe(budget: dict[str, Any]) -> bool:
+    source = budget.get("source")
+    freshness = budget.get("freshness")
+    if source == DEGRADED_LAST_KNOWN_OFFICIAL_SOURCE:
+        pass
+    elif source in {
+        CURRENT_DIRECT_OFFICIAL_SOURCE,
+        FRESH_DIRECT_OFFICIAL_CACHE_AUTHORITY_SOURCE,
+    } and freshness == "fresh":
+        pass
+    else:
+        return False
+
+    context_window = _positive_context_int(
+        budget.get("model_context_window", budget.get("context_window"))
+    )
+    effective_percent = _positive_context_int(budget.get("effective_context_window_percent"))
+    effective_window = _positive_context_int(budget.get("effective_context_window"))
+    auto_compact_token_limit = _positive_context_int(
+        budget.get("model_auto_compact_token_limit")
+    )
+    return bool(
+        context_window is not None
+        and effective_percent is not None
+        and effective_percent <= 100
+        and effective_window is not None
+        and effective_window <= context_window
+        and auto_compact_token_limit is not None
+        and auto_compact_token_limit <= effective_window
+    )
+
+
 def load_previous_official_context_budgets(
     path: Path = GENERATED_CATALOG_PATH,
 ) -> dict[str, dict[str, Any]]:
@@ -524,7 +742,7 @@ def load_previous_official_context_budgets(
         ):
             continue
         budget = metadata.get("official_context_budget")
-        if isinstance(budget, dict):
+        if isinstance(budget, dict) and _previous_official_context_budget_is_safe(budget):
             budgets[slug] = dict(budget)
     return budgets
 
@@ -539,6 +757,8 @@ def _first_present_value(model: dict[str, Any], *keys: str) -> Any:
 def official_context_signals_from_snapshot(
     snapshot: OfficialSeedSnapshot,
     previous_budgets: dict[str, dict[str, Any]] | None = None,
+    *,
+    direct_cache_authority: DirectOfficialCacheAuthority | None = None,
 ) -> dict[str, dict[str, Any]]:
     signals: dict[str, dict[str, Any]] = {}
     for model in snapshot.models:
@@ -547,31 +767,68 @@ def official_context_signals_from_snapshot(
         if not slug:
             continue
         previous = (previous_budgets or {}).get(slug, {})
+        context_window = _first_present_value(
+            model,
+            "context_window",
+            "contextWindow",
+        )
+        max_context_window = _first_present_value(
+            model,
+            "max_context_window",
+            "maxContextWindow",
+        )
+        effective_context_window_percent = _first_present_value(
+            model,
+            "effective_context_window_percent",
+            "effectiveContextWindowPercent",
+        )
+        auto_compact_token_limit = _first_present_value(
+            model,
+            "auto_compact_token_limit",
+            "model_auto_compact_token_limit",
+            "autoCompactTokenLimit",
+            "modelAutoCompactTokenLimit",
+        )
+        source = snapshot.source
+        freshness = snapshot.context_freshness
+        if (
+            direct_cache_authority is not None
+            and snapshot.source == CURRENT_DIRECT_OFFICIAL_SOURCE
+            and snapshot.context_freshness == "fresh"
+            and all(
+                value is None
+                for value in (
+                    context_window,
+                    max_context_window,
+                    effective_context_window_percent,
+                    auto_compact_token_limit,
+                )
+            )
+        ):
+            cache_values = direct_cache_authority.context_by_slug.get(slug)
+            if cache_values:
+                context_window = cache_values["context_window"]
+                max_context_window = cache_values["max_context_window"]
+                effective_context_window_percent = cache_values[
+                    "effective_context_window_percent"
+                ]
+                auto_compact_token_limit = cache_values.get("auto_compact_token_limit")
+                source = direct_cache_authority.source
+                freshness = direct_cache_authority.freshness
+            else:
+                source = DIRECT_OFFICIAL_CACHE_STATUS_SOURCE
+                freshness = (
+                    direct_cache_authority.freshness
+                    if direct_cache_authority.source == DIRECT_OFFICIAL_CACHE_STATUS_SOURCE
+                    else "missing"
+                )
         signals[slug] = {
-            "context_window": _first_present_value(
-                model,
-                "context_window",
-                "contextWindow",
-            ),
-            "max_context_window": _first_present_value(
-                model,
-                "max_context_window",
-                "maxContextWindow",
-            ),
-            "effective_context_window_percent": _first_present_value(
-                model,
-                "effective_context_window_percent",
-                "effectiveContextWindowPercent",
-            ),
-            "auto_compact_token_limit": _first_present_value(
-                model,
-                "auto_compact_token_limit",
-                "model_auto_compact_token_limit",
-                "autoCompactTokenLimit",
-                "modelAutoCompactTokenLimit",
-            ),
-            "freshness": snapshot.context_freshness,
-            "source": snapshot.source,
+            "context_window": context_window,
+            "max_context_window": max_context_window,
+            "effective_context_window_percent": effective_context_window_percent,
+            "auto_compact_token_limit": auto_compact_token_limit,
+            "freshness": freshness,
+            "source": source,
             "fallback_context_window": previous.get("model_context_window"),
             "fallback_effective_context_window_percent": previous.get(
                 "effective_context_window_percent"
@@ -1361,9 +1618,15 @@ def sync_catalog(*, max_age_seconds: int = 0) -> dict[str, Any]:
     )
     official_models = official_snapshot.models
     previous_official_context_budgets = load_previous_official_context_budgets()
+    direct_cache_authority = (
+        load_fresh_direct_official_cache_authority(official_snapshot)
+        if include_official
+        else None
+    )
     official_context_signals = official_context_signals_from_snapshot(
         official_snapshot,
         previous_official_context_budgets,
+        direct_cache_authority=direct_cache_authority,
     )
     fallback_models = load_fallback_catalog_models(OLLAMA_FALLBACK_PATH)
     client_version = read_client_version(OFFICIAL_SEED_PATH, OLLAMA_FALLBACK_PATH)

--- a/src-python/catalog_sync.py
+++ b/src-python/catalog_sync.py
@@ -56,7 +56,18 @@ def _runtime_codex_dir() -> Path:
 RUNTIME_CODEX_DIR = _runtime_codex_dir()
 BUNDLED_MODEL_CATALOG_DIR = REPO_ROOT / "model-catalogs"
 RUNTIME_MODEL_CATALOG_DIR = RUNTIME_CODEX_DIR / "model-catalogs"
-DIRECT_OFFICIAL_MODELS_CACHE_PATH = RUNTIME_CODEX_DIR / "models_cache.json"
+CODEX_TARGET_HOME_ENV = "CODEXHUB_CODEX_TARGET_HOME"
+
+
+def _direct_official_models_cache_path() -> Path:
+    """Use the Direct Codex target home without changing runtime state paths."""
+
+    target_home_env = os.environ.get(CODEX_TARGET_HOME_ENV)
+    target_home = Path(target_home_env) if target_home_env else RUNTIME_CODEX_DIR
+    return target_home / "models_cache.json"
+
+
+DIRECT_OFFICIAL_MODELS_CACHE_PATH = _direct_official_models_cache_path()
 
 POLICY_PATH = REPO_ROOT / "config" / "catalog_policy.toml"
 OFFICIAL_SEED_PATH = BUNDLED_MODEL_CATALOG_DIR / "openai-plus-ollama-cloud.json"

--- a/src-python/config_overlay.py
+++ b/src-python/config_overlay.py
@@ -9,6 +9,7 @@ from atomic_io import atomic_write_text
 from model_limits import (
     CURRENT_DIRECT_OFFICIAL_SOURCE,
     DEGRADED_LAST_KNOWN_OFFICIAL_SOURCE,
+    FRESH_DIRECT_OFFICIAL_CACHE_AUTHORITY_SOURCE,
 )
 import re
 import sys
@@ -572,7 +573,10 @@ def _selected_official_context_budget(
 
     source = budget.get("source")
     freshness = budget.get("freshness")
-    if source == CURRENT_DIRECT_OFFICIAL_SOURCE:
+    if source in {
+        CURRENT_DIRECT_OFFICIAL_SOURCE,
+        FRESH_DIRECT_OFFICIAL_CACHE_AUTHORITY_SOURCE,
+    }:
         if freshness != "fresh":
             return None
     elif source != DEGRADED_LAST_KNOWN_OFFICIAL_SOURCE:

--- a/src-python/model_limits.py
+++ b/src-python/model_limits.py
@@ -7,8 +7,15 @@ from typing import Any
 
 
 CURRENT_DIRECT_OFFICIAL_SOURCE = "current_direct_official"
+FRESH_DIRECT_OFFICIAL_CACHE_AUTHORITY_SOURCE = "fresh_direct_official_cache_authority"
 DEGRADED_LAST_KNOWN_OFFICIAL_SOURCE = "degraded_last_known_official"
 NATIVE_AUTO_COMPACT_PERCENT = 90
+TRUSTED_FRESH_OFFICIAL_CONTEXT_SOURCES = frozenset(
+    {
+        CURRENT_DIRECT_OFFICIAL_SOURCE,
+        FRESH_DIRECT_OFFICIAL_CACHE_AUTHORITY_SOURCE,
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -61,10 +68,11 @@ def resolve_official_context_budget(
 ) -> OfficialContextBudget | None:
     """Resolve an Official usable-context budget without trusting stale probes.
 
-    A current Direct Official snapshot is the only evidence that may expand a
-    budget.  A degraded snapshot requires a previously resolved safe value and
-    can only hold or tighten it.  Returning ``None`` deliberately fails closed
-    when neither source can establish a safe Official cap.
+    A current Direct Official snapshot or a provenance-checked fresh Direct
+    Official cache authority may expand a budget.  A degraded snapshot requires
+    a previously resolved safe value and can only hold or tighten it.  Returning
+    ``None`` deliberately fails closed when neither source can establish a safe
+    Official cap.
     """
     direct_context = _positive_int(direct_context_window)
     direct_max = _positive_int(direct_max_context_window)
@@ -84,15 +92,15 @@ def resolve_official_context_budget(
         direct_auto_compact_token_limit is not None
         and direct_auto_compact is None
     )
-    trusted_current_direct = (
-        direct_source == CURRENT_DIRECT_OFFICIAL_SOURCE
+    trusted_fresh_direct = (
+        direct_source in TRUSTED_FRESH_OFFICIAL_CONTEXT_SOURCES
         and freshness == "fresh"
         and direct_context is not None
         and direct_percent is not None
         and not direct_is_contradictory
     )
 
-    if trusted_current_direct:
+    if trusted_fresh_direct:
         effective_percent = direct_percent
         effective_window = max(1, direct_context * effective_percent // 100)
         auto_compact_limit = _auto_compact_limit(
@@ -107,7 +115,7 @@ def resolve_official_context_budget(
             effective_context_window=effective_window,
             model_context_window=direct_context,
             model_auto_compact_token_limit=auto_compact_limit,
-            source=CURRENT_DIRECT_OFFICIAL_SOURCE,
+            source=direct_source,
             freshness="fresh",
         )
 

--- a/src-python/model_limits.py
+++ b/src-python/model_limits.py
@@ -50,6 +50,7 @@ def _auto_compact_limit(
     native_limit = context_window * NATIVE_AUTO_COMPACT_PERCENT // 100
     return min(
         requested_limit if requested_limit is not None else native_limit,
+        native_limit,
         effective_context_window,
     )
 

--- a/src-tauri/src/catalog.rs
+++ b/src-tauri/src/catalog.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 const GENERATED_CATALOG_FILE: &str = "codexhub-model-catalog.json";
+const CODEX_TARGET_HOME_ENV: &str = "CODEXHUB_CODEX_TARGET_HOME";
 
 pub fn generate_catalog() -> Result<Vec<Model>, String> {
     models::generate_catalog()
@@ -36,7 +37,13 @@ fn sync_catalog_with_paths(
         paths.catalog_sync_script().to_string_lossy().into_owned(),
         "--sync".to_string(),
     ];
-    let env = vec![("CODEX_HOME".to_string(), paths.codex_dir.clone())];
+    let env = vec![
+        ("CODEX_HOME".to_string(), paths.codex_dir.clone()),
+        (
+            CODEX_TARGET_HOME_ENV.to_string(),
+            paths.codex_target_dir.clone(),
+        ),
+    ];
     let outcome = runner
         .run(python, &args, &env)
         .map_err(|error| format!("catalog sync failed to start: {error}"))?;
@@ -56,20 +63,27 @@ fn sync_catalog_with_paths(
 #[derive(Debug, Clone)]
 struct CatalogPaths {
     codex_dir: PathBuf,
+    codex_target_dir: PathBuf,
     repo_root: PathBuf,
 }
 
 impl CatalogPaths {
     fn runtime() -> Result<Self, String> {
         let codex_dir = runtime_paths::codex_home_dir()?;
+        let codex_target_dir = runtime_paths::codex_target_home_dir()?;
         let repo_root = runtime_paths::resource_root()?;
 
-        Ok(Self::new(codex_dir, repo_root))
+        Ok(Self::new(codex_dir, codex_target_dir, repo_root))
     }
 
-    fn new(codex_dir: impl Into<PathBuf>, repo_root: impl Into<PathBuf>) -> Self {
+    fn new(
+        codex_dir: impl Into<PathBuf>,
+        codex_target_dir: impl Into<PathBuf>,
+        repo_root: impl Into<PathBuf>,
+    ) -> Self {
         Self {
             codex_dir: codex_dir.into(),
+            codex_target_dir: codex_target_dir.into(),
             repo_root: repo_root.into(),
         }
     }
@@ -128,7 +142,7 @@ impl CatalogSyncCommandRunner for ProcessCatalogSyncCommandRunner {
 mod tests {
     use super::{
         sync_catalog_with_paths, CatalogCommandOutcome, CatalogPaths, CatalogSyncCommandRunner,
-        GENERATED_CATALOG_FILE,
+        CODEX_TARGET_HOME_ENV, GENERATED_CATALOG_FILE,
     };
     use std::cell::RefCell;
     use std::collections::BTreeMap;
@@ -137,13 +151,14 @@ mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
-    fn sync_catalog_sets_codex_home_creates_output_dir_and_returns_runtime_catalog_path() {
+    fn sync_catalog_preserves_runtime_and_target_homes_and_returns_runtime_catalog_path() {
         let root = temp_root("catalog-sync");
-        let codex_home = root.join("codex-home");
+        let runtime_home = root.join("runtime-home");
+        let target_home = root.join("codex-target-home");
         let repo_root = root.join("repo-root");
-        let paths = test_paths(&root);
+        let paths = CatalogPaths::new(&runtime_home, &target_home, &repo_root);
         write_fake_catalog_script(&repo_root);
-        let catalog_path = codex_home
+        let catalog_path = runtime_home
             .join("model-catalogs")
             .join(GENERATED_CATALOG_FILE);
         let runner = RecordingCatalogRunner::successful("catalog written\n", catalog_path.clone());
@@ -174,7 +189,15 @@ mod tests {
                 "--sync".to_string()
             ]
         );
-        assert_eq!(commands[0].env.get("CODEX_HOME"), Some(&codex_home));
+        assert_eq!(commands[0].env.get("CODEX_HOME"), Some(&runtime_home));
+        assert_eq!(
+            commands[0].env.get(CODEX_TARGET_HOME_ENV),
+            Some(&target_home)
+        );
+        assert_ne!(
+            commands[0].env.get("CODEX_HOME"),
+            commands[0].env.get(CODEX_TARGET_HOME_ENV)
+        );
     }
 
     #[test]
@@ -259,7 +282,11 @@ mod tests {
     }
 
     fn test_paths(root: &Path) -> CatalogPaths {
-        CatalogPaths::new(root.join("codex-home"), root.join("repo-root"))
+        CatalogPaths::new(
+            root.join("runtime-home"),
+            root.join("codex-target-home"),
+            root.join("repo-root"),
+        )
     }
 
     fn write_fake_catalog_script(repo_root: &Path) {

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -2727,6 +2727,68 @@ mod tests {
     }
 
     #[test]
+    fn codex_0_144_2_model_list_without_numeric_context_fields_preserves_that_absence() {
+        let fixture: Value = serde_json::from_str(include_str!(
+            "../../tests/fixtures/codex_0_144_2_model_list_without_context_fields.json"
+        ))
+        .expect("current Codex model/list fixture");
+        let expected_slugs = [
+            "gpt-5.6-sol",
+            "gpt-5.6-terra",
+            "gpt-5.6-luna",
+            "gpt-5.5",
+            "gpt-5.4",
+            "gpt-5.4-mini",
+            "gpt-5.3-codex-spark",
+        ];
+        let numeric_context_fields = [
+            "context_window",
+            "max_context_window",
+            "contextWindow",
+            "maxContextWindow",
+            "effective_context_window_percent",
+            "effectiveContextWindowPercent",
+            "auto_compact_token_limit",
+            "autoCompactTokenLimit",
+            "model_auto_compact_token_limit",
+            "modelAutoCompactTokenLimit",
+        ];
+
+        let raw_models = fixture["data"].as_array().expect("fixture model list");
+        assert_eq!(raw_models.len(), expected_slugs.len());
+        for raw_model in raw_models {
+            for &field in &numeric_context_fields {
+                assert!(
+                    raw_model.get(field).is_none(),
+                    "fixture must omit {field} from the Direct Official response"
+                );
+            }
+        }
+
+        let subscription_models =
+            subscription_models_from_payload(&fixture).expect("subscription models");
+        assert_eq!(
+            subscription_models
+                .iter()
+                .map(|model| model.slug.as_str())
+                .collect::<Vec<_>>(),
+            expected_slugs
+        );
+
+        for seed in subscription_models
+            .iter()
+            .map(super::official_subscription_seed_model)
+        {
+            for &field in &numeric_context_fields {
+                assert!(
+                    seed.get(field).is_none(),
+                    "seed must not invent a numeric {field}"
+                );
+            }
+        }
+    }
+
+    #[test]
     fn subscription_seed_does_not_overwrite_or_default_raw_app_metadata() {
         let subscription_models = subscription_models_from_payload(&json!({
             "data": [

--- a/src-tauri/src/official_refresh.rs
+++ b/src-tauri/src/official_refresh.rs
@@ -825,6 +825,49 @@ mod tests {
     }
 
     #[test]
+    fn codex_0_144_2_model_list_without_numeric_context_fields_fails_publication_closed() {
+        let fixture: serde_json::Value = serde_json::from_str(include_str!(
+            "../../tests/fixtures/codex_0_144_2_model_list_without_context_fields.json"
+        ))
+        .expect("current Codex model/list fixture");
+        let models = fixture["data"].as_array().expect("fixture model list");
+        assert_eq!(models.len(), 7);
+        assert!(models.iter().all(|model| {
+            [
+                "context_window",
+                "max_context_window",
+                "contextWindow",
+                "maxContextWindow",
+                "effective_context_window_percent",
+                "effectiveContextWindowPercent",
+                "auto_compact_token_limit",
+                "autoCompactTokenLimit",
+            ]
+            .iter()
+            .all(|field| model.get(*field).is_none())
+        }));
+
+        let mut state = OfficialRefreshState::default();
+        record_attempt(&mut state, RefreshTrigger::Manual, 2_000, false);
+        let error = finalize_published_snapshot(
+            &mut state,
+            2_000,
+            true,
+            || Ok(()),
+            BTreeMap::new,
+            || panic!("runtime projection must not run without a safe budget"),
+        )
+        .expect_err("missing numeric context authority must fail publication closed");
+
+        assert_eq!(
+            error,
+            "published Official catalog contains no safe resolved context budget"
+        );
+        assert!(!state.publication_ready);
+        assert_eq!(state.last_success_at, None);
+    }
+
+    #[test]
     fn publication_finalization_updates_runtime_before_marking_the_snapshot_current() {
         let mut state = OfficialRefreshState::default();
         record_attempt(&mut state, RefreshTrigger::Manual, 2_000, false);

--- a/src-tauri/src/official_refresh.rs
+++ b/src-tauri/src/official_refresh.rs
@@ -11,6 +11,8 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 pub(crate) const OFFICIAL_REFRESH_INTERVAL_SECONDS: u64 = 12 * 60 * 60;
 const REFRESH_STATE_FILE: &str = "official-refresh-state.json";
 const GENERATED_CATALOG_FILE: &str = "codexhub-model-catalog.json";
+const FRESH_DIRECT_OFFICIAL_CACHE_AUTHORITY_SOURCE: &str =
+    "fresh_direct_official_cache_authority";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum RefreshTrigger {
@@ -480,6 +482,12 @@ fn published_context_budgets_from_catalog(
             catalog_path.display()
         )
     })?;
+    published_context_budgets_from_catalog_payload(&payload)
+}
+
+fn published_context_budgets_from_catalog_payload(
+    payload: &Value,
+) -> Result<BTreeMap<String, PublishedOfficialBudget>, String> {
     let models = payload
         .get("models")
         .and_then(Value::as_array)
@@ -515,6 +523,7 @@ fn published_context_budgets_from_catalog(
         let trusted = matches!(
             (source, freshness),
             (Some("current_direct_official"), Some("fresh"))
+                | (Some(FRESH_DIRECT_OFFICIAL_CACHE_AUTHORITY_SOURCE), Some("fresh"))
                 | (Some("degraded_last_known_official"), _)
         );
         if !trusted {
@@ -609,10 +618,12 @@ fn unix_timestamp() -> u64 {
 mod tests {
     use super::{
         automatic_refresh_due, finalize_published_snapshot, read_state, record_attempt,
-        refresh_with_flight, should_attempt, update_published_context_budgets, write_state,
-        OfficialRefreshState, PublishedOfficialBudget, RefreshOutcome, RefreshTrigger,
-        SingleFlight, OFFICIAL_REFRESH_INTERVAL_SECONDS,
+        published_context_budgets_from_catalog_payload, refresh_with_flight, should_attempt,
+        update_published_context_budgets, write_state, OfficialRefreshState,
+        PublishedOfficialBudget, RefreshOutcome, RefreshTrigger, SingleFlight,
+        OFFICIAL_REFRESH_INTERVAL_SECONDS,
     };
+    use serde_json::json;
     use std::collections::BTreeMap;
     use std::fs;
     use std::path::PathBuf;
@@ -865,6 +876,49 @@ mod tests {
         );
         assert!(!state.publication_ready);
         assert_eq!(state.last_success_at, None);
+    }
+
+    #[test]
+    fn fresh_direct_cache_authority_budget_is_admitted_after_sanitized_catalog_projection() {
+        let payload = json!({
+            "models": [
+                {
+                    "slug": "gpt-5.6-terra",
+                    "codex_proxy_metadata": {
+                        "provider": "openai",
+                        "upstream_name": "official",
+                        "official_context_budget": {
+                            "source": "fresh_direct_official_cache_authority",
+                            "freshness": "fresh",
+                            "model_context_window": 272000,
+                            "effective_context_window_percent": 95,
+                            "effective_context_window": 258400,
+                            "model_auto_compact_token_limit": 244800
+                        }
+                    }
+                }
+            ]
+        });
+
+        let budgets = published_context_budgets_from_catalog_payload(&payload)
+            .expect("sanitized fresh Direct cache authority budget");
+
+        assert_eq!(
+            budgets.get("gpt-5.6-terra"),
+            Some(&PublishedOfficialBudget {
+                model_context_window: 272000,
+                effective_context_window_percent: 95,
+                effective_context_window: 258400,
+                model_auto_compact_token_limit: 244800,
+            })
+        );
+
+        let mut stale = payload;
+        stale["models"][0]["codex_proxy_metadata"]["official_context_budget"]["freshness"] =
+            json!("stale");
+        assert!(published_context_budgets_from_catalog_payload(&stale)
+            .expect("stale cache authority catalog")
+            .is_empty());
     }
 
     #[test]

--- a/src-tauri/src/official_refresh.rs
+++ b/src-tauri/src/official_refresh.rs
@@ -279,17 +279,14 @@ fn refresh_once(trigger: RefreshTrigger) -> Result<RefreshOutcome, String> {
                     persist_failed_publication(
                         &state_path,
                         &mut state,
-                        format!(
-                            "Direct Official refresh failed: {direct_error}; failed to publish a degraded safe snapshot: \
-                             {publication_error}"
+                        direct_official_refresh_failure_message(
+                            &direct_error,
+                            Some(&publication_error),
                         ),
                     )
                 })?;
             if !current_published_snapshot_available(&state) {
-                return Err(format!(
-                    "Direct Official refresh failed and no previous safe snapshot is available: \
-                     {direct_error}"
-                ));
+                return Err(direct_official_refresh_failure_message(&direct_error, None));
             }
             Ok(RefreshOutcome {
                 trigger,
@@ -378,12 +375,51 @@ fn persist_failed_publication(
     }
 }
 
+fn direct_official_refresh_failure_message(
+    direct_error: &str,
+    publication_error: Option<&str>,
+) -> String {
+    let normalized = direct_error.to_ascii_lowercase();
+    if [
+        "not signed in",
+        "not authenticated",
+        "login",
+        "logged in",
+        "auth unavailable",
+        "auth required",
+        "authentication required",
+        "unauthorized",
+    ]
+        .iter()
+        .any(|marker| normalized.contains(*marker))
+    {
+        return "Codex sign-in is required before a safe CodexHub Official snapshot can be published."
+            .to_string();
+    }
+    match publication_error {
+        Some(publication_error) => format!(
+            "Direct Official refresh failed: {direct_error}; failed to publish a degraded safe snapshot: {publication_error}"
+        ),
+        None => format!(
+            "Direct Official refresh failed and no previous safe snapshot is available: {direct_error}"
+        ),
+    }
+}
+
 fn should_attempt(trigger: RefreshTrigger, state: &OfficialRefreshState, now: u64) -> bool {
     match trigger {
         RefreshTrigger::Startup | RefreshTrigger::Manual => true,
-        RefreshTrigger::Activation | RefreshTrigger::Scheduled | RefreshTrigger::Resume => {
-            automatic_refresh_due(state, now)
+        // Activation is a user-initiated safety gate.  An earlier background
+        // attempt that could not publish a safe snapshot (for example before
+        // the user signs in) must not make the route unavailable for 12h.
+        // Scheduled and resume attempts remain bounded below to avoid a
+        // background retry loop.
+        RefreshTrigger::Activation => {
+            !state.publication_ready
+                || state.published_context_budgets.is_empty()
+                || automatic_refresh_due(state, now)
         }
+        RefreshTrigger::Scheduled | RefreshTrigger::Resume => automatic_refresh_due(state, now),
     }
 }
 
@@ -619,7 +655,8 @@ mod tests {
     use super::{
         automatic_refresh_due, finalize_published_snapshot, read_state, record_attempt,
         published_context_budgets_from_catalog_payload, refresh_with_flight, should_attempt,
-        update_published_context_budgets, write_state, OfficialRefreshState,
+        direct_official_refresh_failure_message, update_published_context_budgets, write_state,
+        OfficialRefreshState,
         PublishedOfficialBudget, RefreshOutcome, RefreshTrigger, SingleFlight,
         OFFICIAL_REFRESH_INTERVAL_SECONDS,
     };
@@ -635,9 +672,17 @@ mod tests {
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     #[test]
-    fn startup_and_manual_are_bounded_triggers_but_activation_waits_twelve_hours() {
+    fn startup_and_manual_are_bounded_triggers_but_activation_waits_with_safe_snapshot() {
         let state = OfficialRefreshState {
             last_success_at: Some(1_000),
+            publication_ready: true,
+            published_context_budgets: budget_map(
+                "gpt-5.6-terra",
+                272_000,
+                95,
+                258_400,
+                240_000,
+            ),
             ..OfficialRefreshState::default()
         };
         let before_due = 1_000 + OFFICIAL_REFRESH_INTERVAL_SECONDS - 1;
@@ -681,16 +726,38 @@ mod tests {
     }
 
     #[test]
-    fn activation_honors_the_failed_automatic_attempt_bound() {
+    fn activation_retries_after_auth_required_startup_without_background_retry_loop() {
         let mut state = OfficialRefreshState::default();
-        record_attempt(&mut state, RefreshTrigger::Scheduled, 1_000, false);
+        record_attempt(&mut state, RefreshTrigger::Startup, 1_000, false);
 
-        assert!(!should_attempt(RefreshTrigger::Activation, &state, 1_001));
-        assert!(should_attempt(
-            RefreshTrigger::Activation,
-            &state,
-            1_000 + OFFICIAL_REFRESH_INTERVAL_SECONDS,
-        ));
+        assert_eq!(state.last_automatic_attempt_at, Some(1_000));
+        assert!(!state.publication_ready);
+        assert!(!automatic_refresh_due(&state, 1_001));
+        assert!(!should_attempt(RefreshTrigger::Scheduled, &state, 1_001));
+        assert!(!should_attempt(RefreshTrigger::Resume, &state, 1_001));
+        assert!(should_attempt(RefreshTrigger::Activation, &state, 1_001));
+    }
+
+    #[test]
+    fn direct_refresh_failure_classifies_auth_required_without_hiding_other_failures() {
+        assert_eq!(
+            direct_official_refresh_failure_message(
+                "Codex auth unavailable",
+                Some("missing safe snapshot"),
+            ),
+            "Codex sign-in is required before a safe CodexHub Official snapshot can be published."
+        );
+        assert_eq!(
+            direct_official_refresh_failure_message("app-server unavailable", None),
+            "Direct Official refresh failed and no previous safe snapshot is available: app-server unavailable"
+        );
+        assert_eq!(
+            direct_official_refresh_failure_message(
+                "app-server unavailable",
+                Some("catalog publication failed"),
+            ),
+            "Direct Official refresh failed: app-server unavailable; failed to publish a degraded safe snapshot: catalog publication failed"
+        );
     }
 
     #[test]
@@ -865,7 +932,7 @@ mod tests {
             2_000,
             true,
             || Ok(()),
-            BTreeMap::new,
+            || Ok(BTreeMap::new()),
             || panic!("runtime projection must not run without a safe budget"),
         )
         .expect_err("missing numeric context authority must fail publication closed");

--- a/tests/fixtures/codex_0_144_2_direct_models_cache.json
+++ b/tests/fixtures/codex_0_144_2_direct_models_cache.json
@@ -1,0 +1,50 @@
+{
+  "fixture_version": 1,
+  "description": "Sanitized fresh Direct Official models cache shape paired with the Codex 0.144.2 no-numeric model/list fixture. Provenance markers are placeholders only and never become catalog diagnostics.",
+  "etag": "sanitized-direct-cache-etag",
+  "client_version": "0.144.1",
+  "fetched_at": "2026-07-15T03:21:42.227236100Z",
+  "models": [
+    {
+      "slug": "gpt-5.6-sol",
+      "context_window": 272000,
+      "max_context_window": 272000,
+      "effective_context_window_percent": 95,
+      "comp_hash": "sanitized-config-marker-sol"
+    },
+    {
+      "slug": "gpt-5.6-terra",
+      "context_window": 272000,
+      "max_context_window": 272000,
+      "effective_context_window_percent": 95,
+      "comp_hash": "sanitized-config-marker-terra"
+    },
+    {
+      "slug": "gpt-5.6-luna",
+      "context_window": 272000,
+      "max_context_window": 272000,
+      "effective_context_window_percent": 95,
+      "comp_hash": "sanitized-config-marker-luna"
+    },
+    {
+      "slug": "gpt-5.5",
+      "comp_hash": "sanitized-config-marker-5-5"
+    },
+    {
+      "slug": "gpt-5.4",
+      "comp_hash": "sanitized-config-marker-5-4"
+    },
+    {
+      "slug": "gpt-5.4-mini",
+      "comp_hash": "sanitized-config-marker-5-4-mini"
+    },
+    {
+      "slug": "gpt-5.3-codex-spark",
+      "comp_hash": "sanitized-config-marker-spark"
+    },
+    {
+      "slug": "gpt-5.6-extra",
+      "comp_hash": "sanitized-config-marker-extra"
+    }
+  ]
+}

--- a/tests/fixtures/codex_0_144_2_model_list_without_context_fields.json
+++ b/tests/fixtures/codex_0_144_2_model_list_without_context_fields.json
@@ -1,0 +1,83 @@
+{
+  "fixture_version": 1,
+  "description": "Sanitized Codex 0.144.2 app-server model/list shape: all current Official models are present, but no numeric context or compaction fields are supplied.",
+  "data": [
+    {
+      "id": "gpt-5.6-sol",
+      "model": "gpt-5.6-sol",
+      "displayName": "GPT-5.6-Sol",
+      "hidden": false,
+      "defaultReasoningEffort": "low",
+      "supportedReasoningEfforts": [
+        { "reasoningEffort": "low", "description": "Low" },
+        { "reasoningEffort": "max", "description": "Max" }
+      ]
+    },
+    {
+      "id": "gpt-5.6-terra",
+      "model": "gpt-5.6-terra",
+      "displayName": "GPT-5.6-Terra",
+      "hidden": false,
+      "defaultReasoningEffort": "low",
+      "supportedReasoningEfforts": [
+        { "reasoningEffort": "low", "description": "Low" },
+        { "reasoningEffort": "max", "description": "Max" }
+      ]
+    },
+    {
+      "id": "gpt-5.6-luna",
+      "model": "gpt-5.6-luna",
+      "displayName": "GPT-5.6-Luna",
+      "hidden": false,
+      "defaultReasoningEffort": "low",
+      "supportedReasoningEfforts": [
+        { "reasoningEffort": "low", "description": "Low" },
+        { "reasoningEffort": "max", "description": "Max" }
+      ]
+    },
+    {
+      "id": "gpt-5.5",
+      "model": "gpt-5.5",
+      "displayName": "GPT-5.5",
+      "hidden": false,
+      "defaultReasoningEffort": "medium",
+      "supportedReasoningEfforts": [
+        { "reasoningEffort": "low", "description": "Low" },
+        { "reasoningEffort": "max", "description": "Max" }
+      ]
+    },
+    {
+      "id": "gpt-5.4",
+      "model": "gpt-5.4",
+      "displayName": "GPT-5.4",
+      "hidden": false,
+      "defaultReasoningEffort": "medium",
+      "supportedReasoningEfforts": [
+        { "reasoningEffort": "low", "description": "Low" },
+        { "reasoningEffort": "max", "description": "Max" }
+      ]
+    },
+    {
+      "id": "gpt-5.4-mini",
+      "model": "gpt-5.4-mini",
+      "displayName": "GPT-5.4-Mini",
+      "hidden": false,
+      "defaultReasoningEffort": "medium",
+      "supportedReasoningEfforts": [
+        { "reasoningEffort": "low", "description": "Low" },
+        { "reasoningEffort": "max", "description": "Max" }
+      ]
+    },
+    {
+      "id": "gpt-5.3-codex-spark",
+      "model": "gpt-5.3-codex-spark",
+      "displayName": "GPT-5.3-Codex-Spark",
+      "hidden": false,
+      "defaultReasoningEffort": "high",
+      "supportedReasoningEfforts": [
+        { "reasoningEffort": "low", "description": "Low" },
+        { "reasoningEffort": "max", "description": "Max" }
+      ]
+    }
+  ]
+}

--- a/tests/test_catalog_sync.py
+++ b/tests/test_catalog_sync.py
@@ -699,6 +699,259 @@ class CatalogSyncTests(unittest.TestCase):
                     {"source": "current_direct_official", "freshness": "fresh"},
                 )
 
+    def test_fresh_direct_cache_authority_recovers_numeric_budget_from_no_numeric_model_list(self):
+        model_list_path = (
+            Path(__file__).parent
+            / "fixtures"
+            / "codex_0_144_2_model_list_without_context_fields.json"
+        )
+        cache_path = (
+            Path(__file__).parent
+            / "fixtures"
+            / "codex_0_144_2_direct_models_cache.json"
+        )
+        raw_models = json.loads(model_list_path.read_text(encoding="utf-8"))["data"]
+        cache_payload = json.loads(cache_path.read_text(encoding="utf-8"))
+        snapshot = catalog_sync.OfficialSeedSnapshot(
+            models=[
+                {
+                    **model,
+                    "slug": model["model"],
+                    "display_name": model["displayName"],
+                }
+                for model in raw_models
+            ],
+            source="current_direct_official",
+            context_freshness="fresh",
+        )
+        cache_timestamp = catalog_sync._catalog_fetched_at_timestamp(cache_payload["fetched_at"])
+        self.assertIsNotNone(cache_timestamp)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            runtime_cache = Path(tmp) / "models_cache.json"
+            runtime_cache.write_text(json.dumps(cache_payload), encoding="utf-8")
+            authority = catalog_sync.load_fresh_direct_official_cache_authority(
+                snapshot,
+                runtime_cache,
+                now_timestamp=cache_timestamp + 1,
+            )
+
+        signals = catalog_sync.official_context_signals_from_snapshot(
+            snapshot,
+            direct_cache_authority=authority,
+        )
+        catalog = build_codex_catalog(
+            snapshot.models,
+            ["glm-5.2:cloud"],
+            self.policy,
+            "0.144.2",
+            official_context_signals=signals,
+        )
+        by_slug = {model["slug"]: model for model in catalog["models"]}
+        serialized_catalog = json.dumps(catalog, sort_keys=True)
+        self.assertNotIn("sanitized-direct-cache-etag", serialized_catalog)
+        self.assertNotIn("sanitized-config-marker", serialized_catalog)
+        self.assertNotIn("models_cache.json", serialized_catalog)
+
+        for slug in ("gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"):
+            with self.subTest(slug=slug):
+                model = by_slug[slug]
+                budget = model["codex_proxy_metadata"]["official_context_budget"]
+                self.assertEqual(model["context_window"], 272_000)
+                self.assertEqual(model["max_context_window"], 272_000)
+                self.assertEqual(model["effective_context_window_percent"], 95)
+                self.assertEqual(
+                    budget["source"],
+                    "fresh_direct_official_cache_authority",
+                )
+                self.assertEqual(budget["freshness"], "fresh")
+                self.assertLessEqual(budget["effective_context_window"], 258_400)
+                self.assertLessEqual(budget["model_auto_compact_token_limit"], 244_800)
+                self.assertLess(budget["model_auto_compact_token_limit"], 249_433)
+                serialized_budget = json.dumps(budget, sort_keys=True)
+                self.assertNotIn("sanitized-direct-cache-etag", serialized_budget)
+                self.assertNotIn("sanitized-config-marker", serialized_budget)
+                self.assertNotIn("models_cache.json", serialized_budget)
+
+        for slug in ("gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex-spark"):
+            with self.subTest(slug=slug):
+                self.assertNotIn("context_window", by_slug[slug])
+        self.assertEqual(by_slug["glm-5.2"]["context_window"], 1_000_000)
+        self.assertNotIn("353400", serialized_catalog)
+
+    def test_direct_cache_authority_rejects_invalid_provenance_identity_and_numeric_evidence(self):
+        model_list_path = (
+            Path(__file__).parent
+            / "fixtures"
+            / "codex_0_144_2_model_list_without_context_fields.json"
+        )
+        cache_path = (
+            Path(__file__).parent
+            / "fixtures"
+            / "codex_0_144_2_direct_models_cache.json"
+        )
+        raw_models = json.loads(model_list_path.read_text(encoding="utf-8"))["data"]
+        fresh_cache = json.loads(cache_path.read_text(encoding="utf-8"))
+        snapshot = catalog_sync.OfficialSeedSnapshot(
+            models=[
+                {
+                    **model,
+                    "slug": model["model"],
+                    "display_name": model["displayName"],
+                }
+                for model in raw_models
+            ],
+            source="current_direct_official",
+            context_freshness="fresh",
+        )
+        cache_timestamp = catalog_sync._catalog_fetched_at_timestamp(fresh_cache["fetched_at"])
+        self.assertIsNotNone(cache_timestamp)
+
+        cases: list[tuple[str, object, float, str]] = []
+        stale_cache = json.loads(json.dumps(fresh_cache))
+        cases.append(
+            (
+                "stale",
+                stale_cache,
+                cache_timestamp + catalog_sync.DIRECT_OFFICIAL_CONTEXT_MAX_AGE_SECONDS,
+                "stale",
+            )
+        )
+        for label, key in (("missing_etag", "etag"), ("missing_client_version", "client_version")):
+            payload = json.loads(json.dumps(fresh_cache))
+            payload.pop(key)
+            cases.append((label, payload, cache_timestamp + 1, "missing"))
+        missing_marker = json.loads(json.dumps(fresh_cache))
+        next(model for model in missing_marker["models"] if model["slug"] == "gpt-5.6-terra").pop(
+            "comp_hash"
+        )
+        cases.append(("missing_comp_hash", missing_marker, cache_timestamp + 1, "missing"))
+        mismatched_identity = json.loads(json.dumps(fresh_cache))
+        next(
+            model for model in mismatched_identity["models"] if model["slug"] == "gpt-5.6-terra"
+        )["slug"] = "gpt-cache-mismatch"
+        cases.append(("mismatched_model_id", mismatched_identity, cache_timestamp + 1, "contradictory"))
+        contradictory_numeric = json.loads(json.dumps(fresh_cache))
+        next(
+            model for model in contradictory_numeric["models"] if model["slug"] == "gpt-5.6-terra"
+        )["max_context_window"] = 271_999
+        cases.append(("contradictory_numeric", contradictory_numeric, cache_timestamp + 1, "contradictory"))
+        duplicate_identity = json.loads(json.dumps(fresh_cache))
+        duplicate_identity["models"].append(
+            dict(next(model for model in duplicate_identity["models"] if model["slug"] == "gpt-5.6-terra"))
+        )
+        cases.append(("duplicate_model_id", duplicate_identity, cache_timestamp + 1, "contradictory"))
+        cases.append(("unparseable", "{not json", cache_timestamp + 1, "missing"))
+
+        for label, payload, now_timestamp, expected_freshness in cases:
+            with self.subTest(label=label), tempfile.TemporaryDirectory() as tmp:
+                runtime_cache = Path(tmp) / "models_cache.json"
+                text = payload if isinstance(payload, str) else json.dumps(payload)
+                runtime_cache.write_text(text, encoding="utf-8")
+                authority = catalog_sync.load_fresh_direct_official_cache_authority(
+                    snapshot,
+                    runtime_cache,
+                    now_timestamp=now_timestamp,
+                )
+                signals = catalog_sync.official_context_signals_from_snapshot(
+                    snapshot,
+                    direct_cache_authority=authority,
+                )
+                catalog = build_codex_catalog(
+                    snapshot.models,
+                    [],
+                    self.policy,
+                    "0.144.2",
+                    official_context_signals=signals,
+                )
+                terra = next(model for model in catalog["models"] if model["slug"] == "gpt-5.6-terra")
+
+                self.assertEqual(authority.context_by_slug, {})
+                self.assertEqual(authority.freshness, expected_freshness)
+                self.assertNotIn("context_window", terra)
+                self.assertEqual(
+                    terra["codex_proxy_metadata"]["official_context_budget"],
+                    {"source": "direct_official_cache", "freshness": expected_freshness},
+                )
+
+    def test_previous_official_budget_requires_proven_safe_resolution_provenance(self):
+        def budget(source: str, freshness: str, context_window: int) -> dict[str, object]:
+            return {
+                "source": source,
+                "freshness": freshness,
+                "model_context_window": context_window,
+                "effective_context_window_percent": 95,
+                "effective_context_window": context_window * 95 // 100,
+                "model_auto_compact_token_limit": context_window * 90 // 100,
+            }
+
+        with tempfile.TemporaryDirectory() as tmp:
+            catalog_path = Path(tmp) / "catalog.json"
+            catalog_path.write_text(
+                json.dumps(
+                    {
+                        "models": [
+                            {
+                                "slug": "gpt-5.6-terra",
+                                "codex_proxy_metadata": {
+                                    "provider": "openai",
+                                    "upstream_name": "official",
+                                    "official_context_budget": budget(
+                                        "fresh_direct_official_cache_authority",
+                                        "fresh",
+                                        272_000,
+                                    ),
+                                },
+                            },
+                            {
+                                "slug": "gpt-5.6-sol",
+                                "codex_proxy_metadata": {
+                                    "provider": "openai",
+                                    "upstream_name": "official",
+                                    "official_context_budget": budget(
+                                        "current_direct_official",
+                                        "stale",
+                                        353_400,
+                                    ),
+                                },
+                            },
+                            {
+                                "slug": "gpt-5.6-luna",
+                                "codex_proxy_metadata": {
+                                    "provider": "openai",
+                                    "upstream_name": "official",
+                                    "official_context_budget": budget(
+                                        "degraded_last_known_official",
+                                        "stale",
+                                        272_000,
+                                    ),
+                                },
+                            },
+                            {
+                                "slug": "gpt-5.5",
+                                "codex_proxy_metadata": {
+                                    "provider": "openai",
+                                    "upstream_name": "official",
+                                    "official_context_budget": budget(
+                                        "stale_probe_cache",
+                                        "fresh",
+                                        353_400,
+                                    ),
+                                },
+                            },
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            budgets = catalog_sync.load_previous_official_context_budgets(catalog_path)
+
+        self.assertEqual(set(budgets), {"gpt-5.6-terra", "gpt-5.6-luna"})
+        self.assertEqual(budgets["gpt-5.6-terra"]["model_context_window"], 272_000)
+        self.assertNotIn("gpt-5.6-sol", budgets)
+        self.assertNotIn("gpt-5.5", budgets)
+
     def test_stale_direct_snapshot_can_only_reuse_a_previously_resolved_budget(self):
         snapshot = catalog_sync.OfficialSeedSnapshot(
             models=[{"slug": "gpt-5.5", "context_window": 400_000}],

--- a/tests/test_catalog_sync.py
+++ b/tests/test_catalog_sync.py
@@ -643,6 +643,62 @@ class CatalogSyncTests(unittest.TestCase):
         self.assertEqual(snapshot.context_freshness, "stale")
         self.assertNotEqual(snapshot.source, "current_direct_official")
 
+    def test_codex_0_144_2_seven_model_fixture_without_numeric_context_fails_closed(self):
+        fixture_path = (
+            Path(__file__).parent
+            / "fixtures"
+            / "codex_0_144_2_model_list_without_context_fields.json"
+        )
+        fixture = json.loads(fixture_path.read_text(encoding="utf-8"))
+        raw_models = fixture["data"]
+        seed_models = [
+            {
+                **model,
+                "slug": model["model"],
+                "display_name": model["displayName"],
+            }
+            for model in raw_models
+        ]
+        snapshot = catalog_sync.OfficialSeedSnapshot(
+            models=seed_models,
+            source="current_direct_official",
+            context_freshness="fresh",
+        )
+        signals = catalog_sync.official_context_signals_from_snapshot(snapshot)
+        catalog = build_codex_catalog(
+            snapshot.models,
+            [],
+            catalog_sync.load_policy(catalog_sync.POLICY_PATH),
+            "0.144.2",
+            official_context_signals=signals,
+        )
+        expected_slugs = [
+            "gpt-5.6-sol",
+            "gpt-5.6-terra",
+            "gpt-5.6-luna",
+            "gpt-5.5",
+            "gpt-5.4",
+            "gpt-5.4-mini",
+            "gpt-5.3-codex-spark",
+        ]
+        numeric_context_fields = (
+            "context_window",
+            "max_context_window",
+            "effective_context_window_percent",
+            "auto_compact_token_limit",
+        )
+
+        self.assertEqual([model["slug"] for model in catalog["models"]], expected_slugs)
+        for slug in expected_slugs:
+            with self.subTest(slug=slug):
+                self.assertTrue(all(signals[slug][field] is None for field in numeric_context_fields))
+                model = next(model for model in catalog["models"] if model["slug"] == slug)
+                self.assertTrue(all(field not in model for field in numeric_context_fields))
+                self.assertEqual(
+                    model["codex_proxy_metadata"]["official_context_budget"],
+                    {"source": "current_direct_official", "freshness": "fresh"},
+                )
+
     def test_stale_direct_snapshot_can_only_reuse_a_previously_resolved_budget(self):
         snapshot = catalog_sync.OfficialSeedSnapshot(
             models=[{"slug": "gpt-5.5", "context_window": 400_000}],

--- a/tests/test_catalog_sync.py
+++ b/tests/test_catalog_sync.py
@@ -1,5 +1,6 @@
 import importlib
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 import tempfile
 import unittest
@@ -778,6 +779,180 @@ class CatalogSyncTests(unittest.TestCase):
                 self.assertNotIn("context_window", by_slug[slug])
         self.assertEqual(by_slug["glm-5.2"]["context_window"], 1_000_000)
         self.assertNotIn("353400", serialized_catalog)
+
+    def test_sync_catalog_reads_target_only_direct_cache_before_same_attempt_publication(self):
+        model_list_path = (
+            Path(__file__).parent
+            / "fixtures"
+            / "codex_0_144_2_model_list_without_context_fields.json"
+        )
+        direct_cache_path = (
+            Path(__file__).parent
+            / "fixtures"
+            / "codex_0_144_2_direct_models_cache.json"
+        )
+        raw_models = json.loads(model_list_path.read_text(encoding="utf-8"))["data"]
+        direct_cache = json.loads(direct_cache_path.read_text(encoding="utf-8"))
+        direct_cache["fetched_at"] = datetime.now(timezone.utc).isoformat()
+        direct_cache["etag"] = "target-cache-private-etag"
+        for model in direct_cache["models"]:
+            model["comp_hash"] = f"target-cache-private-hash-{model['slug']}"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            runtime_home = root / "runtime"
+            target_home = root / "target-home-must-not-leak"
+            runtime_seed = runtime_home / "model-catalogs" / "openai-plus-ollama-cloud.json"
+            target_cache = target_home / "models_cache.json"
+            runtime_seed.parent.mkdir(parents=True)
+            runtime_seed.write_text(
+                json.dumps(
+                    {
+                        "fetched_at": direct_cache["fetched_at"],
+                        "client_version": "0.144.2",
+                        "models": [
+                            {
+                                **model,
+                                "slug": model["model"],
+                                "display_name": model["displayName"],
+                            }
+                            for model in raw_models
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            self.assertFalse((runtime_home / "models_cache.json").exists())
+            self.assertFalse(target_cache.exists())
+            target_cache.parent.mkdir(parents=True)
+            target_cache.write_text(json.dumps(direct_cache), encoding="utf-8")
+
+            try:
+                with patch.dict(
+                    "os.environ",
+                    {
+                        "CODEX_HOME": str(runtime_home),
+                        "CODEXHUB_CODEX_TARGET_HOME": str(target_home),
+                    },
+                    clear=False,
+                ):
+                    importlib.reload(catalog_sync)
+                    self.assertEqual(catalog_sync.RUNTIME_CODEX_DIR, runtime_home)
+                    self.assertEqual(
+                        catalog_sync.DIRECT_OFFICIAL_MODELS_CACHE_PATH,
+                        target_cache,
+                    )
+                    with (
+                        patch.object(catalog_sync, "catalog_cache_is_fresh", return_value=False),
+                        patch.object(catalog_sync, "load_include_official_models", return_value=True),
+                        patch.object(catalog_sync, "load_official_model_sort_order", return_value=[]),
+                        patch.object(catalog_sync, "load_official_disabled_models", return_value=[]),
+                        patch.object(catalog_sync, "load_fallback_catalog_models", return_value=[]),
+                        patch.object(catalog_sync, "read_client_version", return_value="0.144.2"),
+                        patch.object(
+                            catalog_sync,
+                            "discover_ollama_ids",
+                            return_value=([], "test", "ok", ""),
+                        ),
+                        patch.object(catalog_sync, "load_providers", return_value=[]),
+                        patch.object(
+                            catalog_sync,
+                            "catalog_visible_ollama_cloud_models",
+                            return_value=(False, []),
+                        ),
+                        patch.object(catalog_sync, "catalog_visible_external_models", return_value=[]),
+                        patch.object(
+                            catalog_sync,
+                            "discover_ollama_model_metadata",
+                            return_value=({}, ""),
+                        ),
+                        patch.object(catalog_sync, "load_previous_visible_models", return_value=set()),
+                    ):
+                        state = catalog_sync.sync_catalog()
+            finally:
+                importlib.reload(catalog_sync)
+
+            generated_catalog = runtime_home / "model-catalogs" / "codexhub-model-catalog.json"
+            generated_state = runtime_home / "model-catalogs" / "codex-proxy-state.json"
+            self.assertTrue(generated_catalog.is_file())
+            self.assertTrue(generated_state.is_file())
+            self.assertFalse(
+                (target_home / "model-catalogs" / "codexhub-model-catalog.json").exists()
+            )
+            self.assertFalse((target_home / "model-catalogs" / "codex-proxy-state.json").exists())
+            self.assertEqual(state["visible_models"], [model["model"] for model in raw_models])
+
+            serialized_catalog = generated_catalog.read_text(encoding="utf-8")
+            generated = json.loads(serialized_catalog)
+            terra = next(model for model in generated["models"] if model["slug"] == "gpt-5.6-terra")
+            budget = terra["codex_proxy_metadata"]["official_context_budget"]
+            self.assertEqual(terra["context_window"], 272_000)
+            self.assertEqual(budget["source"], "fresh_direct_official_cache_authority")
+            self.assertEqual(budget["freshness"], "fresh")
+            self.assertLessEqual(budget["effective_context_window"], 258_400)
+            self.assertLessEqual(budget["model_auto_compact_token_limit"], 244_800)
+            serialized_state = generated_state.read_text(encoding="utf-8")
+            for generated_artifact in (serialized_catalog, serialized_state):
+                self.assertNotIn("target-cache-private-etag", generated_artifact)
+                self.assertNotIn("target-cache-private-hash", generated_artifact)
+                self.assertNotIn(target_home.name, generated_artifact)
+                self.assertNotIn(str(target_home), generated_artifact)
+                self.assertNotIn("models_cache.json", generated_artifact)
+
+    def test_direct_cache_path_uses_runtime_home_when_target_home_is_not_provided(self):
+        model_list_path = (
+            Path(__file__).parent
+            / "fixtures"
+            / "codex_0_144_2_model_list_without_context_fields.json"
+        )
+        direct_cache_path = (
+            Path(__file__).parent
+            / "fixtures"
+            / "codex_0_144_2_direct_models_cache.json"
+        )
+        raw_models = json.loads(model_list_path.read_text(encoding="utf-8"))["data"]
+        direct_cache = json.loads(direct_cache_path.read_text(encoding="utf-8"))
+        direct_cache["fetched_at"] = datetime.now(timezone.utc).isoformat()
+        with tempfile.TemporaryDirectory() as tmp:
+            runtime_home = Path(tmp) / "runtime"
+            runtime_cache = runtime_home / "models_cache.json"
+            runtime_home.mkdir(parents=True)
+            runtime_cache.write_text(json.dumps(direct_cache), encoding="utf-8")
+            try:
+                with patch.dict(
+                    "os.environ",
+                    {
+                        "CODEX_HOME": str(runtime_home),
+                        "CODEXHUB_CODEX_TARGET_HOME": "",
+                    },
+                    clear=False,
+                ):
+                    importlib.reload(catalog_sync)
+                    self.assertEqual(catalog_sync.RUNTIME_CODEX_DIR, runtime_home)
+                    self.assertEqual(
+                        catalog_sync.DIRECT_OFFICIAL_MODELS_CACHE_PATH,
+                        runtime_cache,
+                    )
+                    authority = catalog_sync.load_fresh_direct_official_cache_authority(
+                        catalog_sync.OfficialSeedSnapshot(
+                            models=[
+                                {
+                                    **model,
+                                    "slug": model["model"],
+                                    "display_name": model["displayName"],
+                                }
+                                for model in raw_models
+                            ],
+                            source="current_direct_official",
+                            context_freshness="fresh",
+                        )
+                    )
+                    self.assertEqual(
+                        authority.context_by_slug["gpt-5.6-terra"]["context_window"],
+                        272_000,
+                    )
+            finally:
+                importlib.reload(catalog_sync)
 
     def test_direct_cache_authority_rejects_invalid_provenance_identity_and_numeric_evidence(self):
         model_list_path = (

--- a/tests/test_config_overlay.py
+++ b/tests/test_config_overlay.py
@@ -23,6 +23,7 @@ from config_overlay import (
     strip_top_level_keys,
     top_level_value,
 )
+from model_limits import FRESH_DIRECT_OFFICIAL_CACHE_AUTHORITY_SOURCE
 
 
 class DeterministicCompactionReplay:
@@ -455,6 +456,73 @@ class ConfigOverlayTests(unittest.TestCase):
             self.assertIn("model_context_window = 400000", restarted)
             self.assertIn("model_auto_compact_token_limit = 380000", restarted)
 
+    def test_overlay_adopts_fresh_direct_cache_authority_and_rejects_a_stale_expansion(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path = tmp / "config.toml"
+            backup_path = tmp / "config.backup.toml"
+            catalog_path = tmp / "catalog.json"
+            config_path.write_text('model = "gpt-5.6-terra"\n', encoding="utf-8")
+
+            catalog_path.write_text(
+                json.dumps(
+                    {
+                        "models": [
+                            {
+                                "slug": "gpt-5.6-terra",
+                                "codex_proxy_metadata": {
+                                    "provider": "openai",
+                                    "upstream_name": "official",
+                                    "official_context_budget": {
+                                        "source": FRESH_DIRECT_OFFICIAL_CACHE_AUTHORITY_SOURCE,
+                                        "freshness": "fresh",
+                                        "model_context_window": 272_000,
+                                        "effective_context_window_percent": 95,
+                                        "effective_context_window": 258_400,
+                                    },
+                                },
+                            }
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            apply_overlay(config_path, backup_path, catalog_path, "http://127.0.0.1:9099")
+            activated = config_path.read_text(encoding="utf-8")
+            self.assertIn("model_context_window = 272000", activated)
+            self.assertIn("model_auto_compact_token_limit = 244800", activated)
+            self.assertLess(244_800, 249_433)
+
+            catalog_path.write_text(
+                json.dumps(
+                    {
+                        "models": [
+                            {
+                                "slug": "gpt-5.6-terra",
+                                "codex_proxy_metadata": {
+                                    "provider": "openai",
+                                    "upstream_name": "official",
+                                    "official_context_budget": {
+                                        "source": FRESH_DIRECT_OFFICIAL_CACHE_AUTHORITY_SOURCE,
+                                        "freshness": "stale",
+                                        "model_context_window": 400_000,
+                                        "effective_context_window_percent": 100,
+                                        "effective_context_window": 400_000,
+                                        "model_auto_compact_token_limit": 380_000,
+                                    },
+                                },
+                            }
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ValueError, "safe current Official context budget"):
+                apply_overlay(config_path, backup_path, catalog_path, "http://127.0.0.1:9099")
+            self.assertEqual(config_path.read_text(encoding="utf-8"), activated)
+
     def test_overlay_preserves_an_explicit_third_party_context_budget(self):
         original = "\n".join(
             [
@@ -481,7 +549,7 @@ class ConfigOverlayTests(unittest.TestCase):
                                     "provider": "openai",
                                     "upstream_name": "official",
                                     "official_context_budget": {
-                                        "source": "current_direct_official",
+                                        "source": FRESH_DIRECT_OFFICIAL_CACHE_AUTHORITY_SOURCE,
                                         "freshness": "fresh",
                                         "model_context_window": 272_000,
                                         "effective_context_window_percent": 100,

--- a/tests/test_model_limits.py
+++ b/tests/test_model_limits.py
@@ -10,6 +10,7 @@ sys.path.insert(0, str(ROOT / "src-python"))
 
 from model_limits import (
     CURRENT_DIRECT_OFFICIAL_SOURCE,
+    FRESH_DIRECT_OFFICIAL_CACHE_AUTHORITY_SOURCE,
     apply_resolved_model_limits,
     load_resolved_model_limits,
     resolve_official_context_budget,
@@ -97,6 +98,45 @@ class ResolvedModelLimitsTests(unittest.TestCase):
         self.assertEqual(budget.effective_context_window, 258_400)
         self.assertEqual(budget.model_auto_compact_token_limit, 244_800)
         self.assertLess(budget.model_auto_compact_token_limit, 249_433)
+
+    def test_fresh_direct_cache_authority_can_tighten_or_adopt_a_higher_budget(self):
+        lower = resolve_official_context_budget(
+            direct_context_window=272_000,
+            direct_max_context_window=272_000,
+            direct_effective_context_window_percent=95,
+            direct_freshness="fresh",
+            direct_source=FRESH_DIRECT_OFFICIAL_CACHE_AUTHORITY_SOURCE,
+            fallback_context_window=353_400,
+            fallback_effective_context_window_percent=100,
+        )
+        higher = resolve_official_context_budget(
+            direct_context_window=400_000,
+            direct_max_context_window=400_000,
+            direct_effective_context_window_percent=100,
+            direct_freshness="fresh",
+            direct_source=FRESH_DIRECT_OFFICIAL_CACHE_AUTHORITY_SOURCE,
+            fallback_context_window=272_000,
+            fallback_effective_context_window_percent=95,
+        )
+        stale_higher = resolve_official_context_budget(
+            direct_context_window=400_000,
+            direct_max_context_window=400_000,
+            direct_effective_context_window_percent=100,
+            direct_freshness="stale",
+            direct_source=FRESH_DIRECT_OFFICIAL_CACHE_AUTHORITY_SOURCE,
+            fallback_context_window=272_000,
+            fallback_effective_context_window_percent=95,
+        )
+
+        self.assertEqual(lower.source, FRESH_DIRECT_OFFICIAL_CACHE_AUTHORITY_SOURCE)
+        self.assertEqual(lower.context_window, 272_000)
+        self.assertEqual(lower.effective_context_window, 258_400)
+        self.assertEqual(lower.model_auto_compact_token_limit, 244_800)
+        self.assertLess(lower.model_auto_compact_token_limit, 249_433)
+        self.assertEqual(higher.source, FRESH_DIRECT_OFFICIAL_CACHE_AUTHORITY_SOURCE)
+        self.assertEqual(higher.context_window, 400_000)
+        self.assertEqual(stale_higher.source, "degraded_last_known_official")
+        self.assertEqual(stale_higher.context_window, 272_000)
 
     def test_missing_direct_effective_percent_cannot_expand_a_budget(self):
         fallback = {

--- a/tests/test_model_limits.py
+++ b/tests/test_model_limits.py
@@ -99,6 +99,35 @@ class ResolvedModelLimitsTests(unittest.TestCase):
         self.assertEqual(budget.model_auto_compact_token_limit, 244_800)
         self.assertLess(budget.model_auto_compact_token_limit, 249_433)
 
+    def test_explicit_direct_compact_threshold_cannot_expand_past_native_ninety_percent(self):
+        for source in (
+            CURRENT_DIRECT_OFFICIAL_SOURCE,
+            FRESH_DIRECT_OFFICIAL_CACHE_AUTHORITY_SOURCE,
+        ):
+            with self.subTest(source=source):
+                budget = resolve_official_context_budget(
+                    direct_context_window=272_000,
+                    direct_max_context_window=272_000,
+                    direct_effective_context_window_percent=95,
+                    direct_auto_compact_token_limit=258_400,
+                    direct_freshness="fresh",
+                    direct_source=source,
+                )
+
+                self.assertEqual(budget.source, source)
+                self.assertEqual(budget.effective_context_window, 258_400)
+                self.assertEqual(budget.model_auto_compact_token_limit, 244_800)
+
+        lower_explicit = resolve_official_context_budget(
+            direct_context_window=272_000,
+            direct_max_context_window=272_000,
+            direct_effective_context_window_percent=95,
+            direct_auto_compact_token_limit=200_000,
+            direct_freshness="fresh",
+            direct_source=FRESH_DIRECT_OFFICIAL_CACHE_AUTHORITY_SOURCE,
+        )
+        self.assertEqual(lower_explicit.model_auto_compact_token_limit, 200_000)
+
     def test_fresh_direct_cache_authority_can_tighten_or_adopt_a_higher_budget(self):
         lower = resolve_official_context_budget(
             direct_context_window=272_000,


### PR DESCRIPTION
Refs #124

## Summary
- Use a freshness- and provenance-validated Direct Official cache from the native Codex target home only when the current app-server model list omits numeric context fields.
- Preserve runtime/target-home separation, sanitized fail-closed publication, stale-probe rejection, and safe hold/tighten behavior.
- Retry an explicit activation when startup has no published safe snapshot, while scheduled and resume retries remain bounded and sign-in-required failures are classified.
- Clamp explicit current-Direct and fresh-cache auto-compaction values to the lower of the explicit value, 90% of the authoritative context window, and the effective usable window; lower explicit values remain unchanged.
- Keep third-party limits and Gateway transport behavior unchanged.

## Verification
- `python -m pytest -q tests/test_model_limits.py tests/test_catalog_sync.py tests/test_config_overlay.py` (109 passed, 41 subtests passed)
- `git diff --check`
- Replacement CI run `29389297494` is green: Python, frontend UI contract, Rust normal/debug tests, clippy, and release flavor contract.
- Rust local checks remain unavailable because `cargo` and `rustfmt` are not configured; CI is the authority for the affected Rust jobs.

The post-merge integrated Debug refresh + switch-mode gate remains required before closing #124.