### PR TITLE
fix: qualify Kimi K2.6 native Responses codec

### DIFF
--- a/config/providers.toml
+++ b/config/providers.toml
@@ -33,6 +33,7 @@ enabled = true
   max_output_tokens = 32768
   sort_order = 3
   enabled = true
+  native_responses_tool_codec = "strict_apply_patch"
 
 [[providers]]
 id = "volc"

--- a/src-python/providers_config.py
+++ b/src-python/providers_config.py
@@ -881,12 +881,6 @@ def _resolved_native_responses_tool_codec(provider: ProviderConfig, model: Model
     )
     if model_codec is not None:
         return model_codec
-    bundled_model_codec = _native_responses_tool_codec_field(
-        model._bundled_native_responses_tool_codec,
-        default=None,
-    )
-    if bundled_model_codec is not None:
-        return bundled_model_codec
     provider_codec = _native_responses_tool_codec_field(
         provider.native_responses_tool_codec,
         default="none",
@@ -894,6 +888,12 @@ def _resolved_native_responses_tool_codec(provider: ProviderConfig, model: Model
     assert provider_codec is not None
     if _provider_native_responses_tool_codec_is_explicit(provider):
         return provider_codec
+    bundled_model_codec = _native_responses_tool_codec_field(
+        model._bundled_native_responses_tool_codec,
+        default=None,
+    )
+    if bundled_model_codec is not None:
+        return bundled_model_codec
     bundled_provider_codec = _native_responses_tool_codec_field(
         provider._bundled_native_responses_tool_codec,
         default=None,

--- a/tests/test_providers_config.py
+++ b/tests/test_providers_config.py
@@ -456,6 +456,36 @@ api_key = "ollama-secret"
         self.assertEqual(unqualified["native_responses_tool_codec"], "none")
         self.assertEqual(qualified["native_responses_tool_codec"], "none")
 
+    def test_explicit_runtime_provider_none_overrides_the_bundled_ollama_codec_selection(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "providers.toml"
+            path.write_text(
+                """
+[[providers]]
+id = "ollama-cloud"
+name = "Ollama Cloud"
+base_url = "https://ollama.example.test/v1"
+api_key = "ollama-secret"
+native_responses_tool_codec = "none"
+
+  [[providers.models]]
+  id = "kimi-k2.6"
+""".lstrip(),
+                encoding="utf-8",
+            )
+
+            configured, unqualified = resolve_ollama_cloud_model(
+                "kimi-k2.6", providers_path=path, require_api_key=False
+            )
+            qualified_configured, qualified = resolve_ollama_cloud_model(
+                "ollama-cloud/kimi-k2.6", providers_path=path, require_api_key=False
+            )
+
+        self.assertTrue(configured)
+        self.assertTrue(qualified_configured)
+        self.assertEqual(unqualified["native_responses_tool_codec"], "none")
+        self.assertEqual(qualified["native_responses_tool_codec"], "none")
+
     def test_inherited_ollama_strategy_prepares_a_deferred_core_tool_surface(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             path = Path(tmpdir) / "providers.toml"

--- a/tests/test_providers_config.py
+++ b/tests/test_providers_config.py
@@ -37,7 +37,9 @@ class ProvidersConfigTests(unittest.TestCase):
         )
         self.assertEqual(configured_models, ["glm-5.2"])
 
-    def test_bundled_ollama_glm_selects_the_only_strict_apply_patch_native_responses_codec(self):
+    def test_bundled_ollama_models_select_the_exact_strict_apply_patch_native_responses_codec_whitelist(
+        self,
+    ):
         providers = load_providers(DEFAULT_PROVIDERS_PATH)
         configured, index = build_ollama_cloud_model_index(providers, require_api_key=False)
         configured_models = [
@@ -48,10 +50,19 @@ class ProvidersConfigTests(unittest.TestCase):
         ]
 
         self.assertTrue(configured)
-        self.assertEqual(configured_models, ["glm-5.2"])
+        self.assertEqual(configured_models, ["glm-5.2", "kimi-k2.6"])
         self.assertEqual(index["glm-5.2"]["native_responses_tool_codec"], "strict_apply_patch")
         self.assertEqual(index["ollama-cloud/glm-5.2"]["native_responses_tool_codec"], "strict_apply_patch")
+        self.assertEqual(index["kimi-k2.6"]["native_responses_tool_codec"], "strict_apply_patch")
+        self.assertEqual(
+            index["ollama-cloud/kimi-k2.6"]["native_responses_tool_codec"],
+            "strict_apply_patch",
+        )
         self.assertEqual(index["minimax-m3"]["native_responses_tool_codec"], "none")
+
+        external_index = build_external_model_index(providers, require_api_key=False)
+        self.assertEqual(external_index["volc/kimi-k2.6"]["native_responses_tool_codec"], "none")
+        self.assertEqual(external_index["minimax-cn/minimax-m3"]["native_responses_tool_codec"], "none")
 
     def test_discover_official_models_fetches_gpt_models_sorted_with_limits(self):
         payload = {
@@ -366,7 +377,7 @@ api_key = "ollama-secret"
         self.assertEqual(unqualified["tool_surface_strategy"], "deferred_core")
         self.assertEqual(qualified["tool_surface_strategy"], "deferred_core")
 
-    def test_runtime_omission_inherits_bundled_native_responses_tool_codec_for_ollama_glm_aliases(self):
+    def test_runtime_omission_inherits_only_the_bundled_ollama_codec_whitelist_for_aliases(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             path = Path(tmpdir) / "providers.toml"
             path.write_text(
@@ -379,21 +390,71 @@ api_key = "ollama-secret"
 
   [[providers.models]]
   id = "glm-5.2"
+
+  [[providers.models]]
+  id = "kimi-k2.6"
+
+  [[providers.models]]
+  id = "minimax-m3"
+
+  [[providers.models]]
+  id = "kimi-k2.7-code"
+""".lstrip(),
+                encoding="utf-8",
+            )
+
+            resolved = {}
+            for model_id in ("glm-5.2", "kimi-k2.6", "minimax-m3", "kimi-k2.7-code"):
+                configured, unqualified = resolve_ollama_cloud_model(
+                    model_id, providers_path=path, require_api_key=False
+                )
+                qualified_configured, qualified = resolve_ollama_cloud_model(
+                    f"ollama-cloud/{model_id}", providers_path=path, require_api_key=False
+                )
+                self.assertTrue(configured)
+                self.assertTrue(qualified_configured)
+                resolved[model_id] = (unqualified, qualified)
+
+        for model_id in ("glm-5.2", "kimi-k2.6"):
+            with self.subTest(model_id=model_id):
+                unqualified, qualified = resolved[model_id]
+                self.assertEqual(unqualified["native_responses_tool_codec"], "strict_apply_patch")
+                self.assertEqual(qualified["native_responses_tool_codec"], "strict_apply_patch")
+        for model_id in ("minimax-m3", "kimi-k2.7-code"):
+            with self.subTest(model_id=model_id):
+                unqualified, qualified = resolved[model_id]
+                self.assertEqual(unqualified["native_responses_tool_codec"], "none")
+                self.assertEqual(qualified["native_responses_tool_codec"], "none")
+
+    def test_explicit_runtime_model_none_overrides_the_bundled_ollama_codec_selection(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "providers.toml"
+            path.write_text(
+                """
+[[providers]]
+id = "ollama-cloud"
+name = "Ollama Cloud"
+base_url = "https://ollama.example.test/v1"
+api_key = "ollama-secret"
+
+  [[providers.models]]
+  id = "kimi-k2.6"
+  native_responses_tool_codec = "none"
 """.lstrip(),
                 encoding="utf-8",
             )
 
             configured, unqualified = resolve_ollama_cloud_model(
-                "glm-5.2", providers_path=path, require_api_key=False
+                "kimi-k2.6", providers_path=path, require_api_key=False
             )
             qualified_configured, qualified = resolve_ollama_cloud_model(
-                "ollama-cloud/glm-5.2", providers_path=path, require_api_key=False
+                "ollama-cloud/kimi-k2.6", providers_path=path, require_api_key=False
             )
 
         self.assertTrue(configured)
         self.assertTrue(qualified_configured)
-        self.assertEqual(unqualified["native_responses_tool_codec"], "strict_apply_patch")
-        self.assertEqual(qualified["native_responses_tool_codec"], "strict_apply_patch")
+        self.assertEqual(unqualified["native_responses_tool_codec"], "none")
+        self.assertEqual(qualified["native_responses_tool_codec"], "none")
 
     def test_inherited_ollama_strategy_prepares_a_deferred_core_tool_surface(self):
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
Closes #144

## Summary

- add the existing native Responses `strict_apply_patch` codec to the exact Ollama Cloud Kimi K2.6 model entry
- preserve GLM-5.2, unqualified/dynamic models, and all non-Ollama Providers
- preserve explicit runtime model and Provider overrides, including explicit `none`, ahead of inherited bundled selections
- keep MiniMax M3 unselected because the evidence set contains an invalid internal patch-grammar run

## Verification

- `python -m pytest -q tests/test_providers_config.py` — 46 passed, 12 subtests
- `python -m pytest -q tests/test_routing.py -k native_responses_tool_codec` — 1 passed, 425 deselected
- one candidate `python -m pytest -q` — 1141 passed, 1 skipped, 305 subtests
- `python scripts/report_quality_gates.py` — report-only, parse errors 0
- `git diff --check` — passed
- Orchestrator Standards/Spec review completed; one Provider-level override precedence finding was corrected red-first, and delta re-review found no remaining issues

## Native Responses evidence

#65 records strict native `/v1/responses` qualification on the same dev base: Kimi K2.6 passed two consecutive `shell_command -> apply_patch -> shell_command` loops with exact single mutation and zero request errors, retries, or protocol fallback. MiniMax M3 remains outside the whitelist because its evidence includes one malformed internal patch body. No Responses-to-Chat conversion is introduced.