### PR TITLE
Return apply_patch adapter validation errors as client errors

### DIFF
--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -10424,6 +10424,7 @@ class DownstreamErrorSpec:
     error: str | None = None
     detail: str | None = None
     error_type: str = "upstream_error"
+    preserve_explicit_error: bool = False
 
 
 def _typed_error_code(
@@ -10568,7 +10569,7 @@ def _downstream_sse_error_payload_for_inbound_format(error: DownstreamErrorSpec)
             error_type=error_type,
         )
     if error.exc is not None:
-        if error.error_type == "upstream_error":
+        if not error.preserve_explicit_error:
             return _downstream_stream_error_payload(upstream_name=error.upstream_name, exc=error.exc)
         return _downstream_stream_error_payload(
             upstream_name=error.upstream_name,
@@ -11926,8 +11927,10 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
         except UpstreamProtocolTranslationError as exc:
             detail = str(exc)
             error_code = exc.cause.code
-            error_status = 400 if error_code == APPLY_PATCH_ADAPTER_ERROR_CODE else 502
-            error_type = "invalid_request_error" if error_status == 400 else error_code
+            is_apply_patch_adapter_error = error_code == APPLY_PATCH_ADAPTER_ERROR_CODE
+            error_status = 400
+            json_error_type = "invalid_request_error" if is_apply_patch_adapter_error else error_code
+            sse_error_type = "invalid_request_error" if is_apply_patch_adapter_error else "upstream_error"
             write_proxy_event(
                 "request_error",
                 request_id=request_id,
@@ -11952,7 +11955,8 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                     exc=exc,
                     error=error_code,
                     detail=detail,
-                    error_type=error_type,
+                    error_type=sse_error_type,
+                    preserve_explicit_error=True,
                 )
                 return
             self._safe_send_downstream_json_error(
@@ -11963,7 +11967,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 exc=exc,
                 error=error_code,
                 detail=detail,
-                error_type=error_type,
+                error_type=json_error_type,
             )
         except ValueError as exc:
             write_proxy_event(
@@ -12597,6 +12601,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
         error: str | None = None,
         detail: str | None = None,
         error_type: str = "upstream_error",
+        preserve_explicit_error: bool = False,
     ) -> None:
         error_spec = DownstreamErrorSpec(
             inbound_format=inbound_format,
@@ -12606,6 +12611,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
             error=error,
             detail=detail,
             error_type=error_type,
+            preserve_explicit_error=preserve_explicit_error,
         )
         if inbound_format == "chat_completions":
             self.wfile.write(

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -10519,11 +10519,12 @@ def _downstream_stream_error_payload(
     exc: BaseException | None = None,
     error: str | None = None,
     detail: str | None = None,
+    error_type: str = "upstream_stream_error",
 ) -> dict[str, Any]:
-    error_type = error or (type(exc).__name__ if exc is not None else "UpstreamStreamError")
+    error_code = error or (type(exc).__name__ if exc is not None else "UpstreamStreamError")
     error_detail = detail or (safe_upstream_error_detail(exc) if exc is not None else "")
     failure_class = _upstream_failure_class(exc) if exc is not None else None
-    if failure_class is None and error_type in {
+    if failure_class is None and error_code in {
         "upstream_stream_idle_timeout",
         "upstream_stream_incomplete",
         "UpstreamStreamError",
@@ -10531,10 +10532,10 @@ def _downstream_stream_error_payload(
     }:
         failure_class = RETRY_FAILURE_QUICK_TRANSIENT
     payload = {
-        "type": "upstream_stream_error",
+        "type": error_type,
         "status": status,
         "upstream": upstream_name,
-        "error": error_type,
+        "error": error_code,
         "detail": error_detail,
         "retry_owner": "client",
     }
@@ -10543,17 +10544,20 @@ def _downstream_stream_error_payload(
         payload["retryable"] = failure_class != RETRY_FAILURE_PERMANENT
     payload["codexhub_error"] = _codexhub_error_payload(
         source=upstream_name,
-        message=error_detail or error_type,
+        message=error_detail or error_code,
         status=status,
         exc=exc,
-        error=error_type,
-        error_type="upstream_stream_error",
+        error=error_code,
+        error_type=error_type,
         failure_class=failure_class,
     )
     return payload
 
 
 def _downstream_sse_error_payload_for_inbound_format(error: DownstreamErrorSpec) -> dict[str, Any]:
+    error_type = error.error_type
+    if error_type == "upstream_error":
+        error_type = "upstream_stream_error"
     if error.inbound_format == "chat_completions":
         return _chat_completion_error_payload(
             upstream_name=error.upstream_name,
@@ -10561,15 +10565,25 @@ def _downstream_sse_error_payload_for_inbound_format(error: DownstreamErrorSpec)
             exc=error.exc,
             error=error.error,
             detail=error.detail,
-            error_type="upstream_stream_error",
+            error_type=error_type,
         )
     if error.exc is not None:
-        return _downstream_stream_error_payload(upstream_name=error.upstream_name, exc=error.exc)
+        if error.error_type == "upstream_error":
+            return _downstream_stream_error_payload(upstream_name=error.upstream_name, exc=error.exc)
+        return _downstream_stream_error_payload(
+            upstream_name=error.upstream_name,
+            status=error.status,
+            exc=error.exc,
+            error=error.error,
+            detail=error.detail,
+            error_type=error_type,
+        )
     return _downstream_stream_error_payload(
         upstream_name=error.upstream_name,
         status=error.status,
         error=error.error or "UpstreamProtocolError",
         detail=error.detail or error.error or "upstream stream failed",
+        error_type=error_type,
     )
 
 
@@ -11912,6 +11926,8 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
         except UpstreamProtocolTranslationError as exc:
             detail = str(exc)
             error_code = exc.cause.code
+            error_status = 400 if error_code == APPLY_PATCH_ADAPTER_ERROR_CODE else 502
+            error_type = "invalid_request_error" if error_status == 400 else error_code
             write_proxy_event(
                 "request_error",
                 request_id=request_id,
@@ -11922,7 +11938,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 upstream_format=upstream_format,
                 behavior_profile=behavior_profile,
                 inbound_format=inbound_format,
-                status=502,
+                status=error_status,
                 error=error_code,
                 detail=detail[:300],
                 duration_ms=int((time.monotonic() - started_at) * 1000),
@@ -11932,21 +11948,22 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 self._write_downstream_sse_error(
                     inbound_format=inbound_format,
                     upstream_name=upstream_name or "upstream_error",
-                    status=502,
+                    status=error_status,
                     exc=exc,
                     error=error_code,
                     detail=detail,
+                    error_type=error_type,
                 )
                 return
             self._safe_send_downstream_json_error(
-                502,
+                error_status,
                 inbound_format=inbound_format,
                 upstream_name=upstream_name or "upstream_error",
                 request_id=request_id,
                 exc=exc,
                 error=error_code,
                 detail=detail,
-                error_type=error_code,
+                error_type=error_type,
             )
         except ValueError as exc:
             write_proxy_event(
@@ -12579,6 +12596,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
         exc: BaseException | None = None,
         error: str | None = None,
         detail: str | None = None,
+        error_type: str = "upstream_error",
     ) -> None:
         error_spec = DownstreamErrorSpec(
             inbound_format=inbound_format,
@@ -12587,6 +12605,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
             exc=exc,
             error=error,
             detail=detail,
+            error_type=error_type,
         )
         if inbound_format == "chat_completions":
             self.wfile.write(

--- a/tests/test_chat_completions_gateway.py
+++ b/tests/test_chat_completions_gateway.py
@@ -951,8 +951,13 @@ class ChatCompletionsEndpointTests(unittest.TestCase):
             CodexProxyHandler.do_POST(handler)
 
         result = json.loads(b"".join(handler.wfile.writes))
-        self.assertEqual(handler._fake.status, 502)
+        self.assertEqual(handler._fake.status, 400)
         self.assertEqual(result["error"]["type"], "unsupported_protocol_semantics")
+        self.assertEqual(
+            result["codexhub_error"]["details"]["failure_class"],
+            codex_proxy.RETRY_FAILURE_PERMANENT,
+        )
+        self.assertFalse(result["codexhub_error"]["retryable"])
 
     def test_post_chat_completions_events_use_proxy_request_kind(self):
         body = json.dumps({

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -7046,20 +7046,25 @@ class RoutingTests(unittest.TestCase):
                 "stream": False,
             }
         ).encode("utf-8")
-        handler, fake = post_handler("/v1/responses", request_body)
-
+        client_attempts = 0
         with patch(
             "codex_proxy._open_upstream_response",
-            return_value=FakeContextResponse(upstream_body),
+            side_effect=[FakeContextResponse(upstream_body) for _ in range(6)],
         ) as open_upstream:
-            CodexProxyHandler._proxy_post_request(handler, inbound_format="responses")
+            for _ in range(6):
+                client_attempts += 1
+                handler, fake = post_handler("/v1/responses", request_body)
+                CodexProxyHandler._proxy_post_request(handler, inbound_format="responses")
+                payload = json.loads(b"".join(fake.wfile.writes))
+                if fake.status not in codex_proxy.TRANSIENT_HTTP_RETRY_STATUSES:
+                    break
 
+        self.assertEqual(client_attempts, 1)
         self.assertEqual(open_upstream.call_count, 1)
         event_names = [call.args[0] for call in self.write_proxy_event.call_args_list if call.args]
         self.assertNotIn("upstream_retry", event_names)
         self.assertNotIn("sse_retry_notice", event_names)
         self.assertEqual(fake.status, 400)
-        payload = json.loads(b"".join(fake.wfile.writes))
         self.assertEqual(payload["codexhub_error"]["code"], "provider.request")
         self.assertEqual(
             payload["codexhub_error"]["details"]["error"],
@@ -7120,6 +7125,107 @@ class RoutingTests(unittest.TestCase):
         self.assertEqual(payload["codexhub_error"]["code"], "provider.request")
         self.assertNotIn("arguments_not_exact", json.dumps(payload))
         self.assertNotIn(private_patch, json.dumps(payload))
+
+    def test_unrelated_protocol_translation_error_is_nonretryable_json_client_error(self):
+        translation_error = codex_proxy.UpstreamProtocolTranslationError(
+            codex_proxy.UnsupportedProtocolTranslationError(
+                "unsupported_protocol_semantics",
+                "Unsupported response semantics.",
+            )
+        )
+        request_body = json.dumps(
+            {
+                "model": "volc/glm-5.2",
+                "input": [{"type": "message", "role": "user", "content": "Return a response."}],
+                "stream": False,
+            }
+        ).encode("utf-8")
+        handler, fake = post_handler("/v1/responses", request_body)
+
+        with (
+            patch(
+                "codex_proxy._open_upstream_response",
+                return_value=FakeContextResponse(b"{}"),
+            ) as open_upstream,
+            patch.object(
+                CodexProxyHandler,
+                "_relay_upstream_response",
+                side_effect=translation_error,
+            ) as relay_upstream,
+        ):
+            CodexProxyHandler._proxy_post_request(handler, inbound_format="responses")
+
+        self.assertEqual(open_upstream.call_count, 1)
+        relay_upstream.assert_called_once()
+        self.assertEqual(fake.status, 400)
+        payload = json.loads(b"".join(fake.wfile.writes))
+        self.assertEqual(payload["codexhub_error"]["code"], "upstream.error")
+        self.assertEqual(
+            payload["codexhub_error"]["details"]["error"],
+            "unsupported_protocol_semantics",
+        )
+        self.assertEqual(
+            payload["codexhub_error"]["details"]["type"],
+            "unsupported_protocol_semantics",
+        )
+        self.assertEqual(
+            payload["codexhub_error"]["details"]["failure_class"],
+            codex_proxy.RETRY_FAILURE_PERMANENT,
+        )
+        self.assertFalse(payload["codexhub_error"]["retryable"])
+
+    def test_unrelated_protocol_translation_sse_keeps_stream_error_envelope(self):
+        translation_error = codex_proxy.UpstreamProtocolTranslationError(
+            codex_proxy.UnsupportedProtocolTranslationError(
+                "unsupported_protocol_semantics",
+                "Unsupported response semantics.",
+            )
+        )
+        request_body = json.dumps(
+            {
+                "model": "volc/glm-5.2",
+                "input": [{"type": "message", "role": "user", "content": "Return a response."}],
+                "stream": True,
+            }
+        ).encode("utf-8")
+        handler, fake = post_handler("/v1/responses", request_body)
+
+        def relay_after_sse_headers(*args, **kwargs):
+            CodexProxyHandler._send_sse_headers(handler, 200, "volcengine")
+            kwargs["mark_downstream_sse_started"]()
+            raise translation_error
+
+        with (
+            patch(
+                "codex_proxy._open_upstream_response",
+                return_value=FakeContextResponse(b"{}"),
+            ) as open_upstream,
+            patch.object(
+                CodexProxyHandler,
+                "_relay_upstream_response",
+                side_effect=relay_after_sse_headers,
+            ) as relay_upstream,
+        ):
+            CodexProxyHandler._proxy_post_request(handler, inbound_format="responses")
+
+        self.assertEqual(open_upstream.call_count, 1)
+        relay_upstream.assert_called_once()
+        self.assertEqual(fake.status, 200)
+        frames = b"".join(fake.wfile.writes).split(b"\n\n")
+        error_frame = next(frame for frame in frames if frame.startswith(b"event: error\n"))
+        error_line = next(line for line in error_frame.splitlines() if line.startswith(b"data: "))
+        payload = json.loads(error_line.removeprefix(b"data: "))
+        self.assertEqual(payload["type"], "upstream_stream_error")
+        self.assertEqual(payload["status"], 400)
+        self.assertEqual(payload["error"], "unsupported_protocol_semantics")
+        self.assertEqual(payload["retry_owner"], "client")
+        self.assertEqual(payload["failure_class"], codex_proxy.RETRY_FAILURE_PERMANENT)
+        self.assertFalse(payload["retryable"])
+        self.assertEqual(payload["codexhub_error"]["code"], "upstream.error")
+        self.assertEqual(
+            payload["codexhub_error"]["details"]["type"],
+            "upstream_stream_error",
+        )
 
     def test_apply_patch_adapter_rejects_conflicting_item_fields_and_custom_call_id_collisions(self):
         fixture = _load_glm_apply_patch_retry_fixture()

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -7028,6 +7028,99 @@ class RoutingTests(unittest.TestCase):
                 self.assertNotIn("input", adapter_event)
                 self.assertNotIn("patch", adapter_event)
 
+    def test_apply_patch_adapter_rejection_is_nonretryable_json_without_replay(self):
+        private_patch = "*** Begin Patch\n*** Update File: secret.txt\n"
+        malformed_item = {
+            "id": "fc_apply_patch",
+            "type": "function_call",
+            "status": "completed",
+            "call_id": "call_apply_patch",
+            "name": "apply_patch",
+            "arguments": json.dumps({"patch": private_patch, "unexpected": True}),
+        }
+        upstream_body = json.dumps({"id": "resp_apply_patch", "output": [malformed_item]}).encode("utf-8")
+        request_body = json.dumps(
+            {
+                "model": "volc/glm-5.2",
+                "input": [{"type": "message", "role": "user", "content": "Apply the patch."}],
+                "stream": False,
+            }
+        ).encode("utf-8")
+        handler, fake = post_handler("/v1/responses", request_body)
+
+        with patch(
+            "codex_proxy._open_upstream_response",
+            return_value=FakeContextResponse(upstream_body),
+        ) as open_upstream:
+            CodexProxyHandler._proxy_post_request(handler, inbound_format="responses")
+
+        self.assertEqual(open_upstream.call_count, 1)
+        event_names = [call.args[0] for call in self.write_proxy_event.call_args_list if call.args]
+        self.assertNotIn("upstream_retry", event_names)
+        self.assertNotIn("sse_retry_notice", event_names)
+        self.assertEqual(fake.status, 400)
+        payload = json.loads(b"".join(fake.wfile.writes))
+        self.assertEqual(payload["codexhub_error"]["code"], "provider.request")
+        self.assertEqual(
+            payload["codexhub_error"]["details"]["error"],
+            "invalid_apply_patch_function_call",
+        )
+        self.assertEqual(
+            payload["codexhub_error"]["details"]["failure_class"],
+            codex_proxy.RETRY_FAILURE_PERMANENT,
+        )
+        self.assertFalse(payload["codexhub_error"]["retryable"])
+        rendered_payload = json.dumps(payload)
+        self.assertNotIn("arguments_not_exact", rendered_payload)
+        self.assertNotIn(private_patch, rendered_payload)
+
+    def test_apply_patch_adapter_rejection_is_nonretryable_sse_without_replay(self):
+        private_patch = "*** Begin Patch\n*** Update File: secret.txt\n"
+        malformed_item = {
+            "id": "fc_apply_patch",
+            "type": "function_call",
+            "status": "completed",
+            "call_id": "call_apply_patch",
+            "name": "apply_patch",
+            "arguments": json.dumps({"patch": private_patch, "unexpected": True}),
+        }
+        upstream_events = [
+            {"type": "response.created", "response": {"id": "resp_apply_patch", "output": []}},
+            {"type": "response.output_item.done", "output_index": 0, "item": malformed_item},
+        ]
+        response = FakeSseResponse(
+            [f"data: {json.dumps(event)}\n\n".encode("utf-8") for event in upstream_events] + [b""]
+        )
+        request_body = json.dumps(
+            {
+                "model": "volc/glm-5.2",
+                "input": [{"type": "message", "role": "user", "content": "Apply the patch."}],
+                "stream": True,
+            }
+        ).encode("utf-8")
+        handler, fake = post_handler("/v1/responses", request_body)
+
+        with patch("codex_proxy._open_upstream_response", return_value=response) as open_upstream:
+            CodexProxyHandler._proxy_post_request(handler, inbound_format="responses")
+
+        self.assertEqual(open_upstream.call_count, 1)
+        event_names = [call.args[0] for call in self.write_proxy_event.call_args_list if call.args]
+        self.assertNotIn("upstream_retry", event_names)
+        self.assertNotIn("sse_retry_notice", event_names)
+        self.assertEqual(fake.status, 200)
+        frames = b"".join(fake.wfile.writes).split(b"\n\n")
+        error_frame = next(frame for frame in frames if frame.startswith(b"event: error\n"))
+        error_line = next(line for line in error_frame.splitlines() if line.startswith(b"data: "))
+        payload = json.loads(error_line.removeprefix(b"data: "))
+        self.assertEqual(payload["type"], "invalid_request_error")
+        self.assertEqual(payload["status"], 400)
+        self.assertEqual(payload["error"], "invalid_apply_patch_function_call")
+        self.assertEqual(payload["failure_class"], codex_proxy.RETRY_FAILURE_PERMANENT)
+        self.assertFalse(payload["retryable"])
+        self.assertEqual(payload["codexhub_error"]["code"], "provider.request")
+        self.assertNotIn("arguments_not_exact", json.dumps(payload))
+        self.assertNotIn(private_patch, json.dumps(payload))
+
     def test_apply_patch_adapter_rejects_conflicting_item_fields_and_custom_call_id_collisions(self):
         fixture = _load_glm_apply_patch_retry_fixture()
         arguments = json.dumps({"patch": fixture["patch"]})


### PR DESCRIPTION
## Summary
- Return malformed `apply_patch` adapter failures through the non-retryable client-error path.
- Preserve the stable error code and sanitized diagnostics for JSON and SSE responses.
- Prove one upstream attempt with no Gateway retry/replay amplification.

## Verification
- `python -m pytest -q tests/test_routing.py -k apply_patch`
- `python -m pytest -q`
- `python scripts/report_quality_gates.py` (report-only; existing baseline findings)

Closes #134