### PR TITLE
docs: publish reliability-gated Wayfinder plan

### DIFF
--- a/docs/superpowers/plans/2026-07-16-wayfinder-github-migration.md
+++ b/docs/superpowers/plans/2026-07-16-wayfinder-github-migration.md
@@ -1836,20 +1836,93 @@ function Set-OrCreateExactIssueComment(
     url = $exactReadback[0].html_url
   }
 }
+function Resolve-ProvenCheckpointHistoricalProvenance(
+  [System.Collections.IDictionary]$Guard,
+  [string]$DesiredBody,
+  [System.Collections.IDictionary]$PriorTranscript,
+  [string]$HistoricalOriginalBody
+) {
+  $DesiredBody = Normalize-IssueCommentBody $DesiredBody
+  $desiredHash = Get-NormalizedBodySha256 $DesiredBody
+  if ($null -ne $PriorTranscript) {
+    $priorHistorical = $PriorTranscript.historical_original
+    $priorHistoricalBody = Normalize-IssueCommentBody ([string]$priorHistorical.normalized_body)
+    if ([string]$priorHistorical.normalized_body_sha256 -cne (Get-NormalizedBodySha256 $priorHistoricalBody)) {
+      throw 'tracked checkpoint transcript historical origin hash mismatch'
+    }
+    if ([long]$PriorTranscript.post_readback.public_comment_id -ne [long]$Guard.prior_public_comment_id -or
+        [string]$PriorTranscript.post_readback.normalized_body_sha256 -cne [string]$Guard.prior_normalized_body_sha256) {
+      throw 'tracked checkpoint transcript does not prove the current prior readback'
+    }
+    return [ordered]@{
+      historical_original = [ordered]@{
+        source = [string]$priorHistorical.source
+        normalized_body = $priorHistoricalBody
+        normalized_body_sha256 = [string]$priorHistorical.normalized_body_sha256
+      }
+      proof_kind = 'tracked-transcript'
+      prior_transcript = $PriorTranscript
+    }
+  }
+
+  if ($Guard.operation_decision -ceq 'create') {
+    return [ordered]@{
+      historical_original = [ordered]@{
+        source = 'Task 8 initial publication desired body'
+        normalized_body = $DesiredBody
+        normalized_body_sha256 = $desiredHash
+      }
+      proof_kind = 'initial-create'
+      prior_transcript = $null
+    }
+  }
+  if ($Guard.operation_decision -ceq 'exact-no-op') {
+    if ([string]$Guard.prior_normalized_body_sha256 -cne $desiredHash -or
+        [string]$Guard.post_normalized_body_sha256 -cne $desiredHash) {
+      throw 'exact-no-op pre/desired/post normalized hashes differ'
+    }
+    return [ordered]@{
+      historical_original = [ordered]@{
+        source = 'Task 8 live exact desired body'
+        normalized_body = $DesiredBody
+        normalized_body_sha256 = $desiredHash
+      }
+      proof_kind = 'live-exact-desired'
+      prior_transcript = $null
+    }
+  }
+  if ($Guard.operation_decision -cne 'patch') { throw 'unsupported checkpoint operation decision' }
+  $historicalBody = Normalize-IssueCommentBody $HistoricalOriginalBody
+  return [ordered]@{
+    historical_original = [ordered]@{
+      source = 'Task 8 execution report exact original published body'
+      normalized_body = $historicalBody
+      normalized_body_sha256 = Get-NormalizedBodySha256 $historicalBody
+    }
+    proof_kind = 'task8-execution-report'
+    prior_transcript = $null
+  }
+}
 function New-CheckpointTranscript(
   [System.Collections.IDictionary]$Guard,
-  [string]$HistoricalOriginalBody,
+  [System.Collections.IDictionary]$ProvenHistoricalProvenance,
   [string]$DesiredBody,
   [string]$ArtifactPath,
   [string]$ArtifactSha256
 ) {
   $DesiredBody = Normalize-IssueCommentBody $DesiredBody
-  if ($Guard.operation_decision -ceq 'create') {
-    $originalSource = 'Task 8 initial publication desired body'
-    $originalBody = $DesiredBody
-  } else {
-    $originalSource = 'Task 8 execution report exact original published body'
-    $originalBody = Normalize-IssueCommentBody $HistoricalOriginalBody
+  $original = $ProvenHistoricalProvenance.historical_original
+  $originalBody = Normalize-IssueCommentBody ([string]$original.normalized_body)
+  if ([string]$original.normalized_body_sha256 -cne (Get-NormalizedBodySha256 $originalBody)) {
+    throw 'proven historical origin hash mismatch'
+  }
+  if ($Guard.operation_decision -ceq 'exact-no-op') {
+    $hashes = @(@(
+      [string]$Guard.prior_normalized_body_sha256,
+      [string]$Guard.desired_normalized_body_sha256,
+      [string]$Guard.post_normalized_body_sha256
+    ) | Select-Object -Unique)
+    if ($hashes.Count -ne 1) { throw 'exact-no-op pre/desired/post normalized hashes differ' }
   }
   return [ordered]@{
     schema_version = 1
@@ -1857,9 +1930,13 @@ function New-CheckpointTranscript(
     issue = 147
     purpose_prefix = '## Reliability-gated Wayfinder migration readback'
     historical_original = [ordered]@{
-      source = $originalSource
+      source = [string]$original.source
       normalized_body = $originalBody
-      normalized_body_sha256 = Get-NormalizedBodySha256 $originalBody
+      normalized_body_sha256 = [string]$original.normalized_body_sha256
+    }
+    historical_provenance = [ordered]@{
+      proof_kind = [string]$ProvenHistoricalProvenance.proof_kind
+      prior_transcript = $ProvenHistoricalProvenance.prior_transcript
     }
     pre_update = [ordered]@{
       public_comment_id = $Guard.prior_public_comment_id
@@ -1908,6 +1985,10 @@ Durable frontier audit: $artifactPath (SHA-256: ``$artifactSha256``).
 Frontier order remains subject to native dependencies and hotset ownership. Map publication is not a claim.
 "@
 $purposePrefix = '## Reliability-gated Wayfinder migration readback'
+$transcriptPath = 'docs/superpowers/reviews/wayfinder-checkpoint-update-v1.json'
+$priorTranscript = if (Test-Path $transcriptPath) {
+  Get-Content -Raw $transcriptPath | ConvertFrom-Json -AsHashtable
+} else { $null }
 $guard = Set-OrCreateExactIssueComment 147 $purposePrefix $comment `
   4994927680 'b6d4d1e9bc58fd013c4968eb2799990fb7afa579572ade93534ee657c35ad82b'
 
@@ -1934,8 +2015,8 @@ Current unclaimed 0.1.6 ready frontier:
 
 Frontier order remains subject to native dependencies and hotset ownership. Map publication is not a claim.
 '@
-$transcript = New-CheckpointTranscript $guard $historicalOriginalBody $comment $artifactPath $artifactSha256
-$transcriptPath = 'docs/superpowers/reviews/wayfinder-checkpoint-update-v1.json'
+$provenance = Resolve-ProvenCheckpointHistoricalProvenance $guard $comment $priorTranscript $historicalOriginalBody
+$transcript = New-CheckpointTranscript $guard $provenance $comment $artifactPath $artifactSha256
 $transcript | ConvertTo-Json -Depth 8 | Set-Content -Encoding utf8NoBOM $transcriptPath
 python scripts/generate_wayfinder_final_audit.py finalize `
   --core $artifactPath `

--- a/docs/superpowers/plans/2026-07-16-wayfinder-github-migration.md
+++ b/docs/superpowers/plans/2026-07-16-wayfinder-github-migration.md
@@ -1760,22 +1760,127 @@ Expected: the generator validates all twelve exact query records, parses/persist
 Run:
 
 ```powershell
-function Write-ExactIssueComment([int]$Issue,[string]$PurposePrefix,[string]$Body) {
-  $Body = ($Body -replace "`r`n","`n").TrimEnd()
-  $comments = @(gh api --paginate "repos/NOirBRight/CodexHub/issues/$Issue/comments?per_page=100" | ConvertFrom-Json)
-  $exact = @($comments | Where-Object body -CEQ $Body)
-  $purpose = @($comments | Where-Object { ([string]$_.body).StartsWith($PurposePrefix,[StringComparison]::Ordinal) })
-  if ($exact.Count -gt 1) { throw "multiple exact comments on #$Issue" }
-  if ($exact.Count -eq 1) {
-    if ($purpose.Count -ne 1) { throw "conflicting same-purpose comment on #$Issue" }
+function Normalize-IssueCommentBody([string]$Body) {
+  return ($Body -replace "`r`n","`n").TrimEnd()
+}
+function Get-NormalizedBodySha256([string]$Body) {
+  $bytes = [Text.Encoding]::UTF8.GetBytes((Normalize-IssueCommentBody $Body))
+  return [Convert]::ToHexString([Security.Cryptography.SHA256]::HashData($bytes)).ToLowerInvariant()
+}
+function Get-IssueComments([int]$Issue) {
+  return @(gh api --paginate "repos/NOirBRight/CodexHub/issues/$Issue/comments?per_page=100" | ConvertFrom-Json)
+}
+function New-IssueComment([int]$Issue,[string]$Body) {
+  gh issue comment $Issue --body $Body | Out-Null
+  if ($LASTEXITCODE -ne 0) { throw "checkpoint create failed on #$Issue" }
+}
+function Update-IssueComment([long]$PublicCommentId,[string]$Body) {
+  @{body=$Body} | ConvertTo-Json -Compress |
+    gh api --method PATCH "repos/NOirBRight/CodexHub/issues/comments/$PublicCommentId" --input - | Out-Null
+  if ($LASTEXITCODE -ne 0) { throw "checkpoint PATCH failed for comment $PublicCommentId" }
+}
+function Set-OrCreateExactIssueComment(
+  [int]$Issue,
+  [string]$PurposePrefix,
+  [string]$DesiredBody,
+  [long]$ExpectedPriorPublicCommentId,
+  [string]$ExpectedPriorNormalizedBodySha256
+) {
+  $DesiredBody = Normalize-IssueCommentBody $DesiredBody
+  $comments = @(Get-IssueComments $Issue)
+  $priorReadbackAt = (Get-Date).ToUniversalTime().ToString('o')
+  $purpose = @($comments | Where-Object { (Normalize-IssueCommentBody $_.body).StartsWith($PurposePrefix,[StringComparison]::Ordinal) })
+  $exact = @($comments | Where-Object { (Normalize-IssueCommentBody $_.body) -ceq $DesiredBody })
+  if ($purpose.Count -gt 1 -or $exact.Count -gt 1) { throw "multiple checkpoint comments on #$Issue" }
+
+  $priorId = $null
+  $priorHash = $null
+  if ($purpose.Count -eq 0) {
+    if ($exact.Count -ne 0) { throw "exact checkpoint lacks purpose prefix on #$Issue" }
+    New-IssueComment $Issue $DesiredBody
+    $operation = 'create'
+    $priorReadbackAt = $null
   } else {
-    if ($purpose.Count -gt 0) { throw "conflicting same-purpose comment on #$Issue" }
-    gh issue comment $Issue --body $Body | Out-Null
+    $selected = $purpose[0]
+    $priorId = [long]$selected.id
+    $priorHash = Get-NormalizedBodySha256 ([string]$selected.body)
+    if ($exact.Count -eq 1) {
+      if ([long]$exact[0].id -ne $priorId) { throw "checkpoint exact-body identity mismatch on #$Issue" }
+      $operation = 'exact-no-op'
+    } else {
+      if ($priorId -ne $ExpectedPriorPublicCommentId) { throw "prior public comment ID mismatch on #$Issue" }
+      if ($priorHash -cne $ExpectedPriorNormalizedBodySha256.ToLowerInvariant()) { throw "prior normalized-body SHA-256 mismatch on #$Issue" }
+      Update-IssueComment $priorId $DesiredBody
+      $operation = 'patch'
+    }
   }
-  $readback = @(gh api --paginate "repos/NOirBRight/CodexHub/issues/$Issue/comments?per_page=100" | ConvertFrom-Json)
-  $matches = @($readback | Where-Object body -CEQ $Body)
-  if ($matches.Count -ne 1) { throw "exact comment readback failed on #$Issue" }
-  $matches[0].html_url
+
+  $readback = @(Get-IssueComments $Issue)
+  $postReadbackAt = (Get-Date).ToUniversalTime().ToString('o')
+  $purposeReadback = @($readback | Where-Object { (Normalize-IssueCommentBody $_.body).StartsWith($PurposePrefix,[StringComparison]::Ordinal) })
+  $exactReadback = @($readback | Where-Object { (Normalize-IssueCommentBody $_.body) -ceq $DesiredBody })
+  if ($purposeReadback.Count -ne 1 -or $exactReadback.Count -ne 1) { throw "exact checkpoint readback failed on #$Issue" }
+  $postId = [long]$exactReadback[0].id
+  if ($null -ne $priorId -and $postId -ne $priorId) { throw "checkpoint identity changed on #$Issue" }
+  return [ordered]@{
+    operation_decision = $operation
+    prior_public_comment_id = $priorId
+    prior_normalized_body_sha256 = $priorHash
+    prior_readback_at = $priorReadbackAt
+    desired_normalized_body_sha256 = Get-NormalizedBodySha256 $DesiredBody
+    post_public_comment_id = $postId
+    post_normalized_body_sha256 = Get-NormalizedBodySha256 ([string]$exactReadback[0].body)
+    post_prefix_multiplicity = $purposeReadback.Count
+    post_exact_body_multiplicity = $exactReadback.Count
+    post_readback_at = $postReadbackAt
+    url = $exactReadback[0].html_url
+  }
+}
+function New-CheckpointTranscript(
+  [System.Collections.IDictionary]$Guard,
+  [string]$HistoricalOriginalBody,
+  [string]$DesiredBody,
+  [string]$ArtifactPath,
+  [string]$ArtifactSha256
+) {
+  $DesiredBody = Normalize-IssueCommentBody $DesiredBody
+  if ($Guard.operation_decision -ceq 'create') {
+    $originalSource = 'Task 8 initial publication desired body'
+    $originalBody = $DesiredBody
+  } else {
+    $originalSource = 'Task 8 execution report exact original published body'
+    $originalBody = Normalize-IssueCommentBody $HistoricalOriginalBody
+  }
+  return [ordered]@{
+    schema_version = 1
+    captured_at = (Get-Date).ToUniversalTime().ToString('o')
+    issue = 147
+    purpose_prefix = '## Reliability-gated Wayfinder migration readback'
+    historical_original = [ordered]@{
+      source = $originalSource
+      normalized_body = $originalBody
+      normalized_body_sha256 = Get-NormalizedBodySha256 $originalBody
+    }
+    pre_update = [ordered]@{
+      public_comment_id = $Guard.prior_public_comment_id
+      normalized_body_sha256 = $Guard.prior_normalized_body_sha256
+      readback_at = $Guard.prior_readback_at
+    }
+    desired = [ordered]@{
+      normalized_body = $DesiredBody
+      normalized_body_sha256 = $Guard.desired_normalized_body_sha256
+      frontier_artifact_path = $ArtifactPath
+      frontier_artifact_sha256 = $ArtifactSha256
+    }
+    operation_decision = $Guard.operation_decision
+    post_readback = [ordered]@{
+      public_comment_id = $Guard.post_public_comment_id
+      normalized_body_sha256 = $Guard.post_normalized_body_sha256
+      prefix_multiplicity = $Guard.post_prefix_multiplicity
+      exact_body_multiplicity = $Guard.post_exact_body_multiplicity
+      readback_at = $Guard.post_readback_at
+    }
+  }
 }
 
 $frontierText = (($frontier | ForEach-Object { "#$($_.number) $($_.title)" }) -join "`n- ")
@@ -1803,13 +1908,8 @@ Durable frontier audit: $artifactPath (SHA-256: ``$artifactSha256``).
 Frontier order remains subject to native dependencies and hotset ownership. Map publication is not a claim.
 "@
 $purposePrefix = '## Reliability-gated Wayfinder migration readback'
-$existing = @(Get-IssueComments 147 | Where-Object { (Normalize-IssueCommentBody $_.body).StartsWith($purposePrefix,[StringComparison]::Ordinal) })
-if ($existing.Count -eq 0) {
-  $guard = Write-ExactIssueComment 147 $purposePrefix $comment
-} else {
-  $guard = Set-ExactIssueComment 147 $purposePrefix $comment `
-    4994927680 'b6d4d1e9bc58fd013c4968eb2799990fb7afa579572ade93534ee657c35ad82b'
-}
+$guard = Set-OrCreateExactIssueComment 147 $purposePrefix $comment `
+  4994927680 'b6d4d1e9bc58fd013c4968eb2799990fb7afa579572ade93534ee657c35ad82b'
 
 $historicalOriginalBody = @'
 ## Reliability-gated Wayfinder migration readback
@@ -1834,35 +1934,7 @@ Current unclaimed 0.1.6 ready frontier:
 
 Frontier order remains subject to native dependencies and hotset ownership. Map publication is not a claim.
 '@
-$desiredBody = Normalize-IssueCommentBody $comment
-$transcript = [ordered]@{
-  schema_version = 1
-  captured_at = (Get-Date).ToUniversalTime().ToString('o')
-  issue = 147
-  purpose_prefix = $purposePrefix
-  historical_original = [ordered]@{
-    source = 'Task 8 execution report exact original published body'
-    normalized_body = Normalize-IssueCommentBody $historicalOriginalBody
-    normalized_body_sha256 = Get-NormalizedBodySha256 $historicalOriginalBody
-  }
-  pre_update = [ordered]@{
-    public_comment_id = [long]($guard.prior_public_comment_id ?? $guard.public_comment_id)
-    normalized_body_sha256 = [string]($guard.prior_normalized_body_sha256 ?? $guard.normalized_body_sha256)
-  }
-  desired = [ordered]@{
-    normalized_body = $desiredBody
-    normalized_body_sha256 = Get-NormalizedBodySha256 $desiredBody
-    frontier_artifact_path = $artifactPath
-    frontier_artifact_sha256 = $artifactSha256
-  }
-  operation_decision = [string]$guard.operation_decision
-  post_readback = [ordered]@{
-    public_comment_id = [long]($guard.post_public_comment_id ?? $guard.public_comment_id)
-    normalized_body_sha256 = Get-NormalizedBodySha256 $desiredBody
-    prefix_multiplicity = [int]($guard.post_prefix_multiplicity ?? $guard.prefix_multiplicity)
-    exact_body_multiplicity = [int]($guard.post_exact_body_multiplicity ?? $guard.exact_body_multiplicity)
-  }
-}
+$transcript = New-CheckpointTranscript $guard $historicalOriginalBody $comment $artifactPath $artifactSha256
 $transcriptPath = 'docs/superpowers/reviews/wayfinder-checkpoint-update-v1.json'
 $transcript | ConvertTo-Json -Depth 8 | Set-Content -Encoding utf8NoBOM $transcriptPath
 python scripts/generate_wayfinder_final_audit.py finalize `

--- a/docs/superpowers/plans/2026-07-16-wayfinder-github-migration.md
+++ b/docs/superpowers/plans/2026-07-16-wayfinder-github-migration.md
@@ -1149,11 +1149,22 @@ Expected: `milestones-and-hierarchy-ok`.
 Run:
 
 ```powershell
+function Normalize-IssueCommentBody([string]$Body) {
+  return ($Body -replace "`r`n","`n").TrimEnd()
+}
+function Get-NormalizedBodySha256([string]$Body) {
+  $normalized = Normalize-IssueCommentBody $Body
+  $bytes = [Text.Encoding]::UTF8.GetBytes($normalized)
+  return [Convert]::ToHexString([Security.Cryptography.SHA256]::HashData($bytes)).ToLowerInvariant()
+}
+function Get-IssueComments([int]$Issue) {
+  return @(gh api --paginate "repos/NOirBRight/CodexHub/issues/$Issue/comments?per_page=100" | ConvertFrom-Json)
+}
 function Write-ExactIssueComment([int]$Issue,[string]$PurposePrefix,[string]$Body) {
-  $Body = ($Body -replace "`r`n","`n").TrimEnd()
+  $Body = Normalize-IssueCommentBody $Body
   $comments = @(gh api --paginate "repos/NOirBRight/CodexHub/issues/$Issue/comments?per_page=100" | ConvertFrom-Json)
-  $exact = @($comments | Where-Object body -CEQ $Body)
-  $purpose = @($comments | Where-Object { ([string]$_.body).StartsWith($PurposePrefix,[StringComparison]::Ordinal) })
+  $exact = @($comments | Where-Object { (Normalize-IssueCommentBody $_.body) -ceq $Body })
+  $purpose = @($comments | Where-Object { (Normalize-IssueCommentBody $_.body).StartsWith($PurposePrefix,[StringComparison]::Ordinal) })
   if ($exact.Count -gt 1) { throw "multiple exact comments on #$Issue" }
   if ($exact.Count -eq 1) {
     if ($purpose.Count -ne 1) { throw "conflicting same-purpose comment on #$Issue" }
@@ -1162,9 +1173,60 @@ function Write-ExactIssueComment([int]$Issue,[string]$PurposePrefix,[string]$Bod
     gh issue comment $Issue --body $Body | Out-Null
   }
   $readback = @(gh api --paginate "repos/NOirBRight/CodexHub/issues/$Issue/comments?per_page=100" | ConvertFrom-Json)
-  $matches = @($readback | Where-Object body -CEQ $Body)
-  if ($matches.Count -ne 1) { throw "exact comment readback failed on #$Issue" }
-  $matches[0].html_url
+  $purposeReadback = @($readback | Where-Object { (Normalize-IssueCommentBody $_.body).StartsWith($PurposePrefix,[StringComparison]::Ordinal) })
+  $matches = @($readback | Where-Object { (Normalize-IssueCommentBody $_.body) -ceq $Body })
+  if ($purposeReadback.Count -ne 1 -or $matches.Count -ne 1) { throw "exact create/no-op readback failed on #$Issue" }
+  return [ordered]@{
+    operation_decision = if ($exact.Count -eq 1) { 'exact-no-op' } else { 'create' }
+    public_comment_id = [long]$matches[0].id
+    normalized_body_sha256 = Get-NormalizedBodySha256 $Body
+    prefix_multiplicity = $purposeReadback.Count
+    exact_body_multiplicity = $matches.Count
+    url = $matches[0].html_url
+  }
+}
+function Set-ExactIssueComment(
+  [int]$Issue,
+  [string]$PurposePrefix,
+  [string]$DesiredBody,
+  [long]$ExpectedPriorPublicCommentId,
+  [string]$ExpectedPriorNormalizedBodySha256
+) {
+  $DesiredBody = Normalize-IssueCommentBody $DesiredBody
+  $comments = @(Get-IssueComments $Issue)
+  $purpose = @($comments | Where-Object { (Normalize-IssueCommentBody $_.body).StartsWith($PurposePrefix,[StringComparison]::Ordinal) })
+  if ($purpose.Count -ne 1) { throw "expected exactly one same-purpose comment on #$Issue" }
+  $exact = @($comments | Where-Object { (Normalize-IssueCommentBody $_.body) -ceq $DesiredBody })
+  if ($exact.Count -gt 1) { throw "multiple exact desired comments on #$Issue" }
+
+  $selected = $purpose[0]
+  $priorHash = Get-NormalizedBodySha256 ([string]$selected.body)
+  if ($exact.Count -eq 1) {
+    $operation = 'exact-no-op'
+  } else {
+    if ([long]$selected.id -ne $ExpectedPriorPublicCommentId) { throw "prior public comment ID mismatch on #$Issue" }
+    if ($priorHash -cne $ExpectedPriorNormalizedBodySha256.ToLowerInvariant()) { throw "prior normalized-body SHA-256 mismatch on #$Issue" }
+    @{body=$DesiredBody} | ConvertTo-Json -Compress |
+      gh api --method PATCH "repos/NOirBRight/CodexHub/issues/comments/$ExpectedPriorPublicCommentId" --input - | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw "checkpoint PATCH failed on #$Issue" }
+    $operation = 'patch'
+  }
+
+  $readback = @(Get-IssueComments $Issue)
+  $purposeReadback = @($readback | Where-Object { (Normalize-IssueCommentBody $_.body).StartsWith($PurposePrefix,[StringComparison]::Ordinal) })
+  $exactReadback = @($readback | Where-Object { (Normalize-IssueCommentBody $_.body) -ceq $DesiredBody })
+  if ($purposeReadback.Count -ne 1 -or $exactReadback.Count -ne 1) { throw "exact checkpoint update readback failed on #$Issue" }
+  if ([long]$exactReadback[0].id -ne [long]$selected.id) { throw "checkpoint identity changed on #$Issue" }
+  return [ordered]@{
+    operation_decision = $operation
+    prior_public_comment_id = [long]$selected.id
+    prior_normalized_body_sha256 = $priorHash
+    desired_normalized_body_sha256 = Get-NormalizedBodySha256 $DesiredBody
+    post_public_comment_id = [long]$exactReadback[0].id
+    post_prefix_multiplicity = $purposeReadback.Count
+    post_exact_body_multiplicity = $exactReadback.Count
+    url = $exactReadback[0].html_url
+  }
 }
 
 git merge-base --is-ancestor 400d19bb dev
@@ -1512,10 +1574,11 @@ Expected: #147 URL and no exception.
 **Files:**
 - GitHub milestones and #147 comments only.
 - Temporary: `$env:TEMP\codexhub-wayfinder-migration\final-issues-api.json`.
+- Durable audit inputs/outputs: `scripts/generate_wayfinder_final_audit.py`, `docs/superpowers/reviews/wayfinder-frontier-ownership-audit-v1.json`, `docs/superpowers/reviews/wayfinder-checkpoint-update-v1.json`, and `docs/superpowers/reviews/wayfinder-final-audit-v1.json`.
 
 **Interfaces:**
 - Consumes: all prior tasks.
-- Produces: closed legacy milestone, exact lifecycle/milestone/hierarchy/dependency validation, and one durable #147 migration checkpoint with the unclaimed frontier.
+- Produces: closed legacy milestone, exact lifecycle/milestone/hierarchy/dependency validation, a self-contained content-addressed audit package, and one durable #147 migration checkpoint with the unclaimed frontier plus the repository-relative frontier artifact path/SHA-256.
 
 - [ ] **Step 1: Close the superseded legacy milestone only after reassignments**
 
@@ -1635,7 +1698,7 @@ Expected: `hierarchy-dependencies-ok`.
 
 - [ ] **Step 5: Prove hotset ownership eligibility and compute the unclaimed 0.1.6 ready frontier**
 
-First build the label/dependency candidate set with the following PowerShell. Then, for every candidate it prints, call native `codex_app__list_threads` twice: once with the exact Issue title and once with `Issue N`. Do not use SQLite. Save only `{issue,queries:[{query,threads,unavailableHosts}]}` to `$env:TEMP\codexhub-wayfinder-migration\frontier-task-evidence.json`; omit Task IDs and local paths. If the native Task tool is unavailable, any host is unavailable, or any matching Task exists, stop with `NEEDS_CONTEXT` rather than guessing.
+First build the label/dependency candidate set with the following PowerShell. Then, for every candidate it prints, call native `codex_app__list_threads` twice: once with the exact Issue title and once with `Issue N`. Do not use SQLite. Preserve the actual sanitized tool output in one JSON object with top-level `captured_at`, `tool`, `limit`, and `records`; every record must contain `issue`, `kind`, `query`, `schemaVersion`, `threads`, and `unavailableHosts`. Write it to `$env:TEMP\codexhub-wayfinder-migration\frontier-task-evidence.json` only when every `threads` and `unavailableHosts` array is empty, so no Task ID can enter the file. If the native Task tool is unavailable, any host is unavailable, any matching Task exists, or the capture timestamp/schema/query is incomplete, stop with `NEEDS_CONTEXT` rather than guessing.
 
 Run:
 
@@ -1661,53 +1724,36 @@ After the native queries are saved, run:
 ```powershell
 $taskEvidenceFile = Join-Path $env:TEMP 'codexhub-wayfinder-migration/frontier-task-evidence.json'
 if (-not (Test-Path $taskEvidenceFile)) { throw 'NEEDS_CONTEXT: native Task evidence is missing' }
-$taskEvidence = @(Get-Content -Raw $taskEvidenceFile | ConvertFrom-Json)
-foreach ($candidate in $labelCandidates) {
-  $record = @($taskEvidence | Where-Object issue -eq $candidate.number)
-  if ($record.Count -ne 1 -or $record[0].queries.Count -ne 2) { throw "NEEDS_CONTEXT: incomplete Task evidence #$($candidate.number)" }
-  $expectedQueries = @($candidate.title,"Issue $($candidate.number)" | Sort-Object)
-  $actualQueries = @($record[0].queries.query | Sort-Object)
-  if (($actualQueries -join '|') -cne ($expectedQueries -join '|')) { throw "NEEDS_CONTEXT: wrong Task queries #$($candidate.number)" }
-  foreach ($query in $record[0].queries) {
-    if ($query.unavailableHosts.Count -ne 0) { throw "NEEDS_CONTEXT: native Task host unavailable #$($candidate.number)" }
-    if ($query.threads.Count -ne 0) { throw "active native Task owns #$($candidate.number)" }
-  }
-}
+$artifactPath = 'docs/superpowers/reviews/wayfinder-frontier-ownership-audit-v1.json'
+python scripts/generate_wayfinder_final_audit.py capture `
+  --native-task-evidence $taskEvidenceFile `
+  --output $artifactPath `
+  --base-ref dev `
+  --planned-path scripts/generate_wayfinder_final_audit.py `
+  --planned-path docs/superpowers/plans/2026-07-16-wayfinder-github-migration.md
+if ($LASTEXITCODE -ne 0) { throw 'frontier audit capture/self-validation failed closed' }
 
-$currentBranch = git branch --show-current
-$worktreeLines = @(git worktree list --porcelain)
-$worktreeBranches = @($worktreeLines | Where-Object { $_ -like 'branch refs/heads/*' } | ForEach-Object { $_.Substring(7) })
-$allowedWorktreeBranches = @('refs/heads/dev',"refs/heads/$currentBranch")
-$extraWorktrees = @($worktreeBranches | Where-Object { $_ -notin $allowedWorktreeBranches })
-if ($extraWorktrees.Count) { throw 'active product worktree requires hotset reconciliation' }
-
-$allBranches = @(git branch --all --format='%(refname:short)')
-$openPrs = @(gh pr list --state open --limit 100 --json number,title,headRefName,baseRefName,url | ConvertFrom-Json)
-foreach ($candidate in $labelCandidates) {
-  $branchPattern = "(?i)(issue[-_/]?$($candidate.number)(\D|$)|#$($candidate.number)(\D|$))"
-  if (@($allBranches | Where-Object { $_ -match $branchPattern }).Count) { throw "candidate branch owns #$($candidate.number)" }
-  if (@($openPrs | Where-Object { $_.headRefName -match $branchPattern -or $_.title -match "#$($candidate.number)(\D|$)" }).Count) { throw "open PR owns #$($candidate.number)" }
-  if ($candidate.assignees.Count -ne 0) { throw "assignee owns #$($candidate.number)" }
-  if (-not $candidate.body.Contains('## Expected hotset')) { throw "missing Expected hotset #$($candidate.number)" }
+$audit = Get-Content -Raw $artifactPath | ConvertFrom-Json
+if ($audit.schema_version -ne 1 -or $audit.artifact_kind -cne 'wayfinder-frontier-ownership-audit') {
+  throw 'frontier audit schema mismatch'
 }
-
-$ownershipEvidence = [ordered]@{
-  captured_at = (Get-Date).ToUniversalTime().ToString('o')
-  candidates = @($labelCandidates.number)
-  native_task_queries = @($taskEvidence | ForEach-Object { @{issue=$_.issue;queries=@($_.queries | ForEach-Object { @{query=$_.query;match_count=$_.threads.Count;unavailable_host_count=$_.unavailableHosts.Count} })} })
-  active_product_worktree_count = $extraWorktrees.Count
-  candidate_branch_count = 0
-  candidate_open_pr_count = 0
-  candidate_assignee_count = 0
-  hotset_preflight = 'Expected hotsets re-read; no native Task or active product worktree owns a candidate hotset.'
+if ($audit.native_task_capture.records.Count -ne (2 * $labelCandidates.Count)) {
+  throw 'frontier native Task record count mismatch'
 }
-$ownershipEvidence | ConvertTo-Json -Depth 8 |
-  Set-Content -Encoding utf8 (Join-Path $env:TEMP 'codexhub-wayfinder-migration/frontier-ownership-evidence.json')
-$frontier = @($labelCandidates)
+$frontier = @($audit.frontier | ForEach-Object {
+  $number = [int]$_
+  $match = @($labelCandidates | Where-Object number -eq $number)
+  if ($match.Count -ne 1) { throw "frontier readback mismatch #$number" }
+  $match[0]
+})
+$artifactSha256 = (Get-FileHash $artifactPath -Algorithm SHA256).Hash.ToLowerInvariant()
+python scripts/generate_wayfinder_final_audit.py validate --artifact $artifactPath
+if ($LASTEXITCODE -ne 0) { throw 'frontier artifact self-validation failed' }
 $frontier | Select-Object number,title,url | Format-Table -AutoSize
+"frontier-artifact=$artifactPath sha256=$artifactSha256"
 ```
 
-Expected: sanitized native Task/worktree/branch/PR/assignee/hotset evidence proves no active ownership conflict. If live state remains unchanged, frontier order is `$localSearchIssue`, `$selectorBindingIssue`, #139, #149, #150, #111. Do not assign or dispatch any candidate.
+Expected: the generator validates all twelve exact query records, parses/persists every candidate's normalized Expected hotset, enumerates revisions/cleanliness/file sets for every worktree/local branch/open PR head, computes per-candidate intersections without inferring ownership from branch names, and records label/dependency eligibility separately from ownership/hotset eligibility. The current planning worktree may be `migration-control` only with zero product-hotset intersections; `dev` must be audited clean rather than trusted. If live state remains unchanged, frontier order is `$localSearchIssue`, `$selectorBindingIssue`, #139, #149, #150, #111. Do not assign or dispatch any candidate.
 
 - [ ] **Step 6: Publish one migration checkpoint comment on #147**
 
@@ -1752,12 +1798,82 @@ Current unclaimed 0.1.6 ready frontier:
 
 Sanitized native Task/worktree/branch/PR/assignee/hotset preflight found no active ownership conflict at publication.
 
+Durable frontier audit: $artifactPath (SHA-256: ``$artifactSha256``).
+
 Frontier order remains subject to native dependencies and hotset ownership. Map publication is not a claim.
 "@
-Write-ExactIssueComment 147 '## Reliability-gated Wayfinder migration readback' $comment
+$purposePrefix = '## Reliability-gated Wayfinder migration readback'
+$existing = @(Get-IssueComments 147 | Where-Object { (Normalize-IssueCommentBody $_.body).StartsWith($purposePrefix,[StringComparison]::Ordinal) })
+if ($existing.Count -eq 0) {
+  $guard = Write-ExactIssueComment 147 $purposePrefix $comment
+} else {
+  $guard = Set-ExactIssueComment 147 $purposePrefix $comment `
+    4994927680 'b6d4d1e9bc58fd013c4968eb2799990fb7afa579572ade93534ee657c35ad82b'
+}
+
+$historicalOriginalBody = @'
+## Reliability-gated Wayfinder migration readback
+
+The approved roadmap migration is complete and read back:
+
+- five active reliability milestones exist with exact membership;
+- the legacy cross-version reliability milestone is closed as superseded;
+- #156 is the ready-for-human Visible Worker gate and #159 is its ready local bounded-search child;
+- #64 is blocked by #156 for the full post-fix collaboration matrix;
+- #28 is narrowed to client discovery performance and #160 owns uninstall cleanup behind #111;
+- every open Issue has exactly one canonical lifecycle label;
+- no ticket was assigned or dispatched by the migration.
+
+Current unclaimed 0.1.6 ready frontier:
+
+- #159 Bound repeated empty tool_search misses for external models
+- #139 Serialize Gateway lifecycle operations and prevent duplicate startup processes
+- #149 Make Rust/Python atomic-file lock ownership and stale recovery safe
+- #150 Coalesce automatic OpenAI usage probes and avoid repeated Codex app-server cold starts
+- #111 Make Windows app autostart registration verifiable and reliable
+
+Frontier order remains subject to native dependencies and hotset ownership. Map publication is not a claim.
+'@
+$desiredBody = Normalize-IssueCommentBody $comment
+$transcript = [ordered]@{
+  schema_version = 1
+  captured_at = (Get-Date).ToUniversalTime().ToString('o')
+  issue = 147
+  purpose_prefix = $purposePrefix
+  historical_original = [ordered]@{
+    source = 'Task 8 execution report exact original published body'
+    normalized_body = Normalize-IssueCommentBody $historicalOriginalBody
+    normalized_body_sha256 = Get-NormalizedBodySha256 $historicalOriginalBody
+  }
+  pre_update = [ordered]@{
+    public_comment_id = [long]($guard.prior_public_comment_id ?? $guard.public_comment_id)
+    normalized_body_sha256 = [string]($guard.prior_normalized_body_sha256 ?? $guard.normalized_body_sha256)
+  }
+  desired = [ordered]@{
+    normalized_body = $desiredBody
+    normalized_body_sha256 = Get-NormalizedBodySha256 $desiredBody
+    frontier_artifact_path = $artifactPath
+    frontier_artifact_sha256 = $artifactSha256
+  }
+  operation_decision = [string]$guard.operation_decision
+  post_readback = [ordered]@{
+    public_comment_id = [long]($guard.post_public_comment_id ?? $guard.public_comment_id)
+    normalized_body_sha256 = Get-NormalizedBodySha256 $desiredBody
+    prefix_multiplicity = [int]($guard.post_prefix_multiplicity ?? $guard.prefix_multiplicity)
+    exact_body_multiplicity = [int]($guard.post_exact_body_multiplicity ?? $guard.exact_body_multiplicity)
+  }
+}
+$transcriptPath = 'docs/superpowers/reviews/wayfinder-checkpoint-update-v1.json'
+$transcript | ConvertTo-Json -Depth 8 | Set-Content -Encoding utf8NoBOM $transcriptPath
+python scripts/generate_wayfinder_final_audit.py finalize `
+  --core $artifactPath `
+  --transcript $transcriptPath `
+  --output docs/superpowers/reviews/wayfinder-final-audit-v1.json
+if ($LASTEXITCODE -ne 0) { throw 'final Wayfinder audit package validation failed' }
+$guard.url
 ```
 
-Expected: one comment URL returned.
+Expected: initial publication remains create-only and guarded; an existing checkpoint is either an exact no-op or a PATCH of only public comment `4994927680` after both its public ID and normalized prior-body SHA-256 match. Readback leaves exactly one same-purpose prefix and one exact desired body. The durable transcript and final self-contained artifact validate before the comment URL is returned.
 
 - [ ] **Step 7: Perform the final no-claim readback**
 
@@ -1776,9 +1892,17 @@ $prs = @(gh pr list --state open --limit 100 `
 if (@($prs | Where-Object { $_.headRefName -match '(?i)wayfinder|issue[-_/]?(159|161|139|149|150|111)' }).Count) {
   throw 'migration/candidate PR exists'
 }
-if (-not (Test-Path (Join-Path $env:TEMP 'codexhub-wayfinder-migration/frontier-ownership-evidence.json'))) {
-  throw 'frontier ownership evidence missing'
+foreach ($path in @(
+  'docs/superpowers/reviews/wayfinder-frontier-ownership-audit-v1.json',
+  'docs/superpowers/reviews/wayfinder-checkpoint-update-v1.json',
+  'docs/superpowers/reviews/wayfinder-final-audit-v1.json'
+)) {
+  if (-not (Test-Path $path)) { throw "durable audit artifact missing: $path" }
 }
+python scripts/generate_wayfinder_final_audit.py validate `
+  --artifact docs/superpowers/reviews/wayfinder-final-audit-v1.json `
+  --live
+if ($LASTEXITCODE -ne 0) { throw 'fresh live final audit failed' }
 git status --short --branch
 ```
 
@@ -1789,7 +1913,7 @@ Expected:
 - #159 and the selector/binding child are present in the exact frontier and ownership-evidence readback;
 - no migration-created product PR exists;
 - no product Issue was assigned by this plan;
-- repository working tree is clean.
+- repository working tree contains only the intended planning generator/docs/audit changes before their scoped commit, and is clean after commit.
 
 ---
 
@@ -1802,6 +1926,6 @@ Before execution handoff, verify this plan against the approved design:
 3. **Type consistency:** `$localSearchIssue`, `$selectorBindingIssue`, `$uninstallIssue`, milestone titles, parent relationships, and dependency direction are identical in every task.
 4. **Scope:** The plan changes only GitHub planning state. Every product Issue receives its own later spec/plan/implementation cycle.
 5. **No hidden claim:** No command assigns an Issue, creates a product branch/worktree, starts a Worker, opens a production PR, or edits product code.
-6. **Retry safety:** Every Task 6/8 comment write uses the exact-body/same-purpose-prefix guard, reads back exactly one match, and returns its URL; hierarchy/dependency writes are idempotent and final assertions compare exact sets.
-7. **Ownership proof:** Task 8 requires sanitized native Task/worktree/branch/PR/assignee/hotset evidence and stops with `NEEDS_CONTEXT` when native Task evidence is unavailable; labels alone never establish frontier eligibility.
+6. **Retry safety:** Every Task 6 comment and initial Task 8 publication uses the create/no-op exact-body/same-purpose-prefix guard. Every Task 8 checkpoint update uses `Set-ExactIssueComment`, optimistic concurrency on the expected public comment ID plus normalized prior-body SHA-256, a single-comment PATCH, and exact post-readback multiplicities.
+7. **Ownership proof:** Task 8's tracked read-only generator validates twelve timestamped/schema-versioned native queries, parses normalized Expected hotsets, enumerates every worktree/local branch/open PR head with revisions and changed-file sets versus `dev`, computes file-based intersections without branch-name inference, keeps label/dependency and ownership/hotset eligibility separate, and stops fail-closed on incomplete evidence or conflicts.
 8. **Review blockers resolved:** Task 1 safely fast-forwards only a clean stale planning branch with no unique commits, requires the design and plan in-tree, emits the full read-only write-set preview, and stops for explicit authorization; Tasks 2–8 use Inline Execution only.

--- a/docs/superpowers/plans/2026-07-16-wayfinder-github-migration.md
+++ b/docs/superpowers/plans/2026-07-16-wayfinder-github-migration.md
@@ -1,0 +1,1273 @@
+# Wayfinder GitHub Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate GitHub Wayfinder #147 from the obsolete feature-first roadmap to the approved reliability-gated release train without claiming or starting product implementation work.
+
+**Architecture:** GitHub remains the only durable work-state authority. The migration is idempotent and readback-driven: snapshot current state, create the five release milestones, decompose mixed-ownership Issues, normalize hierarchy/labels/dependencies, rewrite #147, and recompute the ready frontier. Product code and per-Issue implementation plans remain outside this plan.
+
+**Tech Stack:** PowerShell 7, GitHub CLI (`gh`), GitHub REST API, Git, Markdown.
+
+## Global Constraints
+
+- Repository: `NOirBRight/CodexHub`; integration branch: `dev`.
+- Approved design: `docs/superpowers/specs/2026-07-16-wayfinder-replanning-design.md` at or after commit `59477301`.
+- Use `gh` for every GitHub Issue, milestone, label, dependency, and sub-issue operation.
+- Do not assign an Issue, create a product branch/worktree, start a Worker, edit product code, or open a production PR during this migration.
+- The mandated process-skill name “subagent-driven-development” does not authorize hidden `spawn_agent` execution. Any delegated execution must materialize as a sidebar-visible GPT-5.6 Terra/max or Luna/max Worker with runtime-verified binding and bidirectional receipt; otherwise use explicit Inline Execution.
+- Preserve exactly one canonical lifecycle label on each Issue: `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, or `wontfix`.
+- Preserve reporter evidence. Never publish credentials, Task IDs, callback addresses, private paths, prompts, or raw private traces.
+- Native `blocked_by` edges represent only hard dependencies. Related work remains text-only.
+- A GitHub write is complete only after title/body/labels/state/assignee/milestone/parent/dependencies/URL readback.
+- The five active milestones are exact strings:
+  - `0.1.6 — Codex control-plane reliability`
+  - `0.1.7 — Official GPT reliability`
+  - `0.1.8 — Third-party model certification`
+  - `0.1.9 — Managed client reliability`
+  - `0.1.10 — Existing product reliability`
+- Git commits are required only for this plan document. Implementation tasks mutate GitHub state and use GitHub readback comments as durable checkpoints; they must not create empty repository commits.
+
+---
+
+### Task 1: Capture the read-only migration baseline
+
+**Files:**
+- Read: `docs/superpowers/specs/2026-07-16-wayfinder-replanning-design.md`
+- Temporary: `$env:TEMP\codexhub-wayfinder-migration\issues.json`
+- Temporary: `$env:TEMP\codexhub-wayfinder-migration\issues-api.json`
+- Temporary: `$env:TEMP\codexhub-wayfinder-migration\milestones.json`
+- Temporary: `$env:TEMP\codexhub-wayfinder-migration\map.json`
+- Temporary: `$env:TEMP\codexhub-wayfinder-migration\map-children.json`
+- Temporary: `$env:TEMP\codexhub-wayfinder-migration\open-prs.json`
+
+**Interfaces:**
+- Consumes: approved design commit `59477301` and the current GitHub repository state.
+- Produces: a timestamped, read-only JSON snapshot and a zero-write preflight result used to detect concurrent changes before later tasks.
+
+- [ ] **Step 1: Verify repository identity, branch, and clean working state**
+
+Run:
+
+```powershell
+git remote get-url origin
+git branch --show-current
+git status --short
+git merge-base --is-ancestor 59477301 HEAD
+gh repo view --json nameWithOwner,defaultBranchRef,url
+gh auth status
+```
+
+Expected:
+
+- remote is `https://github.com/NOirBRight/CodexHub.git`;
+- branch is `dev` or an isolated planning branch whose merge-base contains `59477301`;
+- `git status --short` is empty;
+- the ancestry command exits `0`;
+- GitHub repository is `NOirBRight/CodexHub` and authentication succeeds.
+
+- [ ] **Step 2: Capture Issues, REST metadata, milestones, map membership, and PRs**
+
+Run:
+
+```powershell
+$root = Join-Path $env:TEMP 'codexhub-wayfinder-migration'
+New-Item -ItemType Directory -Force -Path $root | Out-Null
+
+gh issue list --state all --limit 1000 `
+  --json number,title,state,body,labels,assignees,author,createdAt,updatedAt,closedAt,comments,url `
+  | Set-Content -Encoding utf8 (Join-Path $root 'issues.json')
+
+gh api --paginate --slurp 'repos/NOirBRight/CodexHub/issues?state=all&per_page=100' `
+  | Set-Content -Encoding utf8 (Join-Path $root 'issues-api.json')
+
+gh api 'repos/NOirBRight/CodexHub/milestones?state=all&per_page=100' `
+  | Set-Content -Encoding utf8 (Join-Path $root 'milestones.json')
+
+gh api repos/NOirBRight/CodexHub/issues/147 `
+  | Set-Content -Encoding utf8 (Join-Path $root 'map.json')
+
+gh api --paginate --slurp repos/NOirBRight/CodexHub/issues/147/sub_issues `
+  | Set-Content -Encoding utf8 (Join-Path $root 'map-children.json')
+
+gh pr list --state open --limit 100 `
+  --json number,title,headRefName,baseRefName,author,url `
+  | Set-Content -Encoding utf8 (Join-Path $root 'open-prs.json')
+```
+
+Expected: all seven files exist and parse as JSON; the Issue snapshot contains 93 Issues at the design baseline, with later additions allowed only after they are reported before any write.
+
+- [ ] **Step 3: Validate the snapshot without changing GitHub**
+
+Run:
+
+```powershell
+@'
+import json, os, pathlib
+root = pathlib.Path(os.environ['TEMP']) / 'codexhub-wayfinder-migration'
+issues = json.loads((root / 'issues.json').read_text(encoding='utf-8-sig'))
+open_issues = [x for x in issues if x['state'] == 'OPEN']
+maps = [x for x in open_issues if 'wayfinder:map' in [l['name'] for l in x['labels']]]
+assert len(maps) == 1 and maps[0]['number'] == 147, maps
+assert all(x['number'] != 147 or x['title'].startswith('Wayfinder:') for x in issues)
+print({'total': len(issues), 'open': len(open_issues), 'map': maps[0]['url']})
+'@ | python -
+```
+
+Expected: one open Wayfinder map, #147. If counts or map identity differ from the snapshot described by the design, stop and reconcile the delta before Task 2.
+
+- [ ] **Step 4: Record the immutable pre-write hashes**
+
+Run:
+
+```powershell
+$root = Join-Path $env:TEMP 'codexhub-wayfinder-migration'
+Get-FileHash (Join-Path $root '*.json') -Algorithm SHA256 `
+  | Sort-Object Path `
+  | Format-Table Hash,Path -AutoSize
+```
+
+Expected: one SHA-256 per snapshot file. Retain this terminal output for the migration review checkpoint.
+
+---
+
+### Task 2: Create the five reliability milestones idempotently
+
+**Files:**
+- Read: `$env:TEMP\codexhub-wayfinder-migration\milestones.json`
+- GitHub objects: repository milestones only.
+
+**Interfaces:**
+- Consumes: Task 1 read-only snapshot.
+- Produces: five open milestones discoverable by their exact titles; later tasks use titles rather than unstable milestone numbers.
+
+- [ ] **Step 1: Define the exact milestone contracts**
+
+Run:
+
+```powershell
+$milestones = [ordered]@{
+  '0.1.6 — Codex control-plane reliability' = 'Exit: one reconciled Gateway lifecycle; sidebar-visible Worker materialization; bidirectional Task communication and receipts; bounded cancellation/exit/restart; recoverable Task state. Only 0.1.6 receives new work while this gate is active.'
+  '0.1.7 — Official GPT reliability' = 'Exit: Official GPT catalog, Task/Worker communication, tool lifecycle, streaming/cancellation, and context authority are reliable enough to serve as the control group for third-party qualification.'
+  '0.1.8 — Third-party model certification' = 'Exit: each supported provider/model/protocol/codec combination has runtime-derived capability evidence, full visible-Worker and Task communication coverage, fail-closed unknown semantics, and a #67 GO/PARTIAL/NO-GO decision.'
+  '0.1.9 — Managed client reliability' = 'Exit: ZCode, OMP, OpenCode, and Pi preview/apply/readback/restore are transactional, identity-faithful, reasoning-faithful, and free of silent Official fallback.'
+  '0.1.10 — Existing product reliability' = 'Exit: remaining existing pricing, Vision Proxy, diagnostics, notification, and uninstall-cleanup defects are resolved without adding new product capabilities.'
+}
+$milestones.GetEnumerator() | Format-Table Name,Value -Wrap
+```
+
+Expected: five exact titles and five non-empty exit contracts.
+
+- [ ] **Step 2: Create or update each milestone**
+
+Run:
+
+```powershell
+foreach ($entry in $milestones.GetEnumerator()) {
+  $existing = @(gh api 'repos/NOirBRight/CodexHub/milestones?state=all&per_page=100' `
+    --jq ".[] | select(.title == \"$($entry.Name)\") | .number")
+  if ($existing.Count -gt 1) { throw "duplicate milestone title: $($entry.Name)" }
+  if ($existing.Count -eq 0) {
+    gh api --method POST repos/NOirBRight/CodexHub/milestones `
+      -f title="$($entry.Name)" `
+      -f description="$($entry.Value)" `
+      -f state='open' | Out-Null
+  } else {
+    gh api --method PATCH "repos/NOirBRight/CodexHub/milestones/$($existing[0])" `
+      -f title="$($entry.Name)" `
+      -f description="$($entry.Value)" `
+      -f state='open' | Out-Null
+  }
+}
+```
+
+Expected: every call succeeds; no duplicate title is created.
+
+- [ ] **Step 3: Read back the milestone contracts**
+
+Run:
+
+```powershell
+$actual = gh api 'repos/NOirBRight/CodexHub/milestones?state=all&per_page=100' | ConvertFrom-Json
+foreach ($entry in $milestones.GetEnumerator()) {
+  $matches = @($actual | Where-Object title -eq $entry.Name)
+  if ($matches.Count -ne 1) { throw "milestone readback count: $($entry.Name)" }
+  if ($matches[0].state -ne 'open') { throw "milestone not open: $($entry.Name)" }
+  if ($matches[0].description -ne $entry.Value) { throw "description mismatch: $($entry.Name)" }
+}
+$actual | Where-Object title -in $milestones.Keys `
+  | Select-Object number,title,state,open_issues,closed_issues `
+  | Sort-Object number | Format-Table -AutoSize
+```
+
+Expected: five unique open milestones with exact descriptions.
+
+---
+
+### Task 3: Decompose #156 into the human Visible Worker gate and a local bounded-search fix
+
+**Files:**
+- Read: `docs/superpowers/specs/2026-07-16-wayfinder-replanning-design.md`
+- GitHub Issue: #156.
+- Create GitHub Issue with exact title: `Bound repeated empty tool_search misses for external models`.
+
+**Interfaces:**
+- Consumes: milestone `0.1.6 — Codex control-plane reliability`.
+- Produces: `$localSearchIssue`, a ready-for-agent CodexHub-owned child of #156; #156 remains the ready-for-human Visible Worker gate; #64 is blocked by #156.
+
+- [ ] **Step 1: Re-read #156 immediately before writing**
+
+Run:
+
+```powershell
+gh issue view 156 --comments `
+  --json number,title,state,body,labels,assignees,milestone,comments,url
+```
+
+Expected: open `bug` + `ready-for-human`; body contains the Host/runtime callback gap and the CodexHub repeated empty-search amplification; the reporter clarification comment ends with `issuecomment-4993730159`.
+
+- [ ] **Step 2: Create the local bounded-search child Issue if absent**
+
+Run:
+
+```powershell
+$title = 'Bound repeated empty tool_search misses for external models'
+$matches = @(gh issue list --state all --limit 100 `
+  --search 'in:title "Bound repeated empty tool_search misses for external models"' `
+  --json number,title,state,url `
+  --jq ".[] | select(.title == \"$title\") | .number")
+if ($matches.Count -gt 1) { throw 'duplicate bounded-search Issues' }
+
+if ($matches.Count -eq 0) {
+  $body = @'
+Part of #156.
+
+## Problem
+
+On the external-model compatibility path, an exact `tool_search` query can return `tools=[]` repeatedly while the same search function remains visible in replayed history. The model may resample the identical unavailable callback query without a terminal policy, amplifying requests, tokens, latency, and cost without creating a callable host tool.
+
+## Outcome
+
+Bound identical empty tool-search misses in the CodexHub adapter and return one sanitized, machine-classifiable unavailable terminal result. A different query and every non-empty result remain unaffected.
+
+## Scope
+
+- Track identical exact-name search misses within one request/turn history.
+- Permit at most two identical empty searches or two additional model samples.
+- On the bound, emit a deterministic unavailable result and prevent a third identical search sample.
+- Preserve successful discovery, distinct queries, call IDs, history, SSE terminalization, and existing Official/third-party tool behavior.
+- Record only sanitized query classification/count/status telemetry; do not record prompts, tool arguments, callback addresses, or Task identifiers.
+
+## Non-goals
+
+- Do not inject a callback schema without a real host handler.
+- Do not implement Codex Host sidebar Worker registration, result receipts, or model-binding readback.
+- Do not use GPT, Hidden Subagent, `codex exec`, Background, or Inline work as a substitute for #156 acceptance.
+- Do not change unrelated retry, transport, apply-patch, or Task activity behavior.
+
+## Acceptance criteria
+
+- [ ] The first exact-name miss returns the existing explicit empty/unavailable search result.
+- [ ] A second identical miss produces one classified terminal unavailable result and no third model sample for that query in the turn.
+- [ ] A distinct legitimate query is not suppressed by the identical-query guard.
+- [ ] A non-empty search result remains unchanged and callable.
+- [ ] History replay preserves call/result identity and exactly one terminal outcome.
+- [ ] Sanitized telemetry records the bound without prompts, callback addresses, credentials, paths, or Task identifiers.
+- [ ] Official, namespace, MCP, collaboration, and strict apply-patch regressions remain green.
+
+## Verification
+
+```powershell
+python -m pytest -q tests/test_routing.py -k "tool_search"
+python -m pytest -q tests/test_codex_semantic_adapter.py
+python -m pytest -q
+python scripts/report_quality_gates.py
+git diff --check
+```
+
+`report_quality_gates.py` is report-only.
+
+## Expected hotset
+
+- `src-python/codex_proxy.py`
+- `src-python/codex_semantic_adapter.py`
+- `tests/test_routing.py`
+- `tests/test_codex_semantic_adapter.py`
+- one sanitized fixture under `tests/fixtures/` if the deterministic replay needs it
+
+## Relationships
+
+- Parent/human Visible Worker gate: #156
+- Full collaboration matrix: #64
+- Deferred search classification: #63
+
+## Execution contract
+
+Execution-Contract: v2
+Verification-Class: strict
+Verification-Commands: targeted routing/semantic-adapter tests; full Python suite once; `git diff --check`; report-only quality gate
+Manual-Evidence: none
+Architecture-Decision: resolved
+Review-Owner: orchestrator
+'@
+  $url = gh issue create --title $title --body $body `
+    --label bug --label ready-for-agent --label wayfinder:task
+  $localSearchIssue = [int]($url.TrimEnd('/') -split '/')[-1]
+} else {
+  $localSearchIssue = [int]$matches[0]
+}
+"localSearchIssue=$localSearchIssue"
+```
+
+Expected: exactly one open Issue with the exact title; record its numeric value as `$localSearchIssue`.
+
+- [ ] **Step 3: Set milestone, parent, labels, and hard dependencies idempotently**
+
+Run:
+
+```powershell
+gh issue edit $localSearchIssue `
+  --add-label bug --add-label ready-for-agent --add-label wayfinder:task `
+  --milestone '0.1.6 — Codex control-plane reliability'
+
+gh issue edit 156 --add-label wayfinder:grilling `
+  --milestone '0.1.6 — Codex control-plane reliability'
+
+function Ensure-SubIssue([int]$Parent, [int]$Child) {
+  $childIssue = gh api "repos/NOirBRight/CodexHub/issues/$Child" | ConvertFrom-Json
+  $expected = "https://api.github.com/repos/NOirBRight/CodexHub/issues/$Parent"
+  if ($childIssue.parent_issue_url -eq $expected) { return }
+  if ($childIssue.parent_issue_url) { throw "#$Child already has parent $($childIssue.parent_issue_url)" }
+  gh api --method POST "repos/NOirBRight/CodexHub/issues/$Parent/sub_issues" `
+    -F sub_issue_id=$childIssue.id | Out-Null
+}
+
+function Ensure-BlockedBy([int]$Blocked, [int]$Blocker) {
+  $existing = @(gh api "repos/NOirBRight/CodexHub/issues/$Blocked/dependencies/blocked_by" `
+    --jq ".[] | select(.number == $Blocker) | .number")
+  if ($existing.Count -eq 0) {
+    $blockerId = gh api "repos/NOirBRight/CodexHub/issues/$Blocker" --jq .id
+    gh api --method POST "repos/NOirBRight/CodexHub/issues/$Blocked/dependencies/blocked_by" `
+      -F issue_id=$blockerId | Out-Null
+  }
+}
+
+Ensure-SubIssue 147 156
+Ensure-SubIssue 156 $localSearchIssue
+Ensure-BlockedBy 156 $localSearchIssue
+Ensure-BlockedBy 64 156
+```
+
+Expected: #156 is a child of #147; the local Issue is a child of #156; #156 is blocked by the local Issue; #64 is blocked by #156.
+
+- [ ] **Step 4: Read back the complete decomposition**
+
+Run:
+
+```powershell
+foreach ($n in 156,$localSearchIssue,64) {
+  gh api "repos/NOirBRight/CodexHub/issues/$n" `
+    --jq '{number,title,state,labels:[.labels[].name],assignees:[.assignees[].login],milestone:(.milestone.title // null),parent:.parent_issue_url,deps:.issue_dependencies_summary,url:.html_url}'
+}
+gh api "repos/NOirBRight/CodexHub/issues/156/dependencies/blocked_by" `
+  --jq '.[] | {number,title,state}'
+gh api "repos/NOirBRight/CodexHub/issues/64/dependencies/blocked_by" `
+  --jq '.[] | {number,title,state}'
+```
+
+Expected: exact hierarchy and dependencies from Step 3; #156 remains unassigned and `ready-for-human`; the local child is unassigned and `ready-for-agent`.
+
+---
+
+### Task 4: Split #28 into client discovery performance and uninstall cleanup
+
+**Files:**
+- GitHub Issue: #28, rewritten in place for probe/catalog discovery performance.
+- Create GitHub Issue with exact title: `Remove CodexHub-owned Windows autostart registration during uninstall`.
+
+**Interfaces:**
+- Consumes: milestones 0.1.9 and 0.1.10; runtime registration owner #111.
+- Produces: #28 as a single-boundary 0.1.9 Issue and `$uninstallIssue` as a 0.1.10 Issue blocked by #111.
+
+- [ ] **Step 1: Re-read #28 and preserve its reporter evidence**
+
+Run:
+
+```powershell
+gh issue view 28 --comments `
+  --json number,title,state,body,labels,assignees,milestone,comments,url
+```
+
+Expected: open enhancement with two mixed concerns: installer uninstall cleanup and probe/catalog discovery performance.
+
+- [ ] **Step 2: Create the uninstall cleanup Issue if absent**
+
+Run:
+
+```powershell
+$title = 'Remove CodexHub-owned Windows autostart registration during uninstall'
+$matches = @(gh issue list --state all --limit 100 `
+  --search 'in:title "Remove CodexHub-owned Windows autostart registration during uninstall"' `
+  --json number,title,state,url `
+  --jq ".[] | select(.title == \"$title\") | .number")
+if ($matches.Count -gt 1) { throw 'duplicate uninstall-cleanup Issues' }
+
+if ($matches.Count -eq 0) {
+  $body = @'
+Split from #28. Runtime registration/readback is owned by #111.
+
+## Problem
+
+CodexHub can create a Windows autostart registration, but the installer/uninstaller contract does not prove that uninstall removes only the CodexHub-owned registration. A stale registration can survive removal, point to a missing executable, or launch an unintended path after reinstall.
+
+## Outcome
+
+The Windows uninstall path removes the exact CodexHub-owned autostart registration using the same ownership identity defined by #111, while preserving unrelated scheduled tasks and user registrations.
+
+## Scope
+
+- Integrate ownership-verified autostart removal into the supported Windows uninstall flow.
+- Treat missing registration as idempotent success.
+- Detect mismatched owner/action/path and fail closed without deleting it.
+- Cover normal/debug build flavors and supported installed-path replacement.
+- Surface uninstall-log evidence without credentials or private path disclosure in user-facing output.
+
+## Non-goals
+
+- Do not redesign runtime enable/disable/readback; #111 owns that contract.
+- Do not delete scheduled tasks by broad name, executable basename, or port.
+- Do not change macOS/Linux startup behavior in this Windows Issue.
+
+## Acceptance criteria
+
+- [ ] Uninstall removes exactly one verified CodexHub-owned Windows autostart registration.
+- [ ] Missing registration is an idempotent success.
+- [ ] A mismatched registration is preserved and reported rather than deleted.
+- [ ] Reinstall after uninstall creates one valid registration with no stale duplicate.
+- [ ] Normal/debug and supported install replacement fixtures preserve the correct executable identity.
+- [ ] A packaged Windows install→enable→uninstall smoke leaves no CodexHub-owned registration and does not change an unrelated control task.
+
+## Verification
+
+```powershell
+Push-Location src-tauri
+cargo test --locked
+cargo clippy --locked --all-targets -- -D warnings
+Pop-Location
+git diff --check
+```
+
+Manual evidence: one packaged Windows install→enable→uninstall control with an unrelated scheduled-task fixture.
+
+## Expected hotset
+
+- `src-tauri/tauri.conf.json`
+- Windows installer/NSIS hooks under `src-tauri/`
+- Rust autostart ownership helpers and focused tests adjacent to #111
+
+## Dependencies
+
+- Blocked by #111.
+
+## Execution contract
+
+Execution-Contract: v2
+Verification-Class: strict
+Verification-Commands: affected Rust tests; full Rust test/clippy suites once; `git diff --check`
+Manual-Evidence: packaged Windows install→enable→uninstall with unrelated-task preservation
+Architecture-Decision: resolved
+Review-Owner: orchestrator
+'@
+  $url = gh issue create --title $title --body $body `
+    --label bug --label ready-for-agent --label wayfinder:task
+  $uninstallIssue = [int]($url.TrimEnd('/') -split '/')[-1]
+} else {
+  $uninstallIssue = [int]$matches[0]
+}
+"uninstallIssue=$uninstallIssue"
+```
+
+Expected: exactly one open uninstall Issue; record its number as `$uninstallIssue`.
+
+- [ ] **Step 3: Rewrite #28 as the discovery-performance Issue**
+
+Run:
+
+```powershell
+$body28 = @"
+The Windows uninstall-cleanup concern from the original report is now owned by #$uninstallIssue.
+
+## Problem
+
+Gateway client version probes and Provider/model catalog discovery remain partly serial, subprocess-heavy, and weakly cached. Startup and configuration flows can repeatedly launch known client probes or repeat unchanged discovery work, while invalidation and concurrency bounds are not explicit.
+
+## Outcome
+
+Make supported Gateway client version probes and Provider/catalog discovery bounded, cache-aware, and observable without changing their configuration semantics.
+
+## Scope
+
+- Inventory supported client version probes and catalog/model discovery calls.
+- Bound subprocess concurrency and duration using the existing timeout/PATH safety from #13.
+- Coalesce identical in-flight work.
+- Cache only results with explicit keys, TTL/invalidation, and manual-refresh behavior.
+- Preserve actionable failure classification and existing discovery output.
+
+## Non-goals
+
+- Do not change Windows uninstall behavior; #$uninstallIssue owns it.
+- Do not add Provider presets, OAuth, automatic Provider enablement, or runtime Models.dev authority.
+- Do not change Gateway routing, retry, or protocol translation.
+
+## Acceptance criteria
+
+- [ ] Identical concurrent probes/discovery requests share one bounded operation.
+- [ ] A valid cache hit starts no subprocess or network discovery request.
+- [ ] Manual refresh bypasses stale cached data but coalesces with an active live refresh.
+- [ ] Timeout, malformed output, missing executable, cancellation, and application exit leave no child process running.
+- [ ] Cache keys and invalidation distinguish client version, executable identity, Provider endpoint, auth reference, and relevant configuration revision without storing secrets.
+- [ ] Existing model/catalog results and unsupported-client behavior remain unchanged.
+
+## Verification
+
+Run focused probe/catalog tests, then the full suite for every changed Rust, Python, or frontend boundary according to `docs/agents/verification-policy.md`. Run `git diff --check`; `python scripts/report_quality_gates.py` remains report-only.
+
+## Expected hotset
+
+- Gateway client probe/version-discovery Rust modules
+- Provider/model catalog discovery commands and caches
+- adjacent focused tests
+
+## Relationships
+
+- Split uninstall work: #$uninstallIssue
+- Existing timeout/PATH hardening: #13
+- Usage app-server singleflight uses a separate boundary: #150
+
+## Execution contract
+
+Execution-Contract: v2
+Verification-Class: standard
+Verification-Commands: targeted probe/catalog tests; affected component full suites once; `git diff --check`; report-only quality gate when source is in scan scope
+Manual-Evidence: none
+Architecture-Decision: resolved
+Review-Owner: orchestrator
+"@
+$tmp = Join-Path $env:TEMP 'codexhub-issue-28-body.md'
+Set-Content -Encoding utf8 $tmp $body28
+gh issue edit 28 `
+  --title 'Bound Gateway client probes and catalog discovery work' `
+  --body-file $tmp `
+  --add-label enhancement --add-label ready-for-agent --add-label wayfinder:task `
+  --milestone '0.1.9 — Managed client reliability'
+```
+
+Expected: #28 owns only bounded probe/catalog discovery and links the exact uninstall Issue.
+
+- [ ] **Step 4: Set hierarchy, milestone, and dependency**
+
+Run:
+
+```powershell
+gh issue edit $uninstallIssue `
+  --add-label bug --add-label ready-for-agent --add-label wayfinder:task `
+  --milestone '0.1.10 — Existing product reliability'
+
+function Ensure-SubIssue([int]$Parent, [int]$Child) {
+  $childIssue = gh api "repos/NOirBRight/CodexHub/issues/$Child" | ConvertFrom-Json
+  $expected = "https://api.github.com/repos/NOirBRight/CodexHub/issues/$Parent"
+  if ($childIssue.parent_issue_url -eq $expected) { return }
+  if ($childIssue.parent_issue_url) { throw "#$Child already has parent $($childIssue.parent_issue_url)" }
+  gh api --method POST "repos/NOirBRight/CodexHub/issues/$Parent/sub_issues" `
+    -F sub_issue_id=$childIssue.id | Out-Null
+}
+function Ensure-BlockedBy([int]$Blocked, [int]$Blocker) {
+  $existing = @(gh api "repos/NOirBRight/CodexHub/issues/$Blocked/dependencies/blocked_by" `
+    --jq ".[] | select(.number == $Blocker) | .number")
+  if ($existing.Count -eq 0) {
+    $blockerId = gh api "repos/NOirBRight/CodexHub/issues/$Blocker" --jq .id
+    gh api --method POST "repos/NOirBRight/CodexHub/issues/$Blocked/dependencies/blocked_by" `
+      -F issue_id=$blockerId | Out-Null
+  }
+}
+Ensure-SubIssue 147 28
+Ensure-SubIssue 147 $uninstallIssue
+Ensure-BlockedBy $uninstallIssue 111
+```
+
+Expected: #28 and the uninstall Issue are direct children of #147; the uninstall Issue is blocked by #111.
+
+- [ ] **Step 5: Read back both contracts**
+
+Run:
+
+```powershell
+gh issue view 28 --json number,title,state,body,labels,assignees,milestone,url
+gh issue view $uninstallIssue --json number,title,state,body,labels,assignees,milestone,url
+gh api "repos/NOirBRight/CodexHub/issues/$uninstallIssue" `
+  --jq '{parent:.parent_issue_url,deps:.issue_dependencies_summary}'
+gh api "repos/NOirBRight/CodexHub/issues/$uninstallIssue/dependencies/blocked_by" `
+  --jq '.[] | {number,title,state}'
+```
+
+Expected: both Issues have complete v2 contracts, exact milestones, one lifecycle label each, no assignee, correct parent, and #111 as the uninstall blocker.
+
+---
+
+### Task 5: Normalize milestone membership, Wayfinder labels, and hierarchy
+
+**Files:**
+- GitHub Issues and sub-issue relationships only.
+
+**Interfaces:**
+- Consumes: `$localSearchIssue` discoverable by exact title and `$uninstallIssue` discoverable by exact title.
+- Produces: every active release Issue assigned to exactly one 0.1.6–0.1.10 milestone; every new-feature parent visible under #147 without an active reliability milestone; nested workstreams retain one parent.
+
+- [ ] **Step 1: Rediscover the two newly created Issue numbers by exact title**
+
+Run:
+
+```powershell
+function Find-ExactIssue([string]$Title) {
+  $matches = @(gh issue list --state all --limit 200 --search "in:title `"$Title`"" `
+    --json number,title,state `
+    --jq ".[] | select(.title == \"$Title\") | .number")
+  if ($matches.Count -ne 1) { throw "exact Issue lookup failed: $Title" }
+  return [int]$matches[0]
+}
+$localSearchIssue = Find-ExactIssue 'Bound repeated empty tool_search misses for external models'
+$uninstallIssue = Find-ExactIssue 'Remove CodexHub-owned Windows autostart registration during uninstall'
+```
+
+Expected: two unique numeric Issue IDs.
+
+- [ ] **Step 2: Assign exact milestone membership**
+
+Run:
+
+```powershell
+$membership = [ordered]@{
+  '0.1.6 — Codex control-plane reliability' = @(111,112,138,139,141,143,149,150,151,156,$localSearchIssue)
+  '0.1.7 — Official GPT reliability' = @(18,19,20,21,104,109,114,157)
+  '0.1.8 — Third-party model certification' = @(17,22,57,58,59,61,62,63,64,65,66,67)
+  '0.1.9 — Managed client reliability' = @(8,28,83,153,154,155)
+  '0.1.10 — Existing product reliability' = @(86,87,88,113,115,126,$uninstallIssue)
+}
+foreach ($entry in $membership.GetEnumerator()) {
+  foreach ($n in $entry.Value) {
+    gh issue edit $n --milestone "$($entry.Name)" | Out-Null
+  }
+}
+```
+
+Expected: every listed open Issue reports the exact milestone; no Issue appears in two arrays.
+
+- [ ] **Step 3: Add the approved Wayfinder type labels without changing lifecycle labels**
+
+Run:
+
+```powershell
+$taskIssues = @(8,28,83,86,87,88,89,90,91,92,93,111,113,115,126,155,157,$localSearchIssue,$uninstallIssue)
+$researchIssues = @(68,104)
+$grillingIssues = @(71,94,109,156)
+
+foreach ($n in $taskIssues) { gh issue edit $n --add-label wayfinder:task | Out-Null }
+foreach ($n in $researchIssues) { gh issue edit $n --add-label wayfinder:research | Out-Null }
+foreach ($n in $grillingIssues) { gh issue edit $n --add-label wayfinder:grilling | Out-Null }
+```
+
+Expected: the added Wayfinder label matches task/research/grilling ownership; existing canonical lifecycle labels remain unchanged.
+
+- [ ] **Step 4: Ensure the approved top-level map membership**
+
+Run:
+
+```powershell
+function Ensure-SubIssue([int]$Parent, [int]$Child) {
+  $childIssue = gh api "repos/NOirBRight/CodexHub/issues/$Child" | ConvertFrom-Json
+  $expected = "https://api.github.com/repos/NOirBRight/CodexHub/issues/$Parent"
+  if ($childIssue.parent_issue_url -eq $expected) { return }
+  if ($childIssue.parent_issue_url) { throw "#$Child already has parent $($childIssue.parent_issue_url)" }
+  gh api --method POST "repos/NOirBRight/CodexHub/issues/$Parent/sub_issues" `
+    -F sub_issue_id=$childIssue.id | Out-Null
+}
+
+$topLevel = @(
+  111,112,138,139,141,143,149,150,151,156,
+  18,19,20,21,104,109,114,157,
+  17,22,57,58,59,61,
+  8,28,83,153,154,155,
+  86,87,88,113,115,126,$uninstallIssue,
+  68,71,73,85,148,152
+)
+foreach ($n in $topLevel) { Ensure-SubIssue 147 $n }
+```
+
+Expected: every listed Issue has parent #147. Existing nested #57 and #73 children are not moved.
+
+- [ ] **Step 5: Ensure the Provider-auth and Claude workstream nesting**
+
+Run:
+
+```powershell
+foreach ($n in 89,90,91,92,93,94) { Ensure-SubIssue 71 $n }
+foreach ($n in 74,75,76,77,78) { Ensure-SubIssue 73 $n }
+```
+
+Expected: #89, #90, #91, #92, #93, and #94 have parent #71; #74, #75, #76, #77, and #78 retain or gain parent #73. Any pre-existing different parent fails closed rather than being silently replaced.
+
+- [ ] **Step 6: Remove active reliability milestones from deferred new-feature work**
+
+Run:
+
+```powershell
+$deferred = @(68,71,73,74,75,76,77,78,85,89,90,91,92,93,94,148,152)
+foreach ($n in $deferred) {
+  $issue = gh api "repos/NOirBRight/CodexHub/issues/$n" | ConvertFrom-Json
+  if ($issue.milestone) { gh issue edit $n --remove-milestone | Out-Null }
+}
+```
+
+Expected: deferred new-feature work has no 0.1.6–0.1.10 or legacy reliability milestone.
+
+- [ ] **Step 7: Read back milestone coverage and hierarchy**
+
+Run:
+
+```powershell
+foreach ($entry in $membership.GetEnumerator()) {
+  foreach ($n in $entry.Value) {
+    $issue = gh api "repos/NOirBRight/CodexHub/issues/$n" | ConvertFrom-Json
+    if ($issue.milestone.title -ne $entry.Name) { throw "milestone mismatch #$n" }
+  }
+}
+
+foreach ($n in $topLevel) {
+  $parent = gh api "repos/NOirBRight/CodexHub/issues/$n" --jq .parent_issue_url
+  if ($parent -ne 'https://api.github.com/repos/NOirBRight/CodexHub/issues/147') {
+    throw "map parent mismatch #$n"
+  }
+}
+'milestones-and-hierarchy-ok'
+```
+
+Expected: `milestones-and-hierarchy-ok`.
+
+---
+
+### Task 6: Reconcile stale Issue state and closure evidence
+
+**Files:**
+- GitHub Issues: #8, #10, #12, #62, #109, #74.
+- Read-only Git history and native Codex Task list for #62 ownership.
+
+**Interfaces:**
+- Consumes: current `dev`/`main`, open PR list, and native Task state.
+- Produces: durable comments for #8/#10/#12; an honest assignee state for #62; unchanged `needs-info` state for #109/#74.
+
+- [ ] **Step 1: Record the current-branch correction on #8**
+
+Run:
+
+```powershell
+git merge-base --is-ancestor 400d19bb dev
+$ancestor = ($LASTEXITCODE -eq 0)
+$moduleExists = Test-Path 'src-tauri/src/gateway/client_adapters.rs'
+if ($ancestor -or $moduleExists) { throw 'The #8 correction assumptions changed; re-diagnose before commenting.' }
+
+$body = @'
+### Wayfinder baseline correction
+
+The earlier local-completion comment does not describe the current `dev` baseline used by the replanned Wayfinder:
+
+- commit `400d19bb` is not an ancestor of current `dev`;
+- `src-tauri/src/gateway/client_adapters.rs` is absent from the current tree.
+
+#8 therefore remains open and is scheduled under `0.1.9 — Managed client reliability`. This comment does not claim the orphaned implementation is reusable; a future Worker must compare it against current code before choosing reimplementation or recovery.
+'@
+gh issue comment 8 --body $body
+```
+
+Expected: comment URL returned; Issue remains open, unassigned, and `ready-for-agent`.
+
+- [ ] **Step 2: Add final ancestry evidence to closed #10 and #12**
+
+Run:
+
+```powershell
+$checks = [ordered]@{10='7de67c51';12='77014e9'}
+foreach ($entry in $checks.GetEnumerator()) {
+  git merge-base --is-ancestor $entry.Value main
+  if ($LASTEXITCODE -ne 0) { throw "#$($entry.Name) fix is not on main" }
+  git merge-base --is-ancestor $entry.Value dev
+  if ($LASTEXITCODE -ne 0) { throw "#$($entry.Name) fix is not on dev" }
+  $state = gh issue view $entry.Name --json state --jq .state
+  if ($state -ne 'CLOSED') { throw "#$($entry.Name) unexpectedly open" }
+  gh issue comment $entry.Name --body "Wayfinder closure reconciliation: fix commit ``$($entry.Value)`` is an ancestor of both current ``main`` and ``dev``. The Issue remains closed; this records the final evidence missing after the earlier post-tag reopen comment."
+}
+```
+
+Expected: both Issues remain closed with one ancestry reconciliation comment each.
+
+- [ ] **Step 3: Reconcile #62 execution ownership without guessing**
+
+Run:
+
+```powershell
+gh issue view 62 --comments `
+  --json number,title,state,labels,assignees,milestone,comments,url
+gh pr list --state open --search 'head:codex/issue-62' `
+  --json number,title,headRefName,baseRefName,url
+```
+
+Then use the native Codex task list and read APIs to look for a sidebar-visible #62 Worker. Do not use SQLite or filesystem inference.
+
+Expected decision:
+
+- if a real #62 Task is Active or has unintegrated durable work, keep the assignee and add no lifecycle comment;
+- if no real #62 Task exists, no open PR exists, and no durable work owner exists, run:
+
+```powershell
+gh issue edit 62 --remove-assignee NOirBRight
+gh issue comment 62 --body 'Wayfinder ownership reconciliation: no active sidebar Worker, open PR, or durable execution owner was found. The stale assignee is removed; #62 remains blocked by #61 and will return to the 0.1.8 frontier only after its native dependencies close.'
+```
+
+- if native Task state is unavailable or ambiguous, leave the assignee unchanged and stop this step with an explicit human reconciliation requirement.
+
+- [ ] **Step 4: Assert #109 and #74 remain explicit needs-info gates**
+
+Run:
+
+```powershell
+foreach ($n in 109,74) {
+  $issue = gh issue view $n --json state,labels,assignees,url | ConvertFrom-Json
+  $labels = @($issue.labels.name)
+  if ($issue.state -ne 'OPEN' -or 'needs-info' -notin $labels) {
+    throw "#$n no longer matches the approved needs-info design"
+  }
+}
+'needs-info-gates-ok'
+```
+
+Expected: `needs-info-gates-ok`; do not promote, assign, close, or manufacture missing evidence.
+
+---
+
+### Task 7: Rewrite Wayfinder map #147
+
+**Files:**
+- GitHub Issue: #147 body.
+- Temporary: `$env:TEMP\codexhub-wayfinder-map-body.md`.
+
+**Interfaces:**
+- Consumes: exact newly created Issue titles, milestone membership, hierarchy, dependencies, and approved design.
+- Produces: one self-contained map body whose first active gate is 0.1.6 and whose lower tiers do not refill.
+
+- [ ] **Step 1: Rediscover dynamic Issue numbers and re-read #147**
+
+Run:
+
+```powershell
+function Find-ExactIssue([string]$Title) {
+  $matches = @(gh issue list --state all --limit 200 --search "in:title `"$Title`"" `
+    --json number,title,state `
+    --jq ".[] | select(.title == \"$Title\") | .number")
+  if ($matches.Count -ne 1) { throw "exact Issue lookup failed: $Title" }
+  return [int]$matches[0]
+}
+$localSearchIssue = Find-ExactIssue 'Bound repeated empty tool_search misses for external models'
+$uninstallIssue = Find-ExactIssue 'Remove CodexHub-owned Windows autostart registration during uninstall'
+gh issue view 147 --comments `
+  --json number,title,state,body,labels,assignees,milestone,comments,url
+```
+
+Expected: #147 remains open, unassigned, and labeled `wayfinder:map` + `ready-for-human`; dynamic issue lookups are unique.
+
+- [ ] **Step 2: Generate the complete approved map body**
+
+Run:
+
+```powershell
+$mapBody = @"
+## Destination
+
+Make CodexHub reliable in this order: Codex internal execution control, Official GPT, individually certified third-party models, existing managed clients, then new features. GitHub Issue contracts and native dependencies are the execution source of truth. Updating this map never claims or dispatches a ticket.
+
+## Priority gates
+
+1. **Codex internal reliability** — control plane, Official GPT, then third-party model certification.
+2. **Existing external-client reliability** — ZCode, OMP, OpenCode, and Pi.
+3. **New features** — release channels, Provider onboarding/auth, Claude Code, Imagegen, and AgentProvider.
+
+Only the active gate receives new work. Already-claimed lower-tier work may finish its bounded scope but does not refill. Credential/privacy exposure, data loss, irreversible migration, non-idempotent side effects, abnormal cost, and active-gate blockers may override this order.
+
+## Execution policy
+
+- Delegated implementation means a native **sidebar-visible Worker Task**, not a Hidden Subagent or Inline execution.
+- Current eligible Workers are GPT-5.6 Terra/max and GPT-5.6 Luna/max after runtime binding and bidirectional receipt preflight.
+- Models never substitute silently. A failed binding stops that lane.
+- Third-party models enter the eligible Worker pool only after #156 and their model-specific certification pass.
+- One Issue has one lane, one editor, and one isolated worktree. GitHub remains the durable state authority.
+
+## 0.1.6 — Codex control-plane reliability
+
+Lifecycle spine: #139 → #143 → #112.
+
+Parallel gates:
+
+- #156 — human Host/runtime gate for a sidebar-visible third-party Worker, effective binding readback, bidirectional communication, receipt, and terminal state;
+- #$localSearchIssue — CodexHub-owned bound for repeated empty `tool_search` misses;
+- #141 — Desktop restart and Task disappearance first-failure evidence;
+- #138 — auditable Task command output, diffs, progress, and terminal state;
+- #150 — coalesced usage probes and app-server child cleanup;
+- #149 — cross-language lock ownership and crash recovery;
+- #151 — saved-workspace migration decision; default is no implicit import;
+- #111 — verifiable Windows autostart registration.
+
+Exit: one reconciled Gateway identity; reliable sidebar Worker materialization and Task communication; bounded stop/exit/restart; recoverable Task state; no silent Worker or model substitution.
+
+## 0.1.7 — Official GPT reliability
+
+- #114 — Official/external Responses disconnect differential;
+- #18 → #19 → #20 — downstream disconnect classification, bounded SSE reader lifecycle, multi-line SSE events;
+- #21 — global upstream concurrency limit;
+- #104 — no stale unsupported GPT-5.2 picker fallback;
+- #109 — paused first-party context-policy gate; it does not block unrelated Official reliability work;
+- #157 — Official context cap cannot override third-party Task models.
+
+Exit: Official GPT is the trustworthy control group for Task/Worker communication, tools, streaming/cancellation, model catalog, and context authority.
+
+## 0.1.8 — Third-party model certification
+
+Reliability: #17 and evidence-gated #22, consuming the completed 0.1.7 transport foundations.
+
+Capability DAG:
+
+```text
+#61 → #62
+       ├─→ #63 ─→ #64
+       ├─→ #65
+       └─→ #66
+#63 + #64 + #65 + #66 → #67 → #58 → #59
+```
+
+#57 remains the parent Gate. Certification is keyed by Codex build + CodexHub version + provider + model + upstream format + route/codec + tool profile. Supported requires visible Worker/Task communication, Direct/Deferred/hosted tools, protocol/history/IDs/SSE, transport/retry/recovery, and model-specific context evidence. Unknown semantics fail closed.
+
+## 0.1.9 — Managed client reliability
+
+- #8 — recover or reimplement client-adapter modularization against current `dev`;
+- #28 — bounded client probes and catalog discovery;
+- #83 — separate persistence, post-save refresh, and endpoint-test failure state;
+- #153 — transactional ZCode generation and crash recovery;
+- #154 — faithful reasoning-level export;
+- #155 — OMP YAML string-type safety.
+
+Exit: ZCode, OMP, OpenCode, and Pi pass preview/apply/readback/restore with faithful model/reasoning identity, crash recovery, and no silent Official fallback.
+
+## 0.1.10 — Existing product reliability
+
+- #86, #87, #88 — pricing source, coverage, and Ollama reference estimates;
+- #113 — atomic Vision Proxy enablement;
+- #115 — privacy-safe diagnostic export;
+- #126 — persistent Home status and Toast-only action feedback;
+- #$uninstallIssue — ownership-safe Windows uninstall cleanup, blocked by #111.
+
+No new product capability is added under this gate.
+
+## 0.2.x+ — New features
+
+These lanes do not refill until 0.1.6–0.1.10 gates complete:
+
+1. Stable/Developer channel: #148 → #152.
+2. Provider presets/auth: #71 with #89, #90, #91, #92, #93, and #94.
+3. Claude Code downstream Messages client: #73 with #74, #75, #76, #77, and #78.
+4. Imagegen compatibility: #68 after its authorization/security boundary is resolved.
+5. AgentProvider: #85, separate from ModelProvider and the model Gateway.
+
+## Decisions so far
+
+- Reliability gates replace the former feature-first 0.1.6–0.3.0 ordering.
+- Stable/Developer is one installation with shared state, but its implementation is deferred to the new-feature tier.
+- Visible Worker, Hidden Subagent, and Inline are distinct execution surfaces and cannot substitute for one another.
+- Terra/Luna Visible Workers implement current work; third-party models join only after certification.
+- Provider/model support is granular and versioned; Responses endpoint naming is not compatibility evidence.
+- #156 is the P0 human Visible Worker gate; #$localSearchIssue is its local CodexHub child; #64 validates the full post-fix collaboration matrix.
+- #8 remains open because its orphaned commit is absent from current `dev`.
+- Every open Issue belongs to a gate, support/decision queue, or new-feature parking area.
+
+## Current frontier
+
+- Human P0 gate: #156.
+- Ready CodexHub candidate: #$localSearchIssue.
+- Independent ready 0.1.6 foundations, subject to hotset ownership: #139, #149, #150, #111.
+- #143 waits for #139; #112 waits for #143.
+- Map publication does not claim any of these tickets.
+
+## Fog / external blockers
+
+- #156 still requires the Codex Host/runtime visible-Worker capability and effective binding readback.
+- #141 must distinguish a CodexHub trigger from an upstream Desktop crash.
+- #151 requires the maintainer migration-policy decision.
+- #109 waits for consistent first-party context guidance.
+- #74 waits for approved real-provider and remaining Messages semantic evidence and stays in the new-feature tier.
+
+## Out of scope
+
+- Hidden Subagent, `codex exec`, Background, shared-directory, or Inline substitution for sidebar-visible Workers.
+- Silent model fallback or inferred effective binding.
+- Side-by-side Stable/Developer installations or a revived live Beta channel.
+- Big-bang Gateway rewrite, generic all-protocol IR, or wholesale Python-to-Rust migration.
+- Production Chat or Messages routes before their evidence/decision gates.
+- Automatic Task archival, Codex SQLite edits, or synthetic rollout state.
+"@
+$mapFile = Join-Path $env:TEMP 'codexhub-wayfinder-map-body.md'
+Set-Content -Encoding utf8 $mapFile $mapBody
+Get-Content -Raw $mapFile
+```
+
+Expected: complete body with real numeric dynamic Issue references, no placeholder text, no old GLM global binding, and no obsolete main→dev precondition.
+
+- [ ] **Step 3: Update #147 body without changing ownership fields**
+
+Run:
+
+```powershell
+gh issue edit 147 --body-file $mapFile
+```
+
+Expected: Issue URL returned; title, state, labels, assignees, and milestone remain unchanged.
+
+- [ ] **Step 4: Read back and verify the map contract**
+
+Run:
+
+```powershell
+$map = gh issue view 147 `
+  --json number,title,state,body,labels,assignees,milestone,url | ConvertFrom-Json
+$required = @(
+  '## Destination','## Priority gates','## Execution policy',
+  '## 0.1.6 — Codex control-plane reliability',
+  '## 0.1.7 — Official GPT reliability',
+  '## 0.1.8 — Third-party model certification',
+  '## 0.1.9 — Managed client reliability',
+  '## 0.1.10 — Existing product reliability',
+  '## 0.2.x+ — New features','## Decisions so far',
+  '## Current frontier','## Fog / external blockers','## Out of scope'
+)
+foreach ($heading in $required) {
+  if (-not $map.body.Contains($heading)) { throw "map missing $heading" }
+}
+if ($map.body -match 'Every Visible Worker.*glm-5\.2|main result back into dev') {
+  throw 'obsolete map contract survived'
+}
+if ($map.state -ne 'OPEN' -or $map.assignees.Count -ne 0) { throw 'map ownership changed' }
+$labels = @($map.labels.name)
+if ('wayfinder:map' -notin $labels -or 'ready-for-human' -notin $labels) { throw 'map labels changed' }
+$map.url
+```
+
+Expected: #147 URL and no exception.
+
+---
+
+### Task 8: Close the legacy milestone, validate global state, and publish the frontier readback
+
+**Files:**
+- GitHub milestones and #147 comments only.
+- Temporary: `$env:TEMP\codexhub-wayfinder-migration\final-issues-api.json`.
+
+**Interfaces:**
+- Consumes: all prior tasks.
+- Produces: closed legacy milestone, exact lifecycle/milestone/hierarchy/dependency validation, and one durable #147 migration checkpoint with the unclaimed frontier.
+
+- [ ] **Step 1: Close the superseded legacy milestone only after reassignments**
+
+Run:
+
+```powershell
+$legacy = gh api 'repos/NOirBRight/CodexHub/milestones?state=all&per_page=100' `
+  --jq '.[] | select(.title == "Third-party model agentic reliability") | .number'
+if (@($legacy).Count -ne 1) { throw 'legacy milestone lookup failed' }
+
+$remaining = gh issue list --state open --limit 1000 `
+  --milestone 'Third-party model agentic reliability' `
+  --json number,title
+if (($remaining | ConvertFrom-Json).Count -ne 0) { throw 'legacy milestone still has open Issues' }
+
+gh api --method PATCH "repos/NOirBRight/CodexHub/milestones/$legacy" `
+  -f state='closed' `
+  -f description='Superseded on 2026-07-16 by the reliability-gated 0.1.6–0.1.10 milestones. Historical issue/decision context remains preserved; this milestone is no longer a scheduling pool.' | Out-Null
+```
+
+Expected: legacy milestone closes only when it has zero open Issues.
+
+- [ ] **Step 2: Validate canonical lifecycle labels across every open Issue**
+
+Run:
+
+```powershell
+$lifecycle = @('needs-triage','needs-info','ready-for-agent','ready-for-human','wontfix')
+$issues = gh issue list --state open --limit 1000 `
+  --json number,title,labels,assignees,milestone,url | ConvertFrom-Json
+$errors = @()
+foreach ($issue in $issues) {
+  $names = @($issue.labels.name)
+  $matches = @($lifecycle | Where-Object { $_ -in $names })
+  if ($matches.Count -ne 1) {
+    $errors += "#$($issue.number) lifecycle=$($matches -join ',')"
+  }
+}
+if ($errors.Count) { throw ($errors -join '; ') }
+"canonical-lifecycle-ok: $($issues.Count) open Issues"
+```
+
+Expected: every open Issue has exactly one canonical lifecycle label.
+
+- [ ] **Step 3: Validate the five milestone memberships exactly**
+
+Run:
+
+```powershell
+function Find-ExactIssue([string]$Title) {
+  $matches = @(gh issue list --state all --limit 200 --search "in:title `"$Title`"" `
+    --json number,title,state `
+    --jq ".[] | select(.title == \"$Title\") | .number")
+  if ($matches.Count -ne 1) { throw "exact Issue lookup failed: $Title" }
+  return [int]$matches[0]
+}
+$localSearchIssue = Find-ExactIssue 'Bound repeated empty tool_search misses for external models'
+$uninstallIssue = Find-ExactIssue 'Remove CodexHub-owned Windows autostart registration during uninstall'
+$expected = [ordered]@{
+  '0.1.6 — Codex control-plane reliability' = @(111,112,138,139,141,143,149,150,151,156,$localSearchIssue)
+  '0.1.7 — Official GPT reliability' = @(18,19,20,21,104,109,114,157)
+  '0.1.8 — Third-party model certification' = @(17,22,57,58,59,61,62,63,64,65,66,67)
+  '0.1.9 — Managed client reliability' = @(8,28,83,153,154,155)
+  '0.1.10 — Existing product reliability' = @(86,87,88,113,115,126,$uninstallIssue)
+}
+foreach ($entry in $expected.GetEnumerator()) {
+  $actual = @(gh issue list --state open --limit 1000 --milestone "$($entry.Name)" `
+    --json number --jq '.[].number' | ForEach-Object { [int]$_ } | Sort-Object)
+  $wanted = @($entry.Value | Sort-Object)
+  if (($actual -join ',') -ne ($wanted -join ',')) {
+    throw "milestone membership mismatch: $($entry.Name); actual=$($actual -join ','); expected=$($wanted -join ',')"
+  }
+}
+'milestone-membership-ok'
+```
+
+Expected: `milestone-membership-ok`.
+
+- [ ] **Step 4: Validate critical hierarchy and dependency edges**
+
+Run:
+
+```powershell
+function Assert-Parent([int]$Child,[int]$Parent) {
+  $actual = gh api "repos/NOirBRight/CodexHub/issues/$Child" --jq .parent_issue_url
+  $expected = "https://api.github.com/repos/NOirBRight/CodexHub/issues/$Parent"
+  if ($actual -ne $expected) { throw "parent mismatch #$Child" }
+}
+function Assert-BlockedBy([int]$Blocked,[int]$Blocker) {
+  $matches = @(gh api "repos/NOirBRight/CodexHub/issues/$Blocked/dependencies/blocked_by" `
+    --jq ".[] | select(.number == $Blocker) | .number")
+  if ($matches.Count -ne 1) { throw "dependency mismatch #$Blocked <- #$Blocker" }
+}
+Assert-Parent 156 147
+Assert-Parent $localSearchIssue 156
+Assert-Parent 64 57
+Assert-Parent 71 147
+Assert-Parent 73 147
+foreach ($n in 89,90,91,92,93,94) { Assert-Parent $n 71 }
+foreach ($n in 74,75,76,77,78) { Assert-Parent $n 73 }
+Assert-BlockedBy 156 $localSearchIssue
+Assert-BlockedBy 64 156
+Assert-BlockedBy $uninstallIssue 111
+'hierarchy-dependencies-ok'
+```
+
+Expected: `hierarchy-dependencies-ok`.
+
+- [ ] **Step 5: Compute the unclaimed 0.1.6 ready frontier**
+
+Run:
+
+```powershell
+$gate = gh issue list --state open --limit 1000 `
+  --milestone '0.1.6 — Codex control-plane reliability' `
+  --json number,title,labels,assignees,url | ConvertFrom-Json
+$readyByNumber = @{}
+foreach ($issue in $gate) {
+  $labels = @($issue.labels.name)
+  $api = gh api "repos/NOirBRight/CodexHub/issues/$($issue.number)" | ConvertFrom-Json
+  if ('ready-for-agent' -in $labels -and
+      $issue.assignees.Count -eq 0 -and
+      $api.issue_dependencies_summary.blocked_by -eq 0) {
+    $readyByNumber[$issue.number] = [pscustomobject]@{number=$issue.number;title=$issue.title;url=$issue.url}
+  }
+}
+$priorityOrder = @($localSearchIssue,139,149,150,111,141,138,151,143,112,156)
+$frontier = @($priorityOrder | Where-Object { $readyByNumber.ContainsKey($_) } | ForEach-Object { $readyByNumber[$_] })
+$frontier | Format-Table -AutoSize
+```
+
+Expected: a non-empty list containing the local bounded-search Issue and other unblocked 0.1.6 candidates such as #139/#149/#150/#111 if their live state has not changed. Do not assign any candidate.
+
+- [ ] **Step 6: Publish one migration checkpoint comment on #147**
+
+Run:
+
+```powershell
+$frontierText = (($frontier | ForEach-Object { "#$($_.number) $($_.title)" }) -join "`n- ")
+$comment = @"
+## Reliability-gated Wayfinder migration readback
+
+The approved roadmap migration is complete and read back:
+
+- five active reliability milestones exist with exact membership;
+- the legacy cross-version reliability milestone is closed as superseded;
+- #156 is the ready-for-human Visible Worker gate and #$localSearchIssue is its ready local bounded-search child;
+- #64 is blocked by #156 for the full post-fix collaboration matrix;
+- #28 is narrowed to client discovery performance and #$uninstallIssue owns uninstall cleanup behind #111;
+- every open Issue has exactly one canonical lifecycle label;
+- no ticket was assigned or dispatched by the migration.
+
+Current unclaimed 0.1.6 ready frontier:
+
+- $frontierText
+
+Frontier order remains subject to native dependencies and hotset ownership. Map publication is not a claim.
+"@
+gh issue comment 147 --body $comment
+```
+
+Expected: one comment URL returned.
+
+- [ ] **Step 7: Perform the final no-claim readback**
+
+Run:
+
+```powershell
+gh issue view 147 --comments `
+  --json number,title,state,labels,assignees,body,comments,url
+gh pr list --state open --limit 100 `
+  --json number,title,headRefName,baseRefName,url
+git status --short --branch
+```
+
+Expected:
+
+- #147 is open, unassigned, and contains the migration checkpoint;
+- no migration-created product PR exists;
+- no product Issue was assigned by this plan;
+- repository working tree is clean.
+
+---
+
+## Self-review checklist
+
+Before execution handoff, verify this plan against the approved design:
+
+1. **Spec coverage:** Tasks 2–8 cover milestones, #156 decomposition, #28 split, all open-Issue routing, stale state, #147 rewrite, dependencies, readback, and frontier recomputation.
+2. **No placeholders:** Dynamic new Issue numbers are discovered by exact titles and stored in variables; no guessed number is embedded.
+3. **Type consistency:** `$localSearchIssue`, `$uninstallIssue`, milestone titles, parent relationships, and dependency direction are identical in every task.
+4. **Scope:** The plan changes only GitHub planning state. Every product Issue receives its own later spec/plan/implementation cycle.
+5. **No hidden claim:** No command assigns an Issue, creates a product branch/worktree, starts a Worker, opens a production PR, or edits product code.

--- a/docs/superpowers/plans/2026-07-16-wayfinder-github-migration.md
+++ b/docs/superpowers/plans/2026-07-16-wayfinder-github-migration.md
@@ -1,10 +1,10 @@
 # Wayfinder GitHub Migration Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans and explicit Inline Execution to implement this plan task-by-task. Do not dispatch Hidden Subagents or delegated Workers for this migration. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Migrate GitHub Wayfinder #147 from the obsolete feature-first roadmap to the approved reliability-gated release train without claiming or starting product implementation work.
 
-**Architecture:** GitHub remains the only durable work-state authority. The migration is idempotent and readback-driven: snapshot current state, create the five release milestones, decompose mixed-ownership Issues, normalize hierarchy/labels/dependencies, rewrite #147, and recompute the ready frontier. Product code and per-Issue implementation plans remain outside this plan.
+**Architecture:** GitHub remains the only durable work-state authority. The migration is a two-phase, idempotent, readback-driven operation: first synchronize an isolated worktree and produce a read-only snapshot plus exact write-set preview; then stop for explicit human authorization before creating milestones, decomposing mixed-ownership Issues, normalizing hierarchy/labels/dependencies, rewriting #147, and recomputing the ready frontier. Product code and per-Issue implementation plans remain outside this plan.
 
 **Tech Stack:** PowerShell 7, GitHub CLI (`gh`), GitHub REST API, Git, Markdown.
 
@@ -12,9 +12,12 @@
 
 - Repository: `NOirBRight/CodexHub`; integration branch: `dev`.
 - Approved design: `docs/superpowers/specs/2026-07-16-wayfinder-replanning-design.md` at or after commit `59477301`.
+- Approved plan baseline: `docs/superpowers/plans/2026-07-16-wayfinder-github-migration.md` at or after commit `51a636c9`.
+- Execute only from a clean linked worktree on a non-protected planning branch. Never execute from `dev`, `main`, `master`, or `develop`.
 - Use `gh` for every GitHub Issue, milestone, label, dependency, and sub-issue operation.
 - Do not assign an Issue, create a product branch/worktree, start a Worker, edit product code, or open a production PR during this migration.
-- The mandated process-skill name “subagent-driven-development” does not authorize hidden `spawn_agent` execution. Any delegated execution must materialize as a sidebar-visible GPT-5.6 Terra/max or Luna/max Worker with runtime-verified binding and bidirectional receipt; otherwise use explicit Inline Execution.
+- Execution mode for this GitHub planning-state migration is fixed to explicit Inline Execution. Do not use `task`-tool dispatch, Hidden Subagents, `spawn_agent`, or delegated Workers. Sidebar-visible Terra/max or Luna/max Workers remain the preferred surface for later product-Issue implementation, not for this sequential migration.
+- Task 1 is mandatory and read-only with respect to GitHub. After Task 1, stop and obtain explicit human authorization for the displayed write set before running any command in Tasks 2–8. Prior generic approval, approval to write the plan, or approval to run the dry run does not authorize GitHub writes.
 - Preserve exactly one canonical lifecycle label on each Issue: `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, or `wontfix`.
 - Preserve reporter evidence. Never publish credentials, Task IDs, callback addresses, private paths, prompts, or raw private traces.
 - Native `blocked_by` edges represent only hard dependencies. Related work remains text-only.
@@ -39,20 +42,51 @@
 - Temporary: `$env:TEMP\codexhub-wayfinder-migration\map.json`
 - Temporary: `$env:TEMP\codexhub-wayfinder-migration\map-children.json`
 - Temporary: `$env:TEMP\codexhub-wayfinder-migration\open-prs.json`
+- Temporary: `$env:TEMP\codexhub-wayfinder-migration\proposed-writes.json`
 
 **Interfaces:**
-- Consumes: approved design commit `59477301` and the current GitHub repository state.
-- Produces: a timestamped, read-only JSON snapshot and a zero-write preflight result used to detect concurrent changes before later tasks.
+- Consumes: approved design commit `59477301`, plan baseline commit `51a636c9`, and the current GitHub repository state.
+- Produces: a synchronized isolated planning worktree, a timestamped read-only JSON snapshot, an exact write-set preview, and a mandatory human authorization checkpoint.
 
-- [ ] **Step 1: Verify repository identity, branch, and clean working state**
+- [ ] **Step 1: Synchronize and verify the isolated planning worktree**
 
 Run:
 
 ```powershell
+$designBase = '59477301'
+$planBase = '51a636c9'
+$protected = @('dev','main','master','develop')
+$branch = git branch --show-current
+$status = @(git status --porcelain)
+if ($status.Count) { throw 'planning worktree is not clean' }
+if (-not $branch -or $branch -in $protected) { throw "unsafe execution branch: $branch" }
+
+$gitDir = [IO.Path]::GetFullPath((git rev-parse --git-dir))
+$gitCommon = [IO.Path]::GetFullPath((git rev-parse --git-common-dir))
+$superproject = git rev-parse --show-superproject-working-tree
+if ($superproject) { throw 'execution directory is a submodule, not the planning worktree' }
+if ($gitDir -eq $gitCommon) { throw 'execution must use a linked worktree' }
+
+git merge-base --is-ancestor $planBase HEAD
+if ($LASTEXITCODE -ne 0) {
+  $counts = @((git rev-list --left-right --count "HEAD...$planBase") -split '\s+')
+  if ([int]$counts[0] -ne 0) {
+    throw "stale branch has unique commits; do not reset or rebase automatically: $($counts -join '/')"
+  }
+  git merge --ff-only $planBase
+  if ($LASTEXITCODE -ne 0) { throw 'safe fast-forward to approved plan baseline failed' }
+}
+
+git merge-base --is-ancestor $designBase HEAD
+if ($LASTEXITCODE -ne 0) { throw 'approved design commit is not an ancestor of HEAD' }
+git merge-base --is-ancestor $planBase HEAD
+if ($LASTEXITCODE -ne 0) { throw 'approved plan baseline is not an ancestor of HEAD' }
+if (-not (Test-Path 'docs/superpowers/specs/2026-07-16-wayfinder-replanning-design.md')) { throw 'design file is not in this worktree' }
+if (-not (Test-Path 'docs/superpowers/plans/2026-07-16-wayfinder-github-migration.md')) { throw 'plan file is not in this worktree' }
+
 git remote get-url origin
 git branch --show-current
 git status --short
-git merge-base --is-ancestor 59477301 HEAD
 gh repo view --json nameWithOwner,defaultBranchRef,url
 gh auth status
 ```
@@ -60,9 +94,9 @@ gh auth status
 Expected:
 
 - remote is `https://github.com/NOirBRight/CodexHub.git`;
-- branch is `dev` or an isolated planning branch whose merge-base contains `59477301`;
+- branch is a non-protected planning branch in a linked worktree;
 - `git status --short` is empty;
-- the ancestry command exits `0`;
+- both `59477301` and `51a636c9` are ancestors of `HEAD`, and both plan files are present in-tree;
 - GitHub repository is `NOirBRight/CodexHub` and authentication succeeds.
 
 - [ ] **Step 2: Capture Issues, REST metadata, milestones, map membership, and PRs**
@@ -94,7 +128,7 @@ gh pr list --state open --limit 100 `
   | Set-Content -Encoding utf8 (Join-Path $root 'open-prs.json')
 ```
 
-Expected: all seven files exist and parse as JSON; the Issue snapshot contains 93 Issues at the design baseline, with later additions allowed only after they are reported before any write.
+Expected: all six snapshot files exist and parse as JSON; the Issue snapshot contains 93 Issues at the design baseline, with later additions allowed only after they are reported before any write.
 
 - [ ] **Step 3: Validate the snapshot without changing GitHub**
 
@@ -128,6 +162,67 @@ Get-FileHash (Join-Path $root '*.json') -Algorithm SHA256 `
 
 Expected: one SHA-256 per snapshot file. Retain this terminal output for the migration review checkpoint.
 
+- [ ] **Step 5: Generate and display the exact GitHub write-set preview**
+
+Run:
+
+```powershell
+$root = Join-Path $env:TEMP 'codexhub-wayfinder-migration'
+$preview = [ordered]@{
+  repository = 'NOirBRight/CodexHub'
+  creates = [ordered]@{
+    milestones = @(
+      '0.1.6 — Codex control-plane reliability',
+      '0.1.7 — Official GPT reliability',
+      '0.1.8 — Third-party model certification',
+      '0.1.9 — Managed client reliability',
+      '0.1.10 — Existing product reliability'
+    )
+    issues_if_absent = @(
+      'Bound repeated empty tool_search misses for external models',
+      'Remove CodexHub-owned Windows autostart registration during uninstall'
+    )
+  }
+  mutations = [ordered]@{
+    milestone_membership_issue_numbers = @(
+      8,17,18,19,20,21,22,28,57,58,59,61,62,63,64,65,66,67,83,
+      86,87,88,104,109,111,112,113,114,115,126,138,139,141,143,
+      149,150,151,153,154,155,156,157
+    )
+    deferred_issue_numbers_remove_milestone = @(68,71,73,74,75,76,77,78,85,89,90,91,92,93,94,148,152)
+    wayfinder_label_issue_numbers = @(8,28,68,71,83,86,87,88,89,90,91,92,93,94,104,109,111,113,115,126,155,156,157)
+    hierarchy_issue_numbers = @(
+      8,17,18,19,20,21,22,28,57,58,59,61,68,71,73,74,75,76,77,78,
+      83,85,86,87,88,89,90,91,92,93,94,104,109,111,112,113,114,115,
+      126,138,139,141,143,148,149,150,151,152,153,154,155,156,157
+    )
+    dependency_edges = @('#156 blocked by bounded-search child','#64 blocked by #156','uninstall child blocked by #111')
+    dynamic_issue_mutations = @(
+      'bounded-search child: bug + ready-for-agent + wayfinder:task, milestone 0.1.6, parent #156',
+      'uninstall child: bug + ready-for-agent + wayfinder:task, milestone 0.1.10, parent #147'
+    )
+    bodies = @('#28 narrowed to discovery performance','#147 replaced with reliability-gated Wayfinder map')
+    comments = @('#8 baseline correction','#10 closure evidence','#12 closure evidence','#62 conditional ownership reconciliation','#147 final migration readback')
+    assignee_changes = @('#62 removal only if native Task and PR readback prove ownership is stale')
+    milestone_close = 'Third-party model agentic reliability, only after zero-open-Issue readback'
+  }
+  prohibited = @('Issue assignment other than conditional stale #62 removal','product branch/worktree','Worker dispatch','product code edit','production PR')
+}
+$preview | ConvertTo-Json -Depth 8 |
+  Set-Content -Encoding utf8 (Join-Path $root 'proposed-writes.json')
+Get-Content -Raw (Join-Path $root 'proposed-writes.json')
+```
+
+Expected: the seventh temporary JSON file exists and displays every class of durable write in Tasks 2–8. If the live snapshot changes any target or creates a title collision, revise the plan and regenerate this preview before requesting authorization.
+
+- [ ] **Step 6: Stop for explicit human authorization**
+
+Present the snapshot counts, SHA-256 hashes, and full `proposed-writes.json`, then ask exactly:
+
+> Authorize Tasks 2–8 to perform the displayed durable GitHub writes on `NOirBRight/CodexHub`?
+
+Expected: stop execution here. Continue to Task 2 only after an explicit affirmative response scoped to Tasks 2–8 and this displayed write set. A response authorizing only the dry run, plan revision, or worktree synchronization is not sufficient.
+
 ---
 
 ### Task 2: Create the five reliability milestones idempotently
@@ -137,7 +232,7 @@ Expected: one SHA-256 per snapshot file. Retain this terminal output for the mig
 - GitHub objects: repository milestones only.
 
 **Interfaces:**
-- Consumes: Task 1 read-only snapshot.
+- Consumes: Task 1 read-only snapshot and the explicit human authorization captured by Task 1 Step 6.
 - Produces: five open milestones discoverable by their exact titles; later tasks use titles rather than unstable milestone numbers.
 
 - [ ] **Step 1: Define the exact milestone contracts**
@@ -229,7 +324,7 @@ Expected: open `bug` + `ready-for-human`; body contains the Host/runtime callbac
 
 Run:
 
-```powershell
+````powershell
 $title = 'Bound repeated empty tool_search misses for external models'
 $matches = @(gh issue list --state all --limit 100 `
   --search 'in:title "Bound repeated empty tool_search misses for external models"' `
@@ -316,7 +411,7 @@ Review-Owner: orchestrator
   $localSearchIssue = [int]$matches[0]
 }
 "localSearchIssue=$localSearchIssue"
-```
+````
 
 Expected: exactly one open Issue with the exact title; record its numeric value as `$localSearchIssue`.
 
@@ -403,7 +498,7 @@ Expected: open enhancement with two mixed concerns: installer uninstall cleanup 
 
 Run:
 
-```powershell
+````powershell
 $title = 'Remove CodexHub-owned Windows autostart registration during uninstall'
 $matches = @(gh issue list --state all --limit 100 `
   --search 'in:title "Remove CodexHub-owned Windows autostart registration during uninstall"' `
@@ -484,7 +579,7 @@ Review-Owner: orchestrator
   $uninstallIssue = [int]$matches[0]
 }
 "uninstallIssue=$uninstallIssue"
-```
+````
 
 Expected: exactly one open uninstall Issue; record its number as `$uninstallIssue`.
 
@@ -886,7 +981,7 @@ Expected: #147 remains open, unassigned, and labeled `wayfinder:map` + `ready-fo
 
 Run:
 
-```powershell
+````powershell
 $mapBody = @"
 ## Destination
 
@@ -1022,7 +1117,7 @@ These lanes do not refill until 0.1.6–0.1.10 gates complete:
 $mapFile = Join-Path $env:TEMP 'codexhub-wayfinder-map-body.md'
 Set-Content -Encoding utf8 $mapFile $mapBody
 Get-Content -Raw $mapFile
-```
+````
 
 Expected: complete body with real numeric dynamic Issue references, no placeholder text, no old GLM global binding, and no obsolete main→dev precondition.
 
@@ -1271,3 +1366,4 @@ Before execution handoff, verify this plan against the approved design:
 3. **Type consistency:** `$localSearchIssue`, `$uninstallIssue`, milestone titles, parent relationships, and dependency direction are identical in every task.
 4. **Scope:** The plan changes only GitHub planning state. Every product Issue receives its own later spec/plan/implementation cycle.
 5. **No hidden claim:** No command assigns an Issue, creates a product branch/worktree, starts a Worker, opens a production PR, or edits product code.
+6. **Review blockers resolved:** Task 1 safely fast-forwards only a clean stale planning branch with no unique commits, requires the design and plan in-tree, emits a read-only write-set preview, and stops for explicit authorization; Tasks 2–8 use Inline Execution only.

--- a/docs/superpowers/plans/2026-07-16-wayfinder-github-migration.md
+++ b/docs/superpowers/plans/2026-07-16-wayfinder-github-migration.md
@@ -180,6 +180,7 @@ $preview = [ordered]@{
     )
     issues_if_absent = @(
       'Bound repeated empty tool_search misses for external models',
+      'Preserve Worker selector and effective binding validation for external delegation',
       'Remove CodexHub-owned Windows autostart registration during uninstall'
     )
   }
@@ -196,12 +197,17 @@ $preview = [ordered]@{
       83,85,86,87,88,89,90,91,92,93,94,104,109,111,112,113,114,115,
       126,138,139,141,143,148,149,150,151,152,153,154,155,156,157
     )
-    dependency_edges = @('#156 blocked by bounded-search child','#64 blocked by #156','uninstall child blocked by #111')
+    dependency_edges = @('#156 blocked by bounded-search child','#156 blocked by selector/binding child','#64 blocked by #156','uninstall child blocked by #111')
     dynamic_issue_mutations = @(
       'bounded-search child: bug + ready-for-agent + wayfinder:task, milestone 0.1.6, parent #156',
+      'selector/binding child: bug + ready-for-agent + wayfinder:task, milestone 0.1.6, parent #156',
       'uninstall child: bug + ready-for-agent + wayfinder:task, milestone 0.1.10, parent #147'
     )
-    bodies = @('#28 narrowed to discovery performance','#147 replaced with reliability-gated Wayfinder map')
+    bodies = @(
+      '#156 title/body rewritten as the Host/runtime-only visible-Worker gate',
+      '#28 narrowed to discovery performance',
+      '#147 replaced with reliability-gated Wayfinder map including both #156 children'
+    )
     comments = @('#8 baseline correction','#10 closure evidence','#12 closure evidence','#62 conditional ownership reconciliation','#147 final migration readback')
     assignee_changes = @('#62 removal only if native Task and PR readback prove ownership is stale')
     milestone_close = 'Third-party model agentic reliability, only after zero-open-Issue readback'
@@ -298,42 +304,173 @@ Expected: five unique open milestones with exact descriptions.
 
 ---
 
-### Task 3: Decompose #156 into the human Visible Worker gate and a local bounded-search fix
+### Task 3: Split #156 into one Host/runtime-only gate and two CodexHub adapter children
 
 **Files:**
 - Read: `docs/superpowers/specs/2026-07-16-wayfinder-replanning-design.md`
-- GitHub Issue: #156.
-- Create GitHub Issue with exact title: `Bound repeated empty tool_search misses for external models`.
+- GitHub Issue: #156, rewritten in place with exact title `Enable sidebar-visible third-party Worker callbacks and binding readback`.
+- Discover or create GitHub Issue with exact title: `Bound repeated empty tool_search misses for external models`.
+- Discover or create GitHub Issue with exact title: `Preserve Worker selector and effective binding validation for external delegation`.
 
 **Interfaces:**
-- Consumes: milestone `0.1.6 — Codex control-plane reliability`.
-- Produces: `$localSearchIssue`, a ready-for-agent CodexHub-owned child of #156; #156 remains the ready-for-human Visible Worker gate; #64 is blocked by #156.
+- Consumes: milestone `0.1.6 — Codex control-plane reliability` and Task 1's immutable pre-write Issue snapshot.
+- Produces: `$localSearchIssue` and `$selectorBindingIssue`, both unassigned ready-for-agent CodexHub children of #156; #156 remains the unassigned ready-for-human Host/runtime-only gate; #156 is blocked by both children; #64 retains blockers #62/#63/#156.
 
-- [ ] **Step 1: Re-read #156 immediately before writing**
+- [ ] **Step 1: Re-read #156, #159, and comments immediately before writing**
 
 Run:
 
 ```powershell
-gh issue view 156 --comments `
-  --json number,title,state,body,labels,assignees,milestone,comments,url
+foreach ($n in 156,159) {
+  gh issue view $n --comments `
+    --json number,title,state,body,labels,assignees,milestone,comments,url
+}
 ```
 
-Expected: open `bug` + `ready-for-human`; body contains the Host/runtime callback gap and the CodexHub repeated empty-search amplification; the reporter clarification comment ends with `issuecomment-4993730159`.
+Expected: #156 is open, unassigned, and `ready-for-human`; #159 is open, unassigned, and `ready-for-agent`; all existing comments and sanitized evidence are visible before any mutation.
 
-- [ ] **Step 2: Create the local bounded-search child Issue if absent**
+- [ ] **Step 2: Rewrite #156 as the exact Host/runtime-only gate with a fresh-body guard**
 
 Run:
 
-````powershell
-$title = 'Bound repeated empty tool_search misses for external models'
-$matches = @(gh issue list --state all --limit 100 `
-  --search 'in:title "Bound repeated empty tool_search misses for external models"' `
-  --json number,title,state,url `
-  --jq ".[] | select(.title == \"$title\") | .number")
-if ($matches.Count -gt 1) { throw 'duplicate bounded-search Issues' }
+`````powershell
+function Get-TextHash([string]$Text) {
+  $bytes = [Text.Encoding]::UTF8.GetBytes(($Text -replace "`r`n","`n").TrimEnd())
+  [Convert]::ToHexString([Security.Cryptography.SHA256]::HashData($bytes)).ToLowerInvariant()
+}
 
-if ($matches.Count -eq 0) {
-  $body = @'
+$hostTitle = 'Enable sidebar-visible third-party Worker callbacks and binding readback'
+$hostBody = @'
+## Priority and external blocker
+
+**Priority: P0 — complete the Host/runtime gate before resuming dependent orchestration work.**
+
+This is a hard external blocker for [NOirBRight/github-work-orchestrator#16](https://github.com/NOirBRight/github-work-orchestrator/issues/16). Keep that Issue stopped and unclaimed until the native sidebar-visible Worker acceptance gate below passes.
+
+## Sanitized reproduction
+
+Environment: Codex Desktop 26.707.12708.0, Codex CLI 0.144.5, CodexHub route, Ollama Cloud native Responses, requested `glm-5.2 / max`.
+
+1. A native worktree Worker was created from the parent and appeared as a separate sidebar Task.
+2. Parent-to-child continuation worked, and the child had functioning shell/MCP tools.
+3. The child could not access a supported parent-result callback or equivalent result-delivery channel. Exact-name searches returned `tools=[]`.
+4. The child could not prove the effective agent type, model, and reasoning through supported readback.
+5. Without a terminal unsupported result, the failed capability search could repeat. A bounded parent continuation stopped the read-only incident; the child returned `BLOCKED` and its worktree stayed clean.
+
+Private rollout, Task, callback, local-path, call, and token identifiers remain excluded. Do not edit Codex SQLite or infer evidence from private IDs.
+
+## Problem
+
+The Codex Host/runtime does not yet provide a complete supported contract for third-party delegated implementation as a native **sidebar-visible Worker Task**. The required contract spans Worker materialization, bidirectional parent/Worker communication, result delivery with a confirmable receipt, effective binding readback, explicit unsupported terminalization, and a visible Active → Done lifecycle.
+
+A model-visible callback schema is not sufficient when the child has no registered native handler. Requested settings are not effective binding evidence.
+
+## Desired outcome
+
+Native Host/runtime delegation can create a sidebar-visible third-party Worker and prove, before implementation begins, that the supported execution surface and effective binding match the request. The parent and Worker can communicate in both directions, the parent receives a confirmable result receipt, unsupported capabilities stop terminally, and the Worker becomes visibly Active and then Done.
+
+## Scope — Host/runtime only
+
+- Materialize delegated implementation as a separate native sidebar-visible Worker Task with supported discovery/readback.
+- Register a supported parent-result callback in the Worker context, or provide an equivalent durable result-delivery channel whose receipt the parent can confirm.
+- Support parent-to-Worker continuation and Worker-to-parent result return in the same isolated lifecycle.
+- Expose supported effective readback for agent type, model, and reasoning effort before edits begin.
+- Return an explicit, machine-classifiable terminal unsupported result when the requested Worker surface, callback/result channel, or binding cannot be provided.
+- Expose supported lifecycle readback showing the Worker transition from Active to Done.
+- Preserve sanitized Host/runtime evidence for a bounded manual replay.
+
+## Non-goals
+
+- Do not implement CodexHub's repeated identical empty-`tool_search` bound; #159 owns that work.
+- Do not implement CodexHub Worker selector/codec preservation or effective-binding validation; #161 owns that work.
+- Do not inject a callback schema without a registered Host/runtime handler.
+- Do not substitute GPT, Hidden Subagent, Inline execution, Background process, `codex exec`, or a shell-launched model for the sidebar-visible Worker.
+- Do not edit Codex SQLite, publish private IDs or local paths, synthesize rollout state, or infer binding from requested settings.
+- Do not broaden into unrelated transport, routing, retry, apply-patch, or Task-activity rendering work.
+
+## Acceptance criteria
+
+- [ ] A native delegation materializes one separate sidebar-visible third-party Worker Task.
+- [ ] Supported readback proves the effective Worker agent type, requested third-party model, and requested reasoning effort before implementation begins.
+- [ ] Missing, unknown, contradictory, rejected, unsupported, or GPT-substituted binding evidence stops terminally before edits.
+- [ ] Parent-to-Worker continuation and Worker-to-parent result delivery both succeed in the same isolated Worker lifecycle.
+- [ ] The parent receives a supported confirmable receipt for the Worker's final result.
+- [ ] An unavailable Worker surface, callback/result channel, or selector returns an explicit terminal unsupported result rather than continuing or substituting another surface.
+- [ ] Supported Task APIs show the separate Worker as Active and then Done.
+- [ ] The real validation performs only a disposable read-only action until surface, binding, and callback/receipt preflight pass.
+- [ ] No GPT, Hidden Subagent, Inline, Background, `codex exec`, or shell-launched substitute appears in the evidence.
+
+## Host/runtime verification and evidence
+
+This Issue does not authorize or invent CodexHub product-code verification. Its acceptance is manual Host/runtime evidence from one isolated native Codex Desktop replay using a third-party model and requested reasoning:
+
+1. create one native sidebar-visible Worker Task;
+2. read back effective Worker agent type, model, and reasoning through supported APIs;
+3. send one parent continuation;
+4. return one Worker result and confirm the parent receipt;
+5. read back Active → Done terminal visibility;
+6. capture only sanitized outcome fields and failure classifications.
+
+## Relationships
+
+- External hard blocker: [NOirBRight/github-work-orchestrator#16](https://github.com/NOirBRight/github-work-orchestrator/issues/16)
+- Broad collaboration verification: #64
+- Deferred discovery classification: #63
+- Runtime plan evidence: #62
+- CodexHub repeated-search child: #159
+- CodexHub selector/binding child: #161
+
+## Expected hotset
+
+Host/runtime-owned, outside this repository:
+
+- native sidebar-visible Worker Task creation/materialization;
+- child Host tool registration or equivalent result-delivery channel and receipt;
+- supported effective agent/model/reasoning readback;
+- supported Worker lifecycle state and explicit unsupported terminalization.
+
+No CodexHub product-code hotset is owned by this Issue.
+
+## Execution contract
+
+Execution-Contract: v2
+Verification-Class: strict
+Verification-Commands: Host/runtime supported-API readback only; no CodexHub product-code command is claimed
+Manual-Evidence: one isolated native third-party sidebar-visible Worker replay proving effective binding, bidirectional communication, confirmed parent receipt, explicit unsupported behavior, and Active → Done visibility
+Architecture-Decision: resolved
+Review-Owner: orchestrator
+'@
+$hostBody = ($hostBody -replace "`r`n","`n").TrimEnd()
+$before = gh issue view 156 --comments `
+  --json number,title,state,body,labels,assignees,milestone,comments,url | ConvertFrom-Json
+$commentGuard = @($before.comments | ForEach-Object { "$($_.id):$(Get-TextHash $_.body)" })
+
+if ($before.title -cne $hostTitle -or (Get-TextHash $before.body) -cne (Get-TextHash $hostBody)) {
+  $snapshot = Get-Content -Raw (Join-Path $env:TEMP 'codexhub-wayfinder-migration/issues.json') | ConvertFrom-Json
+  $baseline = @($snapshot | Where-Object number -eq 156)
+  if ($baseline.Count -ne 1 -or $before.title -cne $baseline[0].title -or
+      (Get-TextHash $before.body) -cne (Get-TextHash $baseline[0].body)) {
+    throw '#156 changed since Task 1 snapshot; do not overwrite fresh evidence'
+  }
+  gh issue edit 156 --title $hostTitle --body $hostBody | Out-Null
+}
+
+$after = gh issue view 156 --comments `
+  --json title,state,body,labels,assignees,milestone,comments,url | ConvertFrom-Json
+$commentReadback = @($after.comments | ForEach-Object { "$($_.id):$(Get-TextHash $_.body)" })
+if ($after.title -cne $hostTitle -or (Get-TextHash $after.body) -cne (Get-TextHash $hostBody)) { throw '#156 exact body readback failed' }
+if (($commentReadback -join '|') -cne ($commentGuard -join '|')) { throw '#156 comments changed' }
+`````
+
+Expected: #156 has the exact Host/runtime-only title/body, all prior comments remain byte-equivalent after line-ending normalization, and no CodexHub product verification is claimed by the parent gate.
+
+- [ ] **Step 3: Discover or create both exact CodexHub children idempotently**
+
+Run:
+
+`````powershell
+$searchTitle = 'Bound repeated empty tool_search misses for external models'
+$searchBody = @'
 Part of #156.
 
 ## Problem
@@ -404,72 +541,208 @@ Manual-Evidence: none
 Architecture-Decision: resolved
 Review-Owner: orchestrator
 '@
-  $url = gh issue create --title $title --body $body `
-    --label bug --label ready-for-agent --label wayfinder:task
-  $localSearchIssue = [int]($url.TrimEnd('/') -split '/')[-1]
-} else {
-  $localSearchIssue = [int]$matches[0]
+$selectorTitle = 'Preserve Worker selector and effective binding validation for external delegation'
+$selectorBody = @'
+Split from #156. This Issue owns only the CodexHub adapter contract for Worker selector preservation and supported effective-binding validation.
+
+## Problem
+
+`spawn_agent.agent_type=worker` is advertised at the adapter boundary but can be removed or weakened during normalization/history processing. The adapter also lacks a fail-closed contract for supported effective agent type, model, and reasoning readback, so requested settings can be mistaken for effective execution evidence.
+
+## Outcome
+
+CodexHub preserves the explicit Worker selector across every adapter stage, or rejects it before child execution, and consumes supported effective binding readback to prove the selected agent type, model, and reasoning. Missing, unknown, contradictory, rejected, or GPT-substituted results fail closed before edits.
+
+## Scope — CodexHub adapter only
+
+- Preserve `spawn_agent.agent_type=worker` across tool declaration, argument normalization, call execution, response normalization, and history replay.
+- Reject unsupported `agent_type` values before child execution; do not delete, coerce, or silently substitute them.
+- Consume the Host/runtime's supported effective agent type, model, and reasoning readback.
+- Require effective readback to agree with the requested Worker selector, third-party model, and reasoning before edits begin.
+- Fail closed for missing, unknown, contradictory, rejected, unsupported, or GPT-substituted readback/results.
+- Emit sanitized, machine-classifiable telemetry for selector preservation/rejection and effective-binding validation outcomes.
+- Add deterministic tests and a focused sanitized fixture derived only from shapes, enums, and synthetic values.
+
+## Non-goals
+
+- Do not register Host callbacks or implement parent-result delivery; #156 owns the Host/runtime surface.
+- Do not implement the repeated identical empty-`tool_search` bound; #159 owns it.
+- Do not use Codex SQLite, private Task/callback IDs, local paths, or rollout records as evidence.
+- Do not broaden into unrelated transport, protocol routing, retry, apply-patch, or Task-activity work.
+- Do not infer binding from requested settings and do not accept GPT substitution.
+
+## Acceptance criteria
+
+- [ ] `agent_type=worker` survives declaration, normalization, call execution, result normalization, and history replay unchanged.
+- [ ] An unsupported selector is rejected with a sanitized terminal classification before child execution.
+- [ ] Supported readback proves the effective agent type, model, and reasoning and matches the request before edits.
+- [ ] Missing, unknown, contradictory, rejected, unsupported, or GPT-substituted readback/result stops before edits.
+- [ ] Existing supported non-Worker collaboration behavior remains unchanged.
+- [ ] Telemetry contains no credentials, prompts, private Task/callback identifiers, rollout data, or local paths.
+
+## Minimal deterministic tests
+
+1. Worker selector survives declaration, normalization, execution, response normalization, and history replay.
+2. Missing and unsupported selector values reject before child execution.
+3. Effective readback matching the requested Worker/model/reasoning passes.
+4. Missing, unknown, contradictory, rejected, unsupported, and GPT-substituted readbacks each fail closed before edits.
+5. Sanitized telemetry records only stable classification fields and synthetic fixture values.
+
+## Verification
+
+```powershell
+python -m pytest -q tests/test_codex_semantic_adapter.py
+python -m pytest -q tests/test_routing.py -k "agent_type or binding"
+python -m pytest -q
+git diff --check
+python scripts/report_quality_gates.py
+```
+
+Run the full Python suite once at the candidate commit. `python scripts/report_quality_gates.py` is report-only.
+
+## Expected hotset
+
+- `src-python/codex_semantic_adapter.py`
+- `src-python/codex_proxy.py` only where the selector/effective-binding result crosses the adapter boundary
+- `tests/test_codex_semantic_adapter.py`
+- focused routing tests for `agent_type`/binding
+- one focused sanitized fixture under `tests/fixtures/` if required
+
+## Relationships
+
+- Parent Host/runtime gate: #156
+- Sibling repeated-search bound: #159
+
+## Execution contract
+
+Execution-Contract: v2
+Verification-Class: strict
+Verification-Commands: targeted `tests/test_codex_semantic_adapter.py`; targeted routing tests for `agent_type`/binding; full Python suite once; `git diff --check`; `python scripts/report_quality_gates.py` report-only
+Manual-Evidence: none; consume only supported effective readback supplied by the Host/runtime contract in #156
+Architecture-Decision: resolved
+Review-Owner: orchestrator
+'@
+$searchBody = ($searchBody -replace "`r`n","`n").TrimEnd()
+$selectorBody = ($selectorBody -replace "`r`n","`n").TrimEnd()
+
+$all = @(gh api --paginate 'repos/NOirBRight/CodexHub/issues?state=all&per_page=100' | ConvertFrom-Json | Where-Object { -not $_.pull_request })
+$potentialSelectorDuplicates = @($all | Where-Object {
+  $_.number -notin @(147,156,159) -and $_.title -cne $selectorTitle -and
+  (($_.title + "`n" + $_.body) -match '(?is)agent_type\s*=\s*worker') -and
+  (($_.title + "`n" + $_.body) -match '(?is)(effective.binding|binding.readback)') -and
+  (($_.title + "`n" + $_.body) -match '(?is)(preserv|normaliz|codec|history)')
+})
+if ($potentialSelectorDuplicates.Count) {
+  throw "possible selector/codec duplicate(s): $(@($potentialSelectorDuplicates.number) -join ',')"
 }
-"localSearchIssue=$localSearchIssue"
-````
 
-Expected: exactly one open Issue with the exact title; record its numeric value as `$localSearchIssue`.
+function Find-OrCreateExactIssue([string]$Title,[string]$Body) {
+  $matches = @($all | Where-Object title -CEQ $Title)
+  if ($matches.Count -gt 1) { throw "duplicate exact-title Issues: $Title" }
+  if ($matches.Count -eq 1) {
+    if ($matches[0].state -ne 'open' -or (Get-TextHash $matches[0].body) -cne (Get-TextHash $Body)) {
+      throw "existing exact-title Issue has conflicting state/body: $Title"
+    }
+    return [int]$matches[0].number
+  }
+  $bodyFile = Join-Path $env:TEMP ("wayfinder-" + [guid]::NewGuid().ToString('N') + '.md')
+  [IO.File]::WriteAllText($bodyFile,$Body,[Text.UTF8Encoding]::new($false))
+  try {
+    $url = gh issue create --title $Title --body-file $bodyFile `
+      --label bug --label ready-for-agent --label wayfinder:task `
+      --milestone '0.1.6 — Codex control-plane reliability'
+    return [int](($url | Select-Object -Last 1).TrimEnd('/') -split '/')[-1]
+  } finally { Remove-Item -LiteralPath $bodyFile -ErrorAction SilentlyContinue }
+}
 
-- [ ] **Step 3: Set milestone, parent, labels, and hard dependencies idempotently**
+$localSearchIssue = Find-OrCreateExactIssue $searchTitle $searchBody
+$selectorBindingIssue = Find-OrCreateExactIssue $selectorTitle $selectorBody
+"localSearchIssue=$localSearchIssue selectorBindingIssue=$selectorBindingIssue"
+`````
+
+Expected: exactly one open Issue exists for each exact title. A possible open or closed duplicate of the selector/codec outcome stops creation for review.
+
+- [ ] **Step 4: Set exact metadata, parents, and dependencies idempotently**
 
 Run:
 
 ```powershell
-gh issue edit $localSearchIssue `
-  --add-label bug --add-label ready-for-agent --add-label wayfinder:task `
-  --milestone '0.1.6 — Codex control-plane reliability'
-
-gh issue edit 156 --add-label wayfinder:grilling `
-  --milestone '0.1.6 — Codex control-plane reliability'
-
-function Ensure-SubIssue([int]$Parent, [int]$Child) {
-  $childIssue = gh api "repos/NOirBRight/CodexHub/issues/$Child" | ConvertFrom-Json
-  $expected = "https://api.github.com/repos/NOirBRight/CodexHub/issues/$Parent"
-  if ($childIssue.parent_issue_url -eq $expected) { return }
-  if ($childIssue.parent_issue_url) { throw "#$Child already has parent $($childIssue.parent_issue_url)" }
-  gh api --method POST "repos/NOirBRight/CodexHub/issues/$Parent/sub_issues" `
-    -F sub_issue_id=$childIssue.id | Out-Null
+$milestone = @(gh api 'repos/NOirBRight/CodexHub/milestones?state=open&per_page=100' |
+  ConvertFrom-Json | Where-Object title -CEQ '0.1.6 — Codex control-plane reliability')
+if ($milestone.Count -ne 1) { throw '0.1.6 milestone lookup failed' }
+foreach ($n in $localSearchIssue,$selectorBindingIssue) {
+  @{labels=@('bug','ready-for-agent','wayfinder:task');milestone=[int]$milestone[0].number} |
+    ConvertTo-Json -Compress | gh api --method PATCH "repos/NOirBRight/CodexHub/issues/$n" --input - | Out-Null
 }
+gh issue edit 156 --add-label wayfinder:grilling `
+  --milestone '0.1.6 — Codex control-plane reliability' | Out-Null
 
-function Ensure-BlockedBy([int]$Blocked, [int]$Blocker) {
-  $existing = @(gh api "repos/NOirBRight/CodexHub/issues/$Blocked/dependencies/blocked_by" `
-    --jq ".[] | select(.number == $Blocker) | .number")
+function Get-Parent([int]$Child) {
+  $json = gh api "repos/NOirBRight/CodexHub/issues/$Child/parent" 2>$null
+  if ($LASTEXITCODE -eq 0) { return ($json | ConvertFrom-Json) }
+  return $null
+}
+function Ensure-SubIssue([int]$Parent,[int]$Child) {
+  $current = Get-Parent $Child
+  if ($current -and $current.number -eq $Parent) { return }
+  if ($current) { throw "#$Child already has parent #$($current.number)" }
+  $childIssue = gh api "repos/NOirBRight/CodexHub/issues/$Child" | ConvertFrom-Json
+  gh api --method POST "repos/NOirBRight/CodexHub/issues/$Parent/sub_issues" `
+    -F "sub_issue_id=$($childIssue.id)" | Out-Null
+}
+function Ensure-BlockedBy([int]$Blocked,[int]$Blocker) {
+  $existing = @(gh api "repos/NOirBRight/CodexHub/issues/$Blocked/dependencies/blocked_by" |
+    ConvertFrom-Json | Where-Object number -eq $Blocker)
+  if ($existing.Count -gt 1) { throw "duplicate dependency #$Blocked <- #$Blocker" }
   if ($existing.Count -eq 0) {
-    $blockerId = gh api "repos/NOirBRight/CodexHub/issues/$Blocker" --jq .id
+    $blocker = gh api "repos/NOirBRight/CodexHub/issues/$Blocker" | ConvertFrom-Json
     gh api --method POST "repos/NOirBRight/CodexHub/issues/$Blocked/dependencies/blocked_by" `
-      -F issue_id=$blockerId | Out-Null
+      -F "issue_id=$($blocker.id)" | Out-Null
   }
 }
 
 Ensure-SubIssue 147 156
 Ensure-SubIssue 156 $localSearchIssue
+Ensure-SubIssue 156 $selectorBindingIssue
 Ensure-BlockedBy 156 $localSearchIssue
+Ensure-BlockedBy 156 $selectorBindingIssue
 Ensure-BlockedBy 64 156
 ```
 
-Expected: #156 is a child of #147; the local Issue is a child of #156; #156 is blocked by the local Issue; #64 is blocked by #156.
+Expected: #156 is a child of #147; both local Issues are children of #156; #156 is blocked by both local Issues; #64 retains #62/#63/#156.
 
-- [ ] **Step 4: Read back the complete decomposition**
+- [ ] **Step 5: Read back the complete split exactly**
 
 Run:
 
 ```powershell
-foreach ($n in 156,$localSearchIssue,64) {
-  gh api "repos/NOirBRight/CodexHub/issues/$n" `
-    --jq '{number,title,state,labels:[.labels[].name],assignees:[.assignees[].login],milestone:(.milestone.title // null),parent:.parent_issue_url,deps:.issue_dependencies_summary,url:.html_url}'
+foreach ($n in 156,$localSearchIssue,$selectorBindingIssue,64) {
+  gh issue view $n --json number,title,state,body,labels,assignees,milestone,url
 }
-gh api "repos/NOirBRight/CodexHub/issues/156/dependencies/blocked_by" `
-  --jq '.[] | {number,title,state}'
-gh api "repos/NOirBRight/CodexHub/issues/64/dependencies/blocked_by" `
-  --jq '.[] | {number,title,state}'
+$host = gh issue view 156 --json state,labels,assignees,milestone | ConvertFrom-Json
+$hostLabels = @($host.labels.name | Sort-Object)
+if ($host.state -ne 'OPEN' -or $host.assignees.Count -ne 0 -or
+    ($hostLabels -join ',') -cne 'bug,ready-for-human,wayfinder:grilling' -or
+    $host.milestone.title -cne '0.1.6 — Codex control-plane reliability') { throw '#156 metadata mismatch' }
+$children156 = @(gh api 'repos/NOirBRight/CodexHub/issues/156/sub_issues' | ConvertFrom-Json | ForEach-Object number | Sort-Object)
+$blocked156 = @(gh api 'repos/NOirBRight/CodexHub/issues/156/dependencies/blocked_by' | ConvertFrom-Json | ForEach-Object number | Sort-Object)
+$blocked64 = @(gh api 'repos/NOirBRight/CodexHub/issues/64/dependencies/blocked_by' | ConvertFrom-Json | ForEach-Object number | Sort-Object)
+$expectedChildren = @($localSearchIssue,$selectorBindingIssue | Sort-Object)
+if (($children156 -join ',') -cne ($expectedChildren -join ',')) { throw '#156 child set mismatch' }
+if (($blocked156 -join ',') -cne ($expectedChildren -join ',')) { throw '#156 blocker set mismatch' }
+if (($blocked64 -join ',') -cne '62,63,156') { throw '#64 blocker set mismatch' }
+foreach ($n in $localSearchIssue,$selectorBindingIssue) {
+  $issue = gh issue view $n --json state,labels,assignees,milestone | ConvertFrom-Json
+  $labels = @($issue.labels.name | Sort-Object)
+  if ($issue.state -ne 'OPEN' -or $issue.assignees.Count -ne 0 -or
+      ($labels -join ',') -cne 'bug,ready-for-agent,wayfinder:task' -or
+      $issue.milestone.title -cne '0.1.6 — Codex control-plane reliability') { throw "child metadata mismatch #$n" }
+  $parent = Get-Parent $n
+  if (-not $parent -or $parent.number -ne 156) { throw "child parent mismatch #$n" }
+}
 ```
 
-Expected: exact hierarchy and dependencies from Step 3; #156 remains unassigned and `ready-for-human`; the local child is unassigned and `ready-for-agent`.
+Expected: exact titles/bodies/metadata, hierarchy, and dependency sets; #156 is unassigned and `ready-for-human`; both children are unassigned and `ready-for-agent`; no Issue claim occurred.
 
 ---
 
@@ -668,12 +941,15 @@ gh issue edit $uninstallIssue `
   --milestone '0.1.10 — Existing product reliability'
 
 function Ensure-SubIssue([int]$Parent, [int]$Child) {
+  $parentJson = gh api "repos/NOirBRight/CodexHub/issues/$Child/parent" 2>$null
+  if ($LASTEXITCODE -eq 0) {
+    $current = $parentJson | ConvertFrom-Json
+    if ($current.number -eq $Parent) { return }
+    throw "#$Child already has parent #$($current.number)"
+  }
   $childIssue = gh api "repos/NOirBRight/CodexHub/issues/$Child" | ConvertFrom-Json
-  $expected = "https://api.github.com/repos/NOirBRight/CodexHub/issues/$Parent"
-  if ($childIssue.parent_issue_url -eq $expected) { return }
-  if ($childIssue.parent_issue_url) { throw "#$Child already has parent $($childIssue.parent_issue_url)" }
   gh api --method POST "repos/NOirBRight/CodexHub/issues/$Parent/sub_issues" `
-    -F sub_issue_id=$childIssue.id | Out-Null
+    -F "sub_issue_id=$($childIssue.id)" | Out-Null
 }
 function Ensure-BlockedBy([int]$Blocked, [int]$Blocker) {
   $existing = @(gh api "repos/NOirBRight/CodexHub/issues/$Blocked/dependencies/blocked_by" `
@@ -698,8 +974,7 @@ Run:
 ```powershell
 gh issue view 28 --json number,title,state,body,labels,assignees,milestone,url
 gh issue view $uninstallIssue --json number,title,state,body,labels,assignees,milestone,url
-gh api "repos/NOirBRight/CodexHub/issues/$uninstallIssue" `
-  --jq '{parent:.parent_issue_url,deps:.issue_dependencies_summary}'
+gh api "repos/NOirBRight/CodexHub/issues/$uninstallIssue/parent" --jq '{number,title,state}'
 gh api "repos/NOirBRight/CodexHub/issues/$uninstallIssue/dependencies/blocked_by" `
   --jq '.[] | {number,title,state}'
 ```
@@ -714,10 +989,10 @@ Expected: both Issues have complete v2 contracts, exact milestones, one lifecycl
 - GitHub Issues and sub-issue relationships only.
 
 **Interfaces:**
-- Consumes: `$localSearchIssue` discoverable by exact title and `$uninstallIssue` discoverable by exact title.
+- Consumes: `$localSearchIssue`, `$selectorBindingIssue`, and `$uninstallIssue`, each discoverable by exact title.
 - Produces: every active release Issue assigned to exactly one 0.1.6–0.1.10 milestone; every new-feature parent visible under #147 without an active reliability milestone; nested workstreams retain one parent.
 
-- [ ] **Step 1: Rediscover the two newly created Issue numbers by exact title**
+- [ ] **Step 1: Rediscover the three newly created Issue numbers by exact title**
 
 Run:
 
@@ -730,10 +1005,11 @@ function Find-ExactIssue([string]$Title) {
   return [int]$matches[0]
 }
 $localSearchIssue = Find-ExactIssue 'Bound repeated empty tool_search misses for external models'
+$selectorBindingIssue = Find-ExactIssue 'Preserve Worker selector and effective binding validation for external delegation'
 $uninstallIssue = Find-ExactIssue 'Remove CodexHub-owned Windows autostart registration during uninstall'
 ```
 
-Expected: two unique numeric Issue IDs.
+Expected: three unique numeric Issue IDs.
 
 - [ ] **Step 2: Assign exact milestone membership**
 
@@ -741,7 +1017,7 @@ Run:
 
 ```powershell
 $membership = [ordered]@{
-  '0.1.6 — Codex control-plane reliability' = @(111,112,138,139,141,143,149,150,151,156,$localSearchIssue)
+  '0.1.6 — Codex control-plane reliability' = @(111,112,138,139,141,143,149,150,151,156,$localSearchIssue,$selectorBindingIssue)
   '0.1.7 — Official GPT reliability' = @(18,19,20,21,104,109,114,157)
   '0.1.8 — Third-party model certification' = @(17,22,57,58,59,61,62,63,64,65,66,67)
   '0.1.9 — Managed client reliability' = @(8,28,83,153,154,155)
@@ -761,7 +1037,7 @@ Expected: every listed open Issue reports the exact milestone; no Issue appears 
 Run:
 
 ```powershell
-$taskIssues = @(8,28,83,86,87,88,89,90,91,92,93,111,113,115,126,155,157,$localSearchIssue,$uninstallIssue)
+$taskIssues = @(8,28,83,86,87,88,89,90,91,92,93,111,113,115,126,155,157,$localSearchIssue,$selectorBindingIssue,$uninstallIssue)
 $researchIssues = @(68,104)
 $grillingIssues = @(71,94,109,156)
 
@@ -778,12 +1054,15 @@ Run:
 
 ```powershell
 function Ensure-SubIssue([int]$Parent, [int]$Child) {
+  $parentJson = gh api "repos/NOirBRight/CodexHub/issues/$Child/parent" 2>$null
+  if ($LASTEXITCODE -eq 0) {
+    $current = $parentJson | ConvertFrom-Json
+    if ($current.number -eq $Parent) { return }
+    throw "#$Child already has parent #$($current.number)"
+  }
   $childIssue = gh api "repos/NOirBRight/CodexHub/issues/$Child" | ConvertFrom-Json
-  $expected = "https://api.github.com/repos/NOirBRight/CodexHub/issues/$Parent"
-  if ($childIssue.parent_issue_url -eq $expected) { return }
-  if ($childIssue.parent_issue_url) { throw "#$Child already has parent $($childIssue.parent_issue_url)" }
   gh api --method POST "repos/NOirBRight/CodexHub/issues/$Parent/sub_issues" `
-    -F sub_issue_id=$childIssue.id | Out-Null
+    -F "sub_issue_id=$($childIssue.id)" | Out-Null
 }
 
 $topLevel = @(
@@ -795,9 +1074,11 @@ $topLevel = @(
   68,71,73,85,148,152
 )
 foreach ($n in $topLevel) { Ensure-SubIssue 147 $n }
+Ensure-SubIssue 156 $localSearchIssue
+Ensure-SubIssue 156 $selectorBindingIssue
 ```
 
-Expected: every listed Issue has parent #147. Existing nested #57 and #73 children are not moved.
+Expected: every listed top-level Issue has parent #147; both local adapter children have parent #156. Existing nested #57 and #73 children are not moved.
 
 - [ ] **Step 5: Ensure the Provider-auth and Claude workstream nesting**
 
@@ -837,10 +1118,14 @@ foreach ($entry in $membership.GetEnumerator()) {
 }
 
 foreach ($n in $topLevel) {
-  $parent = gh api "repos/NOirBRight/CodexHub/issues/$n" --jq .parent_issue_url
-  if ($parent -ne 'https://api.github.com/repos/NOirBRight/CodexHub/issues/147') {
+  $parent = gh api "repos/NOirBRight/CodexHub/issues/$n/parent" --jq .number
+  if ([int]$parent -ne 147) {
     throw "map parent mismatch #$n"
   }
+}
+foreach ($n in $localSearchIssue,$selectorBindingIssue) {
+  $parent = gh api "repos/NOirBRight/CodexHub/issues/$n/parent" --jq .number
+  if ([int]$parent -ne 156) { throw "#156 child mismatch #$n" }
 }
 'milestones-and-hierarchy-ok'
 ```
@@ -864,6 +1149,24 @@ Expected: `milestones-and-hierarchy-ok`.
 Run:
 
 ```powershell
+function Write-ExactIssueComment([int]$Issue,[string]$PurposePrefix,[string]$Body) {
+  $Body = ($Body -replace "`r`n","`n").TrimEnd()
+  $comments = @(gh api --paginate "repos/NOirBRight/CodexHub/issues/$Issue/comments?per_page=100" | ConvertFrom-Json)
+  $exact = @($comments | Where-Object body -CEQ $Body)
+  $purpose = @($comments | Where-Object { ([string]$_.body).StartsWith($PurposePrefix,[StringComparison]::Ordinal) })
+  if ($exact.Count -gt 1) { throw "multiple exact comments on #$Issue" }
+  if ($exact.Count -eq 1) {
+    if ($purpose.Count -ne 1) { throw "conflicting same-purpose comment on #$Issue" }
+  } else {
+    if ($purpose.Count -gt 0) { throw "conflicting same-purpose comment on #$Issue" }
+    gh issue comment $Issue --body $Body | Out-Null
+  }
+  $readback = @(gh api --paginate "repos/NOirBRight/CodexHub/issues/$Issue/comments?per_page=100" | ConvertFrom-Json)
+  $matches = @($readback | Where-Object body -CEQ $Body)
+  if ($matches.Count -ne 1) { throw "exact comment readback failed on #$Issue" }
+  $matches[0].html_url
+}
+
 git merge-base --is-ancestor 400d19bb dev
 $ancestor = ($LASTEXITCODE -eq 0)
 $moduleExists = Test-Path 'src-tauri/src/gateway/client_adapters.rs'
@@ -879,7 +1182,7 @@ The earlier local-completion comment does not describe the current `dev` baselin
 
 #8 therefore remains open and is scheduled under `0.1.9 — Managed client reliability`. This comment does not claim the orphaned implementation is reusable; a future Worker must compare it against current code before choosing reimplementation or recovery.
 '@
-gh issue comment 8 --body $body
+Write-ExactIssueComment 8 '### Wayfinder baseline correction' $body
 ```
 
 Expected: comment URL returned; Issue remains open, unassigned, and `ready-for-agent`.
@@ -889,6 +1192,24 @@ Expected: comment URL returned; Issue remains open, unassigned, and `ready-for-a
 Run:
 
 ```powershell
+function Write-ExactIssueComment([int]$Issue,[string]$PurposePrefix,[string]$Body) {
+  $Body = ($Body -replace "`r`n","`n").TrimEnd()
+  $comments = @(gh api --paginate "repos/NOirBRight/CodexHub/issues/$Issue/comments?per_page=100" | ConvertFrom-Json)
+  $exact = @($comments | Where-Object body -CEQ $Body)
+  $purpose = @($comments | Where-Object { ([string]$_.body).StartsWith($PurposePrefix,[StringComparison]::Ordinal) })
+  if ($exact.Count -gt 1) { throw "multiple exact comments on #$Issue" }
+  if ($exact.Count -eq 1) {
+    if ($purpose.Count -ne 1) { throw "conflicting same-purpose comment on #$Issue" }
+  } else {
+    if ($purpose.Count -gt 0) { throw "conflicting same-purpose comment on #$Issue" }
+    gh issue comment $Issue --body $Body | Out-Null
+  }
+  $readback = @(gh api --paginate "repos/NOirBRight/CodexHub/issues/$Issue/comments?per_page=100" | ConvertFrom-Json)
+  $matches = @($readback | Where-Object body -CEQ $Body)
+  if ($matches.Count -ne 1) { throw "exact comment readback failed on #$Issue" }
+  $matches[0].html_url
+}
+
 $checks = [ordered]@{10='7de67c51';12='77014e9'}
 foreach ($entry in $checks.GetEnumerator()) {
   git merge-base --is-ancestor $entry.Value main
@@ -897,7 +1218,8 @@ foreach ($entry in $checks.GetEnumerator()) {
   if ($LASTEXITCODE -ne 0) { throw "#$($entry.Name) fix is not on dev" }
   $state = gh issue view $entry.Name --json state --jq .state
   if ($state -ne 'CLOSED') { throw "#$($entry.Name) unexpectedly open" }
-  gh issue comment $entry.Name --body "Wayfinder closure reconciliation: fix commit ``$($entry.Value)`` is an ancestor of both current ``main`` and ``dev``. The Issue remains closed; this records the final evidence missing after the earlier post-tag reopen comment."
+  $body = "Wayfinder closure reconciliation: fix commit ``$($entry.Value)`` is an ancestor of both current ``main`` and ``dev``. The Issue remains closed; this records the final evidence missing after the earlier post-tag reopen comment."
+  Write-ExactIssueComment $entry.Name 'Wayfinder closure reconciliation:' $body
 }
 ```
 
@@ -922,8 +1244,27 @@ Expected decision:
 - if no real #62 Task exists, no open PR exists, and no durable work owner exists, run:
 
 ```powershell
+function Write-ExactIssueComment([int]$Issue,[string]$PurposePrefix,[string]$Body) {
+  $Body = ($Body -replace "`r`n","`n").TrimEnd()
+  $comments = @(gh api --paginate "repos/NOirBRight/CodexHub/issues/$Issue/comments?per_page=100" | ConvertFrom-Json)
+  $exact = @($comments | Where-Object body -CEQ $Body)
+  $purpose = @($comments | Where-Object { ([string]$_.body).StartsWith($PurposePrefix,[StringComparison]::Ordinal) })
+  if ($exact.Count -gt 1) { throw "multiple exact comments on #$Issue" }
+  if ($exact.Count -eq 1) {
+    if ($purpose.Count -ne 1) { throw "conflicting same-purpose comment on #$Issue" }
+  } else {
+    if ($purpose.Count -gt 0) { throw "conflicting same-purpose comment on #$Issue" }
+    gh issue comment $Issue --body $Body | Out-Null
+  }
+  $readback = @(gh api --paginate "repos/NOirBRight/CodexHub/issues/$Issue/comments?per_page=100" | ConvertFrom-Json)
+  $matches = @($readback | Where-Object body -CEQ $Body)
+  if ($matches.Count -ne 1) { throw "exact comment readback failed on #$Issue" }
+  $matches[0].html_url
+}
+
 gh issue edit 62 --remove-assignee NOirBRight
-gh issue comment 62 --body 'Wayfinder ownership reconciliation: no active sidebar Worker, open PR, or durable execution owner was found. The stale assignee is removed; #62 remains blocked by #61 and will return to the 0.1.8 frontier only after its native dependencies close.'
+$body = 'Wayfinder ownership reconciliation: no active sidebar Worker, open PR, or durable execution owner was found. The stale assignee is removed; #62 remains blocked by #61 and will return to the 0.1.8 frontier only after its native dependencies close.'
+Write-ExactIssueComment 62 'Wayfinder ownership reconciliation:' $body
 ```
 
 - if native Task state is unavailable or ambiguous, leave the assignee unchanged and stop this step with an explicit human reconciliation requirement.
@@ -970,6 +1311,7 @@ function Find-ExactIssue([string]$Title) {
   return [int]$matches[0]
 }
 $localSearchIssue = Find-ExactIssue 'Bound repeated empty tool_search misses for external models'
+$selectorBindingIssue = Find-ExactIssue 'Preserve Worker selector and effective binding validation for external delegation'
 $uninstallIssue = Find-ExactIssue 'Remove CodexHub-owned Windows autostart registration during uninstall'
 gh issue view 147 --comments `
   --json number,title,state,body,labels,assignees,milestone,comments,url
@@ -1009,8 +1351,9 @@ Lifecycle spine: #139 → #143 → #112.
 
 Parallel gates:
 
-- #156 — human Host/runtime gate for a sidebar-visible third-party Worker, effective binding readback, bidirectional communication, receipt, and terminal state;
+- #156 — Host/runtime-only gate for sidebar-visible third-party Worker materialization, effective binding readback, bidirectional communication, receipt, explicit unsupported terminalization, and Active → Done visibility;
 - #$localSearchIssue — CodexHub-owned bound for repeated empty `tool_search` misses;
+- #$selectorBindingIssue — CodexHub-owned Worker selector preservation and effective binding validation;
 - #141 — Desktop restart and Task disappearance first-failure evidence;
 - #138 — auditable Task command output, diffs, progress, and terminal state;
 - #150 — coalesced usage probes and app-server child cleanup;
@@ -1085,14 +1428,14 @@ These lanes do not refill until 0.1.6–0.1.10 gates complete:
 - Visible Worker, Hidden Subagent, and Inline are distinct execution surfaces and cannot substitute for one another.
 - Terra/Luna Visible Workers implement current work; third-party models join only after certification.
 - Provider/model support is granular and versioned; Responses endpoint naming is not compatibility evidence.
-- #156 is the P0 human Visible Worker gate; #$localSearchIssue is its local CodexHub child; #64 validates the full post-fix collaboration matrix.
+- #156 is the P0 Host/runtime-only Visible Worker gate; its local CodexHub children are #$localSearchIssue for bounded empty search and #$selectorBindingIssue for Worker selector/effective binding validation; #64 validates the full post-fix collaboration matrix.
 - #8 remains open because its orphaned commit is absent from current `dev`.
 - Every open Issue belongs to a gate, support/decision queue, or new-feature parking area.
 
 ## Current frontier
 
 - Human P0 gate: #156.
-- Ready CodexHub candidate: #$localSearchIssue.
+- Ready local CodexHub candidates: #$localSearchIssue and #$selectorBindingIssue.
 - Independent ready 0.1.6 foundations, subject to hotset ownership: #139, #149, #150, #111.
 - #143 waits for #139; #112 waits for #143.
 - Map publication does not claim any of these tickets.
@@ -1230,9 +1573,10 @@ function Find-ExactIssue([string]$Title) {
   return [int]$matches[0]
 }
 $localSearchIssue = Find-ExactIssue 'Bound repeated empty tool_search misses for external models'
+$selectorBindingIssue = Find-ExactIssue 'Preserve Worker selector and effective binding validation for external delegation'
 $uninstallIssue = Find-ExactIssue 'Remove CodexHub-owned Windows autostart registration during uninstall'
 $expected = [ordered]@{
-  '0.1.6 — Codex control-plane reliability' = @(111,112,138,139,141,143,149,150,151,156,$localSearchIssue)
+  '0.1.6 — Codex control-plane reliability' = @(111,112,138,139,141,143,149,150,151,156,$localSearchIssue,$selectorBindingIssue)
   '0.1.7 — Official GPT reliability' = @(18,19,20,21,104,109,114,157)
   '0.1.8 — Third-party model certification' = @(17,22,57,58,59,61,62,63,64,65,66,67)
   '0.1.9 — Managed client reliability' = @(8,28,83,153,154,155)
@@ -1257,9 +1601,8 @@ Run:
 
 ```powershell
 function Assert-Parent([int]$Child,[int]$Parent) {
-  $actual = gh api "repos/NOirBRight/CodexHub/issues/$Child" --jq .parent_issue_url
-  $expected = "https://api.github.com/repos/NOirBRight/CodexHub/issues/$Parent"
-  if ($actual -ne $expected) { throw "parent mismatch #$Child" }
+  $actual = gh api "repos/NOirBRight/CodexHub/issues/$Child/parent" --jq .number
+  if ([int]$actual -ne $Parent) { throw "parent mismatch #$Child" }
 }
 function Assert-BlockedBy([int]$Blocked,[int]$Blocker) {
   $matches = @(gh api "repos/NOirBRight/CodexHub/issues/$Blocked/dependencies/blocked_by" `
@@ -1268,49 +1611,127 @@ function Assert-BlockedBy([int]$Blocked,[int]$Blocker) {
 }
 Assert-Parent 156 147
 Assert-Parent $localSearchIssue 156
+Assert-Parent $selectorBindingIssue 156
 Assert-Parent 64 57
 Assert-Parent 71 147
 Assert-Parent 73 147
 foreach ($n in 89,90,91,92,93,94) { Assert-Parent $n 71 }
 foreach ($n in 74,75,76,77,78) { Assert-Parent $n 73 }
 Assert-BlockedBy 156 $localSearchIssue
+Assert-BlockedBy 156 $selectorBindingIssue
 Assert-BlockedBy 64 156
 Assert-BlockedBy $uninstallIssue 111
+$children156 = @(gh api 'repos/NOirBRight/CodexHub/issues/156/sub_issues' | ConvertFrom-Json | ForEach-Object number | Sort-Object)
+$blocked156 = @(gh api 'repos/NOirBRight/CodexHub/issues/156/dependencies/blocked_by' | ConvertFrom-Json | ForEach-Object number | Sort-Object)
+$blocked64 = @(gh api 'repos/NOirBRight/CodexHub/issues/64/dependencies/blocked_by' | ConvertFrom-Json | ForEach-Object number | Sort-Object)
+$expectedLocal = @($localSearchIssue,$selectorBindingIssue | Sort-Object)
+if (($children156 -join ',') -cne ($expectedLocal -join ',')) { throw '#156 child set mismatch' }
+if (($blocked156 -join ',') -cne ($expectedLocal -join ',')) { throw '#156 dependency set mismatch' }
+if (($blocked64 -join ',') -cne '62,63,156') { throw '#64 dependency set mismatch' }
 'hierarchy-dependencies-ok'
 ```
 
 Expected: `hierarchy-dependencies-ok`.
 
-- [ ] **Step 5: Compute the unclaimed 0.1.6 ready frontier**
+- [ ] **Step 5: Prove hotset ownership eligibility and compute the unclaimed 0.1.6 ready frontier**
+
+First build the label/dependency candidate set with the following PowerShell. Then, for every candidate it prints, call native `codex_app__list_threads` twice: once with the exact Issue title and once with `Issue N`. Do not use SQLite. Save only `{issue,queries:[{query,threads,unavailableHosts}]}` to `$env:TEMP\codexhub-wayfinder-migration\frontier-task-evidence.json`; omit Task IDs and local paths. If the native Task tool is unavailable, any host is unavailable, or any matching Task exists, stop with `NEEDS_CONTEXT` rather than guessing.
 
 Run:
 
 ```powershell
 $gate = gh issue list --state open --limit 1000 `
   --milestone '0.1.6 — Codex control-plane reliability' `
-  --json number,title,labels,assignees,url | ConvertFrom-Json
+  --json number,title,body,labels,assignees,url | ConvertFrom-Json
 $readyByNumber = @{}
 foreach ($issue in $gate) {
   $labels = @($issue.labels.name)
-  $api = gh api "repos/NOirBRight/CodexHub/issues/$($issue.number)" | ConvertFrom-Json
-  if ('ready-for-agent' -in $labels -and
-      $issue.assignees.Count -eq 0 -and
-      $api.issue_dependencies_summary.blocked_by -eq 0) {
-    $readyByNumber[$issue.number] = [pscustomobject]@{number=$issue.number;title=$issue.title;url=$issue.url}
+  $blockers = @(gh api "repos/NOirBRight/CodexHub/issues/$($issue.number)/dependencies/blocked_by" | ConvertFrom-Json)
+  if ('ready-for-agent' -in $labels -and $issue.assignees.Count -eq 0 -and $blockers.Count -eq 0) {
+    $readyByNumber[$issue.number] = $issue
   }
 }
-$priorityOrder = @($localSearchIssue,139,149,150,111,141,138,151,143,112,156)
-$frontier = @($priorityOrder | Where-Object { $readyByNumber.ContainsKey($_) } | ForEach-Object { $readyByNumber[$_] })
-$frontier | Format-Table -AutoSize
+$priorityOrder = @($localSearchIssue,$selectorBindingIssue,139,149,150,111,141,138,151,143,112,156)
+$labelCandidates = @($priorityOrder | Where-Object { $readyByNumber.ContainsKey($_) } | ForEach-Object { $readyByNumber[$_] })
+$labelCandidates | Select-Object number,title | Format-Table -AutoSize
 ```
 
-Expected: a non-empty list containing the local bounded-search Issue and other unblocked 0.1.6 candidates such as #139/#149/#150/#111 if their live state has not changed. Do not assign any candidate.
+After the native queries are saved, run:
+
+```powershell
+$taskEvidenceFile = Join-Path $env:TEMP 'codexhub-wayfinder-migration/frontier-task-evidence.json'
+if (-not (Test-Path $taskEvidenceFile)) { throw 'NEEDS_CONTEXT: native Task evidence is missing' }
+$taskEvidence = @(Get-Content -Raw $taskEvidenceFile | ConvertFrom-Json)
+foreach ($candidate in $labelCandidates) {
+  $record = @($taskEvidence | Where-Object issue -eq $candidate.number)
+  if ($record.Count -ne 1 -or $record[0].queries.Count -ne 2) { throw "NEEDS_CONTEXT: incomplete Task evidence #$($candidate.number)" }
+  $expectedQueries = @($candidate.title,"Issue $($candidate.number)" | Sort-Object)
+  $actualQueries = @($record[0].queries.query | Sort-Object)
+  if (($actualQueries -join '|') -cne ($expectedQueries -join '|')) { throw "NEEDS_CONTEXT: wrong Task queries #$($candidate.number)" }
+  foreach ($query in $record[0].queries) {
+    if ($query.unavailableHosts.Count -ne 0) { throw "NEEDS_CONTEXT: native Task host unavailable #$($candidate.number)" }
+    if ($query.threads.Count -ne 0) { throw "active native Task owns #$($candidate.number)" }
+  }
+}
+
+$currentBranch = git branch --show-current
+$worktreeLines = @(git worktree list --porcelain)
+$worktreeBranches = @($worktreeLines | Where-Object { $_ -like 'branch refs/heads/*' } | ForEach-Object { $_.Substring(7) })
+$allowedWorktreeBranches = @('refs/heads/dev',"refs/heads/$currentBranch")
+$extraWorktrees = @($worktreeBranches | Where-Object { $_ -notin $allowedWorktreeBranches })
+if ($extraWorktrees.Count) { throw 'active product worktree requires hotset reconciliation' }
+
+$allBranches = @(git branch --all --format='%(refname:short)')
+$openPrs = @(gh pr list --state open --limit 100 --json number,title,headRefName,baseRefName,url | ConvertFrom-Json)
+foreach ($candidate in $labelCandidates) {
+  $branchPattern = "(?i)(issue[-_/]?$($candidate.number)(\D|$)|#$($candidate.number)(\D|$))"
+  if (@($allBranches | Where-Object { $_ -match $branchPattern }).Count) { throw "candidate branch owns #$($candidate.number)" }
+  if (@($openPrs | Where-Object { $_.headRefName -match $branchPattern -or $_.title -match "#$($candidate.number)(\D|$)" }).Count) { throw "open PR owns #$($candidate.number)" }
+  if ($candidate.assignees.Count -ne 0) { throw "assignee owns #$($candidate.number)" }
+  if (-not $candidate.body.Contains('## Expected hotset')) { throw "missing Expected hotset #$($candidate.number)" }
+}
+
+$ownershipEvidence = [ordered]@{
+  captured_at = (Get-Date).ToUniversalTime().ToString('o')
+  candidates = @($labelCandidates.number)
+  native_task_queries = @($taskEvidence | ForEach-Object { @{issue=$_.issue;queries=@($_.queries | ForEach-Object { @{query=$_.query;match_count=$_.threads.Count;unavailable_host_count=$_.unavailableHosts.Count} })} })
+  active_product_worktree_count = $extraWorktrees.Count
+  candidate_branch_count = 0
+  candidate_open_pr_count = 0
+  candidate_assignee_count = 0
+  hotset_preflight = 'Expected hotsets re-read; no native Task or active product worktree owns a candidate hotset.'
+}
+$ownershipEvidence | ConvertTo-Json -Depth 8 |
+  Set-Content -Encoding utf8 (Join-Path $env:TEMP 'codexhub-wayfinder-migration/frontier-ownership-evidence.json')
+$frontier = @($labelCandidates)
+$frontier | Select-Object number,title,url | Format-Table -AutoSize
+```
+
+Expected: sanitized native Task/worktree/branch/PR/assignee/hotset evidence proves no active ownership conflict. If live state remains unchanged, frontier order is `$localSearchIssue`, `$selectorBindingIssue`, #139, #149, #150, #111. Do not assign or dispatch any candidate.
 
 - [ ] **Step 6: Publish one migration checkpoint comment on #147**
 
 Run:
 
 ```powershell
+function Write-ExactIssueComment([int]$Issue,[string]$PurposePrefix,[string]$Body) {
+  $Body = ($Body -replace "`r`n","`n").TrimEnd()
+  $comments = @(gh api --paginate "repos/NOirBRight/CodexHub/issues/$Issue/comments?per_page=100" | ConvertFrom-Json)
+  $exact = @($comments | Where-Object body -CEQ $Body)
+  $purpose = @($comments | Where-Object { ([string]$_.body).StartsWith($PurposePrefix,[StringComparison]::Ordinal) })
+  if ($exact.Count -gt 1) { throw "multiple exact comments on #$Issue" }
+  if ($exact.Count -eq 1) {
+    if ($purpose.Count -ne 1) { throw "conflicting same-purpose comment on #$Issue" }
+  } else {
+    if ($purpose.Count -gt 0) { throw "conflicting same-purpose comment on #$Issue" }
+    gh issue comment $Issue --body $Body | Out-Null
+  }
+  $readback = @(gh api --paginate "repos/NOirBRight/CodexHub/issues/$Issue/comments?per_page=100" | ConvertFrom-Json)
+  $matches = @($readback | Where-Object body -CEQ $Body)
+  if ($matches.Count -ne 1) { throw "exact comment readback failed on #$Issue" }
+  $matches[0].html_url
+}
+
 $frontierText = (($frontier | ForEach-Object { "#$($_.number) $($_.title)" }) -join "`n- ")
 $comment = @"
 ## Reliability-gated Wayfinder migration readback
@@ -1319,7 +1740,7 @@ The approved roadmap migration is complete and read back:
 
 - five active reliability milestones exist with exact membership;
 - the legacy cross-version reliability milestone is closed as superseded;
-- #156 is the ready-for-human Visible Worker gate and #$localSearchIssue is its ready local bounded-search child;
+- #156 is the ready-for-human Host/runtime-only Visible Worker gate, #$localSearchIssue is its ready bounded-search child, and #$selectorBindingIssue is its ready selector/effective-binding validation child;
 - #64 is blocked by #156 for the full post-fix collaboration matrix;
 - #28 is narrowed to client discovery performance and #$uninstallIssue owns uninstall cleanup behind #111;
 - every open Issue has exactly one canonical lifecycle label;
@@ -1329,9 +1750,11 @@ Current unclaimed 0.1.6 ready frontier:
 
 - $frontierText
 
+Sanitized native Task/worktree/branch/PR/assignee/hotset preflight found no active ownership conflict at publication.
+
 Frontier order remains subject to native dependencies and hotset ownership. Map publication is not a claim.
 "@
-gh issue comment 147 --body $comment
+Write-ExactIssueComment 147 '## Reliability-gated Wayfinder migration readback' $comment
 ```
 
 Expected: one comment URL returned.
@@ -1343,14 +1766,27 @@ Run:
 ```powershell
 gh issue view 147 --comments `
   --json number,title,state,labels,assignees,body,comments,url
-gh pr list --state open --limit 100 `
-  --json number,title,headRefName,baseRefName,url
+$comments = @(gh api --paginate 'repos/NOirBRight/CodexHub/issues/147/comments?per_page=100' | ConvertFrom-Json)
+$expectedComment = ($comment -replace "`r`n","`n").TrimEnd()
+$prefixMatches = @($comments | Where-Object { ([string]$_.body).StartsWith('## Reliability-gated Wayfinder migration readback',[StringComparison]::Ordinal) })
+$exactMatches = @($comments | Where-Object body -CEQ $expectedComment)
+if ($prefixMatches.Count -ne 1 -or $exactMatches.Count -ne 1) { throw 'checkpoint multiplicity/body mismatch' }
+$prs = @(gh pr list --state open --limit 100 `
+  --json number,title,headRefName,baseRefName,url | ConvertFrom-Json)
+if (@($prs | Where-Object { $_.headRefName -match '(?i)wayfinder|issue[-_/]?(159|161|139|149|150|111)' }).Count) {
+  throw 'migration/candidate PR exists'
+}
+if (-not (Test-Path (Join-Path $env:TEMP 'codexhub-wayfinder-migration/frontier-ownership-evidence.json'))) {
+  throw 'frontier ownership evidence missing'
+}
 git status --short --branch
 ```
 
 Expected:
 
 - #147 is open, unassigned, and contains the migration checkpoint;
+- exactly one checkpoint prefix and exact body remain;
+- #159 and the selector/binding child are present in the exact frontier and ownership-evidence readback;
 - no migration-created product PR exists;
 - no product Issue was assigned by this plan;
 - repository working tree is clean.
@@ -1361,9 +1797,11 @@ Expected:
 
 Before execution handoff, verify this plan against the approved design:
 
-1. **Spec coverage:** Tasks 2–8 cover milestones, #156 decomposition, #28 split, all open-Issue routing, stale state, #147 rewrite, dependencies, readback, and frontier recomputation.
-2. **No placeholders:** Dynamic new Issue numbers are discovered by exact titles and stored in variables; no guessed number is embedded.
-3. **Type consistency:** `$localSearchIssue`, `$uninstallIssue`, milestone titles, parent relationships, and dependency direction are identical in every task.
+1. **Spec coverage:** Tasks 2–8 cover milestones, the full Host-only #156 rewrite, both CodexHub children, #28 split, all open-Issue routing, stale state, #147 rewrite, dependencies, readback, and ownership-backed frontier recomputation.
+2. **No placeholders:** Dynamic new Issue numbers are discovered by exact titles and stored in variables; open and closed selector/codec duplicates are checked before creation; no guessed number is embedded.
+3. **Type consistency:** `$localSearchIssue`, `$selectorBindingIssue`, `$uninstallIssue`, milestone titles, parent relationships, and dependency direction are identical in every task.
 4. **Scope:** The plan changes only GitHub planning state. Every product Issue receives its own later spec/plan/implementation cycle.
 5. **No hidden claim:** No command assigns an Issue, creates a product branch/worktree, starts a Worker, opens a production PR, or edits product code.
-6. **Review blockers resolved:** Task 1 safely fast-forwards only a clean stale planning branch with no unique commits, requires the design and plan in-tree, emits a read-only write-set preview, and stops for explicit authorization; Tasks 2–8 use Inline Execution only.
+6. **Retry safety:** Every Task 6/8 comment write uses the exact-body/same-purpose-prefix guard, reads back exactly one match, and returns its URL; hierarchy/dependency writes are idempotent and final assertions compare exact sets.
+7. **Ownership proof:** Task 8 requires sanitized native Task/worktree/branch/PR/assignee/hotset evidence and stops with `NEEDS_CONTEXT` when native Task evidence is unavailable; labels alone never establish frontier eligibility.
+8. **Review blockers resolved:** Task 1 safely fast-forwards only a clean stale planning branch with no unique commits, requires the design and plan in-tree, emits the full read-only write-set preview, and stops for explicit authorization; Tasks 2–8 use Inline Execution only.

--- a/docs/superpowers/reviews/wayfinder-checkpoint-update-v1.json
+++ b/docs/superpowers/reviews/wayfinder-checkpoint-update-v1.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": 1,
+  "captured_at": "2026-07-16T19:13:35.7585728Z",
+  "issue": 147,
+  "purpose_prefix": "## Reliability-gated Wayfinder migration readback",
+  "historical_original": {
+    "source": "Task 8 execution report exact original published body",
+    "normalized_body": "## Reliability-gated Wayfinder migration readback\n\nThe approved roadmap migration is complete and read back:\n\n- five active reliability milestones exist with exact membership;\n- the legacy cross-version reliability milestone is closed as superseded;\n- #156 is the ready-for-human Visible Worker gate and #159 is its ready local bounded-search child;\n- #64 is blocked by #156 for the full post-fix collaboration matrix;\n- #28 is narrowed to client discovery performance and #160 owns uninstall cleanup behind #111;\n- every open Issue has exactly one canonical lifecycle label;\n- no ticket was assigned or dispatched by the migration.\n\nCurrent unclaimed 0.1.6 ready frontier:\n\n- #159 Bound repeated empty tool_search misses for external models\n- #139 Serialize Gateway lifecycle operations and prevent duplicate startup processes\n- #149 Make Rust/Python atomic-file lock ownership and stale recovery safe\n- #150 Coalesce automatic OpenAI usage probes and avoid repeated Codex app-server cold starts\n- #111 Make Windows app autostart registration verifiable and reliable\n\nFrontier order remains subject to native dependencies and hotset ownership. Map publication is not a claim.",
+    "normalized_body_sha256": "0c09e6b7c4ba7abf432dc43b19860095094912a1b36b3d67c98e0c3870f40fb4"
+  },
+  "pre_update": {
+    "public_comment_id": 4994927680,
+    "normalized_body_sha256": "b6d4d1e9bc58fd013c4968eb2799990fb7afa579572ade93534ee657c35ad82b",
+    "readback_at": "2026-07-16T19:13:35.7634320Z"
+  },
+  "desired": {
+    "normalized_body": "## Reliability-gated Wayfinder migration readback\n\nThe approved roadmap migration is complete and read back:\n\n- five active reliability milestones exist with exact membership;\n- the legacy cross-version reliability milestone is closed as superseded;\n- #156 is the ready-for-human Host/runtime-only Visible Worker gate, #159 is its ready bounded-search child, and #161 is its ready selector/effective-binding validation child;\n- #64 is blocked by #156 for the full post-fix collaboration matrix;\n- #28 is narrowed to client discovery performance and #160 owns uninstall cleanup behind #111;\n- every open Issue has exactly one canonical lifecycle label;\n- no ticket was assigned or dispatched by the migration.\n\nCurrent unclaimed 0.1.6 ready frontier:\n\n- #159 Bound repeated empty tool_search misses for external models\n- #161 Preserve Worker selector and effective binding validation for external delegation\n- #139 Serialize Gateway lifecycle operations and prevent duplicate startup processes\n- #149 Make Rust/Python atomic-file lock ownership and stale recovery safe\n- #150 Coalesce automatic OpenAI usage probes and avoid repeated Codex app-server cold starts\n- #111 Make Windows app autostart registration verifiable and reliable\n\nSanitized native Task/worktree/branch/PR/assignee/hotset preflight found no active ownership conflict at publication.\n\nDurable frontier audit: docs/superpowers/reviews/wayfinder-frontier-ownership-audit-v1.json (SHA-256: `388da2e2f68b3e5c3e8ce5cc99cdfb1ba801941b19e864e3bbb22331c5b6356b`).\n\nFrontier order remains subject to native dependencies and hotset ownership. Map publication is not a claim.",
+    "normalized_body_sha256": "7adca5e559b4757cb13ed0d95b94d890bb07c3bbf096a6185e7685649d311227",
+    "frontier_artifact_path": "docs/superpowers/reviews/wayfinder-frontier-ownership-audit-v1.json",
+    "frontier_artifact_sha256": "388da2e2f68b3e5c3e8ce5cc99cdfb1ba801941b19e864e3bbb22331c5b6356b"
+  },
+  "operation_decision": "patch",
+  "post_readback": {
+    "public_comment_id": 4994927680,
+    "normalized_body_sha256": "7adca5e559b4757cb13ed0d95b94d890bb07c3bbf096a6185e7685649d311227",
+    "prefix_multiplicity": 1,
+    "exact_body_multiplicity": 1,
+    "readback_at": "2026-07-16T19:13:35.7639048Z"
+  }
+}

--- a/docs/superpowers/reviews/wayfinder-checkpoint-update-v1.json
+++ b/docs/superpowers/reviews/wayfinder-checkpoint-update-v1.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "captured_at": "2026-07-16T19:13:35.7585728Z",
+  "captured_at": "2026-07-16T19:46:23.9035374Z",
   "issue": 147,
   "purpose_prefix": "## Reliability-gated Wayfinder migration readback",
   "historical_original": {
@@ -10,21 +10,21 @@
   },
   "pre_update": {
     "public_comment_id": 4994927680,
-    "normalized_body_sha256": "b6d4d1e9bc58fd013c4968eb2799990fb7afa579572ade93534ee657c35ad82b",
-    "readback_at": "2026-07-16T19:13:35.7634320Z"
+    "normalized_body_sha256": "7adca5e559b4757cb13ed0d95b94d890bb07c3bbf096a6185e7685649d311227",
+    "readback_at": "2026-07-16T19:46:23.9088831Z"
   },
   "desired": {
-    "normalized_body": "## Reliability-gated Wayfinder migration readback\n\nThe approved roadmap migration is complete and read back:\n\n- five active reliability milestones exist with exact membership;\n- the legacy cross-version reliability milestone is closed as superseded;\n- #156 is the ready-for-human Host/runtime-only Visible Worker gate, #159 is its ready bounded-search child, and #161 is its ready selector/effective-binding validation child;\n- #64 is blocked by #156 for the full post-fix collaboration matrix;\n- #28 is narrowed to client discovery performance and #160 owns uninstall cleanup behind #111;\n- every open Issue has exactly one canonical lifecycle label;\n- no ticket was assigned or dispatched by the migration.\n\nCurrent unclaimed 0.1.6 ready frontier:\n\n- #159 Bound repeated empty tool_search misses for external models\n- #161 Preserve Worker selector and effective binding validation for external delegation\n- #139 Serialize Gateway lifecycle operations and prevent duplicate startup processes\n- #149 Make Rust/Python atomic-file lock ownership and stale recovery safe\n- #150 Coalesce automatic OpenAI usage probes and avoid repeated Codex app-server cold starts\n- #111 Make Windows app autostart registration verifiable and reliable\n\nSanitized native Task/worktree/branch/PR/assignee/hotset preflight found no active ownership conflict at publication.\n\nDurable frontier audit: docs/superpowers/reviews/wayfinder-frontier-ownership-audit-v1.json (SHA-256: `388da2e2f68b3e5c3e8ce5cc99cdfb1ba801941b19e864e3bbb22331c5b6356b`).\n\nFrontier order remains subject to native dependencies and hotset ownership. Map publication is not a claim.",
-    "normalized_body_sha256": "7adca5e559b4757cb13ed0d95b94d890bb07c3bbf096a6185e7685649d311227",
+    "normalized_body": "## Reliability-gated Wayfinder migration readback\n\nThe approved roadmap migration is complete and read back:\n\n- five active reliability milestones exist with exact membership;\n- the legacy cross-version reliability milestone is closed as superseded;\n- #156 is the ready-for-human Host/runtime-only Visible Worker gate, #159 is its ready bounded-search child, and #161 is its ready selector/effective-binding validation child;\n- #64 is blocked by #156 for the full post-fix collaboration matrix;\n- #28 is narrowed to client discovery performance and #160 owns uninstall cleanup behind #111;\n- every open Issue has exactly one canonical lifecycle label;\n- no ticket was assigned or dispatched by the migration.\n\nCurrent unclaimed 0.1.6 ready frontier:\n\n- #159 Bound repeated empty tool_search misses for external models\n- #161 Preserve Worker selector and effective binding validation for external delegation\n- #139 Serialize Gateway lifecycle operations and prevent duplicate startup processes\n- #149 Make Rust/Python atomic-file lock ownership and stale recovery safe\n- #150 Coalesce automatic OpenAI usage probes and avoid repeated Codex app-server cold starts\n- #111 Make Windows app autostart registration verifiable and reliable\n\nSanitized native Task/worktree/branch/PR/assignee/hotset preflight found no active ownership conflict at publication.\n\nDurable frontier audit: docs/superpowers/reviews/wayfinder-frontier-ownership-audit-v1.json (SHA-256: `bd42794dedd218a960ee8a938712210f9f3b496b61ce69c28637e417eb1d57cd`).\n\nFrontier order remains subject to native dependencies and hotset ownership. Map publication is not a claim.",
+    "normalized_body_sha256": "cc02ae51ee981e810d367e6473d8480d9d5cd4cf7ddd7f1d60acf8e655a7b2bb",
     "frontier_artifact_path": "docs/superpowers/reviews/wayfinder-frontier-ownership-audit-v1.json",
-    "frontier_artifact_sha256": "388da2e2f68b3e5c3e8ce5cc99cdfb1ba801941b19e864e3bbb22331c5b6356b"
+    "frontier_artifact_sha256": "bd42794dedd218a960ee8a938712210f9f3b496b61ce69c28637e417eb1d57cd"
   },
   "operation_decision": "patch",
   "post_readback": {
     "public_comment_id": 4994927680,
-    "normalized_body_sha256": "7adca5e559b4757cb13ed0d95b94d890bb07c3bbf096a6185e7685649d311227",
+    "normalized_body_sha256": "cc02ae51ee981e810d367e6473d8480d9d5cd4cf7ddd7f1d60acf8e655a7b2bb",
     "prefix_multiplicity": 1,
     "exact_body_multiplicity": 1,
-    "readback_at": "2026-07-16T19:13:35.7639048Z"
+    "readback_at": "2026-07-16T19:46:23.9091773Z"
   }
 }

--- a/docs/superpowers/reviews/wayfinder-checkpoint-update-v1.json
+++ b/docs/superpowers/reviews/wayfinder-checkpoint-update-v1.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "captured_at": "2026-07-16T19:46:23.9035374Z",
+  "captured_at": "2026-07-16T20:10:51.7868798Z",
   "issue": 147,
   "purpose_prefix": "## Reliability-gated Wayfinder migration readback",
   "historical_original": {
@@ -8,10 +8,47 @@
     "normalized_body": "## Reliability-gated Wayfinder migration readback\n\nThe approved roadmap migration is complete and read back:\n\n- five active reliability milestones exist with exact membership;\n- the legacy cross-version reliability milestone is closed as superseded;\n- #156 is the ready-for-human Visible Worker gate and #159 is its ready local bounded-search child;\n- #64 is blocked by #156 for the full post-fix collaboration matrix;\n- #28 is narrowed to client discovery performance and #160 owns uninstall cleanup behind #111;\n- every open Issue has exactly one canonical lifecycle label;\n- no ticket was assigned or dispatched by the migration.\n\nCurrent unclaimed 0.1.6 ready frontier:\n\n- #159 Bound repeated empty tool_search misses for external models\n- #139 Serialize Gateway lifecycle operations and prevent duplicate startup processes\n- #149 Make Rust/Python atomic-file lock ownership and stale recovery safe\n- #150 Coalesce automatic OpenAI usage probes and avoid repeated Codex app-server cold starts\n- #111 Make Windows app autostart registration verifiable and reliable\n\nFrontier order remains subject to native dependencies and hotset ownership. Map publication is not a claim.",
     "normalized_body_sha256": "0c09e6b7c4ba7abf432dc43b19860095094912a1b36b3d67c98e0c3870f40fb4"
   },
+  "historical_provenance": {
+    "proof_kind": "tracked-transcript",
+    "prior_transcript": {
+      "schema_version": 1,
+      "captured_at": "2026-07-16T19:46:23.9035374Z",
+      "issue": 147,
+      "purpose_prefix": "## Reliability-gated Wayfinder migration readback",
+      "historical_original": {
+        "source": "Task 8 execution report exact original published body",
+        "normalized_body": "## Reliability-gated Wayfinder migration readback\n\nThe approved roadmap migration is complete and read back:\n\n- five active reliability milestones exist with exact membership;\n- the legacy cross-version reliability milestone is closed as superseded;\n- #156 is the ready-for-human Visible Worker gate and #159 is its ready local bounded-search child;\n- #64 is blocked by #156 for the full post-fix collaboration matrix;\n- #28 is narrowed to client discovery performance and #160 owns uninstall cleanup behind #111;\n- every open Issue has exactly one canonical lifecycle label;\n- no ticket was assigned or dispatched by the migration.\n\nCurrent unclaimed 0.1.6 ready frontier:\n\n- #159 Bound repeated empty tool_search misses for external models\n- #139 Serialize Gateway lifecycle operations and prevent duplicate startup processes\n- #149 Make Rust/Python atomic-file lock ownership and stale recovery safe\n- #150 Coalesce automatic OpenAI usage probes and avoid repeated Codex app-server cold starts\n- #111 Make Windows app autostart registration verifiable and reliable\n\nFrontier order remains subject to native dependencies and hotset ownership. Map publication is not a claim.",
+        "normalized_body_sha256": "0c09e6b7c4ba7abf432dc43b19860095094912a1b36b3d67c98e0c3870f40fb4"
+      },
+      "pre_update": {
+        "public_comment_id": 4994927680,
+        "normalized_body_sha256": "7adca5e559b4757cb13ed0d95b94d890bb07c3bbf096a6185e7685649d311227",
+        "readback_at": "2026-07-16T19:46:23.9088831Z"
+      },
+      "desired": {
+        "normalized_body": "## Reliability-gated Wayfinder migration readback\n\nThe approved roadmap migration is complete and read back:\n\n- five active reliability milestones exist with exact membership;\n- the legacy cross-version reliability milestone is closed as superseded;\n- #156 is the ready-for-human Host/runtime-only Visible Worker gate, #159 is its ready bounded-search child, and #161 is its ready selector/effective-binding validation child;\n- #64 is blocked by #156 for the full post-fix collaboration matrix;\n- #28 is narrowed to client discovery performance and #160 owns uninstall cleanup behind #111;\n- every open Issue has exactly one canonical lifecycle label;\n- no ticket was assigned or dispatched by the migration.\n\nCurrent unclaimed 0.1.6 ready frontier:\n\n- #159 Bound repeated empty tool_search misses for external models\n- #161 Preserve Worker selector and effective binding validation for external delegation\n- #139 Serialize Gateway lifecycle operations and prevent duplicate startup processes\n- #149 Make Rust/Python atomic-file lock ownership and stale recovery safe\n- #150 Coalesce automatic OpenAI usage probes and avoid repeated Codex app-server cold starts\n- #111 Make Windows app autostart registration verifiable and reliable\n\nSanitized native Task/worktree/branch/PR/assignee/hotset preflight found no active ownership conflict at publication.\n\nDurable frontier audit: docs/superpowers/reviews/wayfinder-frontier-ownership-audit-v1.json (SHA-256: `bd42794dedd218a960ee8a938712210f9f3b496b61ce69c28637e417eb1d57cd`).\n\nFrontier order remains subject to native dependencies and hotset ownership. Map publication is not a claim.",
+        "normalized_body_sha256": "cc02ae51ee981e810d367e6473d8480d9d5cd4cf7ddd7f1d60acf8e655a7b2bb",
+        "frontier_artifact_path": "docs/superpowers/reviews/wayfinder-frontier-ownership-audit-v1.json",
+        "frontier_artifact_sha256": "bd42794dedd218a960ee8a938712210f9f3b496b61ce69c28637e417eb1d57cd"
+      },
+      "operation_decision": "patch",
+      "post_readback": {
+        "public_comment_id": 4994927680,
+        "normalized_body_sha256": "cc02ae51ee981e810d367e6473d8480d9d5cd4cf7ddd7f1d60acf8e655a7b2bb",
+        "prefix_multiplicity": 1,
+        "exact_body_multiplicity": 1,
+        "readback_at": "2026-07-16T19:46:23.9091773Z"
+      },
+      "historical_provenance": {
+        "proof_kind": "task8-execution-report",
+        "prior_transcript": null
+      }
+    }
+  },
   "pre_update": {
     "public_comment_id": 4994927680,
-    "normalized_body_sha256": "7adca5e559b4757cb13ed0d95b94d890bb07c3bbf096a6185e7685649d311227",
-    "readback_at": "2026-07-16T19:46:23.9088831Z"
+    "normalized_body_sha256": "cc02ae51ee981e810d367e6473d8480d9d5cd4cf7ddd7f1d60acf8e655a7b2bb",
+    "readback_at": "2026-07-16T20:10:50.9689816Z"
   },
   "desired": {
     "normalized_body": "## Reliability-gated Wayfinder migration readback\n\nThe approved roadmap migration is complete and read back:\n\n- five active reliability milestones exist with exact membership;\n- the legacy cross-version reliability milestone is closed as superseded;\n- #156 is the ready-for-human Host/runtime-only Visible Worker gate, #159 is its ready bounded-search child, and #161 is its ready selector/effective-binding validation child;\n- #64 is blocked by #156 for the full post-fix collaboration matrix;\n- #28 is narrowed to client discovery performance and #160 owns uninstall cleanup behind #111;\n- every open Issue has exactly one canonical lifecycle label;\n- no ticket was assigned or dispatched by the migration.\n\nCurrent unclaimed 0.1.6 ready frontier:\n\n- #159 Bound repeated empty tool_search misses for external models\n- #161 Preserve Worker selector and effective binding validation for external delegation\n- #139 Serialize Gateway lifecycle operations and prevent duplicate startup processes\n- #149 Make Rust/Python atomic-file lock ownership and stale recovery safe\n- #150 Coalesce automatic OpenAI usage probes and avoid repeated Codex app-server cold starts\n- #111 Make Windows app autostart registration verifiable and reliable\n\nSanitized native Task/worktree/branch/PR/assignee/hotset preflight found no active ownership conflict at publication.\n\nDurable frontier audit: docs/superpowers/reviews/wayfinder-frontier-ownership-audit-v1.json (SHA-256: `bd42794dedd218a960ee8a938712210f9f3b496b61ce69c28637e417eb1d57cd`).\n\nFrontier order remains subject to native dependencies and hotset ownership. Map publication is not a claim.",
@@ -19,12 +56,12 @@
     "frontier_artifact_path": "docs/superpowers/reviews/wayfinder-frontier-ownership-audit-v1.json",
     "frontier_artifact_sha256": "bd42794dedd218a960ee8a938712210f9f3b496b61ce69c28637e417eb1d57cd"
   },
-  "operation_decision": "patch",
+  "operation_decision": "exact-no-op",
   "post_readback": {
     "public_comment_id": 4994927680,
     "normalized_body_sha256": "cc02ae51ee981e810d367e6473d8480d9d5cd4cf7ddd7f1d60acf8e655a7b2bb",
     "prefix_multiplicity": 1,
     "exact_body_multiplicity": 1,
-    "readback_at": "2026-07-16T19:46:23.9091773Z"
+    "readback_at": "2026-07-16T20:10:51.7469770Z"
   }
 }

--- a/docs/superpowers/reviews/wayfinder-final-audit-v1.json
+++ b/docs/superpowers/reviews/wayfinder-final-audit-v1.json
@@ -1,0 +1,1493 @@
+{
+  "schema_version": 1,
+  "artifact_kind": "wayfinder-final-migration-audit",
+  "captured_at": "2026-07-16T19:13:41.822373Z",
+  "repository": "NOirBRight/CodexHub",
+  "generator": "scripts/generate_wayfinder_final_audit.py",
+  "frontier_artifact": {
+    "repository_relative_path": "docs/superpowers/reviews/wayfinder-frontier-ownership-audit-v1.json",
+    "sha256": "388da2e2f68b3e5c3e8ce5cc99cdfb1ba801941b19e864e3bbb22331c5b6356b",
+    "embedded": {
+      "schema_version": 1,
+      "artifact_kind": "wayfinder-frontier-ownership-audit",
+      "captured_at": "2026-07-16T19:10:29.752972Z",
+      "repository": "NOirBRight/CodexHub",
+      "generator": "scripts/generate_wayfinder_final_audit.py",
+      "base_ref": "dev",
+      "base_revision": "51a636c98ca90a9766836a7d603c2013211bbeeb",
+      "planning_branch": "wayfinder-github-migration",
+      "planning_revision": "bd2b44034c92cf60a4e5ac598300ef6817a0e02d",
+      "native_task_capture": {
+        "tool": "codex_app__list_threads",
+        "source_capture_file_sha256": "8d8a637e13cae1e791b79525b431c6006cbaf015b4bb1ac88f797692939d9ed5",
+        "source_capture_canonical_json_sha256": "43e40d8eb70cb8e21face20ab7a1d18b30b2a4f3903c783f87387ec6a263aa6e",
+        "captured_at": "2026-07-16T18:53:36.947Z",
+        "limit": 50,
+        "records": [
+          {
+            "issue": 159,
+            "issue_title": "Bound repeated empty tool_search misses for external models",
+            "kind": "exact_title",
+            "query": "Bound repeated empty tool_search misses for external models",
+            "captured_at": "2026-07-16T18:53:36.947Z",
+            "schema_version": 2,
+            "unavailable_hosts": [],
+            "unavailable_host_count": 0,
+            "match_count": 0
+          },
+          {
+            "issue": 159,
+            "issue_title": "Bound repeated empty tool_search misses for external models",
+            "kind": "issue_number",
+            "query": "Issue 159",
+            "captured_at": "2026-07-16T18:53:36.947Z",
+            "schema_version": 2,
+            "unavailable_hosts": [],
+            "unavailable_host_count": 0,
+            "match_count": 0
+          },
+          {
+            "issue": 161,
+            "issue_title": "Preserve Worker selector and effective binding validation for external delegation",
+            "kind": "exact_title",
+            "query": "Preserve Worker selector and effective binding validation for external delegation",
+            "captured_at": "2026-07-16T18:53:36.947Z",
+            "schema_version": 2,
+            "unavailable_hosts": [],
+            "unavailable_host_count": 0,
+            "match_count": 0
+          },
+          {
+            "issue": 161,
+            "issue_title": "Preserve Worker selector and effective binding validation for external delegation",
+            "kind": "issue_number",
+            "query": "Issue 161",
+            "captured_at": "2026-07-16T18:53:36.947Z",
+            "schema_version": 2,
+            "unavailable_hosts": [],
+            "unavailable_host_count": 0,
+            "match_count": 0
+          },
+          {
+            "issue": 139,
+            "issue_title": "Serialize Gateway lifecycle operations and prevent duplicate startup processes",
+            "kind": "exact_title",
+            "query": "Serialize Gateway lifecycle operations and prevent duplicate startup processes",
+            "captured_at": "2026-07-16T18:53:36.947Z",
+            "schema_version": 2,
+            "unavailable_hosts": [],
+            "unavailable_host_count": 0,
+            "match_count": 0
+          },
+          {
+            "issue": 139,
+            "issue_title": "Serialize Gateway lifecycle operations and prevent duplicate startup processes",
+            "kind": "issue_number",
+            "query": "Issue 139",
+            "captured_at": "2026-07-16T18:53:36.947Z",
+            "schema_version": 2,
+            "unavailable_hosts": [],
+            "unavailable_host_count": 0,
+            "match_count": 0
+          },
+          {
+            "issue": 149,
+            "issue_title": "Make Rust/Python atomic-file lock ownership and stale recovery safe",
+            "kind": "exact_title",
+            "query": "Make Rust/Python atomic-file lock ownership and stale recovery safe",
+            "captured_at": "2026-07-16T18:53:36.947Z",
+            "schema_version": 2,
+            "unavailable_hosts": [],
+            "unavailable_host_count": 0,
+            "match_count": 0
+          },
+          {
+            "issue": 149,
+            "issue_title": "Make Rust/Python atomic-file lock ownership and stale recovery safe",
+            "kind": "issue_number",
+            "query": "Issue 149",
+            "captured_at": "2026-07-16T18:53:36.947Z",
+            "schema_version": 2,
+            "unavailable_hosts": [],
+            "unavailable_host_count": 0,
+            "match_count": 0
+          },
+          {
+            "issue": 150,
+            "issue_title": "Coalesce automatic OpenAI usage probes and avoid repeated Codex app-server cold starts",
+            "kind": "exact_title",
+            "query": "Coalesce automatic OpenAI usage probes and avoid repeated Codex app-server cold starts",
+            "captured_at": "2026-07-16T18:53:36.947Z",
+            "schema_version": 2,
+            "unavailable_hosts": [],
+            "unavailable_host_count": 0,
+            "match_count": 0
+          },
+          {
+            "issue": 150,
+            "issue_title": "Coalesce automatic OpenAI usage probes and avoid repeated Codex app-server cold starts",
+            "kind": "issue_number",
+            "query": "Issue 150",
+            "captured_at": "2026-07-16T18:53:36.947Z",
+            "schema_version": 2,
+            "unavailable_hosts": [],
+            "unavailable_host_count": 0,
+            "match_count": 0
+          },
+          {
+            "issue": 111,
+            "issue_title": "Make Windows app autostart registration verifiable and reliable",
+            "kind": "exact_title",
+            "query": "Make Windows app autostart registration verifiable and reliable",
+            "captured_at": "2026-07-16T18:53:36.947Z",
+            "schema_version": 2,
+            "unavailable_hosts": [],
+            "unavailable_host_count": 0,
+            "match_count": 0
+          },
+          {
+            "issue": 111,
+            "issue_title": "Make Windows app autostart registration verifiable and reliable",
+            "kind": "issue_number",
+            "query": "Issue 111",
+            "captured_at": "2026-07-16T18:53:36.947Z",
+            "schema_version": 2,
+            "unavailable_hosts": [],
+            "unavailable_host_count": 0,
+            "match_count": 0
+          }
+        ]
+      },
+      "candidates": [
+        {
+          "number": 159,
+          "title": "Bound repeated empty tool_search misses for external models",
+          "state": "open",
+          "body_normalized_sha256": "dc9f36f3c8c8dcbdc79696205528f1743d56885216d41f821bc59c486d8bc78e",
+          "labels": [
+            "bug",
+            "ready-for-agent",
+            "wayfinder:task"
+          ],
+          "assignees": [],
+          "milestone": "0.1.6 — Codex control-plane reliability",
+          "parent": 156,
+          "blocked_by": [],
+          "children": [],
+          "url": "https://github.com/NOirBRight/CodexHub/issues/159",
+          "expected_hotset": {
+            "entries": [
+              {
+                "raw": "- `src-python/codex_proxy.py`",
+                "normalized": "src-python/codex_proxy.py",
+                "path_matchers": [
+                  "src-python/codex_proxy.py"
+                ]
+              },
+              {
+                "raw": "- `src-python/codex_semantic_adapter.py`",
+                "normalized": "src-python/codex_semantic_adapter.py",
+                "path_matchers": [
+                  "src-python/codex_semantic_adapter.py"
+                ]
+              },
+              {
+                "raw": "- `tests/test_routing.py`",
+                "normalized": "tests/test_routing.py",
+                "path_matchers": [
+                  "tests/test_routing.py"
+                ]
+              },
+              {
+                "raw": "- `tests/test_codex_semantic_adapter.py`",
+                "normalized": "tests/test_codex_semantic_adapter.py",
+                "path_matchers": [
+                  "tests/test_codex_semantic_adapter.py"
+                ]
+              },
+              {
+                "raw": "- one sanitized fixture under `tests/fixtures/` if the deterministic replay needs it",
+                "normalized": "one sanitized fixture under tests/fixtures/ if the deterministic replay needs it",
+                "path_matchers": [
+                  "tests/fixtures/**"
+                ]
+              }
+            ],
+            "matchers": [
+              "src-python/codex_proxy.py",
+              "src-python/codex_semantic_adapter.py",
+              "tests/fixtures/**",
+              "tests/test_codex_semantic_adapter.py",
+              "tests/test_routing.py"
+            ]
+          },
+          "eligibility": {
+            "label_dependency": {
+              "open": true,
+              "ready_for_agent": true,
+              "unassigned": true,
+              "open_blockers": [],
+              "eligible": true,
+              "ineligible_reasons": []
+            },
+            "ownership_hotset": {
+              "native_task_query_count": 2,
+              "native_task_matches": 0,
+              "native_task_unavailable_hosts": 0,
+              "assignees": [],
+              "active_surface_intersections": [],
+              "eligible": true,
+              "ineligible_reasons": []
+            }
+          }
+        },
+        {
+          "number": 161,
+          "title": "Preserve Worker selector and effective binding validation for external delegation",
+          "state": "open",
+          "body_normalized_sha256": "944ad1757538846011da360b880c53889c2aaa68d021cb3634caf1221c88e4f3",
+          "labels": [
+            "bug",
+            "ready-for-agent",
+            "wayfinder:task"
+          ],
+          "assignees": [],
+          "milestone": "0.1.6 — Codex control-plane reliability",
+          "parent": 156,
+          "blocked_by": [],
+          "children": [],
+          "url": "https://github.com/NOirBRight/CodexHub/issues/161",
+          "expected_hotset": {
+            "entries": [
+              {
+                "raw": "- `src-python/codex_semantic_adapter.py`",
+                "normalized": "src-python/codex_semantic_adapter.py",
+                "path_matchers": [
+                  "src-python/codex_semantic_adapter.py"
+                ]
+              },
+              {
+                "raw": "- `src-python/codex_proxy.py` only where the selector/effective-binding result crosses the adapter boundary",
+                "normalized": "src-python/codex_proxy.py only where the selector/effective-binding result crosses the adapter boundary",
+                "path_matchers": [
+                  "src-python/codex_proxy.py"
+                ]
+              },
+              {
+                "raw": "- `tests/test_codex_semantic_adapter.py`",
+                "normalized": "tests/test_codex_semantic_adapter.py",
+                "path_matchers": [
+                  "tests/test_codex_semantic_adapter.py"
+                ]
+              },
+              {
+                "raw": "- focused routing tests for `agent_type`/binding",
+                "normalized": "focused routing tests for agent_type/binding",
+                "path_matchers": [
+                  "tests/test_routing.py"
+                ]
+              },
+              {
+                "raw": "- one focused sanitized fixture under `tests/fixtures/` if required",
+                "normalized": "one focused sanitized fixture under tests/fixtures/ if required",
+                "path_matchers": [
+                  "tests/fixtures/**"
+                ]
+              }
+            ],
+            "matchers": [
+              "src-python/codex_proxy.py",
+              "src-python/codex_semantic_adapter.py",
+              "tests/fixtures/**",
+              "tests/test_codex_semantic_adapter.py",
+              "tests/test_routing.py"
+            ]
+          },
+          "eligibility": {
+            "label_dependency": {
+              "open": true,
+              "ready_for_agent": true,
+              "unassigned": true,
+              "open_blockers": [],
+              "eligible": true,
+              "ineligible_reasons": []
+            },
+            "ownership_hotset": {
+              "native_task_query_count": 2,
+              "native_task_matches": 0,
+              "native_task_unavailable_hosts": 0,
+              "assignees": [],
+              "active_surface_intersections": [],
+              "eligible": true,
+              "ineligible_reasons": []
+            }
+          }
+        },
+        {
+          "number": 139,
+          "title": "Serialize Gateway lifecycle operations and prevent duplicate startup processes",
+          "state": "open",
+          "body_normalized_sha256": "07ed44014139aafc869b96e38c4dd0c64e93bfbda0363a374c226608075c96e9",
+          "labels": [
+            "bug",
+            "ready-for-agent",
+            "wayfinder:task"
+          ],
+          "assignees": [],
+          "milestone": "0.1.6 — Codex control-plane reliability",
+          "parent": 147,
+          "blocked_by": [],
+          "children": [],
+          "url": "https://github.com/NOirBRight/CodexHub/issues/139",
+          "expected_hotset": {
+            "entries": [
+              {
+                "raw": "- src-tauri/src/proxy.rs",
+                "normalized": "src-tauri/src/proxy.rs",
+                "path_matchers": [
+                  "src-tauri/src/proxy.rs"
+                ]
+              },
+              {
+                "raw": "- src-tauri/src/main.rs",
+                "normalized": "src-tauri/src/main.rs",
+                "path_matchers": [
+                  "src-tauri/src/main.rs"
+                ]
+              },
+              {
+                "raw": "- Rust lifecycle coordinator/state tests adjacent to those modules",
+                "normalized": "Rust lifecycle coordinator/state tests adjacent to those modules",
+                "path_matchers": [
+                  "src-tauri/src/**"
+                ]
+              },
+              {
+                "raw": "- Gateway status/control frontend only if needed for Starting/Stopping/Restarting state",
+                "normalized": "Gateway status/control frontend only if needed for Starting/Stopping/Restarting state",
+                "path_matchers": [
+                  "frontend/**"
+                ]
+              }
+            ],
+            "matchers": [
+              "frontend/**",
+              "src-tauri/src/**",
+              "src-tauri/src/main.rs",
+              "src-tauri/src/proxy.rs"
+            ]
+          },
+          "eligibility": {
+            "label_dependency": {
+              "open": true,
+              "ready_for_agent": true,
+              "unassigned": true,
+              "open_blockers": [],
+              "eligible": true,
+              "ineligible_reasons": []
+            },
+            "ownership_hotset": {
+              "native_task_query_count": 2,
+              "native_task_matches": 0,
+              "native_task_unavailable_hosts": 0,
+              "assignees": [],
+              "active_surface_intersections": [],
+              "eligible": true,
+              "ineligible_reasons": []
+            }
+          }
+        },
+        {
+          "number": 149,
+          "title": "Make Rust/Python atomic-file lock ownership and stale recovery safe",
+          "state": "open",
+          "body_normalized_sha256": "167d2242ab99b846f86e6122f13d4ac3b25047506f153f56cdb05fd5b3b01db5",
+          "labels": [
+            "bug",
+            "ready-for-agent",
+            "wayfinder:task"
+          ],
+          "assignees": [],
+          "milestone": "0.1.6 — Codex control-plane reliability",
+          "parent": 147,
+          "blocked_by": [],
+          "children": [],
+          "url": "https://github.com/NOirBRight/CodexHub/issues/149",
+          "expected_hotset": {
+            "entries": [
+              {
+                "raw": "- src-python/atomic_io.py",
+                "normalized": "src-python/atomic_io.py",
+                "path_matchers": [
+                  "src-python/atomic_io.py"
+                ]
+              },
+              {
+                "raw": "- src-tauri/src/safe_file.rs",
+                "normalized": "src-tauri/src/safe_file.rs",
+                "path_matchers": [
+                  "src-tauri/src/safe_file.rs"
+                ]
+              },
+              {
+                "raw": "- tests/test_atomic_io.py",
+                "normalized": "tests/test_atomic_io.py",
+                "path_matchers": [
+                  "tests/test_atomic_io.py"
+                ]
+              },
+              {
+                "raw": "- Focused cross-language subprocess fixtures/tests",
+                "normalized": "Focused cross-language subprocess fixtures/tests",
+                "path_matchers": [
+                  "src-tauri/**",
+                  "tests/**"
+                ]
+              },
+              {
+                "raw": "- Only directly affected atomic-write callers whose error handling must stop swallowing non-absence failures",
+                "normalized": "Only directly affected atomic-write callers whose error handling must stop swallowing non-absence failures",
+                "path_matchers": [
+                  "src-python/**",
+                  "src-tauri/src/**"
+                ]
+              }
+            ],
+            "matchers": [
+              "src-python/**",
+              "src-python/atomic_io.py",
+              "src-tauri/**",
+              "src-tauri/src/**",
+              "src-tauri/src/safe_file.rs",
+              "tests/**",
+              "tests/test_atomic_io.py"
+            ]
+          },
+          "eligibility": {
+            "label_dependency": {
+              "open": true,
+              "ready_for_agent": true,
+              "unassigned": true,
+              "open_blockers": [],
+              "eligible": true,
+              "ineligible_reasons": []
+            },
+            "ownership_hotset": {
+              "native_task_query_count": 2,
+              "native_task_matches": 0,
+              "native_task_unavailable_hosts": 0,
+              "assignees": [],
+              "active_surface_intersections": [],
+              "eligible": true,
+              "ineligible_reasons": []
+            }
+          }
+        },
+        {
+          "number": 150,
+          "title": "Coalesce automatic OpenAI usage probes and avoid repeated Codex app-server cold starts",
+          "state": "open",
+          "body_normalized_sha256": "e7dbdf0e3de5cca7e59fdec83eec20cbbd22cca7382501232e575131826513ad",
+          "labels": [
+            "bug",
+            "ready-for-agent",
+            "wayfinder:task"
+          ],
+          "assignees": [],
+          "milestone": "0.1.6 — Codex control-plane reliability",
+          "parent": 147,
+          "blocked_by": [],
+          "children": [],
+          "url": "https://github.com/NOirBRight/CodexHub/issues/150",
+          "expected_hotset": {
+            "entries": [
+              {
+                "raw": "- frontend/src/pages/ProvidersPage.tsx",
+                "normalized": "frontend/src/pages/ProvidersPage.tsx",
+                "path_matchers": [
+                  "frontend/src/pages/ProvidersPage.tsx"
+                ]
+              },
+              {
+                "raw": "- frontend/src/components/providers/OfficialOpenAIUsagePanel.tsx",
+                "normalized": "frontend/src/components/providers/OfficialOpenAIUsagePanel.tsx",
+                "path_matchers": [
+                  "frontend/src/components/providers/OfficialOpenAIUsagePanel.tsx"
+                ]
+              },
+              {
+                "raw": "- src-tauri/src/openai_usage.rs",
+                "normalized": "src-tauri/src/openai_usage.rs",
+                "path_matchers": [
+                  "src-tauri/src/openai_usage.rs"
+                ]
+              },
+              {
+                "raw": "- frontend/scripts/ui-contract.test.mjs",
+                "normalized": "frontend/scripts/ui-contract.test.mjs",
+                "path_matchers": [
+                  "frontend/scripts/ui-contract.test.mjs"
+                ]
+              },
+              {
+                "raw": "- focused Rust tests adjacent to openai_usage",
+                "normalized": "focused Rust tests adjacent to openai_usage",
+                "path_matchers": [
+                  "src-tauri/src/openai_usage.rs"
+                ]
+              }
+            ],
+            "matchers": [
+              "frontend/scripts/ui-contract.test.mjs",
+              "frontend/src/components/providers/OfficialOpenAIUsagePanel.tsx",
+              "frontend/src/pages/ProvidersPage.tsx",
+              "src-tauri/src/openai_usage.rs"
+            ]
+          },
+          "eligibility": {
+            "label_dependency": {
+              "open": true,
+              "ready_for_agent": true,
+              "unassigned": true,
+              "open_blockers": [],
+              "eligible": true,
+              "ineligible_reasons": []
+            },
+            "ownership_hotset": {
+              "native_task_query_count": 2,
+              "native_task_matches": 0,
+              "native_task_unavailable_hosts": 0,
+              "assignees": [],
+              "active_surface_intersections": [],
+              "eligible": true,
+              "ineligible_reasons": []
+            }
+          }
+        },
+        {
+          "number": 111,
+          "title": "Make Windows app autostart registration verifiable and reliable",
+          "state": "open",
+          "body_normalized_sha256": "ef55ac12e419ddc72949e2c2975899e2d70f1f364f283d3b28b3911d18ad0c05",
+          "labels": [
+            "bug",
+            "ready-for-agent",
+            "wayfinder:task"
+          ],
+          "assignees": [],
+          "milestone": "0.1.6 — Codex control-plane reliability",
+          "parent": 147,
+          "blocked_by": [],
+          "children": [],
+          "url": "https://github.com/NOirBRight/CodexHub/issues/111",
+          "expected_hotset": {
+            "entries": [
+              {
+                "raw": "- `src-tauri/src/autostart.rs`",
+                "normalized": "src-tauri/src/autostart.rs",
+                "path_matchers": [
+                  "src-tauri/src/autostart.rs"
+                ]
+              },
+              {
+                "raw": "- Tauri settings/autostart command and state types",
+                "normalized": "Tauri settings/autostart command and state types",
+                "path_matchers": [
+                  "src-tauri/src/**"
+                ]
+              },
+              {
+                "raw": "- `frontend/src/App.tsx`",
+                "normalized": "frontend/src/App.tsx",
+                "path_matchers": [
+                  "frontend/src/App.tsx"
+                ]
+              },
+              {
+                "raw": "- `frontend/src/pages/SettingsPage.tsx` and/or the settings drawer",
+                "normalized": "frontend/src/pages/SettingsPage.tsx and/or the settings drawer",
+                "path_matchers": [
+                  "frontend/src/components/**/Settings*",
+                  "frontend/src/pages/SettingsPage.tsx"
+                ]
+              },
+              {
+                "raw": "- Rust autostart tests and frontend UI-contract tests",
+                "normalized": "Rust autostart tests and frontend UI-contract tests",
+                "path_matchers": [
+                  "frontend/scripts/**",
+                  "src-tauri/src/**"
+                ]
+              },
+              {
+                "raw": "- A deterministic Windows packaged/portable smoke harness or documented verification",
+                "normalized": "A deterministic Windows packaged/portable smoke harness or documented verification",
+                "path_matchers": [
+                  "docs/**/autostart*",
+                  "docs/*autostart*",
+                  "scripts/**/autostart*",
+                  "scripts/*autostart*"
+                ]
+              }
+            ],
+            "matchers": [
+              "docs/**/autostart*",
+              "docs/*autostart*",
+              "frontend/scripts/**",
+              "frontend/src/App.tsx",
+              "frontend/src/components/**/Settings*",
+              "frontend/src/pages/SettingsPage.tsx",
+              "scripts/**/autostart*",
+              "scripts/*autostart*",
+              "src-tauri/src/**",
+              "src-tauri/src/autostart.rs"
+            ]
+          },
+          "eligibility": {
+            "label_dependency": {
+              "open": true,
+              "ready_for_agent": true,
+              "unassigned": true,
+              "open_blockers": [],
+              "eligible": true,
+              "ineligible_reasons": []
+            },
+            "ownership_hotset": {
+              "native_task_query_count": 2,
+              "native_task_matches": 0,
+              "native_task_unavailable_hosts": 0,
+              "assignees": [],
+              "active_surface_intersections": [],
+              "eligible": true,
+              "ineligible_reasons": []
+            }
+          }
+        }
+      ],
+      "ownership_surfaces": {
+        "worktrees": [
+          {
+            "logical_identity": "worktree:dev",
+            "branch": "dev",
+            "revision": "51a636c98ca90a9766836a7d603c2013211bbeeb",
+            "clean": true,
+            "dirty_files": [],
+            "changed_files_vs_dev": [],
+            "hotset_intersections": {
+              "159": [],
+              "161": [],
+              "139": [],
+              "149": [],
+              "150": [],
+              "111": []
+            },
+            "classification": "audited-baseline",
+            "active": true
+          },
+          {
+            "logical_identity": "worktree:wayfinder-github-migration",
+            "branch": "wayfinder-github-migration",
+            "revision": "bd2b44034c92cf60a4e5ac598300ef6817a0e02d",
+            "clean": false,
+            "dirty_files": [
+              "docs/superpowers/plans/2026-07-16-wayfinder-github-migration.md",
+              "docs/superpowers/specs/2026-07-16-wayfinder-replanning-design.md",
+              "scripts/generate_wayfinder_final_audit.py"
+            ],
+            "changed_files_vs_dev": [
+              "docs/superpowers/plans/2026-07-16-wayfinder-github-migration.md",
+              "docs/superpowers/reviews/wayfinder-checkpoint-update-v1.json",
+              "docs/superpowers/reviews/wayfinder-final-audit-v1.json",
+              "docs/superpowers/reviews/wayfinder-frontier-ownership-audit-v1.json",
+              "docs/superpowers/specs/2026-07-16-wayfinder-replanning-design.md",
+              "scripts/generate_wayfinder_final_audit.py"
+            ],
+            "hotset_intersections": {
+              "159": [],
+              "161": [],
+              "139": [],
+              "149": [],
+              "150": [],
+              "111": []
+            },
+            "classification": "migration-control",
+            "active": true
+          }
+        ],
+        "local_branches": [
+          {
+            "logical_identity": "local-branch:dev",
+            "name": "dev",
+            "revision": "51a636c98ca90a9766836a7d603c2013211bbeeb",
+            "changed_files_vs_dev": [],
+            "hotset_intersections": {
+              "159": [],
+              "161": [],
+              "139": [],
+              "149": [],
+              "150": [],
+              "111": []
+            },
+            "checked_out_in_worktree": true,
+            "open_prs": [],
+            "active": true
+          },
+          {
+            "logical_identity": "local-branch:main",
+            "name": "main",
+            "revision": "ddcbbee77d3faaac3e5f282d2741e8f268f20e79",
+            "changed_files_vs_dev": [],
+            "hotset_intersections": {
+              "159": [],
+              "161": [],
+              "139": [],
+              "149": [],
+              "150": [],
+              "111": []
+            },
+            "checked_out_in_worktree": false,
+            "open_prs": [],
+            "active": false
+          },
+          {
+            "logical_identity": "local-branch:milestone-roadmap-m0-completion",
+            "name": "milestone-roadmap-m0-completion",
+            "revision": "1d0738611acc1f59402c60ad84a81728add5cee4",
+            "changed_files_vs_dev": [],
+            "hotset_intersections": {
+              "159": [],
+              "161": [],
+              "139": [],
+              "149": [],
+              "150": [],
+              "111": []
+            },
+            "checked_out_in_worktree": false,
+            "open_prs": [],
+            "active": false
+          },
+          {
+            "logical_identity": "local-branch:wayfinder-github-migration",
+            "name": "wayfinder-github-migration",
+            "revision": "bd2b44034c92cf60a4e5ac598300ef6817a0e02d",
+            "changed_files_vs_dev": [
+              "docs/superpowers/plans/2026-07-16-wayfinder-github-migration.md",
+              "docs/superpowers/specs/2026-07-16-wayfinder-replanning-design.md"
+            ],
+            "hotset_intersections": {
+              "159": [],
+              "161": [],
+              "139": [],
+              "149": [],
+              "150": [],
+              "111": []
+            },
+            "checked_out_in_worktree": true,
+            "open_prs": [],
+            "active": true
+          }
+        ],
+        "open_pr_heads": []
+      },
+      "frontier": [
+        159,
+        161,
+        139,
+        149,
+        150,
+        111
+      ],
+      "global_github_audit": {
+        "open_issue_count": 63,
+        "canonical_lifecycle_violations": [],
+        "milestone_membership_expected": {
+          "0.1.6 — Codex control-plane reliability": [
+            111,
+            112,
+            138,
+            139,
+            141,
+            143,
+            149,
+            150,
+            151,
+            156,
+            159,
+            161
+          ],
+          "0.1.7 — Official GPT reliability": [
+            18,
+            19,
+            20,
+            21,
+            104,
+            109,
+            114,
+            157
+          ],
+          "0.1.8 — Third-party model certification": [
+            17,
+            22,
+            57,
+            58,
+            59,
+            61,
+            62,
+            63,
+            64,
+            65,
+            66,
+            67
+          ],
+          "0.1.9 — Managed client reliability": [
+            8,
+            28,
+            83,
+            153,
+            154,
+            155
+          ],
+          "0.1.10 — Existing product reliability": [
+            86,
+            87,
+            88,
+            113,
+            115,
+            126,
+            160
+          ]
+        },
+        "milestone_membership_actual": {
+          "0.1.6 — Codex control-plane reliability": [
+            111,
+            112,
+            138,
+            139,
+            141,
+            143,
+            149,
+            150,
+            151,
+            156,
+            159,
+            161
+          ],
+          "0.1.7 — Official GPT reliability": [
+            18,
+            19,
+            20,
+            21,
+            104,
+            109,
+            114,
+            157
+          ],
+          "0.1.8 — Third-party model certification": [
+            17,
+            22,
+            57,
+            58,
+            59,
+            61,
+            62,
+            63,
+            64,
+            65,
+            66,
+            67
+          ],
+          "0.1.9 — Managed client reliability": [
+            8,
+            28,
+            83,
+            153,
+            154,
+            155
+          ],
+          "0.1.10 — Existing product reliability": [
+            86,
+            87,
+            88,
+            113,
+            115,
+            126,
+            160
+          ]
+        },
+        "milestones": [
+          {
+            "number": 3,
+            "title": "0.1.6 — Codex control-plane reliability",
+            "description": "Exit: one reconciled Gateway lifecycle; sidebar-visible Worker materialization; bidirectional Task communication and receipts; bounded cancellation/exit/restart; recoverable Task state. Only 0.1.6 receives new work while this gate is active.",
+            "state": "open",
+            "open_issues": 12,
+            "closed_issues": 0
+          },
+          {
+            "number": 4,
+            "title": "0.1.7 — Official GPT reliability",
+            "description": "Exit: Official GPT catalog, Task/Worker communication, tool lifecycle, streaming/cancellation, and context authority are reliable enough to serve as the control group for third-party qualification.",
+            "state": "open",
+            "open_issues": 8,
+            "closed_issues": 0
+          },
+          {
+            "number": 5,
+            "title": "0.1.8 — Third-party model certification",
+            "description": "Exit: each supported provider/model/protocol/codec combination has runtime-derived capability evidence, full visible-Worker and Task communication coverage, fail-closed unknown semantics, and a #67 GO/PARTIAL/NO-GO decision.",
+            "state": "open",
+            "open_issues": 12,
+            "closed_issues": 0
+          },
+          {
+            "number": 6,
+            "title": "0.1.9 — Managed client reliability",
+            "description": "Exit: ZCode, OMP, OpenCode, and Pi preview/apply/readback/restore are transactional, identity-faithful, reasoning-faithful, and free of silent Official fallback.",
+            "state": "open",
+            "open_issues": 6,
+            "closed_issues": 0
+          },
+          {
+            "number": 7,
+            "title": "0.1.10 — Existing product reliability",
+            "description": "Exit: remaining existing pricing, Vision Proxy, diagnostics, notification, and uninstall-cleanup defects are resolved without adding new product capabilities.",
+            "state": "open",
+            "open_issues": 7,
+            "closed_issues": 0
+          },
+          {
+            "number": 1,
+            "title": "Third-party model agentic reliability",
+            "description": "Superseded on 2026-07-16 by the reliability-gated 0.1.6–0.1.10 milestones. Historical issue/decision context remains preserved; this milestone is no longer a scheduling pool.",
+            "state": "closed",
+            "open_issues": 0,
+            "closed_issues": 10
+          },
+          {
+            "number": 2,
+            "title": "Capability-driven routing rollout",
+            "description": "Superseded on 2026-07-12 by the consolidated Third-party model agentic reliability milestone (#1).",
+            "state": "closed",
+            "open_issues": 0,
+            "closed_issues": 0
+          }
+        ],
+        "open_issue_assignees": {
+          "114": [
+            "NOirBRight"
+          ]
+        },
+        "critical_contracts": {
+          "28": {
+            "number": 28,
+            "title": "Bound Gateway client probes and catalog discovery work",
+            "state": "open",
+            "body_normalized_sha256": "8a882cd0b7af8b87c803cced922f95a2527f04314180fbf6b0df2c571cc58d29",
+            "labels": [
+              "enhancement",
+              "ready-for-agent",
+              "wayfinder:task"
+            ],
+            "assignees": [],
+            "milestone": "0.1.9 — Managed client reliability",
+            "parent": 147,
+            "blocked_by": [],
+            "children": [],
+            "url": "https://github.com/NOirBRight/CodexHub/issues/28"
+          },
+          "147": {
+            "number": 147,
+            "title": "Wayfinder: CodexHub 0.1.6–0.3.0 Gateway and release roadmap",
+            "state": "open",
+            "body_normalized_sha256": "af02920412d7f51fc7d136912c677b4cd7c38127c42a4ca4b805af40d7831c32",
+            "labels": [
+              "enhancement",
+              "ready-for-human",
+              "wayfinder:map"
+            ],
+            "assignees": [],
+            "milestone": null,
+            "parent": null,
+            "blocked_by": [],
+            "children": [
+              8,
+              17,
+              18,
+              19,
+              20,
+              21,
+              22,
+              28,
+              57,
+              58,
+              59,
+              61,
+              68,
+              71,
+              73,
+              83,
+              85,
+              86,
+              87,
+              88,
+              104,
+              109,
+              111,
+              112,
+              113,
+              114,
+              115,
+              126,
+              138,
+              139,
+              141,
+              143,
+              148,
+              149,
+              150,
+              151,
+              152,
+              153,
+              154,
+              155,
+              156,
+              157,
+              160
+            ],
+            "url": "https://github.com/NOirBRight/CodexHub/issues/147"
+          },
+          "156": {
+            "number": 156,
+            "title": "Enable sidebar-visible third-party Worker callbacks and binding readback",
+            "state": "open",
+            "body_normalized_sha256": "9e78522d36707a8806d2f97a7ef332b2c0ef26874dff16e0b5f5ac5f96f10c85",
+            "labels": [
+              "bug",
+              "ready-for-human",
+              "wayfinder:grilling"
+            ],
+            "assignees": [],
+            "milestone": "0.1.6 — Codex control-plane reliability",
+            "parent": 147,
+            "blocked_by": [
+              159,
+              161
+            ],
+            "children": [
+              159,
+              161
+            ],
+            "url": "https://github.com/NOirBRight/CodexHub/issues/156"
+          },
+          "159": {
+            "number": 159,
+            "title": "Bound repeated empty tool_search misses for external models",
+            "state": "open",
+            "body_normalized_sha256": "dc9f36f3c8c8dcbdc79696205528f1743d56885216d41f821bc59c486d8bc78e",
+            "labels": [
+              "bug",
+              "ready-for-agent",
+              "wayfinder:task"
+            ],
+            "assignees": [],
+            "milestone": "0.1.6 — Codex control-plane reliability",
+            "parent": 156,
+            "blocked_by": [],
+            "children": [],
+            "url": "https://github.com/NOirBRight/CodexHub/issues/159"
+          },
+          "160": {
+            "number": 160,
+            "title": "Remove CodexHub-owned Windows autostart registration during uninstall",
+            "state": "open",
+            "body_normalized_sha256": "da57b9a4c6f17cccb010ca6b5c87b3b54c3924551da81446cc073af0da721eeb",
+            "labels": [
+              "bug",
+              "ready-for-agent",
+              "wayfinder:task"
+            ],
+            "assignees": [],
+            "milestone": "0.1.10 — Existing product reliability",
+            "parent": 147,
+            "blocked_by": [
+              111
+            ],
+            "children": [],
+            "url": "https://github.com/NOirBRight/CodexHub/issues/160"
+          },
+          "161": {
+            "number": 161,
+            "title": "Preserve Worker selector and effective binding validation for external delegation",
+            "state": "open",
+            "body_normalized_sha256": "944ad1757538846011da360b880c53889c2aaa68d021cb3634caf1221c88e4f3",
+            "labels": [
+              "bug",
+              "ready-for-agent",
+              "wayfinder:task"
+            ],
+            "assignees": [],
+            "milestone": "0.1.6 — Codex control-plane reliability",
+            "parent": 156,
+            "blocked_by": [],
+            "children": [],
+            "url": "https://github.com/NOirBRight/CodexHub/issues/161"
+          }
+        },
+        "relations": {
+          "57": {
+            "parent": 147,
+            "blocked_by": [],
+            "children": [
+              62,
+              63,
+              64,
+              65,
+              66,
+              67
+            ]
+          },
+          "64": {
+            "parent": 57,
+            "blocked_by": [
+              62,
+              63,
+              156
+            ],
+            "children": []
+          },
+          "71": {
+            "parent": 147,
+            "blocked_by": [],
+            "children": [
+              89,
+              90,
+              91,
+              92,
+              93,
+              94
+            ]
+          },
+          "73": {
+            "parent": 147,
+            "blocked_by": [],
+            "children": [
+              74,
+              75,
+              76,
+              77,
+              78
+            ]
+          },
+          "111": {
+            "parent": 147,
+            "blocked_by": [],
+            "children": []
+          },
+          "147": {
+            "parent": null,
+            "blocked_by": [],
+            "children": [
+              8,
+              17,
+              18,
+              19,
+              20,
+              21,
+              22,
+              28,
+              57,
+              58,
+              59,
+              61,
+              68,
+              71,
+              73,
+              83,
+              85,
+              86,
+              87,
+              88,
+              104,
+              109,
+              111,
+              112,
+              113,
+              114,
+              115,
+              126,
+              138,
+              139,
+              141,
+              143,
+              148,
+              149,
+              150,
+              151,
+              152,
+              153,
+              154,
+              155,
+              156,
+              157,
+              160
+            ]
+          },
+          "156": {
+            "parent": 147,
+            "blocked_by": [
+              159,
+              161
+            ],
+            "children": [
+              159,
+              161
+            ]
+          },
+          "159": {
+            "parent": 156,
+            "blocked_by": [],
+            "children": []
+          },
+          "160": {
+            "parent": 147,
+            "blocked_by": [
+              111
+            ],
+            "children": []
+          },
+          "161": {
+            "parent": 156,
+            "blocked_by": [],
+            "children": []
+          }
+        },
+        "comments": {
+          "8": {
+            "public_comment_id": 4994634611,
+            "purpose_prefix": "### Wayfinder baseline correction",
+            "normalized_body_sha256": "d1450f61411a1069668527e5e11733921b8b30c3ec20b32352885ff01f49912a",
+            "prefix_multiplicity": 1,
+            "exact_body_multiplicity": 1,
+            "created_at": "2026-07-16T17:13:03Z",
+            "updated_at": "2026-07-16T17:13:03Z",
+            "url": "https://github.com/NOirBRight/CodexHub/issues/8#issuecomment-4994634611"
+          },
+          "10": {
+            "public_comment_id": 4994635018,
+            "purpose_prefix": "Wayfinder closure reconciliation:",
+            "normalized_body_sha256": "8b0ce766324b6fa11722802e3c3aa597c71faa6a5c32ed5bba5cd3e91c3235ea",
+            "prefix_multiplicity": 1,
+            "exact_body_multiplicity": 1,
+            "created_at": "2026-07-16T17:13:05Z",
+            "updated_at": "2026-07-16T17:13:05Z",
+            "url": "https://github.com/NOirBRight/CodexHub/issues/10#issuecomment-4994635018"
+          },
+          "12": {
+            "public_comment_id": 4994635403,
+            "purpose_prefix": "Wayfinder closure reconciliation:",
+            "normalized_body_sha256": "60904c5c69e311986fd8fcbde71d35a51aac1ca540510beb853587a3b456d86b",
+            "prefix_multiplicity": 1,
+            "exact_body_multiplicity": 1,
+            "created_at": "2026-07-16T17:13:08Z",
+            "updated_at": "2026-07-16T17:13:08Z",
+            "url": "https://github.com/NOirBRight/CodexHub/issues/12#issuecomment-4994635403"
+          },
+          "62": {
+            "public_comment_id": 4994636467,
+            "purpose_prefix": "Wayfinder ownership reconciliation:",
+            "normalized_body_sha256": "db78e9489281b842d6128d0964a6109dbe43a31c8c381474653c963867919b63",
+            "prefix_multiplicity": 1,
+            "exact_body_multiplicity": 1,
+            "created_at": "2026-07-16T17:13:16Z",
+            "updated_at": "2026-07-16T17:13:16Z",
+            "url": "https://github.com/NOirBRight/CodexHub/issues/62#issuecomment-4994636467"
+          },
+          "147": {
+            "public_comment_id": 4994927680,
+            "purpose_prefix": "## Reliability-gated Wayfinder migration readback",
+            "normalized_body_sha256": "b6d4d1e9bc58fd013c4968eb2799990fb7afa579572ade93534ee657c35ad82b",
+            "prefix_multiplicity": 1,
+            "exact_body_multiplicity": 1,
+            "created_at": "2026-07-16T17:46:29Z",
+            "updated_at": "2026-07-16T18:17:28Z",
+            "url": "https://github.com/NOirBRight/CodexHub/issues/147#issuecomment-4994927680"
+          }
+        }
+      },
+      "derivation": {
+        "label_dependency_rule": "open AND ready-for-agent AND unassigned AND zero open native blockers",
+        "ownership_hotset_rule": "two exact native queries clear AND no unavailable native host AND unassigned AND no active worktree/local-branch/open-PR changed-file intersection with the parsed Expected hotset",
+        "branch_names_used_as_ownership_evidence": false,
+        "inactive_local_branches_block_eligibility": false,
+        "inactive_branch_reason": "A local branch is active only when checked out in a worktree or used as an open PR head; every local branch is still enumerated with its file intersections.",
+        "planning_worktree_rule": "The current planning worktree is migration-control evidence only because its complete changed-file set has zero frontier product-hotset intersections.",
+        "dev_rule": "The dev worktree is independently audited for revision, cleanliness, and changed-file intersections; it is not trusted by name alone.",
+        "result": "eligible"
+      },
+      "sanitization": {
+        "native_task_ids_persisted": false,
+        "local_absolute_paths_persisted": false,
+        "worktree_identity_basis": "branch or detached revision, never filesystem path",
+        "changed_file_paths": "repository-relative"
+      }
+    }
+  },
+  "checkpoint_update_transcript": {
+    "schema_version": 1,
+    "captured_at": "2026-07-16T19:13:35.7585728Z",
+    "issue": 147,
+    "purpose_prefix": "## Reliability-gated Wayfinder migration readback",
+    "historical_original": {
+      "source": "Task 8 execution report exact original published body",
+      "normalized_body": "## Reliability-gated Wayfinder migration readback\n\nThe approved roadmap migration is complete and read back:\n\n- five active reliability milestones exist with exact membership;\n- the legacy cross-version reliability milestone is closed as superseded;\n- #156 is the ready-for-human Visible Worker gate and #159 is its ready local bounded-search child;\n- #64 is blocked by #156 for the full post-fix collaboration matrix;\n- #28 is narrowed to client discovery performance and #160 owns uninstall cleanup behind #111;\n- every open Issue has exactly one canonical lifecycle label;\n- no ticket was assigned or dispatched by the migration.\n\nCurrent unclaimed 0.1.6 ready frontier:\n\n- #159 Bound repeated empty tool_search misses for external models\n- #139 Serialize Gateway lifecycle operations and prevent duplicate startup processes\n- #149 Make Rust/Python atomic-file lock ownership and stale recovery safe\n- #150 Coalesce automatic OpenAI usage probes and avoid repeated Codex app-server cold starts\n- #111 Make Windows app autostart registration verifiable and reliable\n\nFrontier order remains subject to native dependencies and hotset ownership. Map publication is not a claim.",
+      "normalized_body_sha256": "0c09e6b7c4ba7abf432dc43b19860095094912a1b36b3d67c98e0c3870f40fb4"
+    },
+    "pre_update": {
+      "public_comment_id": 4994927680,
+      "normalized_body_sha256": "b6d4d1e9bc58fd013c4968eb2799990fb7afa579572ade93534ee657c35ad82b",
+      "readback_at": "2026-07-16T19:13:35.7634320Z"
+    },
+    "desired": {
+      "normalized_body": "## Reliability-gated Wayfinder migration readback\n\nThe approved roadmap migration is complete and read back:\n\n- five active reliability milestones exist with exact membership;\n- the legacy cross-version reliability milestone is closed as superseded;\n- #156 is the ready-for-human Host/runtime-only Visible Worker gate, #159 is its ready bounded-search child, and #161 is its ready selector/effective-binding validation child;\n- #64 is blocked by #156 for the full post-fix collaboration matrix;\n- #28 is narrowed to client discovery performance and #160 owns uninstall cleanup behind #111;\n- every open Issue has exactly one canonical lifecycle label;\n- no ticket was assigned or dispatched by the migration.\n\nCurrent unclaimed 0.1.6 ready frontier:\n\n- #159 Bound repeated empty tool_search misses for external models\n- #161 Preserve Worker selector and effective binding validation for external delegation\n- #139 Serialize Gateway lifecycle operations and prevent duplicate startup processes\n- #149 Make Rust/Python atomic-file lock ownership and stale recovery safe\n- #150 Coalesce automatic OpenAI usage probes and avoid repeated Codex app-server cold starts\n- #111 Make Windows app autostart registration verifiable and reliable\n\nSanitized native Task/worktree/branch/PR/assignee/hotset preflight found no active ownership conflict at publication.\n\nDurable frontier audit: docs/superpowers/reviews/wayfinder-frontier-ownership-audit-v1.json (SHA-256: `388da2e2f68b3e5c3e8ce5cc99cdfb1ba801941b19e864e3bbb22331c5b6356b`).\n\nFrontier order remains subject to native dependencies and hotset ownership. Map publication is not a claim.",
+      "normalized_body_sha256": "7adca5e559b4757cb13ed0d95b94d890bb07c3bbf096a6185e7685649d311227",
+      "frontier_artifact_path": "docs/superpowers/reviews/wayfinder-frontier-ownership-audit-v1.json",
+      "frontier_artifact_sha256": "388da2e2f68b3e5c3e8ce5cc99cdfb1ba801941b19e864e3bbb22331c5b6356b"
+    },
+    "operation_decision": "patch",
+    "post_readback": {
+      "public_comment_id": 4994927680,
+      "normalized_body_sha256": "7adca5e559b4757cb13ed0d95b94d890bb07c3bbf096a6185e7685649d311227",
+      "prefix_multiplicity": 1,
+      "exact_body_multiplicity": 1,
+      "readback_at": "2026-07-16T19:13:35.7639048Z"
+    }
+  },
+  "derivation": {
+    "frontier": [
+      159,
+      161,
+      139,
+      149,
+      150,
+      111
+    ],
+    "label_dependency_eligibility": {
+      "159": {
+        "open": true,
+        "ready_for_agent": true,
+        "unassigned": true,
+        "open_blockers": [],
+        "eligible": true,
+        "ineligible_reasons": []
+      },
+      "161": {
+        "open": true,
+        "ready_for_agent": true,
+        "unassigned": true,
+        "open_blockers": [],
+        "eligible": true,
+        "ineligible_reasons": []
+      },
+      "139": {
+        "open": true,
+        "ready_for_agent": true,
+        "unassigned": true,
+        "open_blockers": [],
+        "eligible": true,
+        "ineligible_reasons": []
+      },
+      "149": {
+        "open": true,
+        "ready_for_agent": true,
+        "unassigned": true,
+        "open_blockers": [],
+        "eligible": true,
+        "ineligible_reasons": []
+      },
+      "150": {
+        "open": true,
+        "ready_for_agent": true,
+        "unassigned": true,
+        "open_blockers": [],
+        "eligible": true,
+        "ineligible_reasons": []
+      },
+      "111": {
+        "open": true,
+        "ready_for_agent": true,
+        "unassigned": true,
+        "open_blockers": [],
+        "eligible": true,
+        "ineligible_reasons": []
+      }
+    },
+    "ownership_hotset_eligibility": {
+      "159": {
+        "native_task_query_count": 2,
+        "native_task_matches": 0,
+        "native_task_unavailable_hosts": 0,
+        "assignees": [],
+        "active_surface_intersections": [],
+        "eligible": true,
+        "ineligible_reasons": []
+      },
+      "161": {
+        "native_task_query_count": 2,
+        "native_task_matches": 0,
+        "native_task_unavailable_hosts": 0,
+        "assignees": [],
+        "active_surface_intersections": [],
+        "eligible": true,
+        "ineligible_reasons": []
+      },
+      "139": {
+        "native_task_query_count": 2,
+        "native_task_matches": 0,
+        "native_task_unavailable_hosts": 0,
+        "assignees": [],
+        "active_surface_intersections": [],
+        "eligible": true,
+        "ineligible_reasons": []
+      },
+      "149": {
+        "native_task_query_count": 2,
+        "native_task_matches": 0,
+        "native_task_unavailable_hosts": 0,
+        "assignees": [],
+        "active_surface_intersections": [],
+        "eligible": true,
+        "ineligible_reasons": []
+      },
+      "150": {
+        "native_task_query_count": 2,
+        "native_task_matches": 0,
+        "native_task_unavailable_hosts": 0,
+        "assignees": [],
+        "active_surface_intersections": [],
+        "eligible": true,
+        "ineligible_reasons": []
+      },
+      "111": {
+        "native_task_query_count": 2,
+        "native_task_matches": 0,
+        "native_task_unavailable_hosts": 0,
+        "assignees": [],
+        "active_surface_intersections": [],
+        "eligible": true,
+        "ineligible_reasons": []
+      }
+    },
+    "checkpoint_exact_body_guard": "patch",
+    "checkpoint_post_readback_exact": true
+  },
+  "artifact_hashes": {
+    "docs/superpowers/reviews/wayfinder-frontier-ownership-audit-v1.json": "388da2e2f68b3e5c3e8ce5cc99cdfb1ba801941b19e864e3bbb22331c5b6356b",
+    "docs/superpowers/reviews/wayfinder-checkpoint-update-v1.json": "9668c99374b12526ed183291c2c883ab8b80b93dcd3258017b841be22541d646"
+  },
+  "sanitization": {
+    "native_task_ids_persisted": false,
+    "local_absolute_paths_persisted": false,
+    "worktree_identity_basis": "branch or detached revision, never filesystem path",
+    "changed_file_paths": "repository-relative"
+  }
+}

--- a/docs/superpowers/reviews/wayfinder-final-audit-v1.json
+++ b/docs/superpowers/reviews/wayfinder-final-audit-v1.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "artifact_kind": "wayfinder-final-migration-audit",
-  "captured_at": "2026-07-16T19:48:15.733215Z",
+  "captured_at": "2026-07-16T20:11:03.061598Z",
   "repository": "NOirBRight/CodexHub",
   "generator": "scripts/generate_wayfinder_final_audit.py",
   "frontier_artifact": {
@@ -1341,7 +1341,7 @@
   },
   "checkpoint_update_transcript": {
     "schema_version": 1,
-    "captured_at": "2026-07-16T19:46:23.9035374Z",
+    "captured_at": "2026-07-16T20:10:51.7868798Z",
     "issue": 147,
     "purpose_prefix": "## Reliability-gated Wayfinder migration readback",
     "historical_original": {
@@ -1349,10 +1349,47 @@
       "normalized_body": "## Reliability-gated Wayfinder migration readback\n\nThe approved roadmap migration is complete and read back:\n\n- five active reliability milestones exist with exact membership;\n- the legacy cross-version reliability milestone is closed as superseded;\n- #156 is the ready-for-human Visible Worker gate and #159 is its ready local bounded-search child;\n- #64 is blocked by #156 for the full post-fix collaboration matrix;\n- #28 is narrowed to client discovery performance and #160 owns uninstall cleanup behind #111;\n- every open Issue has exactly one canonical lifecycle label;\n- no ticket was assigned or dispatched by the migration.\n\nCurrent unclaimed 0.1.6 ready frontier:\n\n- #159 Bound repeated empty tool_search misses for external models\n- #139 Serialize Gateway lifecycle operations and prevent duplicate startup processes\n- #149 Make Rust/Python atomic-file lock ownership and stale recovery safe\n- #150 Coalesce automatic OpenAI usage probes and avoid repeated Codex app-server cold starts\n- #111 Make Windows app autostart registration verifiable and reliable\n\nFrontier order remains subject to native dependencies and hotset ownership. Map publication is not a claim.",
       "normalized_body_sha256": "0c09e6b7c4ba7abf432dc43b19860095094912a1b36b3d67c98e0c3870f40fb4"
     },
+    "historical_provenance": {
+      "proof_kind": "tracked-transcript",
+      "prior_transcript": {
+        "schema_version": 1,
+        "captured_at": "2026-07-16T19:46:23.9035374Z",
+        "issue": 147,
+        "purpose_prefix": "## Reliability-gated Wayfinder migration readback",
+        "historical_original": {
+          "source": "Task 8 execution report exact original published body",
+          "normalized_body": "## Reliability-gated Wayfinder migration readback\n\nThe approved roadmap migration is complete and read back:\n\n- five active reliability milestones exist with exact membership;\n- the legacy cross-version reliability milestone is closed as superseded;\n- #156 is the ready-for-human Visible Worker gate and #159 is its ready local bounded-search child;\n- #64 is blocked by #156 for the full post-fix collaboration matrix;\n- #28 is narrowed to client discovery performance and #160 owns uninstall cleanup behind #111;\n- every open Issue has exactly one canonical lifecycle label;\n- no ticket was assigned or dispatched by the migration.\n\nCurrent unclaimed 0.1.6 ready frontier:\n\n- #159 Bound repeated empty tool_search misses for external models\n- #139 Serialize Gateway lifecycle operations and prevent duplicate startup processes\n- #149 Make Rust/Python atomic-file lock ownership and stale recovery safe\n- #150 Coalesce automatic OpenAI usage probes and avoid repeated Codex app-server cold starts\n- #111 Make Windows app autostart registration verifiable and reliable\n\nFrontier order remains subject to native dependencies and hotset ownership. Map publication is not a claim.",
+          "normalized_body_sha256": "0c09e6b7c4ba7abf432dc43b19860095094912a1b36b3d67c98e0c3870f40fb4"
+        },
+        "pre_update": {
+          "public_comment_id": 4994927680,
+          "normalized_body_sha256": "7adca5e559b4757cb13ed0d95b94d890bb07c3bbf096a6185e7685649d311227",
+          "readback_at": "2026-07-16T19:46:23.9088831Z"
+        },
+        "desired": {
+          "normalized_body": "## Reliability-gated Wayfinder migration readback\n\nThe approved roadmap migration is complete and read back:\n\n- five active reliability milestones exist with exact membership;\n- the legacy cross-version reliability milestone is closed as superseded;\n- #156 is the ready-for-human Host/runtime-only Visible Worker gate, #159 is its ready bounded-search child, and #161 is its ready selector/effective-binding validation child;\n- #64 is blocked by #156 for the full post-fix collaboration matrix;\n- #28 is narrowed to client discovery performance and #160 owns uninstall cleanup behind #111;\n- every open Issue has exactly one canonical lifecycle label;\n- no ticket was assigned or dispatched by the migration.\n\nCurrent unclaimed 0.1.6 ready frontier:\n\n- #159 Bound repeated empty tool_search misses for external models\n- #161 Preserve Worker selector and effective binding validation for external delegation\n- #139 Serialize Gateway lifecycle operations and prevent duplicate startup processes\n- #149 Make Rust/Python atomic-file lock ownership and stale recovery safe\n- #150 Coalesce automatic OpenAI usage probes and avoid repeated Codex app-server cold starts\n- #111 Make Windows app autostart registration verifiable and reliable\n\nSanitized native Task/worktree/branch/PR/assignee/hotset preflight found no active ownership conflict at publication.\n\nDurable frontier audit: docs/superpowers/reviews/wayfinder-frontier-ownership-audit-v1.json (SHA-256: `bd42794dedd218a960ee8a938712210f9f3b496b61ce69c28637e417eb1d57cd`).\n\nFrontier order remains subject to native dependencies and hotset ownership. Map publication is not a claim.",
+          "normalized_body_sha256": "cc02ae51ee981e810d367e6473d8480d9d5cd4cf7ddd7f1d60acf8e655a7b2bb",
+          "frontier_artifact_path": "docs/superpowers/reviews/wayfinder-frontier-ownership-audit-v1.json",
+          "frontier_artifact_sha256": "bd42794dedd218a960ee8a938712210f9f3b496b61ce69c28637e417eb1d57cd"
+        },
+        "operation_decision": "patch",
+        "post_readback": {
+          "public_comment_id": 4994927680,
+          "normalized_body_sha256": "cc02ae51ee981e810d367e6473d8480d9d5cd4cf7ddd7f1d60acf8e655a7b2bb",
+          "prefix_multiplicity": 1,
+          "exact_body_multiplicity": 1,
+          "readback_at": "2026-07-16T19:46:23.9091773Z"
+        },
+        "historical_provenance": {
+          "proof_kind": "task8-execution-report",
+          "prior_transcript": null
+        }
+      }
+    },
     "pre_update": {
       "public_comment_id": 4994927680,
-      "normalized_body_sha256": "7adca5e559b4757cb13ed0d95b94d890bb07c3bbf096a6185e7685649d311227",
-      "readback_at": "2026-07-16T19:46:23.9088831Z"
+      "normalized_body_sha256": "cc02ae51ee981e810d367e6473d8480d9d5cd4cf7ddd7f1d60acf8e655a7b2bb",
+      "readback_at": "2026-07-16T20:10:50.9689816Z"
     },
     "desired": {
       "normalized_body": "## Reliability-gated Wayfinder migration readback\n\nThe approved roadmap migration is complete and read back:\n\n- five active reliability milestones exist with exact membership;\n- the legacy cross-version reliability milestone is closed as superseded;\n- #156 is the ready-for-human Host/runtime-only Visible Worker gate, #159 is its ready bounded-search child, and #161 is its ready selector/effective-binding validation child;\n- #64 is blocked by #156 for the full post-fix collaboration matrix;\n- #28 is narrowed to client discovery performance and #160 owns uninstall cleanup behind #111;\n- every open Issue has exactly one canonical lifecycle label;\n- no ticket was assigned or dispatched by the migration.\n\nCurrent unclaimed 0.1.6 ready frontier:\n\n- #159 Bound repeated empty tool_search misses for external models\n- #161 Preserve Worker selector and effective binding validation for external delegation\n- #139 Serialize Gateway lifecycle operations and prevent duplicate startup processes\n- #149 Make Rust/Python atomic-file lock ownership and stale recovery safe\n- #150 Coalesce automatic OpenAI usage probes and avoid repeated Codex app-server cold starts\n- #111 Make Windows app autostart registration verifiable and reliable\n\nSanitized native Task/worktree/branch/PR/assignee/hotset preflight found no active ownership conflict at publication.\n\nDurable frontier audit: docs/superpowers/reviews/wayfinder-frontier-ownership-audit-v1.json (SHA-256: `bd42794dedd218a960ee8a938712210f9f3b496b61ce69c28637e417eb1d57cd`).\n\nFrontier order remains subject to native dependencies and hotset ownership. Map publication is not a claim.",
@@ -1360,13 +1397,13 @@
       "frontier_artifact_path": "docs/superpowers/reviews/wayfinder-frontier-ownership-audit-v1.json",
       "frontier_artifact_sha256": "bd42794dedd218a960ee8a938712210f9f3b496b61ce69c28637e417eb1d57cd"
     },
-    "operation_decision": "patch",
+    "operation_decision": "exact-no-op",
     "post_readback": {
       "public_comment_id": 4994927680,
       "normalized_body_sha256": "cc02ae51ee981e810d367e6473d8480d9d5cd4cf7ddd7f1d60acf8e655a7b2bb",
       "prefix_multiplicity": 1,
       "exact_body_multiplicity": 1,
-      "readback_at": "2026-07-16T19:46:23.9091773Z"
+      "readback_at": "2026-07-16T20:10:51.7469770Z"
     }
   },
   "derivation": {
@@ -1484,12 +1521,12 @@
         "ineligible_reasons": []
       }
     },
-    "checkpoint_exact_body_guard": "patch",
+    "checkpoint_exact_body_guard": "exact-no-op",
     "checkpoint_post_readback_exact": true
   },
   "artifact_hashes": {
     "docs/superpowers/reviews/wayfinder-frontier-ownership-audit-v1.json": "bd42794dedd218a960ee8a938712210f9f3b496b61ce69c28637e417eb1d57cd",
-    "docs/superpowers/reviews/wayfinder-checkpoint-update-v1.json": "8274541276784904beee892b298122b3361528abad78e25a375cbb66b4886540"
+    "docs/superpowers/reviews/wayfinder-checkpoint-update-v1.json": "ea2a2cf49ed42dc48bec23828c2ef73884bd05885fd7c848993b1073d5a8990e"
   },
   "sanitization": {
     "native_task_ids_persisted": false,

--- a/docs/superpowers/reviews/wayfinder-final-audit-v1.json
+++ b/docs/superpowers/reviews/wayfinder-final-audit-v1.json
@@ -1,22 +1,22 @@
 {
   "schema_version": 1,
   "artifact_kind": "wayfinder-final-migration-audit",
-  "captured_at": "2026-07-16T19:13:41.822373Z",
+  "captured_at": "2026-07-16T19:48:15.733215Z",
   "repository": "NOirBRight/CodexHub",
   "generator": "scripts/generate_wayfinder_final_audit.py",
   "frontier_artifact": {
     "repository_relative_path": "docs/superpowers/reviews/wayfinder-frontier-ownership-audit-v1.json",
-    "sha256": "388da2e2f68b3e5c3e8ce5cc99cdfb1ba801941b19e864e3bbb22331c5b6356b",
+    "sha256": "bd42794dedd218a960ee8a938712210f9f3b496b61ce69c28637e417eb1d57cd",
     "embedded": {
       "schema_version": 1,
       "artifact_kind": "wayfinder-frontier-ownership-audit",
-      "captured_at": "2026-07-16T19:10:29.752972Z",
+      "captured_at": "2026-07-16T19:44:53.590618Z",
       "repository": "NOirBRight/CodexHub",
       "generator": "scripts/generate_wayfinder_final_audit.py",
       "base_ref": "dev",
       "base_revision": "51a636c98ca90a9766836a7d603c2013211bbeeb",
       "planning_branch": "wayfinder-github-migration",
-      "planning_revision": "bd2b44034c92cf60a4e5ac598300ef6817a0e02d",
+      "planning_revision": "7d60eca9a903672948445bc079ed46316b281907",
       "native_task_capture": {
         "tool": "codex_app__list_threads",
         "source_capture_file_sha256": "8d8a637e13cae1e791b79525b431c6006cbaf015b4bb1ac88f797692939d9ed5",
@@ -608,6 +608,7 @@
                 "normalized": "frontend/src/pages/SettingsPage.tsx and/or the settings drawer",
                 "path_matchers": [
                   "frontend/src/components/**/Settings*",
+                  "frontend/src/components/SettingsDrawer.tsx",
                   "frontend/src/pages/SettingsPage.tsx"
                 ]
               },
@@ -636,6 +637,7 @@
               "frontend/scripts/**",
               "frontend/src/App.tsx",
               "frontend/src/components/**/Settings*",
+              "frontend/src/components/SettingsDrawer.tsx",
               "frontend/src/pages/SettingsPage.tsx",
               "scripts/**/autostart*",
               "scripts/*autostart*",
@@ -687,12 +689,12 @@
           {
             "logical_identity": "worktree:wayfinder-github-migration",
             "branch": "wayfinder-github-migration",
-            "revision": "bd2b44034c92cf60a4e5ac598300ef6817a0e02d",
+            "revision": "7d60eca9a903672948445bc079ed46316b281907",
             "clean": false,
             "dirty_files": [
               "docs/superpowers/plans/2026-07-16-wayfinder-github-migration.md",
-              "docs/superpowers/specs/2026-07-16-wayfinder-replanning-design.md",
-              "scripts/generate_wayfinder_final_audit.py"
+              "scripts/generate_wayfinder_final_audit.py",
+              "scripts/tests/test_wayfinder_final_audit_generator.py"
             ],
             "changed_files_vs_dev": [
               "docs/superpowers/plans/2026-07-16-wayfinder-github-migration.md",
@@ -700,7 +702,8 @@
               "docs/superpowers/reviews/wayfinder-final-audit-v1.json",
               "docs/superpowers/reviews/wayfinder-frontier-ownership-audit-v1.json",
               "docs/superpowers/specs/2026-07-16-wayfinder-replanning-design.md",
-              "scripts/generate_wayfinder_final_audit.py"
+              "scripts/generate_wayfinder_final_audit.py",
+              "scripts/tests/test_wayfinder_final_audit_generator.py"
             ],
             "hotset_intersections": {
               "159": [],
@@ -769,10 +772,14 @@
           {
             "logical_identity": "local-branch:wayfinder-github-migration",
             "name": "wayfinder-github-migration",
-            "revision": "bd2b44034c92cf60a4e5ac598300ef6817a0e02d",
+            "revision": "7d60eca9a903672948445bc079ed46316b281907",
             "changed_files_vs_dev": [
               "docs/superpowers/plans/2026-07-16-wayfinder-github-migration.md",
-              "docs/superpowers/specs/2026-07-16-wayfinder-replanning-design.md"
+              "docs/superpowers/reviews/wayfinder-checkpoint-update-v1.json",
+              "docs/superpowers/reviews/wayfinder-final-audit-v1.json",
+              "docs/superpowers/reviews/wayfinder-frontier-ownership-audit-v1.json",
+              "docs/superpowers/specs/2026-07-16-wayfinder-replanning-design.md",
+              "scripts/generate_wayfinder_final_audit.py"
             ],
             "hotset_intersections": {
               "159": [],
@@ -1305,11 +1312,11 @@
           "147": {
             "public_comment_id": 4994927680,
             "purpose_prefix": "## Reliability-gated Wayfinder migration readback",
-            "normalized_body_sha256": "b6d4d1e9bc58fd013c4968eb2799990fb7afa579572ade93534ee657c35ad82b",
+            "normalized_body_sha256": "7adca5e559b4757cb13ed0d95b94d890bb07c3bbf096a6185e7685649d311227",
             "prefix_multiplicity": 1,
             "exact_body_multiplicity": 1,
             "created_at": "2026-07-16T17:46:29Z",
-            "updated_at": "2026-07-16T18:17:28Z",
+            "updated_at": "2026-07-16T19:13:34Z",
             "url": "https://github.com/NOirBRight/CodexHub/issues/147#issuecomment-4994927680"
           }
         }
@@ -1334,7 +1341,7 @@
   },
   "checkpoint_update_transcript": {
     "schema_version": 1,
-    "captured_at": "2026-07-16T19:13:35.7585728Z",
+    "captured_at": "2026-07-16T19:46:23.9035374Z",
     "issue": 147,
     "purpose_prefix": "## Reliability-gated Wayfinder migration readback",
     "historical_original": {
@@ -1344,22 +1351,22 @@
     },
     "pre_update": {
       "public_comment_id": 4994927680,
-      "normalized_body_sha256": "b6d4d1e9bc58fd013c4968eb2799990fb7afa579572ade93534ee657c35ad82b",
-      "readback_at": "2026-07-16T19:13:35.7634320Z"
+      "normalized_body_sha256": "7adca5e559b4757cb13ed0d95b94d890bb07c3bbf096a6185e7685649d311227",
+      "readback_at": "2026-07-16T19:46:23.9088831Z"
     },
     "desired": {
-      "normalized_body": "## Reliability-gated Wayfinder migration readback\n\nThe approved roadmap migration is complete and read back:\n\n- five active reliability milestones exist with exact membership;\n- the legacy cross-version reliability milestone is closed as superseded;\n- #156 is the ready-for-human Host/runtime-only Visible Worker gate, #159 is its ready bounded-search child, and #161 is its ready selector/effective-binding validation child;\n- #64 is blocked by #156 for the full post-fix collaboration matrix;\n- #28 is narrowed to client discovery performance and #160 owns uninstall cleanup behind #111;\n- every open Issue has exactly one canonical lifecycle label;\n- no ticket was assigned or dispatched by the migration.\n\nCurrent unclaimed 0.1.6 ready frontier:\n\n- #159 Bound repeated empty tool_search misses for external models\n- #161 Preserve Worker selector and effective binding validation for external delegation\n- #139 Serialize Gateway lifecycle operations and prevent duplicate startup processes\n- #149 Make Rust/Python atomic-file lock ownership and stale recovery safe\n- #150 Coalesce automatic OpenAI usage probes and avoid repeated Codex app-server cold starts\n- #111 Make Windows app autostart registration verifiable and reliable\n\nSanitized native Task/worktree/branch/PR/assignee/hotset preflight found no active ownership conflict at publication.\n\nDurable frontier audit: docs/superpowers/reviews/wayfinder-frontier-ownership-audit-v1.json (SHA-256: `388da2e2f68b3e5c3e8ce5cc99cdfb1ba801941b19e864e3bbb22331c5b6356b`).\n\nFrontier order remains subject to native dependencies and hotset ownership. Map publication is not a claim.",
-      "normalized_body_sha256": "7adca5e559b4757cb13ed0d95b94d890bb07c3bbf096a6185e7685649d311227",
+      "normalized_body": "## Reliability-gated Wayfinder migration readback\n\nThe approved roadmap migration is complete and read back:\n\n- five active reliability milestones exist with exact membership;\n- the legacy cross-version reliability milestone is closed as superseded;\n- #156 is the ready-for-human Host/runtime-only Visible Worker gate, #159 is its ready bounded-search child, and #161 is its ready selector/effective-binding validation child;\n- #64 is blocked by #156 for the full post-fix collaboration matrix;\n- #28 is narrowed to client discovery performance and #160 owns uninstall cleanup behind #111;\n- every open Issue has exactly one canonical lifecycle label;\n- no ticket was assigned or dispatched by the migration.\n\nCurrent unclaimed 0.1.6 ready frontier:\n\n- #159 Bound repeated empty tool_search misses for external models\n- #161 Preserve Worker selector and effective binding validation for external delegation\n- #139 Serialize Gateway lifecycle operations and prevent duplicate startup processes\n- #149 Make Rust/Python atomic-file lock ownership and stale recovery safe\n- #150 Coalesce automatic OpenAI usage probes and avoid repeated Codex app-server cold starts\n- #111 Make Windows app autostart registration verifiable and reliable\n\nSanitized native Task/worktree/branch/PR/assignee/hotset preflight found no active ownership conflict at publication.\n\nDurable frontier audit: docs/superpowers/reviews/wayfinder-frontier-ownership-audit-v1.json (SHA-256: `bd42794dedd218a960ee8a938712210f9f3b496b61ce69c28637e417eb1d57cd`).\n\nFrontier order remains subject to native dependencies and hotset ownership. Map publication is not a claim.",
+      "normalized_body_sha256": "cc02ae51ee981e810d367e6473d8480d9d5cd4cf7ddd7f1d60acf8e655a7b2bb",
       "frontier_artifact_path": "docs/superpowers/reviews/wayfinder-frontier-ownership-audit-v1.json",
-      "frontier_artifact_sha256": "388da2e2f68b3e5c3e8ce5cc99cdfb1ba801941b19e864e3bbb22331c5b6356b"
+      "frontier_artifact_sha256": "bd42794dedd218a960ee8a938712210f9f3b496b61ce69c28637e417eb1d57cd"
     },
     "operation_decision": "patch",
     "post_readback": {
       "public_comment_id": 4994927680,
-      "normalized_body_sha256": "7adca5e559b4757cb13ed0d95b94d890bb07c3bbf096a6185e7685649d311227",
+      "normalized_body_sha256": "cc02ae51ee981e810d367e6473d8480d9d5cd4cf7ddd7f1d60acf8e655a7b2bb",
       "prefix_multiplicity": 1,
       "exact_body_multiplicity": 1,
-      "readback_at": "2026-07-16T19:13:35.7639048Z"
+      "readback_at": "2026-07-16T19:46:23.9091773Z"
     }
   },
   "derivation": {
@@ -1481,8 +1488,8 @@
     "checkpoint_post_readback_exact": true
   },
   "artifact_hashes": {
-    "docs/superpowers/reviews/wayfinder-frontier-ownership-audit-v1.json": "388da2e2f68b3e5c3e8ce5cc99cdfb1ba801941b19e864e3bbb22331c5b6356b",
-    "docs/superpowers/reviews/wayfinder-checkpoint-update-v1.json": "9668c99374b12526ed183291c2c883ab8b80b93dcd3258017b841be22541d646"
+    "docs/superpowers/reviews/wayfinder-frontier-ownership-audit-v1.json": "bd42794dedd218a960ee8a938712210f9f3b496b61ce69c28637e417eb1d57cd",
+    "docs/superpowers/reviews/wayfinder-checkpoint-update-v1.json": "8274541276784904beee892b298122b3361528abad78e25a375cbb66b4886540"
   },
   "sanitization": {
     "native_task_ids_persisted": false,

--- a/docs/superpowers/reviews/wayfinder-frontier-ownership-audit-v1.json
+++ b/docs/superpowers/reviews/wayfinder-frontier-ownership-audit-v1.json
@@ -1,0 +1,1324 @@
+{
+  "schema_version": 1,
+  "artifact_kind": "wayfinder-frontier-ownership-audit",
+  "captured_at": "2026-07-16T19:10:29.752972Z",
+  "repository": "NOirBRight/CodexHub",
+  "generator": "scripts/generate_wayfinder_final_audit.py",
+  "base_ref": "dev",
+  "base_revision": "51a636c98ca90a9766836a7d603c2013211bbeeb",
+  "planning_branch": "wayfinder-github-migration",
+  "planning_revision": "bd2b44034c92cf60a4e5ac598300ef6817a0e02d",
+  "native_task_capture": {
+    "tool": "codex_app__list_threads",
+    "source_capture_file_sha256": "8d8a637e13cae1e791b79525b431c6006cbaf015b4bb1ac88f797692939d9ed5",
+    "source_capture_canonical_json_sha256": "43e40d8eb70cb8e21face20ab7a1d18b30b2a4f3903c783f87387ec6a263aa6e",
+    "captured_at": "2026-07-16T18:53:36.947Z",
+    "limit": 50,
+    "records": [
+      {
+        "issue": 159,
+        "issue_title": "Bound repeated empty tool_search misses for external models",
+        "kind": "exact_title",
+        "query": "Bound repeated empty tool_search misses for external models",
+        "captured_at": "2026-07-16T18:53:36.947Z",
+        "schema_version": 2,
+        "unavailable_hosts": [],
+        "unavailable_host_count": 0,
+        "match_count": 0
+      },
+      {
+        "issue": 159,
+        "issue_title": "Bound repeated empty tool_search misses for external models",
+        "kind": "issue_number",
+        "query": "Issue 159",
+        "captured_at": "2026-07-16T18:53:36.947Z",
+        "schema_version": 2,
+        "unavailable_hosts": [],
+        "unavailable_host_count": 0,
+        "match_count": 0
+      },
+      {
+        "issue": 161,
+        "issue_title": "Preserve Worker selector and effective binding validation for external delegation",
+        "kind": "exact_title",
+        "query": "Preserve Worker selector and effective binding validation for external delegation",
+        "captured_at": "2026-07-16T18:53:36.947Z",
+        "schema_version": 2,
+        "unavailable_hosts": [],
+        "unavailable_host_count": 0,
+        "match_count": 0
+      },
+      {
+        "issue": 161,
+        "issue_title": "Preserve Worker selector and effective binding validation for external delegation",
+        "kind": "issue_number",
+        "query": "Issue 161",
+        "captured_at": "2026-07-16T18:53:36.947Z",
+        "schema_version": 2,
+        "unavailable_hosts": [],
+        "unavailable_host_count": 0,
+        "match_count": 0
+      },
+      {
+        "issue": 139,
+        "issue_title": "Serialize Gateway lifecycle operations and prevent duplicate startup processes",
+        "kind": "exact_title",
+        "query": "Serialize Gateway lifecycle operations and prevent duplicate startup processes",
+        "captured_at": "2026-07-16T18:53:36.947Z",
+        "schema_version": 2,
+        "unavailable_hosts": [],
+        "unavailable_host_count": 0,
+        "match_count": 0
+      },
+      {
+        "issue": 139,
+        "issue_title": "Serialize Gateway lifecycle operations and prevent duplicate startup processes",
+        "kind": "issue_number",
+        "query": "Issue 139",
+        "captured_at": "2026-07-16T18:53:36.947Z",
+        "schema_version": 2,
+        "unavailable_hosts": [],
+        "unavailable_host_count": 0,
+        "match_count": 0
+      },
+      {
+        "issue": 149,
+        "issue_title": "Make Rust/Python atomic-file lock ownership and stale recovery safe",
+        "kind": "exact_title",
+        "query": "Make Rust/Python atomic-file lock ownership and stale recovery safe",
+        "captured_at": "2026-07-16T18:53:36.947Z",
+        "schema_version": 2,
+        "unavailable_hosts": [],
+        "unavailable_host_count": 0,
+        "match_count": 0
+      },
+      {
+        "issue": 149,
+        "issue_title": "Make Rust/Python atomic-file lock ownership and stale recovery safe",
+        "kind": "issue_number",
+        "query": "Issue 149",
+        "captured_at": "2026-07-16T18:53:36.947Z",
+        "schema_version": 2,
+        "unavailable_hosts": [],
+        "unavailable_host_count": 0,
+        "match_count": 0
+      },
+      {
+        "issue": 150,
+        "issue_title": "Coalesce automatic OpenAI usage probes and avoid repeated Codex app-server cold starts",
+        "kind": "exact_title",
+        "query": "Coalesce automatic OpenAI usage probes and avoid repeated Codex app-server cold starts",
+        "captured_at": "2026-07-16T18:53:36.947Z",
+        "schema_version": 2,
+        "unavailable_hosts": [],
+        "unavailable_host_count": 0,
+        "match_count": 0
+      },
+      {
+        "issue": 150,
+        "issue_title": "Coalesce automatic OpenAI usage probes and avoid repeated Codex app-server cold starts",
+        "kind": "issue_number",
+        "query": "Issue 150",
+        "captured_at": "2026-07-16T18:53:36.947Z",
+        "schema_version": 2,
+        "unavailable_hosts": [],
+        "unavailable_host_count": 0,
+        "match_count": 0
+      },
+      {
+        "issue": 111,
+        "issue_title": "Make Windows app autostart registration verifiable and reliable",
+        "kind": "exact_title",
+        "query": "Make Windows app autostart registration verifiable and reliable",
+        "captured_at": "2026-07-16T18:53:36.947Z",
+        "schema_version": 2,
+        "unavailable_hosts": [],
+        "unavailable_host_count": 0,
+        "match_count": 0
+      },
+      {
+        "issue": 111,
+        "issue_title": "Make Windows app autostart registration verifiable and reliable",
+        "kind": "issue_number",
+        "query": "Issue 111",
+        "captured_at": "2026-07-16T18:53:36.947Z",
+        "schema_version": 2,
+        "unavailable_hosts": [],
+        "unavailable_host_count": 0,
+        "match_count": 0
+      }
+    ]
+  },
+  "candidates": [
+    {
+      "number": 159,
+      "title": "Bound repeated empty tool_search misses for external models",
+      "state": "open",
+      "body_normalized_sha256": "dc9f36f3c8c8dcbdc79696205528f1743d56885216d41f821bc59c486d8bc78e",
+      "labels": [
+        "bug",
+        "ready-for-agent",
+        "wayfinder:task"
+      ],
+      "assignees": [],
+      "milestone": "0.1.6 — Codex control-plane reliability",
+      "parent": 156,
+      "blocked_by": [],
+      "children": [],
+      "url": "https://github.com/NOirBRight/CodexHub/issues/159",
+      "expected_hotset": {
+        "entries": [
+          {
+            "raw": "- `src-python/codex_proxy.py`",
+            "normalized": "src-python/codex_proxy.py",
+            "path_matchers": [
+              "src-python/codex_proxy.py"
+            ]
+          },
+          {
+            "raw": "- `src-python/codex_semantic_adapter.py`",
+            "normalized": "src-python/codex_semantic_adapter.py",
+            "path_matchers": [
+              "src-python/codex_semantic_adapter.py"
+            ]
+          },
+          {
+            "raw": "- `tests/test_routing.py`",
+            "normalized": "tests/test_routing.py",
+            "path_matchers": [
+              "tests/test_routing.py"
+            ]
+          },
+          {
+            "raw": "- `tests/test_codex_semantic_adapter.py`",
+            "normalized": "tests/test_codex_semantic_adapter.py",
+            "path_matchers": [
+              "tests/test_codex_semantic_adapter.py"
+            ]
+          },
+          {
+            "raw": "- one sanitized fixture under `tests/fixtures/` if the deterministic replay needs it",
+            "normalized": "one sanitized fixture under tests/fixtures/ if the deterministic replay needs it",
+            "path_matchers": [
+              "tests/fixtures/**"
+            ]
+          }
+        ],
+        "matchers": [
+          "src-python/codex_proxy.py",
+          "src-python/codex_semantic_adapter.py",
+          "tests/fixtures/**",
+          "tests/test_codex_semantic_adapter.py",
+          "tests/test_routing.py"
+        ]
+      },
+      "eligibility": {
+        "label_dependency": {
+          "open": true,
+          "ready_for_agent": true,
+          "unassigned": true,
+          "open_blockers": [],
+          "eligible": true,
+          "ineligible_reasons": []
+        },
+        "ownership_hotset": {
+          "native_task_query_count": 2,
+          "native_task_matches": 0,
+          "native_task_unavailable_hosts": 0,
+          "assignees": [],
+          "active_surface_intersections": [],
+          "eligible": true,
+          "ineligible_reasons": []
+        }
+      }
+    },
+    {
+      "number": 161,
+      "title": "Preserve Worker selector and effective binding validation for external delegation",
+      "state": "open",
+      "body_normalized_sha256": "944ad1757538846011da360b880c53889c2aaa68d021cb3634caf1221c88e4f3",
+      "labels": [
+        "bug",
+        "ready-for-agent",
+        "wayfinder:task"
+      ],
+      "assignees": [],
+      "milestone": "0.1.6 — Codex control-plane reliability",
+      "parent": 156,
+      "blocked_by": [],
+      "children": [],
+      "url": "https://github.com/NOirBRight/CodexHub/issues/161",
+      "expected_hotset": {
+        "entries": [
+          {
+            "raw": "- `src-python/codex_semantic_adapter.py`",
+            "normalized": "src-python/codex_semantic_adapter.py",
+            "path_matchers": [
+              "src-python/codex_semantic_adapter.py"
+            ]
+          },
+          {
+            "raw": "- `src-python/codex_proxy.py` only where the selector/effective-binding result crosses the adapter boundary",
+            "normalized": "src-python/codex_proxy.py only where the selector/effective-binding result crosses the adapter boundary",
+            "path_matchers": [
+              "src-python/codex_proxy.py"
+            ]
+          },
+          {
+            "raw": "- `tests/test_codex_semantic_adapter.py`",
+            "normalized": "tests/test_codex_semantic_adapter.py",
+            "path_matchers": [
+              "tests/test_codex_semantic_adapter.py"
+            ]
+          },
+          {
+            "raw": "- focused routing tests for `agent_type`/binding",
+            "normalized": "focused routing tests for agent_type/binding",
+            "path_matchers": [
+              "tests/test_routing.py"
+            ]
+          },
+          {
+            "raw": "- one focused sanitized fixture under `tests/fixtures/` if required",
+            "normalized": "one focused sanitized fixture under tests/fixtures/ if required",
+            "path_matchers": [
+              "tests/fixtures/**"
+            ]
+          }
+        ],
+        "matchers": [
+          "src-python/codex_proxy.py",
+          "src-python/codex_semantic_adapter.py",
+          "tests/fixtures/**",
+          "tests/test_codex_semantic_adapter.py",
+          "tests/test_routing.py"
+        ]
+      },
+      "eligibility": {
+        "label_dependency": {
+          "open": true,
+          "ready_for_agent": true,
+          "unassigned": true,
+          "open_blockers": [],
+          "eligible": true,
+          "ineligible_reasons": []
+        },
+        "ownership_hotset": {
+          "native_task_query_count": 2,
+          "native_task_matches": 0,
+          "native_task_unavailable_hosts": 0,
+          "assignees": [],
+          "active_surface_intersections": [],
+          "eligible": true,
+          "ineligible_reasons": []
+        }
+      }
+    },
+    {
+      "number": 139,
+      "title": "Serialize Gateway lifecycle operations and prevent duplicate startup processes",
+      "state": "open",
+      "body_normalized_sha256": "07ed44014139aafc869b96e38c4dd0c64e93bfbda0363a374c226608075c96e9",
+      "labels": [
+        "bug",
+        "ready-for-agent",
+        "wayfinder:task"
+      ],
+      "assignees": [],
+      "milestone": "0.1.6 — Codex control-plane reliability",
+      "parent": 147,
+      "blocked_by": [],
+      "children": [],
+      "url": "https://github.com/NOirBRight/CodexHub/issues/139",
+      "expected_hotset": {
+        "entries": [
+          {
+            "raw": "- src-tauri/src/proxy.rs",
+            "normalized": "src-tauri/src/proxy.rs",
+            "path_matchers": [
+              "src-tauri/src/proxy.rs"
+            ]
+          },
+          {
+            "raw": "- src-tauri/src/main.rs",
+            "normalized": "src-tauri/src/main.rs",
+            "path_matchers": [
+              "src-tauri/src/main.rs"
+            ]
+          },
+          {
+            "raw": "- Rust lifecycle coordinator/state tests adjacent to those modules",
+            "normalized": "Rust lifecycle coordinator/state tests adjacent to those modules",
+            "path_matchers": [
+              "src-tauri/src/**"
+            ]
+          },
+          {
+            "raw": "- Gateway status/control frontend only if needed for Starting/Stopping/Restarting state",
+            "normalized": "Gateway status/control frontend only if needed for Starting/Stopping/Restarting state",
+            "path_matchers": [
+              "frontend/**"
+            ]
+          }
+        ],
+        "matchers": [
+          "frontend/**",
+          "src-tauri/src/**",
+          "src-tauri/src/main.rs",
+          "src-tauri/src/proxy.rs"
+        ]
+      },
+      "eligibility": {
+        "label_dependency": {
+          "open": true,
+          "ready_for_agent": true,
+          "unassigned": true,
+          "open_blockers": [],
+          "eligible": true,
+          "ineligible_reasons": []
+        },
+        "ownership_hotset": {
+          "native_task_query_count": 2,
+          "native_task_matches": 0,
+          "native_task_unavailable_hosts": 0,
+          "assignees": [],
+          "active_surface_intersections": [],
+          "eligible": true,
+          "ineligible_reasons": []
+        }
+      }
+    },
+    {
+      "number": 149,
+      "title": "Make Rust/Python atomic-file lock ownership and stale recovery safe",
+      "state": "open",
+      "body_normalized_sha256": "167d2242ab99b846f86e6122f13d4ac3b25047506f153f56cdb05fd5b3b01db5",
+      "labels": [
+        "bug",
+        "ready-for-agent",
+        "wayfinder:task"
+      ],
+      "assignees": [],
+      "milestone": "0.1.6 — Codex control-plane reliability",
+      "parent": 147,
+      "blocked_by": [],
+      "children": [],
+      "url": "https://github.com/NOirBRight/CodexHub/issues/149",
+      "expected_hotset": {
+        "entries": [
+          {
+            "raw": "- src-python/atomic_io.py",
+            "normalized": "src-python/atomic_io.py",
+            "path_matchers": [
+              "src-python/atomic_io.py"
+            ]
+          },
+          {
+            "raw": "- src-tauri/src/safe_file.rs",
+            "normalized": "src-tauri/src/safe_file.rs",
+            "path_matchers": [
+              "src-tauri/src/safe_file.rs"
+            ]
+          },
+          {
+            "raw": "- tests/test_atomic_io.py",
+            "normalized": "tests/test_atomic_io.py",
+            "path_matchers": [
+              "tests/test_atomic_io.py"
+            ]
+          },
+          {
+            "raw": "- Focused cross-language subprocess fixtures/tests",
+            "normalized": "Focused cross-language subprocess fixtures/tests",
+            "path_matchers": [
+              "src-tauri/**",
+              "tests/**"
+            ]
+          },
+          {
+            "raw": "- Only directly affected atomic-write callers whose error handling must stop swallowing non-absence failures",
+            "normalized": "Only directly affected atomic-write callers whose error handling must stop swallowing non-absence failures",
+            "path_matchers": [
+              "src-python/**",
+              "src-tauri/src/**"
+            ]
+          }
+        ],
+        "matchers": [
+          "src-python/**",
+          "src-python/atomic_io.py",
+          "src-tauri/**",
+          "src-tauri/src/**",
+          "src-tauri/src/safe_file.rs",
+          "tests/**",
+          "tests/test_atomic_io.py"
+        ]
+      },
+      "eligibility": {
+        "label_dependency": {
+          "open": true,
+          "ready_for_agent": true,
+          "unassigned": true,
+          "open_blockers": [],
+          "eligible": true,
+          "ineligible_reasons": []
+        },
+        "ownership_hotset": {
+          "native_task_query_count": 2,
+          "native_task_matches": 0,
+          "native_task_unavailable_hosts": 0,
+          "assignees": [],
+          "active_surface_intersections": [],
+          "eligible": true,
+          "ineligible_reasons": []
+        }
+      }
+    },
+    {
+      "number": 150,
+      "title": "Coalesce automatic OpenAI usage probes and avoid repeated Codex app-server cold starts",
+      "state": "open",
+      "body_normalized_sha256": "e7dbdf0e3de5cca7e59fdec83eec20cbbd22cca7382501232e575131826513ad",
+      "labels": [
+        "bug",
+        "ready-for-agent",
+        "wayfinder:task"
+      ],
+      "assignees": [],
+      "milestone": "0.1.6 — Codex control-plane reliability",
+      "parent": 147,
+      "blocked_by": [],
+      "children": [],
+      "url": "https://github.com/NOirBRight/CodexHub/issues/150",
+      "expected_hotset": {
+        "entries": [
+          {
+            "raw": "- frontend/src/pages/ProvidersPage.tsx",
+            "normalized": "frontend/src/pages/ProvidersPage.tsx",
+            "path_matchers": [
+              "frontend/src/pages/ProvidersPage.tsx"
+            ]
+          },
+          {
+            "raw": "- frontend/src/components/providers/OfficialOpenAIUsagePanel.tsx",
+            "normalized": "frontend/src/components/providers/OfficialOpenAIUsagePanel.tsx",
+            "path_matchers": [
+              "frontend/src/components/providers/OfficialOpenAIUsagePanel.tsx"
+            ]
+          },
+          {
+            "raw": "- src-tauri/src/openai_usage.rs",
+            "normalized": "src-tauri/src/openai_usage.rs",
+            "path_matchers": [
+              "src-tauri/src/openai_usage.rs"
+            ]
+          },
+          {
+            "raw": "- frontend/scripts/ui-contract.test.mjs",
+            "normalized": "frontend/scripts/ui-contract.test.mjs",
+            "path_matchers": [
+              "frontend/scripts/ui-contract.test.mjs"
+            ]
+          },
+          {
+            "raw": "- focused Rust tests adjacent to openai_usage",
+            "normalized": "focused Rust tests adjacent to openai_usage",
+            "path_matchers": [
+              "src-tauri/src/openai_usage.rs"
+            ]
+          }
+        ],
+        "matchers": [
+          "frontend/scripts/ui-contract.test.mjs",
+          "frontend/src/components/providers/OfficialOpenAIUsagePanel.tsx",
+          "frontend/src/pages/ProvidersPage.tsx",
+          "src-tauri/src/openai_usage.rs"
+        ]
+      },
+      "eligibility": {
+        "label_dependency": {
+          "open": true,
+          "ready_for_agent": true,
+          "unassigned": true,
+          "open_blockers": [],
+          "eligible": true,
+          "ineligible_reasons": []
+        },
+        "ownership_hotset": {
+          "native_task_query_count": 2,
+          "native_task_matches": 0,
+          "native_task_unavailable_hosts": 0,
+          "assignees": [],
+          "active_surface_intersections": [],
+          "eligible": true,
+          "ineligible_reasons": []
+        }
+      }
+    },
+    {
+      "number": 111,
+      "title": "Make Windows app autostart registration verifiable and reliable",
+      "state": "open",
+      "body_normalized_sha256": "ef55ac12e419ddc72949e2c2975899e2d70f1f364f283d3b28b3911d18ad0c05",
+      "labels": [
+        "bug",
+        "ready-for-agent",
+        "wayfinder:task"
+      ],
+      "assignees": [],
+      "milestone": "0.1.6 — Codex control-plane reliability",
+      "parent": 147,
+      "blocked_by": [],
+      "children": [],
+      "url": "https://github.com/NOirBRight/CodexHub/issues/111",
+      "expected_hotset": {
+        "entries": [
+          {
+            "raw": "- `src-tauri/src/autostart.rs`",
+            "normalized": "src-tauri/src/autostart.rs",
+            "path_matchers": [
+              "src-tauri/src/autostart.rs"
+            ]
+          },
+          {
+            "raw": "- Tauri settings/autostart command and state types",
+            "normalized": "Tauri settings/autostart command and state types",
+            "path_matchers": [
+              "src-tauri/src/**"
+            ]
+          },
+          {
+            "raw": "- `frontend/src/App.tsx`",
+            "normalized": "frontend/src/App.tsx",
+            "path_matchers": [
+              "frontend/src/App.tsx"
+            ]
+          },
+          {
+            "raw": "- `frontend/src/pages/SettingsPage.tsx` and/or the settings drawer",
+            "normalized": "frontend/src/pages/SettingsPage.tsx and/or the settings drawer",
+            "path_matchers": [
+              "frontend/src/components/**/Settings*",
+              "frontend/src/pages/SettingsPage.tsx"
+            ]
+          },
+          {
+            "raw": "- Rust autostart tests and frontend UI-contract tests",
+            "normalized": "Rust autostart tests and frontend UI-contract tests",
+            "path_matchers": [
+              "frontend/scripts/**",
+              "src-tauri/src/**"
+            ]
+          },
+          {
+            "raw": "- A deterministic Windows packaged/portable smoke harness or documented verification",
+            "normalized": "A deterministic Windows packaged/portable smoke harness or documented verification",
+            "path_matchers": [
+              "docs/**/autostart*",
+              "docs/*autostart*",
+              "scripts/**/autostart*",
+              "scripts/*autostart*"
+            ]
+          }
+        ],
+        "matchers": [
+          "docs/**/autostart*",
+          "docs/*autostart*",
+          "frontend/scripts/**",
+          "frontend/src/App.tsx",
+          "frontend/src/components/**/Settings*",
+          "frontend/src/pages/SettingsPage.tsx",
+          "scripts/**/autostart*",
+          "scripts/*autostart*",
+          "src-tauri/src/**",
+          "src-tauri/src/autostart.rs"
+        ]
+      },
+      "eligibility": {
+        "label_dependency": {
+          "open": true,
+          "ready_for_agent": true,
+          "unassigned": true,
+          "open_blockers": [],
+          "eligible": true,
+          "ineligible_reasons": []
+        },
+        "ownership_hotset": {
+          "native_task_query_count": 2,
+          "native_task_matches": 0,
+          "native_task_unavailable_hosts": 0,
+          "assignees": [],
+          "active_surface_intersections": [],
+          "eligible": true,
+          "ineligible_reasons": []
+        }
+      }
+    }
+  ],
+  "ownership_surfaces": {
+    "worktrees": [
+      {
+        "logical_identity": "worktree:dev",
+        "branch": "dev",
+        "revision": "51a636c98ca90a9766836a7d603c2013211bbeeb",
+        "clean": true,
+        "dirty_files": [],
+        "changed_files_vs_dev": [],
+        "hotset_intersections": {
+          "159": [],
+          "161": [],
+          "139": [],
+          "149": [],
+          "150": [],
+          "111": []
+        },
+        "classification": "audited-baseline",
+        "active": true
+      },
+      {
+        "logical_identity": "worktree:wayfinder-github-migration",
+        "branch": "wayfinder-github-migration",
+        "revision": "bd2b44034c92cf60a4e5ac598300ef6817a0e02d",
+        "clean": false,
+        "dirty_files": [
+          "docs/superpowers/plans/2026-07-16-wayfinder-github-migration.md",
+          "docs/superpowers/specs/2026-07-16-wayfinder-replanning-design.md",
+          "scripts/generate_wayfinder_final_audit.py"
+        ],
+        "changed_files_vs_dev": [
+          "docs/superpowers/plans/2026-07-16-wayfinder-github-migration.md",
+          "docs/superpowers/reviews/wayfinder-checkpoint-update-v1.json",
+          "docs/superpowers/reviews/wayfinder-final-audit-v1.json",
+          "docs/superpowers/reviews/wayfinder-frontier-ownership-audit-v1.json",
+          "docs/superpowers/specs/2026-07-16-wayfinder-replanning-design.md",
+          "scripts/generate_wayfinder_final_audit.py"
+        ],
+        "hotset_intersections": {
+          "159": [],
+          "161": [],
+          "139": [],
+          "149": [],
+          "150": [],
+          "111": []
+        },
+        "classification": "migration-control",
+        "active": true
+      }
+    ],
+    "local_branches": [
+      {
+        "logical_identity": "local-branch:dev",
+        "name": "dev",
+        "revision": "51a636c98ca90a9766836a7d603c2013211bbeeb",
+        "changed_files_vs_dev": [],
+        "hotset_intersections": {
+          "159": [],
+          "161": [],
+          "139": [],
+          "149": [],
+          "150": [],
+          "111": []
+        },
+        "checked_out_in_worktree": true,
+        "open_prs": [],
+        "active": true
+      },
+      {
+        "logical_identity": "local-branch:main",
+        "name": "main",
+        "revision": "ddcbbee77d3faaac3e5f282d2741e8f268f20e79",
+        "changed_files_vs_dev": [],
+        "hotset_intersections": {
+          "159": [],
+          "161": [],
+          "139": [],
+          "149": [],
+          "150": [],
+          "111": []
+        },
+        "checked_out_in_worktree": false,
+        "open_prs": [],
+        "active": false
+      },
+      {
+        "logical_identity": "local-branch:milestone-roadmap-m0-completion",
+        "name": "milestone-roadmap-m0-completion",
+        "revision": "1d0738611acc1f59402c60ad84a81728add5cee4",
+        "changed_files_vs_dev": [],
+        "hotset_intersections": {
+          "159": [],
+          "161": [],
+          "139": [],
+          "149": [],
+          "150": [],
+          "111": []
+        },
+        "checked_out_in_worktree": false,
+        "open_prs": [],
+        "active": false
+      },
+      {
+        "logical_identity": "local-branch:wayfinder-github-migration",
+        "name": "wayfinder-github-migration",
+        "revision": "bd2b44034c92cf60a4e5ac598300ef6817a0e02d",
+        "changed_files_vs_dev": [
+          "docs/superpowers/plans/2026-07-16-wayfinder-github-migration.md",
+          "docs/superpowers/specs/2026-07-16-wayfinder-replanning-design.md"
+        ],
+        "hotset_intersections": {
+          "159": [],
+          "161": [],
+          "139": [],
+          "149": [],
+          "150": [],
+          "111": []
+        },
+        "checked_out_in_worktree": true,
+        "open_prs": [],
+        "active": true
+      }
+    ],
+    "open_pr_heads": []
+  },
+  "frontier": [
+    159,
+    161,
+    139,
+    149,
+    150,
+    111
+  ],
+  "global_github_audit": {
+    "open_issue_count": 63,
+    "canonical_lifecycle_violations": [],
+    "milestone_membership_expected": {
+      "0.1.6 — Codex control-plane reliability": [
+        111,
+        112,
+        138,
+        139,
+        141,
+        143,
+        149,
+        150,
+        151,
+        156,
+        159,
+        161
+      ],
+      "0.1.7 — Official GPT reliability": [
+        18,
+        19,
+        20,
+        21,
+        104,
+        109,
+        114,
+        157
+      ],
+      "0.1.8 — Third-party model certification": [
+        17,
+        22,
+        57,
+        58,
+        59,
+        61,
+        62,
+        63,
+        64,
+        65,
+        66,
+        67
+      ],
+      "0.1.9 — Managed client reliability": [
+        8,
+        28,
+        83,
+        153,
+        154,
+        155
+      ],
+      "0.1.10 — Existing product reliability": [
+        86,
+        87,
+        88,
+        113,
+        115,
+        126,
+        160
+      ]
+    },
+    "milestone_membership_actual": {
+      "0.1.6 — Codex control-plane reliability": [
+        111,
+        112,
+        138,
+        139,
+        141,
+        143,
+        149,
+        150,
+        151,
+        156,
+        159,
+        161
+      ],
+      "0.1.7 — Official GPT reliability": [
+        18,
+        19,
+        20,
+        21,
+        104,
+        109,
+        114,
+        157
+      ],
+      "0.1.8 — Third-party model certification": [
+        17,
+        22,
+        57,
+        58,
+        59,
+        61,
+        62,
+        63,
+        64,
+        65,
+        66,
+        67
+      ],
+      "0.1.9 — Managed client reliability": [
+        8,
+        28,
+        83,
+        153,
+        154,
+        155
+      ],
+      "0.1.10 — Existing product reliability": [
+        86,
+        87,
+        88,
+        113,
+        115,
+        126,
+        160
+      ]
+    },
+    "milestones": [
+      {
+        "number": 3,
+        "title": "0.1.6 — Codex control-plane reliability",
+        "description": "Exit: one reconciled Gateway lifecycle; sidebar-visible Worker materialization; bidirectional Task communication and receipts; bounded cancellation/exit/restart; recoverable Task state. Only 0.1.6 receives new work while this gate is active.",
+        "state": "open",
+        "open_issues": 12,
+        "closed_issues": 0
+      },
+      {
+        "number": 4,
+        "title": "0.1.7 — Official GPT reliability",
+        "description": "Exit: Official GPT catalog, Task/Worker communication, tool lifecycle, streaming/cancellation, and context authority are reliable enough to serve as the control group for third-party qualification.",
+        "state": "open",
+        "open_issues": 8,
+        "closed_issues": 0
+      },
+      {
+        "number": 5,
+        "title": "0.1.8 — Third-party model certification",
+        "description": "Exit: each supported provider/model/protocol/codec combination has runtime-derived capability evidence, full visible-Worker and Task communication coverage, fail-closed unknown semantics, and a #67 GO/PARTIAL/NO-GO decision.",
+        "state": "open",
+        "open_issues": 12,
+        "closed_issues": 0
+      },
+      {
+        "number": 6,
+        "title": "0.1.9 — Managed client reliability",
+        "description": "Exit: ZCode, OMP, OpenCode, and Pi preview/apply/readback/restore are transactional, identity-faithful, reasoning-faithful, and free of silent Official fallback.",
+        "state": "open",
+        "open_issues": 6,
+        "closed_issues": 0
+      },
+      {
+        "number": 7,
+        "title": "0.1.10 — Existing product reliability",
+        "description": "Exit: remaining existing pricing, Vision Proxy, diagnostics, notification, and uninstall-cleanup defects are resolved without adding new product capabilities.",
+        "state": "open",
+        "open_issues": 7,
+        "closed_issues": 0
+      },
+      {
+        "number": 1,
+        "title": "Third-party model agentic reliability",
+        "description": "Superseded on 2026-07-16 by the reliability-gated 0.1.6–0.1.10 milestones. Historical issue/decision context remains preserved; this milestone is no longer a scheduling pool.",
+        "state": "closed",
+        "open_issues": 0,
+        "closed_issues": 10
+      },
+      {
+        "number": 2,
+        "title": "Capability-driven routing rollout",
+        "description": "Superseded on 2026-07-12 by the consolidated Third-party model agentic reliability milestone (#1).",
+        "state": "closed",
+        "open_issues": 0,
+        "closed_issues": 0
+      }
+    ],
+    "open_issue_assignees": {
+      "114": [
+        "NOirBRight"
+      ]
+    },
+    "critical_contracts": {
+      "28": {
+        "number": 28,
+        "title": "Bound Gateway client probes and catalog discovery work",
+        "state": "open",
+        "body_normalized_sha256": "8a882cd0b7af8b87c803cced922f95a2527f04314180fbf6b0df2c571cc58d29",
+        "labels": [
+          "enhancement",
+          "ready-for-agent",
+          "wayfinder:task"
+        ],
+        "assignees": [],
+        "milestone": "0.1.9 — Managed client reliability",
+        "parent": 147,
+        "blocked_by": [],
+        "children": [],
+        "url": "https://github.com/NOirBRight/CodexHub/issues/28"
+      },
+      "147": {
+        "number": 147,
+        "title": "Wayfinder: CodexHub 0.1.6–0.3.0 Gateway and release roadmap",
+        "state": "open",
+        "body_normalized_sha256": "af02920412d7f51fc7d136912c677b4cd7c38127c42a4ca4b805af40d7831c32",
+        "labels": [
+          "enhancement",
+          "ready-for-human",
+          "wayfinder:map"
+        ],
+        "assignees": [],
+        "milestone": null,
+        "parent": null,
+        "blocked_by": [],
+        "children": [
+          8,
+          17,
+          18,
+          19,
+          20,
+          21,
+          22,
+          28,
+          57,
+          58,
+          59,
+          61,
+          68,
+          71,
+          73,
+          83,
+          85,
+          86,
+          87,
+          88,
+          104,
+          109,
+          111,
+          112,
+          113,
+          114,
+          115,
+          126,
+          138,
+          139,
+          141,
+          143,
+          148,
+          149,
+          150,
+          151,
+          152,
+          153,
+          154,
+          155,
+          156,
+          157,
+          160
+        ],
+        "url": "https://github.com/NOirBRight/CodexHub/issues/147"
+      },
+      "156": {
+        "number": 156,
+        "title": "Enable sidebar-visible third-party Worker callbacks and binding readback",
+        "state": "open",
+        "body_normalized_sha256": "9e78522d36707a8806d2f97a7ef332b2c0ef26874dff16e0b5f5ac5f96f10c85",
+        "labels": [
+          "bug",
+          "ready-for-human",
+          "wayfinder:grilling"
+        ],
+        "assignees": [],
+        "milestone": "0.1.6 — Codex control-plane reliability",
+        "parent": 147,
+        "blocked_by": [
+          159,
+          161
+        ],
+        "children": [
+          159,
+          161
+        ],
+        "url": "https://github.com/NOirBRight/CodexHub/issues/156"
+      },
+      "159": {
+        "number": 159,
+        "title": "Bound repeated empty tool_search misses for external models",
+        "state": "open",
+        "body_normalized_sha256": "dc9f36f3c8c8dcbdc79696205528f1743d56885216d41f821bc59c486d8bc78e",
+        "labels": [
+          "bug",
+          "ready-for-agent",
+          "wayfinder:task"
+        ],
+        "assignees": [],
+        "milestone": "0.1.6 — Codex control-plane reliability",
+        "parent": 156,
+        "blocked_by": [],
+        "children": [],
+        "url": "https://github.com/NOirBRight/CodexHub/issues/159"
+      },
+      "160": {
+        "number": 160,
+        "title": "Remove CodexHub-owned Windows autostart registration during uninstall",
+        "state": "open",
+        "body_normalized_sha256": "da57b9a4c6f17cccb010ca6b5c87b3b54c3924551da81446cc073af0da721eeb",
+        "labels": [
+          "bug",
+          "ready-for-agent",
+          "wayfinder:task"
+        ],
+        "assignees": [],
+        "milestone": "0.1.10 — Existing product reliability",
+        "parent": 147,
+        "blocked_by": [
+          111
+        ],
+        "children": [],
+        "url": "https://github.com/NOirBRight/CodexHub/issues/160"
+      },
+      "161": {
+        "number": 161,
+        "title": "Preserve Worker selector and effective binding validation for external delegation",
+        "state": "open",
+        "body_normalized_sha256": "944ad1757538846011da360b880c53889c2aaa68d021cb3634caf1221c88e4f3",
+        "labels": [
+          "bug",
+          "ready-for-agent",
+          "wayfinder:task"
+        ],
+        "assignees": [],
+        "milestone": "0.1.6 — Codex control-plane reliability",
+        "parent": 156,
+        "blocked_by": [],
+        "children": [],
+        "url": "https://github.com/NOirBRight/CodexHub/issues/161"
+      }
+    },
+    "relations": {
+      "57": {
+        "parent": 147,
+        "blocked_by": [],
+        "children": [
+          62,
+          63,
+          64,
+          65,
+          66,
+          67
+        ]
+      },
+      "64": {
+        "parent": 57,
+        "blocked_by": [
+          62,
+          63,
+          156
+        ],
+        "children": []
+      },
+      "71": {
+        "parent": 147,
+        "blocked_by": [],
+        "children": [
+          89,
+          90,
+          91,
+          92,
+          93,
+          94
+        ]
+      },
+      "73": {
+        "parent": 147,
+        "blocked_by": [],
+        "children": [
+          74,
+          75,
+          76,
+          77,
+          78
+        ]
+      },
+      "111": {
+        "parent": 147,
+        "blocked_by": [],
+        "children": []
+      },
+      "147": {
+        "parent": null,
+        "blocked_by": [],
+        "children": [
+          8,
+          17,
+          18,
+          19,
+          20,
+          21,
+          22,
+          28,
+          57,
+          58,
+          59,
+          61,
+          68,
+          71,
+          73,
+          83,
+          85,
+          86,
+          87,
+          88,
+          104,
+          109,
+          111,
+          112,
+          113,
+          114,
+          115,
+          126,
+          138,
+          139,
+          141,
+          143,
+          148,
+          149,
+          150,
+          151,
+          152,
+          153,
+          154,
+          155,
+          156,
+          157,
+          160
+        ]
+      },
+      "156": {
+        "parent": 147,
+        "blocked_by": [
+          159,
+          161
+        ],
+        "children": [
+          159,
+          161
+        ]
+      },
+      "159": {
+        "parent": 156,
+        "blocked_by": [],
+        "children": []
+      },
+      "160": {
+        "parent": 147,
+        "blocked_by": [
+          111
+        ],
+        "children": []
+      },
+      "161": {
+        "parent": 156,
+        "blocked_by": [],
+        "children": []
+      }
+    },
+    "comments": {
+      "8": {
+        "public_comment_id": 4994634611,
+        "purpose_prefix": "### Wayfinder baseline correction",
+        "normalized_body_sha256": "d1450f61411a1069668527e5e11733921b8b30c3ec20b32352885ff01f49912a",
+        "prefix_multiplicity": 1,
+        "exact_body_multiplicity": 1,
+        "created_at": "2026-07-16T17:13:03Z",
+        "updated_at": "2026-07-16T17:13:03Z",
+        "url": "https://github.com/NOirBRight/CodexHub/issues/8#issuecomment-4994634611"
+      },
+      "10": {
+        "public_comment_id": 4994635018,
+        "purpose_prefix": "Wayfinder closure reconciliation:",
+        "normalized_body_sha256": "8b0ce766324b6fa11722802e3c3aa597c71faa6a5c32ed5bba5cd3e91c3235ea",
+        "prefix_multiplicity": 1,
+        "exact_body_multiplicity": 1,
+        "created_at": "2026-07-16T17:13:05Z",
+        "updated_at": "2026-07-16T17:13:05Z",
+        "url": "https://github.com/NOirBRight/CodexHub/issues/10#issuecomment-4994635018"
+      },
+      "12": {
+        "public_comment_id": 4994635403,
+        "purpose_prefix": "Wayfinder closure reconciliation:",
+        "normalized_body_sha256": "60904c5c69e311986fd8fcbde71d35a51aac1ca540510beb853587a3b456d86b",
+        "prefix_multiplicity": 1,
+        "exact_body_multiplicity": 1,
+        "created_at": "2026-07-16T17:13:08Z",
+        "updated_at": "2026-07-16T17:13:08Z",
+        "url": "https://github.com/NOirBRight/CodexHub/issues/12#issuecomment-4994635403"
+      },
+      "62": {
+        "public_comment_id": 4994636467,
+        "purpose_prefix": "Wayfinder ownership reconciliation:",
+        "normalized_body_sha256": "db78e9489281b842d6128d0964a6109dbe43a31c8c381474653c963867919b63",
+        "prefix_multiplicity": 1,
+        "exact_body_multiplicity": 1,
+        "created_at": "2026-07-16T17:13:16Z",
+        "updated_at": "2026-07-16T17:13:16Z",
+        "url": "https://github.com/NOirBRight/CodexHub/issues/62#issuecomment-4994636467"
+      },
+      "147": {
+        "public_comment_id": 4994927680,
+        "purpose_prefix": "## Reliability-gated Wayfinder migration readback",
+        "normalized_body_sha256": "b6d4d1e9bc58fd013c4968eb2799990fb7afa579572ade93534ee657c35ad82b",
+        "prefix_multiplicity": 1,
+        "exact_body_multiplicity": 1,
+        "created_at": "2026-07-16T17:46:29Z",
+        "updated_at": "2026-07-16T18:17:28Z",
+        "url": "https://github.com/NOirBRight/CodexHub/issues/147#issuecomment-4994927680"
+      }
+    }
+  },
+  "derivation": {
+    "label_dependency_rule": "open AND ready-for-agent AND unassigned AND zero open native blockers",
+    "ownership_hotset_rule": "two exact native queries clear AND no unavailable native host AND unassigned AND no active worktree/local-branch/open-PR changed-file intersection with the parsed Expected hotset",
+    "branch_names_used_as_ownership_evidence": false,
+    "inactive_local_branches_block_eligibility": false,
+    "inactive_branch_reason": "A local branch is active only when checked out in a worktree or used as an open PR head; every local branch is still enumerated with its file intersections.",
+    "planning_worktree_rule": "The current planning worktree is migration-control evidence only because its complete changed-file set has zero frontier product-hotset intersections.",
+    "dev_rule": "The dev worktree is independently audited for revision, cleanliness, and changed-file intersections; it is not trusted by name alone.",
+    "result": "eligible"
+  },
+  "sanitization": {
+    "native_task_ids_persisted": false,
+    "local_absolute_paths_persisted": false,
+    "worktree_identity_basis": "branch or detached revision, never filesystem path",
+    "changed_file_paths": "repository-relative"
+  }
+}

--- a/docs/superpowers/reviews/wayfinder-frontier-ownership-audit-v1.json
+++ b/docs/superpowers/reviews/wayfinder-frontier-ownership-audit-v1.json
@@ -1,13 +1,13 @@
 {
   "schema_version": 1,
   "artifact_kind": "wayfinder-frontier-ownership-audit",
-  "captured_at": "2026-07-16T19:10:29.752972Z",
+  "captured_at": "2026-07-16T19:44:53.590618Z",
   "repository": "NOirBRight/CodexHub",
   "generator": "scripts/generate_wayfinder_final_audit.py",
   "base_ref": "dev",
   "base_revision": "51a636c98ca90a9766836a7d603c2013211bbeeb",
   "planning_branch": "wayfinder-github-migration",
-  "planning_revision": "bd2b44034c92cf60a4e5ac598300ef6817a0e02d",
+  "planning_revision": "7d60eca9a903672948445bc079ed46316b281907",
   "native_task_capture": {
     "tool": "codex_app__list_threads",
     "source_capture_file_sha256": "8d8a637e13cae1e791b79525b431c6006cbaf015b4bb1ac88f797692939d9ed5",
@@ -599,6 +599,7 @@
             "normalized": "frontend/src/pages/SettingsPage.tsx and/or the settings drawer",
             "path_matchers": [
               "frontend/src/components/**/Settings*",
+              "frontend/src/components/SettingsDrawer.tsx",
               "frontend/src/pages/SettingsPage.tsx"
             ]
           },
@@ -627,6 +628,7 @@
           "frontend/scripts/**",
           "frontend/src/App.tsx",
           "frontend/src/components/**/Settings*",
+          "frontend/src/components/SettingsDrawer.tsx",
           "frontend/src/pages/SettingsPage.tsx",
           "scripts/**/autostart*",
           "scripts/*autostart*",
@@ -678,12 +680,12 @@
       {
         "logical_identity": "worktree:wayfinder-github-migration",
         "branch": "wayfinder-github-migration",
-        "revision": "bd2b44034c92cf60a4e5ac598300ef6817a0e02d",
+        "revision": "7d60eca9a903672948445bc079ed46316b281907",
         "clean": false,
         "dirty_files": [
           "docs/superpowers/plans/2026-07-16-wayfinder-github-migration.md",
-          "docs/superpowers/specs/2026-07-16-wayfinder-replanning-design.md",
-          "scripts/generate_wayfinder_final_audit.py"
+          "scripts/generate_wayfinder_final_audit.py",
+          "scripts/tests/test_wayfinder_final_audit_generator.py"
         ],
         "changed_files_vs_dev": [
           "docs/superpowers/plans/2026-07-16-wayfinder-github-migration.md",
@@ -691,7 +693,8 @@
           "docs/superpowers/reviews/wayfinder-final-audit-v1.json",
           "docs/superpowers/reviews/wayfinder-frontier-ownership-audit-v1.json",
           "docs/superpowers/specs/2026-07-16-wayfinder-replanning-design.md",
-          "scripts/generate_wayfinder_final_audit.py"
+          "scripts/generate_wayfinder_final_audit.py",
+          "scripts/tests/test_wayfinder_final_audit_generator.py"
         ],
         "hotset_intersections": {
           "159": [],
@@ -760,10 +763,14 @@
       {
         "logical_identity": "local-branch:wayfinder-github-migration",
         "name": "wayfinder-github-migration",
-        "revision": "bd2b44034c92cf60a4e5ac598300ef6817a0e02d",
+        "revision": "7d60eca9a903672948445bc079ed46316b281907",
         "changed_files_vs_dev": [
           "docs/superpowers/plans/2026-07-16-wayfinder-github-migration.md",
-          "docs/superpowers/specs/2026-07-16-wayfinder-replanning-design.md"
+          "docs/superpowers/reviews/wayfinder-checkpoint-update-v1.json",
+          "docs/superpowers/reviews/wayfinder-final-audit-v1.json",
+          "docs/superpowers/reviews/wayfinder-frontier-ownership-audit-v1.json",
+          "docs/superpowers/specs/2026-07-16-wayfinder-replanning-design.md",
+          "scripts/generate_wayfinder_final_audit.py"
         ],
         "hotset_intersections": {
           "159": [],
@@ -1296,11 +1303,11 @@
       "147": {
         "public_comment_id": 4994927680,
         "purpose_prefix": "## Reliability-gated Wayfinder migration readback",
-        "normalized_body_sha256": "b6d4d1e9bc58fd013c4968eb2799990fb7afa579572ade93534ee657c35ad82b",
+        "normalized_body_sha256": "7adca5e559b4757cb13ed0d95b94d890bb07c3bbf096a6185e7685649d311227",
         "prefix_multiplicity": 1,
         "exact_body_multiplicity": 1,
         "created_at": "2026-07-16T17:46:29Z",
-        "updated_at": "2026-07-16T18:17:28Z",
+        "updated_at": "2026-07-16T19:13:34Z",
         "url": "https://github.com/NOirBRight/CodexHub/issues/147#issuecomment-4994927680"
       }
     }

--- a/docs/superpowers/specs/2026-07-16-wayfinder-replanning-design.md
+++ b/docs/superpowers/specs/2026-07-16-wayfinder-replanning-design.md
@@ -1,0 +1,383 @@
+# Wayfinder 可靠性优先重规划设计
+
+日期：2026-07-16
+
+状态：设计已逐段批准，等待书面规格复核
+
+适用地图：[GitHub Issue #147](https://github.com/NOirBRight/CodexHub/issues/147)
+
+## 1. 背景
+
+当前 Wayfinder #147 按 0.1.6–0.3.0 功能主题组织工作，但它与最新问题台账、里程碑优先级和真实执行能力已经不一致：
+
+- 仓库有 93 个 Issues，其中 60 个 open、33 个 closed；
+- #147 创建后新增了 #155–#157，地图没有完整收录最新 P0；
+- 现有 `Third-party model agentic reliability` 里程碑声明可靠性最高优先，但 #147 先安排 Stable/Developer 发布渠道；
+- #147 要求所有 Worker 使用 GLM-5.2/max，而 #156 已证明该模型的 Worker 回调、工具发现和执行绑定无法满足可靠委派；
+- #8 的评论称实现已合并到本地 `dev`，但提交 `400d19bb` 不在当前 `dev` 历史，对应模块也不存在；
+- 旧 Beta 双安装规格仍留在仓库，但产品决策已改为单安装、共享状态的 Stable/Developer 模型；
+- #147 原有的 main→dev 对账前置条件已由 PR #158 完成，当前基线是 `dev@1d073861`。
+
+本设计把 Wayfinder 改造成门禁驱动的可靠性发布列车。它不实现产品代码，也不领取任何 Issue；GitHub 写入将在规格复核和实施计划批准后执行。
+
+### 1.1 实施范围边界
+
+本规格对应的下一份实施计划只负责 GitHub Wayfinder 迁移：重写 #147、建立/调整 milestones、修正 Issue 归属与依赖、拆分已批准的混合所有权 Issue，并验证新的 frontier。它不会把 0.1.6–0.2.x 的产品代码合并成一份实施计划。每个产品 Issue 继续以自己的 GitHub 验收合同为边界；需要多步设计的 Issue 在进入 frontier 后单独执行 spec→plan→implementation 周期。
+
+## 2. 目标与优先级
+
+### 2.1 优先层
+
+1. **Codex 内部可靠性**
+   - 执行控制面；
+   - Official GPT 可靠性；
+   - 第三方模型分级认证。
+2. **现有外部客户端可靠性**
+   - ZCode、OMP、OpenCode、Pi 等已管理客户端。
+3. **新功能**
+   - Stable/Developer 渠道；
+   - Provider 预设、凭证和 OAuth；
+   - Claude Code Messages；
+   - Imagegen；
+   - AgentProvider。
+
+### 2.2 分层门禁
+
+- 只有当前层持续补充新任务。
+- 较低层已认领任务可以完成当前约定边界，但不继续派生。
+- 凭证或隐私泄露、数据损坏、不可恢复迁移、非幂等副作用、异常费用和当前 Gate 的基础阻断可以越级。
+- 地图、标签、依赖和里程碑更新不等于领取任务。
+
+### 2.3 非目标
+
+- 不以大爆炸方式重写 Python Gateway 或通用协议中间表示；
+- 不把 Claude Code/ACP 当成普通 ModelProvider；
+- 不在证据不足时启用 Responses-to-Chat 或原生 Responses 快速路径；
+- 不因为 endpoint 名为 Responses 就宣称完整 Codex 兼容；
+- 不用 Hidden Subagent、`codex exec`、Background 进程或 Inline 执行冒充 Sidebar-visible Worker；
+- 不修改 Codex SQLite 或合成 Task/rollout 状态。
+
+## 3. Wayfinder 治理模型
+
+### 3.1 单一地图
+
+#147 继续作为唯一 Wayfinder Map。地图正文保存目的、优先层、版本 Gate、已做决策、当前 frontier、Fog 和非目标。GitHub Issues、原生依赖、assignee、milestone 和 PR 是唯一持久工作状态。
+
+### 3.2 Issue 角色
+
+每个 open Issue 必须归入一个主要角色：
+
+- **Gate owner**：定义版本退出条件；
+- **Fix**：修复已证明的缺陷；
+- **Evidence**：生成可重放证据或能力矩阵；
+- **Decision**：需要 Maintainer 作 GO/PARTIAL/NO-GO 或产品选择；
+- **Support**：诊断、发布、恢复或审计能力；
+- **Parking**：有效但不属于当前优先层。
+
+不能保留地图外孤儿、被新证据取代的调度假设，或评论和当前分支互相矛盾的完成状态。
+
+### 3.3 Frontier
+
+候选必须同时满足：
+
+```text
+open
++ 当前 milestone
++ ready-for-agent
++ unassigned
++ 无 open blocker
++ 无 hotset 冲突
+```
+
+选择顺序是 P0 Gate blocker、依赖图中最早的未阻塞节点、地图顺序，以及同级情况下能最早缩小后续风险的独立任务。`ready-for-human` 不进入自动 frontier，但必须显示在 Gate 的 Fog/Decision 区。
+
+## 4. 发布列车
+
+### 4.1 0.1.6 — Codex 执行控制面可靠性
+
+核心依赖：
+
+```text
+#139 Gateway 生命周期单一协调器
+  → #143 两秒内取消和退役
+    → #112 完整退出与更新重启清理
+```
+
+并行 Gate：
+
+- #156：Sidebar-visible third-party Worker、双向通信和结果回执；
+- #141：Desktop 重启和 Task 消失的首个失败边界；
+- #138：Task 活动中的命令、diff 和进度可审计性；
+- #150：合并 usage probe，避免重复冷启动 app-server；
+- #149：Rust/Python 跨语言锁所有权和崩溃恢复；
+- #151：工作区根目录迁移决策，默认不隐式导入；
+- #111：Windows 自动启动注册的真实状态和幂等性。
+
+退出条件：
+
+- Gateway 子进程、监听器、PID 和 UI 状态一致；
+- Sidebar-visible Worker 支持完整父子与 Task 间通信；
+- Worker 正确经历 Active→Done/Failed/Cancelled；
+- 停止、退出、更新和重启不留下工作、子进程或错误所有权；
+- Desktop 重启原因被分类，真实 Task 可恢复且不重复创建；
+- 活动记录足以审计消息、命令、diff 和终态。
+
+### 4.2 0.1.7 — Official GPT 可靠性
+
+范围：#114、#18→#19→#20、#21、#104、#109 的决策状态和 #157。
+
+退出条件：
+
+- Official GPT 主 Task、Visible Worker、Task 通信和工具循环通过；
+- 长流、取消、下游断开和 Gateway 退役有一致分类；
+- Official 模型目录、上下文预算和自动压缩来源一致；
+- Official context cap 不覆盖第三方模型；
+- 未证明由 CodexHub 引起的 Desktop、网络或上游问题不被宣称为已修复。
+
+#109 在一手产品政策矛盾解决前保持 `needs-info`；它不阻塞其他 Official GPT 可靠性工作。
+
+### 4.3 0.1.8 — 第三方模型分级认证
+
+可靠性基础：#17、#22，以及 0.1.7 已完成的 #18–#21。
+
+能力 DAG：
+
+```text
+#61 RoutePlan
+  → #62 Runtime/Gateway 身份捕获
+      → #63 tool_search
+      → #65 Provider/Model 能力矩阵
+      → #66 Responses→Chat 转换矩阵
+      → #63 → #64 Task/协作生命周期
+  #63 + #64 + #65 + #66
+      → #67 人工 GO/PARTIAL/NO-GO
+          → #58 能力驱动原生 Responses
+              → #59 仅在获批范围退役兼容逻辑
+```
+
+#57 保留为父 Gate。每个获认证模型必须单独通过 Task、Visible Worker、Task 间通信、工具发现/执行、协议、长流、取消、并发、重试、恢复和模型专属上下文预算。
+
+### 4.4 0.1.9 — 现有外部客户端可靠性
+
+范围：
+
+- #8：重新实施或恢复 Gateway client adapter 模块化；
+- #28：拆分为客户端探测/目录性能和卸载清理；前者属于 0.1.9；
+- #83：区分 Provider 持久化失败、保存后刷新失败和 endpoint 测试失败；
+- #153：ZCode 三文件事务与崩溃恢复；
+- #154：推理级别忠实导出；
+- #155：OMP YAML 字符串类型安全。
+
+退出条件是 ZCode、OMP、OpenCode 和 Pi 分别完成 preview/apply/readback/restore，配置身份和真实请求一致，部分写入与并发编辑不产生假成功，并且不发生静默 Official fallback 或凭证泄露。
+
+### 4.5 0.1.10 — 既有产品可靠性收尾
+
+范围：#86、#87、#88、#113、#115、#126，以及 #28 的卸载清理部分。该版本只收敛既有行为，不以修复为由加入新产品功能。
+
+### 4.6 0.2.x 以后 — 新功能
+
+只有前述可靠性 Gate 通过后才补充：
+
+1. Stable/Developer 渠道：#148→#152；
+2. Provider 预设与认证：#71、#89、#90、#91、#92、#93、#94；
+3. Claude Code 下游客户端：#73、#74、#75、#76、#77、#78；
+4. Imagegen：#68，先完成授权和安全边界；
+5. AgentProvider：#85，继续与 ModelProvider/Gateway 分离。
+
+## 5. 模型能力认证
+
+### 5.1 认证键
+
+认证针对具体运行组合，而不是 Provider 品牌：
+
+```text
+Codex build
++ CodexHub version
++ provider_id
++ model_id
++ upstream format
++ route mode / codec
++ tool exposure profile
+```
+
+同名模型在不同 Provider、协议路径或 codec 上分别认证。Codex build、Provider schema、协议、codec、Task API、工具注册、上下文或推理元数据变化后，相关认证进入待复验。
+
+### 5.2 支持等级
+
+对外只使用：
+
+- **Supported**：完整门禁通过；
+- **Experimental**：部分证据，明确列出缺失能力；
+- **Unsupported**：已证明不兼容，或未知语义要求失败关闭。
+
+内部决策使用 GO/PARTIAL/NO-GO。PARTIAL 不得在 UI、文档或发布说明中显示成完整支持。
+
+### 5.3 认证维度
+
+| 维度 | 最低证据 |
+| --- | --- |
+| 运行身份 | 请求和实际模型、Provider、推理级别一致 |
+| Task 生命周期 | create/fork/read/list/continue/handoff/complete |
+| Task 通信 | 父子、同级定向消息、回执、顺序和结果聚合 |
+| Visible Worker | 独立 sidebar Task/thread/worktree 和 Active→Done |
+| Hidden Subagent | spawn/send/wait/interrupt/result/cleanup，独立记录 |
+| 工具发现 | Direct、Deferred、`tool_search`、hosted |
+| 工具执行 | declaration、call、result、ID、history |
+| 协议 | 请求、响应、SSE、错误终态、未知 item |
+| 传输 | 长流、断开、取消、并发、重试、恢复 |
+| 上下文 | 原始窗口、有效窗口、自动压缩来源 |
+| 可审计性 | Task 活动、命令、diff、进度和终态 |
+
+证据先保存在 Issue、版本化 fixtures 和 `docs/evidence/`。在 #61/#65 证明需要前，不提前引入新的产品数据库。
+
+## 6. Visible Worker 与 Hidden Subagent
+
+### 6.1 产品定义
+
+本路线图中的委派实施默认指 **Sidebar-visible Worker**：原生创建的独立 Codex Task，具有可发现 thread、隔离 worktree、有效绑定读回、双向通信、确认回执和终态。
+
+Hidden Subagent 是独立能力测试面。即使它成功，也不能替代 Visible Worker 验收。Inline 执行也不能被描述成 Subagent-Driven 或 Visible Worker-Driven。
+
+### 6.2 #156 归属
+
+[#156](https://github.com/NOirBRight/CodexHub/issues/156) 已记录第三方 GLM Worker 无法回调、重复空 `tool_search` 和执行绑定不可证明的问题。截图补充证据已脱敏记录在 [comment 4993730159](https://github.com/NOirBRight/CodexHub/issues/156#issuecomment-4993730159)：`spawn_agent` 返回 `unsupported call`，没有创建委派子任务，后续 Inline 修改不能算 Subagent-Driven，Hidden Subagent 也不能替代 Sidebar-visible Worker。
+
+#156 应拆分为：
+
+- 保留 ready-for-human 的父 Gate，拥有 Host/runtime 的 Sidebar-visible third-party Worker、绑定读回、双向通信和终态；
+- 创建一个 CodexHub 本地子 Issue，限制重复空 `tool_search`、产生结构化 unavailable 终态并防止请求/token 放大；
+- #64 在 #156 之后验证完整 Hidden Subagent 与 Visible Worker 矩阵，不把两个表面合并。
+
+### 6.3 当前实施 Worker
+
+当前 Wayfinder 使用 GPT-5.6 Terra/max 或 GPT-5.6 Luna/max 的 Sidebar-visible Workers。每次派发必须明确选择模型并读回有效绑定；两者不能静默互换。如果一个模型的创建或通信失败，该 lane 停止，可以重新明确选择另一个模型并重新 preflight。
+
+第三方模型在 #156 和对应能力认证通过后加入合格 Visible Worker 池。这不阻塞当前路线，因为 Terra/Luna 可以实施 #156 和其他 0.1.6 工作。
+
+## 7. 执行与失败处理
+
+### 7.1 Lane
+
+| Lane | 用途 | 是否算委派实施 |
+| --- | --- | --- |
+| Visible Worker | Sidebar-visible Task/Worker，独立 thread/worktree | 是，默认 |
+| Inline | Orchestrator 在当前任务直接执行 | 否 |
+| Hidden Subagent | 验证隐藏协作表面 | 否，不替代 Visible Worker |
+
+### 7.2 Preflight
+
+领取和编辑前必须证明：当前 frontier、无 blocker/assignee/hotset 冲突、精确 base SHA、隔离 worktree、真实 Task materialization、有效模型/Provider/reasoning/Worker 读回、父→Worker 测试消息、Worker→父回执，以及权限 profile。
+
+### 7.3 创建与恢复
+
+```text
+create request
+    ├─ materialized → 读回 Task/worktree/binding → 通信 preflight
+    ├─ rejected → 明确失败，不创建第二个 Worker
+    └─ uncertain → 最多一次原生发现/对账，不重复 create
+```
+
+- 回调缺失时在编辑前停止；编辑后出现则保留 worktree/WIP；
+- 模型绑定不一致时立即停止；
+- 同一精确空 `tool_search` 最多两次，之后产生 classified unavailable；
+- Task 消失或 Desktop 重启后通过原生 list/read 恢复，不能创建同名替代；
+- 超时先 interrupt 并确认终态，旧 Worker 仍可能编辑时不能启动继任者；
+- 交接前必须证明原 Worker 终止、所有权明确并保留有用 WIP；
+- 不自动修改或删除 Codex 内部 Task 数据。
+
+一个 Issue 同一时间只有一个编辑者、一个 lane 和一个 worktree。Worker 完成后由 Orchestrator 验证 commit、测试、PR 和回执，再更新 GitHub。
+
+## 8. 验证与发布
+
+### 8.1 Issue 级验证
+
+严格遵守 `docs/agents/verification-policy.md`：fast、standard、strict 使用最高适用等级。Python、Rust、Frontend 只运行受影响边界的本地完整套件一次；GitHub Actions 是 PR 到 `dev`/`main` 的最终自动门禁；`report_quality_gates.py` 始终非阻塞。
+
+### 8.2 Worker 证据
+
+每个真实 Worker 证据记录请求/实际模型、reasoning、Task/thread materialization、worktree ownership、双向回执、终态、修改文件和验证结果。不得记录凭证、私有路径、Task ID、callback 地址、prompt 或完整响应。
+
+### 8.3 版本门禁
+
+- **0.1.6**：Terra 和 Luna 各一次 Visible Worker 双向通信控制；GLM-5.2 在 #156 后完成只读 preflight 和一次受限真实任务；生命周期与 packaged Windows smoke 通过。
+- **0.1.7**：Official 七模型矩阵、Visible Worker、Task 通信、长流/取消/断开和上下文隔离通过。
+- **0.1.8**：每个申请 Supported 的第三方组合有独立矩阵；#67 零未分类项；#58/#59 只启用获批组合；至少一个失败关闭控制通过。
+- **0.1.9**：所有已管理客户端完成 preview/apply/readback/restore、崩溃恢复和无静默 fallback。
+- **0.1.10**：既有产品可靠性 Issues 通过各自验收，不扩大到新功能。
+
+### 8.4 候选流程
+
+1. Issue 在独立 PR 中达到本地候选；
+2. CI、Orchestrator Standards/Spec review 和安全人工证据并行；
+3. 合并到 `dev` 后只验证集成差异；
+4. 构建完整候选并运行版本命名的 packaged/manual gate；
+5. 全绿才进入 Stable；
+6. 核心 Gate 不完整时记录 HOLD，不制造空版本。
+
+在 #148/#152 完成前继续使用现有发布方式，路线图不依赖未实现的 Developer 渠道。
+
+## 9. GitHub 迁移
+
+### 9.1 #147 新结构
+
+```text
+Destination
+Priority gates
+Execution policy
+0.1.6
+0.1.7
+0.1.8
+0.1.9
+0.1.10
+0.2.x+
+Decisions so far
+Current frontier
+Fog / external blockers
+Out of scope
+```
+
+### 9.2 Milestones
+
+建立或重新分配：
+
+- `0.1.6 — Codex control-plane reliability`
+- `0.1.7 — Official GPT reliability`
+- `0.1.8 — Third-party model certification`
+- `0.1.9 — Managed client reliability`
+- `0.1.10 — Existing product reliability`
+
+现有 `Third-party model agentic reliability` 由 0.1.8 接替，保留历史描述但不再作为跨版本活跃调度池。
+
+### 9.3 台账修正
+
+- #155–#157 和 #156 加入 #147；
+- #8 保持 open，移除已在当前 `dev` 实现的错误假设；
+- #28 拆成探测性能与卸载清理；
+- #62 在确认真实执行状态后清理过期 assignee/Worker 描述；
+- #10/#12 核对 main 的最终证据，状态错误则重开或补充正式关闭证据；
+- #109 保持 `needs-info`，不阻塞整个 0.1.7；
+- #74 保持 `needs-info` 并移入新功能停车区；
+- #64 增加对 #156 的 blocked-by；
+- 每个 Issue 保持一个 canonical lifecycle label；
+- 硬依赖使用 GitHub native blocked-by，其他关系只写 Related。
+
+### 9.4 写入顺序
+
+1. 重新读取 Issues、依赖、assignee、milestone 和 open PR，生成预期变更清单；
+2. 更新 #147；
+3. 更新 milestones、子 Issue 和依赖；
+4. 每次写入后 readback；
+5. 重新计算 frontier；
+6. 地图迁移期间不自动 assign 或启动 Worker。
+
+## 10. 设计决策摘要
+
+- 采用门禁驱动的发布列车并重新切分版本；
+- Codex 控制面、Official GPT、第三方模型、现有客户端、新功能严格分层；
+- 当前实施使用 Terra/Luna Sidebar-visible Workers；
+- 第三方模型逐组合认证后进入合格 Worker 池；
+- Visible Worker、Hidden Subagent 和 Inline 是不同执行表面，不能互相冒充；
+- #156 是 0.1.6 的 P0 Host/runtime Gate，并拆出可由 Terra/Luna 实施的 CodexHub 本地防放大子问题；
+- #64 在 0.1.8 负责完整协作矩阵；
+- 所有 open Issues 必须进入 Gate、支撑队列、决策队列或停车场；
+- GitHub 是唯一持久工作状态，Wayfinder 更新本身不领取任务。

--- a/docs/superpowers/specs/2026-07-16-wayfinder-replanning-design.md
+++ b/docs/superpowers/specs/2026-07-16-wayfinder-replanning-design.md
@@ -91,6 +91,8 @@ open
 
 选择顺序是 P0 Gate blocker、依赖图中最早的未阻塞节点、地图顺序，以及同级情况下能最早缩小后续风险的独立任务。`ready-for-human` 不进入自动 frontier，但必须显示在 Gate 的 Fog/Decision 区。
 
+Frontier 发布必须把两类资格分开记录：一类是 label/assignee/native dependency 资格；另一类是所有权/hotset 资格。后者要求对每个候选执行 exact-title 与 `Issue N` 两次原生 Task 查询，任一 Host 不可用或任一匹配都 fail closed；同时从 Issue 正文解析规范化 `## Expected hotset`，枚举所有本地 worktree、本地 branch 和 open PR head 的 revision、clean/dirty 状态及相对 `dev` 的 changed-file 集，并计算逐候选交集。Branch 名称不能当作所有权证据；规划 worktree 只有在完整 changed-file 集与产品 hotset 无交集时才能标记为 migration-control，`dev` 也必须实际审计。脱敏输入、推导、查询 schema/timestamp/availability 和结果保存在 `docs/superpowers/reviews/` 的版本化 artifact 中，#147 checkpoint 记录其 repository-relative path 与 SHA-256；artifact 是审计证据，不是新的工作状态 authority。
+
 ## 4. 发布列车
 
 ### 4.1 0.1.6 — Codex 执行控制面可靠性
@@ -367,8 +369,9 @@ Out of scope
 2. 更新 #147；
 3. 更新 milestones、子 Issue 和依赖；
 4. 每次写入后 readback；
-5. 重新计算 frontier；
-6. 地图迁移期间不自动 assign 或启动 Worker。
+5. 重新计算 frontier，生成并读回 content-addressed 的脱敏 audit artifact；
+6. 首次 checkpoint 使用 exact-body/same-purpose create-only guard；既有 checkpoint 更新必须同时匹配 public comment ID 和规范化 prior-body SHA-256，只 PATCH 该 comment，并读回唯一 prefix/exact body；
+7. 地图迁移期间不自动 assign 或启动 Worker。
 
 ## 10. 设计决策摘要
 

--- a/docs/superpowers/specs/2026-07-16-wayfinder-replanning-design.md
+++ b/docs/superpowers/specs/2026-07-16-wayfinder-replanning-design.md
@@ -244,8 +244,8 @@ Hidden Subagent 是独立能力测试面。即使它成功，也不能替代 Vis
 
 #156 应拆分为：
 
-- 保留 ready-for-human 的父 Gate，拥有 Host/runtime 的 Sidebar-visible third-party Worker、绑定读回、双向通信和终态；
-- 创建一个 CodexHub 本地子 Issue，限制重复空 `tool_search`、产生结构化 unavailable 终态并防止请求/token 放大；
+- 保留 ready-for-human 的 Host/runtime-only 父 Gate，拥有 Sidebar-visible third-party Worker materialization、有效绑定读回、双向通信、结果回执、显式 unsupported 终态和 Active → Done 可见性；
+- 创建两个 CodexHub 本地子 Issue：#159 限制重复空 `tool_search`、产生结构化 unavailable 终态并防止请求/token 放大；#161 保留 Worker selector/codec，并用受支持的有效 agent/model/reasoning 读回 fail closed 地验证绑定；
 - #64 在 #156 之后验证完整 Hidden Subagent 与 Visible Worker 矩阵，不把两个表面合并。
 
 ### 6.3 当前实施 Worker
@@ -350,14 +350,14 @@ Out of scope
 
 ### 9.3 台账修正
 
-- #155–#157 和 #156 加入 #147；
+- #155–#157 和 #156 加入 #147；#159 与 #161 作为 #156 的两个本地子 Issue 保持嵌套；
 - #8 保持 open，移除已在当前 `dev` 实现的错误假设；
 - #28 拆成探测性能与卸载清理；
 - #62 在确认真实执行状态后清理过期 assignee/Worker 描述；
 - #10/#12 核对 main 的最终证据，状态错误则重开或补充正式关闭证据；
 - #109 保持 `needs-info`，不阻塞整个 0.1.7；
 - #74 保持 `needs-info` 并移入新功能停车区；
-- #64 增加对 #156 的 blocked-by；
+- #156 增加对 #159 和 #161 的 blocked-by；#64 保持对 #156 的 blocked-by；
 - 每个 Issue 保持一个 canonical lifecycle label；
 - 硬依赖使用 GitHub native blocked-by，其他关系只写 Related。
 
@@ -377,7 +377,7 @@ Out of scope
 - 当前实施使用 Terra/Luna Sidebar-visible Workers；
 - 第三方模型逐组合认证后进入合格 Worker 池；
 - Visible Worker、Hidden Subagent 和 Inline 是不同执行表面，不能互相冒充；
-- #156 是 0.1.6 的 P0 Host/runtime Gate，并拆出可由 Terra/Luna 实施的 CodexHub 本地防放大子问题；
+- #156 是 0.1.6 的 P0 Host/runtime-only Gate，并拆出两个可由 Terra/Luna 实施的 CodexHub 本地子问题：#159 防止重复空搜索放大，#161 保留 Worker selector/codec 并验证有效绑定；
 - #64 在 0.1.8 负责完整协作矩阵；
 - 所有 open Issues 必须进入 Gate、支撑队列、决策队列或停车场；
 - GitHub 是唯一持久工作状态，Wayfinder 更新本身不领取任务。

--- a/scripts/generate_wayfinder_final_audit.py
+++ b/scripts/generate_wayfinder_final_audit.py
@@ -294,6 +294,7 @@ def _path_matchers(entry: str, number: int) -> list[str]:
         matchers.extend(
             [
                 "frontend/src/pages/SettingsPage.tsx",
+                "frontend/src/components/SettingsDrawer.tsx",
                 "frontend/src/components/**/Settings*",
             ]
         )
@@ -577,6 +578,9 @@ def collect_comment_evidence() -> dict[str, Any]:
             for item in comments
             if normalize_body(item.get("body")).startswith(prefix)
         ]
+        if number == 147 and not purpose:
+            result[str(number)] = None
+            continue
         if len(purpose) != 1:
             raise ValueError(f"same-purpose comment multiplicity on #{number}: {len(purpose)}")
         match = purpose[0]
@@ -916,17 +920,9 @@ def validate_transcript(transcript: dict[str, Any], core_sha256: str) -> None:
         raise ValueError("checkpoint transcript issue mismatch")
     if transcript.get("purpose_prefix") != COMMENT_PREFIXES[147]:
         raise ValueError("checkpoint transcript purpose prefix mismatch")
-    historical = transcript.get("historical_original", {})
-    original_body = normalize_body(historical.get("normalized_body"))
-    if original_body != normalize_body(ORIGINAL_CHECKPOINT_BODY):
-        raise ValueError("checkpoint historical original body mismatch")
-    if historical.get("normalized_body_sha256") != sha256_text(original_body):
-        raise ValueError("checkpoint historical original hash mismatch")
-    pre = transcript.get("pre_update", {})
-    if pre.get("public_comment_id") != CHECKPOINT_COMMENT_ID:
-        raise ValueError("checkpoint prior public comment ID mismatch")
-    if not re.fullmatch(r"[0-9a-f]{64}", str(pre.get("normalized_body_sha256", ""))):
-        raise ValueError("checkpoint prior hash missing")
+    operation = transcript.get("operation_decision")
+    if operation not in {"create", "patch", "exact-no-op"}:
+        raise ValueError("checkpoint operation decision missing")
     desired = transcript.get("desired", {})
     desired_body = normalize_body(desired.get("normalized_body"))
     if desired.get("normalized_body_sha256") != sha256_text(desired_body):
@@ -934,11 +930,32 @@ def validate_transcript(transcript: dict[str, Any], core_sha256: str) -> None:
     required_reference = f"{CORE_ARTIFACT_PATH} (SHA-256: `{core_sha256}`)"
     if required_reference not in desired_body:
         raise ValueError("checkpoint desired body lacks durable artifact path/hash")
-    if transcript.get("operation_decision") not in {"patch", "exact-no-op"}:
-        raise ValueError("checkpoint operation decision missing")
+    historical = transcript.get("historical_original", {})
+    original_body = normalize_body(historical.get("normalized_body"))
+    expected_original = (
+        desired_body if operation == "create" else normalize_body(ORIGINAL_CHECKPOINT_BODY)
+    )
+    if original_body != expected_original:
+        raise ValueError("checkpoint historical original body mismatch")
+    if historical.get("normalized_body_sha256") != sha256_text(original_body):
+        raise ValueError("checkpoint historical original hash mismatch")
+    pre = transcript.get("pre_update", {})
+    if operation == "create":
+        if (
+            pre.get("public_comment_id") is not None
+            or pre.get("normalized_body_sha256") is not None
+        ):
+            raise ValueError("checkpoint create operation invents prior state")
+    else:
+        if not isinstance(pre.get("public_comment_id"), int) or pre["public_comment_id"] <= 0:
+            raise ValueError("checkpoint prior public comment ID missing")
+        if not re.fullmatch(r"[0-9a-f]{64}", str(pre.get("normalized_body_sha256", ""))):
+            raise ValueError("checkpoint prior hash missing")
     post = transcript.get("post_readback", {})
-    if post.get("public_comment_id") != CHECKPOINT_COMMENT_ID:
-        raise ValueError("checkpoint post public comment ID mismatch")
+    if not isinstance(post.get("public_comment_id"), int) or post["public_comment_id"] <= 0:
+        raise ValueError("checkpoint post public comment ID missing")
+    if operation != "create" and post["public_comment_id"] != pre["public_comment_id"]:
+        raise ValueError("checkpoint public comment identity changed")
     if post.get("prefix_multiplicity") != 1 or post.get("exact_body_multiplicity") != 1:
         raise ValueError("checkpoint post-readback multiplicity mismatch")
     if post.get("normalized_body_sha256") != desired.get("normalized_body_sha256"):
@@ -1004,11 +1021,14 @@ def validate_final(final: dict[str, Any]) -> None:
     if not isinstance(transcript, dict):
         raise ValueError("final artifact checkpoint transcript missing")
     validate_transcript(transcript, core_sha)
-    recorded_prior = core["global_github_audit"]["comments"]["147"]
+    recorded_prior = core["global_github_audit"]["comments"].get("147")
     transcript_prior = transcript["pre_update"]
-    if (
-        recorded_prior["public_comment_id"]
-        != transcript_prior["public_comment_id"]
+    if transcript["operation_decision"] == "create":
+        if recorded_prior is not None:
+            raise ValueError("frontier capture unexpectedly contains a checkpoint prior to create")
+    elif (
+        not isinstance(recorded_prior, dict)
+        or recorded_prior["public_comment_id"] != transcript_prior["public_comment_id"]
         or recorded_prior["normalized_body_sha256"]
         != transcript_prior["normalized_body_sha256"]
         or recorded_prior["prefix_multiplicity"] != 1
@@ -1077,8 +1097,9 @@ def compare_live(final: dict[str, Any]) -> None:
                 raise ValueError(
                     f"fresh active surface/hotset intersection: {surface['logical_identity']}"
                 )
+    checkpoint_comment_id = transcript_post["public_comment_id"]
     current_comment = api_json(
-        f"repos/{REPOSITORY}/issues/comments/{CHECKPOINT_COMMENT_ID}"
+        f"repos/{REPOSITORY}/issues/comments/{checkpoint_comment_id}"
     )
     desired = final["checkpoint_update_transcript"]["desired"]
     if sha256_text(normalize_body(current_comment.get("body"))) != desired["normalized_body_sha256"]:
@@ -1089,7 +1110,7 @@ def compare_live(final: dict[str, Any]) -> None:
                 "status": "live-ok",
                 "open_issue_count": fresh_global["open_issue_count"],
                 "frontier": core["frontier"],
-                "checkpoint_comment_id": CHECKPOINT_COMMENT_ID,
+                "checkpoint_comment_id": checkpoint_comment_id,
                 "worktree_count": len(fresh_surfaces["worktrees"]),
                 "local_branch_count": len(fresh_surfaces["local_branches"]),
                 "open_pr_head_count": len(fresh_surfaces["open_pr_heads"]),

--- a/scripts/generate_wayfinder_final_audit.py
+++ b/scripts/generate_wayfinder_final_audit.py
@@ -912,7 +912,11 @@ def validate_core(core: dict[str, Any]) -> None:
     _assert_sanitized(core)
 
 
-def validate_transcript(transcript: dict[str, Any], core_sha256: str) -> None:
+def validate_transcript(
+    transcript: dict[str, Any], core_sha256: str, _provenance_depth: int = 0
+) -> None:
+    if _provenance_depth > 32:
+        raise ValueError("checkpoint historical provenance chain too deep")
     if transcript.get("schema_version") != SCHEMA_VERSION:
         raise ValueError("checkpoint transcript schema mismatch")
     parse_timestamp(transcript.get("captured_at"), "checkpoint transcript")
@@ -932,11 +936,6 @@ def validate_transcript(transcript: dict[str, Any], core_sha256: str) -> None:
         raise ValueError("checkpoint desired body lacks durable artifact path/hash")
     historical = transcript.get("historical_original", {})
     original_body = normalize_body(historical.get("normalized_body"))
-    expected_original = (
-        desired_body if operation == "create" else normalize_body(ORIGINAL_CHECKPOINT_BODY)
-    )
-    if original_body != expected_original:
-        raise ValueError("checkpoint historical original body mismatch")
     if historical.get("normalized_body_sha256") != sha256_text(original_body):
         raise ValueError("checkpoint historical original hash mismatch")
     pre = transcript.get("pre_update", {})
@@ -960,7 +959,75 @@ def validate_transcript(transcript: dict[str, Any], core_sha256: str) -> None:
         raise ValueError("checkpoint post-readback multiplicity mismatch")
     if post.get("normalized_body_sha256") != desired.get("normalized_body_sha256"):
         raise ValueError("checkpoint post-readback body mismatch")
+    if operation == "exact-no-op" and len(
+        {
+            pre.get("normalized_body_sha256"),
+            desired.get("normalized_body_sha256"),
+            post.get("normalized_body_sha256"),
+        }
+    ) != 1:
+        raise ValueError("checkpoint exact-no-op pre/desired/post hashes differ")
+
+    provenance = transcript.get("historical_provenance", {})
+    proof_kind = provenance.get("proof_kind")
+    prior_transcript = provenance.get("prior_transcript")
+    if proof_kind == "initial-create":
+        if operation != "create" or prior_transcript is not None or original_body != desired_body:
+            raise ValueError("checkpoint initial-create provenance mismatch")
+    elif proof_kind == "live-exact-desired":
+        if (
+            operation != "exact-no-op"
+            or prior_transcript is not None
+            or original_body != desired_body
+        ):
+            raise ValueError("checkpoint live-exact provenance mismatch")
+    elif proof_kind == "task8-execution-report":
+        if (
+            operation != "patch"
+            or prior_transcript is not None
+            or original_body != normalize_body(ORIGINAL_CHECKPOINT_BODY)
+        ):
+            raise ValueError("checkpoint execution-report provenance mismatch")
+    elif proof_kind == "tracked-transcript":
+        if operation not in {"patch", "exact-no-op"} or not isinstance(prior_transcript, dict):
+            raise ValueError("checkpoint tracked-transcript provenance mismatch")
+        prior_core_sha = prior_transcript.get("desired", {}).get(
+            "frontier_artifact_sha256"
+        )
+        if not re.fullmatch(r"[0-9a-f]{64}", str(prior_core_sha or "")):
+            raise ValueError("checkpoint prior transcript frontier hash missing")
+        validate_transcript(
+            prior_transcript, str(prior_core_sha), _provenance_depth + 1
+        )
+        if historical != prior_transcript.get("historical_original"):
+            raise ValueError("checkpoint historical origin changed across retry")
+        prior_post = prior_transcript["post_readback"]
+        if (
+            prior_post.get("public_comment_id") != pre.get("public_comment_id")
+            or prior_post.get("normalized_body_sha256")
+            != pre.get("normalized_body_sha256")
+        ):
+            raise ValueError("checkpoint prior transcript does not prove current pre-state")
+    else:
+        raise ValueError("checkpoint historical provenance proof missing")
     _assert_sanitized(transcript)
+
+
+def _captured_checkpoint_prior(
+    transcript: dict[str, Any], core_sha256: str
+) -> dict[str, Any] | None:
+    """Return the checkpoint state captured in the core before a retry chain."""
+    if transcript["operation_decision"] == "create":
+        return None
+    provenance = transcript["historical_provenance"]
+    prior = provenance.get("prior_transcript")
+    if (
+        provenance.get("proof_kind") == "tracked-transcript"
+        and isinstance(prior, dict)
+        and prior.get("desired", {}).get("frontier_artifact_sha256") == core_sha256
+    ):
+        return _captured_checkpoint_prior(prior, core_sha256)
+    return transcript["pre_update"]
 
 
 def build_final(core: dict[str, Any], core_path: str, transcript: dict[str, Any]) -> dict[str, Any]:
@@ -1022,8 +1089,8 @@ def validate_final(final: dict[str, Any]) -> None:
         raise ValueError("final artifact checkpoint transcript missing")
     validate_transcript(transcript, core_sha)
     recorded_prior = core["global_github_audit"]["comments"].get("147")
-    transcript_prior = transcript["pre_update"]
-    if transcript["operation_decision"] == "create":
+    transcript_prior = _captured_checkpoint_prior(transcript, core_sha)
+    if transcript_prior is None:
         if recorded_prior is not None:
             raise ValueError("frontier capture unexpectedly contains a checkpoint prior to create")
     elif (

--- a/scripts/generate_wayfinder_final_audit.py
+++ b/scripts/generate_wayfinder_final_audit.py
@@ -1,0 +1,1240 @@
+#!/usr/bin/env python3
+"""Generate and validate sanitized Wayfinder migration audit artifacts.
+
+This utility is read-only with respect to GitHub and Git. ``capture`` consumes a
+native ``codex_app__list_threads`` JSON capture supplied by the caller, performs
+fresh GET/list operations, and writes the repository artifact named by
+``--output``. ``finalize`` combines that immutable frontier artifact with a
+guarded checkpoint-update transcript. ``validate`` performs offline structural
+and hash validation; add ``--live`` for a fresh read-only GitHub/Git comparison.
+
+The utility never reads Codex SQLite data, persists native Task/thread IDs, or
+persists local absolute paths. It fails closed on incomplete native evidence,
+unavailable hosts, Task matches, or active file/hotset intersections.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import fnmatch
+import hashlib
+import json
+import pathlib
+import re
+import subprocess
+import sys
+import time
+from typing import Any, Iterable
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+REPOSITORY = "NOirBRight/CodexHub"
+SCHEMA_VERSION = 1
+CORE_KIND = "wayfinder-frontier-ownership-audit"
+FINAL_KIND = "wayfinder-final-migration-audit"
+FRONTIER_EXPECTED = [159, 161, 139, 149, 150, 111]
+PRIORITY_ORDER = [159, 161, 139, 149, 150, 111, 141, 138, 151, 143, 112, 156]
+EXPECTED_TITLES = {
+    159: "Bound repeated empty tool_search misses for external models",
+    161: "Preserve Worker selector and effective binding validation for external delegation",
+    139: "Serialize Gateway lifecycle operations and prevent duplicate startup processes",
+    149: "Make Rust/Python atomic-file lock ownership and stale recovery safe",
+    150: "Coalesce automatic OpenAI usage probes and avoid repeated Codex app-server cold starts",
+    111: "Make Windows app autostart registration verifiable and reliable",
+}
+LIFECYCLE_LABELS = {
+    "needs-triage",
+    "needs-info",
+    "ready-for-agent",
+    "ready-for-human",
+    "wontfix",
+}
+EXPECTED_MEMBERSHIP = {
+    "0.1.6 — Codex control-plane reliability": [
+        111,
+        112,
+        138,
+        139,
+        141,
+        143,
+        149,
+        150,
+        151,
+        156,
+        159,
+        161,
+    ],
+    "0.1.7 — Official GPT reliability": [18, 19, 20, 21, 104, 109, 114, 157],
+    "0.1.8 — Third-party model certification": [
+        17,
+        22,
+        57,
+        58,
+        59,
+        61,
+        62,
+        63,
+        64,
+        65,
+        66,
+        67,
+    ],
+    "0.1.9 — Managed client reliability": [8, 28, 83, 153, 154, 155],
+    "0.1.10 — Existing product reliability": [86, 87, 88, 113, 115, 126, 160],
+}
+COMMENT_PREFIXES = {
+    8: "### Wayfinder baseline correction",
+    10: "Wayfinder closure reconciliation:",
+    12: "Wayfinder closure reconciliation:",
+    62: "Wayfinder ownership reconciliation:",
+    147: "## Reliability-gated Wayfinder migration readback",
+}
+CHECKPOINT_COMMENT_ID = 4994927680
+CORE_ARTIFACT_PATH = (
+    "docs/superpowers/reviews/wayfinder-frontier-ownership-audit-v1.json"
+)
+TRANSCRIPT_ARTIFACT_PATH = (
+    "docs/superpowers/reviews/wayfinder-checkpoint-update-v1.json"
+)
+FINAL_ARTIFACT_PATH = "docs/superpowers/reviews/wayfinder-final-audit-v1.json"
+
+ORIGINAL_CHECKPOINT_BODY = """## Reliability-gated Wayfinder migration readback
+
+The approved roadmap migration is complete and read back:
+
+- five active reliability milestones exist with exact membership;
+- the legacy cross-version reliability milestone is closed as superseded;
+- #156 is the ready-for-human Visible Worker gate and #159 is its ready local bounded-search child;
+- #64 is blocked by #156 for the full post-fix collaboration matrix;
+- #28 is narrowed to client discovery performance and #160 owns uninstall cleanup behind #111;
+- every open Issue has exactly one canonical lifecycle label;
+- no ticket was assigned or dispatched by the migration.
+
+Current unclaimed 0.1.6 ready frontier:
+
+- #159 Bound repeated empty tool_search misses for external models
+- #139 Serialize Gateway lifecycle operations and prevent duplicate startup processes
+- #149 Make Rust/Python atomic-file lock ownership and stale recovery safe
+- #150 Coalesce automatic OpenAI usage probes and avoid repeated Codex app-server cold starts
+- #111 Make Windows app autostart registration verifiable and reliable
+
+Frontier order remains subject to native dependencies and hotset ownership. Map publication is not a claim."""
+
+
+def run(*args: str, cwd: pathlib.Path | None = None, check: bool = True) -> str:
+    attempts = 3 if args and args[0] == "gh" else 1
+    result: subprocess.CompletedProcess[str] | None = None
+    for attempt in range(attempts):
+        result = subprocess.run(
+            args,
+            cwd=cwd or ROOT,
+            text=True,
+            encoding="utf-8",
+            capture_output=True,
+        )
+        if result.returncode == 0 or attempt == attempts - 1:
+            break
+        time.sleep(1 + attempt)
+    assert result is not None
+    if check and result.returncode:
+        raise RuntimeError(
+            f"read-only command failed ({' '.join(args)}): {result.stderr.strip()}"
+        )
+    return result.stdout
+
+
+def utc_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def normalize_body(value: str | None) -> str:
+    return (value or "").replace("\r\n", "\n").rstrip()
+
+
+def sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def sha256_file(path: pathlib.Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def canonical_json_sha256(value: Any) -> str:
+    encoded = json.dumps(
+        value, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def serialized_json_sha256(value: Any) -> str:
+    """Hash the exact UTF-8 bytes emitted by :func:`write_json`."""
+    encoded = (json.dumps(value, ensure_ascii=False, indent=2) + "\n").encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def parse_timestamp(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field} capture timestamp missing")
+    candidate = value.replace("Z", "+00:00")
+    parsed = dt.datetime.fromisoformat(candidate)
+    if parsed.tzinfo is None:
+        raise ValueError(f"{field} capture timestamp must include timezone")
+    return value
+
+
+def api_json(path: str) -> Any:
+    return json.loads(run("gh", "api", path))
+
+
+def api_pages(path: str) -> list[dict[str, Any]]:
+    joiner = "&" if "?" in path else "?"
+    values: list[dict[str, Any]] = []
+    page = 1
+    while True:
+        batch = api_json(f"{path}{joiner}per_page=100&page={page}")
+        if not isinstance(batch, list):
+            raise ValueError(f"expected list from GitHub endpoint: {path}")
+        values.extend(batch)
+        if len(batch) < 100:
+            return values
+        page += 1
+
+
+def issue_parent(number: int) -> int | None:
+    output = run(
+        "gh",
+        "api",
+        f"repos/{REPOSITORY}/issues/{number}/parent",
+        check=False,
+    )
+    if not output.strip():
+        return None
+    value = json.loads(output)
+    if value.get("status") == "404" or value.get("message") == "No parent issue found":
+        return None
+    return int(value["number"])
+
+
+def blockers(number: int) -> list[int]:
+    return sorted(
+        int(item["number"])
+        for item in api_pages(
+            f"repos/{REPOSITORY}/issues/{number}/dependencies/blocked_by"
+        )
+    )
+
+
+def children(number: int) -> list[int]:
+    return sorted(
+        int(item["number"])
+        for item in api_pages(f"repos/{REPOSITORY}/issues/{number}/sub_issues")
+    )
+
+
+def issue_snapshot(number: int, include_hotset: bool = False) -> dict[str, Any]:
+    raw = api_json(f"repos/{REPOSITORY}/issues/{number}")
+    body = normalize_body(raw.get("body"))
+    snapshot: dict[str, Any] = {
+        "number": number,
+        "title": raw["title"],
+        "state": raw["state"].lower(),
+        "body_normalized_sha256": sha256_text(body),
+        "labels": sorted(label["name"] for label in raw["labels"]),
+        "assignees": sorted(value["login"] for value in raw["assignees"]),
+        "milestone": raw["milestone"]["title"] if raw["milestone"] else None,
+        "parent": issue_parent(number),
+        "blocked_by": blockers(number),
+        "children": children(number),
+        "url": raw["html_url"],
+    }
+    if include_hotset:
+        snapshot["expected_hotset"] = parse_expected_hotset(body, number)
+    return snapshot
+
+
+def _normalize_hotset_entry(raw: str) -> str:
+    value = raw.strip()
+    value = re.sub(r"^[-*]\s+", "", value)
+    value = value.replace("`", "")
+    value = re.sub(r"\s+", " ", value).strip()
+    return value
+
+
+def _path_matchers(entry: str, number: int) -> list[str]:
+    candidates = re.findall(
+        r"(?<![\w.-])((?:src-python|src-tauri|frontend|tests|scripts|docs)/[A-Za-z0-9_./*-]+)",
+        entry,
+    )
+    matchers: list[str] = []
+    for candidate in candidates:
+        candidate = candidate.rstrip(".,;:)")
+        if candidate.endswith("/"):
+            candidate += "**"
+        matchers.append(candidate)
+
+    lowered = entry.lower()
+    if "fixture" in lowered and "tests/fixtures" in lowered:
+        matchers.append("tests/fixtures/**")
+    if number == 161 and "routing tests" in lowered:
+        matchers.append("tests/test_routing.py")
+    if number == 139 and "rust lifecycle" in lowered:
+        matchers.append("src-tauri/src/**")
+    if number == 139 and "frontend" in lowered:
+        matchers.append("frontend/**")
+    if number == 149 and "cross-language" in lowered:
+        matchers.extend(["tests/**", "src-tauri/**"])
+    if number == 149 and "atomic-write callers" in lowered:
+        matchers.extend(["src-python/**", "src-tauri/src/**"])
+    if number == 150 and "rust tests" in lowered:
+        matchers.append("src-tauri/src/openai_usage.rs")
+    if number == 111 and "tauri settings" in lowered:
+        matchers.append("src-tauri/src/**")
+    if number == 111 and "settings drawer" in lowered:
+        matchers.extend(
+            [
+                "frontend/src/pages/SettingsPage.tsx",
+                "frontend/src/components/**/Settings*",
+            ]
+        )
+    if number == 111 and "ui-contract tests" in lowered:
+        matchers.extend(["src-tauri/src/**", "frontend/scripts/**"])
+    if number == 111 and ("smoke harness" in lowered or "documented verification" in lowered):
+        matchers.extend(
+            [
+                "scripts/*autostart*",
+                "scripts/**/autostart*",
+                "docs/*autostart*",
+                "docs/**/autostart*",
+            ]
+        )
+    return sorted(set(matchers))
+
+
+def parse_expected_hotset(body: str, number: int) -> dict[str, Any]:
+    normalized = normalize_body(body)
+    match = re.search(
+        r"(?ms)^## Expected hotset\s*\n(?P<section>.*?)(?=^##\s+|\Z)", normalized
+    )
+    if not match:
+        raise ValueError(f"missing Expected hotset section on #{number}")
+    raw_entries = [
+        line.strip()
+        for line in match.group("section").splitlines()
+        if re.match(r"^\s*[-*]\s+\S", line)
+    ]
+    if not raw_entries:
+        raise ValueError(f"empty Expected hotset section on #{number}")
+    entries: list[dict[str, Any]] = []
+    all_matchers: list[str] = []
+    for raw in raw_entries:
+        entry = _normalize_hotset_entry(raw)
+        matchers = _path_matchers(entry, number)
+        if not matchers:
+            raise ValueError(f"Expected hotset entry has no path matcher on #{number}: {entry}")
+        entries.append(
+            {"raw": raw, "normalized": entry, "path_matchers": matchers}
+        )
+        all_matchers.extend(matchers)
+    return {"entries": entries, "matchers": sorted(set(all_matchers))}
+
+
+def intersections(files: Iterable[str], matchers: Iterable[str]) -> list[str]:
+    normalized = sorted(set(value.replace("\\", "/") for value in files if value))
+    patterns = list(matchers)
+    return [
+        path
+        for path in normalized
+        if any(fnmatch.fnmatchcase(path, pattern) for pattern in patterns)
+    ]
+
+
+def validate_native_task_capture(
+    capture: dict[str, Any], expected_issues: list[int]
+) -> list[dict[str, Any]]:
+    captured_at = parse_timestamp(capture.get("captured_at"), "native Task")
+    if capture.get("tool") != "codex_app__list_threads":
+        raise ValueError("native Task tool must be codex_app__list_threads")
+    if not isinstance(capture.get("limit"), int) or capture["limit"] <= 0:
+        raise ValueError("native Task capture limit missing")
+    records = capture.get("records")
+    if not isinstance(records, list):
+        raise ValueError("native Task records missing")
+    expected_pairs = {
+        (number, kind)
+        for number in expected_issues
+        for kind in ("exact_title", "issue_number")
+    }
+    actual_pairs = {(record.get("issue"), record.get("kind")) for record in records}
+    if actual_pairs != expected_pairs or len(records) != len(expected_pairs):
+        raise ValueError(
+            f"native Task records incomplete: actual={sorted(actual_pairs)} expected={sorted(expected_pairs)}"
+        )
+    normalized: list[dict[str, Any]] = []
+    for record in records:
+        number = int(record["issue"])
+        kind = record["kind"]
+        expected_query = (
+            EXPECTED_TITLES[number] if kind == "exact_title" else f"Issue {number}"
+        )
+        if record.get("query") != expected_query:
+            raise ValueError(f"native Task query mismatch on #{number} {kind}")
+        if record.get("schemaVersion") != 2:
+            raise ValueError(f"native Task schemaVersion mismatch on #{number} {kind}")
+        threads = record.get("threads")
+        unavailable_hosts = record.get("unavailableHosts")
+        if not isinstance(threads, list) or not isinstance(unavailable_hosts, list):
+            raise ValueError(f"native Task arrays missing on #{number} {kind}")
+        if unavailable_hosts:
+            raise ValueError(f"NEEDS_CONTEXT: native Task host unavailable on #{number}")
+        if threads:
+            raise ValueError(f"active native Task matches #{number}")
+        normalized.append(
+            {
+                "issue": number,
+                "issue_title": EXPECTED_TITLES[number],
+                "kind": kind,
+                "query": expected_query,
+                "captured_at": captured_at,
+                "schema_version": 2,
+                "unavailable_hosts": [],
+                "unavailable_host_count": 0,
+                "match_count": 0,
+            }
+        )
+    normalized.sort(key=lambda value: (expected_issues.index(value["issue"]), value["kind"]))
+    return normalized
+
+
+def _porcelain_paths(output: str) -> list[str]:
+    paths: list[str] = []
+    for line in output.splitlines():
+        if len(line) < 4:
+            continue
+        value = line[3:]
+        if " -> " in value:
+            old, new = value.split(" -> ", 1)
+            paths.extend([old, new])
+        else:
+            paths.append(value)
+    return sorted(set(path.replace("\\", "/") for path in paths))
+
+
+def _diff_files(base_ref: str, revision: str) -> list[str]:
+    output = run("git", "diff", "--name-only", f"{base_ref}...{revision}")
+    return sorted(set(line.strip().replace("\\", "/") for line in output.splitlines() if line.strip()))
+
+
+def _hotset_map(files: list[str], candidates: list[dict[str, Any]]) -> dict[str, list[str]]:
+    return {
+        str(candidate["number"]): intersections(
+            files, candidate["expected_hotset"]["matchers"]
+        )
+        for candidate in candidates
+    }
+
+
+def _parse_worktrees() -> list[dict[str, str]]:
+    output = run("git", "worktree", "list", "--porcelain")
+    blocks = re.split(r"\r?\n\r?\n", output.strip())
+    values: list[dict[str, str]] = []
+    for block in blocks:
+        record: dict[str, str] = {}
+        for line in block.splitlines():
+            if " " in line:
+                key, value = line.split(" ", 1)
+                record[key] = value
+            else:
+                record[line] = "true"
+        if "worktree" in record and "HEAD" in record:
+            values.append(record)
+    return values
+
+
+def collect_surfaces(
+    base_ref: str,
+    candidates: list[dict[str, Any]],
+    planned_paths: list[str],
+) -> dict[str, Any]:
+    worktree_raw = _parse_worktrees()
+    worktrees: list[dict[str, Any]] = []
+    checked_out_branches: set[str] = set()
+    for raw in worktree_raw:
+        revision = raw["HEAD"]
+        branch_ref = raw.get("branch")
+        branch = branch_ref.removeprefix("refs/heads/") if branch_ref else None
+        if branch:
+            checked_out_branches.add(branch)
+        path = pathlib.Path(raw["worktree"])
+        status_output = run(
+            "git", "status", "--porcelain", "--untracked-files=all", cwd=path
+        )
+        dirty_files = _porcelain_paths(status_output)
+        changed_files = sorted(set(_diff_files(base_ref, revision) + dirty_files))
+        try:
+            is_current = path.resolve() == ROOT.resolve()
+        except OSError:
+            is_current = False
+        if is_current:
+            changed_files = sorted(set(changed_files + planned_paths))
+        hotset = _hotset_map(changed_files, candidates)
+        overlapping = sorted(
+            {path for values in hotset.values() for path in values}
+        )
+        if is_current and not overlapping:
+            classification = "migration-control"
+        elif branch == base_ref and not dirty_files and not changed_files:
+            classification = "audited-baseline"
+        elif overlapping:
+            classification = "active-product-hotset"
+        else:
+            classification = "non-overlapping-active-worktree"
+        worktrees.append(
+            {
+                "logical_identity": f"worktree:{branch or 'detached-' + revision[:12]}",
+                "branch": branch,
+                "revision": revision,
+                "clean": not bool(dirty_files),
+                "dirty_files": dirty_files,
+                "changed_files_vs_dev": changed_files,
+                "hotset_intersections": hotset,
+                "classification": classification,
+                "active": True,
+            }
+        )
+
+    open_prs_raw = json.loads(
+        run(
+            "gh",
+            "pr",
+            "list",
+            "--repo",
+            REPOSITORY,
+            "--state",
+            "open",
+            "--limit",
+            "100",
+            "--json",
+            "number,title,headRefName,headRefOid,baseRefName,url",
+        )
+    )
+    prs: list[dict[str, Any]] = []
+    pr_heads: dict[str, list[int]] = {}
+    for raw in open_prs_raw:
+        number = int(raw["number"])
+        pr_heads.setdefault(raw["headRefName"], []).append(number)
+        files = sorted(
+            item["filename"]
+            for item in api_pages(f"repos/{REPOSITORY}/pulls/{number}/files")
+        )
+        prs.append(
+            {
+                "logical_identity": f"pull-request:#{number}",
+                "number": number,
+                "title": raw["title"],
+                "head_ref": raw["headRefName"],
+                "head_revision": raw["headRefOid"],
+                "base_ref": raw["baseRefName"],
+                "changed_files_vs_base": files,
+                "hotset_intersections": _hotset_map(files, candidates),
+                "url": raw["url"],
+                "active": True,
+            }
+        )
+
+    branches: list[dict[str, Any]] = []
+    branch_lines = run(
+        "git", "for-each-ref", "--format=%(refname:short)%09%(objectname)", "refs/heads"
+    ).splitlines()
+    for line in branch_lines:
+        name, revision = line.split("\t", 1)
+        changed_files = _diff_files(base_ref, revision)
+        branches.append(
+            {
+                "logical_identity": f"local-branch:{name}",
+                "name": name,
+                "revision": revision,
+                "changed_files_vs_dev": changed_files,
+                "hotset_intersections": _hotset_map(changed_files, candidates),
+                "checked_out_in_worktree": name in checked_out_branches,
+                "open_prs": sorted(pr_heads.get(name, [])),
+                "active": name in checked_out_branches or bool(pr_heads.get(name)),
+            }
+        )
+    return {
+        "worktrees": sorted(worktrees, key=lambda value: value["logical_identity"]),
+        "local_branches": sorted(branches, key=lambda value: value["name"]),
+        "open_pr_heads": sorted(prs, key=lambda value: value["number"]),
+    }
+
+
+def collect_comment_evidence() -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for number, prefix in COMMENT_PREFIXES.items():
+        comments = api_pages(f"repos/{REPOSITORY}/issues/{number}/comments")
+        purpose = [
+            item
+            for item in comments
+            if normalize_body(item.get("body")).startswith(prefix)
+        ]
+        if len(purpose) != 1:
+            raise ValueError(f"same-purpose comment multiplicity on #{number}: {len(purpose)}")
+        match = purpose[0]
+        body = normalize_body(match.get("body"))
+        exact = [
+            item
+            for item in comments
+            if normalize_body(item.get("body")) == body
+        ]
+        if len(exact) != 1:
+            raise ValueError(f"exact comment multiplicity on #{number}: {len(exact)}")
+        if number == 147 and int(match["id"]) != CHECKPOINT_COMMENT_ID:
+            raise ValueError("checkpoint public comment ID changed")
+        result[str(number)] = {
+            "public_comment_id": int(match["id"]),
+            "purpose_prefix": prefix,
+            "normalized_body_sha256": sha256_text(body),
+            "prefix_multiplicity": 1,
+            "exact_body_multiplicity": 1,
+            "created_at": match["created_at"],
+            "updated_at": match["updated_at"],
+            "url": match["html_url"],
+        }
+    return result
+
+
+def collect_global_audit() -> dict[str, Any]:
+    all_issues = [
+        item
+        for item in api_pages(f"repos/{REPOSITORY}/issues?state=all")
+        if "pull_request" not in item
+    ]
+    open_issues = [item for item in all_issues if item["state"] == "open"]
+    lifecycle_violations = []
+    for item in open_issues:
+        labels = {label["name"] for label in item["labels"]}
+        matches = sorted(labels & LIFECYCLE_LABELS)
+        if len(matches) != 1:
+            lifecycle_violations.append(
+                {"issue": int(item["number"]), "lifecycle_labels": matches}
+            )
+    if lifecycle_violations:
+        raise ValueError(f"canonical lifecycle violations: {lifecycle_violations}")
+    membership_actual = {
+        title: sorted(
+            int(item["number"])
+            for item in open_issues
+            if item.get("milestone") and item["milestone"]["title"] == title
+        )
+        for title in EXPECTED_MEMBERSHIP
+    }
+    if membership_actual != EXPECTED_MEMBERSHIP:
+        raise ValueError(f"milestone membership mismatch: {membership_actual}")
+    milestones = api_pages(f"repos/{REPOSITORY}/milestones?state=all")
+    milestone_records = [
+        {
+            "number": int(item["number"]),
+            "title": item["title"],
+            "description": item.get("description"),
+            "state": item["state"],
+            "open_issues": int(item["open_issues"]),
+            "closed_issues": int(item["closed_issues"]),
+        }
+        for item in milestones
+    ]
+    open_assignees = {
+        str(item["number"]): sorted(value["login"] for value in item["assignees"])
+        for item in open_issues
+        if item["assignees"]
+    }
+    contracts = {
+        str(number): issue_snapshot(number)
+        for number in [28, 147, 156, 159, 160, 161]
+    }
+    relations = {
+        str(number): {
+            "parent": issue_parent(number),
+            "blocked_by": blockers(number),
+            "children": children(number),
+        }
+        for number in [57, 64, 71, 73, 111, 147, 156, 159, 160, 161]
+    }
+    if relations["156"]["children"] != [159, 161]:
+        raise ValueError("#156 child set mismatch")
+    if relations["156"]["blocked_by"] != [159, 161]:
+        raise ValueError("#156 blocker set mismatch")
+    if relations["64"]["blocked_by"] != [62, 63, 156]:
+        raise ValueError("#64 blocker set mismatch")
+    if relations["160"]["blocked_by"] != [111]:
+        raise ValueError("#160 blocker set mismatch")
+    return {
+        "open_issue_count": len(open_issues),
+        "canonical_lifecycle_violations": lifecycle_violations,
+        "milestone_membership_expected": EXPECTED_MEMBERSHIP,
+        "milestone_membership_actual": membership_actual,
+        "milestones": milestone_records,
+        "open_issue_assignees": open_assignees,
+        "critical_contracts": contracts,
+        "relations": relations,
+        "comments": collect_comment_evidence(),
+    }
+
+
+def _candidate_eligibility(
+    candidate: dict[str, Any],
+    task_records: list[dict[str, Any]],
+    surfaces: dict[str, Any],
+) -> dict[str, Any]:
+    number = candidate["number"]
+    label_dependency_reasons: list[str] = []
+    if candidate["state"] != "open":
+        label_dependency_reasons.append("not-open")
+    if "ready-for-agent" not in candidate["labels"]:
+        label_dependency_reasons.append("not-ready-for-agent")
+    if candidate["assignees"]:
+        label_dependency_reasons.append("assigned")
+    if candidate["blocked_by"]:
+        label_dependency_reasons.append("blocked")
+
+    candidate_tasks = [record for record in task_records if record["issue"] == number]
+    ownership_reasons: list[str] = []
+    if len(candidate_tasks) != 2:
+        ownership_reasons.append("incomplete-native-task-evidence")
+    if any(record["unavailable_host_count"] for record in candidate_tasks):
+        ownership_reasons.append("native-task-host-unavailable")
+    if any(record["match_count"] for record in candidate_tasks):
+        ownership_reasons.append("native-task-match")
+    if candidate["assignees"]:
+        ownership_reasons.append("assignee")
+    active_intersections: list[dict[str, Any]] = []
+    for kind in ("worktrees", "local_branches", "open_pr_heads"):
+        for surface in surfaces[kind]:
+            hits = surface["hotset_intersections"][str(number)]
+            if surface["active"] and hits:
+                active_intersections.append(
+                    {
+                        "surface": surface["logical_identity"],
+                        "changed_files": hits,
+                    }
+                )
+    if active_intersections:
+        ownership_reasons.append("active-file-hotset-intersection")
+    return {
+        "label_dependency": {
+            "open": candidate["state"] == "open",
+            "ready_for_agent": "ready-for-agent" in candidate["labels"],
+            "unassigned": not bool(candidate["assignees"]),
+            "open_blockers": candidate["blocked_by"],
+            "eligible": not label_dependency_reasons,
+            "ineligible_reasons": label_dependency_reasons,
+        },
+        "ownership_hotset": {
+            "native_task_query_count": len(candidate_tasks),
+            "native_task_matches": sum(record["match_count"] for record in candidate_tasks),
+            "native_task_unavailable_hosts": sum(
+                record["unavailable_host_count"] for record in candidate_tasks
+            ),
+            "assignees": candidate["assignees"],
+            "active_surface_intersections": active_intersections,
+            "eligible": not ownership_reasons,
+            "ineligible_reasons": ownership_reasons,
+        },
+    }
+
+
+def _assert_sanitized(value: Any) -> None:
+    serialized = json.dumps(value, ensure_ascii=False)
+    if re.search(r"(?i)\b[A-Z]:[\\/]", serialized):
+        raise ValueError("artifact contains a local absolute path")
+    if re.search(r'"(?:thread_id|task_id|rollout_id|callback_id)"\s*:', serialized):
+        raise ValueError("artifact contains a private identifier field")
+
+
+def build_core(
+    native_capture: dict[str, Any],
+    base_ref: str,
+    planned_paths: list[str],
+    native_capture_file_sha256: str | None = None,
+) -> dict[str, Any]:
+    task_records = validate_native_task_capture(native_capture, FRONTIER_EXPECTED)
+    candidates = [issue_snapshot(number, include_hotset=True) for number in FRONTIER_EXPECTED]
+    for candidate in candidates:
+        expected_title = EXPECTED_TITLES[candidate["number"]]
+        if candidate["title"] != expected_title:
+            raise ValueError(f"title mismatch on #{candidate['number']}")
+    surfaces = collect_surfaces(base_ref, candidates, planned_paths)
+    for candidate in candidates:
+        candidate["eligibility"] = _candidate_eligibility(
+            candidate, task_records, surfaces
+        )
+    frontier = [
+        number
+        for number in PRIORITY_ORDER
+        if number in FRONTIER_EXPECTED
+        and next(item for item in candidates if item["number"] == number)[
+            "eligibility"
+        ]["label_dependency"]["eligible"]
+        and next(item for item in candidates if item["number"] == number)[
+            "eligibility"
+        ]["ownership_hotset"]["eligible"]
+    ]
+    if frontier != FRONTIER_EXPECTED:
+        raise ValueError(f"frontier fail-closed mismatch: {frontier}")
+
+    for surface in surfaces["worktrees"]:
+        if surface["classification"] == "active-product-hotset":
+            raise ValueError(
+                f"active worktree intersects a frontier hotset: {surface['logical_identity']}"
+            )
+    for surface in surfaces["local_branches"]:
+        if surface["active"] and any(surface["hotset_intersections"].values()):
+            raise ValueError(
+                f"active local branch intersects a frontier hotset: {surface['logical_identity']}"
+            )
+    for surface in surfaces["open_pr_heads"]:
+        if any(surface["hotset_intersections"].values()):
+            raise ValueError(
+                f"open PR intersects a frontier hotset: {surface['logical_identity']}"
+            )
+
+    core = {
+        "schema_version": SCHEMA_VERSION,
+        "artifact_kind": CORE_KIND,
+        "captured_at": utc_now(),
+        "repository": REPOSITORY,
+        "generator": "scripts/generate_wayfinder_final_audit.py",
+        "base_ref": base_ref,
+        "base_revision": run("git", "rev-parse", base_ref).strip(),
+        "planning_branch": run("git", "branch", "--show-current").strip(),
+        "planning_revision": run("git", "rev-parse", "HEAD").strip(),
+        "native_task_capture": {
+            "tool": "codex_app__list_threads",
+            "source_capture_file_sha256": native_capture_file_sha256,
+            "source_capture_canonical_json_sha256": canonical_json_sha256(native_capture),
+            "captured_at": native_capture["captured_at"],
+            "limit": native_capture["limit"],
+            "records": task_records,
+        },
+        "candidates": candidates,
+        "ownership_surfaces": surfaces,
+        "frontier": frontier,
+        "global_github_audit": collect_global_audit(),
+        "derivation": {
+            "label_dependency_rule": "open AND ready-for-agent AND unassigned AND zero open native blockers",
+            "ownership_hotset_rule": "two exact native queries clear AND no unavailable native host AND unassigned AND no active worktree/local-branch/open-PR changed-file intersection with the parsed Expected hotset",
+            "branch_names_used_as_ownership_evidence": False,
+            "inactive_local_branches_block_eligibility": False,
+            "inactive_branch_reason": "A local branch is active only when checked out in a worktree or used as an open PR head; every local branch is still enumerated with its file intersections.",
+            "planning_worktree_rule": "The current planning worktree is migration-control evidence only because its complete changed-file set has zero frontier product-hotset intersections.",
+            "dev_rule": "The dev worktree is independently audited for revision, cleanliness, and changed-file intersections; it is not trusted by name alone.",
+            "result": "eligible",
+        },
+        "sanitization": {
+            "native_task_ids_persisted": False,
+            "local_absolute_paths_persisted": False,
+            "worktree_identity_basis": "branch or detached revision, never filesystem path",
+            "changed_file_paths": "repository-relative",
+        },
+    }
+    _assert_sanitized(core)
+    validate_core(core)
+    return core
+
+
+def validate_core(core: dict[str, Any]) -> None:
+    if core.get("schema_version") != SCHEMA_VERSION or core.get("artifact_kind") != CORE_KIND:
+        raise ValueError("frontier artifact schema/kind mismatch")
+    parse_timestamp(core.get("captured_at"), "frontier artifact")
+    native = core.get("native_task_capture", {})
+    parse_timestamp(native.get("captured_at"), "native Task")
+    if not re.fullmatch(
+        r"[0-9a-f]{64}", str(native.get("source_capture_file_sha256", ""))
+    ):
+        raise ValueError("native Task source-capture file hash missing")
+    records = native.get("records")
+    if not isinstance(records, list) or len(records) != 12:
+        raise ValueError("frontier artifact must contain 12 native Task records")
+    pairs = {(item.get("issue"), item.get("kind")) for item in records}
+    expected_pairs = {
+        (number, kind)
+        for number in FRONTIER_EXPECTED
+        for kind in ("exact_title", "issue_number")
+    }
+    if pairs != expected_pairs:
+        raise ValueError("frontier artifact native Task pair mismatch")
+    for record in records:
+        number = record["issue"]
+        expected_query = (
+            EXPECTED_TITLES[number]
+            if record["kind"] == "exact_title"
+            else f"Issue {number}"
+        )
+        if record.get("query") != expected_query:
+            raise ValueError("frontier artifact native Task query mismatch")
+        if record.get("schema_version") != 2:
+            raise ValueError("frontier artifact native schema mismatch")
+        if record.get("match_count") != 0:
+            raise ValueError("frontier artifact contains native Task matches")
+        if record.get("unavailable_host_count") != 0 or record.get("unavailable_hosts") != []:
+            raise ValueError("frontier artifact contains unavailable native hosts")
+        parse_timestamp(record.get("captured_at"), "native Task record")
+    candidates = core.get("candidates")
+    if not isinstance(candidates, list) or [item.get("number") for item in candidates] != FRONTIER_EXPECTED:
+        raise ValueError("frontier artifact candidate mismatch")
+    for candidate in candidates:
+        if candidate.get("title") != EXPECTED_TITLES[candidate["number"]]:
+            raise ValueError("frontier artifact title mismatch")
+        hotset = candidate.get("expected_hotset", {})
+        if not hotset.get("entries") or not hotset.get("matchers"):
+            raise ValueError("frontier artifact hotset missing")
+        eligibility = candidate.get("eligibility", {})
+        if not eligibility.get("label_dependency", {}).get("eligible"):
+            raise ValueError("frontier label/dependency eligibility failed")
+        if not eligibility.get("ownership_hotset", {}).get("eligible"):
+            raise ValueError("frontier ownership/hotset eligibility failed")
+    if core.get("frontier") != FRONTIER_EXPECTED:
+        raise ValueError("frontier artifact derived order mismatch")
+    surfaces = core.get("ownership_surfaces", {})
+    for key in ("worktrees", "local_branches", "open_pr_heads"):
+        if not isinstance(surfaces.get(key), list):
+            raise ValueError(f"frontier ownership surface missing: {key}")
+        for surface in surfaces[key]:
+            if "revision" not in surface and "head_revision" not in surface:
+                raise ValueError(f"surface revision missing: {surface.get('logical_identity')}")
+            if "hotset_intersections" not in surface:
+                raise ValueError(f"surface intersections missing: {surface.get('logical_identity')}")
+    if core.get("derivation", {}).get("result") != "eligible":
+        raise ValueError("frontier artifact derivation did not fail closed")
+    _assert_sanitized(core)
+
+
+def validate_transcript(transcript: dict[str, Any], core_sha256: str) -> None:
+    if transcript.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError("checkpoint transcript schema mismatch")
+    parse_timestamp(transcript.get("captured_at"), "checkpoint transcript")
+    if transcript.get("issue") != 147:
+        raise ValueError("checkpoint transcript issue mismatch")
+    if transcript.get("purpose_prefix") != COMMENT_PREFIXES[147]:
+        raise ValueError("checkpoint transcript purpose prefix mismatch")
+    historical = transcript.get("historical_original", {})
+    original_body = normalize_body(historical.get("normalized_body"))
+    if original_body != normalize_body(ORIGINAL_CHECKPOINT_BODY):
+        raise ValueError("checkpoint historical original body mismatch")
+    if historical.get("normalized_body_sha256") != sha256_text(original_body):
+        raise ValueError("checkpoint historical original hash mismatch")
+    pre = transcript.get("pre_update", {})
+    if pre.get("public_comment_id") != CHECKPOINT_COMMENT_ID:
+        raise ValueError("checkpoint prior public comment ID mismatch")
+    if not re.fullmatch(r"[0-9a-f]{64}", str(pre.get("normalized_body_sha256", ""))):
+        raise ValueError("checkpoint prior hash missing")
+    desired = transcript.get("desired", {})
+    desired_body = normalize_body(desired.get("normalized_body"))
+    if desired.get("normalized_body_sha256") != sha256_text(desired_body):
+        raise ValueError("checkpoint desired hash mismatch")
+    required_reference = f"{CORE_ARTIFACT_PATH} (SHA-256: `{core_sha256}`)"
+    if required_reference not in desired_body:
+        raise ValueError("checkpoint desired body lacks durable artifact path/hash")
+    if transcript.get("operation_decision") not in {"patch", "exact-no-op"}:
+        raise ValueError("checkpoint operation decision missing")
+    post = transcript.get("post_readback", {})
+    if post.get("public_comment_id") != CHECKPOINT_COMMENT_ID:
+        raise ValueError("checkpoint post public comment ID mismatch")
+    if post.get("prefix_multiplicity") != 1 or post.get("exact_body_multiplicity") != 1:
+        raise ValueError("checkpoint post-readback multiplicity mismatch")
+    if post.get("normalized_body_sha256") != desired.get("normalized_body_sha256"):
+        raise ValueError("checkpoint post-readback body mismatch")
+    _assert_sanitized(transcript)
+
+
+def build_final(core: dict[str, Any], core_path: str, transcript: dict[str, Any]) -> dict[str, Any]:
+    validate_core(core)
+    core_sha = serialized_json_sha256(core)
+    validate_transcript(transcript, core_sha)
+    final = {
+        "schema_version": SCHEMA_VERSION,
+        "artifact_kind": FINAL_KIND,
+        "captured_at": utc_now(),
+        "repository": REPOSITORY,
+        "generator": "scripts/generate_wayfinder_final_audit.py",
+        "frontier_artifact": {
+            "repository_relative_path": core_path,
+            "sha256": core_sha,
+            "embedded": core,
+        },
+        "checkpoint_update_transcript": transcript,
+        "derivation": {
+            "frontier": core["frontier"],
+            "label_dependency_eligibility": {
+                str(item["number"]): item["eligibility"]["label_dependency"]
+                for item in core["candidates"]
+            },
+            "ownership_hotset_eligibility": {
+                str(item["number"]): item["eligibility"]["ownership_hotset"]
+                for item in core["candidates"]
+            },
+            "checkpoint_exact_body_guard": transcript["operation_decision"],
+            "checkpoint_post_readback_exact": True,
+        },
+        "artifact_hashes": {
+            core_path: core_sha,
+            TRANSCRIPT_ARTIFACT_PATH: serialized_json_sha256(transcript),
+        },
+        "sanitization": core["sanitization"],
+    }
+    _assert_sanitized(final)
+    validate_final(final)
+    return final
+
+
+def validate_final(final: dict[str, Any]) -> None:
+    if final.get("schema_version") != SCHEMA_VERSION or final.get("artifact_kind") != FINAL_KIND:
+        raise ValueError("final artifact schema/kind mismatch")
+    parse_timestamp(final.get("captured_at"), "final artifact")
+    frontier_artifact = final.get("frontier_artifact", {})
+    core = frontier_artifact.get("embedded")
+    if not isinstance(core, dict):
+        raise ValueError("final artifact does not embed frontier evidence")
+    validate_core(core)
+    core_sha = serialized_json_sha256(core)
+    if frontier_artifact.get("repository_relative_path") != CORE_ARTIFACT_PATH:
+        raise ValueError("final artifact frontier path mismatch")
+    if frontier_artifact.get("sha256") != core_sha:
+        raise ValueError("final artifact embedded frontier hash mismatch")
+    transcript = final.get("checkpoint_update_transcript")
+    if not isinstance(transcript, dict):
+        raise ValueError("final artifact checkpoint transcript missing")
+    validate_transcript(transcript, core_sha)
+    recorded_prior = core["global_github_audit"]["comments"]["147"]
+    transcript_prior = transcript["pre_update"]
+    if (
+        recorded_prior["public_comment_id"]
+        != transcript_prior["public_comment_id"]
+        or recorded_prior["normalized_body_sha256"]
+        != transcript_prior["normalized_body_sha256"]
+        or recorded_prior["prefix_multiplicity"] != 1
+        or recorded_prior["exact_body_multiplicity"] != 1
+    ):
+        raise ValueError("frontier capture does not match checkpoint transcript prior readback")
+    hashes = final.get("artifact_hashes", {})
+    if hashes.get(CORE_ARTIFACT_PATH) != core_sha:
+        raise ValueError("final artifact hash manifest mismatch")
+    if hashes.get(TRANSCRIPT_ARTIFACT_PATH) != serialized_json_sha256(transcript):
+        raise ValueError("final transcript hash manifest mismatch")
+    _assert_sanitized(final)
+
+
+def compare_live(final: dict[str, Any]) -> None:
+    validate_final(final)
+    core = final["frontier_artifact"]["embedded"]
+    fresh_global = collect_global_audit()
+    recorded_global = core["global_github_audit"]
+    for key in (
+        "canonical_lifecycle_violations",
+        "milestone_membership_actual",
+        "critical_contracts",
+        "relations",
+    ):
+        if fresh_global[key] != recorded_global[key]:
+            raise ValueError(f"fresh live GitHub audit mismatch: {key}")
+    for number in ("8", "10", "12", "62"):
+        if fresh_global["comments"][number] != recorded_global["comments"][number]:
+            raise ValueError(f"fresh live GitHub audit mismatch: comment #{number}")
+    fresh_checkpoint = fresh_global["comments"]["147"]
+    transcript_post = final["checkpoint_update_transcript"]["post_readback"]
+    if (
+        fresh_checkpoint["public_comment_id"] != transcript_post["public_comment_id"]
+        or fresh_checkpoint["normalized_body_sha256"]
+        != transcript_post["normalized_body_sha256"]
+        or fresh_checkpoint["prefix_multiplicity"]
+        != transcript_post["prefix_multiplicity"]
+        or fresh_checkpoint["exact_body_multiplicity"]
+        != transcript_post["exact_body_multiplicity"]
+    ):
+        raise ValueError("fresh live GitHub audit mismatch: updated checkpoint #147")
+    fresh_candidates = [
+        issue_snapshot(number, include_hotset=True) for number in FRONTIER_EXPECTED
+    ]
+    for fresh, recorded in zip(fresh_candidates, core["candidates"], strict=True):
+        for key in (
+            "number",
+            "title",
+            "state",
+            "body_normalized_sha256",
+            "labels",
+            "assignees",
+            "milestone",
+            "parent",
+            "blocked_by",
+            "children",
+            "expected_hotset",
+        ):
+            if fresh[key] != recorded[key]:
+                raise ValueError(f"fresh frontier Issue mismatch #{fresh['number']}: {key}")
+    fresh_surfaces = collect_surfaces(core["base_ref"], fresh_candidates, [])
+    for kind in ("worktrees", "local_branches", "open_pr_heads"):
+        for surface in fresh_surfaces[kind]:
+            if surface["active"] and any(surface["hotset_intersections"].values()):
+                raise ValueError(
+                    f"fresh active surface/hotset intersection: {surface['logical_identity']}"
+                )
+    current_comment = api_json(
+        f"repos/{REPOSITORY}/issues/comments/{CHECKPOINT_COMMENT_ID}"
+    )
+    desired = final["checkpoint_update_transcript"]["desired"]
+    if sha256_text(normalize_body(current_comment.get("body"))) != desired["normalized_body_sha256"]:
+        raise ValueError("fresh checkpoint body mismatch")
+    print(
+        json.dumps(
+            {
+                "status": "live-ok",
+                "open_issue_count": fresh_global["open_issue_count"],
+                "frontier": core["frontier"],
+                "checkpoint_comment_id": CHECKPOINT_COMMENT_ID,
+                "worktree_count": len(fresh_surfaces["worktrees"]),
+                "local_branch_count": len(fresh_surfaces["local_branches"]),
+                "open_pr_head_count": len(fresh_surfaces["open_pr_heads"]),
+            },
+            ensure_ascii=False,
+        )
+    )
+
+
+def write_json(path: pathlib.Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(
+        (json.dumps(value, ensure_ascii=False, indent=2) + "\n").encode("utf-8")
+    )
+
+
+def read_json(path: pathlib.Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8-sig"))
+    if not isinstance(value, dict):
+        raise ValueError(f"expected JSON object: {path.name}")
+    return value
+
+
+def relative_path(path: pathlib.Path) -> str:
+    return path.resolve().relative_to(ROOT.resolve()).as_posix()
+
+
+def command_capture(args: argparse.Namespace) -> None:
+    native_path = pathlib.Path(args.native_task_evidence)
+    output = pathlib.Path(args.output)
+    planned = sorted(
+        set(
+            args.planned_path
+            + [
+                relative_path(output),
+                CORE_ARTIFACT_PATH,
+                TRANSCRIPT_ARTIFACT_PATH,
+                FINAL_ARTIFACT_PATH,
+            ]
+        )
+    )
+    core = build_core(
+        read_json(native_path),
+        args.base_ref,
+        planned,
+        native_capture_file_sha256=sha256_file(native_path),
+    )
+    write_json(output, core)
+    validate_core(read_json(output))
+    print(
+        json.dumps(
+            {
+                "status": "captured-and-self-validated",
+                "artifact": relative_path(output),
+                "sha256": serialized_json_sha256(core),
+                "file_sha256": sha256_file(output),
+                "frontier": core["frontier"],
+                "native_query_count": len(core["native_task_capture"]["records"]),
+            },
+            ensure_ascii=False,
+        )
+    )
+
+
+def command_finalize(args: argparse.Namespace) -> None:
+    core_path = pathlib.Path(args.core)
+    transcript_path = pathlib.Path(args.transcript)
+    output = pathlib.Path(args.output)
+    core = read_json(core_path)
+    transcript = read_json(transcript_path)
+    final = build_final(core, relative_path(core_path), transcript)
+    write_json(output, final)
+    validate_final(read_json(output))
+    print(
+        json.dumps(
+            {
+                "status": "finalized-and-self-validated",
+                "artifact": relative_path(output),
+                "sha256": serialized_json_sha256(final),
+                "file_sha256": sha256_file(output),
+                "frontier_artifact_sha256": serialized_json_sha256(core),
+                "checkpoint_operation": transcript["operation_decision"],
+            },
+            ensure_ascii=False,
+        )
+    )
+
+
+def command_validate(args: argparse.Namespace) -> None:
+    path = pathlib.Path(args.artifact)
+    value = read_json(path)
+    if value.get("artifact_kind") == CORE_KIND:
+        validate_core(value)
+    elif value.get("artifact_kind") == FINAL_KIND:
+        validate_final(value)
+        if args.live:
+            compare_live(value)
+    else:
+        raise ValueError("unknown Wayfinder audit artifact kind")
+    print(
+        json.dumps(
+            {
+                "status": "validated",
+                "artifact": relative_path(path),
+                "sha256": serialized_json_sha256(value),
+                "file_sha256": sha256_file(path),
+                "live": bool(args.live),
+            },
+            ensure_ascii=False,
+        )
+    )
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description=__doc__)
+    subcommands = result.add_subparsers(dest="command", required=True)
+    capture = subcommands.add_parser("capture", help="capture fresh read-only frontier evidence")
+    capture.add_argument("--native-task-evidence", required=True)
+    capture.add_argument("--output", default=CORE_ARTIFACT_PATH)
+    capture.add_argument("--base-ref", default="dev")
+    capture.add_argument("--planned-path", action="append", default=[])
+    capture.set_defaults(handler=command_capture)
+    finalize = subcommands.add_parser(
+        "finalize", help="combine a frontier artifact and guarded checkpoint transcript"
+    )
+    finalize.add_argument("--core", default=CORE_ARTIFACT_PATH)
+    finalize.add_argument("--transcript", default=TRANSCRIPT_ARTIFACT_PATH)
+    finalize.add_argument("--output", default=FINAL_ARTIFACT_PATH)
+    finalize.set_defaults(handler=command_finalize)
+    validate = subcommands.add_parser("validate", help="self-validate an audit artifact")
+    validate.add_argument("--artifact", required=True)
+    validate.add_argument("--live", action="store_true")
+    validate.set_defaults(handler=command_validate)
+    return result
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        args.handler(args)
+    except (ValueError, RuntimeError, OSError, subprocess.SubprocessError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_wayfinder_final_audit_generator.py
+++ b/scripts/tests/test_wayfinder_final_audit_generator.py
@@ -4,6 +4,7 @@ import json
 import pathlib
 import re
 import subprocess
+import tempfile
 import unittest
 
 
@@ -122,26 +123,31 @@ $cases = @()
 
 Reset-Comments $null
 $guard = Set-OrCreateExactIssueComment 147 {ps_literal(module.COMMENT_PREFIXES[147])} $desired 4994927680L $oldHash
-$cases += [ordered]@{{ guard = $guard; transcript = New-CheckpointTranscript $guard $historical $desired $artifactPath $artifactSha }}
+$proof = Resolve-ProvenCheckpointHistoricalProvenance $guard $desired $null $historical
+$cases += [ordered]@{{ guard = $guard; transcript = New-CheckpointTranscript $guard $proof $desired $artifactPath $artifactSha }}
 
 Reset-Comments $desired
 $guard = Set-OrCreateExactIssueComment 147 {ps_literal(module.COMMENT_PREFIXES[147])} $desired 4994927680L $oldHash
-$cases += [ordered]@{{ guard = $guard; transcript = New-CheckpointTranscript $guard $historical $desired $artifactPath $artifactSha }}
+$proof = Resolve-ProvenCheckpointHistoricalProvenance $guard $desired $null $historical
+$cases += [ordered]@{{ guard = $guard; transcript = New-CheckpointTranscript $guard $proof $desired $artifactPath $artifactSha }}
 
 Reset-Comments $old
 $guard = Set-OrCreateExactIssueComment 147 {ps_literal(module.COMMENT_PREFIXES[147])} $desired 4994927680L $oldHash
-$cases += [ordered]@{{ guard = $guard; transcript = New-CheckpointTranscript $guard $historical $desired $artifactPath $artifactSha }}
+$proof = Resolve-ProvenCheckpointHistoricalProvenance $guard $desired $null $historical
+$cases += [ordered]@{{ guard = $guard; transcript = New-CheckpointTranscript $guard $proof $desired $artifactPath $artifactSha }}
 
 $cases | ConvertTo-Json -Depth 10 -Compress
 '''
-        completed = subprocess.run(
-            ["pwsh", "-NoProfile", "-NonInteractive", "-Command", "-"],
-            input=harness,
-            text=True,
-            encoding="utf-8",
-            capture_output=True,
-            cwd=ROOT,
-        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            harness_path = pathlib.Path(temp_dir) / "checkpoint-sequence.ps1"
+            harness_path.write_text(harness, encoding="utf-8")
+            completed = subprocess.run(
+                ["pwsh", "-NoProfile", "-NonInteractive", "-File", str(harness_path)],
+                text=True,
+                encoding="utf-8",
+                capture_output=True,
+                cwd=ROOT,
+            )
         self.assertEqual(completed.returncode, 0, completed.stderr)
         self.assertTrue(completed.stdout.strip(), completed.stderr or "PowerShell harness produced no JSON")
         cases = json.loads(completed.stdout)
@@ -157,12 +163,30 @@ $cases | ConvertTo-Json -Depth 10 -Compress
         self.assertTrue(all(case["guard"]["post_exact_body_multiplicity"] == 1 for case in cases))
         for case in cases:
             with self.subTest(operation=case["guard"]["operation_decision"]):
-                if case["guard"]["operation_decision"] != "create":
+                if case["guard"]["operation_decision"] == "patch":
                     self.assertEqual(
                         module.normalize_body(case["transcript"]["historical_original"]["normalized_body"]),
                         module.normalize_body(module.ORIGINAL_CHECKPOINT_BODY),
                     )
+                elif case["guard"]["operation_decision"] == "exact-no-op":
+                    self.assertEqual(
+                        module.normalize_body(case["transcript"]["historical_original"]["normalized_body"]),
+                        desired,
+                    )
                 module.validate_transcript(case["transcript"], core_sha)
+        broken_noop = json.loads(json.dumps(cases[1]["transcript"]))
+        broken_noop["pre_update"]["normalized_body_sha256"] = "0" * 64
+        with self.assertRaisesRegex(ValueError, "exact-no-op pre/desired/post hashes differ"):
+            module.validate_transcript(broken_noop, core_sha)
+
+        broken_origin = json.loads(json.dumps(cases[1]["transcript"]))
+        broken_origin["historical_original"] = {
+            "source": "Task 8 execution report exact original published body",
+            "normalized_body": module.ORIGINAL_CHECKPOINT_BODY,
+            "normalized_body_sha256": module.sha256_text(module.ORIGINAL_CHECKPOINT_BODY),
+        }
+        with self.assertRaisesRegex(ValueError, "live-exact provenance mismatch"):
+            module.validate_transcript(broken_origin, core_sha)
 
     def test_initial_checkpoint_transcript_finalizes_without_prior_state(self):
         module = load_module()
@@ -188,6 +212,10 @@ $cases | ConvertTo-Json -Depth 10 -Compress
                 "normalized_body": desired_body,
                 "normalized_body_sha256": desired_hash,
             },
+            "historical_provenance": {
+                "proof_kind": "initial-create",
+                "prior_transcript": None,
+            },
             "pre_update": {
                 "public_comment_id": None,
                 "normalized_body_sha256": None,
@@ -210,6 +238,137 @@ $cases | ConvertTo-Json -Depth 10 -Compress
         }
         final = module.build_final(core, module.CORE_ARTIFACT_PATH, transcript)
         self.assertEqual(final["derivation"]["checkpoint_exact_body_guard"], "create")
+
+    def test_stateful_retries_preserve_proven_historical_origin(self):
+        module = load_module()
+        plan = (ROOT / "docs/superpowers/plans/2026-07-16-wayfinder-github-migration.md").read_text(
+            encoding="utf-8"
+        )
+        task8 = plan.split("### Task 8:", 1)[1]
+        step6 = task8.split("**Step 6:", 1)[1]
+        block = re.search(r"```powershell\n(?P<body>.*?)\n```", step6, re.DOTALL)
+        self.assertIsNotNone(block)
+        prelude = block.group("body").split("$frontierText", 1)[0]
+
+        tracked_core = json.loads((ROOT / module.CORE_ARTIFACT_PATH).read_text(encoding="utf-8"))
+        create_core = json.loads(json.dumps(tracked_core))
+        create_core["global_github_audit"]["comments"]["147"] = None
+        create_core_sha = module.serialized_json_sha256(create_core)
+        create_desired = (
+            module.COMMENT_PREFIXES[147]
+            + "\n\nDurable frontier audit: "
+            + module.CORE_ARTIFACT_PATH
+            + f" (SHA-256: `{create_core_sha}`)."
+        )
+
+        patch_core = json.loads(json.dumps(tracked_core))
+        patch_prior_body = module.COMMENT_PREFIXES[147] + "\n\nPrior checkpoint body."
+        patch_core["global_github_audit"]["comments"]["147"][
+            "normalized_body_sha256"
+        ] = module.sha256_text(patch_prior_body)
+        patch_core_sha = module.serialized_json_sha256(patch_core)
+        self.assertEqual(
+            module.sha256_text(patch_prior_body),
+            patch_core["global_github_audit"]["comments"]["147"]["normalized_body_sha256"],
+        )
+        patch_desired = (
+            module.COMMENT_PREFIXES[147]
+            + "\n\nDurable frontier audit: "
+            + module.CORE_ARTIFACT_PATH
+            + f" (SHA-256: `{patch_core_sha}`).\n\nStateful retry target."
+        )
+
+        def b64(value):
+            return base64.b64encode(value.encode("utf-8")).decode("ascii")
+
+        harness = "$ErrorActionPreference = 'Stop'\nSet-StrictMode -Version Latest\n" + prelude + rf'''
+function Reset-Comments([string]$Body) {{
+  if ($null -eq $Body) {{ $script:comments = @() }} else {{
+    $script:comments = @([pscustomobject]@{{ id = 4994927680L; body = $Body; html_url = 'https://example.invalid/comment' }})
+  }}
+}}
+function Get-IssueComments([int]$Issue) {{ return @($script:comments) }}
+function New-IssueComment([int]$Issue,[string]$Body) {{
+  $script:comments = @([pscustomobject]@{{ id = 4994927680L; body = $Body; html_url = 'https://example.invalid/comment' }})
+}}
+function Update-IssueComment([long]$PublicCommentId,[string]$Body) {{
+  $script:comments = @([pscustomobject]@{{ id = $PublicCommentId; body = $Body; html_url = 'https://example.invalid/comment' }})
+}}
+$prefix = '{module.COMMENT_PREFIXES[147]}'
+$artifactPath = '{module.CORE_ARTIFACT_PATH}'
+$legacy = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('{b64(module.ORIGINAL_CHECKPOINT_BODY)}'))
+$createDesired = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('{b64(create_desired)}'))
+$patchPrior = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('{b64(patch_prior_body)}'))
+$patchDesired = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('{b64(patch_desired)}'))
+
+Reset-Comments $null
+$createGuard = Set-OrCreateExactIssueComment 147 $prefix $createDesired 4994927680L ('0' * 64)
+$createProof = Resolve-ProvenCheckpointHistoricalProvenance $createGuard $createDesired $null $legacy
+$createTranscript = New-CheckpointTranscript $createGuard $createProof $createDesired $artifactPath '{create_core_sha}'
+$createNoopGuard = Set-OrCreateExactIssueComment 147 $prefix $createDesired 4994927680L ('0' * 64)
+$createNoopProof = Resolve-ProvenCheckpointHistoricalProvenance $createNoopGuard $createDesired $createTranscript $legacy
+$createNoopTranscript = New-CheckpointTranscript $createNoopGuard $createNoopProof $createDesired $artifactPath '{create_core_sha}'
+
+Reset-Comments $patchPrior
+$patchPriorHash = Get-NormalizedBodySha256 $patchPrior
+$patchGuard = Set-OrCreateExactIssueComment 147 $prefix $patchDesired 4994927680L $patchPriorHash
+$patchProof = Resolve-ProvenCheckpointHistoricalProvenance $patchGuard $patchDesired $null $legacy
+$patchTranscript = New-CheckpointTranscript $patchGuard $patchProof $patchDesired $artifactPath '{patch_core_sha}'
+$patchNoopGuard = Set-OrCreateExactIssueComment 147 $prefix $patchDesired 4994927680L $patchPriorHash
+$patchNoopProof = Resolve-ProvenCheckpointHistoricalProvenance $patchNoopGuard $patchDesired $patchTranscript $legacy
+$patchNoopTranscript = New-CheckpointTranscript $patchNoopGuard $patchNoopProof $patchDesired $artifactPath '{patch_core_sha}'
+
+$result = [ordered]@{{
+  create = $createTranscript
+  create_noop = $createNoopTranscript
+  patch = $patchTranscript
+  patch_noop = $patchNoopTranscript
+}}
+$json = $result | ConvertTo-Json -Depth 30 -Compress
+if ([string]::IsNullOrWhiteSpace($json)) {{ throw 'PowerShell sequence JSON serialization returned empty output' }}
+Write-Output $json
+'''
+        with tempfile.TemporaryDirectory() as temp_dir:
+            harness_path = pathlib.Path(temp_dir) / "checkpoint-sequence.ps1"
+            harness_path.write_text(harness, encoding="utf-8")
+            completed = subprocess.run(
+                ["pwsh", "-NoProfile", "-NonInteractive", "-File", str(harness_path)],
+                text=True,
+                encoding="utf-8",
+                capture_output=True,
+                cwd=ROOT,
+            )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertTrue(completed.stdout.strip(), completed.stderr or "PowerShell sequence produced no JSON")
+        transcripts = json.loads(completed.stdout)
+
+        for first, retry, core in (
+            ("create", "create_noop", create_core),
+            ("patch", "patch_noop", patch_core),
+        ):
+            self.assertEqual(
+                transcripts[first]["historical_original"],
+                transcripts[retry]["historical_original"],
+            )
+            self.assertEqual(transcripts[retry]["operation_decision"], "exact-no-op")
+            hashes = {
+                transcripts[retry]["pre_update"]["normalized_body_sha256"],
+                transcripts[retry]["desired"]["normalized_body_sha256"],
+                transcripts[retry]["post_readback"]["normalized_body_sha256"],
+            }
+            self.assertEqual(len(hashes), 1)
+            module.build_final(core, module.CORE_ARTIFACT_PATH, transcripts[first])
+            module.build_final(core, module.CORE_ARTIFACT_PATH, transcripts[retry])
+
+        self.assertIsNone(transcripts["create"]["pre_update"]["normalized_body_sha256"])
+        self.assertEqual(
+            transcripts["create"]["historical_original"]["normalized_body"],
+            create_desired,
+        )
+        self.assertEqual(
+            transcripts["patch"]["pre_update"]["normalized_body_sha256"],
+            module.sha256_text(patch_prior_body),
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_wayfinder_final_audit_generator.py
+++ b/scripts/tests/test_wayfinder_final_audit_generator.py
@@ -1,0 +1,216 @@
+import base64
+import importlib.util
+import json
+import pathlib
+import re
+import subprocess
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "generate_wayfinder_final_audit.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("wayfinder_audit", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class WayfinderAuditGeneratorTests(unittest.TestCase):
+    def test_native_capture_requires_exact_uniform_records(self):
+        module = load_module()
+        capture = json.loads(
+            (ROOT / ".superpowers/sdd/wayfinder-native-task-evidence-controller.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        normalized = module.validate_native_task_capture(capture, module.FRONTIER_EXPECTED)
+        self.assertEqual(len(normalized), 12)
+        self.assertTrue(all(record["schema_version"] == 2 for record in normalized))
+        self.assertTrue(all(record["match_count"] == 0 for record in normalized))
+        self.assertTrue(all(record["unavailable_host_count"] == 0 for record in normalized))
+
+        broken = json.loads(json.dumps(capture))
+        broken["records"][0]["query"] = "wrong"
+        with self.assertRaisesRegex(ValueError, "query"):
+            module.validate_native_task_capture(broken, module.FRONTIER_EXPECTED)
+
+    def test_expected_hotset_parser_preserves_entries_and_builds_matchers(self):
+        module = load_module()
+        body = """before\n\n## Expected hotset\n\n- `src-python/example.py`\n- one fixture under `tests/fixtures/` if needed\n\n## Relationships\nnone\n"""
+        parsed = module.parse_expected_hotset(body, 159)
+        self.assertEqual([entry["normalized"] for entry in parsed["entries"]], [
+            "src-python/example.py",
+            "one fixture under tests/fixtures/ if needed",
+        ])
+        self.assertIn("src-python/example.py", parsed["matchers"])
+        self.assertIn("tests/fixtures/**", parsed["matchers"])
+
+    def test_path_intersections_are_file_based_not_branch_name_based(self):
+        module = load_module()
+        self.assertEqual(
+            module.intersections(
+                ["docs/superpowers/plans/example.md", "src-python/codex_proxy.py"],
+                ["src-python/codex_proxy.py", "tests/fixtures/**"],
+            ),
+            ["src-python/codex_proxy.py"],
+        )
+
+    def test_settings_drawer_hotset_matches_direct_and_nested_paths_only(self):
+        module = load_module()
+        matchers = module._path_matchers("the Settings drawer", 111)
+        self.assertEqual(
+            module.intersections(
+                [
+                    "frontend/src/components/SettingsDrawer.tsx",
+                    "frontend/src/components/settings/SettingsDrawer.tsx",
+                    "frontend/src/components/UnrelatedDrawer.tsx",
+                ],
+                matchers,
+            ),
+            [
+                "frontend/src/components/SettingsDrawer.tsx",
+                "frontend/src/components/settings/SettingsDrawer.tsx",
+            ],
+        )
+
+    def test_task8_comment_helper_supports_create_noop_patch_and_transcripts(self):
+        module = load_module()
+        plan = (ROOT / "docs/superpowers/plans/2026-07-16-wayfinder-github-migration.md").read_text(
+            encoding="utf-8"
+        )
+        task8 = plan.split("### Task 8:", 1)[1]
+        step6 = task8.split("**Step 6:", 1)[1]
+        block = re.search(r"```powershell\n(?P<body>.*?)\n```", step6, re.DOTALL)
+        self.assertIsNotNone(block)
+        prelude = block.group("body").split("$frontierText", 1)[0]
+
+        core_sha = "a" * 64
+        desired = (
+            module.COMMENT_PREFIXES[147]
+            + "\n\nDurable frontier audit: "
+            + module.CORE_ARTIFACT_PATH
+            + f" (SHA-256: `{core_sha}`)."
+        )
+
+        def ps_literal(value):
+            return "'" + value.replace("'", "''") + "'"
+
+        harness = "$ErrorActionPreference = 'Stop'\nSet-StrictMode -Version Latest\n" + prelude + rf'''
+function Reset-Comments([string]$Body) {{
+  if ($null -eq $Body) {{ $script:comments = @() }} else {{
+    $script:comments = @([pscustomobject]@{{ id = 4994927680L; body = $Body; html_url = 'https://example.invalid/comment' }})
+  }}
+}}
+function Get-IssueComments([int]$Issue) {{ return @($script:comments) }}
+function New-IssueComment([int]$Issue,[string]$Body) {{
+  $script:comments = @([pscustomobject]@{{ id = 4994927680L; body = $Body; html_url = 'https://example.invalid/comment' }})
+}}
+function Update-IssueComment([long]$PublicCommentId,[string]$Body) {{
+  $script:comments = @([pscustomobject]@{{ id = $PublicCommentId; body = $Body; html_url = 'https://example.invalid/comment' }})
+}}
+$desired = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('{base64.b64encode(desired.encode('utf-8')).decode('ascii')}'))
+$historical = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('{base64.b64encode(module.ORIGINAL_CHECKPOINT_BODY.encode('utf-8')).decode('ascii')}'))
+$artifactPath = {ps_literal(module.CORE_ARTIFACT_PATH)}
+$artifactSha = '{core_sha}'
+$old = {ps_literal(module.COMMENT_PREFIXES[147] + chr(10) + chr(10) + 'old checkpoint body')}
+$oldHash = Get-NormalizedBodySha256 $old
+$cases = @()
+
+Reset-Comments $null
+$guard = Set-OrCreateExactIssueComment 147 {ps_literal(module.COMMENT_PREFIXES[147])} $desired 4994927680L $oldHash
+$cases += [ordered]@{{ guard = $guard; transcript = New-CheckpointTranscript $guard $historical $desired $artifactPath $artifactSha }}
+
+Reset-Comments $desired
+$guard = Set-OrCreateExactIssueComment 147 {ps_literal(module.COMMENT_PREFIXES[147])} $desired 4994927680L $oldHash
+$cases += [ordered]@{{ guard = $guard; transcript = New-CheckpointTranscript $guard $historical $desired $artifactPath $artifactSha }}
+
+Reset-Comments $old
+$guard = Set-OrCreateExactIssueComment 147 {ps_literal(module.COMMENT_PREFIXES[147])} $desired 4994927680L $oldHash
+$cases += [ordered]@{{ guard = $guard; transcript = New-CheckpointTranscript $guard $historical $desired $artifactPath $artifactSha }}
+
+$cases | ConvertTo-Json -Depth 10 -Compress
+'''
+        completed = subprocess.run(
+            ["pwsh", "-NoProfile", "-NonInteractive", "-Command", "-"],
+            input=harness,
+            text=True,
+            encoding="utf-8",
+            capture_output=True,
+            cwd=ROOT,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertTrue(completed.stdout.strip(), completed.stderr or "PowerShell harness produced no JSON")
+        cases = json.loads(completed.stdout)
+        self.assertEqual(
+            [case["guard"]["operation_decision"] for case in cases],
+            ["create", "exact-no-op", "patch"],
+        )
+        expected_keys = set(cases[0]["guard"])
+        self.assertTrue(all(set(case["guard"]) == expected_keys for case in cases))
+        self.assertIsNone(cases[0]["guard"]["prior_public_comment_id"])
+        self.assertIsNone(cases[0]["guard"]["prior_normalized_body_sha256"])
+        self.assertTrue(all(case["guard"]["post_prefix_multiplicity"] == 1 for case in cases))
+        self.assertTrue(all(case["guard"]["post_exact_body_multiplicity"] == 1 for case in cases))
+        for case in cases:
+            with self.subTest(operation=case["guard"]["operation_decision"]):
+                if case["guard"]["operation_decision"] != "create":
+                    self.assertEqual(
+                        module.normalize_body(case["transcript"]["historical_original"]["normalized_body"]),
+                        module.normalize_body(module.ORIGINAL_CHECKPOINT_BODY),
+                    )
+                module.validate_transcript(case["transcript"], core_sha)
+
+    def test_initial_checkpoint_transcript_finalizes_without_prior_state(self):
+        module = load_module()
+        core = json.loads(
+            (ROOT / module.CORE_ARTIFACT_PATH).read_text(encoding="utf-8")
+        )
+        core["global_github_audit"]["comments"]["147"] = None
+        core_sha = module.serialized_json_sha256(core)
+        desired_body = (
+            module.COMMENT_PREFIXES[147]
+            + "\n\nDurable frontier audit: "
+            + module.CORE_ARTIFACT_PATH
+            + f" (SHA-256: `{core_sha}`)."
+        )
+        desired_hash = module.sha256_text(desired_body)
+        transcript = {
+            "schema_version": 1,
+            "captured_at": "2026-07-17T00:00:00Z",
+            "issue": 147,
+            "purpose_prefix": module.COMMENT_PREFIXES[147],
+            "historical_original": {
+                "source": "Task 8 initial publication desired body",
+                "normalized_body": desired_body,
+                "normalized_body_sha256": desired_hash,
+            },
+            "pre_update": {
+                "public_comment_id": None,
+                "normalized_body_sha256": None,
+                "readback_at": None,
+            },
+            "desired": {
+                "normalized_body": desired_body,
+                "normalized_body_sha256": desired_hash,
+                "frontier_artifact_path": module.CORE_ARTIFACT_PATH,
+                "frontier_artifact_sha256": core_sha,
+            },
+            "operation_decision": "create",
+            "post_readback": {
+                "public_comment_id": 1,
+                "normalized_body_sha256": desired_hash,
+                "prefix_multiplicity": 1,
+                "exact_body_multiplicity": 1,
+                "readback_at": "2026-07-17T00:00:01Z",
+            },
+        }
+        final = module.build_final(core, module.CORE_ARTIFACT_PATH, transcript)
+        self.assertEqual(final["derivation"]["checkpoint_exact_body_guard"], "create")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- redesign Wayfinder around reliability-gated 0.1.6–0.1.10 milestones
- persist the retry-safe GitHub migration plan and content-addressed audit evidence
- add the read-only final-audit generator and deterministic regression tests

## Why

Codex control-plane, official GPT, and third-party model reliability must gate external-client reliability and new features. The plan now separates Host/runtime Worker obligations from CodexHub adapter obligations and preserves a verifiable, retry-safe migration record.

## Validation

- 7 targeted generator/audit tests
- 41 fenced PowerShell blocks parsed with zero AST errors
- content-addressed frontier/checkpoint/final artifacts validated
- fresh live GitHub audit: 63 open Issues, frontier `[159,161,139,149,150,111]`
- 12 native Task ownership queries: zero matches, zero unavailable hosts
- independent final review: no Critical, Important, or Minor findings
- `git diff --check origin/dev..HEAD`
