### PR TITLE
fix(gateway): bound repeated empty tool search

### DIFF
--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -632,6 +632,9 @@ TOOL_SEARCH_EXPLICIT_FUNCTION_TOOL = {
         "additionalProperties": False,
     },
 }
+TOOL_SEARCH_EMPTY_MISS_BOUND = 2
+TOOL_SEARCH_UNAVAILABLE_QUERY_CLASSIFICATION = "identical_exact_query"
+TOOL_SEARCH_UNAVAILABLE_STATUS = "unavailable"
 BROWSER_CONTEXT_MARKERS = (
     "# in app browser",
     "# browser comments",
@@ -5004,6 +5007,75 @@ def _normalize_tool_search_arguments(value: Any) -> dict[str, Any] | None:
     return _semantic_normalize_tool_search_arguments(value)
 
 
+def _bounded_empty_tool_search_terminal_calls(value: Any) -> dict[str, int]:
+    if not isinstance(value, list):
+        return {}
+
+    queries_by_call_id: dict[str, str] = {}
+    empty_call_ids_by_query: dict[str, list[str]] = {}
+    successful_queries: set[str] = set()
+    for item in value:
+        if not isinstance(item, Mapping):
+            continue
+        call_id = item.get("call_id")
+        if not isinstance(call_id, str) or not call_id:
+            continue
+        if item.get("type") == "tool_search_call":
+            arguments = _normalize_tool_search_arguments(item.get("arguments"))
+            if arguments is None or _is_multi_agent_discovery_arguments(arguments):
+                continue
+            queries_by_call_id[call_id] = arguments["query"]
+            continue
+        if item.get("type") != "tool_search_output":
+            continue
+        query = queries_by_call_id.pop(call_id, None)
+        tools = item.get("tools")
+        if query is None or not isinstance(tools, list):
+            continue
+        if tools:
+            successful_queries.add(query)
+            continue
+        empty_call_ids_by_query.setdefault(query, []).append(call_id)
+
+    terminal_calls: dict[str, int] = {}
+    for query, call_ids in empty_call_ids_by_query.items():
+        if query in successful_queries or len(call_ids) < TOOL_SEARCH_EMPTY_MISS_BOUND:
+            continue
+        terminal_calls[call_ids[TOOL_SEARCH_EMPTY_MISS_BOUND - 1]] = TOOL_SEARCH_EMPTY_MISS_BOUND
+    return terminal_calls
+
+
+def _terminalize_bounded_empty_tool_search_misses(
+    payload: dict[str, Any],
+    terminal_calls: Mapping[str, int],
+) -> bool:
+    input_items = payload.get("input")
+    if not isinstance(input_items, list) or not terminal_calls:
+        return False
+
+    rewritten_items: list[Any] = []
+    changed = False
+    for item in input_items:
+        if (
+            isinstance(item, Mapping)
+            and item.get("type") == "tool_search_output"
+            and isinstance(item.get("call_id"), str)
+            and item["call_id"] in terminal_calls
+        ):
+            rewritten = dict(item)
+            rewritten["status"] = TOOL_SEARCH_UNAVAILABLE_STATUS
+            rewritten["query_classification"] = TOOL_SEARCH_UNAVAILABLE_QUERY_CLASSIFICATION
+            rewritten["empty_miss_count"] = terminal_calls[item["call_id"]]
+            rewritten["terminal"] = True
+            rewritten_items.append(rewritten)
+            changed = True
+            continue
+        rewritten_items.append(item)
+    if changed:
+        payload["input"] = rewritten_items
+    return changed
+
+
 def _is_multi_agent_discovery_arguments(arguments: Mapping[str, Any] | None) -> bool:
     if not arguments:
         return False
@@ -5857,6 +5929,13 @@ def _compatible_tool_message(item: Mapping[str, Any]) -> dict[str, str] | None:
             )
             lines.append(
                 "next_action: call multi_agent_v1__spawn_agent to create the child agent; do not call tool_search again for the same multi-agent query."
+            )
+        if item.get("query_classification") == TOOL_SEARCH_UNAVAILABLE_QUERY_CLASSIFICATION:
+            lines.append(f"query_classification: {TOOL_SEARCH_UNAVAILABLE_QUERY_CLASSIFICATION}")
+            lines.append(f"empty_miss_count: {TOOL_SEARCH_EMPTY_MISS_BOUND}")
+            lines.append("terminal: true")
+            lines.append(
+                "required_next_action: continue without the unavailable tool; do not call tool_search again for this exact query."
             )
         _append_internal_field(lines, "tools", item.get("tools"))
     else:
@@ -7485,6 +7564,20 @@ def compatible_request_body(
     semantic_repair_enabled = subagent_semantic_repair_enabled(event_context)
     if isinstance(event_context, dict):
         event_context["tool_protocol"] = tool_protocol
+    bounded_tool_search_terminal_calls = (
+        {}
+        if raw_provider_probe
+        else _bounded_empty_tool_search_terminal_calls(payload.get("input"))
+    )
+    if _terminalize_bounded_empty_tool_search_misses(payload, bounded_tool_search_terminal_calls):
+        for count in bounded_tool_search_terminal_calls.values():
+            write_proxy_event(
+                "tool_search_empty_miss_bound",
+                query_classification=TOOL_SEARCH_UNAVAILABLE_QUERY_CLASSIFICATION,
+                count=count,
+                status=TOOL_SEARCH_UNAVAILABLE_STATUS,
+            )
+        changed = True
     if raw_provider_probe:
         pass
     else:
@@ -7519,7 +7612,9 @@ def compatible_request_body(
     # broader discovery service; eager remains the #105-compatible surface.
     # Worker subagents retain their established restricted surface.
     include_tool_search = (
-        tool_surface_strategy == "deferred_core" and not subagent_worker_context
+        tool_surface_strategy == "deferred_core"
+        and not subagent_worker_context
+        and not bounded_tool_search_terminal_calls
     )
     subagent_state = (
         build_subagent_state(input_items)

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -1506,8 +1506,9 @@ def _diagnostic_transport_phase(failure_phase: str | None) -> str | None:
 
 
 def write_proxy_event(event: str, **fields: Any) -> None:
-    _observe_gateway_diagnostic("observe_proxy_event", event, fields)
-    payload = proxy_telemetry.prepare_event_payload(event, fields, RUNTIME_CODEX_DIR)
+    public_fields = _public_event_context(fields)
+    _observe_gateway_diagnostic("observe_proxy_event", event, public_fields)
+    payload = proxy_telemetry.prepare_event_payload(event, public_fields, RUNTIME_CODEX_DIR)
     _enqueue_gateway_event_payload(payload)
 
 
@@ -1616,6 +1617,14 @@ def _capture_usage(
     usage_capture.update(_normalize_usage_for_event(usage, missing_reason=missing_reason))
 
 
+def _public_event_context(context: Mapping[str, Any] | None) -> dict[str, Any]:
+    return {
+        key: value
+        for key, value in (context or {}).items()
+        if not str(key).startswith("_")
+    }
+
+
 def _usage_observed_context(
     event_context: Mapping[str, Any] | None,
     *,
@@ -1625,11 +1634,7 @@ def _usage_observed_context(
     upstream_format: str,
     inbound_format: str,
 ) -> dict[str, Any]:
-    context = {
-        key: value
-        for key, value in (event_context or {}).items()
-        if not str(key).startswith("_")
-    }
+    context = _public_event_context(event_context)
     context.update(
         {
             "request_id": request_id,
@@ -1708,7 +1713,7 @@ def _offer_official_passthrough_usage_line(context: Mapping[str, Any], line: byt
         return
     _start_official_passthrough_usage_worker()
     try:
-        OFFICIAL_PASSTHROUGH_USAGE_QUEUE.put_nowait((dict(context), line))
+        OFFICIAL_PASSTHROUGH_USAGE_QUEUE.put_nowait((_public_event_context(context), line))
     except queue.Full:
         return
 
@@ -1754,7 +1759,7 @@ def _offer_usage_observed_body(context: Mapping[str, Any], body: bytes) -> None:
         return
     _start_usage_observed_worker()
     try:
-        USAGE_OBSERVED_QUEUE.put_nowait(("body", dict(context), body, None))
+        USAGE_OBSERVED_QUEUE.put_nowait(("body", _public_event_context(context), body, None))
     except queue.Full:
         return
 
@@ -1769,7 +1774,7 @@ def _offer_usage_observed_sse_line(
         return
     _start_usage_observed_worker()
     try:
-        USAGE_OBSERVED_QUEUE.put_nowait(("sse", dict(context), line, upstream_format))
+        USAGE_OBSERVED_QUEUE.put_nowait(("sse", _public_event_context(context), line, upstream_format))
     except queue.Full:
         return
 
@@ -1804,13 +1809,13 @@ def _usage_observed_worker() -> None:
 def _write_adapter_event(event_context: Mapping[str, Any] | None, event: str, **fields: Any) -> None:
     if event_context is None:
         return
-    payload = {key: value for key, value in event_context.items() if not str(key).startswith("_")}
+    payload = _public_event_context(event_context)
     payload.update(fields)
     write_proxy_event(event, **payload)
 
 
 def _event_context_with_request_kind(context: Mapping[str, Any], request_kind: str) -> dict[str, Any]:
-    payload = dict(context)
+    payload = _public_event_context(context)
     existing = payload.get("request_kind")
     if isinstance(existing, str) and existing and existing != request_kind:
         payload.setdefault("client_request_kind", existing)
@@ -13524,7 +13529,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                             write_transparent_line(pending_line)
                     except OSError as exc:
                         self.close_connection = True
-                        event_fields = dict(event_context or {})
+                        event_fields = _public_event_context(event_context)
                         for key in (
                             "request_id",
                             "model",
@@ -13556,7 +13561,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                     write_transparent_line(line)
                 except OSError as exc:
                     self.close_connection = True
-                    event_fields = dict(event_context or {})
+                    event_fields = _public_event_context(event_context)
                     for key in (
                         "request_id",
                         "model",
@@ -13866,7 +13871,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                     ensure_ascii=True,
                     separators=(",", ":"),
                 ).encode("utf-8")
-                event_fields = dict(event_context or {})
+                event_fields = _public_event_context(event_context)
                 event_fields.pop("request_id", None)
                 event_fields.pop("model", None)
                 event_fields.pop("upstream", None)
@@ -13889,7 +13894,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                     else _responses_body_is_empty(body)
                 )
                 if status < 400 and request_kind != RETRY_REQUEST_COMPACT and empty_non_compact:
-                    event_fields = dict(event_context) if event_context else {}
+                    event_fields = _public_event_context(event_context)
                     event_fields.pop("request_id", None)
                     event_fields.pop("model", None)
                     event_fields.pop("upstream", None)
@@ -13979,7 +13984,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
         if is_event_stream:
             def finish_downstream_stream_closed(exc: OSError) -> int:
                 self.close_connection = True
-                event_fields = dict(event_context or {})
+                event_fields = _public_event_context(event_context)
                 for key in ("request_id", "model", "upstream", "status", "error", "detail"):
                     event_fields.pop(key, None)
                 write_proxy_event(

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -5116,6 +5116,163 @@ def _restrict_bounded_tool_search_queries(payload: dict[str, Any], bounded_queri
     return changed
 
 
+def _tool_search_query_digest(query: str) -> bytes:
+    return hashlib.sha256(query.encode("utf-8")).digest()
+
+
+def _bounded_tool_search_query_digests(event_context: Mapping[str, Any] | None) -> set[bytes]:
+    value = (event_context or {}).get("_bounded_tool_search_query_digests")
+    if not isinstance(value, (set, frozenset)):
+        return set()
+    return {digest for digest in value if isinstance(digest, bytes)}
+
+
+def _tool_search_call_arguments(value: Mapping[str, Any]) -> dict[str, Any] | None:
+    if value.get("type") == "tool_search_call":
+        return _normalize_tool_search_arguments(value.get("arguments"))
+    if value.get("type") == "function_call" and value.get("name") == "tool_search":
+        return _normalize_tool_search_arguments(value.get("arguments"))
+    return None
+
+
+def _bounded_tool_search_unavailable_message(item: Mapping[str, Any]) -> dict[str, Any]:
+    message: dict[str, Any] = {
+        "type": "message",
+        "role": "assistant",
+        "status": "completed",
+        "content": [
+            {
+                "type": "output_text",
+                "text": (
+                    "tool_search_unavailable\n"
+                    f"query_classification: {TOOL_SEARCH_UNAVAILABLE_QUERY_CLASSIFICATION}\n"
+                    f"empty_miss_count: {TOOL_SEARCH_EMPTY_MISS_BOUND}\n"
+                    f"status: {TOOL_SEARCH_UNAVAILABLE_STATUS}\n"
+                    "terminal: true\n"
+                    "execution: suppressed"
+                ),
+            }
+        ],
+    }
+    item_id = item.get("id")
+    if isinstance(item_id, str) and item_id:
+        message["id"] = item_id
+    return message
+
+
+def _suppress_bounded_tool_search_calls(
+    value: Any,
+    event_context: Mapping[str, Any] | None,
+) -> tuple[Any, bool]:
+    bounded_digests = _bounded_tool_search_query_digests(event_context)
+    if not bounded_digests:
+        return value, False
+
+    if isinstance(event_context, dict):
+        candidates_value = event_context.setdefault("_tool_search_stream_candidate_item_ids", set())
+        candidate_item_ids = candidates_value if isinstance(candidates_value, set) else set()
+        event_context["_tool_search_stream_candidate_item_ids"] = candidate_item_ids
+        suppressed_value = event_context.setdefault("_bounded_tool_search_suppressed_item_ids", set())
+        suppressed_item_ids = suppressed_value if isinstance(suppressed_value, set) else set()
+        event_context["_bounded_tool_search_suppressed_item_ids"] = suppressed_item_ids
+    else:
+        candidate_item_ids = set()
+        suppressed_item_ids = set()
+
+    return _suppress_bounded_tool_search_calls_inner(
+        value,
+        bounded_digests,
+        candidate_item_ids,
+        suppressed_item_ids,
+    )
+
+
+def _suppress_bounded_tool_search_calls_inner(
+    value: Any,
+    bounded_digests: set[bytes],
+    candidate_item_ids: set[str],
+    suppressed_item_ids: set[str],
+) -> tuple[Any, bool]:
+    if isinstance(value, list):
+        changed = False
+        rewritten_items: list[Any] = []
+        for item in value:
+            replacement, item_changed = _suppress_bounded_tool_search_calls_inner(
+                item,
+                bounded_digests,
+                candidate_item_ids,
+                suppressed_item_ids,
+            )
+            if replacement is None:
+                changed = True
+                continue
+            rewritten_items.append(replacement)
+            changed = changed or item_changed
+        return (rewritten_items if changed else value), changed
+
+    if not isinstance(value, dict):
+        return value, False
+
+    event_type = value.get("type")
+    if event_type == "response.output_item.added":
+        item = value.get("item")
+        if isinstance(item, Mapping):
+            item_id = item.get("id")
+            if (
+                isinstance(item_id, str)
+                and item_id
+                and (
+                    item.get("type") == "tool_search_call"
+                    or (item.get("type") == "function_call" and item.get("name") == "tool_search")
+                )
+            ):
+                candidate_item_ids.add(item_id)
+    elif event_type in {"response.function_call_arguments.delta", "response.function_call_arguments.done"}:
+        item_id = value.get("item_id")
+        if isinstance(item_id, str) and item_id in suppressed_item_ids:
+            return None, True
+        if (
+            event_type == "response.function_call_arguments.done"
+            and isinstance(item_id, str)
+            and item_id in candidate_item_ids
+        ):
+            arguments = _normalize_tool_search_arguments(value.get("arguments"))
+            if (
+                arguments is not None
+                and _tool_search_query_digest(arguments["query"]) in bounded_digests
+            ):
+                suppressed_item_ids.add(item_id)
+                return None, True
+
+    arguments = _tool_search_call_arguments(value)
+    if (
+        arguments is not None
+        and _tool_search_query_digest(arguments["query"]) in bounded_digests
+    ):
+        item_id = value.get("id")
+        if isinstance(item_id, str) and item_id:
+            suppressed_item_ids.add(item_id)
+        return _bounded_tool_search_unavailable_message(value), True
+
+    changed = False
+    rewritten = dict(value)
+    for key, item in value.items():
+        replacement, item_changed = _suppress_bounded_tool_search_calls_inner(
+            item,
+            bounded_digests,
+            candidate_item_ids,
+            suppressed_item_ids,
+        )
+        if replacement is None:
+            rewritten.pop(key, None)
+            changed = True
+            continue
+        if item_changed:
+            rewritten[key] = replacement
+            changed = True
+    return (rewritten if changed else value), changed
+
+
 def _is_multi_agent_discovery_arguments(arguments: Mapping[str, Any] | None) -> bool:
     if not arguments:
         return False
@@ -7612,6 +7769,13 @@ def compatible_request_body(
     bounded_tool_search_queries = {
         query for query, _count in bounded_tool_search_terminal_calls.values()
     }
+    if isinstance(event_context, dict):
+        if bounded_tool_search_queries:
+            event_context["_bounded_tool_search_query_digests"] = frozenset(
+                _tool_search_query_digest(query) for query in bounded_tool_search_queries
+            )
+        else:
+            event_context.pop("_bounded_tool_search_query_digests", None)
     if _terminalize_bounded_empty_tool_search_misses(payload, bounded_tool_search_terminal_calls):
         for _query, count in bounded_tool_search_terminal_calls.values():
             write_proxy_event(
@@ -8812,6 +8976,8 @@ def compatible_response_body(
             surface="body",
         )
     changed = changed or alias_changed
+    payload, bounded_tool_search_changed = _suppress_bounded_tool_search_calls(payload, event_context)
+    changed = changed or bounded_tool_search_changed
     payload, post_final_multi_agent_changed = _suppress_multi_agent_calls_after_lifecycle_final(
         payload,
         event_context,
@@ -8867,6 +9033,10 @@ def compatible_sse_line(
             surface="sse",
         )
     changed = changed or alias_changed
+    payload, bounded_tool_search_changed = _suppress_bounded_tool_search_calls(payload, event_context)
+    if payload is None:
+        return b""
+    changed = changed or bounded_tool_search_changed
     payload, post_final_multi_agent_changed = _suppress_multi_agent_calls_after_lifecycle_final(
         payload,
         event_context,
@@ -13750,6 +13920,12 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                     for event in response_events:
                         if behavior_profile != BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED:
                             event, _ = _normalize_third_party_tool_call(event)
+                            event, _ = _suppress_bounded_tool_search_calls(
+                                event,
+                                compatibility_event_context,
+                            )
+                            if event is None:
+                                continue
                             event, _ = _downgrade_invalid_third_party_tool_calls(event)
                             event, _ = _guard_duplicate_multi_agent_spawn_calls(event, event_context)
                         event_type = event.get("type")
@@ -14373,6 +14549,10 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         event_context=compatibility_event_context,
                     )
                     events, _ = _normalize_third_party_tool_call(events)
+                    events, _ = _suppress_bounded_tool_search_calls(
+                        events,
+                        compatibility_event_context,
+                    )
                     _write_adapter_event(
                         event_context,
                         "chat_to_responses_event_summary",

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -5007,7 +5007,7 @@ def _normalize_tool_search_arguments(value: Any) -> dict[str, Any] | None:
     return _semantic_normalize_tool_search_arguments(value)
 
 
-def _bounded_empty_tool_search_terminal_calls(value: Any) -> dict[str, int]:
+def _bounded_empty_tool_search_terminal_calls(value: Any) -> dict[str, tuple[str, int]]:
     if not isinstance(value, list):
         return {}
 
@@ -5037,17 +5037,20 @@ def _bounded_empty_tool_search_terminal_calls(value: Any) -> dict[str, int]:
             continue
         empty_call_ids_by_query.setdefault(query, []).append(call_id)
 
-    terminal_calls: dict[str, int] = {}
+    terminal_calls: dict[str, tuple[str, int]] = {}
     for query, call_ids in empty_call_ids_by_query.items():
         if query in successful_queries or len(call_ids) < TOOL_SEARCH_EMPTY_MISS_BOUND:
             continue
-        terminal_calls[call_ids[TOOL_SEARCH_EMPTY_MISS_BOUND - 1]] = TOOL_SEARCH_EMPTY_MISS_BOUND
+        terminal_calls[call_ids[TOOL_SEARCH_EMPTY_MISS_BOUND - 1]] = (
+            query,
+            TOOL_SEARCH_EMPTY_MISS_BOUND,
+        )
     return terminal_calls
 
 
 def _terminalize_bounded_empty_tool_search_misses(
     payload: dict[str, Any],
-    terminal_calls: Mapping[str, int],
+    terminal_calls: Mapping[str, tuple[str, int]],
 ) -> bool:
     input_items = payload.get("input")
     if not isinstance(input_items, list) or not terminal_calls:
@@ -5065,7 +5068,8 @@ def _terminalize_bounded_empty_tool_search_misses(
             rewritten = dict(item)
             rewritten["status"] = TOOL_SEARCH_UNAVAILABLE_STATUS
             rewritten["query_classification"] = TOOL_SEARCH_UNAVAILABLE_QUERY_CLASSIFICATION
-            rewritten["empty_miss_count"] = terminal_calls[item["call_id"]]
+            _, count = terminal_calls[item["call_id"]]
+            rewritten["empty_miss_count"] = count
             rewritten["terminal"] = True
             rewritten_items.append(rewritten)
             changed = True
@@ -5073,6 +5077,42 @@ def _terminalize_bounded_empty_tool_search_misses(
         rewritten_items.append(item)
     if changed:
         payload["input"] = rewritten_items
+    return changed
+
+
+def _restrict_bounded_tool_search_queries(payload: dict[str, Any], bounded_queries: set[str]) -> bool:
+    tools = payload.get("tools")
+    if not isinstance(tools, list) or not bounded_queries:
+        return False
+
+    restriction = {"enum": sorted(bounded_queries)}
+    changed = False
+    rewritten_tools: list[Any] = []
+    for tool in tools:
+        if not (
+            isinstance(tool, Mapping)
+            and tool.get("type") == "function"
+            and tool.get("name") == TOOL_SEARCH_EXPLICIT_FUNCTION_TOOL["name"]
+        ):
+            rewritten_tools.append(tool)
+            continue
+        rewritten_tool = dict(tool)
+        parameters = dict(_tool_parameters_schema(tool))
+        properties_value = parameters.get("properties")
+        properties = dict(properties_value) if isinstance(properties_value, Mapping) else {}
+        query_value = properties.get("query")
+        query_schema = dict(query_value) if isinstance(query_value, Mapping) else {"type": "string"}
+        if "not" in query_schema:
+            query_schema = {"allOf": [query_schema, {"not": restriction}]}
+        else:
+            query_schema["not"] = restriction
+        properties["query"] = query_schema
+        parameters["properties"] = properties
+        rewritten_tool["parameters"] = parameters
+        rewritten_tools.append(rewritten_tool)
+        changed = True
+    if changed:
+        payload["tools"] = rewritten_tools
     return changed
 
 
@@ -7569,8 +7609,11 @@ def compatible_request_body(
         if raw_provider_probe
         else _bounded_empty_tool_search_terminal_calls(payload.get("input"))
     )
+    bounded_tool_search_queries = {
+        query for query, _count in bounded_tool_search_terminal_calls.values()
+    }
     if _terminalize_bounded_empty_tool_search_misses(payload, bounded_tool_search_terminal_calls):
-        for count in bounded_tool_search_terminal_calls.values():
+        for _query, count in bounded_tool_search_terminal_calls.values():
             write_proxy_event(
                 "tool_search_empty_miss_bound",
                 query_classification=TOOL_SEARCH_UNAVAILABLE_QUERY_CLASSIFICATION,
@@ -7614,7 +7657,6 @@ def compatible_request_body(
     include_tool_search = (
         tool_surface_strategy == "deferred_core"
         and not subagent_worker_context
-        and not bounded_tool_search_terminal_calls
     )
     subagent_state = (
         build_subagent_state(input_items)
@@ -7958,6 +8000,8 @@ def compatible_request_body(
                 wait_agent_ids=wait_agent_ids,
                 close_agent_ids=close_agent_ids,
             )
+            if _restrict_bounded_tool_search_queries(payload, bounded_tool_search_queries):
+                changed = True
             write_proxy_event(
                 "external_tool_surface_prepared",
                 tool_surface_strategy=tool_surface_strategy,

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -12366,6 +12366,171 @@ Execution constraints:
         self.assertNotIn(distinct_query, query_schema["not"]["enum"])
         self.assertEqual(json.dumps(payload).count("query_classification: identical_exact_query"), 1)
 
+    def test_deferred_tool_search_response_body_suppresses_third_bounded_query_and_keeps_distinct_callable(self):
+        bounded_query = "mcp__synthetic__body_bounded"
+        distinct_query = "mcp__synthetic__body_distinct"
+        event_context = {}
+        history = [
+            {
+                "type": "tool_search_call",
+                "call_id": "call_body_first",
+                "arguments": {"query": bounded_query},
+            },
+            {"type": "tool_search_output", "call_id": "call_body_first", "tools": []},
+            {
+                "type": "tool_search_call",
+                "call_id": "call_body_second",
+                "arguments": {"query": bounded_query},
+            },
+            {"type": "tool_search_output", "call_id": "call_body_second", "tools": []},
+        ]
+        compatible_request_body(
+            json.dumps(
+                {
+                    "model": "glm-5.2",
+                    "input": history,
+                    "tools": [dict(codex_proxy.TOOL_SEARCH_EXPLICIT_FUNCTION_TOOL)],
+                }
+            ).encode("utf-8"),
+            {
+                "name": "ollama_cloud",
+                "tool_protocol": "responses_structured",
+                "tool_surface_strategy": "deferred_core",
+            },
+            event_context=event_context,
+        )
+        response = {
+            "id": "resp_tool_search_bound",
+            "object": "response",
+            "status": "completed",
+            "output": [
+                {
+                    "id": "fc_body_bounded",
+                    "type": "function_call",
+                    "status": "completed",
+                    "call_id": "call_body_third",
+                    "name": "tool_search",
+                    "arguments": json.dumps({"query": bounded_query}),
+                },
+                {
+                    "id": "fc_body_distinct",
+                    "type": "function_call",
+                    "status": "completed",
+                    "call_id": "call_body_distinct",
+                    "name": "tool_search",
+                    "arguments": json.dumps({"query": distinct_query}),
+                },
+            ],
+        }
+
+        transformed = compatible_response_body(
+            json.dumps(response).encode("utf-8"),
+            "ollama_cloud",
+            event_context=event_context,
+        )
+        output = json.loads(transformed)["output"]
+        terminal_text = output[0]["content"][0]["text"]
+
+        self.assertEqual(output[0]["type"], "message")
+        self.assertEqual(output[0]["role"], "assistant")
+        self.assertIn("tool_search_unavailable", terminal_text)
+        self.assertIn("query_classification: identical_exact_query", terminal_text)
+        self.assertIn("status: unavailable", terminal_text)
+        self.assertIn("terminal: true", terminal_text)
+        self.assertNotIn(bounded_query, terminal_text)
+        self.assertNotIn("tool_search_call", json.dumps(output[0]))
+        self.assertEqual(output[1]["type"], "tool_search_call")
+        self.assertEqual(output[1]["call_id"], "call_body_distinct")
+        self.assertEqual(output[1]["arguments"], {"query": distinct_query})
+        self.assertEqual(output[1]["execution"], "client")
+        self.assertEqual(output[1]["status"], "completed")
+        self.assertNotIn(bounded_query, repr(event_context))
+        self.assertNotIn(distinct_query, repr(event_context))
+        telemetry_text = repr(self.write_proxy_event.call_args_list)
+        self.assertNotIn(bounded_query, telemetry_text)
+        self.assertNotIn(distinct_query, telemetry_text)
+        self.assertNotIn("_bounded_tool_search_query_digests", telemetry_text)
+
+    def test_deferred_tool_search_sse_suppresses_third_bounded_query_and_keeps_distinct_callable(self):
+        bounded_query = "mcp__synthetic__sse_bounded"
+        distinct_query = "mcp__synthetic__sse_distinct"
+        event_context = {}
+        history = [
+            {
+                "type": "tool_search_call",
+                "call_id": "call_sse_first",
+                "arguments": {"query": bounded_query},
+            },
+            {"type": "tool_search_output", "call_id": "call_sse_first", "tools": []},
+            {
+                "type": "tool_search_call",
+                "call_id": "call_sse_second",
+                "arguments": {"query": bounded_query},
+            },
+            {"type": "tool_search_output", "call_id": "call_sse_second", "tools": []},
+        ]
+        compatible_request_body(
+            json.dumps(
+                {
+                    "model": "glm-5.2",
+                    "input": history,
+                    "tools": [dict(codex_proxy.TOOL_SEARCH_EXPLICIT_FUNCTION_TOOL)],
+                }
+            ).encode("utf-8"),
+            {
+                "name": "ollama_cloud",
+                "tool_protocol": "responses_structured",
+                "tool_surface_strategy": "deferred_core",
+            },
+            event_context=event_context,
+        )
+
+        def done_line(item_id, call_id, query):
+            return b"data: " + json.dumps(
+                {
+                    "type": "response.output_item.done",
+                    "output_index": 0,
+                    "item": {
+                        "id": item_id,
+                        "type": "function_call",
+                        "status": "completed",
+                        "call_id": call_id,
+                        "name": "tool_search",
+                        "arguments": json.dumps({"query": query}),
+                    },
+                }
+            ).encode("utf-8") + b"\n\n"
+
+        bounded_line = compatible_sse_line(
+            done_line("fc_sse_bounded", "call_sse_third", bounded_query),
+            "ollama_cloud",
+            event_context=event_context,
+        )
+        distinct_line = compatible_sse_line(
+            done_line("fc_sse_distinct", "call_sse_distinct", distinct_query),
+            "ollama_cloud",
+            event_context=event_context,
+        )
+        bounded_item = json.loads(bounded_line.removeprefix(b"data: "))["item"]
+        distinct_item = json.loads(distinct_line.removeprefix(b"data: "))["item"]
+        terminal_text = bounded_item["content"][0]["text"]
+
+        self.assertEqual(bounded_item["type"], "message")
+        self.assertEqual(bounded_item["role"], "assistant")
+        self.assertIn("tool_search_unavailable", terminal_text)
+        self.assertIn("query_classification: identical_exact_query", terminal_text)
+        self.assertIn("status: unavailable", terminal_text)
+        self.assertIn("terminal: true", terminal_text)
+        self.assertNotIn(bounded_query, terminal_text)
+        self.assertNotIn("tool_search_call", json.dumps(bounded_item))
+        self.assertEqual(distinct_item["type"], "tool_search_call")
+        self.assertEqual(distinct_item["call_id"], "call_sse_distinct")
+        self.assertEqual(distinct_item["arguments"], {"query": distinct_query})
+        self.assertEqual(distinct_item["execution"], "client")
+        self.assertEqual(distinct_item["status"], "completed")
+        self.assertNotIn(bounded_query, repr(event_context))
+        self.assertNotIn(distinct_query, repr(event_context))
+
     def test_deferred_tool_search_preserves_exact_non_empty_result_and_follow_up_callable_contract(self):
         discovered_tool = {
             "type": "function",

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -12300,7 +12300,6 @@ Execution constraints:
             and "query_classification: identical_exact_query" in item["content"]
         ]
 
-        self.assertNotIn("tool_search", bounded_tool_names)
         self.assertIn("known_tool", bounded_tool_names)
         self.assertEqual(len(terminal_results), 1)
         self.assertIn("call_id: call_search_second", terminal_results[0])
@@ -12325,50 +12324,29 @@ Execution constraints:
             },
         )
 
-    def test_deferred_tool_search_preserves_distinct_empty_queries_and_non_empty_discovery(self):
+    def test_deferred_tool_search_bound_rejects_third_identical_query_and_allows_distinct_query(self):
+        bounded_query = "mcp__synthetic__bounded_missing"
+        distinct_query = "mcp__synthetic__distinct_missing"
         history = [
             {
                 "type": "tool_search_call",
-                "call_id": "call_distinct_first",
-                "arguments": {"query": "mcp__synthetic__first_missing"},
+                "call_id": "call_bounded_first",
+                "arguments": {"query": bounded_query},
             },
-            {"type": "tool_search_output", "call_id": "call_distinct_first", "tools": []},
+            {"type": "tool_search_output", "call_id": "call_bounded_first", "tools": []},
             {
                 "type": "tool_search_call",
-                "call_id": "call_distinct_second",
-                "arguments": {"query": "mcp__synthetic__second_missing"},
+                "call_id": "call_bounded_second",
+                "arguments": {"query": bounded_query},
             },
-            {"type": "tool_search_output", "call_id": "call_distinct_second", "tools": []},
-            {
-                "type": "tool_search_call",
-                "call_id": "call_found",
-                "arguments": {"query": "known_tool"},
-            },
-            {
-                "type": "tool_search_output",
-                "call_id": "call_found",
-                "tools": [
-                    {
-                        "type": "function",
-                        "name": "known_tool",
-                        "parameters": {"type": "object", "properties": {}},
-                    }
-                ],
-            },
+            {"type": "tool_search_output", "call_id": "call_bounded_second", "tools": []},
         ]
         transformed = compatible_request_body(
             json.dumps(
                 {
                     "model": "glm-5.2",
                     "input": history,
-                    "tools": [
-                        dict(codex_proxy.TOOL_SEARCH_EXPLICIT_FUNCTION_TOOL),
-                        {
-                            "type": "function",
-                            "name": "known_tool",
-                            "parameters": {"type": "object", "properties": {}},
-                        },
-                    ],
+                    "tools": [dict(codex_proxy.TOOL_SEARCH_EXPLICIT_FUNCTION_TOOL)],
                 }
             ).encode("utf-8"),
             {
@@ -12379,13 +12357,98 @@ Execution constraints:
             event_context={},
         )
         payload = json.loads(transformed)
-        tool_names = {tool.get("name") for tool in payload["tools"]}
-        transcript = json.dumps(payload, ensure_ascii=True)
+        search_tools = [tool for tool in payload["tools"] if tool.get("name") == "tool_search"]
 
-        self.assertIn("tool_search", tool_names)
-        self.assertIn("known_tool", tool_names)
-        self.assertIn('"name": "known_tool"', transcript)
-        self.assertNotIn("identical_exact_query", transcript)
+        self.assertEqual(len(search_tools), 1)
+        query_schema = search_tools[0]["parameters"]["properties"]["query"]
+        self.assertEqual(query_schema["not"], {"enum": [bounded_query]})
+        self.assertIn(bounded_query, query_schema["not"]["enum"])
+        self.assertNotIn(distinct_query, query_schema["not"]["enum"])
+        self.assertEqual(json.dumps(payload).count("query_classification: identical_exact_query"), 1)
+
+    def test_deferred_tool_search_preserves_exact_non_empty_result_and_follow_up_callable_contract(self):
+        discovered_tool = {
+            "type": "function",
+            "name": "synthetic_weather_lookup",
+            "description": "Return a synthetic weather label.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "city": {"type": "string"},
+                    "units": {"type": "string", "enum": ["metric", "imperial"]},
+                },
+                "required": ["city"],
+                "additionalProperties": False,
+            },
+        }
+        history = [
+            {
+                "type": "tool_search_call",
+                "call_id": "call_found",
+                "status": "completed",
+                "arguments": {"query": "synthetic_weather_lookup", "limit": 1},
+            },
+            {
+                "type": "tool_search_output",
+                "call_id": "call_found",
+                "status": "completed",
+                "execution": "client",
+                "tools": [discovered_tool],
+            },
+        ]
+        upstream = {
+            "name": "ollama_cloud",
+            "tool_protocol": "responses_structured",
+            "tool_surface_strategy": "deferred_core",
+        }
+
+        discovery_payload = json.loads(
+            compatible_request_body(
+                json.dumps(
+                    {
+                        "model": "glm-5.2",
+                        "input": history,
+                        "tools": [dict(codex_proxy.TOOL_SEARCH_EXPLICIT_FUNCTION_TOOL)],
+                    }
+                ).encode("utf-8"),
+                upstream,
+                event_context={},
+            )
+        )
+        discovery_names = {tool.get("name") for tool in discovery_payload["tools"]}
+        call_transcript = discovery_payload["input"][0]["content"]
+        result_transcript = discovery_payload["input"][1]["content"]
+        replayed_tools = json.loads(result_transcript.split("tools:\n", 1)[1])
+
+        self.assertNotIn(discovered_tool["name"], discovery_names)
+        self.assertIn("call_id: call_found", call_transcript)
+        self.assertIn('"limit":1', call_transcript)
+        self.assertIn("call_id: call_found", result_transcript)
+        self.assertIn("status: completed", result_transcript)
+        self.assertIn("execution:\nclient", result_transcript)
+        self.assertEqual(replayed_tools, [discovered_tool])
+
+        follow_up_payload = json.loads(
+            compatible_request_body(
+                json.dumps(
+                    {
+                        "model": "glm-5.2",
+                        "input": history,
+                        "tools": [dict(codex_proxy.TOOL_SEARCH_EXPLICIT_FUNCTION_TOOL), discovered_tool],
+                    }
+                ).encode("utf-8"),
+                upstream,
+                event_context={},
+            )
+        )
+        callable_tools = [
+            tool for tool in follow_up_payload["tools"] if tool.get("name") == discovered_tool["name"]
+        ]
+
+        self.assertEqual(callable_tools, [discovered_tool])
+        self.assertEqual(callable_tools[0]["parameters"], discovered_tool["parameters"])
+        self.assertEqual(follow_up_payload["input"][0]["content"], call_transcript)
+        self.assertEqual(follow_up_payload["input"][1]["content"], result_transcript)
         self.assertFalse(
             any(
                 call.args and call.args[0] == "tool_search_empty_miss_bound"

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -12206,6 +12206,193 @@ Execution constraints:
             {tool.get("name") for tool in deferred_tools},
         )
 
+    def test_deferred_tool_search_bounds_second_identical_empty_miss_with_sanitized_terminal_result(self):
+        query = "mcp__synthetic__missing_tool"
+        caller_tools = [
+            dict(codex_proxy.TOOL_SEARCH_EXPLICIT_FUNCTION_TOOL),
+            {
+                "type": "function",
+                "name": "known_tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        ]
+        first_miss = [
+            {
+                "type": "tool_search_call",
+                "call_id": "call_search_first",
+                "status": "completed",
+                "arguments": {"query": query},
+            },
+            {
+                "type": "tool_search_output",
+                "call_id": "call_search_first",
+                "status": "completed",
+                "tools": [],
+            },
+        ]
+        second_miss = [
+            {
+                "type": "tool_search_call",
+                "call_id": "call_search_second",
+                "status": "completed",
+                "arguments": {"query": query},
+            },
+            {
+                "type": "tool_search_output",
+                "call_id": "call_search_second",
+                "status": "completed",
+                "tools": [],
+            },
+        ]
+        upstream = {
+            "name": "ollama_cloud",
+            "tool_protocol": "responses_structured",
+            "tool_surface_strategy": "deferred_core",
+        }
+
+        first_payload = json.loads(
+            compatible_request_body(
+                json.dumps(
+                    {
+                        "model": "glm-5.2",
+                        "input": [{"type": "message", "role": "user", "content": "Use the named tool."}, *first_miss],
+                        "tools": caller_tools,
+                    }
+                ).encode("utf-8"),
+                upstream,
+                event_context={},
+            )
+        )
+        first_tool_names = {tool.get("name") for tool in first_payload["tools"]}
+        first_transcript = json.dumps(first_payload, ensure_ascii=True)
+        first_result = first_payload["input"][-1]["content"]
+
+        self.assertIn("tool_search", first_tool_names)
+        self.assertIn("call_search_first", first_transcript)
+        self.assertIn("tools:\n[]", first_result)
+        self.assertNotIn("identical_exact_query", first_transcript)
+
+        self.write_proxy_event.reset_mock()
+        bounded_payload = json.loads(
+            compatible_request_body(
+                json.dumps(
+                    {
+                        "model": "glm-5.2",
+                        "input": [
+                            {"type": "message", "role": "user", "content": "Use the named tool."},
+                            *first_miss,
+                            *second_miss,
+                        ],
+                        "tools": caller_tools,
+                    }
+                ).encode("utf-8"),
+                upstream,
+                event_context={},
+            )
+        )
+        bounded_tool_names = {tool.get("name") for tool in bounded_payload["tools"]}
+        bounded_transcript = json.dumps(bounded_payload, ensure_ascii=True)
+        terminal_results = [
+            item["content"]
+            for item in bounded_payload["input"]
+            if isinstance(item, dict)
+            and isinstance(item.get("content"), str)
+            and "query_classification: identical_exact_query" in item["content"]
+        ]
+
+        self.assertNotIn("tool_search", bounded_tool_names)
+        self.assertIn("known_tool", bounded_tool_names)
+        self.assertEqual(len(terminal_results), 1)
+        self.assertIn("call_id: call_search_second", terminal_results[0])
+        self.assertIn("status: unavailable", terminal_results[0])
+        self.assertIn("empty_miss_count: 2", terminal_results[0])
+        self.assertIn("terminal: true", terminal_results[0])
+        self.assertEqual(bounded_transcript.count("status: unavailable"), 1)
+        self.assertEqual(bounded_transcript.count("call_search_first"), 2)
+        self.assertEqual(bounded_transcript.count("call_search_second"), 2)
+        bound_events = [
+            call
+            for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] == "tool_search_empty_miss_bound"
+        ]
+        self.assertEqual(len(bound_events), 1)
+        self.assertEqual(
+            bound_events[0].kwargs,
+            {
+                "query_classification": "identical_exact_query",
+                "count": 2,
+                "status": "unavailable",
+            },
+        )
+
+    def test_deferred_tool_search_preserves_distinct_empty_queries_and_non_empty_discovery(self):
+        history = [
+            {
+                "type": "tool_search_call",
+                "call_id": "call_distinct_first",
+                "arguments": {"query": "mcp__synthetic__first_missing"},
+            },
+            {"type": "tool_search_output", "call_id": "call_distinct_first", "tools": []},
+            {
+                "type": "tool_search_call",
+                "call_id": "call_distinct_second",
+                "arguments": {"query": "mcp__synthetic__second_missing"},
+            },
+            {"type": "tool_search_output", "call_id": "call_distinct_second", "tools": []},
+            {
+                "type": "tool_search_call",
+                "call_id": "call_found",
+                "arguments": {"query": "known_tool"},
+            },
+            {
+                "type": "tool_search_output",
+                "call_id": "call_found",
+                "tools": [
+                    {
+                        "type": "function",
+                        "name": "known_tool",
+                        "parameters": {"type": "object", "properties": {}},
+                    }
+                ],
+            },
+        ]
+        transformed = compatible_request_body(
+            json.dumps(
+                {
+                    "model": "glm-5.2",
+                    "input": history,
+                    "tools": [
+                        dict(codex_proxy.TOOL_SEARCH_EXPLICIT_FUNCTION_TOOL),
+                        {
+                            "type": "function",
+                            "name": "known_tool",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                    ],
+                }
+            ).encode("utf-8"),
+            {
+                "name": "ollama_cloud",
+                "tool_protocol": "responses_structured",
+                "tool_surface_strategy": "deferred_core",
+            },
+            event_context={},
+        )
+        payload = json.loads(transformed)
+        tool_names = {tool.get("name") for tool in payload["tools"]}
+        transcript = json.dumps(payload, ensure_ascii=True)
+
+        self.assertIn("tool_search", tool_names)
+        self.assertIn("known_tool", tool_names)
+        self.assertIn('"name": "known_tool"', transcript)
+        self.assertNotIn("identical_exact_query", transcript)
+        self.assertFalse(
+            any(
+                call.args and call.args[0] == "tool_search_empty_miss_bound"
+                for call in self.write_proxy_event.call_args_list
+            )
+        )
+
     def test_external_tool_surface_keeps_caller_order_and_deduplicates_flattened_names(self):
         caller_alias = {
             "type": "function",

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -12531,6 +12531,323 @@ Execution constraints:
         self.assertNotIn(bounded_query, repr(event_context))
         self.assertNotIn(distinct_query, repr(event_context))
 
+    def test_deferred_tool_search_standard_sse_lifecycle_suppresses_bounded_arguments_and_preserves_distinct(self):
+        bounded_query = "mcp__synthetic__stream_bounded"
+        distinct_query = "mcp__synthetic__stream_distinct"
+        event_context = {}
+        history = [
+            {
+                "type": "tool_search_call",
+                "call_id": "call_stream_first",
+                "arguments": {"query": bounded_query},
+            },
+            {"type": "tool_search_output", "call_id": "call_stream_first", "tools": []},
+            {
+                "type": "tool_search_call",
+                "call_id": "call_stream_second",
+                "arguments": {"query": bounded_query},
+            },
+            {"type": "tool_search_output", "call_id": "call_stream_second", "tools": []},
+        ]
+        compatible_request_body(
+            json.dumps(
+                {
+                    "model": "glm-5.2",
+                    "input": history,
+                    "tools": [dict(codex_proxy.TOOL_SEARCH_EXPLICIT_FUNCTION_TOOL)],
+                }
+            ).encode("utf-8"),
+            {
+                "name": "ollama_cloud",
+                "tool_protocol": "responses_structured",
+                "tool_surface_strategy": "deferred_core",
+            },
+            event_context=event_context,
+        )
+
+        def sse_line(payload):
+            return b"data: " + json.dumps(payload).encode("utf-8") + b"\n\n"
+
+        def lifecycle(item_id, call_id, query):
+            arguments = json.dumps({"query": query})
+            return [
+                {
+                    "type": "response.output_item.added",
+                    "output_index": 0,
+                    "item": {
+                        "id": item_id,
+                        "type": "function_call",
+                        "status": "in_progress",
+                        "call_id": call_id,
+                        "name": "tool_search",
+                        "arguments": "",
+                    },
+                },
+                {
+                    "type": "response.function_call_arguments.delta",
+                    "item_id": item_id,
+                    "output_index": 0,
+                    "delta": arguments,
+                },
+                {
+                    "type": "response.function_call_arguments.done",
+                    "item_id": item_id,
+                    "output_index": 0,
+                    "arguments": arguments,
+                },
+                {
+                    "type": "response.output_item.done",
+                    "output_index": 0,
+                    "item": {
+                        "id": item_id,
+                        "type": "function_call",
+                        "status": "completed",
+                        "call_id": call_id,
+                        "name": "tool_search",
+                        "arguments": arguments,
+                    },
+                },
+            ]
+
+        bounded_lines = [
+            compatible_sse_line(sse_line(event), "ollama_cloud", event_context=event_context)
+            for event in lifecycle("fc_stream_bounded", "call_stream_third", bounded_query)
+        ]
+        distinct_lines = [
+            compatible_sse_line(sse_line(event), "ollama_cloud", event_context=event_context)
+            for event in lifecycle("fc_stream_distinct", "call_stream_distinct", distinct_query)
+        ]
+        bounded_payloads = [
+            json.loads(line.removeprefix(b"data: ")) for line in bounded_lines if line
+        ]
+        distinct_payloads = [
+            json.loads(line.removeprefix(b"data: ")) for line in distinct_lines if line
+        ]
+        bounded_done = next(
+            payload for payload in bounded_payloads if payload["type"] == "response.output_item.done"
+        )
+        distinct_arguments_done = next(
+            payload
+            for payload in distinct_payloads
+            if payload["type"] == "response.function_call_arguments.done"
+        )
+        distinct_done = next(
+            payload for payload in distinct_payloads if payload["type"] == "response.output_item.done"
+        )
+
+        self.assertEqual(bounded_lines[2], b"")
+        self.assertEqual(
+            sum("terminal: true" in line.decode("utf-8") for line in bounded_lines),
+            1,
+        )
+        self.assertNotIn(bounded_query, bounded_done["item"]["content"][0]["text"])
+        self.assertEqual(bounded_done["item"]["type"], "message")
+        self.assertFalse(
+            any(
+                payload.get("item", {}).get("type") == "tool_search_call"
+                for payload in bounded_payloads
+            )
+        )
+        self.assertEqual(distinct_arguments_done["arguments"], json.dumps({"query": distinct_query}))
+        self.assertEqual(distinct_done["item"]["type"], "tool_search_call")
+        self.assertEqual(distinct_done["item"]["call_id"], "call_stream_distinct")
+        self.assertEqual(distinct_done["item"]["arguments"], {"query": distinct_query})
+        telemetry_text = repr(self.write_proxy_event.call_args_list)
+        self.assertNotIn(bounded_query, telemetry_text)
+        self.assertNotIn(distinct_query, telemetry_text)
+        self.assertNotIn("_bounded_tool_search_query_digests", telemetry_text)
+        self.assertNotIn("_tool_search_stream_candidate_item_ids", telemetry_text)
+        self.assertNotIn("_bounded_tool_search_suppressed_item_ids", telemetry_text)
+        self.assertNotIn("fc_stream_bounded", telemetry_text)
+        self.assertNotIn("fc_stream_distinct", telemetry_text)
+
+    def test_bounded_tool_search_private_state_is_removed_from_handler_diagnostics(self):
+        bounded_query = "mcp__synthetic__diagnostic_bounded"
+        distinct_query = "mcp__synthetic__diagnostic_distinct"
+
+        def guarded_context():
+            context = {}
+            history = [
+                {
+                    "type": "tool_search_call",
+                    "call_id": "call_diagnostic_first",
+                    "arguments": {"query": bounded_query},
+                },
+                {"type": "tool_search_output", "call_id": "call_diagnostic_first", "tools": []},
+                {
+                    "type": "tool_search_call",
+                    "call_id": "call_diagnostic_second",
+                    "arguments": {"query": bounded_query},
+                },
+                {"type": "tool_search_output", "call_id": "call_diagnostic_second", "tools": []},
+            ]
+            compatible_request_body(
+                json.dumps(
+                    {
+                        "model": "glm-5.2",
+                        "input": history,
+                        "tools": [dict(codex_proxy.TOOL_SEARCH_EXPLICIT_FUNCTION_TOOL)],
+                    }
+                ).encode("utf-8"),
+                {
+                    "name": "ollama_cloud",
+                    "tool_protocol": "responses_structured",
+                    "tool_surface_strategy": "deferred_core",
+                },
+                event_context=context,
+            )
+            added = {
+                "type": "response.output_item.added",
+                "output_index": 0,
+                "item": {
+                    "id": "fc_diagnostic_bounded",
+                    "type": "function_call",
+                    "status": "in_progress",
+                    "call_id": "call_diagnostic_third",
+                    "name": "tool_search",
+                    "arguments": "",
+                },
+            }
+            arguments_done = {
+                "type": "response.function_call_arguments.done",
+                "item_id": "fc_diagnostic_bounded",
+                "output_index": 0,
+                "arguments": json.dumps({"query": bounded_query}),
+            }
+            compatible_sse_line(
+                b"data: " + json.dumps(added).encode("utf-8") + b"\n\n",
+                "ollama_cloud",
+                event_context=context,
+            )
+            self.assertEqual(
+                compatible_sse_line(
+                    b"data: " + json.dumps(arguments_done).encode("utf-8") + b"\n\n",
+                    "ollama_cloud",
+                    event_context=context,
+                ),
+                b"",
+            )
+            self.assertIn("_bounded_tool_search_query_digests", context)
+            self.assertIn("_tool_search_stream_candidate_item_ids", context)
+            self.assertIn("_bounded_tool_search_suppressed_item_ids", context)
+            return context
+
+        self.write_proxy_event.reset_mock()
+
+        empty_context = guarded_context()
+        bound_event = next(
+            call
+            for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] == "tool_search_empty_miss_bound"
+        )
+        self.assertEqual(
+            bound_event.kwargs,
+            {"query_classification": "identical_exact_query", "count": 2, "status": "unavailable"},
+        )
+        handler = FakeHandler()
+        empty_response = FakeResponse(
+            json.dumps(
+                {
+                    "id": "resp_diagnostic_empty",
+                    "object": "response",
+                    "status": "completed",
+                    "model": "glm-5.2",
+                    "output": [],
+                }
+            ).encode("utf-8")
+        )
+        CodexProxyHandler._relay_upstream_response(
+            handler,
+            empty_response,
+            "ollama_cloud",
+            request_id="req_diagnostic_empty",
+            model="glm-5.2",
+            upstream_format="responses",
+            inbound_format="responses",
+            caller_stream=False,
+            event_context=empty_context,
+        )
+
+        compact_context = guarded_context()
+        compact_handler = FakeHandler()
+        CodexProxyHandler._relay_upstream_response(
+            compact_handler,
+            FakeResponse(empty_response.body),
+            "ollama_cloud",
+            request_id="req_diagnostic_compact",
+            model="glm-5.2",
+            upstream_format="responses",
+            inbound_format="responses",
+            caller_stream=False,
+            event_context=compact_context,
+            headers_already_sent=True,
+            request_kind=RETRY_REQUEST_COMPACT,
+        )
+
+        close_context = guarded_context()
+        close_handler = FakeHandler()
+        close_handler.wfile = FakeWFile(fail_on_write=lambda data, _index: data == b"data: [DONE]\n\n")
+        close_chunks = [
+            {"choices": [{"delta": {"content": "ok"}, "finish_reason": "stop"}]},
+            {"usage": {"prompt_tokens": 2, "completion_tokens": 1, "total_tokens": 3}, "choices": []},
+        ]
+        close_response = FakeSseResponse(
+            [f"data: {json.dumps(chunk)}\n".encode("utf-8") for chunk in close_chunks]
+            + [b"data: [DONE]\n", b""]
+        )
+        CodexProxyHandler._relay_upstream_response(
+            close_handler,
+            close_response,
+            "ollama_cloud",
+            request_id="req_diagnostic_close",
+            model="glm-5.2",
+            upstream_format="chat_completions",
+            inbound_format="responses",
+            caller_stream=True,
+            event_context=close_context,
+            behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+        )
+
+        diagnostic_names = {
+            "empty_assistant_response",
+            "compact_empty_response",
+            "downstream_stream_closed",
+        }
+        diagnostic_events = [
+            call
+            for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] in diagnostic_names
+        ]
+        self.assertEqual({call.args[0] for call in diagnostic_events}, diagnostic_names)
+        private_keys = {
+            key
+            for context in (empty_context, compact_context, close_context)
+            for key in context
+            if key.startswith("_")
+        }
+        private_values = {
+            repr(value)
+            for context in (empty_context, compact_context, close_context)
+            for key, value in context.items()
+            if key.startswith("_")
+        }
+        digest_values = {
+            digest.hex()
+            for context in (empty_context, compact_context, close_context)
+            for digest in context["_bounded_tool_search_query_digests"]
+        }
+        for event in diagnostic_events:
+            serialized = json.dumps(event.kwargs, ensure_ascii=True, sort_keys=True)
+            self.assertTrue(private_keys.isdisjoint(event.kwargs))
+            self.assertNotIn(bounded_query, serialized)
+            self.assertNotIn(distinct_query, serialized)
+            self.assertNotIn("fc_diagnostic_bounded", serialized)
+            self.assertNotIn("call_diagnostic_third", serialized)
+            for digest_value in digest_values:
+                self.assertNotIn(digest_value, serialized)
+            for private_value in private_values:
+                self.assertNotIn(private_value, serialized)
+
     def test_deferred_tool_search_preserves_exact_non_empty_result_and_follow_up_callable_contract(self):
         discovered_tool = {
             "type": "function",


### PR DESCRIPTION
## What changed

- bound repeated identical empty `tool_search` misses per exact query
- hard-stop a third bounded query in both response-body and multi-event SSE normalization
- preserve distinct queries and non-empty discovered tool contracts
- isolate private guard state from all telemetry projections

## Why

External models can repeatedly resample an unavailable callback query. The adapter now produces one sanitized terminal result at the bound without globally disabling legitimate discovery.

## Issue

Addresses #159. Parent gate: #156.

## Validation

- TDD RED/GREEN evidence preserved in the task report
- routing `tool_search`: 11 passed
- semantic adapter: 5 passed
- telemetry-focused: 20 passed
- strict candidate suite: 1144 passed, 1 skipped, 305 subtests
- report-only quality gate: parse errors 0
- independent Spec review: PASS
- independent Standards review: APPROVED
- `git diff --check a4cd13bf..HEAD`
