### PR TITLE
fix: inherit bundled provider capabilities

### DIFF
--- a/src-python/providers_config.py
+++ b/src-python/providers_config.py
@@ -469,11 +469,7 @@ def _apply_bundled_tool_surface_strategy_defaults(runtime_providers: Iterable[Pr
 
 
 def _providers_require_bundled_tool_surface_defaults(providers: Iterable[ProviderConfig]) -> bool:
-    return any(
-        not _provider_tool_surface_strategy_is_explicit(provider)
-        or any(model.tool_surface_strategy is None for model in provider.models)
-        for provider in providers
-    )
+    return any(model.tool_surface_strategy is None for provider in providers for model in provider.models)
 
 
 def _provider_tool_surface_strategy_is_explicit(provider: ProviderConfig) -> bool:

--- a/src-python/providers_config.py
+++ b/src-python/providers_config.py
@@ -62,6 +62,9 @@ class ModelConfig:
     supported_reasoning_levels: tuple[str, ...] = ()
     default_reasoning_level: str | None = None
     tool_surface_strategy: str | None = None
+    _bundled_tool_surface_strategy: str | None = field(
+        default=None, init=False, repr=False, compare=False
+    )
     sort_order: int = 0
     enabled: bool = True
     codex_enabled: bool = True
@@ -78,6 +81,12 @@ class ProviderConfig:
     available_upstream_formats: tuple[str, ...] = ()
     tool_protocol: str = "auto"
     tool_surface_strategy: str = "eager"
+    _tool_surface_strategy_explicit: bool = field(
+        default=False, init=False, repr=False, compare=False
+    )
+    _bundled_tool_surface_strategy: str | None = field(
+        default=None, init=False, repr=False, compare=False
+    )
     reports_cached_input_tokens: bool = False
     display_prefix: str | None = None
     sort_order: int = 0
@@ -357,8 +366,13 @@ def load_providers(path: Path | None = None) -> list[ProviderConfig]:
         return []
 
     data = tomllib.loads(path.read_text(encoding="utf-8"))
+    providers = _providers_from_data(data)
     if path.resolve() != DEFAULT_PROVIDERS_PATH.resolve():
-        _inherit_missing_tool_surface_strategies_from_bundled_defaults(data)
+        _apply_bundled_tool_surface_strategy_defaults(providers)
+    return providers
+
+
+def _providers_from_data(data: dict[str, Any]) -> list[ProviderConfig]:
     raw_providers = data.get("providers", [])
     if not isinstance(raw_providers, list):
         raise ValueError("providers must be an array of tables")
@@ -396,6 +410,10 @@ def load_providers(path: Path | None = None) -> list[ProviderConfig]:
             )
             indexed_models.append((model_index, model))
 
+        provider_tool_surface_strategy = _tool_surface_strategy_field(
+            raw_provider.get("tool_surface_strategy"), default="eager"
+        )
+        assert provider_tool_surface_strategy is not None
         provider = ProviderConfig(
             id=_string_field(raw_provider.get("id")),
             name=_string_field(raw_provider.get("name")),
@@ -404,80 +422,107 @@ def load_providers(path: Path | None = None) -> list[ProviderConfig]:
             upstream_format=_upstream_format_field(raw_provider.get("upstream_format")),
             available_upstream_formats=_upstream_formats_field(raw_provider.get("available_upstream_formats")),
             tool_protocol=_tool_protocol_field(raw_provider.get("tool_protocol")),
-            tool_surface_strategy=_tool_surface_strategy_field(
-                raw_provider.get("tool_surface_strategy"), default="eager"
-            ),
+            tool_surface_strategy=provider_tool_surface_strategy,
             reports_cached_input_tokens=_bool_field(raw_provider.get("reports_cached_input_tokens"), False),
             display_prefix=_optional_string_field(raw_provider.get("display_prefix")),
             sort_order=_int_field(raw_provider.get("sort_order"), 0),
             enabled=_bool_field(raw_provider.get("enabled"), True),
             models=_sort_by_order(indexed_models),
         )
+        provider._tool_surface_strategy_explicit = "tool_surface_strategy" in raw_provider
         indexed_providers.append((provider_index, provider))
 
     return _sort_by_order(indexed_providers)
 
 
-def _inherit_missing_tool_surface_strategies_from_bundled_defaults(runtime_data: dict[str, Any]) -> None:
-    """Fill omitted runtime strategies from matching bundled provider/model defaults.
-
-    A runtime provider-level strategy is an explicit selection, so it wins over
-    every bundled default for that provider. Otherwise, matching bundled model
-    overrides retain their existing precedence over bundled provider defaults.
-    """
-    if not DEFAULT_PROVIDERS_PATH.exists():
+def _apply_bundled_tool_surface_strategy_defaults(runtime_providers: Iterable[ProviderConfig]) -> None:
+    runtime_providers = list(runtime_providers)
+    if not _providers_require_bundled_tool_surface_defaults(runtime_providers):
         return
 
-    runtime_providers = runtime_data.get("providers")
-    if not isinstance(runtime_providers, list):
-        return
+    try:
+        bundled_data = tomllib.loads(DEFAULT_PROVIDERS_PATH.read_text(encoding="utf-8"))
+        bundled_providers = _providers_from_data(bundled_data)
+    except (OSError, ValueError) as exc:
+        raise ValueError(
+            "bundled providers configuration is required to resolve omitted tool_surface_strategy"
+        ) from exc
 
-    bundled_data = tomllib.loads(DEFAULT_PROVIDERS_PATH.read_text(encoding="utf-8"))
-    bundled_providers = bundled_data.get("providers")
-    if not isinstance(bundled_providers, list):
-        return
-
-    bundled_by_id: dict[str, dict[str, Any]] = {}
-    for bundled_provider in bundled_providers:
-        if not isinstance(bundled_provider, dict):
-            continue
-        provider_id = canonical_model_id(_string_field(bundled_provider.get("id")))
-        if provider_id:
-            bundled_by_id.setdefault(provider_id, bundled_provider)
-
+    bundled_by_id = _provider_config_index_by_id(bundled_providers)
     for runtime_provider in runtime_providers:
-        if not isinstance(runtime_provider, dict):
-            continue
-        provider_id = canonical_model_id(_string_field(runtime_provider.get("id")))
-        bundled_provider = bundled_by_id.get(provider_id)
+        bundled_provider = bundled_by_id.get(_canonical_config_identifier(runtime_provider.id))
         if bundled_provider is None:
             continue
-        if "tool_surface_strategy" in runtime_provider:
-            continue
 
-        if "tool_surface_strategy" in bundled_provider:
-            runtime_provider["tool_surface_strategy"] = bundled_provider["tool_surface_strategy"]
+        if not _provider_tool_surface_strategy_is_explicit(runtime_provider):
+            runtime_provider._bundled_tool_surface_strategy = _bundled_provider_tool_surface_strategy(
+                bundled_provider
+            )
 
-        runtime_models = runtime_provider.get("models")
-        bundled_models = bundled_provider.get("models")
-        if not isinstance(runtime_models, list) or not isinstance(bundled_models, list):
-            continue
-
-        bundled_models_by_id: dict[str, dict[str, Any]] = {}
-        for bundled_model in bundled_models:
-            if not isinstance(bundled_model, dict):
+        bundled_models_by_id = _model_config_index_by_identifier(bundled_provider.models)
+        for runtime_model in runtime_provider.models:
+            if runtime_model.tool_surface_strategy is not None:
                 continue
-            model_id = canonical_model_id(_string_field(bundled_model.get("id")))
-            if model_id:
-                bundled_models_by_id.setdefault(model_id, bundled_model)
+            bundled_model = _matching_model_config(runtime_model, bundled_models_by_id)
+            if bundled_model is not None:
+                runtime_model._bundled_tool_surface_strategy = bundled_model.tool_surface_strategy
 
-        for runtime_model in runtime_models:
-            if not isinstance(runtime_model, dict) or "tool_surface_strategy" in runtime_model:
-                continue
-            model_id = canonical_model_id(_string_field(runtime_model.get("id")))
-            bundled_model = bundled_models_by_id.get(model_id)
-            if bundled_model is not None and "tool_surface_strategy" in bundled_model:
-                runtime_model["tool_surface_strategy"] = bundled_model["tool_surface_strategy"]
+
+def _providers_require_bundled_tool_surface_defaults(providers: Iterable[ProviderConfig]) -> bool:
+    return any(
+        not _provider_tool_surface_strategy_is_explicit(provider)
+        or any(model.tool_surface_strategy is None for model in provider.models)
+        for provider in providers
+    )
+
+
+def _provider_tool_surface_strategy_is_explicit(provider: ProviderConfig) -> bool:
+    strategy = _tool_surface_strategy_field(provider.tool_surface_strategy, default="eager")
+    assert strategy is not None
+    return provider._tool_surface_strategy_explicit or strategy != "eager"
+
+
+def _bundled_provider_tool_surface_strategy(provider: ProviderConfig) -> str | None:
+    if not _provider_tool_surface_strategy_is_explicit(provider):
+        return None
+    return _tool_surface_strategy_field(provider.tool_surface_strategy, default=None)
+
+
+def _canonical_config_identifier(value: Any) -> str:
+    return canonical_model_id(_string_field(value))
+
+
+def _canonical_config_identifiers(values: Iterable[Any]) -> tuple[str, ...]:
+    identifiers: list[str] = []
+    for value in values:
+        identifier = _canonical_config_identifier(value)
+        if identifier and identifier not in identifiers:
+            identifiers.append(identifier)
+    return tuple(identifiers)
+
+
+def _provider_config_index_by_id(providers: Iterable[ProviderConfig]) -> dict[str, ProviderConfig]:
+    result: dict[str, ProviderConfig] = {}
+    for provider in providers:
+        for identifier in _canonical_config_identifiers((provider.id,)):
+            result.setdefault(identifier, provider)
+    return result
+
+
+def _model_config_index_by_identifier(models: Iterable[ModelConfig]) -> dict[str, ModelConfig]:
+    result: dict[str, ModelConfig] = {}
+    for model in models:
+        for identifier in _canonical_config_identifiers((model.id, *model.aliases)):
+            result.setdefault(identifier, model)
+    return result
+
+
+def _matching_model_config(model: ModelConfig, index: dict[str, ModelConfig]) -> ModelConfig | None:
+    for identifier in _canonical_config_identifiers((model.id, *model.aliases)):
+        bundled_model = index.get(identifier)
+        if bundled_model is not None:
+            return bundled_model
+    return None
 
 
 def save_providers(providers: Iterable[ProviderConfig], path: Path = DEFAULT_PROVIDERS_PATH) -> None:
@@ -508,7 +553,7 @@ def save_providers(providers: Iterable[ProviderConfig], path: Path = DEFAULT_PRO
         provider_tool_surface_strategy = _tool_surface_strategy_field(
             provider.tool_surface_strategy, default="eager"
         )
-        if provider_tool_surface_strategy != "eager":
+        if provider._tool_surface_strategy_explicit or provider_tool_surface_strategy != "eager":
             chunks.append(_toml_string_line("tool_surface_strategy", provider_tool_surface_strategy))
         if provider.reports_cached_input_tokens:
             chunks.append(_toml_bool_line("reports_cached_input_tokens", provider.reports_cached_input_tokens))
@@ -700,8 +745,20 @@ def _resolved_tool_surface_strategy(provider: ProviderConfig, model: ModelConfig
     model_strategy = _tool_surface_strategy_field(model.tool_surface_strategy, default=None)
     if model_strategy is not None:
         return model_strategy
+    bundled_model_strategy = _tool_surface_strategy_field(
+        model._bundled_tool_surface_strategy, default=None
+    )
+    if bundled_model_strategy is not None:
+        return bundled_model_strategy
     provider_strategy = _tool_surface_strategy_field(provider.tool_surface_strategy, default="eager")
     assert provider_strategy is not None
+    if _provider_tool_surface_strategy_is_explicit(provider):
+        return provider_strategy
+    bundled_provider_strategy = _tool_surface_strategy_field(
+        provider._bundled_tool_surface_strategy, default=None
+    )
+    if bundled_provider_strategy is not None:
+        return bundled_provider_strategy
     return provider_strategy
 
 

--- a/src-python/providers_config.py
+++ b/src-python/providers_config.py
@@ -357,6 +357,8 @@ def load_providers(path: Path | None = None) -> list[ProviderConfig]:
         return []
 
     data = tomllib.loads(path.read_text(encoding="utf-8"))
+    if path.resolve() != DEFAULT_PROVIDERS_PATH.resolve():
+        _inherit_missing_tool_surface_strategies_from_bundled_defaults(data)
     raw_providers = data.get("providers", [])
     if not isinstance(raw_providers, list):
         raise ValueError("providers must be an array of tables")
@@ -414,6 +416,68 @@ def load_providers(path: Path | None = None) -> list[ProviderConfig]:
         indexed_providers.append((provider_index, provider))
 
     return _sort_by_order(indexed_providers)
+
+
+def _inherit_missing_tool_surface_strategies_from_bundled_defaults(runtime_data: dict[str, Any]) -> None:
+    """Fill omitted runtime strategies from matching bundled provider/model defaults.
+
+    A runtime provider-level strategy is an explicit selection, so it wins over
+    every bundled default for that provider. Otherwise, matching bundled model
+    overrides retain their existing precedence over bundled provider defaults.
+    """
+    if not DEFAULT_PROVIDERS_PATH.exists():
+        return
+
+    runtime_providers = runtime_data.get("providers")
+    if not isinstance(runtime_providers, list):
+        return
+
+    bundled_data = tomllib.loads(DEFAULT_PROVIDERS_PATH.read_text(encoding="utf-8"))
+    bundled_providers = bundled_data.get("providers")
+    if not isinstance(bundled_providers, list):
+        return
+
+    bundled_by_id: dict[str, dict[str, Any]] = {}
+    for bundled_provider in bundled_providers:
+        if not isinstance(bundled_provider, dict):
+            continue
+        provider_id = canonical_model_id(_string_field(bundled_provider.get("id")))
+        if provider_id:
+            bundled_by_id.setdefault(provider_id, bundled_provider)
+
+    for runtime_provider in runtime_providers:
+        if not isinstance(runtime_provider, dict):
+            continue
+        provider_id = canonical_model_id(_string_field(runtime_provider.get("id")))
+        bundled_provider = bundled_by_id.get(provider_id)
+        if bundled_provider is None:
+            continue
+        if "tool_surface_strategy" in runtime_provider:
+            continue
+
+        if "tool_surface_strategy" in bundled_provider:
+            runtime_provider["tool_surface_strategy"] = bundled_provider["tool_surface_strategy"]
+
+        runtime_models = runtime_provider.get("models")
+        bundled_models = bundled_provider.get("models")
+        if not isinstance(runtime_models, list) or not isinstance(bundled_models, list):
+            continue
+
+        bundled_models_by_id: dict[str, dict[str, Any]] = {}
+        for bundled_model in bundled_models:
+            if not isinstance(bundled_model, dict):
+                continue
+            model_id = canonical_model_id(_string_field(bundled_model.get("id")))
+            if model_id:
+                bundled_models_by_id.setdefault(model_id, bundled_model)
+
+        for runtime_model in runtime_models:
+            if not isinstance(runtime_model, dict) or "tool_surface_strategy" in runtime_model:
+                continue
+            model_id = canonical_model_id(_string_field(runtime_model.get("id")))
+            bundled_model = bundled_models_by_id.get(model_id)
+            if bundled_model is not None and "tool_surface_strategy" in bundled_model:
+                runtime_model["tool_surface_strategy"] = bundled_model["tool_surface_strategy"]
 
 
 def save_providers(providers: Iterable[ProviderConfig], path: Path = DEFAULT_PROVIDERS_PATH) -> None:

--- a/tests/test_providers_config.py
+++ b/tests/test_providers_config.py
@@ -321,6 +321,104 @@ enabled = true
         self.assertEqual(ollama["ollama-cloud/glm-5.2"]["tool_surface_strategy"], "deferred_core")
         self.assertEqual(ollama["minimax-m3"]["tool_surface_strategy"], "eager")
 
+    def test_runtime_omission_inherits_bundled_model_strategy_for_ollama_cloud_aliases(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "providers.toml"
+            path.write_text(
+                """
+[[providers]]
+id = "ollama-cloud"
+name = "Ollama Cloud"
+base_url = "https://ollama.example.test/v1"
+api_key = "ollama-secret"
+
+  [[providers.models]]
+  id = "glm-5.2"
+""".lstrip(),
+                encoding="utf-8",
+            )
+
+            configured, unqualified = resolve_ollama_cloud_model(
+                "glm-5.2", providers_path=path, require_api_key=False
+            )
+            qualified_configured, qualified = resolve_ollama_cloud_model(
+                "ollama-cloud/glm-5.2", providers_path=path, require_api_key=False
+            )
+
+        self.assertTrue(configured)
+        self.assertTrue(qualified_configured)
+        self.assertEqual(unqualified["tool_surface_strategy"], "deferred_core")
+        self.assertEqual(qualified["tool_surface_strategy"], "deferred_core")
+
+    def test_runtime_omission_inherits_bundled_provider_strategy(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            bundled_path = root / "bundled-providers.toml"
+            runtime_path = root / "runtime-providers.toml"
+            bundled_path.write_text(
+                """
+[[providers]]
+id = "generic-provider"
+name = "Generic Provider"
+base_url = "https://bundled.example.test/v1"
+api_key = "bundled-secret"
+tool_surface_strategy = "deferred_core"
+
+  [[providers.models]]
+  id = "generic-model"
+""".lstrip(),
+                encoding="utf-8",
+            )
+            runtime_path.write_text(
+                """
+[[providers]]
+id = "generic-provider"
+name = "Generic Provider"
+base_url = "https://runtime.example.test/v1"
+api_key = "runtime-secret"
+
+  [[providers.models]]
+  id = "generic-model"
+""".lstrip(),
+                encoding="utf-8",
+            )
+
+            with patch("providers_config.DEFAULT_PROVIDERS_PATH", bundled_path):
+                index = build_external_model_index(load_providers(runtime_path), require_api_key=False)
+
+        self.assertEqual(index["generic-provider/generic-model"]["tool_surface_strategy"], "deferred_core")
+
+    def test_runtime_explicit_strategies_override_bundled_model_default(self):
+        for label, provider_strategy, model_strategy in (
+            ("provider", "eager", None),
+            ("model", None, "eager"),
+        ):
+            with self.subTest(label=label), tempfile.TemporaryDirectory() as tmpdir:
+                path = Path(tmpdir) / "providers.toml"
+                provider_line = (
+                    f'tool_surface_strategy = "{provider_strategy}"\n' if provider_strategy else ""
+                )
+                model_line = f'  tool_surface_strategy = "{model_strategy}"\n' if model_strategy else ""
+                path.write_text(
+                    f"""
+[[providers]]
+id = "ollama-cloud"
+name = "Ollama Cloud"
+base_url = "https://ollama.example.test/v1"
+api_key = "ollama-secret"
+{provider_line}
+  [[providers.models]]
+  id = "glm-5.2"
+{model_line}""".lstrip(),
+                    encoding="utf-8",
+                )
+
+                _, resolved = resolve_ollama_cloud_model(
+                    "glm-5.2", providers_path=path, require_api_key=False
+                )
+
+            self.assertEqual(resolved["tool_surface_strategy"], "eager")
+
     def test_tool_surface_strategy_rejects_invalid_provider_and_model_configuration(self):
         for provider_strategy, model_strategy in (("unknown", None), ("eager", "unknown")):
             with self.subTest(provider_strategy=provider_strategy, model_strategy=model_strategy):

--- a/tests/test_providers_config.py
+++ b/tests/test_providers_config.py
@@ -350,6 +350,79 @@ api_key = "ollama-secret"
         self.assertEqual(unqualified["tool_surface_strategy"], "deferred_core")
         self.assertEqual(qualified["tool_surface_strategy"], "deferred_core")
 
+    def test_inherited_ollama_strategy_prepares_a_deferred_core_tool_surface(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "providers.toml"
+            path.write_text(
+                """
+[[providers]]
+id = "ollama-cloud"
+name = "Ollama Cloud"
+base_url = "https://ollama.example.test/v1"
+api_key = "ollama-secret"
+
+  [[providers.models]]
+  id = "glm-5.2"
+""".lstrip(),
+                encoding="utf-8",
+            )
+            _, resolved = resolve_ollama_cloud_model(
+                "glm-5.2", providers_path=path, require_api_key=False
+            )
+
+        shell_command = {
+            "type": "function",
+            "name": "shell_command",
+            "description": "Run a PowerShell command.",
+            "parameters": {"type": "object", "properties": {}},
+        }
+        apply_patch = {
+            "type": "custom",
+            "name": "apply_patch",
+            "description": "Apply a unified diff patch.",
+        }
+        namespace = {
+            "type": "namespace",
+            "name": "mcp__synthetic_namespace",
+            "description": "Synthetic namespace used to prove the prepared tool surface.",
+            "tools": [
+                {
+                    "type": "function",
+                    "name": f"synthetic_tool_{index:03d}",
+                    "parameters": {"type": "object", "properties": {}},
+                }
+                for index in range(200)
+            ],
+        }
+        from codex_proxy import compatible_request_body
+
+        prepared = json.loads(
+            compatible_request_body(
+                json.dumps(
+                    {
+                        "model": "glm-5.2",
+                        "input": "Use the visible core tools only.",
+                        "tools": [shell_command, apply_patch, namespace],
+                    }
+                ).encode("utf-8"),
+                {"name": resolved["upstream_name"], **resolved},
+            )
+        )
+        prepared_tools = prepared["tools"]
+        prepared_names = {
+            tool["name"]
+            for tool in prepared_tools
+            if isinstance(tool, dict) and isinstance(tool.get("name"), str)
+        }
+
+        self.assertEqual(resolved["tool_surface_strategy"], "deferred_core")
+        self.assertEqual(prepared_tools[:2], [shell_command, apply_patch])
+        self.assertFalse(any(tool.get("type") == "namespace" for tool in prepared_tools))
+        self.assertFalse(
+            any(name.startswith("mcp__synthetic_namespace__synthetic_tool_") for name in prepared_names)
+        )
+        self.assertIn("tool_search", prepared_names)
+
     def test_runtime_omission_inherits_bundled_provider_strategy(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
@@ -388,36 +461,178 @@ api_key = "runtime-secret"
 
         self.assertEqual(index["generic-provider/generic-model"]["tool_surface_strategy"], "deferred_core")
 
-    def test_runtime_explicit_strategies_override_bundled_model_default(self):
-        for label, provider_strategy, model_strategy in (
-            ("provider", "eager", None),
-            ("model", None, "eager"),
-        ):
-            with self.subTest(label=label), tempfile.TemporaryDirectory() as tmpdir:
-                path = Path(tmpdir) / "providers.toml"
-                provider_line = (
-                    f'tool_surface_strategy = "{provider_strategy}"\n' if provider_strategy else ""
+    def test_runtime_bundled_model_override_wins_over_explicit_provider_and_roundtrips(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            bundled_path = root / "bundled-providers.toml"
+            runtime_path = root / "runtime-providers.toml"
+            saved_path = root / "saved-providers.toml"
+            bundled_path.write_text(
+                """
+[[providers]]
+id = "generic-provider"
+name = "Generic Provider"
+base_url = "https://bundled.example.test/v1"
+api_key = "bundled-secret"
+tool_surface_strategy = "deferred_core"
+
+  [[providers.models]]
+  id = "known-model"
+  tool_surface_strategy = "deferred_core"
+""".lstrip(),
+                encoding="utf-8",
+            )
+            runtime_path.write_text(
+                """
+[[providers]]
+id = "generic-provider"
+name = "Generic Provider"
+base_url = "https://runtime.example.test/v1"
+api_key = "runtime-secret"
+tool_surface_strategy = "eager"
+
+  [[providers.models]]
+  id = "known-model"
+
+  [[providers.models]]
+  id = "unrelated-model"
+""".lstrip(),
+                encoding="utf-8",
+            )
+
+            with patch("providers_config.DEFAULT_PROVIDERS_PATH", bundled_path):
+                loaded = load_providers(runtime_path)
+                initial_index = build_external_model_index(loaded, require_api_key=False)
+                save_providers(loaded, saved_path)
+                saved_toml = saved_path.read_text(encoding="utf-8")
+                reloaded_index = build_external_model_index(
+                    load_providers(saved_path), require_api_key=False
                 )
-                model_line = f'  tool_surface_strategy = "{model_strategy}"\n' if model_strategy else ""
-                path.write_text(
-                    f"""
+
+        self.assertIsNone(loaded[0].models[0].tool_surface_strategy)
+        self.assertEqual(initial_index["generic-provider/known-model"]["tool_surface_strategy"], "deferred_core")
+        self.assertEqual(initial_index["generic-provider/unrelated-model"]["tool_surface_strategy"], "eager")
+        self.assertIn('tool_surface_strategy = "eager"', saved_toml)
+        self.assertNotIn('  tool_surface_strategy = "deferred_core"', saved_toml)
+        self.assertEqual(reloaded_index["generic-provider/known-model"]["tool_surface_strategy"], "deferred_core")
+        self.assertEqual(reloaded_index["generic-provider/unrelated-model"]["tool_surface_strategy"], "eager")
+
+    def test_runtime_explicit_model_strategy_overrides_bundled_model_default(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "providers.toml"
+            path.write_text(
+                """
 [[providers]]
 id = "ollama-cloud"
 name = "Ollama Cloud"
 base_url = "https://ollama.example.test/v1"
 api_key = "ollama-secret"
-{provider_line}
+
   [[providers.models]]
   id = "glm-5.2"
-{model_line}""".lstrip(),
+  tool_surface_strategy = "eager"
+""".lstrip(),
+                encoding="utf-8",
+            )
+
+            _, resolved = resolve_ollama_cloud_model(
+                "glm-5.2", providers_path=path, require_api_key=False
+            )
+
+        self.assertEqual(resolved["tool_surface_strategy"], "eager")
+
+    def test_runtime_omission_inherits_bundled_model_strategy_through_canonical_aliases(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            bundled_path = root / "bundled-providers.toml"
+            runtime_path = root / "runtime-providers.toml"
+            bundled_path.write_text(
+                """
+[[providers]]
+id = "alias-provider"
+name = "Alias Provider"
+base_url = "https://bundled.example.test/v1"
+api_key = "bundled-secret"
+
+  [[providers.models]]
+  id = "canonical-model"
+  aliases = ["legacy-model:cloud"]
+  tool_surface_strategy = "deferred_core"
+""".lstrip(),
+                encoding="utf-8",
+            )
+            runtime_path.write_text(
+                """
+[[providers]]
+id = "alias-provider"
+name = "Alias Provider"
+base_url = "https://runtime.example.test/v1"
+api_key = "runtime-secret"
+
+  [[providers.models]]
+  id = " legacy-model "
+""".lstrip(),
+                encoding="utf-8",
+            )
+
+            with patch("providers_config.DEFAULT_PROVIDERS_PATH", bundled_path):
+                index = build_external_model_index(load_providers(runtime_path), require_api_key=False)
+
+        self.assertEqual(index["alias-provider/legacy-model"]["tool_surface_strategy"], "deferred_core")
+
+    def test_runtime_omission_fails_closed_without_readable_bundled_defaults(self):
+        for label, bundled_text in (("missing", None), ("malformed", "[[providers]\n")):
+            with self.subTest(label=label), tempfile.TemporaryDirectory() as tmpdir:
+                root = Path(tmpdir)
+                bundled_path = root / "bundled-providers.toml"
+                runtime_path = root / "runtime-providers.toml"
+                if bundled_text is not None:
+                    bundled_path.write_text(bundled_text, encoding="utf-8")
+                runtime_path.write_text(
+                    """
+[[providers]]
+id = "runtime-provider"
+name = "Runtime Provider"
+base_url = "https://runtime.example.test/v1"
+api_key = "runtime-secret"
+
+  [[providers.models]]
+  id = "runtime-model"
+""".lstrip(),
                     encoding="utf-8",
                 )
 
-                _, resolved = resolve_ollama_cloud_model(
-                    "glm-5.2", providers_path=path, require_api_key=False
-                )
+                with patch("providers_config.DEFAULT_PROVIDERS_PATH", bundled_path):
+                    with self.assertRaisesRegex(
+                        ValueError, "bundled providers configuration is required"
+                    ):
+                        load_providers(runtime_path)
 
-            self.assertEqual(resolved["tool_surface_strategy"], "eager")
+    def test_complete_runtime_strategies_do_not_require_bundled_defaults(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            bundled_path = root / "missing-bundled-providers.toml"
+            runtime_path = root / "runtime-providers.toml"
+            runtime_path.write_text(
+                """
+[[providers]]
+id = "runtime-provider"
+name = "Runtime Provider"
+base_url = "https://runtime.example.test/v1"
+api_key = "runtime-secret"
+tool_surface_strategy = "eager"
+
+  [[providers.models]]
+  id = "runtime-model"
+  tool_surface_strategy = "eager"
+""".lstrip(),
+                encoding="utf-8",
+            )
+
+            with patch("providers_config.DEFAULT_PROVIDERS_PATH", bundled_path):
+                index = build_external_model_index(load_providers(runtime_path), require_api_key=False)
+
+        self.assertEqual(index["runtime-provider/runtime-model"]["tool_surface_strategy"], "eager")
 
     def test_tool_surface_strategy_rejects_invalid_provider_and_model_configuration(self):
         for provider_strategy, model_strategy in (("unknown", None), ("eager", "unknown")):

--- a/tests/test_providers_config.py
+++ b/tests/test_providers_config.py
@@ -608,7 +608,7 @@ api_key = "runtime-secret"
                     ):
                         load_providers(runtime_path)
 
-    def test_complete_runtime_strategies_do_not_require_bundled_defaults(self):
+    def test_explicit_runtime_model_strategy_does_not_require_bundled_defaults(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             bundled_path = root / "missing-bundled-providers.toml"
@@ -620,7 +620,6 @@ id = "runtime-provider"
 name = "Runtime Provider"
 base_url = "https://runtime.example.test/v1"
 api_key = "runtime-secret"
-tool_surface_strategy = "eager"
 
   [[providers.models]]
   id = "runtime-model"


### PR DESCRIPTION
## Summary
- Inherit an omitted runtime `tool_surface_strategy` from matching bundled provider/model defaults.
- Keep explicit runtime provider and model strategies authoritative.
- Cover qualified and unqualified Ollama Cloud resolution plus generic provider inheritance.

## Verification
- `python -m pytest -q tests/test_providers_config.py`
- `python -m pytest -q` (1122 passed, 1 skipped, 293 subtests passed)
- `python scripts/report_quality_gates.py` (report-only; existing findings)

No Rust or frontend boundary changed: their optional strategy fields already preserve omission and explicit values.

Closes #108