### PR TITLE
fix(gateway): serialize lifecycle operations

### DIFF
--- a/frontend/scripts/ui-contract.test.mjs
+++ b/frontend/scripts/ui-contract.test.mjs
@@ -327,12 +327,28 @@ test("Gateway lifecycle transitions disable Start and failed actions clear stale
   ]);
   const runtimeAction = appSource.match(/const runRuntimeAction = useCallback\(async \([\s\S]*?\n  \}, \[[^\]]*\]\);/)?.[0] ?? "";
 
-  assert.match(typesSource, /gateway_lifecycle: "stopped" \| "starting" \| "running" \| "stopping" \| "restarting" \| "failed"/);
-  assert.match(runtimeBarSource, /const lifecycleTransitionActive = \["starting", "stopping", "restarting"\]\.includes/);
+  assert.match(typesSource, /gateway_lifecycle: "unavailable" \| "stopped" \| "starting" \| "running" \| "stopping" \| "restarting" \| "failed"/);
+  assert.match(runtimeBarSource, /const lifecycleTransitionActive = \["unavailable", "starting", "stopping", "restarting"\]\.includes/);
   assert.match(runtimeBarSource, /disabled=\{Boolean\(busy\) \|\| !status \|\| lifecycleTransitionActive\}/);
   assert.match(appSource, /data: key === "status" \? null : cache\.data/);
   assert.match(runtimeAction, /catch \(err\) \{[\s\S]*await refreshRuntimeStatus\(\{ force: true \}\)/);
   assert.match(runtimeAction, /updateToast\(toastId, \{[\s\S]*tone: "error"/);
+});
+
+test("settings restart failures and tray lifecycle feedback preserve truthful runtime state", async () => {
+  const [appSource, mainSource] = await Promise.all([
+    readFile(appPath, "utf8"),
+    readFile(tauriMainPath, "utf8"),
+  ]);
+  const saveSettings = appSource.match(/const saveSettings = useCallback\(async \(next: Settings\) => \{[\s\S]*?\n  \}, \[[^\]]*\]\);/)?.[0] ?? "";
+  const trayListener = appSource.match(/listen<TrayToastPayload>\("codexhub:toast",[\s\S]*?\n    \}\)/)?.[0] ?? "";
+
+  assert.match(saveSettings, /catch \(err\) \{[\s\S]*await refreshRuntimeStatus\(\{ force: true \}\)/);
+  assert.match(appSource, /type TrayToastPayload = \{[\s\S]*id: string;[\s\S]*tone: "loading" \| "success" \| "error"/);
+  assert.match(trayListener, /trayToastIds\.current\.get\(event\.payload\.id\)/);
+  assert.match(trayListener, /updateToast\(existingToastId,/);
+  assert.match(mainSource, /emit_tray_toast\([\s\S]*"loading"/);
+  assert.match(mainSource, /tauri::async_runtime::spawn_blocking/);
 });
 
 test("provider page state, editors, actions, and shared helpers stay in focused modules", async () => {

--- a/frontend/scripts/ui-contract.test.mjs
+++ b/frontend/scripts/ui-contract.test.mjs
@@ -319,6 +319,22 @@ test("runtime data uses app-level cached refreshes instead of page lifecycle rel
   assert.doesNotMatch(providersSource, /async function load\(\)/);
 });
 
+test("Gateway lifecycle transitions disable Start and failed actions clear stale Running state", async () => {
+  const [appSource, runtimeBarSource, typesSource] = await Promise.all([
+    readFile(appPath, "utf8"),
+    readFile(runtimeBarPath, "utf8"),
+    readFile(typesPath, "utf8"),
+  ]);
+  const runtimeAction = appSource.match(/const runRuntimeAction = useCallback\(async \([\s\S]*?\n  \}, \[[^\]]*\]\);/)?.[0] ?? "";
+
+  assert.match(typesSource, /gateway_lifecycle: "stopped" \| "starting" \| "running" \| "stopping" \| "restarting" \| "failed"/);
+  assert.match(runtimeBarSource, /const lifecycleTransitionActive = \["starting", "stopping", "restarting"\]\.includes/);
+  assert.match(runtimeBarSource, /disabled=\{Boolean\(busy\) \|\| !status \|\| lifecycleTransitionActive\}/);
+  assert.match(appSource, /data: key === "status" \? null : cache\.data/);
+  assert.match(runtimeAction, /catch \(err\) \{[\s\S]*await refreshRuntimeStatus\(\{ force: true \}\)/);
+  assert.match(runtimeAction, /updateToast\(toastId, \{[\s\S]*tone: "error"/);
+});
+
 test("provider page state, editors, actions, and shared helpers stay in focused modules", async () => {
   const [pageSource, usageSource, navigationSource, editorSource, controlsSource, modelSource, catalogActionsSource, dateSource, labelsSource, updateSource, officialModelsSource, endpointSource, formSource] = await Promise.all([
     readFile(providersPagePath, "utf8"),
@@ -580,8 +596,10 @@ test("desktop startup opens the gateway backend and reuses the existing app inst
     "gateway startup should run after packaged resources are registered",
   );
   assert.match(mainSource, /fn start_gateway_on_launch\(\)/);
-  assert.match(mainSource, /tauri::async_runtime::spawn_blocking\(\|\|/);
-  assert.match(mainSource, /proxy::start\(\)/);
+  assert.match(mainSource, /std::thread::spawn\(move \|\|/);
+  assert.match(mainSource, /proxy::start_after\(\|\|/);
+  assert.match(mainSource, /launch_ready\.signal\(\)/);
+  assert.match(mainSource, /ready_rx\.recv\(\)/);
   assert.match(cargoSource, /tauri-plugin-single-instance\s*=\s*"2"/);
   assert.match(mainSource, /tauri_plugin_single_instance::init\(\|app,[\s\S]*show_main_window\(app\)/);
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -47,8 +47,9 @@ type RuntimeSnapshot = {
 };
 
 type TrayToastPayload = {
+  id: string;
   text: string;
-  tone: "success" | "error";
+  tone: "loading" | "success" | "error";
 };
 
 type LoadRuntimeOptions = {
@@ -334,6 +335,7 @@ export default function App() {
   const startupUpdateCheckStarted = useRef(false);
   const updateAvailableToastId = useRef<string | null>(null);
   const updateInstallToastId = useRef<string | null>(null);
+  const trayToastIds = useRef<Map<string, string>>(new Map());
   runtimeRef.current = runtime;
   const settingsLoaded = Boolean(runtime.settings.data);
 
@@ -767,10 +769,22 @@ export default function App() {
     let disposed = false;
     let unlisten: (() => void) | null = null;
     void listen<TrayToastPayload>("codexhub:toast", (event) => {
-      showToast({
-        text: event.payload.text,
-        tone: event.payload.tone,
-      });
+      const existingToastId = trayToastIds.current.get(event.payload.id);
+      if (existingToastId) {
+        updateToast(existingToastId, {
+          action: null,
+          text: event.payload.text,
+          tone: event.payload.tone,
+        });
+        if (event.payload.tone !== "loading") {
+          trayToastIds.current.delete(event.payload.id);
+        }
+        return;
+      }
+      const toastId = showToast({ text: event.payload.text, tone: event.payload.tone });
+      if (event.payload.tone === "loading") {
+        trayToastIds.current.set(event.payload.id, toastId);
+      }
     })
       .then((nextUnlisten) => {
         if (disposed) {
@@ -786,7 +800,7 @@ export default function App() {
       disposed = true;
       unlisten?.();
     };
-  }, [showToast]);
+  }, [showToast, updateToast]);
 
   useEffect(() => {
     const timer = window.setTimeout(() => {
@@ -982,6 +996,7 @@ export default function App() {
     } catch (err) {
       const message = messageFromError(err);
       setBanner(message);
+      await refreshRuntimeStatus({ force: true });
       throw err;
     } finally {
       setBusy(null);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -141,6 +141,7 @@ function setCacheError(current: RuntimeSnapshot, key: RuntimeCacheKey, error: st
     ...current,
     [key]: {
       ...cache,
+      data: key === "status" ? null : cache.data,
       loading: false,
       error,
     },
@@ -940,6 +941,7 @@ export default function App() {
     } catch (err) {
       const message = messageFromError(err);
       setBanner(message);
+      await refreshRuntimeStatus({ force: true });
       if (toastId) {
         updateToast(toastId, {
           action: null,

--- a/frontend/src/components/RuntimeBar.tsx
+++ b/frontend/src/components/RuntimeBar.tsx
@@ -30,7 +30,7 @@ export function RuntimeBar({
 }: RuntimeBarProps) {
   const { t } = useTranslation();
   const running = status?.proxy_running ?? false;
-  const lifecycleTransitionActive = ["starting", "stopping", "restarting"].includes(
+  const lifecycleTransitionActive = ["unavailable", "starting", "stopping", "restarting"].includes(
     status?.gateway_lifecycle ?? "",
   );
   const port = status?.proxy_port ?? settings?.proxy_port ?? 9099;

--- a/frontend/src/components/RuntimeBar.tsx
+++ b/frontend/src/components/RuntimeBar.tsx
@@ -30,6 +30,9 @@ export function RuntimeBar({
 }: RuntimeBarProps) {
   const { t } = useTranslation();
   const running = status?.proxy_running ?? false;
+  const lifecycleTransitionActive = ["starting", "stopping", "restarting"].includes(
+    status?.gateway_lifecycle ?? "",
+  );
   const port = status?.proxy_port ?? settings?.proxy_port ?? 9099;
   const address = `${settings?.gateway_bind_address || "127.0.0.1"}:${port}`;
   const runtimeHint = formatRuntimeHint(message);
@@ -78,7 +81,7 @@ export function RuntimeBar({
         <button
           type="button"
           className="focus-ring inline-flex h-8 w-8 items-center justify-center rounded-control bg-surface text-slate-700 shadow-control transition-[box-shadow,background-color,transform] duration-150 ease-out hover:bg-white hover:shadow-raised active:scale-[0.96]"
-          disabled={Boolean(busy)}
+          disabled={Boolean(busy) || !status || lifecycleTransitionActive}
           onClick={running ? onStop : onStart}
           aria-label={running ? t("runtime.stopRuntime") : t("runtime.startRuntime")}
           title={running ? t("runtime.stopRuntime") : t("runtime.startRuntime")}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -96,6 +96,7 @@ export interface AppStatus {
   proxy_port: number;
   proxy_build?: string | null;
   message: string;
+  gateway_lifecycle: "stopped" | "starting" | "running" | "stopping" | "restarting" | "failed";
   history_sync_status?: string | null;
   history_sync_message?: string | null;
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -96,7 +96,7 @@ export interface AppStatus {
   proxy_port: number;
   proxy_build?: string | null;
   message: string;
-  gateway_lifecycle: "stopped" | "starting" | "running" | "stopping" | "restarting" | "failed";
+  gateway_lifecycle: "unavailable" | "stopped" | "starting" | "running" | "stopping" | "restarting" | "failed";
   history_sync_status?: string | null;
   history_sync_message?: string | null;
 }

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -511,6 +511,7 @@ dependencies = [
  "tokio",
  "toml 0.8.2",
  "which",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,3 +27,15 @@ sha2 = "0.10"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 which = "6"
 log = "0.4"
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.59", features = [
+  "Win32_Foundation",
+  "Win32_NetworkManagement_IpHelper",
+  "Win32_Security",
+  "Win32_Storage_FileSystem",
+  "Win32_System_Diagnostics_ToolHelp",
+  "Win32_System_JobObjects",
+  "Win32_System_Pipes",
+  "Win32_System_Threading",
+] }

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -71,6 +71,11 @@ pub fn switch_mode_with_takeover(
 
     let mut status =
         switch_mode_with_paths_takeover(mode, auto_sync, force_takeover, &paths, &python, &runner)?;
+    let lifecycle = crate::proxy::status()?;
+    status.proxy_running = lifecycle.proxy_running;
+    status.proxy_port = lifecycle.proxy_port;
+    status.proxy_build = lifecycle.proxy_build;
+    status.gateway_lifecycle = lifecycle.gateway_lifecycle;
     let settings = get_settings_with_paths(&paths).unwrap_or_default();
     let target_provider = if mode == "custom" || settings.unified_codex_history {
         "custom"
@@ -929,8 +934,8 @@ fn switch_mode_with_paths_takeover_as_owner(
         proxy_running: false,
         proxy_port: settings.proxy_port,
         proxy_build: None,
-        message: format!("Switched to {mode} mode; proxy lifecycle is handled separately"),
-        gateway_lifecycle: crate::gateway_transaction::GatewayLifecyclePhase::Stopped,
+        message: format!("Switched to {mode} mode; Gateway lifecycle is handled separately"),
+        gateway_lifecycle: crate::gateway_transaction::GatewayLifecyclePhase::Unavailable,
         history_sync_status: None,
         history_sync_message: None,
     })
@@ -1766,6 +1771,10 @@ base_url = "https://ark.cn-beijing.volces.com/api/coding/v3"
         assert_eq!(status.mode, "custom");
         assert_eq!(status.proxy_port, 4555);
         assert!(!status.proxy_running);
+        assert_eq!(
+            status.gateway_lifecycle,
+            crate::gateway_transaction::GatewayLifecyclePhase::Unavailable
+        );
         assert!(status.message.contains("custom"));
 
         let commands = runner.commands.borrow();

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -930,6 +930,7 @@ fn switch_mode_with_paths_takeover_as_owner(
         proxy_port: settings.proxy_port,
         proxy_build: None,
         message: format!("Switched to {mode} mode; proxy lifecycle is handled separately"),
+        gateway_lifecycle: crate::gateway_transaction::GatewayLifecyclePhase::Stopped,
         history_sync_status: None,
         history_sync_message: None,
     })

--- a/src-tauri/src/gateway_lifecycle.rs
+++ b/src-tauri/src/gateway_lifecycle.rs
@@ -1,0 +1,691 @@
+use crate::AppStatus;
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GatewayIdentity {
+    pub pid: u32,
+    pub port: u16,
+    pub script_path: String,
+    pub script_sha256: Option<String>,
+    pub started_at_unix_ms: u64,
+}
+
+#[derive(Debug)]
+pub(crate) struct GatewayLifecycleSnapshot {
+    pub(crate) status: AppStatus,
+    pub(crate) identity: Option<GatewayIdentity>,
+}
+
+#[derive(Debug)]
+pub(crate) struct GatewayStartOutcome {
+    pub(crate) snapshot: GatewayLifecycleSnapshot,
+    pub(crate) spawned: bool,
+}
+
+pub(crate) trait GatewayLifecycleBackend {
+    fn snapshot(&self) -> Result<GatewayLifecycleSnapshot, String>;
+    fn start(&self) -> Result<GatewayStartOutcome, String>;
+    fn stop(&self) -> Result<AppStatus, String>;
+
+    fn can_reuse(&self, _snapshot: &GatewayLifecycleSnapshot) -> bool {
+        true
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LifecyclePhase {
+    Stopped,
+    Starting,
+    Running,
+    Stopping,
+    Restarting,
+    Failed,
+}
+
+#[derive(Debug)]
+struct GatewayLifecycleState {
+    phase: LifecyclePhase,
+    published: Option<GatewayIdentity>,
+    session_owned: Option<GatewayIdentity>,
+    last_error: Option<String>,
+}
+
+impl Default for GatewayLifecycleState {
+    fn default() -> Self {
+        Self {
+            phase: LifecyclePhase::Stopped,
+            published: None,
+            session_owned: None,
+            last_error: None,
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct GatewayLifecycleCoordinator {
+    state: Mutex<GatewayLifecycleState>,
+}
+
+impl GatewayLifecycleCoordinator {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn status<B>(&self, backend: &B) -> Result<GatewayLifecycleSnapshot, String>
+    where
+        B: GatewayLifecycleBackend,
+    {
+        let mut state = self.lock_state()?;
+        match backend.snapshot() {
+            Ok(snapshot) if snapshot.identity.is_some() => {
+                Self::publish_snapshot(&mut state, &snapshot, false)?;
+                Ok(snapshot)
+            }
+            Ok(snapshot) => {
+                state.phase = LifecyclePhase::Stopped;
+                state.published = None;
+                state.session_owned = None;
+                state.last_error = None;
+                Ok(snapshot)
+            }
+            Err(error) => Self::fail_reconciliation(&mut state, error),
+        }
+    }
+
+    pub(crate) fn start<B, Prepare>(
+        &self,
+        backend: &B,
+        prepare: Prepare,
+    ) -> Result<GatewayLifecycleSnapshot, String>
+    where
+        B: GatewayLifecycleBackend,
+        Prepare: FnOnce() -> Result<(), String>,
+    {
+        let mut state = self.lock_state()?;
+        state.phase = LifecyclePhase::Starting;
+        state.last_error = None;
+
+        match backend.snapshot() {
+            Ok(snapshot) if snapshot.identity.is_some() && backend.can_reuse(&snapshot) => {
+                Self::publish_snapshot(&mut state, &snapshot, false)?;
+                return Ok(snapshot);
+            }
+            Ok(_) => {}
+            Err(error) => return Self::fail_reconciliation(&mut state, error),
+        }
+
+        if let Err(error) = prepare() {
+            return Self::fail_preserving_identity(&mut state, error);
+        }
+
+        match backend.start() {
+            Ok(outcome) => {
+                Self::publish_snapshot(&mut state, &outcome.snapshot, outcome.spawned)?;
+                Ok(outcome.snapshot)
+            }
+            Err(error) => Self::fail(&mut state, error),
+        }
+    }
+
+    pub(crate) fn stop<B>(&self, backend: &B) -> Result<AppStatus, String>
+    where
+        B: GatewayLifecycleBackend,
+    {
+        let mut state = self.lock_state()?;
+        state.phase = LifecyclePhase::Stopping;
+        state.last_error = None;
+
+        match backend.stop() {
+            Ok(status) if !status.proxy_running => {
+                state.phase = LifecyclePhase::Stopped;
+                state.published = None;
+                state.session_owned = None;
+                Ok(status)
+            }
+            Ok(status) => {
+                state.phase = LifecyclePhase::Failed;
+                state.published = None;
+                state.session_owned = None;
+                state.last_error = Some(status.message.clone());
+                Ok(status)
+            }
+            Err(error) => Self::fail_reconciliation(&mut state, error),
+        }
+    }
+
+    pub(crate) fn restart<B, Prepare>(
+        &self,
+        backend: &B,
+        prepare: Prepare,
+    ) -> Result<GatewayLifecycleSnapshot, String>
+    where
+        B: GatewayLifecycleBackend,
+        Prepare: FnOnce() -> Result<(), String>,
+    {
+        let mut state = self.lock_state()?;
+        state.phase = LifecyclePhase::Restarting;
+        state.last_error = None;
+
+        if let Err(error) = prepare() {
+            return Self::fail_preserving_identity(&mut state, error);
+        }
+
+        let stopped = match backend.stop() {
+            Ok(status) => status,
+            Err(error) => return Self::fail_reconciliation(&mut state, error),
+        };
+        if stopped.proxy_running {
+            return Self::fail(
+                &mut state,
+                format!(
+                    "Gateway restart refused because stop did not release port {}: {}",
+                    stopped.proxy_port, stopped.message
+                ),
+            );
+        }
+        state.published = None;
+        state.session_owned = None;
+
+        match backend.start() {
+            Ok(outcome) => {
+                Self::publish_snapshot(&mut state, &outcome.snapshot, outcome.spawned)?;
+                Ok(outcome.snapshot)
+            }
+            Err(error) => Self::fail(&mut state, error),
+        }
+    }
+
+    #[cfg(test)]
+    fn published_identity(&self) -> Option<GatewayIdentity> {
+        self.state
+            .lock()
+            .ok()
+            .and_then(|state| state.published.clone())
+    }
+
+    pub(crate) fn session_owned_identity(&self) -> Option<GatewayIdentity> {
+        self.state
+            .lock()
+            .ok()
+            .and_then(|state| state.session_owned.clone())
+    }
+
+    #[cfg(test)]
+    fn phase(&self) -> LifecyclePhase {
+        self.state
+            .lock()
+            .map(|state| state.phase)
+            .unwrap_or(LifecyclePhase::Failed)
+    }
+
+    fn lock_state(&self) -> Result<MutexGuard<'_, GatewayLifecycleState>, String> {
+        self.state
+            .lock()
+            .map_err(|_| "Gateway lifecycle coordinator lock is poisoned".to_string())
+    }
+
+    fn publish_snapshot(
+        state: &mut GatewayLifecycleState,
+        snapshot: &GatewayLifecycleSnapshot,
+        spawned: bool,
+    ) -> Result<(), String> {
+        let Some(identity) = snapshot.identity.clone() else {
+            return Self::fail(
+                state,
+                "Gateway lifecycle refused to publish Running without a reconciled identity"
+                    .to_string(),
+            );
+        };
+        if !snapshot.status.proxy_running {
+            return Self::fail(
+                state,
+                "Gateway lifecycle refused to publish an identity while health is not running"
+                    .to_string(),
+            );
+        }
+
+        if state.session_owned.as_ref() != Some(&identity) {
+            state.session_owned = None;
+        }
+        if spawned {
+            state.session_owned = Some(identity.clone());
+        }
+        state.published = Some(identity);
+        state.phase = LifecyclePhase::Running;
+        state.last_error = None;
+        Ok(())
+    }
+
+    fn fail<T>(state: &mut GatewayLifecycleState, error: String) -> Result<T, String> {
+        state.phase = LifecyclePhase::Failed;
+        state.published = None;
+        state.session_owned = None;
+        state.last_error = Some(error.clone());
+        Err(error)
+    }
+
+    fn fail_preserving_identity<T>(
+        state: &mut GatewayLifecycleState,
+        error: String,
+    ) -> Result<T, String> {
+        state.phase = LifecyclePhase::Failed;
+        state.last_error = Some(error.clone());
+        Err(error)
+    }
+
+    fn fail_reconciliation<T>(
+        state: &mut GatewayLifecycleState,
+        error: String,
+    ) -> Result<T, String> {
+        state.phase = LifecyclePhase::Failed;
+        state.published = None;
+        state.last_error = Some(error.clone());
+        Err(error)
+    }
+}
+
+static GATEWAY_LIFECYCLE: OnceLock<GatewayLifecycleCoordinator> = OnceLock::new();
+
+pub(crate) fn coordinator() -> &'static GatewayLifecycleCoordinator {
+    GATEWAY_LIFECYCLE.get_or_init(GatewayLifecycleCoordinator::new)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Barrier, Mutex};
+    use std::thread;
+
+    #[test]
+    fn coordinator_coalesces_concurrent_starts_to_one_spawn_and_identity() {
+        let coordinator = Arc::new(GatewayLifecycleCoordinator::new());
+        let entered_start = Arc::new(Barrier::new(2));
+        let backend =
+            Arc::new(FakeLifecycleBackend::stopped().pause_next_start(entered_start.clone()));
+
+        let first_coordinator = Arc::clone(&coordinator);
+        let first_backend = Arc::clone(&backend);
+        let first =
+            thread::spawn(move || first_coordinator.start(first_backend.as_ref(), || Ok(())));
+        entered_start.wait();
+
+        let second_coordinator = Arc::clone(&coordinator);
+        let second_backend = Arc::clone(&backend);
+        let second =
+            thread::spawn(move || second_coordinator.start(second_backend.as_ref(), || Ok(())));
+
+        let first = first
+            .join()
+            .expect("first start thread")
+            .expect("first start");
+        let second = second
+            .join()
+            .expect("second start thread")
+            .expect("second start");
+
+        assert_eq!(backend.spawn_count(), 1);
+        assert_eq!(first.identity, second.identity);
+        assert_eq!(first.status.message, second.status.message);
+        assert_eq!(coordinator.session_owned_identity(), first.identity);
+    }
+
+    #[test]
+    fn coordinator_reuses_healthy_managed_identity_without_preparing_or_spawning() {
+        let identity = fake_identity(41);
+        let coordinator = GatewayLifecycleCoordinator::new();
+        let backend = FakeLifecycleBackend::running(identity.clone());
+        let prepare_calls = std::cell::Cell::new(0);
+
+        let snapshot = coordinator
+            .start(&backend, || {
+                prepare_calls.set(prepare_calls.get() + 1);
+                Ok(())
+            })
+            .expect("reuse running Gateway");
+
+        assert_eq!(snapshot.identity, Some(identity));
+        assert_eq!(backend.spawn_count(), 0);
+        assert_eq!(prepare_calls.get(), 0);
+        assert_eq!(coordinator.session_owned_identity(), None);
+    }
+
+    #[test]
+    fn coordinator_replaces_healthy_identity_that_backend_marks_non_reusable() {
+        let coordinator = GatewayLifecycleCoordinator::new();
+        let backend = FakeLifecycleBackend::running(fake_identity(41))
+            .with_next_pid(42)
+            .replace_on_start();
+        let prepare_calls = std::cell::Cell::new(0);
+
+        let snapshot = coordinator
+            .start(&backend, || {
+                prepare_calls.set(prepare_calls.get() + 1);
+                Ok(())
+            })
+            .expect("replace incompatible managed Gateway");
+
+        assert_eq!(snapshot.identity, Some(fake_identity(42)));
+        assert_eq!(backend.spawn_count(), 1);
+        assert_eq!(prepare_calls.get(), 1);
+        assert_eq!(coordinator.session_owned_identity(), snapshot.identity);
+    }
+
+    #[test]
+    fn coordinator_restart_owns_stop_to_replacement_boundary_against_start() {
+        let old_identity = fake_identity(51);
+        let coordinator = Arc::new(GatewayLifecycleCoordinator::new());
+        let entered_stop = Arc::new(Barrier::new(2));
+        let backend = Arc::new(
+            FakeLifecycleBackend::running(old_identity)
+                .with_next_pid(52)
+                .pause_next_stop(entered_stop.clone()),
+        );
+
+        let restart_coordinator = Arc::clone(&coordinator);
+        let restart_backend = Arc::clone(&backend);
+        let restart =
+            thread::spawn(move || restart_coordinator.restart(restart_backend.as_ref(), || Ok(())));
+        entered_stop.wait();
+
+        let start_coordinator = Arc::clone(&coordinator);
+        let start_backend = Arc::clone(&backend);
+        let concurrent_start =
+            thread::spawn(move || start_coordinator.start(start_backend.as_ref(), || Ok(())));
+
+        let replacement = restart
+            .join()
+            .expect("restart thread")
+            .expect("restart replacement");
+        let reused = concurrent_start
+            .join()
+            .expect("concurrent start thread")
+            .expect("concurrent start");
+
+        assert_eq!(replacement.identity, Some(fake_identity(52)));
+        assert_eq!(reused.identity, replacement.identity);
+        assert_eq!(backend.spawn_count(), 1);
+        assert_eq!(backend.stop_count(), 1);
+        assert_eq!(backend.events(), vec!["stop:51", "spawn:52", "snapshot:52"]);
+        assert_eq!(coordinator.session_owned_identity(), replacement.identity);
+    }
+
+    #[test]
+    fn coordinator_serializes_start_then_stop_without_stale_publication() {
+        let coordinator = Arc::new(GatewayLifecycleCoordinator::new());
+        let entered_start = Arc::new(Barrier::new(2));
+        let backend =
+            Arc::new(FakeLifecycleBackend::stopped().pause_next_start(entered_start.clone()));
+
+        let start_coordinator = Arc::clone(&coordinator);
+        let start_backend = Arc::clone(&backend);
+        let start =
+            thread::spawn(move || start_coordinator.start(start_backend.as_ref(), || Ok(())));
+        entered_start.wait();
+
+        let stop_coordinator = Arc::clone(&coordinator);
+        let stop_backend = Arc::clone(&backend);
+        let stop = thread::spawn(move || stop_coordinator.stop(stop_backend.as_ref()));
+
+        assert!(start.join().expect("start thread").is_ok());
+        let stopped = stop.join().expect("stop thread").expect("stop");
+
+        assert!(!stopped.proxy_running);
+        assert_eq!(
+            backend.events(),
+            vec!["snapshot:none", "spawn:42", "stop:42"]
+        );
+        assert_eq!(coordinator.session_owned_identity(), None);
+        assert_eq!(coordinator.phase(), LifecyclePhase::Stopped);
+    }
+
+    #[test]
+    fn coordinator_failed_start_publishes_no_identity_or_session_handoff() {
+        let coordinator = GatewayLifecycleCoordinator::new();
+        let backend = FakeLifecycleBackend::stopped().fail_next_start("spawn failed");
+
+        let error = coordinator
+            .start(&backend, || Ok(()))
+            .expect_err("start should fail");
+
+        assert_eq!(error, "spawn failed");
+        assert_eq!(coordinator.published_identity(), None);
+        assert_eq!(coordinator.session_owned_identity(), None);
+        assert_eq!(coordinator.phase(), LifecyclePhase::Failed);
+    }
+
+    #[test]
+    fn coordinator_stop_error_unpublishes_running_but_preserves_safe_session_handoff() {
+        let coordinator = GatewayLifecycleCoordinator::new();
+        let backend = FakeLifecycleBackend::stopped();
+        let started = coordinator
+            .start(&backend, || Ok(()))
+            .expect("session start");
+        backend.fail_next_stop("stop inspection failed");
+
+        let error = coordinator.stop(&backend).expect_err("stop should fail");
+
+        assert_eq!(error, "stop inspection failed");
+        assert_eq!(coordinator.published_identity(), None);
+        assert_eq!(coordinator.session_owned_identity(), started.identity);
+        assert_eq!(coordinator.phase(), LifecyclePhase::Failed);
+    }
+
+    #[test]
+    fn coordinator_status_preserves_session_handoff_only_for_same_identity() {
+        let coordinator = GatewayLifecycleCoordinator::new();
+        let backend = FakeLifecycleBackend::stopped();
+        let started = coordinator
+            .start(&backend, || Ok(()))
+            .expect("session start");
+
+        let refreshed = coordinator.status(&backend).expect("status refresh");
+
+        assert_eq!(refreshed.identity, started.identity);
+        assert_eq!(coordinator.session_owned_identity(), started.identity);
+    }
+
+    #[test]
+    fn coordinator_status_clears_handoff_after_external_identity_replacement() {
+        let coordinator = GatewayLifecycleCoordinator::new();
+        let backend = FakeLifecycleBackend::stopped();
+        coordinator
+            .start(&backend, || Ok(()))
+            .expect("session start");
+        backend.replace_identity(fake_identity(77));
+
+        let refreshed = coordinator.status(&backend).expect("replacement status");
+
+        assert_eq!(refreshed.identity, Some(fake_identity(77)));
+        assert_eq!(coordinator.session_owned_identity(), None);
+    }
+
+    fn fake_identity(pid: u32) -> GatewayIdentity {
+        GatewayIdentity {
+            pid,
+            port: 9099,
+            script_path: "C:/CodexHub/codex_proxy.py".to_string(),
+            script_sha256: Some("fake-sha256".to_string()),
+            started_at_unix_ms: u64::from(pid),
+        }
+    }
+
+    struct FakeLifecycleBackend {
+        state: Mutex<FakeLifecycleState>,
+    }
+
+    struct FakeLifecycleState {
+        identity: Option<GatewayIdentity>,
+        next_pid: u32,
+        spawn_count: usize,
+        stop_count: usize,
+        events: Vec<String>,
+        pause_next_start: Option<Arc<Barrier>>,
+        pause_next_stop: Option<Arc<Barrier>>,
+        fail_next_start: Option<String>,
+        fail_next_stop: Option<String>,
+        replace_on_start: bool,
+    }
+
+    impl FakeLifecycleBackend {
+        fn stopped() -> Self {
+            Self {
+                state: Mutex::new(FakeLifecycleState {
+                    identity: None,
+                    next_pid: 42,
+                    spawn_count: 0,
+                    stop_count: 0,
+                    events: Vec::new(),
+                    pause_next_start: None,
+                    pause_next_stop: None,
+                    fail_next_start: None,
+                    fail_next_stop: None,
+                    replace_on_start: false,
+                }),
+            }
+        }
+
+        fn running(identity: GatewayIdentity) -> Self {
+            let backend = Self::stopped();
+            backend.state.lock().unwrap().identity = Some(identity);
+            backend
+        }
+
+        fn with_next_pid(self, pid: u32) -> Self {
+            self.state.lock().unwrap().next_pid = pid;
+            self
+        }
+
+        fn pause_next_start(self, barrier: Arc<Barrier>) -> Self {
+            self.state.lock().unwrap().pause_next_start = Some(barrier);
+            self
+        }
+
+        fn pause_next_stop(self, barrier: Arc<Barrier>) -> Self {
+            self.state.lock().unwrap().pause_next_stop = Some(barrier);
+            self
+        }
+
+        fn fail_next_start(self, message: &str) -> Self {
+            self.state.lock().unwrap().fail_next_start = Some(message.to_string());
+            self
+        }
+
+        fn replace_on_start(self) -> Self {
+            self.state.lock().unwrap().replace_on_start = true;
+            self
+        }
+
+        fn fail_next_stop(&self, message: &str) {
+            self.state.lock().unwrap().fail_next_stop = Some(message.to_string());
+        }
+
+        fn spawn_count(&self) -> usize {
+            self.state.lock().unwrap().spawn_count
+        }
+
+        fn stop_count(&self) -> usize {
+            self.state.lock().unwrap().stop_count
+        }
+
+        fn events(&self) -> Vec<String> {
+            self.state.lock().unwrap().events.clone()
+        }
+
+        fn replace_identity(&self, identity: GatewayIdentity) {
+            self.state.lock().unwrap().identity = Some(identity);
+        }
+
+        fn snapshot_from_state(state: &FakeLifecycleState) -> GatewayLifecycleSnapshot {
+            match &state.identity {
+                Some(identity) => GatewayLifecycleSnapshot {
+                    status: fake_status(true, format!("Gateway running with PID {}", identity.pid)),
+                    identity: Some(identity.clone()),
+                },
+                None => GatewayLifecycleSnapshot {
+                    status: fake_status(false, "Gateway is not running"),
+                    identity: None,
+                },
+            }
+        }
+    }
+
+    impl GatewayLifecycleBackend for FakeLifecycleBackend {
+        fn snapshot(&self) -> Result<GatewayLifecycleSnapshot, String> {
+            let mut state = self.state.lock().unwrap();
+            let event = state
+                .identity
+                .as_ref()
+                .map(|identity| format!("snapshot:{}", identity.pid))
+                .unwrap_or_else(|| "snapshot:none".to_string());
+            state.events.push(event);
+            Ok(Self::snapshot_from_state(&state))
+        }
+
+        fn start(&self) -> Result<GatewayStartOutcome, String> {
+            let (pause, snapshot) = {
+                let mut state = self.state.lock().unwrap();
+                if state.identity.is_some() && !state.replace_on_start {
+                    let snapshot = Self::snapshot_from_state(&state);
+                    return Ok(GatewayStartOutcome {
+                        snapshot,
+                        spawned: false,
+                    });
+                }
+                state.identity = None;
+                if let Some(failure) = state.fail_next_start.take() {
+                    return Err(failure);
+                }
+                let identity = fake_identity(state.next_pid);
+                state.spawn_count += 1;
+                state.events.push(format!("spawn:{}", identity.pid));
+                state.identity = Some(identity);
+                let pause = state.pause_next_start.take();
+                let snapshot = Self::snapshot_from_state(&state);
+                (pause, snapshot)
+            };
+            if let Some(pause) = pause {
+                pause.wait();
+            }
+            Ok(GatewayStartOutcome {
+                snapshot,
+                spawned: true,
+            })
+        }
+
+        fn can_reuse(&self, _snapshot: &GatewayLifecycleSnapshot) -> bool {
+            !self.state.lock().unwrap().replace_on_start
+        }
+
+        fn stop(&self) -> Result<AppStatus, String> {
+            let pause = {
+                let mut state = self.state.lock().unwrap();
+                if let Some(failure) = state.fail_next_stop.take() {
+                    return Err(failure);
+                }
+                state.stop_count += 1;
+                let pid = state.identity.take().map(|identity| identity.pid);
+                state.events.push(
+                    pid.map(|pid| format!("stop:{pid}"))
+                        .unwrap_or_else(|| "stop:none".to_string()),
+                );
+                state.pause_next_stop.take()
+            };
+            if let Some(pause) = pause {
+                pause.wait();
+            }
+            Ok(fake_status(false, "Gateway stopped"))
+        }
+    }
+
+    fn fake_status(running: bool, message: impl Into<String>) -> AppStatus {
+        AppStatus {
+            mode: "custom".to_string(),
+            proxy_running: running,
+            proxy_port: 9099,
+            proxy_build: running.then(|| "test".to_string()),
+            message: message.into(),
+            history_sync_status: None,
+            history_sync_message: None,
+        }
+    }
+}

--- a/src-tauri/src/gateway_lifecycle.rs
+++ b/src-tauri/src/gateway_lifecycle.rs
@@ -1,4 +1,8 @@
 use crate::AppStatus;
+use crate::gateway_transaction::{
+    GatewayLifecyclePhase, LifecycleTransactionGate,
+};
+use std::path::Path;
 use std::sync::{Mutex, MutexGuard, OnceLock};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -23,7 +27,9 @@ pub(crate) struct GatewayStartOutcome {
 }
 
 pub(crate) trait GatewayLifecycleBackend {
+    fn lifecycle_gate_path(&self) -> &Path;
     fn snapshot(&self) -> Result<GatewayLifecycleSnapshot, String>;
+    fn transitional_status(&self, phase: GatewayLifecyclePhase) -> Result<AppStatus, String>;
     fn start(&self) -> Result<GatewayStartOutcome, String>;
     fn stop(&self) -> Result<AppStatus, String>;
 
@@ -32,15 +38,7 @@ pub(crate) trait GatewayLifecycleBackend {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum LifecyclePhase {
-    Stopped,
-    Starting,
-    Running,
-    Stopping,
-    Restarting,
-    Failed,
-}
+type LifecyclePhase = GatewayLifecyclePhase;
 
 #[derive(Debug)]
 struct GatewayLifecycleState {
@@ -75,7 +73,20 @@ impl GatewayLifecycleCoordinator {
     where
         B: GatewayLifecycleBackend,
     {
-        let mut state = self.lock_state()?;
+        if let Some(phase) = LifecycleTransactionGate::inspect(backend.lifecycle_gate_path())? {
+            let status = backend.transitional_status(phase)?;
+            let mut state = self.lock_state();
+            state.phase = phase;
+            state.published = None;
+            state.last_error = None;
+            return Ok(GatewayLifecycleSnapshot {
+                status,
+                identity: None,
+            });
+        }
+        let _transaction =
+            LifecycleTransactionGate::acquire_silent(backend.lifecycle_gate_path())?;
+        let mut state = self.lock_state();
         match backend.snapshot() {
             Ok(snapshot) if snapshot.identity.is_some() => {
                 Self::publish_snapshot(&mut state, &snapshot, false)?;
@@ -101,29 +112,53 @@ impl GatewayLifecycleCoordinator {
         B: GatewayLifecycleBackend,
         Prepare: FnOnce() -> Result<(), String>,
     {
-        let mut state = self.lock_state()?;
-        state.phase = LifecyclePhase::Starting;
-        state.last_error = None;
+        let _transaction = LifecycleTransactionGate::acquire(
+            backend.lifecycle_gate_path(),
+            LifecyclePhase::Starting,
+        )?;
+        {
+            let mut state = self.lock_state();
+            state.phase = LifecyclePhase::Starting;
+            state.last_error = None;
+        }
 
         match backend.snapshot() {
             Ok(snapshot) if snapshot.identity.is_some() && backend.can_reuse(&snapshot) => {
+                let mut state = self.lock_state();
                 Self::publish_snapshot(&mut state, &snapshot, false)?;
                 return Ok(snapshot);
             }
-            Ok(_) => {}
-            Err(error) => return Self::fail_reconciliation(&mut state, error),
+            Ok(snapshot) if snapshot.identity.is_some() => {
+                let mut state = self.lock_state();
+                Self::publish_snapshot(&mut state, &snapshot, false)?;
+                state.phase = LifecyclePhase::Starting;
+            }
+            Ok(_) => {
+                let mut state = self.lock_state();
+                Self::clear_stopped(&mut state);
+                state.phase = LifecyclePhase::Starting;
+            }
+            Err(error) => {
+                let mut state = self.lock_state();
+                return Self::fail_reconciliation(&mut state, error);
+            }
         }
 
         if let Err(error) = prepare() {
+            let mut state = self.lock_state();
             return Self::fail_preserving_identity(&mut state, error);
         }
 
         match backend.start() {
             Ok(outcome) => {
+                let mut state = self.lock_state();
                 Self::publish_snapshot(&mut state, &outcome.snapshot, outcome.spawned)?;
                 Ok(outcome.snapshot)
             }
-            Err(error) => Self::fail(&mut state, error),
+            Err(error) => {
+                let mut state = self.lock_state();
+                Self::fail(&mut state, error)
+            }
         }
     }
 
@@ -131,25 +166,30 @@ impl GatewayLifecycleCoordinator {
     where
         B: GatewayLifecycleBackend,
     {
-        let mut state = self.lock_state()?;
-        state.phase = LifecyclePhase::Stopping;
-        state.last_error = None;
+        let _transaction = LifecycleTransactionGate::acquire(
+            backend.lifecycle_gate_path(),
+            LifecyclePhase::Stopping,
+        )?;
+        {
+            let mut state = self.lock_state();
+            state.phase = LifecyclePhase::Stopping;
+            state.last_error = None;
+        }
 
         match backend.stop() {
             Ok(status) if !status.proxy_running => {
-                state.phase = LifecyclePhase::Stopped;
-                state.published = None;
-                state.session_owned = None;
+                let mut state = self.lock_state();
+                Self::clear_stopped(&mut state);
                 Ok(status)
             }
             Ok(status) => {
-                state.phase = LifecyclePhase::Failed;
-                state.published = None;
-                state.session_owned = None;
-                state.last_error = Some(status.message.clone());
-                Ok(status)
+                let mut state = self.lock_state();
+                Self::fail_preserving_identity(&mut state, status.message)
             }
-            Err(error) => Self::fail_reconciliation(&mut state, error),
+            Err(error) => {
+                let mut state = self.lock_state();
+                Self::fail_reconciliation(&mut state, error)
+            }
         }
     }
 
@@ -162,19 +202,47 @@ impl GatewayLifecycleCoordinator {
         B: GatewayLifecycleBackend,
         Prepare: FnOnce() -> Result<(), String>,
     {
-        let mut state = self.lock_state()?;
-        state.phase = LifecyclePhase::Restarting;
-        state.last_error = None;
+        let _transaction = LifecycleTransactionGate::acquire(
+            backend.lifecycle_gate_path(),
+            LifecyclePhase::Restarting,
+        )?;
+        {
+            let mut state = self.lock_state();
+            state.phase = LifecyclePhase::Restarting;
+            state.last_error = None;
+        }
+
+        match backend.snapshot() {
+            Ok(snapshot) if snapshot.identity.is_some() => {
+                let mut state = self.lock_state();
+                Self::publish_snapshot(&mut state, &snapshot, false)?;
+                state.phase = LifecyclePhase::Restarting;
+            }
+            Ok(_) => {
+                let mut state = self.lock_state();
+                Self::clear_stopped(&mut state);
+                state.phase = LifecyclePhase::Restarting;
+            }
+            Err(error) => {
+                let mut state = self.lock_state();
+                return Self::fail_reconciliation(&mut state, error);
+            }
+        }
 
         if let Err(error) = prepare() {
+            let mut state = self.lock_state();
             return Self::fail_preserving_identity(&mut state, error);
         }
 
         let stopped = match backend.stop() {
             Ok(status) => status,
-            Err(error) => return Self::fail_reconciliation(&mut state, error),
+            Err(error) => {
+                let mut state = self.lock_state();
+                return Self::fail_reconciliation(&mut state, error);
+            }
         };
         if stopped.proxy_running {
+            let mut state = self.lock_state();
             return Self::fail(
                 &mut state,
                 format!(
@@ -183,45 +251,61 @@ impl GatewayLifecycleCoordinator {
                 ),
             );
         }
-        state.published = None;
-        state.session_owned = None;
+        {
+            let mut state = self.lock_state();
+            Self::clear_stopped(&mut state);
+            state.phase = LifecyclePhase::Restarting;
+        }
 
         match backend.start() {
             Ok(outcome) => {
+                let mut state = self.lock_state();
                 Self::publish_snapshot(&mut state, &outcome.snapshot, outcome.spawned)?;
                 Ok(outcome.snapshot)
             }
-            Err(error) => Self::fail(&mut state, error),
+            Err(error) => {
+                let mut state = self.lock_state();
+                Self::fail(&mut state, error)
+            }
         }
     }
 
     #[cfg(test)]
     fn published_identity(&self) -> Option<GatewayIdentity> {
-        self.state
-            .lock()
-            .ok()
-            .and_then(|state| state.published.clone())
+        self.lock_state().published.clone()
     }
 
     pub(crate) fn session_owned_identity(&self) -> Option<GatewayIdentity> {
-        self.state
-            .lock()
-            .ok()
-            .and_then(|state| state.session_owned.clone())
+        self.lock_state().session_owned.clone()
     }
 
     #[cfg(test)]
     fn phase(&self) -> LifecyclePhase {
-        self.state
-            .lock()
-            .map(|state| state.phase)
-            .unwrap_or(LifecyclePhase::Failed)
+        self.lock_state().phase
     }
 
-    fn lock_state(&self) -> Result<MutexGuard<'_, GatewayLifecycleState>, String> {
-        self.state
-            .lock()
-            .map_err(|_| "Gateway lifecycle coordinator lock is poisoned".to_string())
+    fn lock_state(&self) -> MutexGuard<'_, GatewayLifecycleState> {
+        match self.state.lock() {
+            Ok(state) => state,
+            Err(poisoned) => {
+                let mut state = poisoned.into_inner();
+                state.phase = LifecyclePhase::Failed;
+                state.published = None;
+                state.last_error = Some(
+                    "Gateway lifecycle state recovered after an internal panic; reconciliation is required"
+                        .to_string(),
+                );
+                self.state.clear_poison();
+                state
+            }
+        }
+    }
+
+    fn clear_stopped(state: &mut GatewayLifecycleState) {
+        state.phase = LifecyclePhase::Stopped;
+        state.published = None;
+        state.session_owned = None;
+        state.last_error = None;
     }
 
     fn publish_snapshot(
@@ -293,26 +377,63 @@ pub(crate) fn coordinator() -> &'static GatewayLifecycleCoordinator {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Arc, Barrier, Mutex};
+    use crate::gateway_transaction::{GatewayLifecyclePhase, LifecycleTransactionGate};
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::{mpsc, Arc, Barrier, Mutex};
     use std::thread;
+    use std::time::Duration;
+
+    #[derive(Clone)]
+    struct PauseControl {
+        entered: Arc<Barrier>,
+        release: Arc<Barrier>,
+    }
+
+    impl PauseControl {
+        fn new() -> Self {
+            Self {
+                entered: Arc::new(Barrier::new(2)),
+                release: Arc::new(Barrier::new(2)),
+            }
+        }
+
+        fn hold(&self) {
+            self.entered.wait();
+            self.release.wait();
+        }
+    }
 
     #[test]
     fn coordinator_coalesces_concurrent_starts_to_one_spawn_and_identity() {
         let coordinator = Arc::new(GatewayLifecycleCoordinator::new());
-        let entered_start = Arc::new(Barrier::new(2));
-        let backend =
-            Arc::new(FakeLifecycleBackend::stopped().pause_next_start(entered_start.clone()));
+        let pause = PauseControl::new();
+        let backend = Arc::new(FakeLifecycleBackend::stopped().pause_next_start(pause.clone()));
 
         let first_coordinator = Arc::clone(&coordinator);
         let first_backend = Arc::clone(&backend);
         let first =
             thread::spawn(move || first_coordinator.start(first_backend.as_ref(), || Ok(())));
-        entered_start.wait();
+        pause.entered.wait();
 
         let second_coordinator = Arc::clone(&coordinator);
         let second_backend = Arc::clone(&backend);
-        let second =
-            thread::spawn(move || second_coordinator.start(second_backend.as_ref(), || Ok(())));
+        let (second_attempt_tx, second_attempt_rx) = mpsc::channel();
+        let (second_done_tx, second_done_rx) = mpsc::channel();
+        let second = thread::spawn(move || {
+            second_attempt_tx.send(()).expect("publish second attempt");
+            let result = second_coordinator.start(second_backend.as_ref(), || Ok(()));
+            second_done_tx.send(()).expect("publish second completion");
+            result
+        });
+        second_attempt_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("second contender attempted start");
+        assert!(matches!(
+            second_done_rx.recv_timeout(Duration::from_millis(150)),
+            Err(mpsc::RecvTimeoutError::Timeout)
+        ));
+        pause.release.wait();
 
         let first = first
             .join()
@@ -374,23 +495,37 @@ mod tests {
     fn coordinator_restart_owns_stop_to_replacement_boundary_against_start() {
         let old_identity = fake_identity(51);
         let coordinator = Arc::new(GatewayLifecycleCoordinator::new());
-        let entered_stop = Arc::new(Barrier::new(2));
+        let pause = PauseControl::new();
         let backend = Arc::new(
             FakeLifecycleBackend::running(old_identity)
                 .with_next_pid(52)
-                .pause_next_stop(entered_stop.clone()),
+                .pause_next_stop(pause.clone()),
         );
 
         let restart_coordinator = Arc::clone(&coordinator);
         let restart_backend = Arc::clone(&backend);
         let restart =
             thread::spawn(move || restart_coordinator.restart(restart_backend.as_ref(), || Ok(())));
-        entered_stop.wait();
+        pause.entered.wait();
 
         let start_coordinator = Arc::clone(&coordinator);
         let start_backend = Arc::clone(&backend);
-        let concurrent_start =
-            thread::spawn(move || start_coordinator.start(start_backend.as_ref(), || Ok(())));
+        let (start_attempt_tx, start_attempt_rx) = mpsc::channel();
+        let (start_done_tx, start_done_rx) = mpsc::channel();
+        let concurrent_start = thread::spawn(move || {
+            start_attempt_tx.send(()).expect("publish start attempt");
+            let result = start_coordinator.start(start_backend.as_ref(), || Ok(()));
+            start_done_tx.send(()).expect("publish start completion");
+            result
+        });
+        start_attempt_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("concurrent start attempted");
+        assert!(matches!(
+            start_done_rx.recv_timeout(Duration::from_millis(150)),
+            Err(mpsc::RecvTimeoutError::Timeout)
+        ));
+        pause.release.wait();
 
         let replacement = restart
             .join()
@@ -405,26 +540,43 @@ mod tests {
         assert_eq!(reused.identity, replacement.identity);
         assert_eq!(backend.spawn_count(), 1);
         assert_eq!(backend.stop_count(), 1);
-        assert_eq!(backend.events(), vec!["stop:51", "spawn:52", "snapshot:52"]);
+        assert_eq!(
+            backend.events(),
+            vec!["snapshot:51", "stop:51", "spawn:52", "snapshot:52"]
+        );
         assert_eq!(coordinator.session_owned_identity(), replacement.identity);
     }
 
     #[test]
     fn coordinator_serializes_start_then_stop_without_stale_publication() {
         let coordinator = Arc::new(GatewayLifecycleCoordinator::new());
-        let entered_start = Arc::new(Barrier::new(2));
-        let backend =
-            Arc::new(FakeLifecycleBackend::stopped().pause_next_start(entered_start.clone()));
+        let pause = PauseControl::new();
+        let backend = Arc::new(FakeLifecycleBackend::stopped().pause_next_start(pause.clone()));
 
         let start_coordinator = Arc::clone(&coordinator);
         let start_backend = Arc::clone(&backend);
         let start =
             thread::spawn(move || start_coordinator.start(start_backend.as_ref(), || Ok(())));
-        entered_start.wait();
+        pause.entered.wait();
 
         let stop_coordinator = Arc::clone(&coordinator);
         let stop_backend = Arc::clone(&backend);
-        let stop = thread::spawn(move || stop_coordinator.stop(stop_backend.as_ref()));
+        let (stop_attempt_tx, stop_attempt_rx) = mpsc::channel();
+        let (stop_done_tx, stop_done_rx) = mpsc::channel();
+        let stop = thread::spawn(move || {
+            stop_attempt_tx.send(()).expect("publish stop attempt");
+            let result = stop_coordinator.stop(stop_backend.as_ref());
+            stop_done_tx.send(()).expect("publish stop completion");
+            result
+        });
+        stop_attempt_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("concurrent stop attempted");
+        assert!(matches!(
+            stop_done_rx.recv_timeout(Duration::from_millis(150)),
+            Err(mpsc::RecvTimeoutError::Timeout)
+        ));
+        pause.release.wait();
 
         assert!(start.join().expect("start thread").is_ok());
         let stopped = stop.join().expect("stop thread").expect("stop");
@@ -450,6 +602,70 @@ mod tests {
         assert_eq!(error, "spawn failed");
         assert_eq!(coordinator.published_identity(), None);
         assert_eq!(coordinator.session_owned_identity(), None);
+        assert_eq!(coordinator.phase(), LifecyclePhase::Failed);
+    }
+
+    #[test]
+    fn start_from_definitively_stopped_clears_stale_session_before_preparation_failure() {
+        let coordinator = GatewayLifecycleCoordinator::new();
+        let backend = FakeLifecycleBackend::stopped();
+        coordinator.start(&backend, || Ok(())).expect("session start");
+        backend.replace_identity(None);
+
+        let error = coordinator
+            .start(&backend, || Err("preparation failed".to_string()))
+            .expect_err("preparation should fail");
+
+        assert_eq!(error, "preparation failed");
+        assert_eq!(coordinator.published_identity(), None);
+        assert_eq!(coordinator.session_owned_identity(), None);
+    }
+
+    #[test]
+    fn status_reports_cross_process_transition_without_entering_backend_snapshot() {
+        let coordinator = GatewayLifecycleCoordinator::new();
+        let backend = FakeLifecycleBackend::stopped();
+        let _guard = LifecycleTransactionGate::acquire(
+            backend.lifecycle_gate_path(),
+            GatewayLifecyclePhase::Restarting,
+        )
+        .expect("hold external gate");
+
+        let snapshot = coordinator.status(&backend).expect("transition status");
+
+        assert_eq!(
+            snapshot.status.gateway_lifecycle,
+            GatewayLifecyclePhase::Restarting
+        );
+        assert!(backend.events().is_empty());
+    }
+
+    #[test]
+    fn poisoned_state_recovers_failed_without_dropping_session_handoff() {
+        let coordinator = Arc::new(GatewayLifecycleCoordinator::new());
+        let backend = FakeLifecycleBackend::stopped();
+        let started = coordinator.start(&backend, || Ok(())).expect("session start");
+        let poison_target = Arc::clone(&coordinator);
+        let _ = thread::spawn(move || {
+            let _guard = poison_target.state.lock().expect("state lock");
+            panic!("poison lifecycle state");
+        })
+        .join();
+
+        assert_eq!(coordinator.session_owned_identity(), started.identity);
+        assert_eq!(coordinator.phase(), LifecyclePhase::Failed);
+    }
+
+    #[test]
+    fn unsuccessful_stop_is_an_error_not_a_successful_running_status() {
+        let coordinator = GatewayLifecycleCoordinator::new();
+        let backend = FakeLifecycleBackend::running(fake_identity(91)).leave_running_on_stop();
+
+        let error = coordinator
+            .stop(&backend)
+            .expect_err("a stop that leaves the Gateway running must fail");
+
+        assert!(error.contains("did not stop"));
         assert_eq!(coordinator.phase(), LifecyclePhase::Failed);
     }
 
@@ -511,6 +727,7 @@ mod tests {
 
     struct FakeLifecycleBackend {
         state: Mutex<FakeLifecycleState>,
+        gate_path: PathBuf,
     }
 
     struct FakeLifecycleState {
@@ -519,16 +736,23 @@ mod tests {
         spawn_count: usize,
         stop_count: usize,
         events: Vec<String>,
-        pause_next_start: Option<Arc<Barrier>>,
-        pause_next_stop: Option<Arc<Barrier>>,
+        pause_next_start: Option<PauseControl>,
+        pause_next_stop: Option<PauseControl>,
         fail_next_start: Option<String>,
         fail_next_stop: Option<String>,
         replace_on_start: bool,
+        leave_running_on_stop: bool,
     }
 
     impl FakeLifecycleBackend {
         fn stopped() -> Self {
+            static NEXT_GATE: AtomicU64 = AtomicU64::new(1);
             Self {
+                gate_path: std::env::temp_dir().join(format!(
+                    "codexhub-fake-lifecycle-{}-{}.lock",
+                    std::process::id(),
+                    NEXT_GATE.fetch_add(1, Ordering::Relaxed)
+                )),
                 state: Mutex::new(FakeLifecycleState {
                     identity: None,
                     next_pid: 42,
@@ -540,6 +764,7 @@ mod tests {
                     fail_next_start: None,
                     fail_next_stop: None,
                     replace_on_start: false,
+                    leave_running_on_stop: false,
                 }),
             }
         }
@@ -555,14 +780,23 @@ mod tests {
             self
         }
 
-        fn pause_next_start(self, barrier: Arc<Barrier>) -> Self {
-            self.state.lock().unwrap().pause_next_start = Some(barrier);
+        fn pause_next_start(self, pause: PauseControl) -> Self {
+            self.state.lock().unwrap().pause_next_start = Some(pause);
             self
         }
 
-        fn pause_next_stop(self, barrier: Arc<Barrier>) -> Self {
-            self.state.lock().unwrap().pause_next_stop = Some(barrier);
+        fn pause_next_stop(self, pause: PauseControl) -> Self {
+            self.state.lock().unwrap().pause_next_stop = Some(pause);
             self
+        }
+
+        fn leave_running_on_stop(self) -> Self {
+            self.state.lock().unwrap().leave_running_on_stop = true;
+            self
+        }
+
+        fn lifecycle_gate_path(&self) -> &Path {
+            &self.gate_path
         }
 
         fn fail_next_start(self, message: &str) -> Self {
@@ -591,18 +825,26 @@ mod tests {
             self.state.lock().unwrap().events.clone()
         }
 
-        fn replace_identity(&self, identity: GatewayIdentity) {
-            self.state.lock().unwrap().identity = Some(identity);
+        fn replace_identity(&self, identity: impl Into<Option<GatewayIdentity>>) {
+            self.state.lock().unwrap().identity = identity.into();
         }
 
         fn snapshot_from_state(state: &FakeLifecycleState) -> GatewayLifecycleSnapshot {
             match &state.identity {
                 Some(identity) => GatewayLifecycleSnapshot {
-                    status: fake_status(true, format!("Gateway running with PID {}", identity.pid)),
+                    status: fake_status(
+                        true,
+                        format!("Gateway running with PID {}", identity.pid),
+                        GatewayLifecyclePhase::Running,
+                    ),
                     identity: Some(identity.clone()),
                 },
                 None => GatewayLifecycleSnapshot {
-                    status: fake_status(false, "Gateway is not running"),
+                    status: fake_status(
+                        false,
+                        "Gateway is not running",
+                        GatewayLifecyclePhase::Stopped,
+                    ),
                     identity: None,
                 },
             }
@@ -610,6 +852,17 @@ mod tests {
     }
 
     impl GatewayLifecycleBackend for FakeLifecycleBackend {
+        fn lifecycle_gate_path(&self) -> &Path {
+            self.lifecycle_gate_path()
+        }
+
+        fn transitional_status(
+            &self,
+            phase: GatewayLifecyclePhase,
+        ) -> Result<AppStatus, String> {
+            Ok(fake_status(false, format!("Gateway is {phase:?}"), phase))
+        }
+
         fn snapshot(&self) -> Result<GatewayLifecycleSnapshot, String> {
             let mut state = self.state.lock().unwrap();
             let event = state
@@ -644,7 +897,7 @@ mod tests {
                 (pause, snapshot)
             };
             if let Some(pause) = pause {
-                pause.wait();
+                pause.hold();
             }
             Ok(GatewayStartOutcome {
                 snapshot,
@@ -657,33 +910,54 @@ mod tests {
         }
 
         fn stop(&self) -> Result<AppStatus, String> {
-            let pause = {
+            let (pause, leave_running) = {
                 let mut state = self.state.lock().unwrap();
                 if let Some(failure) = state.fail_next_stop.take() {
                     return Err(failure);
                 }
                 state.stop_count += 1;
-                let pid = state.identity.take().map(|identity| identity.pid);
+                let pid = if state.leave_running_on_stop {
+                    state.identity.as_ref().map(|identity| identity.pid)
+                } else {
+                    state.identity.take().map(|identity| identity.pid)
+                };
                 state.events.push(
                     pid.map(|pid| format!("stop:{pid}"))
                         .unwrap_or_else(|| "stop:none".to_string()),
                 );
-                state.pause_next_stop.take()
+                (state.pause_next_stop.take(), state.leave_running_on_stop)
             };
             if let Some(pause) = pause {
-                pause.wait();
+                pause.hold();
             }
-            Ok(fake_status(false, "Gateway stopped"))
+            Ok(fake_status(
+                leave_running,
+                if leave_running {
+                    "Gateway did not stop"
+                } else {
+                    "Gateway stopped"
+                },
+                if leave_running {
+                    GatewayLifecyclePhase::Running
+                } else {
+                    GatewayLifecyclePhase::Stopped
+                },
+            ))
         }
     }
 
-    fn fake_status(running: bool, message: impl Into<String>) -> AppStatus {
+    fn fake_status(
+        running: bool,
+        message: impl Into<String>,
+        gateway_lifecycle: GatewayLifecyclePhase,
+    ) -> AppStatus {
         AppStatus {
             mode: "custom".to_string(),
             proxy_running: running,
             proxy_port: 9099,
             proxy_build: running.then(|| "test".to_string()),
             message: message.into(),
+            gateway_lifecycle,
             history_sync_status: None,
             history_sync_message: None,
         }

--- a/src-tauri/src/gateway_lifecycle.rs
+++ b/src-tauri/src/gateway_lifecycle.rs
@@ -1,6 +1,6 @@
 use crate::AppStatus;
 use crate::gateway_transaction::{
-    GatewayLifecyclePhase, LifecycleTransactionGate,
+    GatewayLifecyclePhase, LifecycleGateAccess, LifecycleTransactionGate,
 };
 use std::path::Path;
 use std::sync::{Mutex, MutexGuard, OnceLock};
@@ -11,6 +11,7 @@ pub struct GatewayIdentity {
     pub port: u16,
     pub script_path: String,
     pub script_sha256: Option<String>,
+    pub process_start_id: Option<String>,
     pub started_at_unix_ms: u64,
 }
 
@@ -26,11 +27,26 @@ pub(crate) struct GatewayStartOutcome {
     pub(crate) spawned: bool,
 }
 
+#[derive(Debug)]
+pub(crate) struct GatewayStartFailure {
+    pub(crate) message: String,
+    pub(crate) recovery_identity: Option<GatewayIdentity>,
+}
+
+impl From<String> for GatewayStartFailure {
+    fn from(message: String) -> Self {
+        Self {
+            message,
+            recovery_identity: None,
+        }
+    }
+}
+
 pub(crate) trait GatewayLifecycleBackend {
     fn lifecycle_gate_path(&self) -> &Path;
     fn snapshot(&self) -> Result<GatewayLifecycleSnapshot, String>;
     fn transitional_status(&self, phase: GatewayLifecyclePhase) -> Result<AppStatus, String>;
-    fn start(&self) -> Result<GatewayStartOutcome, String>;
+    fn start(&self) -> Result<GatewayStartOutcome, GatewayStartFailure>;
     fn stop(&self) -> Result<AppStatus, String>;
 
     fn can_reuse(&self, _snapshot: &GatewayLifecycleSnapshot) -> bool {
@@ -65,7 +81,7 @@ pub(crate) struct GatewayLifecycleCoordinator {
 }
 
 impl GatewayLifecycleCoordinator {
-    fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self::default()
     }
 
@@ -73,33 +89,40 @@ impl GatewayLifecycleCoordinator {
     where
         B: GatewayLifecycleBackend,
     {
-        if let Some(phase) = LifecycleTransactionGate::inspect(backend.lifecycle_gate_path())? {
-            let status = backend.transitional_status(phase)?;
-            let mut state = self.lock_state();
-            state.phase = phase;
-            state.published = None;
-            state.last_error = None;
-            return Ok(GatewayLifecycleSnapshot {
-                status,
-                identity: None,
-            });
-        }
-        let _transaction =
-            LifecycleTransactionGate::acquire_silent(backend.lifecycle_gate_path())?;
-        let mut state = self.lock_state();
+        let _transaction = match LifecycleTransactionGate::inspect_or_acquire(
+            backend.lifecycle_gate_path(),
+        )? {
+            LifecycleGateAccess::Held(phase) => {
+                let status = backend.transitional_status(phase)?;
+                let mut state = self.lock_state();
+                state.phase = phase;
+                state.published = None;
+                state.last_error = None;
+                return Ok(GatewayLifecycleSnapshot {
+                    status,
+                    identity: None,
+                });
+            }
+            LifecycleGateAccess::Acquired(transaction) => transaction,
+        };
         match backend.snapshot() {
             Ok(snapshot) if snapshot.identity.is_some() => {
+                let mut state = self.lock_state();
                 Self::publish_snapshot(&mut state, &snapshot, false)?;
                 Ok(snapshot)
             }
             Ok(snapshot) => {
+                let mut state = self.lock_state();
                 state.phase = LifecyclePhase::Stopped;
                 state.published = None;
                 state.session_owned = None;
                 state.last_error = None;
                 Ok(snapshot)
             }
-            Err(error) => Self::fail_reconciliation(&mut state, error),
+            Err(error) => {
+                let mut state = self.lock_state();
+                Self::fail_reconciliation(&mut state, error)
+            }
         }
     }
 
@@ -155,9 +178,9 @@ impl GatewayLifecycleCoordinator {
                 Self::publish_snapshot(&mut state, &outcome.snapshot, outcome.spawned)?;
                 Ok(outcome.snapshot)
             }
-            Err(error) => {
+            Err(failure) => {
                 let mut state = self.lock_state();
-                Self::fail(&mut state, error)
+                Self::fail_with_recovery(&mut state, failure)
             }
         }
     }
@@ -263,9 +286,9 @@ impl GatewayLifecycleCoordinator {
                 Self::publish_snapshot(&mut state, &outcome.snapshot, outcome.spawned)?;
                 Ok(outcome.snapshot)
             }
-            Err(error) => {
+            Err(failure) => {
                 let mut state = self.lock_state();
-                Self::fail(&mut state, error)
+                Self::fail_with_recovery(&mut state, failure)
             }
         }
     }
@@ -348,6 +371,17 @@ impl GatewayLifecycleCoordinator {
         Err(error)
     }
 
+    fn fail_with_recovery<T>(
+        state: &mut GatewayLifecycleState,
+        failure: GatewayStartFailure,
+    ) -> Result<T, String> {
+        state.phase = LifecyclePhase::Failed;
+        state.published = None;
+        state.session_owned = failure.recovery_identity;
+        state.last_error = Some(failure.message.clone());
+        Err(failure.message)
+    }
+
     fn fail_preserving_identity<T>(
         state: &mut GatewayLifecycleState,
         error: String,
@@ -418,21 +452,18 @@ mod tests {
 
         let second_coordinator = Arc::clone(&coordinator);
         let second_backend = Arc::clone(&backend);
-        let (second_attempt_tx, second_attempt_rx) = mpsc::channel();
+        let contention_ack = LifecycleTransactionGate::enable_test_contention_ack(
+            backend.lifecycle_gate_path(),
+        )
+        .expect("enable start contention acknowledgement");
         let (second_done_tx, second_done_rx) = mpsc::channel();
         let second = thread::spawn(move || {
-            second_attempt_tx.send(()).expect("publish second attempt");
             let result = second_coordinator.start(second_backend.as_ref(), || Ok(()));
             second_done_tx.send(()).expect("publish second completion");
             result
         });
-        second_attempt_rx
-            .recv_timeout(Duration::from_secs(1))
-            .expect("second contender attempted start");
-        assert!(matches!(
-            second_done_rx.recv_timeout(Duration::from_millis(150)),
-            Err(mpsc::RecvTimeoutError::Timeout)
-        ));
+        wait_for_file(&contention_ack);
+        assert!(matches!(second_done_rx.try_recv(), Err(mpsc::TryRecvError::Empty)));
         pause.release.wait();
 
         let first = first
@@ -510,21 +541,18 @@ mod tests {
 
         let start_coordinator = Arc::clone(&coordinator);
         let start_backend = Arc::clone(&backend);
-        let (start_attempt_tx, start_attempt_rx) = mpsc::channel();
+        let contention_ack = LifecycleTransactionGate::enable_test_contention_ack(
+            backend.lifecycle_gate_path(),
+        )
+        .expect("enable restart/start contention acknowledgement");
         let (start_done_tx, start_done_rx) = mpsc::channel();
         let concurrent_start = thread::spawn(move || {
-            start_attempt_tx.send(()).expect("publish start attempt");
             let result = start_coordinator.start(start_backend.as_ref(), || Ok(()));
             start_done_tx.send(()).expect("publish start completion");
             result
         });
-        start_attempt_rx
-            .recv_timeout(Duration::from_secs(1))
-            .expect("concurrent start attempted");
-        assert!(matches!(
-            start_done_rx.recv_timeout(Duration::from_millis(150)),
-            Err(mpsc::RecvTimeoutError::Timeout)
-        ));
+        wait_for_file(&contention_ack);
+        assert!(matches!(start_done_rx.try_recv(), Err(mpsc::TryRecvError::Empty)));
         pause.release.wait();
 
         let replacement = restart
@@ -561,21 +589,18 @@ mod tests {
 
         let stop_coordinator = Arc::clone(&coordinator);
         let stop_backend = Arc::clone(&backend);
-        let (stop_attempt_tx, stop_attempt_rx) = mpsc::channel();
+        let contention_ack = LifecycleTransactionGate::enable_test_contention_ack(
+            backend.lifecycle_gate_path(),
+        )
+        .expect("enable start/stop contention acknowledgement");
         let (stop_done_tx, stop_done_rx) = mpsc::channel();
         let stop = thread::spawn(move || {
-            stop_attempt_tx.send(()).expect("publish stop attempt");
             let result = stop_coordinator.stop(stop_backend.as_ref());
             stop_done_tx.send(()).expect("publish stop completion");
             result
         });
-        stop_attempt_rx
-            .recv_timeout(Duration::from_secs(1))
-            .expect("concurrent stop attempted");
-        assert!(matches!(
-            stop_done_rx.recv_timeout(Duration::from_millis(150)),
-            Err(mpsc::RecvTimeoutError::Timeout)
-        ));
+        wait_for_file(&contention_ack);
+        assert!(matches!(stop_done_rx.try_recv(), Err(mpsc::TryRecvError::Empty)));
         pause.release.wait();
 
         assert!(start.join().expect("start thread").is_ok());
@@ -602,6 +627,23 @@ mod tests {
         assert_eq!(error, "spawn failed");
         assert_eq!(coordinator.published_identity(), None);
         assert_eq!(coordinator.session_owned_identity(), None);
+        assert_eq!(coordinator.phase(), LifecyclePhase::Failed);
+    }
+
+    #[test]
+    fn coordinator_failed_start_preserves_structured_recovery_handoff() {
+        let recovery = fake_identity(73);
+        let coordinator = GatewayLifecycleCoordinator::new();
+        let backend = FakeLifecycleBackend::stopped()
+            .fail_next_start_with_recovery("startup failed", recovery.clone());
+
+        let error = coordinator
+            .start(&backend, || Ok(()))
+            .expect_err("start should surface recovery failure");
+
+        assert_eq!(error, "startup failed");
+        assert_eq!(coordinator.published_identity(), None);
+        assert_eq!(coordinator.session_owned_identity(), Some(recovery));
         assert_eq!(coordinator.phase(), LifecyclePhase::Failed);
     }
 
@@ -721,8 +763,20 @@ mod tests {
             port: 9099,
             script_path: "C:/CodexHub/codex_proxy.py".to_string(),
             script_sha256: Some("fake-sha256".to_string()),
+            process_start_id: Some(format!("fake-start-{pid}")),
             started_at_unix_ms: u64::from(pid),
         }
+    }
+
+    fn wait_for_file(path: &Path) {
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        while std::time::Instant::now() < deadline {
+            if path.exists() {
+                return;
+            }
+            thread::yield_now();
+        }
+        panic!("gate-boundary contention acknowledgement was not published: {}", path.display());
     }
 
     struct FakeLifecycleBackend {
@@ -739,6 +793,7 @@ mod tests {
         pause_next_start: Option<PauseControl>,
         pause_next_stop: Option<PauseControl>,
         fail_next_start: Option<String>,
+        fail_next_start_recovery: Option<GatewayIdentity>,
         fail_next_stop: Option<String>,
         replace_on_start: bool,
         leave_running_on_stop: bool,
@@ -762,6 +817,7 @@ mod tests {
                     pause_next_start: None,
                     pause_next_stop: None,
                     fail_next_start: None,
+                    fail_next_start_recovery: None,
                     fail_next_stop: None,
                     replace_on_start: false,
                     leave_running_on_stop: false,
@@ -801,6 +857,18 @@ mod tests {
 
         fn fail_next_start(self, message: &str) -> Self {
             self.state.lock().unwrap().fail_next_start = Some(message.to_string());
+            self
+        }
+
+        fn fail_next_start_with_recovery(
+            self,
+            message: &str,
+            recovery: GatewayIdentity,
+        ) -> Self {
+            let mut state = self.state.lock().unwrap();
+            state.fail_next_start = Some(message.to_string());
+            state.fail_next_start_recovery = Some(recovery);
+            drop(state);
             self
         }
 
@@ -874,7 +942,7 @@ mod tests {
             Ok(Self::snapshot_from_state(&state))
         }
 
-        fn start(&self) -> Result<GatewayStartOutcome, String> {
+        fn start(&self) -> Result<GatewayStartOutcome, GatewayStartFailure> {
             let (pause, snapshot) = {
                 let mut state = self.state.lock().unwrap();
                 if state.identity.is_some() && !state.replace_on_start {
@@ -886,7 +954,10 @@ mod tests {
                 }
                 state.identity = None;
                 if let Some(failure) = state.fail_next_start.take() {
-                    return Err(failure);
+                    return Err(GatewayStartFailure {
+                        message: failure,
+                        recovery_identity: state.fail_next_start_recovery.take(),
+                    });
                 }
                 let identity = fake_identity(state.next_pid);
                 state.spawn_count += 1;

--- a/src-tauri/src/gateway_transaction.rs
+++ b/src-tauri/src/gateway_transaction.rs
@@ -1,0 +1,305 @@
+use serde::{Deserialize, Serialize};
+use std::fs::{self, File, OpenOptions};
+use std::path::{Path, PathBuf};
+use std::thread;
+use std::time::{Duration, Instant};
+
+const PHASE_PUBLICATION_TIMEOUT: Duration = Duration::from_millis(250);
+const PHASE_PUBLICATION_POLL: Duration = Duration::from_millis(5);
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GatewayLifecyclePhase {
+    #[default]
+    Stopped,
+    Starting,
+    Running,
+    Stopping,
+    Restarting,
+    Failed,
+}
+
+impl GatewayLifecyclePhase {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Stopped => "stopped",
+            Self::Starting => "starting",
+            Self::Running => "running",
+            Self::Stopping => "stopping",
+            Self::Restarting => "restarting",
+            Self::Failed => "failed",
+        }
+    }
+
+    fn parse(value: &str) -> Option<Self> {
+        match value.trim() {
+            "stopped" => Some(Self::Stopped),
+            "starting" => Some(Self::Starting),
+            "running" => Some(Self::Running),
+            "stopping" => Some(Self::Stopping),
+            "restarting" => Some(Self::Restarting),
+            "failed" => Some(Self::Failed),
+            _ => None,
+        }
+    }
+}
+
+/// One OS-released lifecycle transaction gate shared by every CodexHub process.
+///
+/// This intentionally uses the platform file-lock primitive rather than the
+/// repository's atomic-write lock files: there is no stale-lock deletion or
+/// recovery policy, because the operating system releases ownership when the
+/// process or file handle exits.
+pub(crate) struct LifecycleTransactionGate {
+    file: File,
+    phase_path: PathBuf,
+}
+
+impl LifecycleTransactionGate {
+    pub(crate) fn acquire_silent(path: &Path) -> Result<Self, String> {
+        let file = open_gate_file(path)?;
+        file.lock().map_err(|error| {
+            format!(
+                "failed to acquire Gateway lifecycle transaction gate {}: {error}",
+                path.display()
+            )
+        })?;
+        Ok(Self {
+            file,
+            phase_path: phase_path(path),
+        })
+    }
+
+    pub(crate) fn acquire(
+        path: &Path,
+        phase: GatewayLifecyclePhase,
+    ) -> Result<Self, String> {
+        let file = open_gate_file(path)?;
+        file.lock().map_err(|error| {
+            format!(
+                "failed to acquire Gateway lifecycle transaction gate {}: {error}",
+                path.display()
+            )
+        })?;
+        let phase_path = phase_path(path);
+        if let Err(error) = fs::write(&phase_path, phase.as_str()) {
+            let _ = file.unlock();
+            return Err(format!(
+                "failed to publish Gateway lifecycle phase {}: {error}",
+                phase_path.display()
+            ));
+        }
+        Ok(Self { file, phase_path })
+    }
+
+    /// Returns the phase held by another process, or `None` while this caller
+    /// can own the transaction gate. A bounded retry closes the tiny interval
+    /// between OS-lock acquisition and phase publication.
+    pub(crate) fn inspect(path: &Path) -> Result<Option<GatewayLifecyclePhase>, String> {
+        let deadline = Instant::now() + PHASE_PUBLICATION_TIMEOUT;
+        loop {
+            let file = open_gate_file(path)?;
+            match file.try_lock() {
+                Ok(()) => {
+                    let _ = fs::remove_file(phase_path(path));
+                    file.unlock().map_err(|error| {
+                        format!(
+                            "failed to release Gateway lifecycle transaction gate {}: {error}",
+                            path.display()
+                        )
+                    })?;
+                    return Ok(None);
+                }
+                Err(std::fs::TryLockError::WouldBlock) => {
+                    if let Ok(value) = fs::read_to_string(phase_path(path)) {
+                        if let Some(phase) = GatewayLifecyclePhase::parse(&value) {
+                            return Ok(Some(phase));
+                        }
+                    }
+                    if Instant::now() >= deadline {
+                        return Err(format!(
+                            "Gateway lifecycle transaction gate {} is held without a readable phase",
+                            path.display()
+                        ));
+                    }
+                    thread::sleep(PHASE_PUBLICATION_POLL);
+                }
+                Err(std::fs::TryLockError::Error(error)) => {
+                    return Err(format!(
+                        "failed to inspect Gateway lifecycle transaction gate {}: {error}",
+                        path.display()
+                    ))
+                }
+            }
+        }
+    }
+}
+
+impl Drop for LifecycleTransactionGate {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.phase_path);
+        let _ = self.file.unlock();
+    }
+}
+
+fn open_gate_file(path: &Path) -> Result<File, String> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|error| {
+            format!(
+                "failed to create Gateway lifecycle directory {}: {error}",
+                parent.display()
+            )
+        })?;
+    }
+    OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(path)
+        .map_err(|error| {
+            format!(
+                "failed to open Gateway lifecycle transaction gate {}: {error}",
+                path.display()
+            )
+        })
+}
+
+fn phase_path(path: &Path) -> PathBuf {
+    let mut value = path.as_os_str().to_os_string();
+    value.push(".phase");
+    PathBuf::from(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{GatewayLifecyclePhase, LifecycleTransactionGate};
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::process::{Command, Stdio};
+    use std::thread;
+    use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+    const HELPER_ENV: &str = "CODEXHUB_LIFECYCLE_GATE_HELPER";
+    const LOCK_ENV: &str = "CODEXHUB_LIFECYCLE_GATE_PATH";
+    const ATTEMPTED_ENV: &str = "CODEXHUB_LIFECYCLE_GATE_ATTEMPTED";
+    const ENTERED_ENV: &str = "CODEXHUB_LIFECYCLE_GATE_ENTERED";
+    const RELEASE_ENV: &str = "CODEXHUB_LIFECYCLE_GATE_RELEASE";
+
+    #[test]
+    fn lifecycle_gate_process_helper() {
+        if std::env::var_os(HELPER_ENV).is_none() {
+            return;
+        }
+        let lock_path = PathBuf::from(std::env::var_os(LOCK_ENV).expect("helper lock path"));
+        let attempted =
+            PathBuf::from(std::env::var_os(ATTEMPTED_ENV).expect("helper attempted path"));
+        let entered = PathBuf::from(std::env::var_os(ENTERED_ENV).expect("helper entered path"));
+        let release = PathBuf::from(std::env::var_os(RELEASE_ENV).expect("helper release path"));
+
+        fs::write(&attempted, b"attempted").expect("publish helper attempt");
+        let _guard = LifecycleTransactionGate::acquire(
+            &lock_path,
+            GatewayLifecyclePhase::Starting,
+        )
+        .expect("helper acquire lifecycle gate");
+        fs::write(&entered, b"entered").expect("publish helper entry");
+        wait_until(Duration::from_secs(10), || release.exists());
+    }
+
+    #[test]
+    fn lifecycle_gate_serializes_real_processes_and_reports_holder_phase() {
+        let root = test_root("cross-process");
+        let lock_path = root.join("lifecycle.lock");
+        let first_attempted = root.join("first-attempted");
+        let first_entered = root.join("first-entered");
+        let first_release = root.join("first-release");
+        let second_attempted = root.join("second-attempted");
+        let second_entered = root.join("second-entered");
+        let second_release = root.join("second-release");
+
+        let mut first = spawn_helper(
+            &lock_path,
+            &first_attempted,
+            &first_entered,
+            &first_release,
+        );
+        wait_until(Duration::from_secs(10), || first_entered.exists());
+        let mut second = spawn_helper(
+            &lock_path,
+            &second_attempted,
+            &second_entered,
+            &second_release,
+        );
+
+        wait_until(Duration::from_secs(10), || second_attempted.exists());
+        thread::sleep(Duration::from_millis(100));
+        assert!(
+            !second_entered.exists(),
+            "second process must remain blocked while the first owns the production gate"
+        );
+        assert_eq!(
+            LifecycleTransactionGate::inspect(&lock_path).expect("inspect held gate"),
+            Some(GatewayLifecyclePhase::Starting)
+        );
+
+        fs::write(&first_release, b"release").expect("release first helper");
+        wait_until(Duration::from_secs(10), || second_entered.exists());
+        fs::write(&second_release, b"release").expect("release second helper");
+        assert!(first.wait().expect("wait first helper").success());
+        assert!(second.wait().expect("wait second helper").success());
+        assert_eq!(
+            LifecycleTransactionGate::inspect(&lock_path).expect("inspect released gate"),
+            None
+        );
+        let _ = fs::remove_dir_all(root);
+    }
+
+    fn spawn_helper(
+        lock_path: &Path,
+        attempted: &Path,
+        entered: &Path,
+        release: &Path,
+    ) -> std::process::Child {
+        Command::new(std::env::current_exe().expect("current test executable"))
+            .args([
+                "--exact",
+                "gateway_transaction::tests::lifecycle_gate_process_helper",
+                "--nocapture",
+            ])
+            .env(HELPER_ENV, "1")
+            .env(LOCK_ENV, lock_path)
+            .env(ATTEMPTED_ENV, attempted)
+            .env(ENTERED_ENV, entered)
+            .env(RELEASE_ENV, release)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn lifecycle gate helper")
+    }
+
+    fn wait_until(timeout: Duration, condition: impl Fn() -> bool) {
+        let deadline = Instant::now() + timeout;
+        while Instant::now() < deadline {
+            if condition() {
+                return;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+        panic!("condition was not met within {timeout:?}");
+    }
+
+    fn test_root(label: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "codexhub-lifecycle-gate-{label}-{}-{nanos}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&path).expect("create test root");
+        path
+    }
+}

--- a/src-tauri/src/gateway_transaction.rs
+++ b/src-tauri/src/gateway_transaction.rs
@@ -2,14 +2,14 @@ use serde::{Deserialize, Serialize};
 use std::fs::{self, File, OpenOptions};
 use std::path::{Path, PathBuf};
 use std::thread;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
-const PHASE_PUBLICATION_TIMEOUT: Duration = Duration::from_millis(250);
 const PHASE_PUBLICATION_POLL: Duration = Duration::from_millis(5);
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum GatewayLifecyclePhase {
+    Unavailable,
     #[default]
     Stopped,
     Starting,
@@ -22,6 +22,7 @@ pub enum GatewayLifecyclePhase {
 impl GatewayLifecyclePhase {
     fn as_str(self) -> &'static str {
         match self {
+            Self::Unavailable => "unavailable",
             Self::Stopped => "stopped",
             Self::Starting => "starting",
             Self::Running => "running",
@@ -33,6 +34,7 @@ impl GatewayLifecyclePhase {
 
     fn parse(value: &str) -> Option<Self> {
         match value.trim() {
+            "unavailable" => Some(Self::Unavailable),
             "stopped" => Some(Self::Stopped),
             "starting" => Some(Self::Starting),
             "running" => Some(Self::Running),
@@ -55,15 +57,26 @@ pub(crate) struct LifecycleTransactionGate {
     phase_path: PathBuf,
 }
 
+pub(crate) enum LifecycleGateAccess {
+    Acquired(LifecycleTransactionGate),
+    Held(GatewayLifecyclePhase),
+}
+
+impl LifecycleGateAccess {
+    #[cfg(test)]
+    pub(crate) fn held_phase(&self) -> Option<GatewayLifecyclePhase> {
+        match self {
+            Self::Acquired(_) => None,
+            Self::Held(phase) => Some(*phase),
+        }
+    }
+}
+
 impl LifecycleTransactionGate {
+    #[cfg(test)]
     pub(crate) fn acquire_silent(path: &Path) -> Result<Self, String> {
         let file = open_gate_file(path)?;
-        file.lock().map_err(|error| {
-            format!(
-                "failed to acquire Gateway lifecycle transaction gate {}: {error}",
-                path.display()
-            )
-        })?;
+        lock_gate_file(&file, path)?;
         Ok(Self {
             file,
             phase_path: phase_path(path),
@@ -75,12 +88,7 @@ impl LifecycleTransactionGate {
         phase: GatewayLifecyclePhase,
     ) -> Result<Self, String> {
         let file = open_gate_file(path)?;
-        file.lock().map_err(|error| {
-            format!(
-                "failed to acquire Gateway lifecycle transaction gate {}: {error}",
-                path.display()
-            )
-        })?;
+        lock_gate_file(&file, path)?;
         let phase_path = phase_path(path);
         if let Err(error) = fs::write(&phase_path, phase.as_str()) {
             let _ = file.unlock();
@@ -92,36 +100,25 @@ impl LifecycleTransactionGate {
         Ok(Self { file, phase_path })
     }
 
-    /// Returns the phase held by another process, or `None` while this caller
-    /// can own the transaction gate. A bounded retry closes the tiny interval
-    /// between OS-lock acquisition and phase publication.
-    pub(crate) fn inspect(path: &Path) -> Result<Option<GatewayLifecyclePhase>, String> {
-        let deadline = Instant::now() + PHASE_PUBLICATION_TIMEOUT;
+    /// Atomically returns either an owned silent guard or the phase published
+    /// by a lifecycle holder. Phase-less status holders are waited out rather
+    /// than misclassified as corrupt after an arbitrary timeout.
+    pub(crate) fn inspect_or_acquire(path: &Path) -> Result<LifecycleGateAccess, String> {
+        let file = open_gate_file(path)?;
         loop {
-            let file = open_gate_file(path)?;
             match file.try_lock() {
                 Ok(()) => {
-                    let _ = fs::remove_file(phase_path(path));
-                    file.unlock().map_err(|error| {
-                        format!(
-                            "failed to release Gateway lifecycle transaction gate {}: {error}",
-                            path.display()
-                        )
-                    })?;
-                    return Ok(None);
+                    let phase_path = phase_path(path);
+                    let _ = fs::remove_file(&phase_path);
+                    return Ok(LifecycleGateAccess::Acquired(Self { file, phase_path }));
                 }
                 Err(std::fs::TryLockError::WouldBlock) => {
                     if let Ok(value) = fs::read_to_string(phase_path(path)) {
                         if let Some(phase) = GatewayLifecyclePhase::parse(&value) {
-                            return Ok(Some(phase));
+                            return Ok(LifecycleGateAccess::Held(phase));
                         }
                     }
-                    if Instant::now() >= deadline {
-                        return Err(format!(
-                            "Gateway lifecycle transaction gate {} is held without a readable phase",
-                            path.display()
-                        ));
-                    }
+                    notify_test_contention(path);
                     thread::sleep(PHASE_PUBLICATION_POLL);
                 }
                 Err(std::fs::TryLockError::Error(error)) => {
@@ -133,6 +130,60 @@ impl LifecycleTransactionGate {
             }
         }
     }
+
+    #[cfg(test)]
+    pub(crate) fn enable_test_contention_ack(path: &Path) -> Result<PathBuf, String> {
+        let watch = test_contention_watch_path(path);
+        let ack = test_contention_ack_path(path);
+        let _ = fs::remove_file(&ack);
+        fs::write(&watch, b"watch").map_err(|error| {
+            format!(
+                "failed to enable lifecycle contention acknowledgement {}: {error}",
+                watch.display()
+            )
+        })?;
+        Ok(ack)
+    }
+}
+
+fn lock_gate_file(file: &File, path: &Path) -> Result<(), String> {
+    match file.try_lock() {
+        Ok(()) => Ok(()),
+        Err(std::fs::TryLockError::WouldBlock) => {
+            notify_test_contention(path);
+            file.lock().map_err(|error| {
+                format!(
+                    "failed to acquire Gateway lifecycle transaction gate {}: {error}",
+                    path.display()
+                )
+            })
+        }
+        Err(std::fs::TryLockError::Error(error)) => Err(format!(
+            "failed to acquire Gateway lifecycle transaction gate {}: {error}",
+            path.display()
+        )),
+    }
+}
+
+#[cfg(test)]
+fn notify_test_contention(path: &Path) {
+    let watch = test_contention_watch_path(path);
+    if watch.exists() {
+        let _ = fs::write(test_contention_ack_path(path), b"would-block");
+    }
+}
+
+#[cfg(not(test))]
+fn notify_test_contention(_path: &Path) {}
+
+#[cfg(test)]
+fn test_contention_watch_path(path: &Path) -> PathBuf {
+    sidecar_path(path, ".test-contention-watch")
+}
+
+#[cfg(test)]
+fn test_contention_ack_path(path: &Path) -> PathBuf {
+    sidecar_path(path, ".test-contention-ack")
 }
 
 impl Drop for LifecycleTransactionGate {
@@ -166,14 +217,18 @@ fn open_gate_file(path: &Path) -> Result<File, String> {
 }
 
 fn phase_path(path: &Path) -> PathBuf {
+    sidecar_path(path, ".phase")
+}
+
+fn sidecar_path(path: &Path, suffix: &str) -> PathBuf {
     let mut value = path.as_os_str().to_os_string();
-    value.push(".phase");
+    value.push(suffix);
     PathBuf::from(value)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{GatewayLifecyclePhase, LifecycleTransactionGate};
+    use super::{GatewayLifecyclePhase, LifecycleGateAccess, LifecycleTransactionGate};
     use std::fs;
     use std::path::{Path, PathBuf};
     use std::process::{Command, Stdio};
@@ -182,7 +237,6 @@ mod tests {
 
     const HELPER_ENV: &str = "CODEXHUB_LIFECYCLE_GATE_HELPER";
     const LOCK_ENV: &str = "CODEXHUB_LIFECYCLE_GATE_PATH";
-    const ATTEMPTED_ENV: &str = "CODEXHUB_LIFECYCLE_GATE_ATTEMPTED";
     const ENTERED_ENV: &str = "CODEXHUB_LIFECYCLE_GATE_ENTERED";
     const RELEASE_ENV: &str = "CODEXHUB_LIFECYCLE_GATE_RELEASE";
 
@@ -192,12 +246,9 @@ mod tests {
             return;
         }
         let lock_path = PathBuf::from(std::env::var_os(LOCK_ENV).expect("helper lock path"));
-        let attempted =
-            PathBuf::from(std::env::var_os(ATTEMPTED_ENV).expect("helper attempted path"));
         let entered = PathBuf::from(std::env::var_os(ENTERED_ENV).expect("helper entered path"));
         let release = PathBuf::from(std::env::var_os(RELEASE_ENV).expect("helper release path"));
 
-        fs::write(&attempted, b"attempted").expect("publish helper attempt");
         let _guard = LifecycleTransactionGate::acquire(
             &lock_path,
             GatewayLifecyclePhase::Starting,
@@ -211,36 +262,35 @@ mod tests {
     fn lifecycle_gate_serializes_real_processes_and_reports_holder_phase() {
         let root = test_root("cross-process");
         let lock_path = root.join("lifecycle.lock");
-        let first_attempted = root.join("first-attempted");
         let first_entered = root.join("first-entered");
         let first_release = root.join("first-release");
-        let second_attempted = root.join("second-attempted");
         let second_entered = root.join("second-entered");
         let second_release = root.join("second-release");
 
         let mut first = spawn_helper(
             &lock_path,
-            &first_attempted,
             &first_entered,
             &first_release,
         );
         wait_until(Duration::from_secs(10), || first_entered.exists());
+        let second_attempted = LifecycleTransactionGate::enable_test_contention_ack(&lock_path)
+            .expect("enable gate-boundary contention ack");
         let mut second = spawn_helper(
             &lock_path,
-            &second_attempted,
             &second_entered,
             &second_release,
         );
 
         wait_until(Duration::from_secs(10), || second_attempted.exists());
-        thread::sleep(Duration::from_millis(100));
         assert!(
             !second_entered.exists(),
             "second process must remain blocked while the first owns the production gate"
         );
         assert_eq!(
-            LifecycleTransactionGate::inspect(&lock_path).expect("inspect held gate"),
-            Some(GatewayLifecyclePhase::Starting)
+            LifecycleTransactionGate::inspect_or_acquire(&lock_path)
+                .expect("inspect held gate")
+                .held_phase(),
+            Some(GatewayLifecyclePhase::Starting),
         );
 
         fs::write(&first_release, b"release").expect("release first helper");
@@ -249,15 +299,40 @@ mod tests {
         assert!(first.wait().expect("wait first helper").success());
         assert!(second.wait().expect("wait second helper").success());
         assert_eq!(
-            LifecycleTransactionGate::inspect(&lock_path).expect("inspect released gate"),
-            None
+            LifecycleTransactionGate::inspect_or_acquire(&lock_path)
+                .expect("inspect released gate")
+                .held_phase(),
+            None,
         );
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn silent_status_holder_is_waited_out_without_phase_timeout_or_inspect_gap() {
+        let root = test_root("silent-status");
+        let lock_path = root.join("lifecycle.lock");
+        let holder = LifecycleTransactionGate::acquire_silent(&lock_path).expect("silent holder");
+        let attempted = LifecycleTransactionGate::enable_test_contention_ack(&lock_path)
+            .expect("enable contention ack");
+        let contender_path = lock_path.clone();
+        let contender = thread::spawn(move || {
+            LifecycleTransactionGate::inspect_or_acquire(&contender_path)
+        });
+
+        wait_until(Duration::from_secs(10), || attempted.exists());
+        drop(holder);
+        let access = contender
+            .join()
+            .expect("status contender thread")
+            .expect("silent holder must not be misclassified");
+
+        assert!(matches!(access, LifecycleGateAccess::Acquired(_)));
+        drop(access);
         let _ = fs::remove_dir_all(root);
     }
 
     fn spawn_helper(
         lock_path: &Path,
-        attempted: &Path,
         entered: &Path,
         release: &Path,
     ) -> std::process::Child {
@@ -269,7 +344,6 @@ mod tests {
             ])
             .env(HELPER_ENV, "1")
             .env(LOCK_ENV, lock_path)
-            .env(ATTEMPTED_ENV, attempted)
             .env(ENTERED_ENV, entered)
             .env(RELEASE_ENV, release)
             .stdin(Stdio::null())

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -9,6 +9,7 @@ mod cli;
 mod config;
 mod diagnostics;
 mod gateway;
+mod gateway_lifecycle;
 mod history;
 mod models;
 mod openai_usage;
@@ -316,8 +317,7 @@ fn switch_mode(mode: String, auto_sync: bool, force_takeover: Option<bool>) -> R
 
 #[tauri::command]
 fn start_proxy() -> Result<AppStatus, String> {
-    official_refresh::refresh_before_official_activation()?;
-    proxy::start()
+    proxy::start_after(official_refresh::refresh_before_official_activation)
 }
 
 #[tauri::command]
@@ -327,8 +327,7 @@ fn stop_proxy() -> Result<AppStatus, String> {
 
 #[tauri::command]
 fn restart_proxy() -> Result<AppStatus, String> {
-    official_refresh::refresh_before_official_activation()?;
-    proxy::restart()
+    proxy::restart_after(official_refresh::refresh_before_official_activation)
 }
 
 #[tauri::command]
@@ -749,7 +748,7 @@ fn run_tray_action(app: &AppHandle, id: &str) {
             report_tray_action(app, "Start Gateway", start_proxy());
         }
         TRAY_STOP_GATEWAY => {
-            report_tray_action(app, "Stop Gateway", proxy::stop());
+            report_tray_action(app, "Stop Gateway", stop_proxy());
         }
         TRAY_RESTART_GATEWAY => {
             report_tray_action(app, "Restart Gateway", restart_proxy());
@@ -986,36 +985,38 @@ fn run_gui() {
 
 fn start_gateway_on_launch() {
     tauri::async_runtime::spawn_blocking(|| {
-        if let Err(error) = official_refresh::refresh_at_startup() {
-            log::warn!("startup Official model refresh failed: {error}");
-        }
         official_refresh::start_scheduled_refresh_loop();
         let Ok(settings) = config::get_settings() else {
             return;
         };
-        if let Err(error) = start_gateway_after_startup(
-            settings.auto_start_gateway,
-            official_refresh::refresh_before_official_activation,
-            proxy::start,
-        ) {
+        let start = || {
+            proxy::start_after(|| {
+                if let Err(error) = official_refresh::refresh_at_startup() {
+                    log::warn!("startup Official model refresh failed: {error}");
+                }
+                official_refresh::refresh_before_official_activation()
+            })
+        };
+        if let Err(error) = start_gateway_after_startup(settings.auto_start_gateway, start) {
             eprintln!("failed to start CodexHub gateway on app launch: {error}");
+        } else if !settings.auto_start_gateway {
+            if let Err(error) = official_refresh::refresh_at_startup() {
+                log::warn!("startup Official model refresh failed: {error}");
+            }
         }
     });
 }
 
-fn start_gateway_after_startup<ActivateOfficial, StartGateway>(
+fn start_gateway_after_startup<StartGateway>(
     auto_start_gateway: bool,
-    activate_official: ActivateOfficial,
     start_gateway: StartGateway,
 ) -> Result<bool, String>
 where
-    ActivateOfficial: FnOnce() -> Result<(), String>,
     StartGateway: FnOnce() -> Result<AppStatus, String>,
 {
     if !auto_start_gateway {
         return Ok(false);
     }
-    activate_official()?;
     start_gateway()?;
     Ok(true)
 }
@@ -1041,20 +1042,16 @@ mod tests {
     use std::cell::Cell;
 
     #[test]
-    fn auto_start_refuses_to_launch_the_gateway_without_a_safe_official_snapshot() {
+    fn auto_start_propagates_coordinated_precondition_failure_once() {
         let starts = Cell::new(0);
-        let error = start_gateway_after_startup(
-            true,
-            || Err("safe Official snapshot is unavailable".to_string()),
-            || {
-                starts.set(starts.get() + 1);
-                Ok(status())
-            },
-        )
-        .expect_err("unsafe Official activation must block auto-start");
+        let error = start_gateway_after_startup(true, || {
+            starts.set(starts.get() + 1);
+            Err("safe Official snapshot is unavailable".to_string())
+        })
+        .expect_err("coordinated precondition must block auto-start");
 
         assert!(error.contains("safe Official snapshot"));
-        assert_eq!(starts.get(), 0);
+        assert_eq!(starts.get(), 1);
     }
 
     #[test]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -22,6 +22,7 @@ mod web_bridge;
 
 use serde::{Deserialize, Serialize};
 use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
 use tauri::{AppHandle, Emitter, Manager, RunEvent, Window, WindowEvent};
 
 #[cfg(desktop)]
@@ -41,6 +42,7 @@ const TRAY_TOAST_EVENT: &str = "codexhub:toast";
 
 #[derive(Debug, Clone, Serialize)]
 struct TrayToast {
+    id: String,
     text: String,
     tone: String,
 }
@@ -205,7 +207,7 @@ impl AppStatus {
             proxy_port: app_flavor::default_gateway_port(),
             proxy_build: None,
             message: message.into(),
-            gateway_lifecycle: crate::gateway_transaction::GatewayLifecyclePhase::Stopped,
+            gateway_lifecycle: crate::gateway_transaction::GatewayLifecyclePhase::Unavailable,
             history_sync_status: None,
             history_sync_message: None,
         }
@@ -749,13 +751,13 @@ fn run_tray_action(app: &AppHandle, id: &str) {
             );
         }
         TRAY_START_GATEWAY => {
-            report_tray_action(app, "Start Gateway", start_proxy());
+            run_tray_lifecycle_action(app, "Start Gateway", start_proxy);
         }
         TRAY_STOP_GATEWAY => {
-            report_tray_action(app, "Stop Gateway", stop_proxy());
+            run_tray_lifecycle_action(app, "Stop Gateway", stop_proxy);
         }
         TRAY_RESTART_GATEWAY => {
-            report_tray_action(app, "Restart Gateway", restart_proxy());
+            run_tray_lifecycle_action(app, "Restart Gateway", restart_proxy);
         }
         TRAY_EXIT => app.exit(0),
         _ => {}
@@ -763,23 +765,60 @@ fn run_tray_action(app: &AppHandle, id: &str) {
 }
 
 fn report_tray_action(app: &AppHandle, action: &str, result: Result<AppStatus, String>) {
-    let toast = tray_toast_for(action, result);
+    let toast = tray_toast_for(next_tray_toast_id(), action, result);
+    emit_tray_toast(app, toast);
+}
+
+fn run_tray_lifecycle_action(
+    app: &AppHandle,
+    action: &'static str,
+    work: fn() -> Result<AppStatus, String>,
+) {
+    let toast_id = next_tray_toast_id();
+    emit_tray_toast(app, tray_loading_toast(toast_id.clone(), action));
+    let app = app.clone();
+    std::mem::drop(tauri::async_runtime::spawn_blocking(move || {
+        let result = work();
+        emit_tray_toast(&app, tray_toast_for(toast_id, action, result));
+    }));
+}
+
+fn emit_tray_toast(app: &AppHandle, toast: TrayToast) {
     if let Err(error) = app.emit(TRAY_TOAST_EVENT, toast) {
         log::warn!("failed to emit tray action feedback: {error}");
     }
 }
 
-fn tray_toast_for(action: &str, result: Result<AppStatus, String>) -> TrayToast {
+fn tray_loading_toast(id: String, action: &str) -> TrayToast {
+    TrayToast {
+        id,
+        text: format!("{action}..."),
+        tone: "loading".to_string(),
+    }
+}
+
+fn tray_toast_for(id: String, action: &str, result: Result<AppStatus, String>) -> TrayToast {
     match result {
         Ok(status) => TrayToast {
+            id,
             text: format!("{action}: {}", status.message),
             tone: "success".to_string(),
         },
         Err(error) => TrayToast {
+            id,
             text: format!("{action} failed: {error}"),
             tone: "error".to_string(),
         },
     }
+}
+
+fn next_tray_toast_id() -> String {
+    static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+    format!(
+        "tray-lifecycle-{}-{}",
+        std::process::id(),
+        NEXT_ID.fetch_add(1, Ordering::Relaxed)
+    )
 }
 
 #[cfg(target_os = "windows")]
@@ -1069,7 +1108,7 @@ fn main() {
 
 #[cfg(test)]
 mod tests {
-    use super::{start_gateway_after_startup, tray_toast_for, AppStatus};
+    use super::{start_gateway_after_startup, tray_loading_toast, tray_toast_for, AppStatus};
     use std::cell::Cell;
 
     #[test]
@@ -1087,14 +1126,21 @@ mod tests {
 
     #[test]
     fn tray_state_actions_always_produce_success_or_error_feedback() {
-        let success = tray_toast_for("Start Gateway", Ok(status()));
+        let loading = tray_loading_toast("same-toast".to_string(), "Start Gateway");
+        assert_eq!(loading.id, "same-toast");
+        assert_eq!(loading.tone, "loading");
+
+        let success = tray_toast_for("same-toast".to_string(), "Start Gateway", Ok(status()));
+        assert_eq!(success.id, loading.id);
         assert_eq!(success.tone, "success");
         assert!(success.text.contains("Start Gateway"));
 
         let failure = tray_toast_for(
+            "same-toast".to_string(),
             "Start Gateway",
             Err("safe snapshot unavailable".to_string()),
         );
+        assert_eq!(failure.id, loading.id);
         assert_eq!(failure.tone, "error");
         assert!(failure.text.contains("safe snapshot unavailable"));
     }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -10,6 +10,7 @@ mod config;
 mod diagnostics;
 mod gateway;
 mod gateway_lifecycle;
+mod gateway_transaction;
 mod history;
 mod models;
 mod openai_usage;
@@ -188,6 +189,8 @@ pub struct AppStatus {
     pub proxy_port: u16,
     pub proxy_build: Option<String>,
     pub message: String,
+    #[serde(default)]
+    pub gateway_lifecycle: gateway_transaction::GatewayLifecyclePhase,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub history_sync_status: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -202,6 +205,7 @@ impl AppStatus {
             proxy_port: app_flavor::default_gateway_port(),
             proxy_build: None,
             message: message.into(),
+            gateway_lifecycle: crate::gateway_transaction::GatewayLifecyclePhase::Stopped,
             history_sync_status: None,
             history_sync_message: None,
         }
@@ -984,13 +988,16 @@ fn run_gui() {
 }
 
 fn start_gateway_on_launch() {
-    tauri::async_runtime::spawn_blocking(|| {
+    let (ready_tx, ready_rx) = std::sync::mpsc::sync_channel(1);
+    std::thread::spawn(move || {
+        let mut launch_ready = StartupLaunchReady::new(ready_tx);
         official_refresh::start_scheduled_refresh_loop();
         let Ok(settings) = config::get_settings() else {
             return;
         };
         let start = || {
             proxy::start_after(|| {
+                launch_ready.signal();
                 if let Err(error) = official_refresh::refresh_at_startup() {
                     log::warn!("startup Official model refresh failed: {error}");
                 }
@@ -1000,11 +1007,35 @@ fn start_gateway_on_launch() {
         if let Err(error) = start_gateway_after_startup(settings.auto_start_gateway, start) {
             eprintln!("failed to start CodexHub gateway on app launch: {error}");
         } else if !settings.auto_start_gateway {
+            launch_ready.signal();
             if let Err(error) = official_refresh::refresh_at_startup() {
                 log::warn!("startup Official model refresh failed: {error}");
             }
         }
     });
+    // Do not expose the initial window until automatic startup either owns the
+    // cross-process gate (and publishes Starting) or has already completed.
+    let _ = ready_rx.recv();
+}
+
+struct StartupLaunchReady(Option<std::sync::mpsc::SyncSender<()>>);
+
+impl StartupLaunchReady {
+    fn new(sender: std::sync::mpsc::SyncSender<()>) -> Self {
+        Self(Some(sender))
+    }
+
+    fn signal(&mut self) {
+        if let Some(sender) = self.0.take() {
+            let _ = sender.send(());
+        }
+    }
+}
+
+impl Drop for StartupLaunchReady {
+    fn drop(&mut self) {
+        self.signal();
+    }
 }
 
 fn start_gateway_after_startup<StartGateway>(
@@ -1075,6 +1106,7 @@ mod tests {
             proxy_port: 9099,
             proxy_build: None,
             message: "Gateway state updated".to_string(),
+            gateway_lifecycle: crate::gateway_transaction::GatewayLifecyclePhase::Stopped,
             history_sync_status: None,
             history_sync_message: None,
         }

--- a/src-tauri/src/proxy.rs
+++ b/src-tauri/src/proxy.rs
@@ -1608,10 +1608,7 @@ where
     R: Read + AsRawHandle,
 {
     let mut chunk = [0u8; 1024];
-    loop {
-        let Some(buffer) = buffer.upgrade() else {
-            break;
-        };
+    while let Some(buffer) = buffer.upgrade() {
         let mut available = 0u32;
         let readable = unsafe {
             PeekNamedPipe(
@@ -2999,6 +2996,25 @@ mod tests {
     use std::thread;
     use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
+    fn wait_for_missing_process(pid: u32) {
+        // On Windows the inspection shells out to PowerShell/CIM, which can
+        // itself stall under parallel test load; retry instead of failing on
+        // one slow attempt.
+        let deadline = Instant::now() + Duration::from_secs(30);
+        let mut last = String::from("inspection did not run");
+        while Instant::now() < deadline {
+            match super::inspect_process(pid) {
+                Ok(InspectedProcess::Missing) => return,
+                Ok(InspectedProcess::Running(_)) => {
+                    last = format!("PID {pid} is still running");
+                }
+                Err(error) => last = error,
+            }
+            thread::sleep(Duration::from_millis(200));
+        }
+        panic!("process {pid} did not disappear within the bounded window: {last}");
+    }
+
     #[cfg(windows)]
     #[test]
     fn bounded_inspection_command_kills_and_reaps_a_hung_child() {
@@ -3008,7 +3024,7 @@ mod tests {
             "-NoProfile",
             "-Command",
             &format!(
-                "$PID | Set-Content -NoNewline -Path $env:CODEXHUB_TEST_PID_PATH; Write-Error '{sentinel}'; Start-Sleep -Seconds 10"
+                "$PID | Set-Content -NoNewline -Path $env:CODEXHUB_TEST_PID_PATH; Write-Error '{sentinel}'; Start-Sleep -Seconds 60"
             ),
         ]);
         let root = temp_root("bounded-inspection-command");
@@ -3016,7 +3032,10 @@ mod tests {
         command.env("CODEXHUB_TEST_PID_PATH", &pid_path);
         command.stdout(Stdio::piped()).stderr(Stdio::piped());
         super::configure_no_window(&mut command);
-        let deadline = Instant::now() + Duration::from_secs(5);
+        // Generous deadline: PowerShell cold start under parallel test load can
+        // take several seconds and the helper must write its PID first. The
+        // timeout path still triggers because the helper sleeps far longer.
+        let deadline = Instant::now() + Duration::from_secs(15);
 
         let error =
             run_bounded_inspection_command(command, deadline, WindowsInspectionKind::Process)
@@ -3028,10 +3047,7 @@ mod tests {
             .expect("helper PID")
             .parse::<u32>()
             .expect("numeric helper PID");
-        assert!(matches!(
-            super::inspect_process(pid),
-            Ok(InspectedProcess::Missing)
-        ));
+        wait_for_missing_process(pid);
     }
 
     #[cfg(windows)]
@@ -3043,20 +3059,23 @@ mod tests {
             .to_string_lossy()
             .replace(char::from(39), "''");
         let script = format!(
-            "$child = Start-Process powershell -ArgumentList '-NoProfile','-Command','Start-Sleep -Seconds 10' -NoNewWindow -PassThru; $child.Id | Set-Content -NoNewline -Path '{escaped_path}'; [Console]::Out.Write('parent-exited')"
+            "$child = Start-Process powershell -ArgumentList '-NoProfile','-Command','Start-Sleep -Seconds 60' -NoNewWindow -PassThru; $child.Id | Set-Content -NoNewline -Path '{escaped_path}'; [Console]::Out.Write('parent-exited')"
         );
         let (result_tx, result_rx) = std::sync::mpsc::channel();
         let worker = thread::spawn(move || {
+            // Generous timeout: the parent chains two PowerShell cold starts
+            // (itself plus Start-Process), which can take well over five
+            // seconds under parallel test load.
             let result = run_windows_inspection(
                 &script,
                 WindowsInspectionKind::Process,
-                Duration::from_secs(5),
+                Duration::from_secs(20),
             );
             let _ = result_tx.send(result);
         });
 
         let output = result_rx
-            .recv_timeout(Duration::from_secs(5))
+            .recv_timeout(Duration::from_secs(25))
             .expect("inspection must not wait for a descendant-held output pipe")
             .expect("parent inspection should exit successfully");
         assert_eq!(String::from_utf8_lossy(&output.stdout), "parent-exited");
@@ -3065,10 +3084,7 @@ mod tests {
             .expect("descendant PID")
             .parse::<u32>()
             .expect("numeric descendant PID");
-        assert!(matches!(
-            super::inspect_process(descendant_pid),
-            Ok(InspectedProcess::Missing)
-        ));
+        wait_for_missing_process(descendant_pid);
     }
 
     #[cfg(windows)]
@@ -3314,10 +3330,7 @@ mod tests {
         assert_eq!(read_pid(&paths).expect("PID removed"), None);
         let pid = spawned_pid.load(Ordering::SeqCst);
         let _cleanup = PidCleanup::new(pid);
-        assert!(matches!(
-            super::inspect_process(pid),
-            Ok(InspectedProcess::Missing)
-        ));
+        wait_for_missing_process(pid);
     }
 
     #[test]
@@ -3353,11 +3366,8 @@ mod tests {
         assert!(error.message.contains("listener PID 999999"));
         assert_eq!(read_pid(&paths).expect("read PID"), None);
         let pid = spawned_pid.load(Ordering::SeqCst);
-        let inspected = super::inspect_process(pid);
-        if matches!(inspected, Ok(InspectedProcess::Running(_))) {
-            let _ = kill_process(pid);
-        }
-        assert!(matches!(inspected, Ok(InspectedProcess::Missing)));
+        let _cleanup = PidCleanup::new(pid);
+        wait_for_missing_process(pid);
     }
 
     #[test]
@@ -3392,11 +3402,8 @@ mod tests {
         assert!(error.message.contains("listener inspection unavailable"));
         assert_eq!(read_pid(&paths).expect("read PID"), None);
         let pid = spawned_pid.load(Ordering::SeqCst);
-        let inspected = super::inspect_process(pid);
-        if matches!(inspected, Ok(InspectedProcess::Running(_))) {
-            let _ = kill_process(pid);
-        }
-        assert!(matches!(inspected, Ok(InspectedProcess::Missing)));
+        let _cleanup = PidCleanup::new(pid);
+        wait_for_missing_process(pid);
     }
 
     #[test]

--- a/src-tauri/src/proxy.rs
+++ b/src-tauri/src/proxy.rs
@@ -2,6 +2,7 @@ use crate::gateway_lifecycle::{
     coordinator as gateway_lifecycle, GatewayIdentity, GatewayLifecycleBackend,
     GatewayLifecycleSnapshot, GatewayStartOutcome,
 };
+use crate::gateway_transaction::GatewayLifecyclePhase;
 use crate::AppStatus;
 use crate::Settings;
 use crate::{build_info, runtime_paths, safe_file};
@@ -121,6 +122,10 @@ impl ProxyPaths {
         self.proxy_dir().join("proxy.pid")
     }
 
+    fn lifecycle_gate_path(&self) -> PathBuf {
+        self.proxy_dir().join("lifecycle.lock")
+    }
+
     fn codex_config_path(&self) -> PathBuf {
         self.codex_target_dir.join("config.toml")
     }
@@ -136,17 +141,24 @@ impl ProxyPaths {
 
 struct ProxyLifecycleBackend {
     paths: ProxyPaths,
+    lifecycle_gate_path: PathBuf,
 }
 
 impl ProxyLifecycleBackend {
     fn runtime() -> Result<Self, String> {
+        let paths = ProxyPaths::runtime()?;
         Ok(Self {
-            paths: ProxyPaths::runtime()?,
+            lifecycle_gate_path: paths.lifecycle_gate_path(),
+            paths,
         })
     }
 }
 
 impl GatewayLifecycleBackend for ProxyLifecycleBackend {
+    fn lifecycle_gate_path(&self) -> &Path {
+        &self.lifecycle_gate_path
+    }
+
     fn snapshot(&self) -> Result<GatewayLifecycleSnapshot, String> {
         reconciled_snapshot_with_controls(
             &self.paths,
@@ -154,6 +166,29 @@ impl GatewayLifecycleBackend for ProxyLifecycleBackend {
             &SystemProcessInspector,
             &SystemListenerInspector,
         )
+    }
+
+    fn transitional_status(&self, phase: GatewayLifecyclePhase) -> Result<AppStatus, String> {
+        let settings = read_settings(&self.paths)?;
+        let mode = read_mode(&self.paths)?;
+        let (proxy_running, message) = match phase {
+            GatewayLifecyclePhase::Starting => (false, "Gateway is starting"),
+            GatewayLifecyclePhase::Stopping => (true, "Gateway is stopping"),
+            GatewayLifecyclePhase::Restarting => (true, "Gateway is restarting"),
+            GatewayLifecyclePhase::Running => (true, "Gateway is running"),
+            GatewayLifecyclePhase::Stopped => (false, "Gateway is stopped"),
+            GatewayLifecyclePhase::Failed => (false, "Gateway lifecycle needs reconciliation"),
+        };
+        Ok(AppStatus {
+            mode,
+            proxy_running,
+            proxy_port: settings.proxy_port,
+            proxy_build: None,
+            message: message.to_string(),
+            gateway_lifecycle: phase,
+            history_sync_status: None,
+            history_sync_message: None,
+        })
     }
 
     fn start(&self) -> Result<GatewayStartOutcome, String> {
@@ -314,6 +349,8 @@ struct ProxyPidMetadata {
     script_path: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     script_sha256: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    process_start_id: Option<String>,
     started_at_unix_ms: u64,
 }
 
@@ -325,6 +362,7 @@ impl ProxyPidMetadata {
             port,
             script_path: comparable_path(script),
             script_sha256: file_sha256(script),
+            process_start_id: None,
             started_at_unix_ms: SystemTime::now()
                 .duration_since(UNIX_EPOCH)
                 .unwrap_or_default()
@@ -409,6 +447,7 @@ fn reconciled_snapshot_with_controls(
                 proxy_port: settings.proxy_port,
                 proxy_build: None,
                 message: "Gateway is not running".to_string(),
+                gateway_lifecycle: GatewayLifecyclePhase::Stopped,
                 history_sync_status: None,
                 history_sync_message: None,
             },
@@ -452,16 +491,14 @@ fn reconciled_snapshot_with_controls(
 
     let listener_pid = listener_inspector.listening_pid(settings.proxy_port)?;
     let Some(listener_pid) = listener_pid else {
-        remove_pid(paths)?;
         return Err(format!(
-            "Gateway health responds on port {}, but no TCP listener owner could be reconciled; removed managed PID {pid} without stopping the process",
+            "Gateway health responds on port {}, but no TCP listener owner could be reconciled; preserved exact managed PID {pid} for ownership-safe recovery",
             settings.proxy_port
         ));
     };
     if listener_pid != pid {
-        remove_pid(paths)?;
         return Err(format!(
-            "Gateway health responds on port {}, but listener PID {listener_pid} differs from managed PID {pid}; removed stale PID identity without stopping either process",
+            "Gateway health responds on port {}, but listener PID {listener_pid} differs from exact managed PID {pid}; preserved the managed PID identity without stopping either process",
             settings.proxy_port
         ));
     }
@@ -484,6 +521,7 @@ fn reconciled_snapshot_with_controls(
             proxy_port: settings.proxy_port,
             proxy_build: response.build.clone(),
             message: format!("Gateway running with PID {pid}"),
+            gateway_lifecycle: GatewayLifecyclePhase::Running,
             history_sync_status: None,
             history_sync_message: None,
         },
@@ -491,6 +529,7 @@ fn reconciled_snapshot_with_controls(
     })
 }
 
+#[cfg(test)]
 fn status_with_paths(paths: &ProxyPaths) -> Result<AppStatus, String> {
     let settings = read_settings(paths)?;
     let mode = read_mode(paths)?;
@@ -516,6 +555,11 @@ fn status_with_paths(paths: &ProxyPaths) -> Result<AppStatus, String> {
             "Proxy is healthy".to_string()
         } else {
             "Proxy is not running".to_string()
+        },
+        gateway_lifecycle: if proxy_running {
+            GatewayLifecyclePhase::Running
+        } else {
+            GatewayLifecyclePhase::Stopped
         },
         history_sync_status: None,
         history_sync_message: None,
@@ -664,6 +708,8 @@ where
     })?;
     let output_capture = capture_child_stdio(&mut child);
     let pid = child.id();
+    let mut record =
+        ProxyPidRecord::Managed(ProxyPidMetadata::new(pid, settings.proxy_port, &script));
 
     let startup = match wait_for_startup(
         &mut child,
@@ -680,14 +726,40 @@ where
                 &mut child,
                 output_capture,
                 error,
+                &record,
+                inspector,
             ))
         }
     };
 
     match startup {
         StartupOutcome::Healthy(response) if response.is_running() => {
-            let record =
-                ProxyPidRecord::Managed(ProxyPidMetadata::new(pid, settings.proxy_port, &script));
+            let process_start_id = match inspector.inspect(pid) {
+                Ok(InspectedProcess::Running(info)) => info.process_start_id,
+                Ok(InspectedProcess::Missing) => {
+                    return Err(clean_up_failed_start(
+                        paths,
+                        &mut child,
+                        output_capture,
+                        format!("spawned Gateway PID {pid} disappeared before ownership fencing"),
+                        &record,
+                        inspector,
+                    ))
+                }
+                Err(error) => {
+                    return Err(clean_up_failed_start(
+                        paths,
+                        &mut child,
+                        output_capture,
+                        format!("failed to fence spawned Gateway PID {pid}: {error}"),
+                        &record,
+                        inspector,
+                    ))
+                }
+            };
+            if let ProxyPidRecord::Managed(metadata) = &mut record {
+                metadata.process_start_id = process_start_id;
+            }
             let verification =
                 verify_proxy_process(&record, paths, settings.proxy_port, inspector)?;
             if verification != (VerifiedProxyProcess::Verified { pid }) {
@@ -698,6 +770,8 @@ where
                     format!(
                         "spawned Gateway PID {pid} ownership could not be reconciled: {verification:?}"
                     ),
+                    &record,
+                    inspector,
                 ));
             }
 
@@ -709,6 +783,8 @@ where
                         &mut child,
                         output_capture,
                         error,
+                        &record,
+                        inspector,
                     ))
                 }
             };
@@ -724,15 +800,19 @@ where
                         "spawned Gateway PID {pid} became healthy, but {detail} owns port {}",
                         settings.proxy_port
                     ),
+                    &record,
+                    inspector,
                 ));
             }
 
-            if let Err(error) = write_pid(paths, pid, settings.proxy_port, &script) {
+            if let Err(error) = write_pid_record(paths, &record) {
                 return Err(clean_up_failed_start(
                     paths,
                     &mut child,
                     output_capture,
                     error,
+                    &record,
+                    inspector,
                 ));
             }
             match reconciled_snapshot_with_controls(
@@ -750,6 +830,8 @@ where
                     &mut child,
                     output_capture,
                     error,
+                    &record,
+                    inspector,
                 )),
             }
         }
@@ -761,6 +843,8 @@ where
                 "proxy returned a non-running health response at http://127.0.0.1:{}/health",
                 settings.proxy_port
             ),
+            &record,
+            inspector,
         )),
         StartupOutcome::Exited(status) => {
             let _ = remove_pid(paths);
@@ -782,6 +866,8 @@ where
                 ),
                 &StartupOutputSnapshot::default(),
             ),
+            &record,
+            inspector,
         )),
     }
 }
@@ -791,32 +877,34 @@ fn clean_up_failed_start(
     child: &mut Child,
     output_capture: StartupOutputCapture,
     reason: String,
+    record: &ProxyPidRecord,
+    inspector: &dyn ProcessInspector,
 ) -> String {
-    let termination_error = terminate_child(child).err();
-    let pid_error = remove_pid(paths).err();
-    let output = output_capture.finish();
-    let mut message = format_startup_failure(reason, &output);
-    if let Some(error) = termination_error {
-        message.push_str(&format!(
-            "\nfailed to terminate spawned child safely: {error}"
-        ));
-    }
-    if let Some(error) = pid_error {
-        message.push_str(&format!(
-            "\nfailed to remove unpublished PID identity: {error}"
-        ));
-    }
-    message
+    clean_up_failed_start_with_controls(
+        paths,
+        child,
+        output_capture,
+        reason,
+        record,
+        inspector,
+        &SystemChildTerminator,
+    )
 }
 
 fn stop_with_paths(paths: &ProxyPaths) -> Result<AppStatus, String> {
-    stop_with_paths_and_controls(paths, &SystemProcessKiller, &SystemProcessInspector)
+    stop_with_paths_and_controls(
+        paths,
+        &SystemProcessKiller,
+        &SystemProcessInspector,
+        &SystemListenerInspector,
+    )
 }
 
 fn stop_with_paths_and_controls(
     paths: &ProxyPaths,
     killer: &dyn ProcessKiller,
     inspector: &dyn ProcessInspector,
+    listener_inspector: &dyn ListenerInspector,
 ) -> Result<AppStatus, String> {
     let settings = read_settings(paths)?;
     let mode = read_mode(paths)?;
@@ -834,46 +922,46 @@ fn stop_with_paths_and_controls(
             pid_record,
             killer,
             inspector,
+            listener_inspector,
         );
     }
 
     let Some(pid_record) = pid_record else {
-        return stop_running_proxy_without_pid(
-            paths,
-            mode,
-            settings.proxy_port,
-            &settings.gateway_client_key,
-        );
+        return Err(format!(
+            "Gateway health responds on port {}, but no managed PID identity exists; refusing to send shutdown to the external listener",
+            settings.proxy_port
+        ));
     };
 
-    match verify_proxy_process(&pid_record, paths, settings.proxy_port, inspector)? {
+    let pid = match verify_proxy_process(&pid_record, paths, settings.proxy_port, inspector)? {
         VerifiedProxyProcess::Verified { pid } => pid,
         VerifiedProxyProcess::Missing { pid } => {
             remove_pid(paths)?;
-            return stop_running_proxy_with_stale_pid(
-                paths,
-                mode,
-                settings.proxy_port,
-                pid,
-                &settings.gateway_client_key,
-                "PID no longer exists".to_string(),
-            );
+            return Err(format!(
+                "Gateway health responds on port {}, but managed PID {pid} no longer exists; removed stale identity and refused shutdown",
+                settings.proxy_port
+            ));
         }
         VerifiedProxyProcess::Mismatch { pid, reason } => {
             remove_pid(paths)?;
-            return stop_running_proxy_with_stale_pid(
-                paths,
-                mode,
-                settings.proxy_port,
-                pid,
-                &settings.gateway_client_key,
-                format!("ownership could not be verified: {reason}"),
-            );
+            return Err(format!(
+                "Gateway health responds on port {}, but managed PID {pid} ownership could not be verified ({reason}); removed stale identity and refused shutdown",
+                settings.proxy_port
+            ));
         }
     };
 
+    verify_listener_owner(pid, settings.proxy_port, listener_inspector, "before shutdown")?;
+
     let _ = request_shutdown(settings.proxy_port, &settings.gateway_client_key);
     if wait_for_stopped(settings.proxy_port, GRACEFUL_STOP_TIMEOUT)? {
+        confirm_managed_process_stopped(
+            &pid_record,
+            paths,
+            settings.proxy_port,
+            inspector,
+            GRACEFUL_STOP_TIMEOUT,
+        )?;
         remove_pid(paths)?;
         return Ok(AppStatus {
             mode,
@@ -881,44 +969,34 @@ fn stop_with_paths_and_controls(
             proxy_port: settings.proxy_port,
             proxy_build: None,
             message: "Proxy stopped gracefully".to_string(),
+            gateway_lifecycle: GatewayLifecyclePhase::Stopped,
             history_sync_status: None,
             history_sync_message: None,
         });
     }
 
-    let pid = match verify_proxy_process(&pid_record, paths, settings.proxy_port, inspector)? {
-        VerifiedProxyProcess::Verified { pid } => pid,
-        VerifiedProxyProcess::Missing { pid } => {
-            remove_pid(paths)?;
-            return stop_running_proxy_with_stale_pid(
-                paths,
-                mode,
-                settings.proxy_port,
-                pid,
-                &settings.gateway_client_key,
-                "PID disappeared before force kill".to_string(),
-            );
-        }
-        VerifiedProxyProcess::Mismatch { pid, reason } => {
-            remove_pid(paths)?;
-            return stop_running_proxy_with_stale_pid(
-                paths,
-                mode,
-                settings.proxy_port,
-                pid,
-                &settings.gateway_client_key,
-                format!("ownership could not be verified before force kill: {reason}"),
-            );
-        }
-    };
-
-    killer.kill(pid)?;
+    let pid = force_kill_after_graceful_timeout(
+        paths,
+        &pid_record,
+        settings.proxy_port,
+        killer,
+        inspector,
+        listener_inspector,
+    )?;
     if !wait_for_stopped(settings.proxy_port, KILL_STOP_TIMEOUT)? {
         return Err(format!(
             "sent kill signal to proxy PID {pid}, but health still responds on port {}",
             settings.proxy_port
         ));
     }
+
+    confirm_managed_process_stopped(
+        &pid_record,
+        paths,
+        settings.proxy_port,
+        inspector,
+        KILL_STOP_TIMEOUT,
+    )?;
 
     remove_pid(paths)?;
     Ok(AppStatus {
@@ -927,65 +1005,44 @@ fn stop_with_paths_and_controls(
         proxy_port: settings.proxy_port,
         proxy_build: None,
         message: format!("Proxy PID {pid} stopped"),
+        gateway_lifecycle: GatewayLifecyclePhase::Stopped,
         history_sync_status: None,
         history_sync_message: None,
     })
 }
 
-fn stop_running_proxy_with_stale_pid(
+fn force_kill_after_graceful_timeout(
     paths: &ProxyPaths,
-    mode: String,
+    record: &ProxyPidRecord,
     port: u16,
-    pid: u32,
-    gateway_client_key: &str,
-    reason: String,
-) -> Result<AppStatus, String> {
-    let _ = request_shutdown(port, gateway_client_key);
-    if wait_for_stopped(port, GRACEFUL_STOP_TIMEOUT)? {
-        return Ok(AppStatus {
-            mode,
-            proxy_running: false,
-            proxy_port: port,
-            proxy_build: None,
-            message: format!(
-                "Proxy stopped gracefully after removing stale proxy PID {pid}: {reason}"
-            ),
-            history_sync_status: None,
-            history_sync_message: None,
-        });
-    }
+    killer: &dyn ProcessKiller,
+    inspector: &dyn ProcessInspector,
+    listener_inspector: &dyn ListenerInspector,
+) -> Result<u32, String> {
+    let pid = match verify_proxy_process(record, paths, port, inspector)? {
+        VerifiedProxyProcess::Verified { pid } => pid,
+        VerifiedProxyProcess::Missing { pid } => {
+            remove_pid(paths)?;
+            return Err(format!(
+                "managed Gateway PID {pid} disappeared before force kill; preserved truthful failure for reconciliation"
+            ));
+        }
+        VerifiedProxyProcess::Mismatch { pid, reason } => {
+            remove_pid(paths)?;
+            return Err(format!(
+                "managed Gateway PID {pid} ownership could not be verified before force kill: {reason}"
+            ));
+        }
+    };
 
-    let mut status = status_with_paths(paths)?;
-    status.message = format!(
-        "Proxy health responds on port {port}, but stale PID {pid} was removed because {reason}; shutdown endpoint did not stop it and no force kill was attempted"
-    );
-    Ok(status)
-}
-
-fn stop_running_proxy_without_pid(
-    paths: &ProxyPaths,
-    mode: String,
-    port: u16,
-    gateway_client_key: &str,
-) -> Result<AppStatus, String> {
-    let _ = request_shutdown(port, gateway_client_key);
-    if wait_for_stopped(port, GRACEFUL_STOP_TIMEOUT)? {
-        return Ok(AppStatus {
-            mode,
-            proxy_running: false,
-            proxy_port: port,
-            proxy_build: None,
-            message: "Proxy stopped gracefully without a proxy PID file".to_string(),
-            history_sync_status: None,
-            history_sync_message: None,
-        });
-    }
-
-    let mut status = status_with_paths(paths)?;
-    status.message = format!(
-        "Proxy health responds on port {port}, but no proxy PID file was found; shutdown endpoint did not stop it and no force kill was attempted"
-    );
-    Ok(status)
+    verify_listener_owner(
+        pid,
+        port,
+        listener_inspector,
+        "immediately before force kill",
+    )?;
+    killer.kill(pid)?;
+    Ok(pid)
 }
 
 fn stop_when_health_unavailable(
@@ -995,11 +1052,25 @@ fn stop_when_health_unavailable(
     pid_record: Option<ProxyPidRecord>,
     killer: &dyn ProcessKiller,
     inspector: &dyn ProcessInspector,
+    listener_inspector: &dyn ListenerInspector,
 ) -> Result<AppStatus, String> {
     let message = match pid_record {
         Some(record) => match verify_proxy_process(&record, paths, port, inspector)? {
             VerifiedProxyProcess::Verified { pid } => {
+                verify_listener_owner(
+                    pid,
+                    port,
+                    listener_inspector,
+                    "immediately before force kill while health is unavailable",
+                )?;
                 killer.kill(pid)?;
+                confirm_managed_process_stopped(
+                    &record,
+                    paths,
+                    port,
+                    inspector,
+                    KILL_STOP_TIMEOUT,
+                )?;
                 remove_pid(paths)?;
                 format!("Proxy PID {pid} stopped after health endpoint was unavailable")
             }
@@ -1023,9 +1094,57 @@ fn stop_when_health_unavailable(
         proxy_port: port,
         proxy_build: None,
         message,
+        gateway_lifecycle: GatewayLifecyclePhase::Stopped,
         history_sync_status: None,
         history_sync_message: None,
     })
+}
+
+fn verify_listener_owner(
+    pid: u32,
+    port: u16,
+    listener_inspector: &dyn ListenerInspector,
+    action: &str,
+) -> Result<(), String> {
+    let listener_pid = listener_inspector.listening_pid(port)?;
+    if listener_pid == Some(pid) {
+        return Ok(());
+    }
+    let owner = listener_pid
+        .map(|value| format!("PID {value}"))
+        .unwrap_or_else(|| "no process".to_string());
+    Err(format!(
+        "exact managed Gateway PID {pid} does not own the current listener on port {port} {action} ({owner}); refusing destructive action and preserving durable ownership"
+    ))
+}
+
+fn confirm_managed_process_stopped(
+    record: &ProxyPidRecord,
+    paths: &ProxyPaths,
+    port: u16,
+    inspector: &dyn ProcessInspector,
+    timeout: Duration,
+) -> Result<(), String> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        match verify_proxy_process(record, paths, port, inspector)? {
+            VerifiedProxyProcess::Missing { .. } => return Ok(()),
+            VerifiedProxyProcess::Verified { pid } => {
+                if Instant::now() >= deadline {
+                    return Err(format!(
+                        "Gateway PID {pid} did not exit within {} ms; preserved durable ownership",
+                        timeout.as_millis()
+                    ));
+                }
+            }
+            VerifiedProxyProcess::Mismatch { pid, reason } => {
+                return Err(format!(
+                    "Gateway PID {pid} changed identity while confirming termination ({reason}); preserved PID metadata for reconciliation"
+                ));
+            }
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
 }
 
 fn build_start_command(
@@ -1242,12 +1361,107 @@ where
     }
 }
 
-fn terminate_child(child: &mut Child) -> Result<(), String> {
-    child
-        .kill()
-        .map_err(|error| format!("failed to kill proxy child process: {error}"))?;
-    let _ = child.wait();
-    Ok(())
+trait ChildTerminator {
+    /// Returns true only when child exit was confirmed within the bounded wait.
+    fn terminate(&self, child: &mut Child) -> Result<bool, String>;
+}
+
+struct SystemChildTerminator;
+
+impl ChildTerminator for SystemChildTerminator {
+    fn terminate(&self, child: &mut Child) -> Result<bool, String> {
+        if child
+            .try_wait()
+            .map_err(|error| format!("failed to inspect proxy child process: {error}"))?
+            .is_some()
+        {
+            return Ok(true);
+        }
+        if let Err(error) = child.kill() {
+            return match child.try_wait() {
+                Ok(Some(_)) => Ok(true),
+                Ok(None) => Err(format!("failed to kill proxy child process: {error}")),
+                Err(wait_error) => Err(format!(
+                    "failed to kill proxy child process: {error}; exit inspection also failed: {wait_error}"
+                )),
+            };
+        }
+
+        let deadline = Instant::now() + KILL_STOP_TIMEOUT;
+        loop {
+            match child.try_wait() {
+                Ok(Some(_)) => return Ok(true),
+                Ok(None) if Instant::now() < deadline => {
+                    thread::sleep(Duration::from_millis(25));
+                }
+                Ok(None) => return Ok(false),
+                Err(error) => {
+                    return Err(format!(
+                        "failed to confirm proxy child termination: {error}"
+                    ))
+                }
+            }
+        }
+    }
+}
+
+fn clean_up_failed_start_with_controls(
+    paths: &ProxyPaths,
+    child: &mut Child,
+    output_capture: StartupOutputCapture,
+    reason: String,
+    record: &ProxyPidRecord,
+    inspector: &dyn ProcessInspector,
+    terminator: &dyn ChildTerminator,
+) -> String {
+    let termination = terminator.terminate(child);
+    let confirmed = matches!(termination, Ok(true));
+    let output = if confirmed {
+        output_capture.finish()
+    } else {
+        output_capture.snapshot()
+    };
+    let mut message = format_startup_failure(reason, &output);
+
+    if confirmed {
+        if let Err(error) = remove_pid(paths) {
+            message.push_str(&format!("\nfailed to remove terminated child PID identity: {error}"));
+        }
+        return message;
+    }
+
+    match termination {
+        Ok(false) => message.push_str("\nspawned child termination could not be confirmed within the bounded cleanup window"),
+        Err(error) => message.push_str(&format!(
+            "\nspawned child termination could not be confirmed: {error}"
+        )),
+        Ok(true) => unreachable!(),
+    }
+
+    match verify_proxy_process(record, paths, record.expected_port(0), inspector) {
+        Ok(VerifiedProxyProcess::Verified { pid }) => {
+            match write_pid_record(paths, record) {
+                Ok(()) => message.push_str(&format!(
+                    "\npreserved durable ownership for verified live Gateway PID {pid}"
+                )),
+                Err(error) => message.push_str(&format!(
+                    "\nfailed to persist verified live Gateway ownership: {error}"
+                )),
+            }
+        }
+        Ok(VerifiedProxyProcess::Missing { .. }) => {
+            if let Err(error) = remove_pid(paths) {
+                message.push_str(&format!("\nfailed to remove exited child PID identity: {error}"));
+            }
+        }
+        Ok(VerifiedProxyProcess::Mismatch { pid, reason }) => message.push_str(&format!(
+            "\nPID {pid} could not be durably claimed after failed cleanup because ownership changed: {reason}"
+        )),
+        Err(error) => message.push_str(&format!(
+            "\nfailed to reconcile child ownership after bounded cleanup: {error}"
+        )),
+    }
+    message
 }
 
 fn format_startup_failure(message: String, output: &StartupOutputSnapshot) -> String {
@@ -1281,23 +1495,27 @@ enum InspectedProcess {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ProcessInfo {
-    command_line: String,
     args: Vec<String>,
+    process_start_id: Option<String>,
 }
 
 impl ProcessInfo {
-    fn from_command_line(command_line: String) -> Self {
+    #[cfg(windows)]
+    fn from_command_line_with_start_id(
+        command_line: String,
+        process_start_id: Option<String>,
+    ) -> Self {
         Self {
             args: split_command_line(&command_line),
-            command_line,
+            process_start_id,
         }
     }
 
     #[cfg(any(test, not(windows)))]
     fn from_args(args: Vec<String>) -> Self {
         Self {
-            command_line: args.join(" "),
             args,
+            process_start_id: None,
         }
     }
 }
@@ -1373,6 +1591,17 @@ fn verify_proxy_command_line(
         ));
     }
 
+    if let ProxyPidRecord::Managed(metadata) = record {
+        if let Some(expected_start_id) = metadata.process_start_id.as_ref() {
+            if info.process_start_id.as_ref() != Some(expected_start_id) {
+                return Err(format!(
+                    "process start identity differs from managed PID metadata (expected {expected_start_id:?}, found {:?})",
+                    info.process_start_id
+                ));
+            }
+        }
+    }
+
     if !command_line_has_script_name(info, "codex_proxy.py") {
         return Err("command line does not include codex_proxy.py".to_string());
     }
@@ -1407,8 +1636,6 @@ fn command_line_has_script_name(info: &ProcessInfo, script_name: &str) -> bool {
     info.args
         .iter()
         .any(|arg| path_file_name_eq(arg, script_name))
-        || normalized_command_text(&info.command_line)
-            .contains(&normalized_command_text(script_name))
 }
 
 fn command_line_has_script_path(info: &ProcessInfo, expected_script: &str) -> bool {
@@ -1416,7 +1643,6 @@ fn command_line_has_script_path(info: &ProcessInfo, expected_script: &str) -> bo
     info.args
         .iter()
         .any(|arg| normalized_path_text(arg) == expected)
-        || normalized_path_text(&info.command_line).contains(&expected)
 }
 
 fn path_file_name_eq(arg: &str, expected_name: &str) -> bool {
@@ -1691,14 +1917,22 @@ fn read_pid_record(paths: &ProxyPaths) -> Result<Option<ProxyPidRecord>, String>
         .map_err(|error| format!("invalid proxy PID in {}: {error}", path.display()))
 }
 
+#[cfg(test)]
 fn write_pid(paths: &ProxyPaths, pid: u32, port: u16, script: &Path) -> Result<(), String> {
+    let metadata = ProxyPidMetadata::new(pid, port, script);
+    write_pid_record(paths, &ProxyPidRecord::Managed(metadata))
+}
+
+fn write_pid_record(paths: &ProxyPaths, record: &ProxyPidRecord) -> Result<(), String> {
     fs::create_dir_all(paths.proxy_dir()).map_err(|error| {
         format!(
             "failed to create proxy runtime directory {}: {error}",
             paths.proxy_dir().display()
         )
     })?;
-    let metadata = ProxyPidMetadata::new(pid, port, script);
+    let ProxyPidRecord::Managed(metadata) = record else {
+        return Err("refusing to publish legacy PID metadata for a new Gateway".to_string());
+    };
     let text = serde_json::to_string_pretty(&metadata)
         .map_err(|error| format!("failed to encode proxy PID metadata: {error}"))?;
     safe_file::write_text_atomic(&paths.pid_path(), &format!("{text}\n")).map_err(|error| {
@@ -1865,7 +2099,7 @@ fn inspect_process(pid: u32) -> Result<InspectedProcess, String> {
     let script = format!(
         "$p = Get-CimInstance -ClassName Win32_Process -Filter 'ProcessId = {pid}' -ErrorAction SilentlyContinue; \
          if ($null -eq $p) {{ exit 3 }}; \
-         [Console]::Out.Write([string]$p.CommandLine)"
+         [Console]::Out.Write((@{{ command_line = [string]$p.CommandLine; process_start_id = [string]$p.CreationDate }} | ConvertTo-Json -Compress))"
     );
     let mut command = Command::new("powershell");
     command.args(["-NoProfile", "-Command", &script]);
@@ -1885,10 +2119,21 @@ fn inspect_process(pid: u32) -> Result<InspectedProcess, String> {
         ));
     }
 
-    let command_line = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    Ok(InspectedProcess::Running(ProcessInfo::from_command_line(
-        command_line,
-    )))
+    #[derive(Deserialize)]
+    struct WindowsProcessInspection {
+        command_line: String,
+        process_start_id: String,
+    }
+    let inspection: WindowsProcessInspection =
+        serde_json::from_slice(&output.stdout).map_err(|error| {
+            format!("failed to parse process identity for PID {pid}: {error}")
+        })?;
+    Ok(InspectedProcess::Running(
+        ProcessInfo::from_command_line_with_start_id(
+            inspection.command_line,
+            (!inspection.process_start_id.is_empty()).then_some(inspection.process_start_id),
+        ),
+    ))
 }
 
 #[cfg(not(windows))]
@@ -1918,7 +2163,19 @@ fn inspect_process(pid: u32) -> Result<InspectedProcess, String> {
         .filter(|part| !part.is_empty())
         .map(|part| String::from_utf8_lossy(part).to_string())
         .collect::<Vec<_>>();
-    Ok(InspectedProcess::Running(ProcessInfo::from_args(args)))
+    let process_start_id = fs::read_to_string(format!("/proc/{pid}/stat"))
+        .ok()
+        .and_then(|stat| process_start_ticks(&stat))
+        .map(|ticks| format!("proc-start-ticks:{ticks}"));
+    let mut info = ProcessInfo::from_args(args);
+    info.process_start_id = process_start_id;
+    Ok(InspectedProcess::Running(info))
+}
+
+#[cfg(not(windows))]
+fn process_start_ticks(stat: &str) -> Option<&str> {
+    let after_command = stat.rsplit_once(')')?.1.trim();
+    after_command.split_whitespace().nth(19)
 }
 
 #[cfg(windows)]
@@ -1971,12 +2228,15 @@ fn format_process_failure(label: &str, pid: u32, output: std::process::Output) -
 #[cfg(test)]
 mod tests {
     use super::{
-        build_start_command, comparable_path, configure_start_stdio, detect_mode, find_python,
-        kill_process, read_pid, read_pid_record, reconciled_snapshot_with_controls,
+        build_start_command, capture_child_stdio, clean_up_failed_start_with_controls,
+        comparable_path, configure_start_stdio, detect_mode, find_python,
+        force_kill_after_graceful_timeout, kill_process, read_pid, read_pid_record,
+        reconciled_snapshot_with_controls,
         start_with_paths, start_with_paths_and_controls, start_with_paths_and_waiter,
-        status_with_paths, stop_with_paths, stop_with_paths_and_controls, write_pid,
-        InspectedProcess, ListenerInspector, ProcessInfo, ProcessInspector, ProcessKiller,
-        ProxyPaths, ProxyPidMetadata, ProxyPidRecord, StartupOutcome, DEBUG_DIAGNOSTIC_BOOTSTRAP,
+        status_with_paths, stop_with_paths, stop_with_paths_and_controls, verify_proxy_command_line,
+        write_pid, ChildTerminator, InspectedProcess, ListenerInspector, ProcessInfo,
+        ProcessInspector, ProcessKiller, ProxyPaths, ProxyPidMetadata, ProxyPidRecord, StartupOutcome,
+        DEBUG_DIAGNOSTIC_BOOTSTRAP,
     };
     use crate::Settings;
     use std::cell::RefCell;
@@ -1985,6 +2245,7 @@ mod tests {
     use std::net::TcpListener;
     use std::path::{Path, PathBuf};
     use std::process::Command;
+    use std::collections::VecDeque;
     use std::sync::{
         atomic::{AtomicU32, Ordering},
         Arc,
@@ -2038,7 +2299,7 @@ mod tests {
     }
 
     #[test]
-    fn reconciled_snapshot_rejects_listener_pid_mismatch_and_removes_stale_pid() {
+    fn reconciled_snapshot_preserves_exact_managed_pid_when_listener_differs() {
         let root = temp_root("reconciled-listener-mismatch");
         let paths = test_paths(&root);
         let port = free_port();
@@ -2058,7 +2319,7 @@ mod tests {
 
         assert!(error.contains("listener PID 54321"));
         assert!(error.contains("managed PID 12345"));
-        assert_eq!(read_pid(&paths).expect("read PID"), None);
+        assert_eq!(read_pid(&paths).expect("read PID"), Some(12_345));
     }
 
     #[test]
@@ -2301,7 +2562,7 @@ model_catalog_json = "model-catalogs/codex-proxy-official-ollama.json"
     }
 
     #[test]
-    fn stop_kills_pid_when_health_is_unavailable_and_command_line_matches() {
+    fn stop_preserves_exact_non_listening_child_when_health_is_unavailable() {
         let root = temp_root("stale-pid");
         let paths = test_paths(&root);
         let port = free_port();
@@ -2310,11 +2571,17 @@ model_catalog_json = "model-catalogs/codex-proxy-official-ollama.json"
         let killer = RecordingKiller::default();
         let inspector = RecordingInspector::new(fake_proxy_process(&paths, port));
 
-        let status = stop_with_paths_and_controls(&paths, &killer, &inspector).expect("stop stale");
+        let error = stop_with_paths_and_controls(
+            &paths,
+            &killer,
+            &inspector,
+            &FixedListenerInspector::new(None),
+        )
+        .expect_err("non-listening child must remain durably tracked");
 
-        assert!(!status.proxy_running);
-        assert_eq!(read_pid(&paths).expect("pid removed"), None);
-        assert_eq!(killer.killed.borrow().as_slice(), &[12_345]);
+        assert!(error.contains("does not own the current listener"));
+        assert_eq!(read_pid(&paths).expect("pid preserved"), Some(12_345));
+        assert!(killer.killed.borrow().is_empty());
         assert_eq!(inspector.inspected.borrow().as_slice(), &[12_345]);
     }
 
@@ -2334,8 +2601,13 @@ model_catalog_json = "model-catalogs/codex-proxy-official-ollama.json"
                 port.to_string(),
             ])));
 
-        let status =
-            stop_with_paths_and_controls(&paths, &killer, &inspector).expect("stop mismatch");
+        let status = stop_with_paths_and_controls(
+            &paths,
+            &killer,
+            &inspector,
+            &FixedListenerInspector::new(None),
+        )
+        .expect("stop mismatch");
 
         assert!(!status.proxy_running);
         assert!(status.message.contains("was not killed"));
@@ -2344,7 +2616,7 @@ model_catalog_json = "model-catalogs/codex-proxy-official-ollama.json"
     }
 
     #[test]
-    fn stop_treats_mismatched_pid_as_stale_when_health_responds() {
+    fn stop_refuses_shutdown_when_health_owner_is_not_exact_managed_pid() {
         let root = temp_root("pid-mismatch-health-running");
         let paths = test_paths(&root);
         let port = free_port();
@@ -2360,34 +2632,39 @@ model_catalog_json = "model-catalogs/codex-proxy-official-ollama.json"
                 port.to_string(),
             ])));
 
-        let status = stop_with_paths_and_controls(&paths, &killer, &inspector)
-            .expect("stop should not error on stale mismatched pid");
+        let error = stop_with_paths_and_controls(
+            &paths,
+            &killer,
+            &inspector,
+            &FixedListenerInspector::new(Some(54_321)),
+        )
+        .expect_err("external listener must never receive shutdown");
 
-        assert!(!status.proxy_running);
-        assert!(status.message.contains("Proxy stopped gracefully"));
-        assert!(status.message.contains("stale proxy PID 12345"));
+        assert!(error.contains("ownership could not be verified"));
         assert_eq!(read_pid(&paths).expect("pid removed"), None);
         assert!(killer.killed.borrow().is_empty());
         health_server.join().expect("health server joins");
     }
 
     #[test]
-    fn stop_treats_missing_pid_file_as_external_running_proxy() {
+    fn stop_refuses_shutdown_for_external_running_proxy_without_pid() {
         let root = temp_root("pid-missing-health-running");
         let paths = test_paths(&root);
         let port = free_port();
         write_settings(&paths, port);
-        let health_server = spawn_health_then_shutdown_server(port);
+        let health_server = spawn_single_health_response(port);
         let killer = RecordingKiller::default();
         let inspector = RecordingInspector::new(InspectedProcess::Missing);
 
-        let status = stop_with_paths_and_controls(&paths, &killer, &inspector)
-            .expect("stop should not error when running proxy has no pid file");
+        let error = stop_with_paths_and_controls(
+            &paths,
+            &killer,
+            &inspector,
+            &FixedListenerInspector::new(Some(54_321)),
+        )
+        .expect_err("external listener must not receive shutdown");
 
-        assert!(!status.proxy_running);
-        assert!(status
-            .message
-            .contains("Proxy stopped gracefully without a proxy PID file"));
+        assert!(error.contains("no managed PID identity"));
         assert_eq!(read_pid(&paths).expect("pid remains missing"), None);
         assert!(killer.killed.borrow().is_empty());
         assert!(inspector.inspected.borrow().is_empty());
@@ -2404,13 +2681,55 @@ model_catalog_json = "model-catalogs/codex-proxy-official-ollama.json"
         let killer = RecordingKiller::default();
         let inspector = RecordingInspector::new(InspectedProcess::Missing);
 
-        let status =
-            stop_with_paths_and_controls(&paths, &killer, &inspector).expect("stop missing");
+        let status = stop_with_paths_and_controls(
+            &paths,
+            &killer,
+            &inspector,
+            &FixedListenerInspector::new(None),
+        )
+        .expect("stop missing");
 
         assert!(!status.proxy_running);
         assert!(status.message.contains("Removed stale proxy PID 12345"));
         assert_eq!(read_pid(&paths).expect("pid removed"), None);
         assert!(killer.killed.borrow().is_empty());
+    }
+
+    #[test]
+    fn stop_rechecks_current_listener_immediately_before_force_kill() {
+        let root = temp_root("listener-changed-before-kill");
+        let paths = test_paths(&root);
+        let port = free_port();
+        let pid = 12_345;
+        write_settings(&paths, port);
+        write_pid(&paths, pid, port, &paths.proxy_script_path()).expect("write pid");
+        let killer = RecordingKiller::default();
+        let inspector = RecordingInspector::new(fake_proxy_process(&paths, port));
+        let listener = SequenceListenerInspector::new([Some(54_321)]);
+        let record = read_pid_record(&paths)
+            .expect("read PID record")
+            .expect("managed PID record");
+
+        let error = force_kill_after_graceful_timeout(
+            &paths,
+            &record,
+            port,
+            &killer,
+            &inspector,
+            &listener,
+        )
+        .expect_err("changed listener must fence force kill");
+
+        assert!(
+            error.contains("immediately before force kill"),
+            "{error}; listener calls: {:?}; remaining: {:?}",
+            listener.calls.borrow(),
+            listener.pids.borrow()
+        );
+        assert!(error.contains("PID 54321"));
+        assert!(killer.killed.borrow().is_empty());
+        assert_eq!(read_pid(&paths).expect("pid preserved"), Some(pid));
+        assert_eq!(listener.calls.borrow().as_slice(), &[port]);
     }
 
     #[test]
@@ -2459,6 +2778,90 @@ time.sleep(10)
         assert!(error.contains("startup stderr"));
         assert!(error.contains("fake proxy stderr during startup"));
         assert_eq!(read_pid(&paths).expect("pid removed"), None);
+    }
+
+    #[test]
+    fn failed_start_cleanup_is_bounded_and_persists_identity_when_kill_is_unconfirmed() {
+        let root = temp_root("bounded-failed-cleanup");
+        let paths = test_paths(&root);
+        let port = free_port();
+        write_settings(&paths, port);
+        write_fake_proxy_script(&paths, "import time\ntime.sleep(30)");
+        let mut command = Command::new(find_python(&paths));
+        command.args(["-c", "import time; time.sleep(30)"]);
+        configure_start_stdio(&mut command);
+        let mut child = command.spawn().expect("spawn cleanup child");
+        let pid = child.id();
+        let capture = capture_child_stdio(&mut child);
+        let record = ProxyPidRecord::Managed(ProxyPidMetadata::new(
+            pid,
+            port,
+            &paths.proxy_script_path(),
+        ));
+        let inspector = RecordingInspector::new(fake_proxy_process(&paths, port));
+        let started = Instant::now();
+
+        let error = clean_up_failed_start_with_controls(
+            &paths,
+            &mut child,
+            capture,
+            "startup reconciliation failed".to_string(),
+            &record,
+            &inspector,
+            &UnconfirmedTerminator,
+        );
+
+        assert!(started.elapsed() < Duration::from_millis(500));
+        assert!(error.contains("termination could not be confirmed"));
+        assert_eq!(read_pid(&paths).expect("durable PID"), Some(pid));
+        kill_process(pid).expect("clean up live child");
+        let _ = child.wait();
+        let _ = super::remove_pid(&paths);
+    }
+
+    #[test]
+    fn exact_process_verification_rejects_raw_substring_only_script_matches() {
+        let root = temp_root("exact-command-args");
+        let paths = test_paths(&root);
+        let port = free_port();
+        let record = ProxyPidRecord::Managed(ProxyPidMetadata::new(
+            12_345,
+            port,
+            &paths.proxy_script_path(),
+        ));
+        let misleading = ProcessInfo::from_args(vec![
+            "python".to_string(),
+            "wrapper.py".to_string(),
+            "--note".to_string(),
+            format!("{}.backup", comparable_path(&paths.proxy_script_path())),
+            "--port".to_string(),
+            port.to_string(),
+        ]);
+
+        let error = verify_proxy_command_line(&record, &paths, port, &misleading)
+            .expect_err("raw substring must not establish exact process ownership");
+
+        assert!(error.contains("codex_proxy.py"));
+    }
+
+    #[test]
+    fn exact_process_verification_fences_pid_reuse_with_process_start_identity() {
+        let root = temp_root("pid-reuse-fence");
+        let paths = test_paths(&root);
+        let port = free_port();
+        let mut metadata = ProxyPidMetadata::new(12_345, port, &paths.proxy_script_path());
+        metadata.process_start_id = Some("original-start".to_string());
+        let record = ProxyPidRecord::Managed(metadata);
+        let mut reused = match fake_proxy_process(&paths, port) {
+            InspectedProcess::Running(info) => info,
+            InspectedProcess::Missing => unreachable!(),
+        };
+        reused.process_start_id = Some("reused-start".to_string());
+
+        let error = verify_proxy_command_line(&record, &paths, port, &reused)
+            .expect_err("same PID and args with a different start identity must be rejected");
+
+        assert!(error.contains("process start identity"));
     }
 
     #[test]
@@ -2826,34 +3229,6 @@ time.sleep(10)
         })
     }
 
-    fn spawn_health_then_shutdown_server(port: u16) -> std::thread::JoinHandle<()> {
-        std::thread::spawn(move || {
-            let listener = TcpListener::bind(("127.0.0.1", port)).expect("bind health port");
-            for _ in 0..2 {
-                let (mut stream, _) = listener.accept().expect("accept request");
-                let mut buffer = [0u8; 1024];
-                let count = std::io::Read::read(&mut stream, &mut buffer).unwrap_or(0);
-                let request = String::from_utf8_lossy(&buffer[..count]);
-                if request.starts_with("POST /shutdown ") {
-                    stream
-                        .write_all(
-                            b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
-                        )
-                        .expect("write shutdown response");
-                    break;
-                }
-                let body = r#"{"ok":true,"build":"test","features":[]}"#;
-                write!(
-                    stream,
-                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-                    body.len(),
-                    body
-                )
-                .expect("write health response");
-            }
-        })
-    }
-
     fn write_settings(paths: &ProxyPaths, port: u16) {
         fs::create_dir_all(paths.proxy_dir()).unwrap();
         let settings = Settings {
@@ -2883,6 +3258,30 @@ time.sleep(10)
 
     struct FixedListenerInspector {
         pid: Option<u32>,
+    }
+
+    struct SequenceListenerInspector {
+        pids: RefCell<VecDeque<Option<u32>>>,
+        calls: RefCell<Vec<u16>>,
+    }
+
+    impl SequenceListenerInspector {
+        fn new(pids: impl IntoIterator<Item = Option<u32>>) -> Self {
+            Self {
+                pids: RefCell::new(pids.into_iter().collect()),
+                calls: RefCell::new(Vec::new()),
+            }
+        }
+    }
+
+    impl ListenerInspector for SequenceListenerInspector {
+        fn listening_pid(&self, port: u16) -> Result<Option<u32>, String> {
+            self.calls.borrow_mut().push(port);
+            self.pids
+                .borrow_mut()
+                .pop_front()
+                .ok_or_else(|| "unexpected listener inspection".to_string())
+        }
     }
 
     impl FixedListenerInspector {
@@ -2990,6 +3389,14 @@ time.sleep(10)
     #[derive(Default)]
     struct RecordingKiller {
         killed: RefCell<Vec<u32>>,
+    }
+
+    struct UnconfirmedTerminator;
+
+    impl ChildTerminator for UnconfirmedTerminator {
+        fn terminate(&self, _child: &mut std::process::Child) -> Result<bool, String> {
+            Ok(false)
+        }
     }
 
     impl ProcessKiller for RecordingKiller {

--- a/src-tauri/src/proxy.rs
+++ b/src-tauri/src/proxy.rs
@@ -1,6 +1,6 @@
 use crate::gateway_lifecycle::{
     coordinator as gateway_lifecycle, GatewayIdentity, GatewayLifecycleBackend,
-    GatewayLifecycleSnapshot, GatewayStartOutcome,
+    GatewayLifecycleSnapshot, GatewayStartFailure, GatewayStartOutcome,
 };
 use crate::gateway_transaction::GatewayLifecyclePhase;
 use crate::AppStatus;
@@ -24,7 +24,8 @@ const SHUTDOWN_TIMEOUT: Duration = Duration::from_millis(800);
 const START_TIMEOUT: Duration = Duration::from_secs(20);
 const GRACEFUL_STOP_TIMEOUT: Duration = Duration::from_secs(2);
 const KILL_STOP_TIMEOUT: Duration = Duration::from_secs(5);
-const PID_FILE_VERSION: u32 = 1;
+const PID_FILE_VERSION: u32 = 2;
+const LEGACY_PID_FILE_VERSION: u32 = 1;
 const START_OUTPUT_CAPTURE_LIMIT: usize = 8 * 1024;
 const MANAGED_OVERLAY_MARKER_BEGIN: &str = "# BEGIN CODEX PROXY SESSION CONFIG";
 const MANAGED_OVERLAY_MARKER_END: &str = "# END CODEX PROXY SESSION CONFIG";
@@ -172,6 +173,7 @@ impl GatewayLifecycleBackend for ProxyLifecycleBackend {
         let settings = read_settings(&self.paths)?;
         let mode = read_mode(&self.paths)?;
         let (proxy_running, message) = match phase {
+            GatewayLifecyclePhase::Unavailable => (false, "Gateway lifecycle is unavailable"),
             GatewayLifecyclePhase::Starting => (false, "Gateway is starting"),
             GatewayLifecyclePhase::Stopping => (true, "Gateway is stopping"),
             GatewayLifecyclePhase::Restarting => (true, "Gateway is restarting"),
@@ -191,7 +193,7 @@ impl GatewayLifecycleBackend for ProxyLifecycleBackend {
         })
     }
 
-    fn start(&self) -> Result<GatewayStartOutcome, String> {
+    fn start(&self) -> Result<GatewayStartOutcome, GatewayStartFailure> {
         start_outcome_with_paths(&self.paths)
     }
 
@@ -351,18 +353,40 @@ struct ProxyPidMetadata {
     script_sha256: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     process_start_id: Option<String>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    recovery: bool,
     started_at_unix_ms: u64,
 }
 
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+
 impl ProxyPidMetadata {
-    fn new(pid: u32, port: u16, script: &Path) -> Self {
+    #[cfg(test)]
+    fn new(pid: u32, port: u16, script: &Path, process_start_id: String) -> Self {
+        Self::with_identity(pid, port, script, Some(process_start_id), false)
+    }
+
+    fn recovery(pid: u32, port: u16, script: &Path) -> Self {
+        Self::with_identity(pid, port, script, None, true)
+    }
+
+    fn with_identity(
+        pid: u32,
+        port: u16,
+        script: &Path,
+        process_start_id: Option<String>,
+        recovery: bool,
+    ) -> Self {
         Self {
             version: PID_FILE_VERSION,
             pid,
             port,
             script_path: comparable_path(script),
             script_sha256: file_sha256(script),
-            process_start_id: None,
+            process_start_id,
+            recovery,
             started_at_unix_ms: SystemTime::now()
                 .duration_since(UNIX_EPOCH)
                 .unwrap_or_default()
@@ -380,6 +404,7 @@ impl From<&ProxyPidMetadata> for GatewayIdentity {
             port: metadata.port,
             script_path: metadata.script_path.clone(),
             script_sha256: metadata.script_sha256.clone(),
+            process_start_id: metadata.process_start_id.clone(),
             started_at_unix_ms: metadata.started_at_unix_ms,
         }
     }
@@ -412,6 +437,20 @@ impl ProxyPidRecord {
             Self::Legacy(_) => None,
         }
     }
+
+    fn process_start_id(&self) -> Option<&String> {
+        match self {
+            Self::Managed(metadata) => metadata.process_start_id.as_ref(),
+            Self::Legacy(_) => None,
+        }
+    }
+
+    fn gateway_identity(&self) -> Option<GatewayIdentity> {
+        match self {
+            Self::Managed(metadata) => Some(GatewayIdentity::from(metadata)),
+            Self::Legacy(_) => None,
+        }
+    }
 }
 
 fn reconciled_snapshot_with_controls(
@@ -422,9 +461,13 @@ fn reconciled_snapshot_with_controls(
 ) -> Result<GatewayLifecycleSnapshot, String> {
     let settings = read_settings(paths)?;
     let mode = read_mode(paths)?;
-    let health = health_probe(settings.proxy_port)?;
-    let running_health = health.as_ref().filter(|response| response.is_running());
     let pid_record = read_pid_record(paths)?;
+    let reconciliation_port = pid_record
+        .as_ref()
+        .map(|record| record.expected_port(settings.proxy_port))
+        .unwrap_or(settings.proxy_port);
+    let health = health_probe(reconciliation_port)?;
+    let running_health = health.as_ref().filter(|response| response.is_running());
 
     let Some(response) = running_health else {
         if let Some(record) = pid_record {
@@ -432,11 +475,16 @@ fn reconciled_snapshot_with_controls(
                 VerifiedProxyProcess::Verified { pid } => {
                     return Err(format!(
                         "managed Gateway PID {pid} exists but health is unavailable on port {}; stop it through the lifecycle coordinator before starting another process",
-                        settings.proxy_port
+                        reconciliation_port
                     ));
                 }
                 VerifiedProxyProcess::Missing { .. } | VerifiedProxyProcess::Mismatch { .. } => {
                     remove_pid(paths)?
+                }
+                VerifiedProxyProcess::Unknown { pid, reason } => {
+                    return Err(format!(
+                        "managed Gateway PID {pid} could not be inspected ({reason}); preserved durable ownership for reconciliation"
+                    ));
                 }
             }
         }
@@ -458,48 +506,45 @@ fn reconciled_snapshot_with_controls(
     let Some(pid_record) = pid_record else {
         return Err(format!(
             "Gateway health responds on port {}, but no managed PID identity exists; refusing to claim or replace the external listener",
-            settings.proxy_port
+            reconciliation_port
         ));
     };
     let pid = pid_record.pid();
-    if pid_record.expected_port(settings.proxy_port) != settings.proxy_port {
-        remove_pid(paths)?;
-        return Err(format!(
-            "Gateway health responds on port {}, but managed PID {pid} records port {}; removed stale PID identity without stopping either process",
-            settings.proxy_port,
-            pid_record.expected_port(settings.proxy_port)
-        ));
-    }
 
-    match verify_proxy_process(&pid_record, paths, settings.proxy_port, inspector)? {
+    match verify_proxy_process(&pid_record, paths, reconciliation_port, inspector)? {
         VerifiedProxyProcess::Verified { .. } => {}
         VerifiedProxyProcess::Missing { .. } => {
             remove_pid(paths)?;
             return Err(format!(
                 "Gateway health responds on port {}, but managed PID {pid} no longer exists; removed stale PID identity without stopping the listener",
-                settings.proxy_port
+                reconciliation_port
             ));
         }
         VerifiedProxyProcess::Mismatch { reason, .. } => {
             remove_pid(paths)?;
             return Err(format!(
                 "Gateway health responds on port {}, but managed PID {pid} ownership could not be verified ({reason}); removed stale PID identity without stopping either process",
-                settings.proxy_port
+                reconciliation_port
+            ));
+        }
+        VerifiedProxyProcess::Unknown { reason, .. } => {
+            return Err(format!(
+                "Gateway health responds on port {reconciliation_port}, but managed PID {pid} inspection is unavailable ({reason}); preserved durable ownership"
             ));
         }
     }
 
-    let listener_pid = listener_inspector.listening_pid(settings.proxy_port)?;
+    let listener_pid = listener_inspector.listening_pid(reconciliation_port)?;
     let Some(listener_pid) = listener_pid else {
         return Err(format!(
             "Gateway health responds on port {}, but no TCP listener owner could be reconciled; preserved exact managed PID {pid} for ownership-safe recovery",
-            settings.proxy_port
+            reconciliation_port
         ));
     };
     if listener_pid != pid {
         return Err(format!(
             "Gateway health responds on port {}, but listener PID {listener_pid} differs from exact managed PID {pid}; preserved the managed PID identity without stopping either process",
-            settings.proxy_port
+            reconciliation_port
         ));
     }
 
@@ -510,6 +555,7 @@ fn reconciled_snapshot_with_controls(
             port: settings.proxy_port,
             script_path: comparable_path(&paths.proxy_script_path()),
             script_sha256: file_sha256(&paths.proxy_script_path()),
+            process_start_id: None,
             started_at_unix_ms: 0,
         },
     };
@@ -518,7 +564,7 @@ fn reconciled_snapshot_with_controls(
         status: AppStatus {
             mode,
             proxy_running: true,
-            proxy_port: settings.proxy_port,
+            proxy_port: reconciliation_port,
             proxy_build: response.build.clone(),
             message: format!("Gateway running with PID {pid}"),
             gateway_lifecycle: GatewayLifecyclePhase::Running,
@@ -552,9 +598,9 @@ fn status_with_paths(paths: &ProxyPaths) -> Result<AppStatus, String> {
         proxy_port: settings.proxy_port,
         proxy_build,
         message: if proxy_running {
-            "Proxy is healthy".to_string()
+            "Gateway is healthy".to_string()
         } else {
-            "Proxy is not running".to_string()
+            "Gateway is not running".to_string()
         },
         gateway_lifecycle: if proxy_running {
             GatewayLifecyclePhase::Running
@@ -568,10 +614,12 @@ fn status_with_paths(paths: &ProxyPaths) -> Result<AppStatus, String> {
 
 #[cfg(test)]
 fn start_with_paths(paths: &ProxyPaths) -> Result<AppStatus, String> {
-    start_outcome_with_paths(paths).map(|outcome| outcome.snapshot.status)
+    start_outcome_with_paths(paths)
+        .map(|outcome| outcome.snapshot.status)
+        .map_err(|failure| failure.message)
 }
 
-fn start_outcome_with_paths(paths: &ProxyPaths) -> Result<GatewayStartOutcome, String> {
+fn start_outcome_with_paths(paths: &ProxyPaths) -> Result<GatewayStartOutcome, GatewayStartFailure> {
     replace_managed_proxy_from_previous_bundle(paths)?;
     start_outcome_with_paths_and_timeout(paths, START_TIMEOUT)
 }
@@ -610,7 +658,7 @@ fn file_sha256(path: &Path) -> Option<String> {
 fn start_outcome_with_paths_and_timeout(
     paths: &ProxyPaths,
     timeout: Duration,
-) -> Result<GatewayStartOutcome, String> {
+) -> Result<GatewayStartOutcome, GatewayStartFailure> {
     start_with_paths_and_controls(
         paths,
         timeout,
@@ -652,6 +700,7 @@ where
         wait_for_startup,
     )
     .map(|outcome| outcome.snapshot.status)
+    .map_err(|failure| failure.message)
 }
 
 fn start_with_paths_and_controls<F>(
@@ -662,7 +711,7 @@ fn start_with_paths_and_controls<F>(
     inspector: &dyn ProcessInspector,
     listener_inspector: &dyn ListenerInspector,
     wait_for_startup: F,
-) -> Result<GatewayStartOutcome, String>
+) -> Result<GatewayStartOutcome, GatewayStartFailure>
 where
     F: FnOnce(
         &mut Child,
@@ -685,12 +734,12 @@ where
     let settings = read_settings(paths)?;
     let script = paths.proxy_script_path();
     if !script.exists() {
-        return Err(format!("proxy script not found: {}", script.display()));
+        return Err(format!("Gateway script not found: {}", script.display()).into());
     }
 
     fs::create_dir_all(paths.proxy_dir()).map_err(|error| {
         format!(
-            "failed to create proxy runtime directory {}: {error}",
+            "failed to create Gateway runtime directory {}: {error}",
             paths.proxy_dir().display()
         )
     })?;
@@ -701,7 +750,7 @@ where
 
     let mut child = command.spawn().map_err(|error| {
         format!(
-            "failed to start proxy with {} {}: {error}",
+            "failed to start Gateway with {} {}: {error}",
             python.display(),
             script.display()
         )
@@ -709,7 +758,7 @@ where
     let output_capture = capture_child_stdio(&mut child);
     let pid = child.id();
     let mut record =
-        ProxyPidRecord::Managed(ProxyPidMetadata::new(pid, settings.proxy_port, &script));
+        ProxyPidRecord::Managed(ProxyPidMetadata::recovery(pid, settings.proxy_port, &script));
 
     let startup = match wait_for_startup(
         &mut child,
@@ -758,7 +807,18 @@ where
                 }
             };
             if let ProxyPidRecord::Managed(metadata) = &mut record {
-                metadata.process_start_id = process_start_id;
+                let Some(process_start_id) = process_start_id else {
+                    return Err(clean_up_failed_start(
+                        paths,
+                        &mut child,
+                        output_capture,
+                        format!("spawned Gateway PID {pid} has no process creation identity"),
+                        &record,
+                        inspector,
+                    ));
+                };
+                metadata.process_start_id = Some(process_start_id);
+                metadata.recovery = false;
             }
             let verification =
                 verify_proxy_process(&record, paths, settings.proxy_port, inspector)?;
@@ -840,7 +900,7 @@ where
             &mut child,
             output_capture,
             format!(
-                "proxy returned a non-running health response at http://127.0.0.1:{}/health",
+                "Gateway returned a non-running health response at http://127.0.0.1:{}/health",
                 settings.proxy_port
             ),
             &record,
@@ -850,9 +910,10 @@ where
             let _ = remove_pid(paths);
             let output = output_capture.finish();
             Err(format_startup_failure(
-                format!("proxy process exited before health became ready with status {status:?}"),
+                format!("Gateway process exited before health became ready with status {status:?}"),
                 &output,
-            ))
+            )
+            .into())
         }
         StartupOutcome::TimedOut => Err(clean_up_failed_start(
             paths,
@@ -860,7 +921,7 @@ where
             output_capture,
             format_startup_failure(
                 format!(
-                    "proxy did not become healthy within {} seconds at http://127.0.0.1:{}/health",
+                    "Gateway did not become healthy within {} seconds at http://127.0.0.1:{}/health",
                     timeout.as_secs(),
                     settings.proxy_port
                 ),
@@ -879,7 +940,7 @@ fn clean_up_failed_start(
     reason: String,
     record: &ProxyPidRecord,
     inspector: &dyn ProcessInspector,
-) -> String {
+) -> GatewayStartFailure {
     clean_up_failed_start_with_controls(
         paths,
         child,
@@ -909,7 +970,11 @@ fn stop_with_paths_and_controls(
     let settings = read_settings(paths)?;
     let mode = read_mode(paths)?;
     let pid_record = read_pid_record(paths)?;
-    let was_running = health(settings.proxy_port)?
+    let lifecycle_port = pid_record
+        .as_ref()
+        .map(|record| record.expected_port(settings.proxy_port))
+        .unwrap_or(settings.proxy_port);
+    let was_running = health(lifecycle_port)?
         .as_ref()
         .map(HealthResponse::is_running)
         .unwrap_or(false);
@@ -918,7 +983,7 @@ fn stop_with_paths_and_controls(
         return stop_when_health_unavailable(
             paths,
             mode,
-            settings.proxy_port,
+            lifecycle_port,
             pid_record,
             killer,
             inspector,
@@ -929,36 +994,41 @@ fn stop_with_paths_and_controls(
     let Some(pid_record) = pid_record else {
         return Err(format!(
             "Gateway health responds on port {}, but no managed PID identity exists; refusing to send shutdown to the external listener",
-            settings.proxy_port
+            lifecycle_port
         ));
     };
 
-    let pid = match verify_proxy_process(&pid_record, paths, settings.proxy_port, inspector)? {
+    let pid = match verify_proxy_process(&pid_record, paths, lifecycle_port, inspector)? {
         VerifiedProxyProcess::Verified { pid } => pid,
         VerifiedProxyProcess::Missing { pid } => {
             remove_pid(paths)?;
             return Err(format!(
                 "Gateway health responds on port {}, but managed PID {pid} no longer exists; removed stale identity and refused shutdown",
-                settings.proxy_port
+                lifecycle_port
             ));
         }
         VerifiedProxyProcess::Mismatch { pid, reason } => {
             remove_pid(paths)?;
             return Err(format!(
                 "Gateway health responds on port {}, but managed PID {pid} ownership could not be verified ({reason}); removed stale identity and refused shutdown",
-                settings.proxy_port
+                lifecycle_port
+            ));
+        }
+        VerifiedProxyProcess::Unknown { pid, reason } => {
+            return Err(format!(
+                "managed Gateway PID {pid} inspection is unavailable before shutdown ({reason}); preserved durable ownership"
             ));
         }
     };
 
-    verify_listener_owner(pid, settings.proxy_port, listener_inspector, "before shutdown")?;
+    verify_listener_owner(pid, lifecycle_port, listener_inspector, "before shutdown")?;
 
-    let _ = request_shutdown(settings.proxy_port, &settings.gateway_client_key);
-    if wait_for_stopped(settings.proxy_port, GRACEFUL_STOP_TIMEOUT)? {
+    let _ = request_shutdown(lifecycle_port, &settings.gateway_client_key);
+    if wait_for_stopped(lifecycle_port, GRACEFUL_STOP_TIMEOUT)? {
         confirm_managed_process_stopped(
             &pid_record,
             paths,
-            settings.proxy_port,
+            lifecycle_port,
             inspector,
             GRACEFUL_STOP_TIMEOUT,
         )?;
@@ -966,9 +1036,9 @@ fn stop_with_paths_and_controls(
         return Ok(AppStatus {
             mode,
             proxy_running: false,
-            proxy_port: settings.proxy_port,
+            proxy_port: lifecycle_port,
             proxy_build: None,
-            message: "Proxy stopped gracefully".to_string(),
+            message: "Gateway stopped gracefully".to_string(),
             gateway_lifecycle: GatewayLifecyclePhase::Stopped,
             history_sync_status: None,
             history_sync_message: None,
@@ -978,22 +1048,22 @@ fn stop_with_paths_and_controls(
     let pid = force_kill_after_graceful_timeout(
         paths,
         &pid_record,
-        settings.proxy_port,
+        lifecycle_port,
         killer,
         inspector,
         listener_inspector,
     )?;
-    if !wait_for_stopped(settings.proxy_port, KILL_STOP_TIMEOUT)? {
+    if !wait_for_stopped(lifecycle_port, KILL_STOP_TIMEOUT)? {
         return Err(format!(
-            "sent kill signal to proxy PID {pid}, but health still responds on port {}",
-            settings.proxy_port
+            "sent kill signal to Gateway PID {pid}, but health still responds on port {}",
+            lifecycle_port
         ));
     }
 
     confirm_managed_process_stopped(
         &pid_record,
         paths,
-        settings.proxy_port,
+        lifecycle_port,
         inspector,
         KILL_STOP_TIMEOUT,
     )?;
@@ -1002,9 +1072,9 @@ fn stop_with_paths_and_controls(
     Ok(AppStatus {
         mode,
         proxy_running: false,
-        proxy_port: settings.proxy_port,
+        proxy_port: lifecycle_port,
         proxy_build: None,
-        message: format!("Proxy PID {pid} stopped"),
+        message: format!("Gateway PID {pid} stopped"),
         gateway_lifecycle: GatewayLifecyclePhase::Stopped,
         history_sync_status: None,
         history_sync_message: None,
@@ -1031,6 +1101,11 @@ fn force_kill_after_graceful_timeout(
             remove_pid(paths)?;
             return Err(format!(
                 "managed Gateway PID {pid} ownership could not be verified before force kill: {reason}"
+            ));
+        }
+        VerifiedProxyProcess::Unknown { pid, reason } => {
+            return Err(format!(
+                "managed Gateway PID {pid} inspection is unavailable before force kill ({reason}); preserved durable ownership"
             ));
         }
     };
@@ -1072,20 +1147,25 @@ fn stop_when_health_unavailable(
                     KILL_STOP_TIMEOUT,
                 )?;
                 remove_pid(paths)?;
-                format!("Proxy PID {pid} stopped after health endpoint was unavailable")
+                format!("Gateway PID {pid} stopped after health endpoint was unavailable")
             }
             VerifiedProxyProcess::Missing { pid } => {
                 remove_pid(paths)?;
-                format!("Removed stale proxy PID {pid}; health endpoint was unavailable")
+                format!("Removed stale Gateway PID {pid}; health endpoint was unavailable")
             }
             VerifiedProxyProcess::Mismatch { pid, reason } => {
                 remove_pid(paths)?;
                 format!(
-                    "Proxy health endpoint was unavailable, but PID {pid} was not killed because ownership could not be verified: {reason}; removed PID file"
+                    "Gateway health endpoint was unavailable, but PID {pid} was not killed because ownership could not be verified: {reason}; removed PID file"
                 )
             }
+            VerifiedProxyProcess::Unknown { pid, reason } => {
+                return Err(format!(
+                    "managed Gateway PID {pid} inspection is unavailable while health is unavailable ({reason}); preserved durable ownership"
+                ));
+            }
         },
-        None => "Proxy is not running".to_string(),
+        None => "Gateway is not running".to_string(),
     };
 
     Ok(AppStatus {
@@ -1141,6 +1221,13 @@ fn confirm_managed_process_stopped(
                 return Err(format!(
                     "Gateway PID {pid} changed identity while confirming termination ({reason}); preserved PID metadata for reconciliation"
                 ));
+            }
+            VerifiedProxyProcess::Unknown { pid, reason } => {
+                if Instant::now() >= deadline {
+                    return Err(format!(
+                        "Gateway PID {pid} could not be inspected while confirming termination ({reason}); preserved durable ownership"
+                    ));
+                }
             }
         }
         thread::sleep(Duration::from_millis(50));
@@ -1372,7 +1459,7 @@ impl ChildTerminator for SystemChildTerminator {
     fn terminate(&self, child: &mut Child) -> Result<bool, String> {
         if child
             .try_wait()
-            .map_err(|error| format!("failed to inspect proxy child process: {error}"))?
+            .map_err(|error| format!("failed to inspect Gateway child process: {error}"))?
             .is_some()
         {
             return Ok(true);
@@ -1380,9 +1467,9 @@ impl ChildTerminator for SystemChildTerminator {
         if let Err(error) = child.kill() {
             return match child.try_wait() {
                 Ok(Some(_)) => Ok(true),
-                Ok(None) => Err(format!("failed to kill proxy child process: {error}")),
+                Ok(None) => Err(format!("failed to kill Gateway child process: {error}")),
                 Err(wait_error) => Err(format!(
-                    "failed to kill proxy child process: {error}; exit inspection also failed: {wait_error}"
+                    "failed to kill Gateway child process: {error}; exit inspection also failed: {wait_error}"
                 )),
             };
         }
@@ -1397,7 +1484,7 @@ impl ChildTerminator for SystemChildTerminator {
                 Ok(None) => return Ok(false),
                 Err(error) => {
                     return Err(format!(
-                        "failed to confirm proxy child termination: {error}"
+                        "failed to confirm Gateway child termination: {error}"
                     ))
                 }
             }
@@ -1413,7 +1500,7 @@ fn clean_up_failed_start_with_controls(
     record: &ProxyPidRecord,
     inspector: &dyn ProcessInspector,
     terminator: &dyn ChildTerminator,
-) -> String {
+) -> GatewayStartFailure {
     let termination = terminator.terminate(child);
     let confirmed = matches!(termination, Ok(true));
     let output = if confirmed {
@@ -1427,7 +1514,10 @@ fn clean_up_failed_start_with_controls(
         if let Err(error) = remove_pid(paths) {
             message.push_str(&format!("\nfailed to remove terminated child PID identity: {error}"));
         }
-        return message;
+        return GatewayStartFailure {
+            message,
+            recovery_identity: None,
+        };
     }
 
     match termination {
@@ -1438,12 +1528,16 @@ fn clean_up_failed_start_with_controls(
         Ok(true) => unreachable!(),
     }
 
+    let mut recovery_identity = None;
     match verify_proxy_process(record, paths, record.expected_port(0), inspector) {
         Ok(VerifiedProxyProcess::Verified { pid }) => {
             match write_pid_record(paths, record) {
-                Ok(()) => message.push_str(&format!(
-                    "\npreserved durable ownership for verified live Gateway PID {pid}"
-                )),
+                Ok(()) => {
+                    message.push_str(&format!(
+                        "\npreserved durable ownership for verified live Gateway PID {pid}"
+                    ));
+                    recovery_identity = record.gateway_identity();
+                }
                 Err(error) => message.push_str(&format!(
                     "\nfailed to persist verified live Gateway ownership: {error}"
                 )),
@@ -1457,11 +1551,25 @@ fn clean_up_failed_start_with_controls(
         Ok(VerifiedProxyProcess::Mismatch { pid, reason }) => message.push_str(&format!(
             "\nPID {pid} could not be durably claimed after failed cleanup because ownership changed: {reason}"
         )),
+        Ok(VerifiedProxyProcess::Unknown { pid, reason }) => {
+            message.push_str(&format!(
+                "\nprocess inspection unavailable for spawned Gateway PID {pid}: {reason}"
+            ));
+            match write_pid_record(paths, record) {
+                Ok(()) => recovery_identity = record.gateway_identity(),
+                Err(error) => message.push_str(&format!(
+                    "\nfailed to persist spawn-known Gateway recovery ownership: {error}"
+                )),
+            }
+        }
         Err(error) => message.push_str(&format!(
             "\nfailed to reconcile child ownership after bounded cleanup: {error}"
         )),
     }
-    message
+    GatewayStartFailure {
+        message,
+        recovery_identity,
+    }
 }
 
 fn format_startup_failure(message: String, output: &StartupOutputSnapshot) -> String {
@@ -1525,6 +1633,7 @@ enum VerifiedProxyProcess {
     Verified { pid: u32 },
     Missing { pid: u32 },
     Mismatch { pid: u32, reason: String },
+    Unknown { pid: u32, reason: String },
 }
 
 struct SystemProcessKiller;
@@ -1561,7 +1670,7 @@ fn verify_proxy_process(
     let process = match inspector.inspect(pid) {
         Ok(process) => process,
         Err(error) => {
-            return Ok(VerifiedProxyProcess::Mismatch {
+            return Ok(VerifiedProxyProcess::Unknown {
                 pid,
                 reason: format!("process command line inspection failed: {error}"),
             });
@@ -1572,13 +1681,53 @@ fn verify_proxy_process(
         return Ok(VerifiedProxyProcess::Missing { pid });
     };
 
-    match verify_proxy_command_line(record, paths, settings_port, &info) {
-        Ok(()) => Ok(VerifiedProxyProcess::Verified { pid }),
-        Err(reason) => Ok(VerifiedProxyProcess::Mismatch { pid, reason }),
+    if let Err(reason) = verify_proxy_command_shape(record, paths, settings_port, &info) {
+        return Ok(VerifiedProxyProcess::Mismatch { pid, reason });
     }
+
+    let Some(expected_start_id) = record.process_start_id() else {
+        return Ok(VerifiedProxyProcess::Unknown {
+            pid,
+            reason: "durable PID metadata has no process creation identity; refusing destructive ownership claims"
+                .to_string(),
+        });
+    };
+    if info.process_start_id.as_ref() != Some(expected_start_id) {
+        return Ok(VerifiedProxyProcess::Mismatch {
+            pid,
+            reason: format!(
+                "process start identity differs from managed PID metadata (expected {expected_start_id:?}, found {:?})",
+                info.process_start_id
+            ),
+        });
+    }
+    Ok(VerifiedProxyProcess::Verified { pid })
 }
 
+#[cfg(test)]
 fn verify_proxy_command_line(
+    record: &ProxyPidRecord,
+    paths: &ProxyPaths,
+    settings_port: u16,
+    info: &ProcessInfo,
+) -> Result<(), String> {
+    verify_proxy_command_shape(record, paths, settings_port, info)?;
+    let Some(expected_start_id) = record.process_start_id() else {
+        return Err(
+            "durable PID metadata has no process creation identity; ownership is not destructively verifiable"
+                .to_string(),
+        );
+    };
+    if info.process_start_id.as_ref() != Some(expected_start_id) {
+        return Err(format!(
+            "process start identity differs from managed PID metadata (expected {expected_start_id:?}, found {:?})",
+            info.process_start_id
+        ));
+    }
+    Ok(())
+}
+
+fn verify_proxy_command_shape(
     record: &ProxyPidRecord,
     paths: &ProxyPaths,
     settings_port: u16,
@@ -1589,17 +1738,6 @@ fn verify_proxy_command_line(
         return Err(format!(
             "command line does not include expected --port {expected_port}"
         ));
-    }
-
-    if let ProxyPidRecord::Managed(metadata) = record {
-        if let Some(expected_start_id) = metadata.process_start_id.as_ref() {
-            if info.process_start_id.as_ref() != Some(expected_start_id) {
-                return Err(format!(
-                    "process start identity differs from managed PID metadata (expected {expected_start_id:?}, found {:?})",
-                    info.process_start_id
-                ));
-            }
-        }
     }
 
     if !command_line_has_script_name(info, "codex_proxy.py") {
@@ -1846,7 +1984,7 @@ fn wait_for_startup_health(
         }
         if let Some(status) = child
             .try_wait()
-            .map_err(|error| format!("failed to poll proxy child process: {error}"))?
+            .map_err(|error| format!("failed to poll Gateway child process: {error}"))?
         {
             return Ok(StartupOutcome::Exited(status));
         }
@@ -1886,7 +2024,7 @@ fn read_pid_record(paths: &ProxyPaths) -> Result<Option<ProxyPidRecord>, String>
         Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
         Err(error) => {
             return Err(format!(
-                "failed to read proxy PID file {}: {error}",
+                "failed to read Gateway PID file {}: {error}",
                 path.display()
             ));
         }
@@ -1899,12 +2037,21 @@ fn read_pid_record(paths: &ProxyPaths) -> Result<Option<ProxyPidRecord>, String>
 
     if trimmed.starts_with('{') {
         let metadata: ProxyPidMetadata = serde_json::from_str(trimmed).map_err(|error| {
-            format!("invalid proxy PID metadata in {}: {error}", path.display())
+            format!("invalid Gateway PID metadata in {}: {error}", path.display())
         })?;
-        if metadata.version != PID_FILE_VERSION {
+        if metadata.version != PID_FILE_VERSION && metadata.version != LEGACY_PID_FILE_VERSION {
             return Err(format!(
-                "unsupported proxy PID metadata version {} in {}",
+                "unsupported Gateway PID metadata version {} in {}",
                 metadata.version,
+                path.display()
+            ));
+        }
+        if metadata.version == PID_FILE_VERSION
+            && !metadata.recovery
+            && metadata.process_start_id.as_deref().is_none_or(str::is_empty)
+        {
+            return Err(format!(
+                "managed Gateway PID metadata version {PID_FILE_VERSION} in {} is missing the required process creation identity",
                 path.display()
             ));
         }
@@ -1914,19 +2061,24 @@ fn read_pid_record(paths: &ProxyPaths) -> Result<Option<ProxyPidRecord>, String>
     trimmed
         .parse::<u32>()
         .map(|pid| Some(ProxyPidRecord::Legacy(pid)))
-        .map_err(|error| format!("invalid proxy PID in {}: {error}", path.display()))
+        .map_err(|error| format!("invalid Gateway PID in {}: {error}", path.display()))
 }
 
 #[cfg(test)]
 fn write_pid(paths: &ProxyPaths, pid: u32, port: u16, script: &Path) -> Result<(), String> {
-    let metadata = ProxyPidMetadata::new(pid, port, script);
+    let metadata = ProxyPidMetadata::new(pid, port, script, test_process_start_id(pid));
     write_pid_record(paths, &ProxyPidRecord::Managed(metadata))
+}
+
+#[cfg(test)]
+fn test_process_start_id(pid: u32) -> String {
+    format!("test-process-start-{pid}")
 }
 
 fn write_pid_record(paths: &ProxyPaths, record: &ProxyPidRecord) -> Result<(), String> {
     fs::create_dir_all(paths.proxy_dir()).map_err(|error| {
         format!(
-            "failed to create proxy runtime directory {}: {error}",
+            "failed to create Gateway runtime directory {}: {error}",
             paths.proxy_dir().display()
         )
     })?;
@@ -1934,10 +2086,10 @@ fn write_pid_record(paths: &ProxyPaths, record: &ProxyPidRecord) -> Result<(), S
         return Err("refusing to publish legacy PID metadata for a new Gateway".to_string());
     };
     let text = serde_json::to_string_pretty(&metadata)
-        .map_err(|error| format!("failed to encode proxy PID metadata: {error}"))?;
+        .map_err(|error| format!("failed to encode Gateway PID metadata: {error}"))?;
     safe_file::write_text_atomic(&paths.pid_path(), &format!("{text}\n")).map_err(|error| {
         format!(
-            "failed to write proxy PID file {}: {error}",
+            "failed to write Gateway PID file {}: {error}",
             paths.pid_path().display()
         )
     })
@@ -1948,7 +2100,7 @@ fn remove_pid(paths: &ProxyPaths) -> Result<(), String> {
         Ok(()) => Ok(()),
         Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
         Err(error) => Err(format!(
-            "failed to remove proxy PID file {}: {error}",
+            "failed to remove Gateway PID file {}: {error}",
             paths.pid_path().display()
         )),
     }
@@ -2235,8 +2387,8 @@ mod tests {
         start_with_paths, start_with_paths_and_controls, start_with_paths_and_waiter,
         status_with_paths, stop_with_paths, stop_with_paths_and_controls, verify_proxy_command_line,
         write_pid, ChildTerminator, InspectedProcess, ListenerInspector, ProcessInfo,
-        ProcessInspector, ProcessKiller, ProxyPaths, ProxyPidMetadata, ProxyPidRecord, StartupOutcome,
-        DEBUG_DIAGNOSTIC_BOOTSTRAP,
+        ProcessInspector, ProcessKiller, ProxyLifecycleBackend, ProxyPaths, ProxyPidMetadata,
+        ProxyPidRecord, StartupOutcome, VerifiedProxyProcess, DEBUG_DIAGNOSTIC_BOOTSTRAP,
     };
     use crate::Settings;
     use std::cell::RefCell;
@@ -2391,7 +2543,7 @@ mod tests {
         )
         .expect_err("listener mismatch must fail startup");
 
-        assert!(error.contains("listener PID 999999"));
+        assert!(error.message.contains("listener PID 999999"));
         assert_eq!(read_pid(&paths).expect("read PID"), None);
         let pid = spawned_pid.load(Ordering::SeqCst);
         let inspected = super::inspect_process(pid);
@@ -2430,7 +2582,7 @@ mod tests {
         )
         .expect_err("listener inspection failure must fail startup");
 
-        assert!(error.contains("listener inspection unavailable"));
+        assert!(error.message.contains("listener inspection unavailable"));
         assert_eq!(read_pid(&paths).expect("read PID"), None);
         let pid = spawned_pid.load(Ordering::SeqCst);
         let inspected = super::inspect_process(pid);
@@ -2527,7 +2679,9 @@ model_catalog_json = "model-catalogs/codex-proxy-official-ollama.json"
         assert_eq!(metadata.pid, 42);
         assert_eq!(metadata.port, 4555);
         assert_eq!(metadata.script_path, comparable_path(&script));
-        assert_eq!(metadata.version, 1);
+        assert_eq!(metadata.version, 2);
+        assert_eq!(metadata.process_start_id, Some(super::test_process_start_id(42)));
+        assert!(!metadata.recovery);
         let text = fs::read_to_string(paths.pid_path()).expect("pid text");
         let parsed: ProxyPidMetadata = serde_json::from_str(&text).expect("metadata json");
         assert_eq!(parsed.pid, 42);
@@ -2690,7 +2844,7 @@ model_catalog_json = "model-catalogs/codex-proxy-official-ollama.json"
         .expect("stop missing");
 
         assert!(!status.proxy_running);
-        assert!(status.message.contains("Removed stale proxy PID 12345"));
+        assert!(status.message.contains("Removed stale Gateway PID 12345"));
         assert_eq!(read_pid(&paths).expect("pid removed"), None);
         assert!(killer.killed.borrow().is_empty());
     }
@@ -2793,7 +2947,7 @@ time.sleep(10)
         let mut child = command.spawn().expect("spawn cleanup child");
         let pid = child.id();
         let capture = capture_child_stdio(&mut child);
-        let record = ProxyPidRecord::Managed(ProxyPidMetadata::new(
+        let record = ProxyPidRecord::Managed(ProxyPidMetadata::recovery(
             pid,
             port,
             &paths.proxy_script_path(),
@@ -2801,7 +2955,7 @@ time.sleep(10)
         let inspector = RecordingInspector::new(fake_proxy_process(&paths, port));
         let started = Instant::now();
 
-        let error = clean_up_failed_start_with_controls(
+        let failure = clean_up_failed_start_with_controls(
             &paths,
             &mut child,
             capture,
@@ -2812,11 +2966,108 @@ time.sleep(10)
         );
 
         assert!(started.elapsed() < Duration::from_millis(500));
-        assert!(error.contains("termination could not be confirmed"));
+        assert!(failure.message.contains("termination could not be confirmed"));
+        assert_eq!(
+            failure.recovery_identity.as_ref().map(|identity| identity.pid),
+            Some(pid)
+        );
         assert_eq!(read_pid(&paths).expect("durable PID"), Some(pid));
         kill_process(pid).expect("clean up live child");
         let _ = child.wait();
         let _ = super::remove_pid(&paths);
+    }
+
+    #[test]
+    fn failed_start_cleanup_preserves_spawn_known_recovery_when_inspection_is_unknown() {
+        let root = temp_root("unknown-failed-cleanup");
+        let paths = test_paths(&root);
+        let port = free_port();
+        write_settings(&paths, port);
+        write_fake_proxy_script(&paths, "import time\ntime.sleep(30)");
+        let mut command = Command::new(find_python(&paths));
+        command.args(["-c", "import time; time.sleep(30)"]);
+        configure_start_stdio(&mut command);
+        let mut child = command.spawn().expect("spawn cleanup child");
+        let pid = child.id();
+        let capture = capture_child_stdio(&mut child);
+        let record = ProxyPidRecord::Managed(ProxyPidMetadata::recovery(
+            pid,
+            port,
+            &paths.proxy_script_path(),
+        ));
+
+        let failure = clean_up_failed_start_with_controls(
+            &paths,
+            &mut child,
+            capture,
+            "startup reconciliation failed".to_string(),
+            &record,
+            &ErroringInspector,
+            &UnconfirmedTerminator,
+        );
+
+        assert!(failure.message.contains("inspection unavailable"));
+        assert_eq!(
+            failure.recovery_identity.as_ref().map(|identity| identity.pid),
+            Some(pid)
+        );
+        assert_eq!(read_pid(&paths).expect("durable recovery PID"), Some(pid));
+        kill_process(pid).expect("clean up live child");
+        let _ = child.wait();
+        let _ = super::remove_pid(&paths);
+    }
+
+    #[test]
+    fn unknown_process_inspection_preserves_durable_identity() {
+        let root = temp_root("unknown-inspection");
+        let paths = test_paths(&root);
+        let port = free_port();
+        let pid = 12_345;
+        write_settings(&paths, port);
+        write_pid(&paths, pid, port, &paths.proxy_script_path()).expect("write PID");
+
+        let error = reconciled_snapshot_with_controls(
+            &paths,
+            &|_| Ok(None),
+            &ErroringInspector,
+            &FixedListenerInspector::new(None),
+        )
+        .expect_err("unknown process inspection must not become stopped");
+
+        assert!(error.contains("inspection unavailable"));
+        assert_eq!(read_pid(&paths).expect("PID preserved"), Some(pid));
+    }
+
+    #[test]
+    fn legacy_v1_without_process_start_identity_is_never_destructively_verified() {
+        let root = temp_root("legacy-v1-unfenced");
+        let paths = test_paths(&root);
+        let port = free_port();
+        let pid = 12_345;
+        write_settings(&paths, port);
+        fs::create_dir_all(paths.proxy_dir()).unwrap();
+        fs::write(
+            paths.pid_path(),
+            format!(
+                "{{\"version\":1,\"pid\":{pid},\"port\":{port},\"script_path\":{:?},\"started_at_unix_ms\":1}}",
+                comparable_path(&paths.proxy_script_path())
+            ),
+        )
+        .unwrap();
+        let record = read_pid_record(&paths)
+            .expect("read legacy v1")
+            .expect("legacy record");
+
+        let verification = super::verify_proxy_process(
+            &record,
+            &paths,
+            port,
+            &RecordingInspector::new(fake_proxy_process(&paths, port)),
+        )
+        .expect("verification result");
+
+        assert!(matches!(verification, VerifiedProxyProcess::Unknown { pid: value, .. } if value == pid));
+        assert_eq!(read_pid(&paths).expect("legacy PID preserved"), Some(pid));
     }
 
     #[test]
@@ -2828,6 +3079,7 @@ time.sleep(10)
             12_345,
             port,
             &paths.proxy_script_path(),
+            super::test_process_start_id(12_345),
         ));
         let misleading = ProcessInfo::from_args(vec![
             "python".to_string(),
@@ -2849,7 +3101,12 @@ time.sleep(10)
         let root = temp_root("pid-reuse-fence");
         let paths = test_paths(&root);
         let port = free_port();
-        let mut metadata = ProxyPidMetadata::new(12_345, port, &paths.proxy_script_path());
+        let mut metadata = ProxyPidMetadata::new(
+            12_345,
+            port,
+            &paths.proxy_script_path(),
+            "original-start".to_string(),
+        );
         metadata.process_start_id = Some("original-start".to_string());
         let record = ProxyPidRecord::Managed(metadata);
         let mut reused = match fake_proxy_process(&paths, port) {
@@ -3095,8 +3352,8 @@ time.sleep(10)
             let stop_status = stop_with_paths(&paths)?;
             ensure(!stop_status.proxy_running, "stop status should be stopped")?;
             ensure(
-                stop_status.message == "Proxy stopped gracefully",
-                "stop should use the proxy /shutdown endpoint",
+                stop_status.message == "Gateway stopped gracefully",
+                "stop should use the Gateway /shutdown endpoint",
             )?;
             ensure(read_pid(&paths)?.is_none(), "stop should remove PID")?;
 
@@ -3107,6 +3364,45 @@ time.sleep(10)
 
         let _ = stop_with_paths(&paths);
         result.expect("python proxy lifecycle");
+    }
+
+    #[test]
+    fn restart_after_settings_port_change_stops_recorded_port_before_starting_new_port() {
+        let root = temp_root("python-port-change-restart");
+        let repo_root = copy_python_sources_to_temp_repo(&root);
+        let paths = ProxyPaths::new(root.join("codex-home"), repo_root);
+        let old_port = free_port();
+        let new_port = free_port();
+        write_settings(&paths, old_port);
+
+        let result = (|| {
+            let old_status = start_with_paths(&paths)?;
+            ensure(old_status.proxy_port == old_port, "old Gateway should use old port")?;
+            let old_pid = read_pid(&paths)?.ok_or_else(|| "old PID missing".to_string())?;
+            write_settings(&paths, new_port);
+            let backend = ProxyLifecycleBackend {
+                lifecycle_gate_path: paths.lifecycle_gate_path(),
+                paths: paths.clone(),
+            };
+            let coordinator = crate::gateway_lifecycle::GatewayLifecycleCoordinator::new();
+
+            let replacement = coordinator.restart(&backend, || Ok(()))?;
+
+            ensure(
+                replacement.status.proxy_running && replacement.status.proxy_port == new_port,
+                "replacement Gateway should run on new settings port",
+            )?;
+            let new_pid = read_pid(&paths)?.ok_or_else(|| "replacement PID missing".to_string())?;
+            ensure(new_pid != old_pid, "restart should replace the old process")?;
+            ensure(
+                super::health(old_port)?.is_none(),
+                "old recorded port should be released before replacement publication",
+            )?;
+            Ok::<(), String>(())
+        })();
+
+        let _ = stop_with_paths(&paths);
+        result.expect("port-change restart lifecycle");
     }
 
     #[test]
@@ -3324,14 +3620,16 @@ time.sleep(10)
     }
 
     fn fake_proxy_process(paths: &ProxyPaths, port: u16) -> InspectedProcess {
-        InspectedProcess::Running(ProcessInfo::from_args(vec![
+        let mut info = ProcessInfo::from_args(vec![
             "python".to_string(),
             comparable_path(&paths.proxy_script_path()),
             "--host".to_string(),
             "127.0.0.1".to_string(),
             "--port".to_string(),
             port.to_string(),
-        ]))
+        ]);
+        info.process_start_id = Some(super::test_process_start_id(12_345));
+        InspectedProcess::Running(info)
     }
 
     fn copy_python_sources_to_temp_repo(root: &Path) -> PathBuf {
@@ -3424,6 +3722,14 @@ time.sleep(10)
         fn inspect(&self, pid: u32) -> Result<InspectedProcess, String> {
             self.inspected.borrow_mut().push(pid);
             Ok(self.process.clone())
+        }
+    }
+
+    struct ErroringInspector;
+
+    impl ProcessInspector for ErroringInspector {
+        fn inspect(&self, _pid: u32) -> Result<InspectedProcess, String> {
+            Err("process inspection unavailable".to_string())
         }
     }
 }

--- a/src-tauri/src/proxy.rs
+++ b/src-tauri/src/proxy.rs
@@ -10,14 +10,52 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::fs;
 use std::io::{self, Read};
+#[cfg(windows)]
+use std::io::{Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::{Arc, Mutex};
+#[cfg(windows)]
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 #[cfg(windows)]
+use std::os::windows::fs::OpenOptionsExt;
+#[cfg(windows)]
+use std::os::windows::io::AsRawHandle;
+#[cfg(windows)]
 use std::os::windows::process::CommandExt;
+#[cfg(windows)]
+use windows_sys::Win32::Foundation::{
+    CloseHandle, FILETIME, HANDLE, INVALID_HANDLE_VALUE, ERROR_INSUFFICIENT_BUFFER, NO_ERROR,
+};
+#[cfg(windows)]
+use windows_sys::Win32::NetworkManagement::IpHelper::{
+    GetExtendedTcpTable, MIB_TCPROW_OWNER_PID, MIB_TCPTABLE_OWNER_PID,
+    TCP_TABLE_OWNER_PID_LISTENER,
+};
+#[cfg(windows)]
+use windows_sys::Win32::Storage::FileSystem::{
+    FILE_ATTRIBUTE_TEMPORARY, FILE_FLAG_DELETE_ON_CLOSE, FILE_SHARE_DELETE,
+};
+#[cfg(windows)]
+use windows_sys::Win32::System::Diagnostics::ToolHelp::{
+    CreateToolhelp32Snapshot, Thread32First, Thread32Next, TH32CS_SNAPTHREAD, THREADENTRY32,
+};
+#[cfg(windows)]
+use windows_sys::Win32::System::JobObjects::{
+    AssignProcessToJobObject, CreateJobObjectW, SetInformationJobObject, TerminateJobObject,
+    JobObjectExtendedLimitInformation, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+    JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+};
+#[cfg(windows)]
+use windows_sys::Win32::System::Pipes::PeekNamedPipe;
+#[cfg(windows)]
+use windows_sys::Win32::System::Threading::{
+    GetProcessTimes, OpenProcess, OpenThread, ResumeThread, PROCESS_QUERY_LIMITED_INFORMATION,
+    THREAD_SUSPEND_RESUME,
+};
 
 const HEALTH_TIMEOUT: Duration = Duration::from_millis(800);
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_millis(800);
@@ -27,6 +65,10 @@ const KILL_STOP_TIMEOUT: Duration = Duration::from_secs(5);
 const PID_FILE_VERSION: u32 = 2;
 const LEGACY_PID_FILE_VERSION: u32 = 1;
 const START_OUTPUT_CAPTURE_LIMIT: usize = 8 * 1024;
+#[cfg(windows)]
+const WINDOWS_INSPECTION_OUTPUT_LIMIT: usize = 64 * 1024;
+#[cfg(windows)]
+const WINDOWS_INSPECTION_TIMEOUT: Duration = Duration::from_secs(5);
 const MANAGED_OVERLAY_MARKER_BEGIN: &str = "# BEGIN CODEX PROXY SESSION CONFIG";
 const MANAGED_OVERLAY_MARKER_END: &str = "# END CODEX PROXY SESSION CONFIG";
 // This is intentionally reached only from the compile-selected Rust debug
@@ -372,6 +414,15 @@ impl ProxyPidMetadata {
         Self::with_identity(pid, port, script, None, true)
     }
 
+    fn recovery_with_identity(
+        pid: u32,
+        port: u16,
+        script: &Path,
+        process_start_id: String,
+    ) -> Self {
+        Self::with_identity(pid, port, script, Some(process_start_id), true)
+    }
+
     fn with_identity(
         pid: u32,
         port: u16,
@@ -503,13 +554,70 @@ fn reconciled_snapshot_with_controls(
         });
     };
 
-    let Some(pid_record) = pid_record else {
+    let Some(mut pid_record) = pid_record else {
         return Err(format!(
             "Gateway health responds on port {}, but no managed PID identity exists; refusing to claim or replace the external listener",
             reconciliation_port
         ));
     };
     let pid = pid_record.pid();
+    let recovery_pending = matches!(
+        &pid_record,
+        ProxyPidRecord::Managed(metadata) if metadata.recovery
+    );
+    let recovery_requires_identity = matches!(
+        &pid_record,
+        ProxyPidRecord::Managed(metadata) if metadata.recovery && metadata.process_start_id.is_none()
+    );
+
+    if recovery_requires_identity {
+        let process = inspector.inspect(pid).map_err(|error| {
+            format!(
+                "Gateway health responds on port {reconciliation_port}, but managed PID {pid} inspection is unavailable (process command line inspection failed: {error}); preserved durable ownership"
+            )
+        })?;
+        let InspectedProcess::Running(info) = process else {
+            remove_pid(paths)?;
+            return Err(format!(
+                "Gateway health responds on port {}, but managed PID {pid} no longer exists; removed stale PID identity without stopping the listener",
+                reconciliation_port
+            ));
+        };
+        if let Err(reason) = verify_proxy_command_shape(
+            &pid_record,
+            paths,
+            reconciliation_port,
+            &info,
+        ) {
+            remove_pid(paths)?;
+            return Err(format!(
+                "Gateway health responds on port {}, but managed PID {pid} ownership could not be verified ({reason}); removed stale PID identity without stopping either process",
+                reconciliation_port
+            ));
+        }
+        let listener_pid = listener_inspector.listening_pid(reconciliation_port)?;
+        if listener_pid != Some(pid) {
+            let detail = listener_pid
+                .map(|value| format!("listener PID {value}"))
+                .unwrap_or_else(|| "no TCP listener owner".to_string());
+            return Err(format!(
+                "Gateway health responds on port {reconciliation_port}, but {detail} differs from exact managed PID {pid}; preserved the managed PID identity without stopping either process"
+            ));
+        }
+        let Some(process_start_id) = info.process_start_id else {
+            return Err(format!(
+                "Gateway health responds on port {reconciliation_port}, but managed PID {pid} inspection has no process creation identity; preserved durable ownership"
+            ));
+        };
+        if let ProxyPidRecord::Managed(metadata) = &mut pid_record {
+            metadata.process_start_id = Some(process_start_id);
+            metadata.recovery = false;
+        }
+    } else if recovery_pending {
+        if let ProxyPidRecord::Managed(metadata) = &mut pid_record {
+            metadata.recovery = false;
+        }
+    }
 
     match verify_proxy_process(&pid_record, paths, reconciliation_port, inspector)? {
         VerifiedProxyProcess::Verified { .. } => {}
@@ -546,6 +654,10 @@ fn reconciled_snapshot_with_controls(
             "Gateway health responds on port {}, but listener PID {listener_pid} differs from exact managed PID {pid}; preserved the managed PID identity without stopping either process",
             reconciliation_port
         ));
+    }
+
+    if recovery_pending {
+        write_pid_record(paths, &pid_record)?;
     }
 
     let identity = match &pid_record {
@@ -757,8 +869,29 @@ where
     })?;
     let output_capture = capture_child_stdio(&mut child);
     let pid = child.id();
-    let mut record =
-        ProxyPidRecord::Managed(ProxyPidMetadata::recovery(pid, settings.proxy_port, &script));
+    let process_start_id = match inspector.spawned_process_start_id(&child) {
+        Ok(process_start_id) => process_start_id,
+        Err(error) => {
+            return Err(clean_up_failed_start(
+                paths,
+                &mut child,
+                output_capture,
+                error,
+                &ProxyPidRecord::Managed(ProxyPidMetadata::recovery(
+                    pid,
+                    settings.proxy_port,
+                    &script,
+                )),
+                inspector,
+            ))
+        }
+    };
+    let mut record = ProxyPidRecord::Managed(ProxyPidMetadata::recovery_with_identity(
+        pid,
+        settings.proxy_port,
+        &script,
+        process_start_id,
+    ));
 
     let startup = match wait_for_startup(
         &mut child,
@@ -783,8 +916,21 @@ where
 
     match startup {
         StartupOutcome::Healthy(response) if response.is_running() => {
-            let process_start_id = match inspector.inspect(pid) {
-                Ok(InspectedProcess::Running(info)) => info.process_start_id,
+            match inspector.inspect(pid) {
+                Ok(InspectedProcess::Running(info)) => {
+                    if info.process_start_id.as_ref() != record.process_start_id() {
+                        return Err(clean_up_failed_start(
+                            paths,
+                            &mut child,
+                            output_capture,
+                            format!(
+                                "spawned Gateway PID {pid} process creation identity changed during startup fencing"
+                            ),
+                            &record,
+                            inspector,
+                        ));
+                    }
+                }
                 Ok(InspectedProcess::Missing) => {
                     return Err(clean_up_failed_start(
                         paths,
@@ -805,23 +951,13 @@ where
                         inspector,
                     ))
                 }
-            };
-            if let ProxyPidRecord::Managed(metadata) = &mut record {
-                let Some(process_start_id) = process_start_id else {
-                    return Err(clean_up_failed_start(
-                        paths,
-                        &mut child,
-                        output_capture,
-                        format!("spawned Gateway PID {pid} has no process creation identity"),
-                        &record,
-                        inspector,
-                    ));
-                };
-                metadata.process_start_id = Some(process_start_id);
+            }
+            let mut verified_record = record.clone();
+            if let ProxyPidRecord::Managed(metadata) = &mut verified_record {
                 metadata.recovery = false;
             }
             let verification =
-                verify_proxy_process(&record, paths, settings.proxy_port, inspector)?;
+                verify_proxy_process(&verified_record, paths, settings.proxy_port, inspector)?;
             if verification != (VerifiedProxyProcess::Verified { pid }) {
                 return Err(clean_up_failed_start(
                     paths,
@@ -865,6 +1001,7 @@ where
                 ));
             }
 
+            record = verified_record;
             if let Err(error) = write_pid_record(paths, &record) {
                 return Err(clean_up_failed_start(
                     paths,
@@ -1347,16 +1484,35 @@ struct StartupOutputCapture {
     stdout: Arc<Mutex<BoundedOutput>>,
     stderr: Arc<Mutex<BoundedOutput>>,
     handles: Mutex<Vec<thread::JoinHandle<()>>>,
+    #[cfg(windows)]
+    stop: Arc<AtomicBool>,
 }
 
 impl StartupOutputCapture {
+    #[cfg(windows)]
+    fn capture_reader<R>(&self, reader: R, stream: StartupStream)
+    where
+        R: Read + AsRawHandle + Send + 'static,
+    {
+        let buffer = match stream {
+            StartupStream::Stdout => Arc::downgrade(&self.stdout),
+            StartupStream::Stderr => Arc::downgrade(&self.stderr),
+        };
+        let stop = Arc::clone(&self.stop);
+        let handle = thread::spawn(move || drain_reader_to_buffer(reader, buffer, stop));
+        if let Ok(mut handles) = self.handles.lock() {
+            handles.push(handle);
+        }
+    }
+
+    #[cfg(not(windows))]
     fn capture_reader<R>(&self, reader: R, stream: StartupStream)
     where
         R: Read + Send + 'static,
     {
         let buffer = match stream {
-            StartupStream::Stdout => Arc::clone(&self.stdout),
-            StartupStream::Stderr => Arc::clone(&self.stderr),
+            StartupStream::Stdout => Arc::downgrade(&self.stdout),
+            StartupStream::Stderr => Arc::downgrade(&self.stderr),
         };
         let handle = thread::spawn(move || drain_reader_to_buffer(reader, buffer));
         if let Ok(mut handles) = self.handles.lock() {
@@ -1365,12 +1521,24 @@ impl StartupOutputCapture {
     }
 
     fn finish(self) -> StartupOutputSnapshot {
+        #[cfg(windows)]
+        self.stop.store(true, Ordering::Release);
+        self.join_readers();
+        self.snapshot()
+    }
+
+    #[cfg(windows)]
+    fn stop_readers(&self) {
+        self.stop.store(true, Ordering::Release);
+        self.join_readers();
+    }
+
+    fn join_readers(&self) {
         if let Ok(mut handles) = self.handles.lock() {
             for handle in handles.drain(..) {
                 let _ = handle.join();
             }
         }
-        self.snapshot()
     }
 
     fn snapshot(&self) -> StartupOutputSnapshot {
@@ -1430,7 +1598,57 @@ impl BoundedOutput {
     }
 }
 
-fn drain_reader_to_buffer<R>(mut reader: R, buffer: Arc<Mutex<BoundedOutput>>)
+#[cfg(windows)]
+fn drain_reader_to_buffer<R>(
+    mut reader: R,
+    buffer: std::sync::Weak<Mutex<BoundedOutput>>,
+    stop: Arc<AtomicBool>,
+)
+where
+    R: Read + AsRawHandle,
+{
+    let mut chunk = [0u8; 1024];
+    loop {
+        let Some(buffer) = buffer.upgrade() else {
+            break;
+        };
+        let mut available = 0u32;
+        let readable = unsafe {
+            PeekNamedPipe(
+                reader.as_raw_handle() as HANDLE,
+                std::ptr::null_mut(),
+                0,
+                std::ptr::null_mut(),
+                &mut available,
+                std::ptr::null_mut(),
+            )
+        };
+        if readable == 0 {
+            break;
+        }
+        if available == 0 {
+            if stop.load(Ordering::Acquire) {
+                break;
+            }
+            drop(buffer);
+            thread::sleep(Duration::from_millis(20));
+            continue;
+        }
+        let count = available.min(chunk.len() as u32) as usize;
+        match reader.read(&mut chunk[..count]) {
+            Ok(0) => break,
+            Ok(count) => {
+                if let Ok(mut buffer) = buffer.lock() {
+                    buffer.append(&chunk[..count]);
+                }
+            }
+            Err(_) => break,
+        }
+    }
+}
+
+#[cfg(not(windows))]
+fn drain_reader_to_buffer<R>(mut reader: R, buffer: std::sync::Weak<Mutex<BoundedOutput>>)
 where
     R: Read,
 {
@@ -1439,6 +1657,9 @@ where
         match reader.read(&mut chunk) {
             Ok(0) => break,
             Ok(count) => {
+                let Some(buffer) = buffer.upgrade() else {
+                    break;
+                };
                 if let Ok(mut buffer) = buffer.lock() {
                     buffer.append(&chunk[..count]);
                 }
@@ -1506,6 +1727,8 @@ fn clean_up_failed_start_with_controls(
     let output = if confirmed {
         output_capture.finish()
     } else {
+        #[cfg(windows)]
+        output_capture.stop_readers();
         output_capture.snapshot()
     };
     let mut message = format_startup_failure(reason, &output);
@@ -1589,6 +1812,10 @@ trait ProcessKiller {
 
 trait ProcessInspector {
     fn inspect(&self, pid: u32) -> Result<InspectedProcess, String>;
+
+    fn spawned_process_start_id(&self, child: &Child) -> Result<String, String> {
+        child_process_start_id(child)
+    }
 }
 
 trait ListenerInspector {
@@ -1667,6 +1894,13 @@ fn verify_proxy_process(
     inspector: &dyn ProcessInspector,
 ) -> Result<VerifiedProxyProcess, String> {
     let pid = record.pid();
+    if matches!(record, ProxyPidRecord::Managed(metadata) if metadata.recovery) {
+        return Ok(VerifiedProxyProcess::Unknown {
+            pid,
+            reason: "spawn-known recovery ownership is pending health, process, and listener activation"
+                .to_string(),
+        });
+    }
     let process = match inspector.inspect(pid) {
         Ok(process) => process,
         Err(error) => {
@@ -2173,41 +2407,396 @@ fn configure_no_window(command: &mut Command) {
 }
 
 #[cfg(windows)]
-fn inspect_listener_pid(port: u16) -> Result<Option<u32>, String> {
-    let script = format!(
-        "$rows = @(Get-NetTCPConnection -State Listen -LocalPort {port} -ErrorAction SilentlyContinue | Where-Object {{ $_.LocalAddress -eq '127.0.0.1' }} | Select-Object -ExpandProperty OwningProcess -Unique); \
-         if ($rows.Count -eq 0) {{ exit 3 }}; \
-         if ($rows.Count -ne 1) {{ [Console]::Error.Write(($rows -join ',')); exit 4 }}; \
-         [Console]::Out.Write([string]$rows[0])"
-    );
+#[derive(Clone, Copy)]
+enum WindowsInspectionKind {
+    Process,
+    #[cfg(test)]
+    Listener,
+}
+
+#[cfg(windows)]
+impl WindowsInspectionKind {
+    fn timeout_error(self) -> &'static str {
+        match self {
+            Self::Process => "Gateway process inspection timed out",
+            #[cfg(test)]
+            Self::Listener => "Gateway listener inspection timed out",
+        }
+    }
+
+    fn start_error(self) -> &'static str {
+        match self {
+            Self::Process => "failed to start Gateway process inspection",
+            #[cfg(test)]
+            Self::Listener => "failed to start Gateway listener inspection",
+        }
+    }
+
+    fn stop_error(self) -> &'static str {
+        match self {
+            Self::Process => "failed to stop Gateway process inspection",
+            #[cfg(test)]
+            Self::Listener => "failed to stop Gateway listener inspection",
+        }
+    }
+
+    fn wait_error(self) -> &'static str {
+        match self {
+            Self::Process => "failed to wait for Gateway process inspection",
+            #[cfg(test)]
+            Self::Listener => "failed to wait for Gateway listener inspection",
+        }
+    }
+}
+
+#[cfg(windows)]
+fn run_windows_inspection(
+    script: &str,
+    kind: WindowsInspectionKind,
+    timeout: Duration,
+) -> Result<std::process::Output, String> {
     let mut command = Command::new("powershell");
-    command.args(["-NoProfile", "-Command", &script]);
+    command.args(["-NoProfile", "-Command", script]);
     configure_no_window(&mut command);
-    let output = command
-        .output()
-        .map_err(|error| format!("failed to inspect listener on port {port}: {error}"))?;
+    run_bounded_inspection_command(command, Instant::now() + timeout, kind)
+}
 
-    if output.status.code() == Some(3) {
-        return Ok(None);
-    }
-    if output.status.code() == Some(4) {
-        return Err(format!(
-            "multiple TCP listener owners were reported for 127.0.0.1:{port}: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
-        ));
-    }
-    if !output.status.success() {
-        return Err(format!(
-            "Get-NetTCPConnection failed for 127.0.0.1:{port} with status {:?}: {}",
-            output.status.code(),
-            String::from_utf8_lossy(&output.stderr).trim()
-        ));
+#[cfg(windows)]
+struct WindowsInspectionJob(HANDLE);
+
+#[cfg(windows)]
+impl WindowsInspectionJob {
+    fn new(kind: WindowsInspectionKind) -> Result<Self, String> {
+        let handle = unsafe { CreateJobObjectW(std::ptr::null(), std::ptr::null()) };
+        if handle.is_null() {
+            return Err(kind.start_error().to_string());
+        }
+
+        let mut limits: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = unsafe { std::mem::zeroed() };
+        limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+        let configured = unsafe {
+            SetInformationJobObject(
+                handle,
+                JobObjectExtendedLimitInformation,
+                std::ptr::addr_of!(limits).cast(),
+                std::mem::size_of_val(&limits) as u32,
+            )
+        };
+        if configured == 0 {
+            unsafe { CloseHandle(handle) };
+            return Err(kind.start_error().to_string());
+        }
+        Ok(Self(handle))
     }
 
-    let text = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    text.parse::<u32>()
-        .map(Some)
-        .map_err(|error| format!("invalid listener PID {text:?} for port {port}: {error}"))
+    fn assign(&self, child: &Child, kind: WindowsInspectionKind) -> Result<(), String> {
+        let assigned = unsafe {
+            AssignProcessToJobObject(self.0, child.as_raw_handle() as HANDLE)
+        };
+        if assigned == 0 {
+            Err(kind.start_error().to_string())
+        } else {
+            Ok(())
+        }
+    }
+
+    fn terminate(&self, kind: WindowsInspectionKind) -> Result<(), String> {
+        if unsafe { TerminateJobObject(self.0, 1) } == 0 {
+            Err(kind.stop_error().to_string())
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[cfg(windows)]
+impl Drop for WindowsInspectionJob {
+    fn drop(&mut self) {
+        unsafe { CloseHandle(self.0) };
+    }
+}
+
+#[cfg(windows)]
+fn inspection_output_file(kind: WindowsInspectionKind) -> Result<fs::File, String> {
+    let mut options = fs::OpenOptions::new();
+    options
+        .read(true)
+        .write(true)
+        .create_new(true)
+        .share_mode(FILE_SHARE_DELETE)
+        .custom_flags(FILE_ATTRIBUTE_TEMPORARY | FILE_FLAG_DELETE_ON_CLOSE);
+
+    for attempt in 0..32u32 {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "codexhub-inspection-{}-{nonce}-{attempt}.tmp",
+            std::process::id()
+        ));
+        match options.open(path) {
+            Ok(file) => return Ok(file),
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+            Err(_) => return Err(kind.start_error().to_string()),
+        }
+    }
+    Err(kind.start_error().to_string())
+}
+
+#[cfg(windows)]
+fn read_inspection_output(mut file: fs::File) -> Vec<u8> {
+    if file.seek(SeekFrom::Start(0)).is_err() {
+        return Vec::new();
+    }
+    let mut bytes = Vec::new();
+    let _ = file
+        .take((WINDOWS_INSPECTION_OUTPUT_LIMIT + 1) as u64)
+        .read_to_end(&mut bytes);
+    bytes.truncate(WINDOWS_INSPECTION_OUTPUT_LIMIT);
+    bytes
+}
+
+#[cfg(windows)]
+fn resume_suspended_inspection_child(
+    child: &Child,
+    kind: WindowsInspectionKind,
+) -> Result<(), String> {
+    let snapshot = unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0) };
+    if snapshot == INVALID_HANDLE_VALUE {
+        return Err(kind.start_error().to_string());
+    }
+
+    let mut entry: THREADENTRY32 = unsafe { std::mem::zeroed() };
+    entry.dwSize = std::mem::size_of::<THREADENTRY32>() as u32;
+    let mut found = unsafe { Thread32First(snapshot, &mut entry) } != 0;
+    let mut thread_id = None;
+    while found {
+        if entry.th32OwnerProcessID == child.id() {
+            thread_id = Some(entry.th32ThreadID);
+            break;
+        }
+        found = unsafe { Thread32Next(snapshot, &mut entry) } != 0;
+    }
+    unsafe { CloseHandle(snapshot) };
+
+    let Some(thread_id) = thread_id else {
+        return Err(kind.start_error().to_string());
+    };
+    let thread = unsafe { OpenThread(THREAD_SUSPEND_RESUME, 0, thread_id) };
+    if thread.is_null() {
+        return Err(kind.start_error().to_string());
+    }
+    let resumed = unsafe { ResumeThread(thread) };
+    unsafe { CloseHandle(thread) };
+    if resumed == u32::MAX {
+        Err(kind.start_error().to_string())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
+fn stop_and_reap_inspection_child(
+    child: &mut Child,
+    job: &WindowsInspectionJob,
+    deadline: Instant,
+    kind: WindowsInspectionKind,
+) -> Result<(), String> {
+    job.terminate(kind)?;
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => return Ok(()),
+            Ok(None) if Instant::now() < deadline => thread::sleep(
+                Duration::from_millis(20)
+                    .min(deadline.saturating_duration_since(Instant::now())),
+            ),
+            Ok(None) => return Ok(()),
+            Err(_) => return Err(kind.stop_error().to_string()),
+        }
+    }
+}
+
+#[cfg(windows)]
+fn run_bounded_inspection_command(
+    mut command: Command,
+    deadline: Instant,
+    kind: WindowsInspectionKind,
+) -> Result<std::process::Output, String> {
+    let stdout = inspection_output_file(kind)?;
+    let stderr = inspection_output_file(kind)?;
+    command.stdout(Stdio::from(
+        stdout
+            .try_clone()
+            .map_err(|_| kind.start_error().to_string())?,
+    ));
+    command.stderr(Stdio::from(
+        stderr
+            .try_clone()
+            .map_err(|_| kind.start_error().to_string())?,
+    ));
+
+    let job = WindowsInspectionJob::new(kind)?;
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+    const CREATE_SUSPENDED: u32 = 0x0000_0004;
+    command.creation_flags(CREATE_NO_WINDOW | CREATE_SUSPENDED);
+    let mut child = command.spawn().map_err(|_| kind.start_error().to_string())?;
+    if let Err(error) = job.assign(&child, kind) {
+        let _ = child.kill();
+        let _ = child.wait();
+        return Err(error);
+    }
+    if let Err(error) = resume_suspended_inspection_child(&child, kind) {
+        let _ = stop_and_reap_inspection_child(&mut child, &job, deadline, kind);
+        return Err(error);
+    }
+
+    let remaining = deadline.saturating_duration_since(Instant::now());
+    let cleanup_budget = (remaining / 4).min(Duration::from_millis(250));
+    let inspection_deadline = deadline.checked_sub(cleanup_budget).unwrap_or(deadline);
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) if Instant::now() < inspection_deadline => {
+                thread::sleep(Duration::from_millis(20).min(
+                    inspection_deadline.saturating_duration_since(Instant::now()),
+                ))
+            }
+            Ok(None) => {
+                stop_and_reap_inspection_child(&mut child, &job, deadline, kind)?;
+                return Err(kind.timeout_error().to_string());
+            }
+            Err(_) => {
+                stop_and_reap_inspection_child(&mut child, &job, deadline, kind)?;
+                return Err(kind.wait_error().to_string());
+            }
+        }
+    };
+
+    Ok(std::process::Output {
+        status,
+        stdout: read_inspection_output(stdout),
+        stderr: read_inspection_output(stderr),
+    })
+}
+
+#[cfg(windows)]
+fn windows_filetime_start_id(filetime: FILETIME) -> String {
+    let ticks = ((filetime.dwHighDateTime as u64) << 32) | filetime.dwLowDateTime as u64;
+    format!("windows-filetime-ms:{}", ticks / 10_000)
+}
+
+#[cfg(windows)]
+fn process_start_id_from_handle(handle: HANDLE) -> Result<String, String> {
+    let mut creation: FILETIME = unsafe { std::mem::zeroed() };
+    let mut exit: FILETIME = unsafe { std::mem::zeroed() };
+    let mut kernel: FILETIME = unsafe { std::mem::zeroed() };
+    let mut user: FILETIME = unsafe { std::mem::zeroed() };
+    if unsafe { GetProcessTimes(handle, &mut creation, &mut exit, &mut kernel, &mut user) } == 0 {
+        return Err("failed to read Gateway process creation identity".to_string());
+    }
+    Ok(windows_filetime_start_id(creation))
+}
+
+#[cfg(windows)]
+fn child_process_start_id(child: &Child) -> Result<String, String> {
+    process_start_id_from_handle(child.as_raw_handle() as HANDLE)
+}
+
+#[cfg(not(windows))]
+fn child_process_start_id(child: &Child) -> Result<String, String> {
+    match inspect_process(child.id())? {
+        InspectedProcess::Running(info) => info
+            .process_start_id
+            .ok_or_else(|| "spawned Gateway process has no process creation identity".to_string()),
+        InspectedProcess::Missing => Err("spawned Gateway process disappeared".to_string()),
+    }
+}
+
+#[cfg(windows)]
+fn process_start_id_for_pid(pid: u32) -> Result<String, String> {
+    let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
+    if handle.is_null() {
+        return Err("failed to open Gateway process for creation identity".to_string());
+    }
+    let result = process_start_id_from_handle(handle);
+    unsafe { CloseHandle(handle) };
+    result
+}
+
+#[cfg(windows)]
+fn inspect_listener_pid(port: u16) -> Result<Option<u32>, String> {
+    const AF_INET: u32 = 2;
+    const LOOPBACK_NETWORK_ORDER: u32 = 0x0100_007f;
+    let mut size = 0u32;
+    loop {
+        let sizing = unsafe {
+            GetExtendedTcpTable(
+                std::ptr::null_mut(),
+                &mut size,
+                0,
+                AF_INET,
+                TCP_TABLE_OWNER_PID_LISTENER,
+                0,
+            )
+        };
+        if sizing == NO_ERROR {
+            return Ok(None);
+        }
+        if sizing != ERROR_INSUFFICIENT_BUFFER {
+            return Err(format!(
+                "failed to size the Windows TCP listener table: error {sizing}"
+            ));
+        }
+        if size < std::mem::size_of::<u32>() as u32 {
+            return Ok(None);
+        }
+
+        let mut buffer = vec![0u8; size as usize];
+        let status = unsafe {
+            GetExtendedTcpTable(
+                buffer.as_mut_ptr().cast(),
+                &mut size,
+                0,
+                AF_INET,
+                TCP_TABLE_OWNER_PID_LISTENER,
+                0,
+            )
+        };
+        if status == ERROR_INSUFFICIENT_BUFFER {
+            continue;
+        }
+        if status != NO_ERROR {
+            return Err(format!(
+                "failed to inspect the Windows TCP listener table: error {status}"
+            ));
+        }
+
+        let table = unsafe { &*(buffer.as_ptr().cast::<MIB_TCPTABLE_OWNER_PID>()) };
+        let max_entries = (buffer.len() - std::mem::size_of::<u32>())
+            / std::mem::size_of::<MIB_TCPROW_OWNER_PID>();
+        let num_entries = (table.dwNumEntries as usize).min(max_entries);
+        let rows = unsafe {
+            std::slice::from_raw_parts(table.table.as_ptr(), num_entries)
+        };
+        let mut owners = rows
+            .iter()
+            .filter(|row: &&MIB_TCPROW_OWNER_PID| {
+                row.dwLocalAddr == LOOPBACK_NETWORK_ORDER
+                    && (row.dwLocalPort as u16).to_be() == port
+            })
+            .map(|row| row.dwOwningPid)
+            .collect::<Vec<_>>();
+        owners.sort_unstable();
+        owners.dedup();
+        return match owners.as_slice() {
+            [] => Ok(None),
+            [pid] => Ok(Some(*pid)),
+            _ => Err(format!(
+                "multiple TCP listener owners were reported for 127.0.0.1:{port}: {owners:?}"
+            )),
+        };
+    }
 }
 
 #[cfg(not(windows))]
@@ -2251,14 +2840,13 @@ fn inspect_process(pid: u32) -> Result<InspectedProcess, String> {
     let script = format!(
         "$p = Get-CimInstance -ClassName Win32_Process -Filter 'ProcessId = {pid}' -ErrorAction SilentlyContinue; \
          if ($null -eq $p) {{ exit 3 }}; \
-         [Console]::Out.Write((@{{ command_line = [string]$p.CommandLine; process_start_id = [string]$p.CreationDate }} | ConvertTo-Json -Compress))"
+         [Console]::Out.Write((@{{ command_line = [string]$p.CommandLine }} | ConvertTo-Json -Compress))"
     );
-    let mut command = Command::new("powershell");
-    command.args(["-NoProfile", "-Command", &script]);
-    configure_no_window(&mut command);
-    let output = command
-        .output()
-        .map_err(|error| format!("failed to inspect PID {pid} with PowerShell/CIM: {error}"))?;
+    let output = run_windows_inspection(
+        &script,
+        WindowsInspectionKind::Process,
+        WINDOWS_INSPECTION_TIMEOUT,
+    )?;
 
     if output.status.code() == Some(3) {
         return Ok(InspectedProcess::Missing);
@@ -2274,16 +2862,16 @@ fn inspect_process(pid: u32) -> Result<InspectedProcess, String> {
     #[derive(Deserialize)]
     struct WindowsProcessInspection {
         command_line: String,
-        process_start_id: String,
     }
     let inspection: WindowsProcessInspection =
         serde_json::from_slice(&output.stdout).map_err(|error| {
             format!("failed to parse process identity for PID {pid}: {error}")
         })?;
+    let process_start_id = process_start_id_for_pid(pid)?;
     Ok(InspectedProcess::Running(
         ProcessInfo::from_command_line_with_start_id(
             inspection.command_line,
-            (!inspection.process_start_id.is_empty()).then_some(inspection.process_start_id),
+            Some(process_start_id),
         ),
     ))
 }
@@ -2390,6 +2978,10 @@ mod tests {
         ProcessInspector, ProcessKiller, ProxyLifecycleBackend, ProxyPaths, ProxyPidMetadata,
         ProxyPidRecord, StartupOutcome, VerifiedProxyProcess, DEBUG_DIAGNOSTIC_BOOTSTRAP,
     };
+    #[cfg(windows)]
+    use super::{
+        run_bounded_inspection_command, run_windows_inspection, WindowsInspectionKind,
+    };
     use crate::Settings;
     use std::cell::RefCell;
     use std::fs;
@@ -2397,6 +2989,8 @@ mod tests {
     use std::net::TcpListener;
     use std::path::{Path, PathBuf};
     use std::process::Command;
+    #[cfg(windows)]
+    use std::process::Stdio;
     use std::collections::VecDeque;
     use std::sync::{
         atomic::{AtomicU32, Ordering},
@@ -2404,6 +2998,104 @@ mod tests {
     };
     use std::thread;
     use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+    #[cfg(windows)]
+    #[test]
+    fn bounded_inspection_command_kills_and_reaps_a_hung_child() {
+        let sentinel = "private-inspection-sentinel";
+        let mut command = Command::new("powershell");
+        command.args([
+            "-NoProfile",
+            "-Command",
+            &format!(
+                "$PID | Set-Content -NoNewline -Path $env:CODEXHUB_TEST_PID_PATH; Write-Error '{sentinel}'; Start-Sleep -Seconds 10"
+            ),
+        ]);
+        let root = temp_root("bounded-inspection-command");
+        let pid_path = root.join("helper.pid");
+        command.env("CODEXHUB_TEST_PID_PATH", &pid_path);
+        command.stdout(Stdio::piped()).stderr(Stdio::piped());
+        super::configure_no_window(&mut command);
+        let deadline = Instant::now() + Duration::from_secs(5);
+
+        let error =
+            run_bounded_inspection_command(command, deadline, WindowsInspectionKind::Process)
+                .expect_err("hung inspection must time out");
+
+        assert_eq!(error, "Gateway process inspection timed out");
+        assert!(!error.contains(sentinel));
+        let pid = fs::read_to_string(&pid_path)
+            .expect("helper PID")
+            .parse::<u32>()
+            .expect("numeric helper PID");
+        assert!(matches!(
+            super::inspect_process(pid),
+            Ok(InspectedProcess::Missing)
+        ));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn inspection_returns_when_a_descendant_inherits_output_handles() {
+        let root = temp_root("inspection-descendant");
+        let descendant_pid_path = root.join("descendant.pid");
+        let escaped_path = descendant_pid_path
+            .to_string_lossy()
+            .replace(char::from(39), "''");
+        let script = format!(
+            "$child = Start-Process powershell -ArgumentList '-NoProfile','-Command','Start-Sleep -Seconds 10' -NoNewWindow -PassThru; $child.Id | Set-Content -NoNewline -Path '{escaped_path}'; [Console]::Out.Write('parent-exited')"
+        );
+        let (result_tx, result_rx) = std::sync::mpsc::channel();
+        let worker = thread::spawn(move || {
+            let result = run_windows_inspection(
+                &script,
+                WindowsInspectionKind::Process,
+                Duration::from_secs(5),
+            );
+            let _ = result_tx.send(result);
+        });
+
+        let output = result_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("inspection must not wait for a descendant-held output pipe")
+            .expect("parent inspection should exit successfully");
+        assert_eq!(String::from_utf8_lossy(&output.stdout), "parent-exited");
+        worker.join().expect("inspection worker joins");
+        let descendant_pid = fs::read_to_string(descendant_pid_path)
+            .expect("descendant PID")
+            .parse::<u32>()
+            .expect("numeric descendant PID");
+        assert!(matches!(
+            super::inspect_process(descendant_pid),
+            Ok(InspectedProcess::Missing)
+        ));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn process_and_listener_inspection_timeouts_are_sanitized() {
+        for (kind, expected) in [
+            (
+                WindowsInspectionKind::Process,
+                "Gateway process inspection timed out",
+            ),
+            (
+                WindowsInspectionKind::Listener,
+                "Gateway listener inspection timed out",
+            ),
+        ] {
+            let sentinel = "private-command-line-sentinel";
+            let error = run_windows_inspection(
+                &format!("Write-Error '{sentinel}'; Start-Sleep -Seconds 5"),
+                kind,
+                Duration::from_millis(100),
+            )
+            .expect_err("hung PowerShell inspection must time out");
+
+            assert_eq!(error, expected);
+            assert!(!error.contains(sentinel));
+        }
+    }
 
     #[test]
     fn status_returns_not_running_when_health_endpoint_is_unavailable() {
@@ -2448,6 +3140,79 @@ mod tests {
             snapshot.status.message,
             format!("Gateway running with PID {pid}")
         );
+    }
+
+    #[test]
+    fn reconciled_snapshot_upgrades_spawn_known_recovery_after_identity_returns() {
+        let root = temp_root("reconciled-recovery-upgrade");
+        let paths = test_paths(&root);
+        let port = free_port();
+        let pid = 12_345;
+        write_settings(&paths, port);
+        write_fake_proxy_script(&paths, "print('test')");
+        let recovery = ProxyPidRecord::Managed(ProxyPidMetadata::recovery(
+            pid,
+            port,
+            &paths.proxy_script_path(),
+        ));
+        super::write_pid_record(&paths, &recovery).expect("write recovery PID metadata");
+        let inspector = RecordingInspector::new(fake_proxy_process(&paths, port));
+        let listener = FixedListenerInspector::new(Some(pid));
+
+        let snapshot = reconciled_snapshot_with_controls(
+            &paths,
+            &|_| Ok(Some(healthy_response())),
+            &inspector,
+            &listener,
+        )
+        .expect("recovery identity should be upgraded");
+
+        assert!(snapshot.status.proxy_running);
+        let identity = snapshot.identity.expect("upgraded identity");
+        assert_eq!(identity.pid, pid);
+        assert_eq!(identity.process_start_id, Some(super::test_process_start_id(pid)));
+        let ProxyPidRecord::Managed(metadata) = read_pid_record(&paths)
+            .expect("read upgraded PID metadata")
+            .expect("upgraded PID metadata")
+        else {
+            panic!("expected managed PID metadata");
+        };
+        assert!(!metadata.recovery);
+        assert_eq!(metadata.process_start_id, identity.process_start_id);
+    }
+
+    #[test]
+    fn reconciled_snapshot_does_not_activate_recovery_when_listener_differs() {
+        let root = temp_root("recovery-listener-mismatch");
+        let paths = test_paths(&root);
+        let port = free_port();
+        let pid = 12_345;
+        write_settings(&paths, port);
+        write_fake_proxy_script(&paths, "print('test')");
+        let recovery = ProxyPidRecord::Managed(ProxyPidMetadata::recovery(
+            pid,
+            port,
+            &paths.proxy_script_path(),
+        ));
+        super::write_pid_record(&paths, &recovery).expect("write recovery PID metadata");
+
+        let error = reconciled_snapshot_with_controls(
+            &paths,
+            &|_| Ok(Some(healthy_response())),
+            &RecordingInspector::new(fake_proxy_process(&paths, port)),
+            &FixedListenerInspector::new(Some(54_321)),
+        )
+        .expect_err("listener mismatch must block recovery activation");
+
+        assert!(error.contains("listener PID 54321"));
+        let ProxyPidRecord::Managed(metadata) = read_pid_record(&paths)
+            .expect("read recovery PID metadata")
+            .expect("recovery PID metadata")
+        else {
+            panic!("expected managed PID metadata");
+        };
+        assert!(metadata.recovery);
+        assert_eq!(metadata.process_start_id, None);
     }
 
     #[test]
@@ -2511,6 +3276,48 @@ mod tests {
         assert_eq!(identity.pid, listener_pid.load(Ordering::SeqCst));
         kill_process(identity.pid).expect("clean up test child");
         let _ = super::remove_pid(&paths);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn post_spawn_inspection_timeout_cleans_up_gateway_without_leaking_output() {
+        let root = temp_root("post-spawn-inspection-timeout");
+        let paths = test_paths(&root);
+        let port = free_port();
+        write_settings(&paths, port);
+        write_fake_proxy_script(&paths, "import time\ntime.sleep(30)");
+        let spawned_pid = Arc::new(AtomicU32::new(0));
+        let health_calls = std::cell::Cell::new(0usize);
+        let started = Instant::now();
+
+        let error = start_with_paths_and_controls(
+            &paths,
+            Duration::from_secs(1),
+            Duration::ZERO,
+            &|_| {
+                let call = health_calls.get();
+                health_calls.set(call + 1);
+                Ok((call > 0).then(healthy_response))
+            },
+            &TimeoutAfterSpawnInspector,
+            &FixedListenerInspector::new(None),
+            |child, _, _, _, _, _| {
+                spawned_pid.store(child.id(), Ordering::SeqCst);
+                Ok(StartupOutcome::Healthy(healthy_response()))
+            },
+        )
+        .expect_err("post-spawn process inspection must time out");
+
+        assert!(started.elapsed() < Duration::from_secs(3));
+        assert!(error.message.contains("Gateway process inspection timed out"));
+        assert!(!error.message.contains("private-post-spawn-sentinel"));
+        assert_eq!(read_pid(&paths).expect("PID removed"), None);
+        let pid = spawned_pid.load(Ordering::SeqCst);
+        let _cleanup = PidCleanup::new(pid);
+        assert!(matches!(
+            super::inspect_process(pid),
+            Ok(InspectedProcess::Missing)
+        ));
     }
 
     #[test]
@@ -2934,6 +3741,82 @@ time.sleep(10)
         assert_eq!(read_pid(&paths).expect("pid removed"), None);
     }
 
+    #[cfg(windows)]
+    #[test]
+    fn startup_output_finish_returns_when_descendant_inherits_pipe() {
+        let root = temp_root("startup-output-descendant");
+        let descendant_pid_path = root.join("descendant.pid");
+        let escaped_path = descendant_pid_path
+            .to_string_lossy()
+            .replace(char::from(39), "''");
+        let mut command = Command::new("powershell");
+        command.args([
+            "-NoProfile",
+            "-Command",
+            &format!(
+                "$child = Start-Process powershell -ArgumentList '-NoProfile','-Command','Start-Sleep -Seconds 10' -NoNewWindow -PassThru; $child.Id | Set-Content -NoNewline -Path '{escaped_path}'; [Console]::Out.Write('parent-exited')"
+            ),
+        ]);
+        configure_start_stdio(&mut command);
+        super::configure_no_window(&mut command);
+        let mut child = command.spawn().expect("spawn output parent");
+        let capture = capture_child_stdio(&mut child);
+        child.wait().expect("output parent exits");
+        let descendant_pid = fs::read_to_string(descendant_pid_path)
+            .expect("descendant PID")
+            .parse::<u32>()
+            .expect("numeric descendant PID");
+        let _cleanup = PidCleanup::new(descendant_pid);
+        let (result_tx, result_rx) = std::sync::mpsc::channel();
+        let worker = thread::spawn(move || {
+            let _ = result_tx.send(capture.finish());
+        });
+
+        let output = result_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("finish must not wait for descendant-held pipe");
+        worker.join().expect("capture worker joins");
+        assert_eq!(output.stdout, "parent-exited");
+    }
+
+    #[test]
+    fn failed_start_cleanup_releases_output_capture_when_kill_is_unconfirmed() {
+        let root = temp_root("unconfirmed-capture-release");
+        let paths = test_paths(&root);
+        let port = free_port();
+        write_settings(&paths, port);
+        write_fake_proxy_script(&paths, "import time\ntime.sleep(30)");
+        let mut command = Command::new(find_python(&paths));
+        command.args(["-c", "import time; time.sleep(30)"]);
+        configure_start_stdio(&mut command);
+        let mut child = command.spawn().expect("spawn cleanup child");
+        let pid = child.id();
+        let capture = capture_child_stdio(&mut child);
+        let stdout = Arc::downgrade(&capture.stdout);
+        let stderr = Arc::downgrade(&capture.stderr);
+        let record = ProxyPidRecord::Managed(ProxyPidMetadata::recovery(
+            pid,
+            port,
+            &paths.proxy_script_path(),
+        ));
+
+        let _ = clean_up_failed_start_with_controls(
+            &paths,
+            &mut child,
+            capture,
+            "startup reconciliation failed".to_string(),
+            &record,
+            &ErroringInspector,
+            &UnconfirmedTerminator,
+        );
+
+        assert!(stdout.upgrade().is_none());
+        assert!(stderr.upgrade().is_none());
+        kill_process(pid).expect("clean up live child");
+        let _ = child.wait();
+        let _ = super::remove_pid(&paths);
+    }
+
     #[test]
     fn failed_start_cleanup_is_bounded_and_persists_identity_when_kill_is_unconfirmed() {
         let root = temp_root("bounded-failed-cleanup");
@@ -3068,6 +3951,33 @@ time.sleep(10)
 
         assert!(matches!(verification, VerifiedProxyProcess::Unknown { pid: value, .. } if value == pid));
         assert_eq!(read_pid(&paths).expect("legacy PID preserved"), Some(pid));
+    }
+
+    #[test]
+    fn recovery_with_identity_is_not_destructively_verified_before_activation() {
+        let root = temp_root("recovery-not-destructive");
+        let paths = test_paths(&root);
+        let port = free_port();
+        write_fake_proxy_script(&paths, "print('test')");
+        let record = ProxyPidRecord::Managed(ProxyPidMetadata::recovery_with_identity(
+            12_345,
+            port,
+            &paths.proxy_script_path(),
+            super::test_process_start_id(12_345),
+        ));
+
+        let verification = super::verify_proxy_process(
+            &record,
+            &paths,
+            port,
+            &RecordingInspector::new(fake_proxy_process(&paths, port)),
+        )
+        .expect("verification result");
+
+        assert!(matches!(
+            verification,
+            VerifiedProxyProcess::Unknown { pid: 12_345, .. }
+        ));
     }
 
     #[test]
@@ -3723,6 +4633,19 @@ time.sleep(10)
             self.inspected.borrow_mut().push(pid);
             Ok(self.process.clone())
         }
+
+        fn spawned_process_start_id(
+            &self,
+            _child: &std::process::Child,
+        ) -> Result<String, String> {
+            match &self.process {
+                InspectedProcess::Running(info) => info
+                    .process_start_id
+                    .clone()
+                    .ok_or_else(|| "test process has no start identity".to_string()),
+                InspectedProcess::Missing => Err("test process is missing".to_string()),
+            }
+        }
     }
 
     struct ErroringInspector;
@@ -3730,6 +4653,37 @@ time.sleep(10)
     impl ProcessInspector for ErroringInspector {
         fn inspect(&self, _pid: u32) -> Result<InspectedProcess, String> {
             Err("process inspection unavailable".to_string())
+        }
+    }
+
+    #[cfg(windows)]
+    struct TimeoutAfterSpawnInspector;
+
+    #[cfg(windows)]
+    impl ProcessInspector for TimeoutAfterSpawnInspector {
+        fn inspect(&self, _pid: u32) -> Result<InspectedProcess, String> {
+            run_windows_inspection(
+                "Write-Error 'private-post-spawn-sentinel'; Start-Sleep -Seconds 10",
+                WindowsInspectionKind::Process,
+                Duration::from_millis(200),
+            )
+            .map(|_| InspectedProcess::Missing)
+        }
+    }
+
+    struct PidCleanup {
+        pid: u32,
+    }
+
+    impl PidCleanup {
+        fn new(pid: u32) -> Self {
+            Self { pid }
+        }
+    }
+
+    impl Drop for PidCleanup {
+        fn drop(&mut self) {
+            let _ = kill_process(self.pid);
         }
     }
 }

--- a/src-tauri/src/proxy.rs
+++ b/src-tauri/src/proxy.rs
@@ -1,3 +1,7 @@
+use crate::gateway_lifecycle::{
+    coordinator as gateway_lifecycle, GatewayIdentity, GatewayLifecycleBackend,
+    GatewayLifecycleSnapshot, GatewayStartOutcome,
+};
 use crate::AppStatus;
 use crate::Settings;
 use crate::{build_info, runtime_paths, safe_file};
@@ -29,20 +33,42 @@ const MANAGED_OVERLAY_MARKER_END: &str = "# END CODEX PROXY SESSION CONFIG";
 const DEBUG_DIAGNOSTIC_BOOTSTRAP: &str = "import atexit, os, sys; from pathlib import Path; import codex_proxy, diagnostic_recorder; from diagnostic_control import DiagnosticControlBridge; runtime_home = Path(os.environ['CODEXHUB_DIAGNOSTICS_RUNTIME_HOME']); recorder = diagnostic_recorder.for_compile_flavor(runtime_home, 'debug', build_version=os.environ['CODEXHUB_DIAGNOSTICS_BUILD_VERSION'], source_revision=os.environ['CODEXHUB_DIAGNOSTICS_SOURCE_REVISION']); codex_proxy.GATEWAY_DIAGNOSTIC_RECORDER = recorder; control = DiagnosticControlBridge(recorder, runtime_home); control.start(); atexit.register(recorder.shutdown); atexit.register(control.shutdown); raise SystemExit(codex_proxy.main(sys.argv[2:]))";
 
 pub fn status() -> Result<AppStatus, String> {
-    status_with_paths(&ProxyPaths::runtime()?)
+    let backend = ProxyLifecycleBackend::runtime()?;
+    gateway_lifecycle()
+        .status(&backend)
+        .map(|snapshot| snapshot.status)
 }
 
-pub fn start() -> Result<AppStatus, String> {
-    start_with_paths(&ProxyPaths::runtime()?)
+pub fn start_after<Prepare>(prepare: Prepare) -> Result<AppStatus, String>
+where
+    Prepare: FnOnce() -> Result<(), String>,
+{
+    let backend = ProxyLifecycleBackend::runtime()?;
+    gateway_lifecycle()
+        .start(&backend, prepare)
+        .map(|snapshot| snapshot.status)
 }
 
 pub fn stop() -> Result<AppStatus, String> {
-    stop_with_paths(&ProxyPaths::runtime()?)
+    let backend = ProxyLifecycleBackend::runtime()?;
+    gateway_lifecycle().stop(&backend)
 }
 
-pub fn restart() -> Result<AppStatus, String> {
-    stop()?;
-    start()
+pub fn restart_after<Prepare>(prepare: Prepare) -> Result<AppStatus, String>
+where
+    Prepare: FnOnce() -> Result<(), String>,
+{
+    let backend = ProxyLifecycleBackend::runtime()?;
+    gateway_lifecycle()
+        .restart(&backend, prepare)
+        .map(|snapshot| snapshot.status)
+}
+
+/// Ownership-safe handoff for #112 terminal-exit cleanup. #139 intentionally
+/// exposes the identity without acting on application exit or update restart.
+#[allow(dead_code)]
+pub(crate) fn session_owned_identity() -> Option<GatewayIdentity> {
+    gateway_lifecycle().session_owned_identity()
 }
 
 #[derive(Debug, Clone)]
@@ -105,6 +131,48 @@ impl ProxyPaths {
 
     fn proxy_script_dir(&self) -> PathBuf {
         self.repo_root.join("src-python")
+    }
+}
+
+struct ProxyLifecycleBackend {
+    paths: ProxyPaths,
+}
+
+impl ProxyLifecycleBackend {
+    fn runtime() -> Result<Self, String> {
+        Ok(Self {
+            paths: ProxyPaths::runtime()?,
+        })
+    }
+}
+
+impl GatewayLifecycleBackend for ProxyLifecycleBackend {
+    fn snapshot(&self) -> Result<GatewayLifecycleSnapshot, String> {
+        reconciled_snapshot_with_controls(
+            &self.paths,
+            &health,
+            &SystemProcessInspector,
+            &SystemListenerInspector,
+        )
+    }
+
+    fn start(&self) -> Result<GatewayStartOutcome, String> {
+        start_outcome_with_paths(&self.paths)
+    }
+
+    fn stop(&self) -> Result<AppStatus, String> {
+        stop_with_paths(&self.paths)
+    }
+
+    fn can_reuse(&self, snapshot: &GatewayLifecycleSnapshot) -> bool {
+        let Some(identity) = snapshot.identity.as_ref() else {
+            return false;
+        };
+        let current_script = self.paths.proxy_script_path();
+        normalized_path_text(&identity.script_path)
+            == normalized_path_text(&current_script.to_string_lossy())
+            && identity.script_sha256.is_some()
+            && identity.script_sha256 == file_sha256(&current_script)
     }
 }
 
@@ -267,6 +335,18 @@ impl ProxyPidMetadata {
     }
 }
 
+impl From<&ProxyPidMetadata> for GatewayIdentity {
+    fn from(metadata: &ProxyPidMetadata) -> Self {
+        Self {
+            pid: metadata.pid,
+            port: metadata.port,
+            script_path: metadata.script_path.clone(),
+            script_sha256: metadata.script_sha256.clone(),
+            started_at_unix_ms: metadata.started_at_unix_ms,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum ProxyPidRecord {
     Managed(ProxyPidMetadata),
@@ -294,6 +374,121 @@ impl ProxyPidRecord {
             Self::Legacy(_) => None,
         }
     }
+}
+
+fn reconciled_snapshot_with_controls(
+    paths: &ProxyPaths,
+    health_probe: &dyn Fn(u16) -> Result<Option<HealthResponse>, String>,
+    inspector: &dyn ProcessInspector,
+    listener_inspector: &dyn ListenerInspector,
+) -> Result<GatewayLifecycleSnapshot, String> {
+    let settings = read_settings(paths)?;
+    let mode = read_mode(paths)?;
+    let health = health_probe(settings.proxy_port)?;
+    let running_health = health.as_ref().filter(|response| response.is_running());
+    let pid_record = read_pid_record(paths)?;
+
+    let Some(response) = running_health else {
+        if let Some(record) = pid_record {
+            match verify_proxy_process(&record, paths, settings.proxy_port, inspector)? {
+                VerifiedProxyProcess::Verified { pid } => {
+                    return Err(format!(
+                        "managed Gateway PID {pid} exists but health is unavailable on port {}; stop it through the lifecycle coordinator before starting another process",
+                        settings.proxy_port
+                    ));
+                }
+                VerifiedProxyProcess::Missing { .. } | VerifiedProxyProcess::Mismatch { .. } => {
+                    remove_pid(paths)?
+                }
+            }
+        }
+        return Ok(GatewayLifecycleSnapshot {
+            status: AppStatus {
+                mode,
+                proxy_running: false,
+                proxy_port: settings.proxy_port,
+                proxy_build: None,
+                message: "Gateway is not running".to_string(),
+                history_sync_status: None,
+                history_sync_message: None,
+            },
+            identity: None,
+        });
+    };
+
+    let Some(pid_record) = pid_record else {
+        return Err(format!(
+            "Gateway health responds on port {}, but no managed PID identity exists; refusing to claim or replace the external listener",
+            settings.proxy_port
+        ));
+    };
+    let pid = pid_record.pid();
+    if pid_record.expected_port(settings.proxy_port) != settings.proxy_port {
+        remove_pid(paths)?;
+        return Err(format!(
+            "Gateway health responds on port {}, but managed PID {pid} records port {}; removed stale PID identity without stopping either process",
+            settings.proxy_port,
+            pid_record.expected_port(settings.proxy_port)
+        ));
+    }
+
+    match verify_proxy_process(&pid_record, paths, settings.proxy_port, inspector)? {
+        VerifiedProxyProcess::Verified { .. } => {}
+        VerifiedProxyProcess::Missing { .. } => {
+            remove_pid(paths)?;
+            return Err(format!(
+                "Gateway health responds on port {}, but managed PID {pid} no longer exists; removed stale PID identity without stopping the listener",
+                settings.proxy_port
+            ));
+        }
+        VerifiedProxyProcess::Mismatch { reason, .. } => {
+            remove_pid(paths)?;
+            return Err(format!(
+                "Gateway health responds on port {}, but managed PID {pid} ownership could not be verified ({reason}); removed stale PID identity without stopping either process",
+                settings.proxy_port
+            ));
+        }
+    }
+
+    let listener_pid = listener_inspector.listening_pid(settings.proxy_port)?;
+    let Some(listener_pid) = listener_pid else {
+        remove_pid(paths)?;
+        return Err(format!(
+            "Gateway health responds on port {}, but no TCP listener owner could be reconciled; removed managed PID {pid} without stopping the process",
+            settings.proxy_port
+        ));
+    };
+    if listener_pid != pid {
+        remove_pid(paths)?;
+        return Err(format!(
+            "Gateway health responds on port {}, but listener PID {listener_pid} differs from managed PID {pid}; removed stale PID identity without stopping either process",
+            settings.proxy_port
+        ));
+    }
+
+    let identity = match &pid_record {
+        ProxyPidRecord::Managed(metadata) => GatewayIdentity::from(metadata),
+        ProxyPidRecord::Legacy(pid) => GatewayIdentity {
+            pid: *pid,
+            port: settings.proxy_port,
+            script_path: comparable_path(&paths.proxy_script_path()),
+            script_sha256: file_sha256(&paths.proxy_script_path()),
+            started_at_unix_ms: 0,
+        },
+    };
+
+    Ok(GatewayLifecycleSnapshot {
+        status: AppStatus {
+            mode,
+            proxy_running: true,
+            proxy_port: settings.proxy_port,
+            proxy_build: response.build.clone(),
+            message: format!("Gateway running with PID {pid}"),
+            history_sync_status: None,
+            history_sync_message: None,
+        },
+        identity: Some(identity),
+    })
 }
 
 fn status_with_paths(paths: &ProxyPaths) -> Result<AppStatus, String> {
@@ -327,9 +522,14 @@ fn status_with_paths(paths: &ProxyPaths) -> Result<AppStatus, String> {
     })
 }
 
+#[cfg(test)]
 fn start_with_paths(paths: &ProxyPaths) -> Result<AppStatus, String> {
+    start_outcome_with_paths(paths).map(|outcome| outcome.snapshot.status)
+}
+
+fn start_outcome_with_paths(paths: &ProxyPaths) -> Result<GatewayStartOutcome, String> {
     replace_managed_proxy_from_previous_bundle(paths)?;
-    start_with_paths_and_timeout(paths, START_TIMEOUT)
+    start_outcome_with_paths_and_timeout(paths, START_TIMEOUT)
 }
 
 fn replace_managed_proxy_from_previous_bundle(paths: &ProxyPaths) -> Result<(), String> {
@@ -339,8 +539,8 @@ fn replace_managed_proxy_from_previous_bundle(paths: &ProxyPaths) -> Result<(), 
     let current_script = paths.proxy_script_path();
     let path_matches = normalized_path_text(&metadata.script_path)
         == normalized_path_text(&current_script.to_string_lossy());
-    let fingerprint_matches = metadata.script_sha256.is_some()
-        && metadata.script_sha256 == file_sha256(&current_script);
+    let fingerprint_matches =
+        metadata.script_sha256.is_some() && metadata.script_sha256 == file_sha256(&current_script);
     if path_matches && fingerprint_matches {
         return Ok(());
     }
@@ -363,30 +563,24 @@ fn file_sha256(path: &Path) -> Option<String> {
     Some(format!("{:x}", hasher.finalize()))
 }
 
-fn start_with_paths_and_timeout(
+fn start_outcome_with_paths_and_timeout(
     paths: &ProxyPaths,
     timeout: Duration,
-) -> Result<AppStatus, String> {
-    start_with_paths_and_timing(paths, timeout, Duration::from_millis(200), &health)
-}
-
-fn start_with_paths_and_timing(
-    paths: &ProxyPaths,
-    timeout: Duration,
-    poll_interval: Duration,
-    health_probe: &dyn Fn(u16) -> Result<Option<HealthResponse>, String>,
-) -> Result<AppStatus, String> {
-    start_with_paths_and_waiter(
+) -> Result<GatewayStartOutcome, String> {
+    start_with_paths_and_controls(
         paths,
         timeout,
-        poll_interval,
-        health_probe,
+        Duration::from_millis(200),
+        &health,
+        &SystemProcessInspector,
+        &SystemListenerInspector,
         |child, port, timeout, poll_interval, health_probe, _output_capture| {
             wait_for_startup_health(child, port, timeout, poll_interval, health_probe)
         },
     )
 }
 
+#[cfg(test)]
 fn start_with_paths_and_waiter<F>(
     paths: &ProxyPaths,
     timeout: Duration,
@@ -404,22 +598,47 @@ where
         &StartupOutputCapture,
     ) -> Result<StartupOutcome, String>,
 {
-    let settings = read_settings(paths)?;
-    let mode = read_mode(paths)?;
-    if let Some(response) = health_probe(settings.proxy_port)? {
-        if response.is_running() {
-            return Ok(AppStatus {
-                mode,
-                proxy_running: true,
-                proxy_port: settings.proxy_port,
-                proxy_build: response.build,
-                message: "Proxy is already running".to_string(),
-                history_sync_status: None,
-                history_sync_message: None,
-            });
-        }
+    start_with_paths_and_controls(
+        paths,
+        timeout,
+        poll_interval,
+        health_probe,
+        &SystemProcessInspector,
+        &SystemListenerInspector,
+        wait_for_startup,
+    )
+    .map(|outcome| outcome.snapshot.status)
+}
+
+fn start_with_paths_and_controls<F>(
+    paths: &ProxyPaths,
+    timeout: Duration,
+    poll_interval: Duration,
+    health_probe: &dyn Fn(u16) -> Result<Option<HealthResponse>, String>,
+    inspector: &dyn ProcessInspector,
+    listener_inspector: &dyn ListenerInspector,
+    wait_for_startup: F,
+) -> Result<GatewayStartOutcome, String>
+where
+    F: FnOnce(
+        &mut Child,
+        u16,
+        Duration,
+        Duration,
+        &dyn Fn(u16) -> Result<Option<HealthResponse>, String>,
+        &StartupOutputCapture,
+    ) -> Result<StartupOutcome, String>,
+{
+    let existing =
+        reconciled_snapshot_with_controls(paths, health_probe, inspector, listener_inspector)?;
+    if existing.identity.is_some() {
+        return Ok(GatewayStartOutcome {
+            snapshot: existing,
+            spawned: false,
+        });
     }
 
+    let settings = read_settings(paths)?;
     let script = paths.proxy_script_path();
     if !script.exists() {
         return Err(format!("proxy script not found: {}", script.display()));
@@ -445,28 +664,104 @@ where
     })?;
     let output_capture = capture_child_stdio(&mut child);
     let pid = child.id();
-    if let Err(error) = write_pid(paths, pid, settings.proxy_port, &script) {
-        let _ = terminate_child(&mut child);
-        return Err(error);
-    }
 
-    match wait_for_startup(
+    let startup = match wait_for_startup(
         &mut child,
         settings.proxy_port,
         timeout,
         poll_interval,
         health_probe,
         &output_capture,
-    )? {
-        StartupOutcome::Healthy(response) => Ok(AppStatus {
-            mode,
-            proxy_running: true,
-            proxy_port: settings.proxy_port,
-            proxy_build: response.build,
-            message: format!("Proxy started with PID {pid}"),
-            history_sync_status: None,
-            history_sync_message: None,
-        }),
+    ) {
+        Ok(startup) => startup,
+        Err(error) => {
+            return Err(clean_up_failed_start(
+                paths,
+                &mut child,
+                output_capture,
+                error,
+            ))
+        }
+    };
+
+    match startup {
+        StartupOutcome::Healthy(response) if response.is_running() => {
+            let record =
+                ProxyPidRecord::Managed(ProxyPidMetadata::new(pid, settings.proxy_port, &script));
+            let verification =
+                verify_proxy_process(&record, paths, settings.proxy_port, inspector)?;
+            if verification != (VerifiedProxyProcess::Verified { pid }) {
+                return Err(clean_up_failed_start(
+                    paths,
+                    &mut child,
+                    output_capture,
+                    format!(
+                        "spawned Gateway PID {pid} ownership could not be reconciled: {verification:?}"
+                    ),
+                ));
+            }
+
+            let listener_pid = match listener_inspector.listening_pid(settings.proxy_port) {
+                Ok(listener_pid) => listener_pid,
+                Err(error) => {
+                    return Err(clean_up_failed_start(
+                        paths,
+                        &mut child,
+                        output_capture,
+                        error,
+                    ))
+                }
+            };
+            if listener_pid != Some(pid) {
+                let detail = listener_pid
+                    .map(|listener_pid| format!("listener PID {listener_pid}"))
+                    .unwrap_or_else(|| "no listener PID".to_string());
+                return Err(clean_up_failed_start(
+                    paths,
+                    &mut child,
+                    output_capture,
+                    format!(
+                        "spawned Gateway PID {pid} became healthy, but {detail} owns port {}",
+                        settings.proxy_port
+                    ),
+                ));
+            }
+
+            if let Err(error) = write_pid(paths, pid, settings.proxy_port, &script) {
+                return Err(clean_up_failed_start(
+                    paths,
+                    &mut child,
+                    output_capture,
+                    error,
+                ));
+            }
+            match reconciled_snapshot_with_controls(
+                paths,
+                health_probe,
+                inspector,
+                listener_inspector,
+            ) {
+                Ok(snapshot) => Ok(GatewayStartOutcome {
+                    snapshot,
+                    spawned: true,
+                }),
+                Err(error) => Err(clean_up_failed_start(
+                    paths,
+                    &mut child,
+                    output_capture,
+                    error,
+                )),
+            }
+        }
+        StartupOutcome::Healthy(_) => Err(clean_up_failed_start(
+            paths,
+            &mut child,
+            output_capture,
+            format!(
+                "proxy returned a non-running health response at http://127.0.0.1:{}/health",
+                settings.proxy_port
+            ),
+        )),
         StartupOutcome::Exited(status) => {
             let _ = remove_pid(paths);
             let output = output_capture.finish();
@@ -475,20 +770,43 @@ where
                 &output,
             ))
         }
-        StartupOutcome::TimedOut => {
-            let _ = terminate_child(&mut child);
-            let _ = remove_pid(paths);
-            let output = output_capture.finish();
-            Err(format_startup_failure(
+        StartupOutcome::TimedOut => Err(clean_up_failed_start(
+            paths,
+            &mut child,
+            output_capture,
+            format_startup_failure(
                 format!(
                     "proxy did not become healthy within {} seconds at http://127.0.0.1:{}/health",
                     timeout.as_secs(),
                     settings.proxy_port
                 ),
-                &output,
-            ))
-        }
+                &StartupOutputSnapshot::default(),
+            ),
+        )),
     }
+}
+
+fn clean_up_failed_start(
+    paths: &ProxyPaths,
+    child: &mut Child,
+    output_capture: StartupOutputCapture,
+    reason: String,
+) -> String {
+    let termination_error = terminate_child(child).err();
+    let pid_error = remove_pid(paths).err();
+    let output = output_capture.finish();
+    let mut message = format_startup_failure(reason, &output);
+    if let Some(error) = termination_error {
+        message.push_str(&format!(
+            "\nfailed to terminate spawned child safely: {error}"
+        ));
+    }
+    if let Some(error) = pid_error {
+        message.push_str(&format!(
+            "\nfailed to remove unpublished PID identity: {error}"
+        ));
+    }
+    message
 }
 
 fn stop_with_paths(paths: &ProxyPaths) -> Result<AppStatus, String> {
@@ -727,7 +1045,10 @@ fn build_start_command(
             .arg(script)
             .env("CODEXHUB_DIAGNOSTICS_RUNTIME_HOME", paths.codex_dir.clone())
             .env("CODEXHUB_DIAGNOSTICS_BUILD_VERSION", build.semantic_version)
-            .env("CODEXHUB_DIAGNOSTICS_SOURCE_REVISION", build.source_revision);
+            .env(
+                "CODEXHUB_DIAGNOSTICS_SOURCE_REVISION",
+                build.source_revision,
+            );
     } else {
         command.arg(script);
     }
@@ -948,6 +1269,10 @@ trait ProcessInspector {
     fn inspect(&self, pid: u32) -> Result<InspectedProcess, String>;
 }
 
+trait ListenerInspector {
+    fn listening_pid(&self, port: u16) -> Result<Option<u32>, String>;
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum InspectedProcess {
     Missing,
@@ -997,6 +1322,14 @@ struct SystemProcessInspector;
 impl ProcessInspector for SystemProcessInspector {
     fn inspect(&self, pid: u32) -> Result<InspectedProcess, String> {
         inspect_process(pid)
+    }
+}
+
+struct SystemListenerInspector;
+
+impl ListenerInspector for SystemListenerInspector {
+    fn listening_pid(&self, port: u16) -> Result<Option<u32>, String> {
+        inspect_listener_pid(port)
     }
 }
 
@@ -1454,6 +1787,80 @@ fn configure_no_window(command: &mut Command) {
 }
 
 #[cfg(windows)]
+fn inspect_listener_pid(port: u16) -> Result<Option<u32>, String> {
+    let script = format!(
+        "$rows = @(Get-NetTCPConnection -State Listen -LocalPort {port} -ErrorAction SilentlyContinue | Where-Object {{ $_.LocalAddress -eq '127.0.0.1' }} | Select-Object -ExpandProperty OwningProcess -Unique); \
+         if ($rows.Count -eq 0) {{ exit 3 }}; \
+         if ($rows.Count -ne 1) {{ [Console]::Error.Write(($rows -join ',')); exit 4 }}; \
+         [Console]::Out.Write([string]$rows[0])"
+    );
+    let mut command = Command::new("powershell");
+    command.args(["-NoProfile", "-Command", &script]);
+    configure_no_window(&mut command);
+    let output = command
+        .output()
+        .map_err(|error| format!("failed to inspect listener on port {port}: {error}"))?;
+
+    if output.status.code() == Some(3) {
+        return Ok(None);
+    }
+    if output.status.code() == Some(4) {
+        return Err(format!(
+            "multiple TCP listener owners were reported for 127.0.0.1:{port}: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    if !output.status.success() {
+        return Err(format!(
+            "Get-NetTCPConnection failed for 127.0.0.1:{port} with status {:?}: {}",
+            output.status.code(),
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+
+    let text = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    text.parse::<u32>()
+        .map(Some)
+        .map_err(|error| format!("invalid listener PID {text:?} for port {port}: {error}"))
+}
+
+#[cfg(not(windows))]
+fn inspect_listener_pid(port: u16) -> Result<Option<u32>, String> {
+    let output = match Command::new("lsof")
+        .args(["-nP", &format!("-iTCP:{port}"), "-sTCP:LISTEN", "-t"])
+        .output()
+    {
+        Ok(output) => output,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            return Err(
+                "listener ownership reconciliation requires lsof on this platform".to_string(),
+            )
+        }
+        Err(error) => {
+            return Err(format!(
+                "failed to inspect listener on port {port}: {error}"
+            ))
+        }
+    };
+    if !output.status.success() && output.stdout.is_empty() {
+        return Ok(None);
+    }
+    let mut pids = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| line.trim().parse::<u32>().ok())
+        .collect::<Vec<_>>();
+    pids.sort_unstable();
+    pids.dedup();
+    match pids.as_slice() {
+        [] => Ok(None),
+        [pid] => Ok(Some(*pid)),
+        _ => Err(format!(
+            "multiple TCP listener owners were reported for 127.0.0.1:{port}: {pids:?}"
+        )),
+    }
+}
+
+#[cfg(windows)]
 fn inspect_process(pid: u32) -> Result<InspectedProcess, String> {
     let script = format!(
         "$p = Get-CimInstance -ClassName Win32_Process -Filter 'ProcessId = {pid}' -ErrorAction SilentlyContinue; \
@@ -1565,10 +1972,11 @@ fn format_process_failure(label: &str, pid: u32, output: std::process::Output) -
 mod tests {
     use super::{
         build_start_command, comparable_path, configure_start_stdio, detect_mode, find_python,
-        read_pid, read_pid_record, start_with_paths, start_with_paths_and_waiter, status_with_paths,
-        stop_with_paths, stop_with_paths_and_controls, write_pid, InspectedProcess, ProcessInfo,
-        ProcessInspector, ProcessKiller, ProxyPaths, ProxyPidMetadata, ProxyPidRecord,
-        StartupOutcome, DEBUG_DIAGNOSTIC_BOOTSTRAP,
+        kill_process, read_pid, read_pid_record, reconciled_snapshot_with_controls,
+        start_with_paths, start_with_paths_and_controls, start_with_paths_and_waiter,
+        status_with_paths, stop_with_paths, stop_with_paths_and_controls, write_pid,
+        InspectedProcess, ListenerInspector, ProcessInfo, ProcessInspector, ProcessKiller,
+        ProxyPaths, ProxyPidMetadata, ProxyPidRecord, StartupOutcome, DEBUG_DIAGNOSTIC_BOOTSTRAP,
     };
     use crate::Settings;
     use std::cell::RefCell;
@@ -1577,6 +1985,10 @@ mod tests {
     use std::net::TcpListener;
     use std::path::{Path, PathBuf};
     use std::process::Command;
+    use std::sync::{
+        atomic::{AtomicU32, Ordering},
+        Arc,
+    };
     use std::thread;
     use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
@@ -1592,6 +2004,179 @@ mod tests {
         assert!(!status.proxy_running);
         assert_eq!(status.proxy_port, read_settings_port(&paths));
         assert_eq!(status.proxy_build, None);
+    }
+
+    #[test]
+    fn reconciled_snapshot_requires_matching_health_pid_process_and_listener_identity() {
+        let root = temp_root("reconciled-snapshot");
+        let paths = test_paths(&root);
+        let port = free_port();
+        let pid = 12_345;
+        write_settings(&paths, port);
+        write_fake_proxy_script(&paths, "print('test')");
+        write_pid(&paths, pid, port, &paths.proxy_script_path()).expect("write PID metadata");
+        let inspector = RecordingInspector::new(fake_proxy_process(&paths, port));
+        let listener = FixedListenerInspector::new(Some(pid));
+
+        let snapshot = reconciled_snapshot_with_controls(
+            &paths,
+            &|_| Ok(Some(healthy_response())),
+            &inspector,
+            &listener,
+        )
+        .expect("reconciled snapshot");
+
+        assert!(snapshot.status.proxy_running);
+        assert_eq!(
+            snapshot.identity.as_ref().map(|identity| identity.pid),
+            Some(pid)
+        );
+        assert_eq!(
+            snapshot.status.message,
+            format!("Gateway running with PID {pid}")
+        );
+    }
+
+    #[test]
+    fn reconciled_snapshot_rejects_listener_pid_mismatch_and_removes_stale_pid() {
+        let root = temp_root("reconciled-listener-mismatch");
+        let paths = test_paths(&root);
+        let port = free_port();
+        write_settings(&paths, port);
+        write_fake_proxy_script(&paths, "print('test')");
+        write_pid(&paths, 12_345, port, &paths.proxy_script_path()).expect("write PID metadata");
+        let inspector = RecordingInspector::new(fake_proxy_process(&paths, port));
+        let listener = FixedListenerInspector::new(Some(54_321));
+
+        let error = reconciled_snapshot_with_controls(
+            &paths,
+            &|_| Ok(Some(healthy_response())),
+            &inspector,
+            &listener,
+        )
+        .expect_err("mismatched listener must not publish Running");
+
+        assert!(error.contains("listener PID 54321"));
+        assert!(error.contains("managed PID 12345"));
+        assert_eq!(read_pid(&paths).expect("read PID"), None);
+    }
+
+    #[test]
+    fn start_does_not_publish_pid_until_health_and_listener_reconcile() {
+        let root = temp_root("late-pid-publication");
+        let paths = test_paths(&root);
+        let port = free_port();
+        write_settings(&paths, port);
+        write_fake_proxy_script(&paths, "import time\ntime.sleep(30)");
+        let listener_pid = Arc::new(AtomicU32::new(0));
+        let listener = AtomicListenerInspector::new(Arc::clone(&listener_pid));
+        let inspector = RecordingInspector::new(fake_proxy_process(&paths, port));
+        let health_calls = std::cell::Cell::new(0usize);
+
+        let outcome = start_with_paths_and_controls(
+            &paths,
+            Duration::from_secs(1),
+            Duration::ZERO,
+            &|_| {
+                let call = health_calls.get();
+                health_calls.set(call + 1);
+                Ok((call > 0).then(healthy_response))
+            },
+            &inspector,
+            &listener,
+            |child, _, _, _, _, _| {
+                assert_eq!(read_pid(&paths).expect("read unpublished PID"), None);
+                listener_pid.store(child.id(), Ordering::SeqCst);
+                Ok(StartupOutcome::Healthy(healthy_response()))
+            },
+        )
+        .expect("start after reconciliation");
+
+        let identity = outcome.snapshot.identity.expect("published identity");
+        assert!(outcome.spawned);
+        assert_eq!(read_pid(&paths).expect("read PID"), Some(identity.pid));
+        assert_eq!(identity.pid, listener_pid.load(Ordering::SeqCst));
+        kill_process(identity.pid).expect("clean up test child");
+        let _ = super::remove_pid(&paths);
+    }
+
+    #[test]
+    fn start_listener_mismatch_terminates_spawned_child_and_removes_pid() {
+        let root = temp_root("spawned-listener-mismatch");
+        let paths = test_paths(&root);
+        let port = free_port();
+        write_settings(&paths, port);
+        write_fake_proxy_script(&paths, "import time\ntime.sleep(30)");
+        let spawned_pid = Arc::new(AtomicU32::new(0));
+        let inspector = RecordingInspector::new(fake_proxy_process(&paths, port));
+        let listener = FixedListenerInspector::new(Some(999_999));
+        let health_calls = std::cell::Cell::new(0usize);
+
+        let error = start_with_paths_and_controls(
+            &paths,
+            Duration::from_secs(1),
+            Duration::ZERO,
+            &|_| {
+                let call = health_calls.get();
+                health_calls.set(call + 1);
+                Ok((call > 0).then(healthy_response))
+            },
+            &inspector,
+            &listener,
+            |child, _, _, _, _, _| {
+                spawned_pid.store(child.id(), Ordering::SeqCst);
+                Ok(StartupOutcome::Healthy(healthy_response()))
+            },
+        )
+        .expect_err("listener mismatch must fail startup");
+
+        assert!(error.contains("listener PID 999999"));
+        assert_eq!(read_pid(&paths).expect("read PID"), None);
+        let pid = spawned_pid.load(Ordering::SeqCst);
+        let inspected = super::inspect_process(pid);
+        if matches!(inspected, Ok(InspectedProcess::Running(_))) {
+            let _ = kill_process(pid);
+        }
+        assert!(matches!(inspected, Ok(InspectedProcess::Missing)));
+    }
+
+    #[test]
+    fn start_listener_inspection_failure_terminates_spawned_child() {
+        let root = temp_root("spawned-listener-inspection-error");
+        let paths = test_paths(&root);
+        let port = free_port();
+        write_settings(&paths, port);
+        write_fake_proxy_script(&paths, "import time\ntime.sleep(30)");
+        let spawned_pid = Arc::new(AtomicU32::new(0));
+        let inspector = RecordingInspector::new(fake_proxy_process(&paths, port));
+        let health_calls = std::cell::Cell::new(0usize);
+
+        let error = start_with_paths_and_controls(
+            &paths,
+            Duration::from_secs(1),
+            Duration::ZERO,
+            &|_| {
+                let call = health_calls.get();
+                health_calls.set(call + 1);
+                Ok((call > 0).then(healthy_response))
+            },
+            &inspector,
+            &FailingListenerInspector,
+            |child, _, _, _, _, _| {
+                spawned_pid.store(child.id(), Ordering::SeqCst);
+                Ok(StartupOutcome::Healthy(healthy_response()))
+            },
+        )
+        .expect_err("listener inspection failure must fail startup");
+
+        assert!(error.contains("listener inspection unavailable"));
+        assert_eq!(read_pid(&paths).expect("read PID"), None);
+        let pid = spawned_pid.load(Ordering::SeqCst);
+        let inspected = super::inspect_process(pid);
+        if matches!(inspected, Ok(InspectedProcess::Running(_))) {
+            let _ = kill_process(pid);
+        }
+        assert!(matches!(inspected, Ok(InspectedProcess::Missing)));
     }
 
     #[test]
@@ -2059,7 +2644,10 @@ time.sleep(10)
             .collect::<std::collections::BTreeMap<_, _>>();
 
         assert_eq!(envs.get("CODEX_HOME"), Some(&Some(runtime_home)));
-        assert_eq!(envs.get("CODEXHUB_CODEX_TARGET_HOME"), Some(&Some(target_home)));
+        assert_eq!(
+            envs.get("CODEXHUB_CODEX_TARGET_HOME"),
+            Some(&Some(target_home))
+        );
         assert_eq!(paths.codex_config_path(), root.join(".codex/config.toml"));
     }
 
@@ -2172,7 +2760,10 @@ time.sleep(10)
                 .map_err(|error| format!("update in-place script: {error}"))?;
 
             let new_status = start_with_paths(&paths)?;
-            ensure(new_status.proxy_running, "upgraded in-place bundle should start")?;
+            ensure(
+                new_status.proxy_running,
+                "upgraded in-place bundle should start",
+            )?;
             let new_pid = read_pid(&paths)?
                 .ok_or_else(|| "upgraded in-place bundle should own the proxy PID".to_string())?;
             ensure(
@@ -2281,6 +2872,56 @@ time.sleep(10)
     fn write_fake_proxy_script(paths: &ProxyPaths, body: &str) {
         fs::create_dir_all(paths.proxy_script_dir()).unwrap();
         fs::write(paths.proxy_script_path(), body.trim_start()).unwrap();
+    }
+
+    fn healthy_response() -> super::HealthResponse {
+        super::HealthResponse {
+            ok: Some(true),
+            build: Some("test".to_string()),
+        }
+    }
+
+    struct FixedListenerInspector {
+        pid: Option<u32>,
+    }
+
+    impl FixedListenerInspector {
+        fn new(pid: Option<u32>) -> Self {
+            Self { pid }
+        }
+    }
+
+    impl ListenerInspector for FixedListenerInspector {
+        fn listening_pid(&self, _port: u16) -> Result<Option<u32>, String> {
+            Ok(self.pid)
+        }
+    }
+
+    struct AtomicListenerInspector {
+        pid: Arc<AtomicU32>,
+    }
+
+    impl AtomicListenerInspector {
+        fn new(pid: Arc<AtomicU32>) -> Self {
+            Self { pid }
+        }
+    }
+
+    impl ListenerInspector for AtomicListenerInspector {
+        fn listening_pid(&self, _port: u16) -> Result<Option<u32>, String> {
+            match self.pid.load(Ordering::SeqCst) {
+                0 => Ok(None),
+                pid => Ok(Some(pid)),
+            }
+        }
+    }
+
+    struct FailingListenerInspector;
+
+    impl ListenerInspector for FailingListenerInspector {
+        fn listening_pid(&self, _port: u16) -> Result<Option<u32>, String> {
+            Err("listener inspection unavailable".to_string())
+        }
     }
 
     fn fake_proxy_process(paths: &ProxyPaths, port: u16) -> InspectedProcess {


### PR DESCRIPTION
## Summary
- serialize Gateway start/stop/restart across desktop GUI, CLI, tray, web bridge, and automatic startup with one OS-managed lifecycle transaction
- reconcile health, PID metadata, exact process identity, and listener ownership before publishing Running
- fence PID reuse with process-creation identity (`windows-filetime-ms`, validated against CIM `Win32_Process.CreationDate` at millisecond granularity), preserve structured failed-start recovery ownership, and keep port-change restart on the old recorded port through stop
- native `GetExtendedTcpTable` listener-ownership query (replaces the PowerShell listener provider that failed the reliability gate), with a sizing-retry loop and scoped `AssignProcessToJobObject` failure cleanup
- publish authoritative lifecycle phases to the frontend and use one loading-to-result Toast for tray operations

## Verification
- final candidate `176fc722`: proxy module 40/40; Rust full suite normal 352/352 and debug 351/351; strict clippy (`--all-targets -D warnings`); `git diff --check` clean
- prior strict candidate gates: frontend build, UI contract 141/141, report-only quality gate
- independent candidate review: Spec PASS; Quality APPROVED; Critical 0; Important 0 on the reviewed waves; final-wave findings (recovery-record destructive fence, job-object assign-failure orphan, listener-table sizing race) closed test-first with targeted checks plus full Rust gates per the repository verification policy (later review is delta-only)

## Manual gate complete
The Issue-required packaged Windows Debug timing smoke ran against a portable Debug build of `176fc722` (runtime `flavor.json` confirmed `flavor=debug`, `diagnostics_enabled=true`, matching `source_revision`). Port 9099 was naturally free; no unrelated process was stopped or modified.

- Leg A — `tray:Start Gateway` while auto-start pending: pending fence at click boundary `phase=starting`, automatic `startup` trigger, `publication_ready=false`, `last_attempt_success=false`, fence-to-click 0.008 s. Exactly one Gateway child, exactly one port-9099 listener, child parented to the app, health OK, UI Running, and UI status / `proxy.pid` / listener owner / child PID all identical. Cleanup fully green.
- Leg B — `window:Connect to Codex Hub` while auto-start pending: identical fence conditions, fence-to-click 0.0 s; same single-child / single-listener / four-way PID agreement assertions all true. Cleanup fully green.

The smoke driver itself went through independent review (FAIL → fixes → delta re-review → one Important cleanup-fallback TOCTOU fix confined to a branch untriggered in the accepted runs → final delta re-review PASS). Public evidence files (`public-evidence.json`, `public-cleanup.json`, `ui-action.txt`, `flavor.json`) contain no PIDs, paths, or owner metadata; screenshots and runtime introspection artifacts remain private per evidence review and are not attached.

Full procedure and per-run evidence are recorded in the local implementation report (`.superpowers/sdd/issue-139-report.md`, ignored).

Refs #139
