### PR TITLE
fix(gateway): make native Responses apply_patch contracts symmetric

### DIFF
--- a/config/providers.toml
+++ b/config/providers.toml
@@ -24,6 +24,7 @@ enabled = true
   sort_order = 2
   enabled = true
   tool_surface_strategy = "deferred_core"
+  native_responses_tool_codec = "strict_apply_patch"
 
   [[providers.models]]
   id = "kimi-k2.6"

--- a/scripts/qualify-issue-108-glm-tool-surface.ps1
+++ b/scripts/qualify-issue-108-glm-tool-surface.ps1
@@ -14,6 +14,7 @@ param(
     [switch]$CaptureGatewayDigestReplay,
     [string]$EvidenceFixture = '',
     [switch]$ExternalIsolationQualification,
+    [switch]$Issue140NativeResponsesQualification,
     [int]$ReadinessTimeoutSeconds = 60,
     [string]$QualificationEvidenceOutput = '',
     [string]$QualificationFailureOutput = '',
@@ -635,6 +636,45 @@ function Get-AdaptedTelemetryCount {
         }
     }
     return $total
+}
+
+function Get-CapturedApplyPatchDeclarations {
+    param(
+        [object[]]$CaptureEvents,
+        [ValidateSet('caller', 'upstream')]
+        [string]$Surface
+    )
+
+    $stage = if ($Surface -eq 'caller') { 'before' } else { 'after' }
+    $declarations = [System.Collections.Generic.List[object]]::new()
+    foreach ($captureEvent in $CaptureEvents) {
+        if ($captureEvent.stage -ne $stage -or $null -eq $captureEvent.shape) {
+            continue
+        }
+        $tools = [System.Collections.Generic.List[object]]::new()
+        if ($Surface -eq 'caller') {
+            foreach ($inputItem in @($captureEvent.shape.input)) {
+                foreach ($tool in @($inputItem.tools)) {
+                    if ($null -ne $tool) {
+                        [void]$tools.Add($tool)
+                    }
+                }
+            }
+        }
+        else {
+            foreach ($tool in @($captureEvent.shape.tools)) {
+                if ($null -ne $tool) {
+                    [void]$tools.Add($tool)
+                }
+            }
+        }
+        foreach ($tool in $tools) {
+            if ($tool.name -eq 'apply_patch') {
+                [void]$declarations.Add($tool)
+            }
+        }
+    }
+    return $declarations.ToArray()
 }
 
 function Test-ExpectedGlmGatewayRoute {
@@ -1467,6 +1507,9 @@ if ($CaptureGatewayDigestReplay) {
 if ($HistoryAdapterNegativeControl -and -not $FailFastAfterFirstPostSuccessToolChoice) {
     throw 'The history-adapter negative control requires fail-fast tool-choice stopping.'
 }
+if ($Issue140NativeResponsesQualification -and -not $ExternalIsolationQualification) {
+    throw 'The Issue 140 native Responses qualification requires external isolation.'
+}
 
 $ollamaApiKey = [Environment]::GetEnvironmentVariable('OLLAMA_API_KEY')
 if ([string]::IsNullOrWhiteSpace($ollamaApiKey)) {
@@ -1529,7 +1572,7 @@ if ($ExternalIsolationQualification -and [string]::IsNullOrWhiteSpace($Qualifica
     $QualificationFailureOutput = Join-Path $OutputDir 'sanitized-qualification-failure.json'
 }
 $summary = [ordered]@{
-    mode = if ($HistoryAdapterNegativeControl) { 'history_adapter_disabled_negative_control' } elseif ($ExternalIsolationQualification) { 'external_isolation_qualification' } else { 'qualification' }
+    mode = if ($HistoryAdapterNegativeControl) { 'history_adapter_disabled_negative_control' } elseif ($Issue140NativeResponsesQualification) { 'issue140_native_responses_qualification' } elseif ($ExternalIsolationQualification) { 'external_isolation_qualification' } else { 'qualification' }
     model = 'ollama-cloud/glm-5.2'
     expected_upstream = 'ollama_cloud'
     expected_route_mode = 'codexhub'
@@ -1647,6 +1690,25 @@ def _tool_shape(tools):
             result.append({"kind": type(tool).__name__})
             continue
         item = {"type": tool.get("type"), "name": tool.get("name"), "keys": sorted(tool)}
+        if tool.get("name") == "apply_patch" and tool.get("type") == "custom":
+            tool_format = tool.get("format")
+            item["format_keys"] = sorted(tool_format) if isinstance(tool_format, dict) else None
+            item["format_type"] = tool_format.get("type") if isinstance(tool_format, dict) else None
+            item["format_syntax"] = tool_format.get("syntax") if isinstance(tool_format, dict) else None
+            definition = tool_format.get("definition") if isinstance(tool_format, dict) else None
+            item["definition_present"] = isinstance(definition, str) and bool(definition.strip())
+        elif tool.get("name") == "apply_patch" and tool.get("type") == "function":
+            parameters = tool.get("parameters")
+            properties = parameters.get("properties") if isinstance(parameters, dict) else None
+            patch_schema = properties.get("patch") if isinstance(properties, dict) else None
+            item["strict"] = tool.get("strict")
+            item["parameter_keys"] = sorted(parameters) if isinstance(parameters, dict) else None
+            item["property_names"] = sorted(properties) if isinstance(properties, dict) else None
+            item["patch_schema_keys"] = sorted(patch_schema) if isinstance(patch_schema, dict) else None
+            item["patch_type"] = patch_schema.get("type") if isinstance(patch_schema, dict) else None
+            item["patch_min_length"] = patch_schema.get("minLength") if isinstance(patch_schema, dict) else None
+            item["required"] = parameters.get("required") if isinstance(parameters, dict) else None
+            item["additional_properties"] = parameters.get("additionalProperties") if isinstance(parameters, dict) else None
         nested = tool.get("tools")
         if isinstance(nested, list):
             item["nested_tools"] = _tool_shape(nested)
@@ -2192,14 +2254,7 @@ Automated qualification: follow this exact tool sequence and use no other tools.
 2. Call apply_patch exactly once to replace only issue108-before with issue108-after in qualification-target.txt. Do not use shell to write the file.
 3. Call shell_command exactly once to read only qualification-target.txt and verify issue108-after.
 After a successful apply_patch result, step 2 is complete. Do not call apply_patch again for any reason: your next and only tool call must be the step-3 shell_command. Treat a repeated apply_patch call as an incorrect result.
-For the apply_patch action, emit exactly one upstream function-call argument named patch whose value is exactly this one-operation patch, with no duplicate hunks or additional file operations:
-*** Begin Patch
-*** Update File: qualification-target.txt
-@@
--issue108-before
-+issue108-after
-*** End Patch
-Do not use an empty argument name or additional arguments.
+Decide the patch contents from the file you read and the requested replacement.
 Do not call tool_search, collaboration tools, namespaces, or any other tool. Do not edit or create any other file. Finish with exactly: SENTINEL:issue108-shell-apply-shell
 '@
     $cli = Start-TrackedCodex -CommandPath $CodexCommand -Arguments $cliArguments -WorkingDirectory $testWorkspace -Environment $cliEnvironment
@@ -2304,11 +2359,21 @@ Do not call tool_search, collaboration tools, namespaces, or any other tool. Do 
     $surfaceEvents = @($events | Where-Object { $_.event -eq 'external_tool_surface_prepared' })
     $adapterEvents = @($events | Where-Object { $_.event -eq 'third_party_apply_patch_freeform_adapter' })
     $historyAdapterEvents = @($events | Where-Object { $_.event -eq 'third_party_apply_patch_freeform_history_adapter' })
+    $nativeResponsesToolCodecEvents = @($events | Where-Object { $_.event -eq 'native_responses_tool_codec' })
     $applyPatchAdapterAdaptedCount = Get-AdaptedTelemetryCount -Events $adapterEvents
     $applyPatchHistoryAdapterAdaptedCount = Get-AdaptedTelemetryCount -Events $historyAdapterEvents
+    $nativeResponsesToolCodecAdaptedCount = Get-AdaptedTelemetryCount -Events @(
+        $nativeResponsesToolCodecEvents | Where-Object { $_.codec -eq 'strict_apply_patch' }
+    )
     $requestErrors = @($events | Where-Object { $_.event -eq 'request_error' })
     $upstreamRetryEvents = @($events | Where-Object { $_.event -eq 'upstream_retry' })
     $upstreamProtocolFallbackEvents = @($events | Where-Object { $_.event -eq 'upstream_protocol_fallback' })
+    $callerApplyPatchDeclarations = @(
+        Get-CapturedApplyPatchDeclarations -CaptureEvents $captureEvents -Surface 'caller'
+    )
+    $upstreamApplyPatchDeclarations = @(
+        Get-CapturedApplyPatchDeclarations -CaptureEvents $captureEvents -Surface 'upstream'
+    )
     $postSuccessStructuredHistoryPairCounts = [System.Collections.Generic.List[int]]::new()
     for ($index = 0; $index -lt $captureEvents.Count; $index++) {
         if ($captureEvents[$index].stage -ne 'post_success_apply_patch_result') {
@@ -2401,6 +2466,35 @@ Do not call tool_search, collaboration tools, namespaces, or any other tool. Do 
     if ($applyPatchAdapterAdaptedCount -le 0) {
         [void]$failures.Add('the third-party apply_patch freeform adapter never reported adapted')
     }
+    if ($nativeResponsesToolCodecAdaptedCount -le 0) {
+        [void]$failures.Add('native Responses tool codec never reported strict_apply_patch/adapted')
+    }
+    if ($callerApplyPatchDeclarations.Count -eq 0 -or @(
+        $callerApplyPatchDeclarations | Where-Object {
+            $_.type -ne 'custom' -or
+            (@($_.format_keys) -join ',') -ne 'definition,syntax,type' -or
+            $_.format_type -ne 'grammar' -or
+            $_.format_syntax -ne 'lark' -or
+            $_.definition_present -ne $true
+        }
+    ).Count -gt 0) {
+        [void]$failures.Add('caller apply_patch declaration did not expose the exact grammar contract')
+    }
+    if ($upstreamApplyPatchDeclarations.Count -eq 0 -or @(
+        $upstreamApplyPatchDeclarations | Where-Object {
+            $_.type -ne 'function' -or
+            $_.strict -ne $true -or
+            (@($_.parameter_keys) -join ',') -ne 'additionalProperties,properties,required,type' -or
+            (@($_.property_names) -join ',') -ne 'patch' -or
+            (@($_.patch_schema_keys) -join ',') -ne 'minLength,type' -or
+            $_.patch_type -ne 'string' -or
+            [int]$_.patch_min_length -ne 1 -or
+            (@($_.required) -join ',') -ne 'patch' -or
+            $_.additional_properties -ne $false
+        }
+    ).Count -gt 0) {
+        [void]$failures.Add('upstream apply_patch declaration did not expose the exact strict function contract')
+    }
     if ($HistoryAdapterNegativeControl) {
         if ($applyPatchHistoryAdapterAdaptedCount -ne 0) {
             [void]$failures.Add('history-adapter negative control unexpectedly reported adapted history')
@@ -2440,6 +2534,12 @@ Do not call tool_search, collaboration tools, namespaces, or any other tool. Do 
     $summary.apply_patch_history_adapter_outcomes = @($historyAdapterEvents | ForEach-Object { [string]$_.outcome })
     $summary.apply_patch_adapter_adapted_count = $applyPatchAdapterAdaptedCount
     $summary.apply_patch_history_adapter_adapted_count = $applyPatchHistoryAdapterAdaptedCount
+    $summary.native_responses_tool_codec_outcomes = @(
+        $nativeResponsesToolCodecEvents | ForEach-Object { '{0}/{1}' -f $_.codec, $_.outcome }
+    )
+    $summary.native_responses_tool_codec_adapted_count = $nativeResponsesToolCodecAdaptedCount
+    $summary.caller_apply_patch_grammar_contract_count = $callerApplyPatchDeclarations.Count
+    $summary.upstream_strict_apply_patch_contract_count = $upstreamApplyPatchDeclarations.Count
     $summary.post_success_tool_choice = $postSuccessToolChoice
     $summary.post_success_structured_history_pair_counts = @($postSuccessStructuredHistoryPairCounts)
     $summary.stopped_after_first_post_success_tool_choice = $stoppedForPostSuccessToolChoice
@@ -2447,10 +2547,19 @@ Do not call tool_search, collaboration tools, namespaces, or any other tool. Do 
     $summary.tool_search_call_count = $toolSearchChoiceEvents.Count
     $summary.upstream_retry_event_count = $upstreamRetryEvents.Count
     $summary.upstream_protocol_fallback_event_count = $upstreamProtocolFallbackEvents.Count
+    $summary.request_error_event_count = $requestErrors.Count
     $summary.git_status = @($statusLines)
     $summary.git_numstat = $numstat
     $summary.failures = @($failures)
     $summary.passed = $failures.Count -eq 0
+    $summary.native_responses_contract_evidence_validated = (
+        $nativeResponsesToolCodecAdaptedCount -gt 0 -and
+        $callerApplyPatchDeclarations.Count -gt 0 -and
+        $upstreamApplyPatchDeclarations.Count -gt 0 -and
+        $requestErrors.Count -eq 0 -and
+        $upstreamRetryEvents.Count -eq 0 -and
+        $upstreamProtocolFallbackEvents.Count -eq 0
+    )
 }
 catch {
     Add-SanitizedSummaryFailure -Summary $summary -Code (Get-SanitizedQualificationFailureCode -ErrorRecord $_)
@@ -2465,7 +2574,7 @@ finally {
     if ($null -ne $gateway) {
         Complete-TrackedProcess -Tracked $gateway -Name 'gateway' -StdoutPath $gatewayStdoutPath -StderrPath $gatewayStderrPath -Summary $summary
     }
-    if ($ExternalIsolationQualification) {
+    if ($ExternalIsolationQualification -and -not $Issue140NativeResponsesQualification) {
         $allArtifactGatewayEvents = @(Read-JsonLines -Path (Join-Path $runtimeHome 'proxy\codex-proxy-events.jsonl'))
         $allArtifactCaptureEvents = @(Read-JsonLines -Path $requestShapePath)
         $artifactCapturePhase = if ($summary.readiness_preflight_passed) { 'acceptance' } else { 'preflight' }

--- a/scripts/qualify-issue-140-glm-native-responses-tools.ps1
+++ b/scripts/qualify-issue-140-glm-native-responses-tools.ps1
@@ -1,0 +1,121 @@
+param(
+    [string]$Workspace = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path,
+    [string]$OutputDir = '',
+    [string]$CodexCommand = '',
+    [int]$TimeoutSeconds = 240,
+    [int]$GatewayStartupSeconds = 20,
+    [int]$ReadinessTimeoutSeconds = 60
+)
+
+$ErrorActionPreference = 'Stop'
+$Workspace = (Resolve-Path -LiteralPath $Workspace).Path
+if ([string]::IsNullOrWhiteSpace($OutputDir)) {
+    $OutputDir = Join-Path ([System.IO.Path]::GetTempPath()) (
+        'codexhub-issue140-{0}-{1}' -f $PID, (Get-Date -Format 'yyyyMMddHHmmss')
+    )
+}
+$OutputDir = [System.IO.Path]::GetFullPath($OutputDir)
+New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
+
+$qualificationScript = Join-Path $PSScriptRoot 'qualify-issue-108-glm-tool-surface.ps1'
+$powerShellPath = (Get-Process -Id $PID).Path
+$runs = [System.Collections.Generic.List[object]]::new()
+
+foreach ($runNumber in 1..2) {
+    $runOutputDir = Join-Path $OutputDir ("pass-{0}" -f $runNumber)
+    New-Item -ItemType Directory -Force -Path $runOutputDir | Out-Null
+    $arguments = @(
+        '-NoLogo',
+        '-NoProfile',
+        '-File', $qualificationScript,
+        '-Workspace', $Workspace,
+        '-OutputDir', $runOutputDir,
+        '-TimeoutSeconds', "$TimeoutSeconds",
+        '-GatewayStartupSeconds', "$GatewayStartupSeconds",
+        '-ReadinessTimeoutSeconds', "$ReadinessTimeoutSeconds",
+        '-ExternalIsolationQualification',
+        '-Issue140NativeResponsesQualification'
+    )
+    if (-not [string]::IsNullOrWhiteSpace($CodexCommand)) {
+        $arguments += @('-CodexCommand', $CodexCommand)
+    }
+
+    $childOutput = (& $powerShellPath @arguments 2>&1 | Out-String)
+    $childExitCode = $LASTEXITCODE
+    $runDirectory = @(
+        Get-ChildItem -LiteralPath $runOutputDir -Directory -Filter 'run-*' |
+            Sort-Object LastWriteTimeUtc -Descending
+    ) | Select-Object -First 1
+    $childSummary = $null
+    if ($null -ne $runDirectory) {
+        $childSummaryPath = Join-Path $runDirectory.FullName 'summary.json'
+        if (Test-Path -LiteralPath $childSummaryPath) {
+            $childSummary = Get-Content -LiteralPath $childSummaryPath -Raw | ConvertFrom-Json
+        }
+    }
+
+    $toolSequence = if ($null -ne $childSummary) {
+        @($childSummary.tool_sequence)
+    }
+    else {
+        @()
+    }
+    $mutationValid = (
+        $null -ne $childSummary -and
+        (@($childSummary.git_status) -join "`n") -eq ' M qualification-target.txt' -and
+        [string]$childSummary.git_numstat -eq "1`t1`tqualification-target.txt"
+    )
+    $runPassed = (
+        $childExitCode -eq 0 -and
+        $null -ne $childSummary -and
+        [bool]$childSummary.passed -and
+        [bool]$childSummary.native_responses_contract_evidence_validated -and
+        ($toolSequence -join ',') -eq 'shell_command,apply_patch,shell_command' -and
+        $mutationValid -and
+        [int]$childSummary.native_responses_tool_codec_adapted_count -gt 0 -and
+        [int]$childSummary.caller_apply_patch_grammar_contract_count -gt 0 -and
+        [int]$childSummary.upstream_strict_apply_patch_contract_count -gt 0 -and
+        [int]$childSummary.request_error_event_count -eq 0 -and
+        [int]$childSummary.upstream_retry_event_count -eq 0 -and
+        [int]$childSummary.upstream_protocol_fallback_event_count -eq 0
+    )
+    [void]$runs.Add([ordered]@{
+        run_number = $runNumber
+        child_exit_code = $childExitCode
+        passed = $runPassed
+        tool_sequence = @($toolSequence)
+        mutation_valid = $mutationValid
+        native_responses_tool_codec_adapted_count = if ($null -ne $childSummary) {
+            [int]$childSummary.native_responses_tool_codec_adapted_count
+        }
+        else { 0 }
+        request_error_event_count = if ($null -ne $childSummary) {
+            [int]$childSummary.request_error_event_count
+        }
+        else { 0 }
+        upstream_retry_event_count = if ($null -ne $childSummary) {
+            [int]$childSummary.upstream_retry_event_count
+        }
+        else { 0 }
+        upstream_protocol_fallback_event_count = if ($null -ne $childSummary) {
+            [int]$childSummary.upstream_protocol_fallback_event_count
+        }
+        else { 0 }
+        child_output_present = -not [string]::IsNullOrWhiteSpace($childOutput)
+    })
+}
+
+$summary = [ordered]@{
+    schema = 'codexhub.issue140.native-responses-tools-qualification.v1'
+    model = 'ollama-cloud/glm-5.2'
+    expected_run_count = 2
+    completed_run_count = @($runs | Where-Object { $_.passed }).Count
+    runs = @($runs)
+    passed = @($runs).Count -eq 2 -and @($runs | Where-Object { -not $_.passed }).Count -eq 0
+}
+$summaryPath = Join-Path $OutputDir 'summary.json'
+$summary | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $summaryPath -Encoding UTF8
+Get-Content -LiteralPath $summaryPath -Raw
+if (-not $summary.passed) {
+    exit 1
+}

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -11326,6 +11326,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
             proxy_request_context["raw_provider_probe"] = True
         model = None
         model_requested = None
+        upstream: Mapping[str, Any] | None = None
         upstream_name = None
         upstream_format = "responses"
         reports_cached_input_tokens = False
@@ -11334,6 +11335,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
         route_policy_event_fields: dict[str, Any] = {}
         vision_proxy_policy = VISION_PROXY_DISABLED
         downstream_sse_started = False
+        response_lifecycle_state: dict[str, str] = {}
         caller_body = b""
         caller_request_observability: dict[str, Any] = {}
         request_observability: dict[str, Any] = {}
@@ -11860,6 +11862,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                                     request_kind=request_kind,
                                     defer_stream_errors=relay_attempt < relay_attempts,
                                     mark_downstream_sse_started=mark_downstream_sse_started,
+                                    response_lifecycle_state=response_lifecycle_state,
                                     behavior_profile=behavior_profile,
                                 )
                             break
@@ -12142,6 +12145,11 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
             error_status = 400
             json_error_type = "invalid_request_error" if is_apply_patch_adapter_error else error_code
             sse_error_type = "invalid_request_error" if is_apply_patch_adapter_error else "upstream_error"
+            selected_native_responses_tool_codec = (
+                upstream.get("native_responses_tool_codec", "none")
+                if isinstance(upstream, Mapping)
+                else "none"
+            )
             write_proxy_event(
                 "request_error",
                 request_id=request_id,
@@ -12159,7 +12167,11 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 **proxy_request_context,
             )
             if downstream_sse_started:
-                if is_apply_patch_adapter_error and inbound_format == "responses":
+                if (
+                    is_apply_patch_adapter_error
+                    and inbound_format == "responses"
+                    and selected_native_responses_tool_codec == "strict_apply_patch"
+                ):
                     self._write_sse_event(
                         "response.failed",
                         _responses_failed_event_for_stream_error(
@@ -12169,6 +12181,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                             exc=exc,
                             error=error_code,
                             detail=detail,
+                            response_id=response_lifecycle_state.get("response_id"),
                         ),
                     )
                     write_proxy_event(
@@ -12176,6 +12189,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         request_id=request_id,
                         model=canonical_model_id(model) if model else None,
                         upstream=upstream_name,
+                        codec=selected_native_responses_tool_codec,
                         disposition="response.failed",
                         failure_class=RETRY_FAILURE_PERMANENT,
                         retry_count=0,
@@ -13308,6 +13322,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
         request_kind: str = RETRY_REQUEST_MAIN_GENERATION,
         defer_stream_errors: bool = False,
         mark_downstream_sse_started: Callable[[], None] | None = None,
+        response_lifecycle_state: dict[str, str] | None = None,
         behavior_profile: str | None = None,
     ) -> int:
         status = getattr(response, "status", None) or getattr(response, "code", 502)
@@ -13333,6 +13348,16 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
 
         def observe_diagnostic_sse_line(line: bytes) -> None:
             _observe_gateway_diagnostic("observe_sse_line", request_id, len(line))
+
+        def remember_response_id(payload: Mapping[str, Any]) -> None:
+            if response_lifecycle_state is None:
+                return
+            response_payload = payload.get("response")
+            if not isinstance(response_payload, Mapping):
+                return
+            response_id = response_payload.get("id")
+            if isinstance(response_id, str) and response_id:
+                response_lifecycle_state["response_id"] = response_id
 
         if (
             behavior_profile == BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED
@@ -14293,6 +14318,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         original_payload = _parse_sse_json_payload(line) if upstream_name != "official" else None
                         usage_payload = _parse_sse_json_payload(line)
                         if isinstance(usage_payload, Mapping):
+                            remember_response_id(usage_payload)
                             event_type = usage_payload.get("type")
                             if isinstance(event_type, str) and (event_type.startswith("response.") or event_type == "error"):
                                 saw_response_event = True
@@ -14576,6 +14602,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                     usage_payload = _parse_sse_json_payload(line)
                     buffer_current_line = False
                     if isinstance(usage_payload, Mapping):
+                        remember_response_id(usage_payload)
                         event_type = usage_payload.get("type")
                         if isinstance(event_type, str) and (event_type.startswith("response.") or event_type == "error"):
                             last_response_event_type = event_type

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -27,7 +27,7 @@ import sys
 import threading
 import time
 import tomllib
-from typing import Any, Callable, Mapping
+from typing import Any, Callable, Mapping, NoReturn
 import uuid
 import zlib
 from urllib.error import HTTPError, URLError
@@ -615,6 +615,9 @@ TOOL_PROTOCOLS = {"auto", "responses_structured", "chat_tools", "text_compat", "
 STRUCTURED_TOOL_PROTOCOLS = {"responses_structured", "chat_tools"}
 TOOL_SURFACE_STRATEGIES = {"eager", "deferred_core"}
 TOOL_SURFACE_STRATEGY_ERROR_CODE = "invalid_external_tool_surface_strategy"
+NATIVE_RESPONSES_TOOL_CODECS = {"none", "strict_apply_patch"}
+NATIVE_RESPONSES_TOOL_CODEC_ERROR_CODE = "invalid_native_responses_tool_codec"
+NATIVE_RESPONSES_TOOL_CONTRACT_ERROR_CODE = "invalid_native_responses_tool_contract"
 TOOL_SEARCH_EXPLICIT_FUNCTION_TOOL = {
     "type": "function",
     "name": "tool_search",
@@ -1987,6 +1990,9 @@ def ollama_cloud_runtime_upstream(model_id: str, policy: Any) -> dict[str, Any] 
         "upstream_format": runtime_model.get("upstream_format", "responses"),
         "tool_protocol": runtime_model.get("tool_protocol", "auto"),
         "tool_surface_strategy": runtime_model.get("tool_surface_strategy", "eager"),
+        "native_responses_tool_codec": runtime_model.get(
+            "native_responses_tool_codec", "none"
+        ),
         "reports_cached_input_tokens": False,
         "input_modalities": tuple(runtime_model.get("input_modalities") or ("text",)),
     }
@@ -2088,6 +2094,9 @@ def choose_upstream(model_id: str) -> dict[str, Any]:
             "upstream_format": external_model.get("upstream_format", "responses"),
             "tool_protocol": external_model.get("tool_protocol", "auto"),
             "tool_surface_strategy": external_model.get("tool_surface_strategy", "eager"),
+            "native_responses_tool_codec": external_model.get(
+                "native_responses_tool_codec", "none"
+            ),
             "reports_cached_input_tokens": bool(external_model.get("reports_cached_input_tokens")),
             "input_modalities": tuple(external_model.get("input_modalities") or ("text",)),
         }
@@ -4254,6 +4263,203 @@ def _external_tool_surface_strategy(upstream: Mapping[str, Any]) -> str:
             "External tool surface strategy is invalid.",
         )
     )
+
+
+def _external_native_responses_tool_codec(upstream: Mapping[str, Any]) -> str:
+    configured = upstream.get("native_responses_tool_codec", "none")
+    if isinstance(configured, str) and configured in NATIVE_RESPONSES_TOOL_CODECS:
+        return configured
+    write_proxy_event("native_responses_tool_codec_rejected", reason="invalid_codec")
+    raise UpstreamProtocolTranslationError(
+        UnsupportedProtocolTranslationError(
+            NATIVE_RESPONSES_TOOL_CODEC_ERROR_CODE,
+            "External native Responses tool codec is invalid.",
+        )
+    )
+
+
+STRICT_APPLY_PATCH_EXAMPLE = """*** Begin Patch
+*** Update File: example.txt
+@@
+-before
++after
+*** End Patch"""
+STRICT_APPLY_PATCH_CUSTOM_TOOL_FIELDS = frozenset(
+    {"type", "name", "description", "format"}
+)
+STRICT_APPLY_PATCH_FORMAT_FIELDS = frozenset(
+    {"type", "syntax", "definition"}
+)
+
+
+def _raise_native_responses_tool_contract_error(
+    event_context: Mapping[str, Any] | None,
+    *,
+    codec: str,
+    reason: str,
+    count: int = 1,
+) -> NoReturn:
+    _write_adapter_event(
+        event_context,
+        "native_responses_tool_codec",
+        codec=codec,
+        outcome="rejected",
+        count=count,
+        reason=reason,
+    )
+    raise UpstreamProtocolTranslationError(
+        UnsupportedProtocolTranslationError(
+            NATIVE_RESPONSES_TOOL_CONTRACT_ERROR_CODE,
+            "External native Responses apply_patch declaration is ambiguous or lossy.",
+        )
+    )
+
+
+def _validate_strict_apply_patch_custom_tool(
+    tool: Mapping[str, Any],
+    event_context: Mapping[str, Any] | None,
+    *,
+    codec: str,
+) -> None:
+    if set(tool) != STRICT_APPLY_PATCH_CUSTOM_TOOL_FIELDS:
+        _raise_native_responses_tool_contract_error(
+            event_context,
+            codec=codec,
+            reason="custom_tool_fields_not_exact",
+        )
+    description = tool.get("description")
+    tool_format = tool.get("format")
+    if not isinstance(description, str) or not description.strip():
+        _raise_native_responses_tool_contract_error(
+            event_context,
+            codec=codec,
+            reason="missing_description",
+        )
+    if not isinstance(tool_format, Mapping) or set(tool_format) != STRICT_APPLY_PATCH_FORMAT_FIELDS:
+        _raise_native_responses_tool_contract_error(
+            event_context,
+            codec=codec,
+            reason="format_fields_not_exact",
+        )
+    if tool_format.get("type") != "grammar":
+        _raise_native_responses_tool_contract_error(
+            event_context,
+            codec=codec,
+            reason="format_not_grammar",
+        )
+    if not isinstance(tool_format.get("syntax"), str) or not tool_format["syntax"].strip():
+        _raise_native_responses_tool_contract_error(
+            event_context,
+            codec=codec,
+            reason="missing_grammar_syntax",
+        )
+    if not isinstance(tool_format.get("definition"), str) or not tool_format["definition"].strip():
+        _raise_native_responses_tool_contract_error(
+            event_context,
+            codec=codec,
+            reason="missing_grammar_definition",
+        )
+
+
+def _strict_apply_patch_function_tool(tool: Mapping[str, Any]) -> dict[str, Any]:
+    description_parts: list[str] = []
+    description = tool.get("description")
+    if isinstance(description, str) and description.strip():
+        description_parts.append(description.strip())
+    tool_format = tool.get("format")
+    if isinstance(tool_format, Mapping):
+        grammar = tool_format.get("definition")
+        if isinstance(grammar, str) and grammar.strip():
+            syntax = tool_format.get("syntax")
+            grammar_label = f"Original freeform grammar ({syntax}):" if isinstance(syntax, str) and syntax else "Original freeform grammar:"
+            description_parts.append(f"{grammar_label}\n{grammar.strip()}")
+    description_parts.append(
+        "Provide the complete patch in the required `patch` string. "
+        f"Example:\n{STRICT_APPLY_PATCH_EXAMPLE}"
+    )
+    return {
+        "type": "function",
+        "name": APPLY_PATCH_FUNCTION_NAME,
+        "description": "\n\n".join(description_parts),
+        "strict": True,
+        "parameters": {
+            "type": "object",
+            "properties": {"patch": {"type": "string", "minLength": 1}},
+            "required": ["patch"],
+            "additionalProperties": False,
+        },
+    }
+
+
+def _adapt_native_responses_tool_declarations(
+    payload: dict[str, Any],
+    upstream: Mapping[str, Any],
+    event_context: Mapping[str, Any] | None,
+) -> bool:
+    codec = _external_native_responses_tool_codec(upstream)
+    if codec == "none":
+        return False
+    tools = payload.get("tools")
+    if not isinstance(tools, list):
+        return False
+
+    apply_patch_tools = [
+        tool
+        for tool in tools
+        if isinstance(tool, Mapping) and tool.get("name") == APPLY_PATCH_FUNCTION_NAME
+    ]
+    if len(apply_patch_tools) > 1:
+        _raise_native_responses_tool_contract_error(
+            event_context,
+            codec=codec,
+            reason="duplicate_declaration",
+            count=len(apply_patch_tools),
+        )
+    if not apply_patch_tools:
+        _write_adapter_event(
+            event_context,
+            "native_responses_tool_codec",
+            codec=codec,
+            outcome="untouched",
+            count=0,
+        )
+        return False
+    apply_patch_tool = apply_patch_tools[0]
+    if apply_patch_tool.get("type") != "custom":
+        _raise_native_responses_tool_contract_error(
+            event_context,
+            codec=codec,
+            reason="declaration_not_custom",
+        )
+    _validate_strict_apply_patch_custom_tool(
+        apply_patch_tool,
+        event_context,
+        codec=codec,
+    )
+
+    rewritten_tools: list[Any] = []
+    adapted = 0
+    for tool in tools:
+        if (
+            isinstance(tool, Mapping)
+            and tool.get("type") == "custom"
+            and tool.get("name") == APPLY_PATCH_FUNCTION_NAME
+        ):
+            rewritten_tools.append(_strict_apply_patch_function_tool(tool))
+            adapted += 1
+        else:
+            rewritten_tools.append(tool)
+    if not adapted:
+        return False
+    payload["tools"] = rewritten_tools
+    _write_adapter_event(
+        event_context,
+        "native_responses_tool_codec",
+        codec=codec,
+        outcome="adapted",
+        count=adapted,
+    )
+    return True
 
 
 def _structured_tool_function_call_item(item: Mapping[str, Any]) -> dict[str, Any] | None:
@@ -7577,6 +7783,11 @@ def compatible_request_body(
         if not changed:
             return body
         return json.dumps(payload, ensure_ascii=True, separators=(",", ":")).encode("utf-8")
+    if (
+        tool_protocol == "responses_structured"
+        and _adapt_native_responses_tool_declarations(payload, upstream, event_context)
+    ):
+        changed = True
     allow_codex_tools = tool_protocol != "none"
     if inject_codex_tools and allow_codex_tools and not raw_provider_probe:
         if lifecycle_complete:
@@ -11948,16 +12159,39 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 **proxy_request_context,
             )
             if downstream_sse_started:
-                self._write_downstream_sse_error(
-                    inbound_format=inbound_format,
-                    upstream_name=upstream_name or "upstream_error",
-                    status=error_status,
-                    exc=exc,
-                    error=error_code,
-                    detail=detail,
-                    error_type=sse_error_type,
-                    preserve_explicit_error=True,
-                )
+                if is_apply_patch_adapter_error and inbound_format == "responses":
+                    self._write_sse_event(
+                        "response.failed",
+                        _responses_failed_event_for_stream_error(
+                            upstream_name=upstream_name or "upstream_error",
+                            model=canonical_model_id(model) if model else None,
+                            status=error_status,
+                            exc=exc,
+                            error=error_code,
+                            detail=detail,
+                        ),
+                    )
+                    write_proxy_event(
+                        "third_party_apply_patch_terminal",
+                        request_id=request_id,
+                        model=canonical_model_id(model) if model else None,
+                        upstream=upstream_name,
+                        disposition="response.failed",
+                        failure_class=RETRY_FAILURE_PERMANENT,
+                        retry_count=0,
+                    )
+                    self.close_connection = True
+                else:
+                    self._write_downstream_sse_error(
+                        inbound_format=inbound_format,
+                        upstream_name=upstream_name or "upstream_error",
+                        status=error_status,
+                        exc=exc,
+                        error=error_code,
+                        detail=detail,
+                        error_type=sse_error_type,
+                        preserve_explicit_error=True,
+                    )
                 return
             self._safe_send_downstream_json_error(
                 error_status,

--- a/src-python/providers_config.py
+++ b/src-python/providers_config.py
@@ -48,6 +48,7 @@ EXTERNAL_PROVIDER_EXCLUDED_IDS = {"ollama-cloud"}
 UPSTREAM_FORMATS = {"auto", "responses", "chat_completions", "anthropic_messages"}
 TOOL_PROTOCOLS = {"auto", "responses_structured", "chat_tools", "text_compat", "none"}
 TOOL_SURFACE_STRATEGIES = {"eager", "deferred_core"}
+NATIVE_RESPONSES_TOOL_CODECS = {"none", "strict_apply_patch"}
 
 
 @dataclass
@@ -62,7 +63,11 @@ class ModelConfig:
     supported_reasoning_levels: tuple[str, ...] = ()
     default_reasoning_level: str | None = None
     tool_surface_strategy: str | None = None
+    native_responses_tool_codec: str | None = None
     _bundled_tool_surface_strategy: str | None = field(
+        default=None, init=False, repr=False, compare=False
+    )
+    _bundled_native_responses_tool_codec: str | None = field(
         default=None, init=False, repr=False, compare=False
     )
     sort_order: int = 0
@@ -81,10 +86,17 @@ class ProviderConfig:
     available_upstream_formats: tuple[str, ...] = ()
     tool_protocol: str = "auto"
     tool_surface_strategy: str = "eager"
+    native_responses_tool_codec: str = "none"
     _tool_surface_strategy_explicit: bool = field(
         default=False, init=False, repr=False, compare=False
     )
     _bundled_tool_surface_strategy: str | None = field(
+        default=None, init=False, repr=False, compare=False
+    )
+    _native_responses_tool_codec_explicit: bool = field(
+        default=False, init=False, repr=False, compare=False
+    )
+    _bundled_native_responses_tool_codec: str | None = field(
         default=None, init=False, repr=False, compare=False
     )
     reports_cached_input_tokens: bool = False
@@ -208,6 +220,7 @@ def build_external_model_index(
 
             alias = canonical_model_id(f"{provider_id}/{model_id}")
             tool_surface_strategy = _resolved_tool_surface_strategy(provider, model)
+            native_responses_tool_codec = _resolved_native_responses_tool_codec(provider, model)
             entry = {
                 "alias": alias,
                 "provider_alias": provider_id,
@@ -218,6 +231,7 @@ def build_external_model_index(
                 "upstream_format": provider.upstream_format,
                 "tool_protocol": provider.tool_protocol,
                 "tool_surface_strategy": tool_surface_strategy,
+                "native_responses_tool_codec": native_responses_tool_codec,
                 "reports_cached_input_tokens": provider.reports_cached_input_tokens,
                 "upstream_model": _upstream_model_name(model),
                 "context_window": model.context_window,
@@ -287,6 +301,7 @@ def build_ollama_cloud_model_index(
 
             qualified_alias = canonical_model_id(f"{provider_id}/{model_id}")
             tool_surface_strategy = _resolved_tool_surface_strategy(provider, model)
+            native_responses_tool_codec = _resolved_native_responses_tool_codec(provider, model)
             entry = {
                 "alias": qualified_alias,
                 "provider_alias": provider_id,
@@ -297,6 +312,7 @@ def build_ollama_cloud_model_index(
                 "upstream_format": provider.upstream_format,
                 "tool_protocol": provider.tool_protocol,
                 "tool_surface_strategy": tool_surface_strategy,
+                "native_responses_tool_codec": native_responses_tool_codec,
                 "upstream_model": _upstream_model_name(model),
                 "context_window": model.context_window,
                 "max_output_tokens": model.max_output_tokens,
@@ -369,6 +385,7 @@ def load_providers(path: Path | None = None) -> list[ProviderConfig]:
     providers = _providers_from_data(data)
     if path.resolve() != DEFAULT_PROVIDERS_PATH.resolve():
         _apply_bundled_tool_surface_strategy_defaults(providers)
+        _apply_bundled_native_responses_tool_codec_defaults(providers)
     return providers
 
 
@@ -403,6 +420,9 @@ def _providers_from_data(data: dict[str, Any]) -> list[ProviderConfig]:
                 tool_surface_strategy=_tool_surface_strategy_field(
                     raw_model.get("tool_surface_strategy"), default=None
                 ),
+                native_responses_tool_codec=_native_responses_tool_codec_field(
+                    raw_model.get("native_responses_tool_codec"), default=None
+                ),
                 sort_order=_int_field(raw_model.get("sort_order"), 0),
                 enabled=_bool_field(raw_model.get("enabled"), True),
                 codex_enabled=_bool_field(raw_model.get("codex_enabled"), True),
@@ -414,6 +434,10 @@ def _providers_from_data(data: dict[str, Any]) -> list[ProviderConfig]:
             raw_provider.get("tool_surface_strategy"), default="eager"
         )
         assert provider_tool_surface_strategy is not None
+        provider_native_responses_tool_codec = _native_responses_tool_codec_field(
+            raw_provider.get("native_responses_tool_codec"), default="none"
+        )
+        assert provider_native_responses_tool_codec is not None
         provider = ProviderConfig(
             id=_string_field(raw_provider.get("id")),
             name=_string_field(raw_provider.get("name")),
@@ -423,6 +447,7 @@ def _providers_from_data(data: dict[str, Any]) -> list[ProviderConfig]:
             available_upstream_formats=_upstream_formats_field(raw_provider.get("available_upstream_formats")),
             tool_protocol=_tool_protocol_field(raw_provider.get("tool_protocol")),
             tool_surface_strategy=provider_tool_surface_strategy,
+            native_responses_tool_codec=provider_native_responses_tool_codec,
             reports_cached_input_tokens=_bool_field(raw_provider.get("reports_cached_input_tokens"), False),
             display_prefix=_optional_string_field(raw_provider.get("display_prefix")),
             sort_order=_int_field(raw_provider.get("sort_order"), 0),
@@ -430,6 +455,9 @@ def _providers_from_data(data: dict[str, Any]) -> list[ProviderConfig]:
             models=_sort_by_order(indexed_models),
         )
         provider._tool_surface_strategy_explicit = "tool_surface_strategy" in raw_provider
+        provider._native_responses_tool_codec_explicit = (
+            "native_responses_tool_codec" in raw_provider
+        )
         indexed_providers.append((provider_index, provider))
 
     return _sort_by_order(indexed_providers)
@@ -470,6 +498,65 @@ def _apply_bundled_tool_surface_strategy_defaults(runtime_providers: Iterable[Pr
 
 def _providers_require_bundled_tool_surface_defaults(providers: Iterable[ProviderConfig]) -> bool:
     return any(model.tool_surface_strategy is None for provider in providers for model in provider.models)
+
+
+def _apply_bundled_native_responses_tool_codec_defaults(
+    runtime_providers: Iterable[ProviderConfig],
+) -> None:
+    runtime_providers = list(runtime_providers)
+    if not any(
+        model.native_responses_tool_codec is None
+        for provider in runtime_providers
+        for model in provider.models
+    ):
+        return
+
+    try:
+        bundled_data = tomllib.loads(DEFAULT_PROVIDERS_PATH.read_text(encoding="utf-8"))
+        bundled_providers = _providers_from_data(bundled_data)
+    except (OSError, ValueError):
+        # No codec is the conservative compatibility default when bundled
+        # selection authority cannot be read.
+        return
+
+    bundled_by_id = _provider_config_index_by_id(bundled_providers)
+    for runtime_provider in runtime_providers:
+        bundled_provider = bundled_by_id.get(_canonical_config_identifier(runtime_provider.id))
+        if bundled_provider is None:
+            continue
+
+        if not _provider_native_responses_tool_codec_is_explicit(runtime_provider):
+            runtime_provider._bundled_native_responses_tool_codec = (
+                _bundled_provider_native_responses_tool_codec(bundled_provider)
+            )
+
+        bundled_models_by_id = _model_config_index_by_identifier(bundled_provider.models)
+        for runtime_model in runtime_provider.models:
+            if runtime_model.native_responses_tool_codec is not None:
+                continue
+            bundled_model = _matching_model_config(runtime_model, bundled_models_by_id)
+            if bundled_model is not None:
+                runtime_model._bundled_native_responses_tool_codec = (
+                    bundled_model.native_responses_tool_codec
+                )
+
+
+def _provider_native_responses_tool_codec_is_explicit(provider: ProviderConfig) -> bool:
+    codec = _native_responses_tool_codec_field(
+        provider.native_responses_tool_codec,
+        default="none",
+    )
+    assert codec is not None
+    return provider._native_responses_tool_codec_explicit or codec != "none"
+
+
+def _bundled_provider_native_responses_tool_codec(provider: ProviderConfig) -> str | None:
+    if not _provider_native_responses_tool_codec_is_explicit(provider):
+        return None
+    return _native_responses_tool_codec_field(
+        provider.native_responses_tool_codec,
+        default=None,
+    )
 
 
 def _provider_tool_surface_strategy_is_explicit(provider: ProviderConfig) -> bool:
@@ -551,6 +638,13 @@ def save_providers(providers: Iterable[ProviderConfig], path: Path = DEFAULT_PRO
         )
         if provider._tool_surface_strategy_explicit or provider_tool_surface_strategy != "eager":
             chunks.append(_toml_string_line("tool_surface_strategy", provider_tool_surface_strategy))
+        provider_native_responses_tool_codec = _native_responses_tool_codec_field(
+            provider.native_responses_tool_codec, default="none"
+        )
+        if provider_native_responses_tool_codec != "none":
+            chunks.append(
+                _toml_string_line("native_responses_tool_codec", provider_native_responses_tool_codec)
+            )
         if provider.reports_cached_input_tokens:
             chunks.append(_toml_bool_line("reports_cached_input_tokens", provider.reports_cached_input_tokens))
         chunks.extend(
@@ -591,6 +685,17 @@ def save_providers(providers: Iterable[ProviderConfig], path: Path = DEFAULT_PRO
             if model_tool_surface_strategy is not None:
                 chunks.append(
                     _toml_string_line("tool_surface_strategy", model_tool_surface_strategy, indent="  ")
+                )
+            model_native_responses_tool_codec = _native_responses_tool_codec_field(
+                model.native_responses_tool_codec, default=None
+            )
+            if model_native_responses_tool_codec is not None:
+                chunks.append(
+                    _toml_string_line(
+                        "native_responses_tool_codec",
+                        model_native_responses_tool_codec,
+                        indent="  ",
+                    )
                 )
             chunks.extend(
                 [
@@ -756,6 +861,46 @@ def _resolved_tool_surface_strategy(provider: ProviderConfig, model: ModelConfig
     if bundled_provider_strategy is not None:
         return bundled_provider_strategy
     return provider_strategy
+
+
+def _native_responses_tool_codec_field(value: Any, *, default: str | None) -> str | None:
+    if value is None:
+        return default
+    if not isinstance(value, str):
+        raise ValueError("native_responses_tool_codec must be none or strict_apply_patch")
+    codec = value.strip().lower()
+    if codec not in NATIVE_RESPONSES_TOOL_CODECS:
+        raise ValueError("native_responses_tool_codec must be none or strict_apply_patch")
+    return codec
+
+
+def _resolved_native_responses_tool_codec(provider: ProviderConfig, model: ModelConfig) -> str:
+    model_codec = _native_responses_tool_codec_field(
+        model.native_responses_tool_codec,
+        default=None,
+    )
+    if model_codec is not None:
+        return model_codec
+    bundled_model_codec = _native_responses_tool_codec_field(
+        model._bundled_native_responses_tool_codec,
+        default=None,
+    )
+    if bundled_model_codec is not None:
+        return bundled_model_codec
+    provider_codec = _native_responses_tool_codec_field(
+        provider.native_responses_tool_codec,
+        default="none",
+    )
+    assert provider_codec is not None
+    if _provider_native_responses_tool_codec_is_explicit(provider):
+        return provider_codec
+    bundled_provider_codec = _native_responses_tool_codec_field(
+        provider._bundled_native_responses_tool_codec,
+        default=None,
+    )
+    if bundled_provider_codec is not None:
+        return bundled_provider_codec
+    return provider_codec
 
 
 def _int_field(value: Any, default: int) -> int:

--- a/tests/fixtures/glm_apply_patch_retry_loop.json
+++ b/tests/fixtures/glm_apply_patch_retry_loop.json
@@ -9,6 +9,20 @@
     "repeated_call_count": 2
   },
   "patch": "*** Begin Patch\n*** Update File: SANITIZED_TARGET\n@@\n-OLD\n+NEW\n*** End Patch\n",
+  "observed_incompatible_arguments": {
+    "empty_key": {
+      "": "*** Begin Patch\n*** Update File: SANITIZED_TARGET\n@@\n-OLD\n+NEW\n*** End Patch\n"
+    },
+    "content_path": {
+      "content": "*** Begin Patch\n*** Update File: SANITIZED_TARGET\n@@\n-OLD\n+NEW\n*** End Patch\n",
+      "path": "SANITIZED_TARGET"
+    },
+    "patch_path_pattern": {
+      "patch": "*** Begin Patch\n*** Update File: SANITIZED_TARGET\n@@\n-OLD\n+NEW\n*** End Patch\n",
+      "path": "SANITIZED_TARGET",
+      "pattern": "OLD"
+    }
+  },
   "body_response": {
     "id": "<chat-response-id>",
     "model": "<third-party-glm>",

--- a/tests/test_providers_config.py
+++ b/tests/test_providers_config.py
@@ -37,6 +37,22 @@ class ProvidersConfigTests(unittest.TestCase):
         )
         self.assertEqual(configured_models, ["glm-5.2"])
 
+    def test_bundled_ollama_glm_selects_the_only_strict_apply_patch_native_responses_codec(self):
+        providers = load_providers(DEFAULT_PROVIDERS_PATH)
+        configured, index = build_ollama_cloud_model_index(providers, require_api_key=False)
+        configured_models = [
+            model.id
+            for provider in providers
+            for model in provider.models
+            if model.native_responses_tool_codec is not None
+        ]
+
+        self.assertTrue(configured)
+        self.assertEqual(configured_models, ["glm-5.2"])
+        self.assertEqual(index["glm-5.2"]["native_responses_tool_codec"], "strict_apply_patch")
+        self.assertEqual(index["ollama-cloud/glm-5.2"]["native_responses_tool_codec"], "strict_apply_patch")
+        self.assertEqual(index["minimax-m3"]["native_responses_tool_codec"], "none")
+
     def test_discover_official_models_fetches_gpt_models_sorted_with_limits(self):
         payload = {
             "data": [
@@ -349,6 +365,35 @@ api_key = "ollama-secret"
         self.assertTrue(qualified_configured)
         self.assertEqual(unqualified["tool_surface_strategy"], "deferred_core")
         self.assertEqual(qualified["tool_surface_strategy"], "deferred_core")
+
+    def test_runtime_omission_inherits_bundled_native_responses_tool_codec_for_ollama_glm_aliases(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "providers.toml"
+            path.write_text(
+                """
+[[providers]]
+id = "ollama-cloud"
+name = "Ollama Cloud"
+base_url = "https://ollama.example.test/v1"
+api_key = "ollama-secret"
+
+  [[providers.models]]
+  id = "glm-5.2"
+""".lstrip(),
+                encoding="utf-8",
+            )
+
+            configured, unqualified = resolve_ollama_cloud_model(
+                "glm-5.2", providers_path=path, require_api_key=False
+            )
+            qualified_configured, qualified = resolve_ollama_cloud_model(
+                "ollama-cloud/glm-5.2", providers_path=path, require_api_key=False
+            )
+
+        self.assertTrue(configured)
+        self.assertTrue(qualified_configured)
+        self.assertEqual(unqualified["native_responses_tool_codec"], "strict_apply_patch")
+        self.assertEqual(qualified["native_responses_tool_codec"], "strict_apply_patch")
 
     def test_inherited_ollama_strategy_prepares_a_deferred_core_tool_surface(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -7107,7 +7107,7 @@ class RoutingTests(unittest.TestCase):
         self.assertNotIn("arguments_not_exact", rendered_payload)
         self.assertNotIn(private_patch, rendered_payload)
 
-    def test_apply_patch_adapter_rejection_is_nonretryable_sse_without_replay(self):
+    def test_apply_patch_adapter_rejection_sse_terminal_is_codec_scoped_and_preserves_response_id(self):
         private_patch = "*** Begin Patch\n*** Update File: secret.txt\n"
         malformed_item = {
             "id": "fc_apply_patch",
@@ -7121,9 +7121,6 @@ class RoutingTests(unittest.TestCase):
             {"type": "response.created", "response": {"id": "resp_apply_patch", "output": []}},
             {"type": "response.output_item.done", "output_index": 0, "item": malformed_item},
         ]
-        response = FakeSseResponse(
-            [f"data: {json.dumps(event)}\n\n".encode("utf-8") for event in upstream_events] + [b""]
-        )
         request_body = json.dumps(
             {
                 "model": "volc/glm-5.2",
@@ -7131,51 +7128,103 @@ class RoutingTests(unittest.TestCase):
                 "stream": True,
             }
         ).encode("utf-8")
-        handler, fake = post_handler("/v1/responses", request_body)
+        cases = (
+            ("unselected", "none", b"event: error\n"),
+            ("selected", "strict_apply_patch", b"event: response.failed\n"),
+        )
+        for case, codec, expected_prefix in cases:
+            with self.subTest(case=case):
+                self.write_proxy_event.reset_mock()
+                response = FakeSseResponse(
+                    [f"data: {json.dumps(event)}\n\n".encode("utf-8") for event in upstream_events]
+                    + [b""]
+                )
+                handler, fake = post_handler("/v1/responses", request_body)
+                with (
+                    patch.dict(
+                        self.external_model,
+                        {"native_responses_tool_codec": codec},
+                    ),
+                    patch(
+                        "codex_proxy._open_upstream_response",
+                        return_value=response,
+                    ) as open_upstream,
+                ):
+                    CodexProxyHandler._proxy_post_request(
+                        handler,
+                        inbound_format="responses",
+                    )
 
-        with patch("codex_proxy._open_upstream_response", return_value=response) as open_upstream:
-            CodexProxyHandler._proxy_post_request(handler, inbound_format="responses")
+                self.assertEqual(open_upstream.call_count, 1)
+                event_names = [
+                    call.args[0]
+                    for call in self.write_proxy_event.call_args_list
+                    if call.args
+                ]
+                self.assertNotIn("upstream_retry", event_names)
+                self.assertNotIn("sse_retry_notice", event_names)
+                self.assertEqual(fake.status, 200)
+                frames = b"".join(fake.wfile.writes).split(b"\n\n")
+                terminal_frames = [
+                    frame for frame in frames if frame.startswith(expected_prefix)
+                ]
+                self.assertEqual(len(terminal_frames), 1)
 
-        self.assertEqual(open_upstream.call_count, 1)
-        event_names = [call.args[0] for call in self.write_proxy_event.call_args_list if call.args]
-        self.assertNotIn("upstream_retry", event_names)
-        self.assertNotIn("sse_retry_notice", event_names)
-        self.assertEqual(fake.status, 200)
-        frames = b"".join(fake.wfile.writes).split(b"\n\n")
-        failed_frames = [
-            frame for frame in frames if frame.startswith(b"event: response.failed\n")
-        ]
-        self.assertEqual(len(failed_frames), 1)
-        self.assertFalse(any(frame.startswith(b"event: error\n") for frame in frames))
-        failed_line = next(
-            line for line in failed_frames[0].splitlines() if line.startswith(b"data: ")
-        )
-        payload = json.loads(failed_line.removeprefix(b"data: "))
-        self.assertEqual(payload["type"], "response.failed")
-        self.assertEqual(payload["response"]["status"], "failed")
-        self.assertEqual(
-            payload["response"]["error"]["code"],
-            "invalid_apply_patch_function_call",
-        )
-        self.assertEqual(
-            payload["response"]["error"]["failure_class"],
-            codex_proxy.RETRY_FAILURE_PERMANENT,
-        )
-        self.assertFalse(payload["response"]["error"]["retryable"])
-        self.assertNotIn("arguments_not_exact", json.dumps(payload))
-        self.assertNotIn(private_patch, json.dumps(payload))
-        terminal_event = next(
-            call.kwargs
-            for call in self.write_proxy_event.call_args_list
-            if call.args and call.args[0] == "third_party_apply_patch_terminal"
-        )
-        self.assertEqual(terminal_event["disposition"], "response.failed")
-        self.assertEqual(
-            terminal_event["failure_class"], codex_proxy.RETRY_FAILURE_PERMANENT
-        )
-        self.assertEqual(terminal_event["retry_count"], 0)
-        for forbidden in ("arguments", "input", "patch", "path", "content", "pattern"):
-            self.assertNotIn(forbidden, terminal_event)
+                if codec == "none":
+                    self.assertFalse(
+                        any(
+                            frame.startswith(b"event: response.failed\n")
+                            for frame in frames
+                        )
+                    )
+                    self.assertNotIn("third_party_apply_patch_terminal", event_names)
+                    continue
+
+                self.assertFalse(
+                    any(frame.startswith(b"event: error\n") for frame in frames)
+                )
+                failed_line = next(
+                    line
+                    for line in terminal_frames[0].splitlines()
+                    if line.startswith(b"data: ")
+                )
+                payload = json.loads(failed_line.removeprefix(b"data: "))
+                self.assertEqual(payload["type"], "response.failed")
+                self.assertEqual(payload["response"]["id"], "resp_apply_patch")
+                self.assertEqual(payload["response"]["status"], "failed")
+                self.assertEqual(
+                    payload["response"]["error"]["code"],
+                    "invalid_apply_patch_function_call",
+                )
+                self.assertEqual(
+                    payload["response"]["error"]["failure_class"],
+                    codex_proxy.RETRY_FAILURE_PERMANENT,
+                )
+                self.assertFalse(payload["response"]["error"]["retryable"])
+                self.assertNotIn("arguments_not_exact", json.dumps(payload))
+                self.assertNotIn(private_patch, json.dumps(payload))
+                terminal_event = next(
+                    call.kwargs
+                    for call in self.write_proxy_event.call_args_list
+                    if call.args and call.args[0] == "third_party_apply_patch_terminal"
+                )
+                self.assertEqual(terminal_event["codec"], "strict_apply_patch")
+                self.assertEqual(terminal_event["disposition"], "response.failed")
+                self.assertEqual(
+                    terminal_event["failure_class"],
+                    codex_proxy.RETRY_FAILURE_PERMANENT,
+                )
+                self.assertEqual(terminal_event["retry_count"], 0)
+                for forbidden in (
+                    "arguments",
+                    "input",
+                    "patch",
+                    "path",
+                    "content",
+                    "pattern",
+                    "response_id",
+                ):
+                    self.assertNotIn(forbidden, terminal_event)
 
     def test_unrelated_protocol_translation_error_is_nonretryable_json_client_error(self):
         translation_error = codex_proxy.UpstreamProtocolTranslationError(

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -5023,6 +5023,28 @@ class RoutingTests(unittest.TestCase):
         self.assertEqual(unqualified["tool_surface_strategy"], "deferred_core")
         self.assertEqual(qualified["tool_surface_strategy"], "deferred_core")
 
+    def test_runtime_ollama_native_responses_tool_codec_is_copied_for_qualified_and_unqualified_routes(self):
+        runtime_model = {
+            "alias": "ollama-cloud/glm-5.2",
+            "provider_alias": "ollama-cloud",
+            "upstream_name": "ollama_cloud",
+            "base_url": "https://ollama.example.test/v1",
+            "api_key": "ollama-runtime-token",
+            "upstream_model": "glm-5.2",
+            "upstream_format": "responses",
+            "tool_protocol": "auto",
+            "tool_surface_strategy": "deferred_core",
+            "native_responses_tool_codec": "strict_apply_patch",
+            "input_modalities": ("text",),
+        }
+
+        with patch("codex_proxy.resolve_ollama_cloud_model", return_value=(True, runtime_model)):
+            unqualified = choose_upstream("glm-5.2")
+            qualified = choose_upstream("ollama-cloud/glm-5.2")
+
+        self.assertEqual(unqualified["native_responses_tool_codec"], "strict_apply_patch")
+        self.assertEqual(qualified["native_responses_tool_codec"], "strict_apply_patch")
+
     def test_runtime_ollama_provider_rejects_disabled_model_despite_static_policy_allowlist(self):
         with patch("codex_proxy.resolve_ollama_cloud_model", return_value=(True, None)):
             with self.assertRaises(ValueError) as context:
@@ -6996,6 +7018,12 @@ class RoutingTests(unittest.TestCase):
             "duplicate": '{"patch":"one","patch":"two"}',
             "extra": json.dumps({"patch": fixture["patch"], "extra": "unexpected"}),
         }
+        malformed_arguments.update(
+            {
+                f"observed_{shape}": json.dumps(arguments)
+                for shape, arguments in fixture["observed_incompatible_arguments"].items()
+            }
+        )
 
         for shape, arguments in malformed_arguments.items():
             with self.subTest(shape=shape):
@@ -7114,17 +7142,40 @@ class RoutingTests(unittest.TestCase):
         self.assertNotIn("sse_retry_notice", event_names)
         self.assertEqual(fake.status, 200)
         frames = b"".join(fake.wfile.writes).split(b"\n\n")
-        error_frame = next(frame for frame in frames if frame.startswith(b"event: error\n"))
-        error_line = next(line for line in error_frame.splitlines() if line.startswith(b"data: "))
-        payload = json.loads(error_line.removeprefix(b"data: "))
-        self.assertEqual(payload["type"], "invalid_request_error")
-        self.assertEqual(payload["status"], 400)
-        self.assertEqual(payload["error"], "invalid_apply_patch_function_call")
-        self.assertEqual(payload["failure_class"], codex_proxy.RETRY_FAILURE_PERMANENT)
-        self.assertFalse(payload["retryable"])
-        self.assertEqual(payload["codexhub_error"]["code"], "provider.request")
+        failed_frames = [
+            frame for frame in frames if frame.startswith(b"event: response.failed\n")
+        ]
+        self.assertEqual(len(failed_frames), 1)
+        self.assertFalse(any(frame.startswith(b"event: error\n") for frame in frames))
+        failed_line = next(
+            line for line in failed_frames[0].splitlines() if line.startswith(b"data: ")
+        )
+        payload = json.loads(failed_line.removeprefix(b"data: "))
+        self.assertEqual(payload["type"], "response.failed")
+        self.assertEqual(payload["response"]["status"], "failed")
+        self.assertEqual(
+            payload["response"]["error"]["code"],
+            "invalid_apply_patch_function_call",
+        )
+        self.assertEqual(
+            payload["response"]["error"]["failure_class"],
+            codex_proxy.RETRY_FAILURE_PERMANENT,
+        )
+        self.assertFalse(payload["response"]["error"]["retryable"])
         self.assertNotIn("arguments_not_exact", json.dumps(payload))
         self.assertNotIn(private_patch, json.dumps(payload))
+        terminal_event = next(
+            call.kwargs
+            for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] == "third_party_apply_patch_terminal"
+        )
+        self.assertEqual(terminal_event["disposition"], "response.failed")
+        self.assertEqual(
+            terminal_event["failure_class"], codex_proxy.RETRY_FAILURE_PERMANENT
+        )
+        self.assertEqual(terminal_event["retry_count"], 0)
+        for forbidden in ("arguments", "input", "patch", "path", "content", "pattern"):
+            self.assertNotIn(forbidden, terminal_event)
 
     def test_unrelated_protocol_translation_error_is_nonretryable_json_client_error(self):
         translation_error = codex_proxy.UpstreamProtocolTranslationError(
@@ -9098,6 +9149,108 @@ class RoutingTests(unittest.TestCase):
         self.assertEqual(history_events[0]["count"], 1)
         for forbidden in ("id", "call_id", "name", "input", "output", "patch", "arguments"):
             self.assertNotIn(forbidden, history_events[0])
+
+    def test_selected_native_responses_codec_round_trips_apply_patch_and_next_history_once(self):
+        fixture = _load_glm_apply_patch_history_native_ids_fixture()
+        apply_patch_tool = {
+            "type": "custom",
+            "name": "apply_patch",
+            "description": "Apply one patch using the caller grammar.",
+            "format": {
+                "type": "grammar",
+                "syntax": "lark",
+                "definition": "start: begin_patch update_file end_patch",
+            },
+        }
+        upstream = {
+            "name": "ollama_cloud",
+            "upstream_format": "responses",
+            "tool_protocol": "responses_structured",
+            "native_responses_tool_codec": "strict_apply_patch",
+        }
+        initial_request = json.loads(
+            compatible_request_body(
+                json.dumps(
+                    {
+                        "model": "glm-5.2",
+                        "input": [{"type": "message", "role": "user", "content": "Edit it."}],
+                        "tools": [apply_patch_tool],
+                    }
+                ).encode("utf-8"),
+                upstream,
+                event_context={"request_id": "request-initial"},
+                inject_codex_tools=False,
+            )
+        )
+        function_item = {
+            "id": "fc_sanitized_apply_patch",
+            "type": "function_call",
+            "status": "completed",
+            "call_id": "call_sanitized_apply_patch",
+            "name": "apply_patch",
+            "arguments": json.dumps(
+                {"patch": fixture["input"][1]["input"]},
+                ensure_ascii=True,
+                separators=(",", ":"),
+            ),
+        }
+        unrelated_item = {
+            "id": "fc_unrelated",
+            "type": "function_call",
+            "status": "completed",
+            "call_id": "call_unrelated",
+            "name": "shell_command",
+            "arguments": json.dumps({"command": "Get-Content target.txt"}),
+        }
+        caller_response = json.loads(
+            compatible_response_body(
+                json.dumps(
+                    {"id": "resp_sanitized", "output": [unrelated_item, function_item]}
+                ).encode("utf-8"),
+                "ollama_cloud",
+                event_context={"request_id": "request-initial"},
+            )
+        )
+        caller_apply_patch = caller_response["output"][1]
+        next_request = json.loads(
+            compatible_request_body(
+                json.dumps(
+                    {
+                        "model": "glm-5.2",
+                        "input": [
+                            caller_apply_patch,
+                            {
+                                "type": "custom_tool_call_output",
+                                "call_id": caller_apply_patch["call_id"],
+                                "output": "Success. Updated target.txt",
+                            },
+                            {"type": "message", "role": "user", "content": "Verify it."},
+                        ],
+                        "tools": [apply_patch_tool],
+                    }
+                ).encode("utf-8"),
+                upstream,
+                event_context={"request_id": "request-next"},
+                inject_codex_tools=False,
+            )
+        )
+
+        self.assertEqual(initial_request["tools"][0]["type"], "function")
+        self.assertEqual(
+            [item["id"] for item in caller_response["output"]],
+            ["fc_unrelated", "fc_sanitized_apply_patch"],
+        )
+        self.assertEqual(caller_apply_patch["type"], "custom_tool_call")
+        self.assertEqual(caller_apply_patch["id"], "fc_sanitized_apply_patch")
+        self.assertEqual(caller_apply_patch["call_id"], "call_sanitized_apply_patch")
+        self.assertEqual(caller_apply_patch["input"], fixture["input"][1]["input"])
+        self.assertEqual(
+            [item["type"] for item in next_request["input"]],
+            ["function_call", "function_call_output", "message"],
+        )
+        self.assertEqual(next_request["input"][0]["call_id"], "call_sanitized_apply_patch")
+        self.assertEqual(next_request["input"][1]["call_id"], "call_sanitized_apply_patch")
+        self.assertEqual(next_request["tools"][0]["type"], "function")
 
     def test_responses_structured_provider_preserves_body_originated_apply_patch_continuation(self):
         fixture = _load_glm_apply_patch_retry_fixture()
@@ -12166,6 +12319,121 @@ Execution constraints:
             "mcp__synthetic_namespace__deferred",
             {tool.get("name") for tool in payload["tools"] if isinstance(tool, dict)},
         )
+
+    def test_native_responses_apply_patch_codec_is_opt_in_and_emits_one_strict_patch_field(self):
+        apply_patch = {
+            "type": "custom",
+            "name": "apply_patch",
+            "description": "Apply a patch using the caller's grammar.",
+            "format": {
+                "type": "grammar",
+                "syntax": "lark",
+                "definition": "start: begin_patch update_file end_patch",
+            },
+        }
+        body = json.dumps(
+            {
+                "model": "glm-5.2",
+                "input": [{"type": "message", "role": "user", "content": "Make the requested edit."}],
+                "tools": [apply_patch],
+            }
+        ).encode("utf-8")
+        upstream = {
+            "name": "ollama_cloud",
+            "upstream_format": "responses",
+            "tool_protocol": "responses_structured",
+            "tool_surface_strategy": "deferred_core",
+        }
+
+        unselected = json.loads(
+            compatible_request_body(body, upstream, inject_codex_tools=False)
+        )
+        selected = json.loads(
+            compatible_request_body(
+                body,
+                {**upstream, "native_responses_tool_codec": "strict_apply_patch"},
+                inject_codex_tools=False,
+            )
+        )
+
+        self.assertEqual(unselected["tools"], [apply_patch])
+        self.assertEqual(
+            selected["tools"][0],
+            {
+                "type": "function",
+                "name": "apply_patch",
+                "description": selected["tools"][0]["description"],
+                "strict": True,
+                "parameters": {
+                    "type": "object",
+                    "properties": {"patch": {"type": "string", "minLength": 1}},
+                    "required": ["patch"],
+                    "additionalProperties": False,
+                },
+            },
+        )
+        description = selected["tools"][0]["description"]
+        self.assertIn(apply_patch["description"], description)
+        self.assertIn(apply_patch["format"]["definition"], description)
+        self.assertIn("*** Begin Patch", description)
+        self.assertIn("*** End Patch", description)
+
+    def test_native_responses_apply_patch_codec_rejects_ambiguous_or_lossy_custom_declarations(self):
+        apply_patch = {
+            "type": "custom",
+            "name": "apply_patch",
+            "description": "Apply a patch using the caller's grammar.",
+            "format": {
+                "type": "grammar",
+                "syntax": "lark",
+                "definition": "start: begin_patch update_file end_patch",
+            },
+        }
+        upstream = {
+            "name": "ollama_cloud",
+            "upstream_format": "responses",
+            "tool_protocol": "responses_structured",
+            "native_responses_tool_codec": "strict_apply_patch",
+        }
+        malformed_tools = {
+            "duplicate": [apply_patch, dict(apply_patch)],
+            "unknown_field": [{**apply_patch, "unexpected": True}],
+            "missing_grammar": [{key: value for key, value in apply_patch.items() if key != "format"}],
+        }
+
+        for shape, tools in malformed_tools.items():
+            with self.subTest(shape=shape):
+                with self.assertRaises(codex_proxy.UpstreamProtocolTranslationError) as raised:
+                    compatible_request_body(
+                        json.dumps(
+                            {"model": "glm-5.2", "input": "Edit the file.", "tools": tools}
+                        ).encode("utf-8"),
+                        upstream,
+                        event_context={"request_id": "<sanitized-request-id>"},
+                        inject_codex_tools=False,
+                    )
+
+                self.assertEqual(
+                    raised.exception.cause.code,
+                    "invalid_native_responses_tool_contract",
+                )
+                rejected = next(
+                    call.kwargs
+                    for call in self.write_proxy_event.call_args_list
+                    if call.args and call.args[0] == "native_responses_tool_codec"
+                )
+                self.assertEqual(rejected["codec"], "strict_apply_patch")
+                self.assertEqual(rejected["outcome"], "rejected")
+                for forbidden in (
+                    "description",
+                    "format",
+                    "grammar",
+                    "patch",
+                    "arguments",
+                    "input",
+                ):
+                    self.assertNotIn(forbidden, rejected)
+                self.write_proxy_event.reset_mock()
 
     def test_external_tool_surface_preparation_telemetry_uses_sanitized_structural_counts(self):
         shell_command = {

--- a/tests/test_smoke_scripts.py
+++ b/tests/test_smoke_scripts.py
@@ -663,6 +663,49 @@ def test_issue_108_qualification_rejects_retry_and_protocol_fallback_evidence():
     assert "qualification recorded an upstream protocol fallback" in source
 
 
+def test_issue_140_glm_qualification_does_not_coach_apply_patch_argument_shape():
+    source = (
+        ROOT / "scripts" / "qualify-issue-108-glm-tool-surface.ps1"
+    ).read_text(encoding="utf-8-sig")
+
+    assert "Decide the patch contents from the file you read and the requested replacement." in source
+    assert "argument named patch" not in source
+    assert "Do not use an empty argument name" not in source
+    assert "whose value is exactly this one-operation patch" not in source
+
+
+def test_issue_140_glm_qualification_requires_selected_codec_and_live_contract_evidence():
+    source = (
+        ROOT / "scripts" / "qualify-issue-108-glm-tool-surface.ps1"
+    ).read_text(encoding="utf-8-sig")
+
+    assert "native_responses_tool_codec" in source
+    assert "strict_apply_patch" in source
+    assert "native Responses tool codec never reported strict_apply_patch/adapted" in source
+    assert "caller apply_patch declaration did not expose the exact grammar contract" in source
+    assert "upstream apply_patch declaration did not expose the exact strict function contract" in source
+    assert "native_responses_tool_codec_adapted_count" in source
+    assert "caller_apply_patch_grammar_contract_count" in source
+    assert "upstream_strict_apply_patch_contract_count" in source
+    assert "Issue140NativeResponsesQualification" in source
+    assert "native_responses_contract_evidence_validated" in source
+
+
+def test_issue_140_glm_qualification_runs_two_independent_natural_tool_loops():
+    source = (
+        ROOT / "scripts" / "qualify-issue-140-glm-native-responses-tools.ps1"
+    ).read_text(encoding="utf-8-sig")
+
+    assert "1..2" in source
+    assert "qualify-issue-108-glm-tool-surface.ps1" in source
+    assert "-ExternalIsolationQualification" in source
+    assert "-Issue140NativeResponsesQualification" in source
+    assert "completed_run_count" in source
+    assert "expected_run_count = 2" in source
+    assert "shell_command,apply_patch,shell_command" in source
+    assert "native_responses_tool_codec_adapted_count" in source
+
+
 def test_issue_108_qualification_uses_synthetic_gateway_bearer_and_whitelisted_children():
     source = (
         ROOT / "scripts" / "qualify-issue-108-glm-tool-surface.ps1"


### PR DESCRIPTION
## What changed

- add a generic provider/model-selectable `native_responses_tool_codec` with `none` and `strict_apply_patch`
- enable `strict_apply_patch` for `ollama-cloud/glm-5.2` through bundled configuration
- translate Codex custom/freeform `apply_patch` into one strict upstream function schema and symmetrically restore calls plus next-turn history
- emit exactly one non-retryable `response.failed` terminal for codec-local failures while preserving unselected third-party behavior and upstream response IDs
- replace the coached qualification with a dedicated natural two-run GLM tool-loop E2E

## Why

GLM-5.2 supports native Responses and ordinary function calling, but it does not reliably honor Codex's custom/freeform `apply_patch` argument contract. The prior qualification explicitly coached the ideal `{patch}` shape and masked natural malformed calls. In real Desktop tasks those fail-closed adapter rejections caused the streamed turn to reconnect and replay.

This keeps the caller-visible Codex contract unchanged while presenting a machine-enforced structured contract only to configured upstream models that require it. The codec seam is generic; GLM-5.2 is the first model enabled after live qualification.

## Validation

- natural GLM E2E passed twice with `shell_command -> apply_patch -> shell_command`
- each run changed its target exactly once
- zero request errors, upstream retries, protocol fallbacks, duplicate tool calls, or Official fallback
- focused routing: 22 passed, 32 subtests
- provider configuration: 44 passed, 8 subtests
- smoke scripts: 29 passed
- full Python: 1140 passed, 1 skipped, 299 subtests
- report-only quality gate completed with no parse errors
- Standards and Spec review plus delta re-review: no remaining findings
- `git diff --check` passed

## Manual Desktop acceptance

Passed on 2026-07-16 with the packaged Debug candidate built from 7733e771:

- one fresh projectless Codex Desktop task ran two consecutive turns on ollama-cloud/glm-5.2
- each turn's raw rollout order was exactly shell_command -> apply_patch -> shell_command
- all six tool calls had paired non-empty outputs; both apply_patch calls produced the expected add/update diffs
- the second turn restored the first turn's tool history and produced the exact two-line final file
- every GLM request stayed on the local Gateway and resolved to provider ollama_cloud
- codec selection remained strict_apply_patch; all requests completed with HTTP 200
- Codex recorded zero responses_retry or stream-disconnect events
- Gateway recorded no retry, request error, failed terminal, protocol fallback, duplicate tool call, or Official-model fallback
- one Gateway child and one matching 9099 listener remained throughout

Closes #140
