### PR TITLE
fix: show published Official limits after refresh

### DIFF
--- a/frontend/scripts/ui-contract.test.mjs
+++ b/frontend/scripts/ui-contract.test.mjs
@@ -51,6 +51,7 @@ const tauriConfigSourcePath = new URL("../../src-tauri/src/config.rs", import.me
 const tauriMainPath = new URL("../../src-tauri/src/main.rs", import.meta.url);
 const tauriOpenAiUsagePath = new URL("../../src-tauri/src/openai_usage.rs", import.meta.url);
 const tauriModelsPath = new URL("../../src-tauri/src/models.rs", import.meta.url);
+const tauriOfficialRefreshPath = new URL("../../src-tauri/src/official_refresh.rs", import.meta.url);
 const tauriWebBridgePath = new URL("../../src-tauri/src/web_bridge.rs", import.meta.url);
 const i18nIndexPath = new URL("../src/i18n/index.ts", import.meta.url);
 const enLocalePath = new URL("../src/i18n/locales/en-US.ts", import.meta.url);
@@ -2099,6 +2100,85 @@ test("official alias merge keeps all-false disabled and ORs any true", async () 
     assert.equal(merged.length, 1, item.name);
     assert.equal(merged[0].enabled, item.expected, item.name);
   }
+});
+
+test("published Official catalog context limits outrank stale metadata after refresh", async () => {
+  const [providersSource, settingsSource] = await Promise.all([
+    readProviderContractSource(),
+    readFile(settingsLibPath, "utf8"),
+  ]);
+  const functionNames = [
+    "mergeOfficialModelSources",
+    "officialModelIdSet",
+    "isOfficialModel",
+    "filterCodexVisibleOfficialModels",
+    "isOfficialGatewayFastVariant",
+  ];
+  const blocks = functionNames.map((name) => {
+    const block = providersSource.match(new RegExp(`function ${name}\\([\\s\\S]*?^}`, "m"))?.[0];
+    assert.ok(block, `${name} source`);
+    return block;
+  });
+  const normalizeSource = settingsSource.match(/export function normalizeOfficialModelId[\s\S]*?^}/m)?.[0] ?? "";
+  const javascript = ts.transpileModule(
+    `${normalizeSource}\n${blocks.join("\n")}\nexport { mergeOfficialModelSources };`,
+    { compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2022 } },
+  ).outputText;
+  const moduleUrl = `data:text/javascript;base64,${Buffer.from(javascript).toString("base64")}`;
+  const { mergeOfficialModelSources } = await import(moduleUrl);
+
+  const [model] = mergeOfficialModelSources(
+    [{
+      id: "openai/gpt-5.6-terra",
+      context_window: 272000,
+      max_context_window: 272000,
+      effective_source: "fresh_direct_official_cache_authority",
+      max_source: "fresh_direct_official_cache_authority",
+      confidence: "verified",
+      verified_at: "2026-07-15T03:21:42Z",
+      display_name: "Published Terra",
+      enabled: false,
+    }],
+    [{
+      id: "gpt-5.6-terra",
+      context_window: 353400,
+      max_context_window: 353400,
+      effective_source: "pinned_metadata",
+      max_source: "pinned_metadata",
+      confidence: "fallback",
+      verified_at: "2025-01-01T00:00:00Z",
+      display_name: "Fresh metadata Terra",
+      default_reasoning_level: "high",
+      enabled: true,
+    }],
+  );
+
+  assert.equal(model.id, "gpt-5.6-terra");
+  assert.equal(model.context_window, 272000);
+  assert.equal(model.max_context_window, 272000);
+  assert.equal(model.effective_source, "fresh_direct_official_cache_authority");
+  assert.equal(model.max_source, "fresh_direct_official_cache_authority");
+  assert.equal(model.confidence, "verified");
+  assert.equal(model.verified_at, "2026-07-15T03:21:42Z");
+  assert.equal(model.display_name, "Fresh metadata Terra");
+  assert.equal(model.default_reasoning_level, "high");
+  assert.equal(model.enabled, true);
+});
+
+test("manual and quiet Official refresh expose only the post-publication catalog", async () => {
+  const [actionsSource, refreshSource] = await Promise.all([
+    readFile(providerCatalogActionsPath, "utf8"),
+    readFile(tauriOfficialRefreshPath, "utf8"),
+  ]);
+  const refreshAction = actionsSource.match(/async function refreshOfficialModels[\s\S]*?(?=async function discoverForForm)/)?.[0] ?? "";
+  const refreshManual = refreshSource.match(/pub\(crate\) fn refresh_manual[\s\S]*?(?=pub\(crate\) fn refresh_after_resume)/)?.[0] ?? "";
+  const manualResultModels = refreshSource.match(/fn manual_refresh_models[\s\S]*?(?=fn published_official_catalog_models)/)?.[0] ?? "";
+
+  assert.match(refreshAction, /const quiet = options\?\.quiet \?\? false;/);
+  assert.match(refreshAction, /const refreshResult = await api\.refreshOfficialModels\(\);/);
+  assert.match(refreshManual, /let outcome = refresh\(RefreshTrigger::Manual\)\?;/);
+  assert.match(refreshManual, /models: manual_refresh_models\([\s\S]*?outcome\.snapshot_available,[\s\S]*?outcome\.models,[\s\S]*?published_official_catalog_models,/);
+  assert.match(manualResultModels, /if snapshot_available \{[\s\S]*?load_published_catalog\(\)[\s\S]*?\} else \{[\s\S]*?Ok\(outcome_models\)/);
 });
 
 test("official OpenAI controls are locked while Codex auth is missing", async () => {

--- a/frontend/src/lib/officialModels.ts
+++ b/frontend/src/lib/officialModels.ts
@@ -84,6 +84,14 @@ export function refreshedOfficialModelOrder(currentOrder: string[], refreshedMod
 
 export function mergeOfficialModelSources(catalog: Model[], metadata: Model[]) {
   const knownOfficialIds = officialModelIdSet(catalog, metadata);
+  const resolvedCatalogLimitFields = [
+    "context_window",
+    "max_context_window",
+    "effective_source",
+    "max_source",
+    "confidence",
+    "verified_at",
+  ] as const;
   const merged = new Map<string, Model>();
   for (const model of catalog.filter(isOfficialModel)) {
     const canonicalId = normalizeOfficialModelId(model.id, knownOfficialIds);
@@ -100,20 +108,30 @@ export function mergeOfficialModelSources(catalog: Model[], metadata: Model[]) {
         : model.enabled ?? true,
     });
   }
+  const publishedCatalogModels = new Map(merged);
   for (const model of metadata.filter(isOfficialModel)) {
     const canonicalId = normalizeOfficialModelId(model.id, knownOfficialIds);
     if (!canonicalId) {
       continue;
     }
     const existing = merged.get(canonicalId);
-    merged.set(canonicalId, {
+    const mergedModel: Model = {
       ...existing,
       ...model,
       id: canonicalId,
       enabled: existing
         ? (existing.enabled ?? true) || (model.enabled ?? true)
         : model.enabled ?? true,
-    });
+    };
+    const catalogModel = publishedCatalogModels.get(canonicalId);
+    if (catalogModel) {
+      for (const field of resolvedCatalogLimitFields) {
+        if (Object.prototype.hasOwnProperty.call(catalogModel, field)) {
+          Object.assign(mergedModel, { [field]: catalogModel[field] });
+        }
+      }
+    }
+    merged.set(canonicalId, mergedModel);
   }
   return filterCodexVisibleOfficialModels(Array.from(merged.values()));
 }

--- a/src-tauri/src/official_refresh.rs
+++ b/src-tauri/src/official_refresh.rs
@@ -183,10 +183,55 @@ pub(crate) fn refresh_before_official_activation() -> Result<(), String> {
 }
 
 pub(crate) fn refresh_manual() -> Result<OfficialRefreshResult, String> {
-    refresh(RefreshTrigger::Manual).map(|outcome| OfficialRefreshResult {
-        models: outcome.models,
-        restart_required: outcome.restart_required,
+    let outcome = refresh(RefreshTrigger::Manual)?;
+    let restart_required = outcome.restart_required;
+    Ok(OfficialRefreshResult {
+        // The generated catalog is atomically published before refresh()
+        // succeeds.  Never let the raw acquisition vector (which can retain
+        // stale metadata defaults) bypass that resolved snapshot in the UI.
+        models: manual_refresh_models(
+            outcome.snapshot_available,
+            outcome.models,
+            published_official_catalog_models,
+        )?,
+        restart_required,
     })
+}
+
+fn manual_refresh_models<LoadPublishedCatalog>(
+    snapshot_available: bool,
+    outcome_models: Vec<Model>,
+    load_published_catalog: LoadPublishedCatalog,
+) -> Result<Vec<Model>, String>
+where
+    LoadPublishedCatalog: FnOnce() -> Result<Vec<Model>, String>,
+{
+    if snapshot_available {
+        load_published_catalog()
+    } else {
+        Ok(outcome_models)
+    }
+}
+
+fn published_official_catalog_models() -> Result<Vec<Model>, String> {
+    let models = models::list_models()
+        .map_err(|_| "failed to reload the published Official catalog".to_string())?;
+    published_official_models_from_catalog(models)
+}
+
+fn published_official_models_from_catalog(models: Vec<Model>) -> Result<Vec<Model>, String> {
+    let official_models = models
+        .into_iter()
+        .filter(|model| {
+            let id = model.id.trim();
+            let id = id.strip_prefix("openai/").unwrap_or(id);
+            id.starts_with("gpt-")
+        })
+        .collect::<Vec<_>>();
+    if official_models.is_empty() {
+        return Err("published Official catalog contains no current Official models".to_string());
+    }
+    Ok(official_models)
 }
 
 pub(crate) fn refresh_after_resume() -> Result<(), String> {
@@ -653,13 +698,15 @@ fn unix_timestamp() -> u64 {
 #[cfg(test)]
 mod tests {
     use super::{
-        automatic_refresh_due, finalize_published_snapshot, read_state, record_attempt,
-        published_context_budgets_from_catalog_payload, refresh_with_flight, should_attempt,
+        automatic_refresh_due, finalize_published_snapshot, manual_refresh_models, read_state,
+        record_attempt, published_context_budgets_from_catalog_payload,
+        published_official_models_from_catalog, refresh_with_flight, should_attempt,
         direct_official_refresh_failure_message, update_published_context_budgets, write_state,
         OfficialRefreshState,
         PublishedOfficialBudget, RefreshOutcome, RefreshTrigger, SingleFlight,
         OFFICIAL_REFRESH_INTERVAL_SECONDS,
     };
+    use crate::Model;
     use serde_json::json;
     use std::collections::BTreeMap;
     use std::fs;
@@ -758,6 +805,52 @@ mod tests {
             ),
             "Direct Official refresh failed: app-server unavailable; failed to publish a degraded safe snapshot: catalog publication failed"
         );
+    }
+
+    #[test]
+    fn manual_refresh_result_reloads_only_the_published_official_catalog_models() {
+        let prepublication_model = Model {
+            id: "gpt-5.6-terra".to_string(),
+            context_window: Some(353_400),
+            max_context_window: Some(353_400),
+            ..Model::default()
+        };
+        let catalog_models = vec![
+            Model {
+                id: "openai/gpt-5.6-terra".to_string(),
+                context_window: Some(272_000),
+                max_context_window: Some(272_000),
+                ..Model::default()
+            },
+            Model {
+                id: "anthropic/claude-test".to_string(),
+                context_window: Some(400_000),
+                max_context_window: Some(400_000),
+                ..Model::default()
+            },
+        ];
+
+        let models = manual_refresh_models(true, vec![prepublication_model.clone()], || {
+            published_official_models_from_catalog(catalog_models)
+        })
+        .expect("published Official catalog models");
+
+        assert_eq!(models.len(), 1);
+        assert_eq!(models[0].id, "openai/gpt-5.6-terra");
+        assert_eq!(models[0].context_window, Some(272_000));
+        assert_eq!(models[0].max_context_window, Some(272_000));
+        assert_ne!(models[0].context_window, prepublication_model.context_window);
+        assert_ne!(models[0].max_context_window, prepublication_model.max_context_window);
+    }
+
+    #[test]
+    fn manual_refresh_preserves_disabled_official_models_as_an_empty_result() {
+        let models = manual_refresh_models(false, Vec::new(), || {
+            Err("disabled Official models must not reload a prior catalog".to_string())
+        })
+        .expect("disabled Official models preserve the original refresh outcome");
+
+        assert!(models.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Return only the atomically published Official catalog to the manual and quiet UI refresh when a safe snapshot is available.
- Preserve disabled Official state when no safe snapshot is available.
- Keep catalog-resolved context limits and their verification fields ahead of stale runtime metadata, while fresh descriptive and planner data still wins.

## Focused evidence
- Deterministic red reproduced stale metadata `353400` overwriting a safely published `272000` context.
- `npm run test:ui-contract` — 138 passed.
- Filtered Rust refresh tests — 3 passed.
- `npm run build` and `git diff --check` passed.

Refs #124