### PR TITLE
fix: tolerate internal Direct cache records

### DIFF
--- a/src-python/catalog_sync.py
+++ b/src-python/catalog_sync.py
@@ -534,7 +534,7 @@ def _nonempty_string(value: Any) -> bool:
     return isinstance(value, str) and bool(value.strip())
 
 
-def _direct_official_model_identity(model: Any) -> str | None:
+def _direct_official_model_identities(model: Any) -> list[str] | None:
     if not isinstance(model, dict):
         return None
     identities: list[str] = []
@@ -547,10 +547,17 @@ def _direct_official_model_identity(model: Any) -> str | None:
         slug = canonical_model_id(value)
         if slug.startswith("openai/gpt-"):
             slug = slug.removeprefix("openai/")
-        if not slug.startswith("gpt-"):
-            return None
         identities.append(slug)
-    if not identities or len(set(identities)) != 1:
+    return identities or None
+
+
+def _direct_official_model_identity(model: Any) -> str | None:
+    identities = _direct_official_model_identities(model)
+    if (
+        identities is None
+        or not all(identity.startswith("gpt-") for identity in identities)
+        or len(set(identities)) != 1
+    ):
         return None
     return identities[0]
 
@@ -560,6 +567,30 @@ def _direct_official_model_index(
 ) -> dict[str, dict[str, Any]] | None:
     indexed: dict[str, dict[str, Any]] = {}
     for model in models:
+        slug = _direct_official_model_identity(model)
+        if slug is None or slug in indexed:
+            return None
+        indexed[slug] = model
+    return indexed
+
+
+def _direct_official_cache_model_index(
+    models: Iterable[Any],
+) -> dict[str, dict[str, Any]] | None:
+    """Index cache entries relevant to the current Official GPT model list.
+
+    Native Direct caches may also contain internal non-GPT entries.  They carry
+    no authority for the Official GPT catalog and are ignored, while any entry
+    that names a GPT model must remain internally coherent and unique.
+    """
+
+    indexed: dict[str, dict[str, Any]] = {}
+    for model in models:
+        identities = _direct_official_model_identities(model)
+        if identities is None:
+            return None
+        if not any(identity.startswith("gpt-") for identity in identities):
+            continue
         slug = _direct_official_model_identity(model)
         if slug is None or slug in indexed:
             return None
@@ -664,12 +695,10 @@ def load_fresh_direct_official_cache_authority(
     if not isinstance(cache_models, list):
         return _unavailable_direct_official_cache_authority("missing")
     current_by_slug = _direct_official_model_index(snapshot.models)
-    cache_by_slug = _direct_official_model_index(
-        [model for model in cache_models if isinstance(model, dict)]
-    )
+    cache_by_slug = _direct_official_cache_model_index(cache_models)
     if current_by_slug is None or cache_by_slug is None or not current_by_slug:
         return _unavailable_direct_official_cache_authority("contradictory")
-    if len(cache_models) != len(cache_by_slug) or not set(current_by_slug).issubset(cache_by_slug):
+    if not set(current_by_slug).issubset(cache_by_slug):
         return _unavailable_direct_official_cache_authority("contradictory")
 
     context_by_slug: dict[str, dict[str, int]] = {}
@@ -680,8 +709,9 @@ def load_fresh_direct_official_cache_authority(
         values = _validated_cache_context_values(cached_model)
         if values is None:
             return _unavailable_direct_official_cache_authority("contradictory")
-        if values:
-            context_by_slug[slug] = values
+        if not values:
+            return _unavailable_direct_official_cache_authority("missing")
+        context_by_slug[slug] = values
 
     if not context_by_slug:
         return _unavailable_direct_official_cache_authority("missing")

--- a/tests/fixtures/codex_0_144_2_direct_models_cache.json
+++ b/tests/fixtures/codex_0_144_2_direct_models_cache.json
@@ -1,8 +1,8 @@
 {
   "fixture_version": 1,
-  "description": "Sanitized fresh Direct Official models cache shape paired with the Codex 0.144.2 no-numeric model/list fixture. Provenance markers are placeholders only and never become catalog diagnostics.",
+  "description": "Sanitized fresh Direct Official models cache shape paired with the Codex 0.144.2 no-numeric model/list fixture, including its unrelated internal entry. Provenance markers are placeholders only and never become catalog diagnostics.",
   "etag": "sanitized-direct-cache-etag",
-  "client_version": "0.144.1",
+  "client_version": "0.144.2",
   "fetched_at": "2026-07-15T03:21:42.227236100Z",
   "models": [
     {
@@ -28,23 +28,34 @@
     },
     {
       "slug": "gpt-5.5",
+      "context_window": 272000,
+      "max_context_window": 272000,
+      "effective_context_window_percent": 95,
       "comp_hash": "sanitized-config-marker-5-5"
     },
     {
       "slug": "gpt-5.4",
+      "context_window": 272000,
+      "max_context_window": 1000000,
+      "effective_context_window_percent": 95,
       "comp_hash": "sanitized-config-marker-5-4"
     },
     {
       "slug": "gpt-5.4-mini",
+      "context_window": 272000,
+      "max_context_window": 272000,
+      "effective_context_window_percent": 95,
       "comp_hash": "sanitized-config-marker-5-4-mini"
     },
     {
       "slug": "gpt-5.3-codex-spark",
+      "context_window": 128000,
+      "max_context_window": 128000,
+      "effective_context_window_percent": 95,
       "comp_hash": "sanitized-config-marker-spark"
     },
     {
-      "slug": "gpt-5.6-extra",
-      "comp_hash": "sanitized-config-marker-extra"
+      "slug": "codex-auto-review"
     }
   ]
 }

--- a/tests/test_catalog_sync.py
+++ b/tests/test_catalog_sync.py
@@ -713,6 +713,10 @@ class CatalogSyncTests(unittest.TestCase):
         )
         raw_models = json.loads(model_list_path.read_text(encoding="utf-8"))["data"]
         cache_payload = json.loads(cache_path.read_text(encoding="utf-8"))
+        self.assertEqual(
+            next(model for model in cache_payload["models"] if model["slug"] == "codex-auto-review"),
+            {"slug": "codex-auto-review"},
+        )
         snapshot = catalog_sync.OfficialSeedSnapshot(
             models=[
                 {
@@ -753,30 +757,41 @@ class CatalogSyncTests(unittest.TestCase):
         self.assertNotIn("sanitized-direct-cache-etag", serialized_catalog)
         self.assertNotIn("sanitized-config-marker", serialized_catalog)
         self.assertNotIn("models_cache.json", serialized_catalog)
+        self.assertNotIn("codex-auto-review", serialized_catalog)
 
-        for slug in ("gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"):
+        expected_context_windows = {
+            "gpt-5.6-sol": 272_000,
+            "gpt-5.6-terra": 272_000,
+            "gpt-5.6-luna": 272_000,
+            "gpt-5.5": 272_000,
+            "gpt-5.4": 272_000,
+            "gpt-5.4-mini": 272_000,
+            "gpt-5.3-codex-spark": 128_000,
+        }
+        self.assertEqual(set(authority.context_by_slug), set(expected_context_windows))
+        for slug, context_window in expected_context_windows.items():
             with self.subTest(slug=slug):
                 model = by_slug[slug]
                 budget = model["codex_proxy_metadata"]["official_context_budget"]
-                self.assertEqual(model["context_window"], 272_000)
-                self.assertEqual(model["max_context_window"], 272_000)
+                self.assertEqual(model["context_window"], context_window)
+                self.assertEqual(model["max_context_window"], context_window)
                 self.assertEqual(model["effective_context_window_percent"], 95)
                 self.assertEqual(
                     budget["source"],
                     "fresh_direct_official_cache_authority",
                 )
                 self.assertEqual(budget["freshness"], "fresh")
-                self.assertLessEqual(budget["effective_context_window"], 258_400)
-                self.assertLessEqual(budget["model_auto_compact_token_limit"], 244_800)
+                self.assertLessEqual(budget["effective_context_window"], context_window * 95 // 100)
+                self.assertLessEqual(
+                    budget["model_auto_compact_token_limit"],
+                    min(context_window * 90 // 100, context_window * 95 // 100),
+                )
                 self.assertLess(budget["model_auto_compact_token_limit"], 249_433)
                 serialized_budget = json.dumps(budget, sort_keys=True)
                 self.assertNotIn("sanitized-direct-cache-etag", serialized_budget)
                 self.assertNotIn("sanitized-config-marker", serialized_budget)
                 self.assertNotIn("models_cache.json", serialized_budget)
 
-        for slug in ("gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex-spark"):
-            with self.subTest(slug=slug):
-                self.assertNotIn("context_window", by_slug[slug])
         self.assertEqual(by_slug["glm-5.2"]["context_window"], 1_000_000)
         self.assertNotIn("353400", serialized_catalog)
 
@@ -796,7 +811,8 @@ class CatalogSyncTests(unittest.TestCase):
         direct_cache["fetched_at"] = datetime.now(timezone.utc).isoformat()
         direct_cache["etag"] = "target-cache-private-etag"
         for model in direct_cache["models"]:
-            model["comp_hash"] = f"target-cache-private-hash-{model['slug']}"
+            if model["slug"].startswith("gpt-"):
+                model["comp_hash"] = f"target-cache-private-hash-{model['slug']}"
 
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -996,6 +1012,22 @@ class CatalogSyncTests(unittest.TestCase):
             payload = json.loads(json.dumps(fresh_cache))
             payload.pop(key)
             cases.append((label, payload, cache_timestamp + 1, "missing"))
+        missing_all_numeric = json.loads(json.dumps(fresh_cache))
+        missing_numeric_model = next(
+            model for model in missing_all_numeric["models"] if model["slug"] == "gpt-5.6-terra"
+        )
+        for key in (
+            "context_window",
+            "max_context_window",
+            "effective_context_window_percent",
+        ):
+            missing_numeric_model.pop(key)
+        cases.append(("missing_all_numeric", missing_all_numeric, cache_timestamp + 1, "missing"))
+        missing_context_window = json.loads(json.dumps(fresh_cache))
+        next(
+            model for model in missing_context_window["models"] if model["slug"] == "gpt-5.6-terra"
+        ).pop("context_window")
+        cases.append(("missing_context_window", missing_context_window, cache_timestamp + 1, "contradictory"))
         missing_marker = json.loads(json.dumps(fresh_cache))
         next(model for model in missing_marker["models"] if model["slug"] == "gpt-5.6-terra").pop(
             "comp_hash"
@@ -1006,6 +1038,11 @@ class CatalogSyncTests(unittest.TestCase):
             model for model in mismatched_identity["models"] if model["slug"] == "gpt-5.6-terra"
         )["slug"] = "gpt-cache-mismatch"
         cases.append(("mismatched_model_id", mismatched_identity, cache_timestamp + 1, "contradictory"))
+        mixed_gpt_identity = json.loads(json.dumps(fresh_cache))
+        next(
+            model for model in mixed_gpt_identity["models"] if model["slug"] == "gpt-5.6-terra"
+        )["model"] = "gpt-5.6-luna"
+        cases.append(("mixed_gpt_identity", mixed_gpt_identity, cache_timestamp + 1, "contradictory"))
         contradictory_numeric = json.loads(json.dumps(fresh_cache))
         next(
             model for model in contradictory_numeric["models"] if model["slug"] == "gpt-5.6-terra"


### PR DESCRIPTION
Refs #124

## Summary
- Accept a fresh Direct Official cache that contains unrelated internal non-GPT records, while indexing numeric authority only for coherent GPT identities.
- Keep every current GPT cache entry fail-closed for missing provenance or numeric fields, invalid values, duplicate identities, and mixed/contradictory identity fields.
- Use the sanitized current 0.144.2 cache shape: all seven current GPT entries resolve from the cache; the unrelated internal entry carries neither numeric fields nor provenance.
- Preserve current-model subset agreement, freshness, atomic read behavior, sanitized publication, stale-larger rejection, and third-party limits.

## Sanitized isolated regression
- The preserved post-merge gate checker now reports `current_direct_official/fresh/7` to `fresh_direct_official_cache_authority/fresh/7`, exactly the seven expected GPT slugs. It emitted no raw paths or cache markers.

## Verification
- `python -m pytest -q tests/test_catalog_sync.py tests/test_model_limits.py tests/test_config_overlay.py` (109 passed, 44 subtests passed)
- `git diff --check`
- Replacement CI run `29390871136` is green: Python, frontend UI contract, Rust normal/debug tests, clippy, and release flavor contract.

The isolated Debug refresh + switch-mode gate must be rerun after this correction merges and a rebuilt artifact is installed.