### PR TITLE
fix(gateway): keep OMP models.yml scalar fields as strings

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codexhub-frontend",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codexhub-frontend",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codexhub-frontend",
   "private": true,
-  "version": "0.1.5",
+  "version": "0.1.6",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "codexhub"
-version = "0.1.6-beta.1"
+version = "0.1.6"
 dependencies = [
  "dirs 5.0.1",
  "log",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "codexhub"
-version = "0.1.5"
+version = "0.1.6-beta.1"
 dependencies = [
  "dirs 5.0.1",
  "log",
@@ -502,6 +502,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "serde_yaml",
  "sha2",
  "tauri",
  "tauri-build",
@@ -3592,6 +3593,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.14.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "serialize-to-javascript"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4750,6 +4764,12 @@ name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codexhub"
-version = "0.1.6-beta.1"
+version = "0.1.6"
 description = "CodexHub desktop backend and CLI"
 authors = ["CodexHub"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codexhub"
-version = "0.1.5"
+version = "0.1.6-beta.1"
 description = "CodexHub desktop backend and CLI"
 authors = ["CodexHub"]
 license = "MIT"
@@ -27,6 +27,9 @@ sha2 = "0.10"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 which = "6"
 log = "0.4"
+
+[dev-dependencies]
+serde_yaml = "0.9"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.59", features = [

--- a/src-tauri/src/gateway.rs
+++ b/src-tauri/src/gateway.rs
@@ -5042,15 +5042,11 @@ fn gateway_base_without_v1(settings: &Settings) -> String {
 }
 
 fn yaml_scalar(value: &str) -> String {
-    if !value.is_empty()
-        && value
-            .chars()
-            .all(|char| char.is_ascii_alphanumeric() || "-_./:".contains(char))
-    {
-        value.to_string()
-    } else {
-        serde_json::to_string(value).unwrap_or_else(|_| "\"\"".to_string())
-    }
+    // Always emit a double-quoted scalar. YAML double-quoted strings accept
+    // JSON escaping, so every value round-trips as a string even when it
+    // resembles a number, boolean, null, timestamp, anchor, alias, or
+    // collection — a lexical allowlist cannot prove any of those.
+    serde_json::to_string(value).unwrap_or_else(|_| "\"\"".to_string())
 }
 
 fn is_top_level_yaml_key(line: &str, key: &str) -> bool {
@@ -6394,10 +6390,10 @@ mod tests {
         assert!(ollama_models.iter().any(|model| model["id"] == "glm-5.2"));
         assert!(volc_models.iter().any(|model| model["id"] == "glm-5.2"));
         assert!(omp_text.contains("codexhub-ollama-cloud:"));
-        assert!(omp_text.contains("baseUrl: http://127.0.0.1:9099/v1/providers/ollama-cloud"));
+        assert!(omp_text.contains("baseUrl: \"http://127.0.0.1:9099/v1/providers/ollama-cloud\""));
         assert!(omp_text.contains("codexhub-volc:"));
-        assert!(omp_text.contains("baseUrl: http://127.0.0.1:9099/v1/providers/volc"));
-        assert!(omp_text.contains("id: glm-5.2"));
+        assert!(omp_text.contains("baseUrl: \"http://127.0.0.1:9099/v1/providers/volc\""));
+        assert!(omp_text.contains("id: \"glm-5.2\""));
     }
 
     #[test]
@@ -6556,15 +6552,121 @@ mod tests {
 
         assert!(text.contains("codexhub-openai:"));
         assert!(text.contains("api: openai-responses"));
-        assert!(text.contains("id: gpt-5.5"));
+        assert!(text.contains("id: \"gpt-5.5\""));
         assert!(text.contains("x-codex-client-id: omp"));
-        assert!(text.contains("id: gpt-5.5-fast"));
-        assert!(text.contains("id: gpt-5.4-fast"));
+        assert!(text.contains("id: \"gpt-5.5-fast\""));
         assert!(text.contains("codexhub-minimax:"));
         assert!(text.contains("api: openai-completions"));
-        assert!(text.contains("id: minimax-m3"));
+        assert!(text.contains("id: \"minimax-m3\""));
         assert!(text.contains("name: \"MiniMax M3\""));
         assert!(!text.contains("minimax/minimax-m3-lite"));
+    }
+
+    fn yaml_string(value: &serde_yaml::Value) -> &str {
+        match value {
+            serde_yaml::Value::String(text) => text.as_str(),
+            other => panic!("expected YAML string, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn omp_models_yaml_keeps_implicitly_typed_scalars_as_strings() {
+        let settings = Settings {
+            gateway_client_key: "2026-07-17".to_string(),
+            ..Settings::default()
+        };
+        let mut provider = client_export_test_providers().remove(0);
+        provider.models = vec![
+            Model {
+                id: "5.4".to_string(),
+                display_name: Some("5.4".to_string()),
+                gateway_exported: true,
+                ..Model::default()
+            },
+            Model {
+                id: "true".to_string(),
+                display_name: Some("null".to_string()),
+                gateway_exported: true,
+                ..Model::default()
+            },
+            Model {
+                id: "1e3".to_string(),
+                display_name: Some("~".to_string()),
+                gateway_exported: true,
+                ..Model::default()
+            },
+            Model {
+                id: "0x10".to_string(),
+                display_name: Some("[a, b]".to_string()),
+                gateway_exported: true,
+                ..Model::default()
+            },
+            Model {
+                id: "*alias".to_string(),
+                display_name: Some("&anchor".to_string()),
+                gateway_exported: true,
+                ..Model::default()
+            },
+        ];
+        let providers = vec![provider];
+
+        let text = omp_models_yml_text(&settings, &providers, "minimax/5.4").unwrap();
+        let document: serde_yaml::Value = serde_yaml::from_str(&text).unwrap();
+
+        let provider_doc = document
+            .get("providers")
+            .and_then(|providers| providers.get("codexhub-minimax"))
+            .expect("provider document");
+        assert_eq!(
+            yaml_string(provider_doc.get("baseUrl").expect("baseUrl")),
+            "http://127.0.0.1:9099/v1/providers/minimax"
+        );
+        assert_eq!(
+            yaml_string(provider_doc.get("apiKey").expect("apiKey")),
+            "2026-07-17"
+        );
+        let models = provider_doc
+            .get("models")
+            .and_then(|models| models.as_sequence())
+            .expect("models");
+        let expected = [
+            ("5.4", "5.4"),
+            ("true", "null"),
+            ("1e3", "~"),
+            ("0x10", "[a, b]"),
+            ("*alias", "&anchor"),
+        ];
+        assert_eq!(models.len(), expected.len());
+        for (model, (id, name)) in models.iter().zip(expected) {
+            assert_eq!(yaml_string(model.get("id").expect("model id")), id);
+            assert_eq!(yaml_string(model.get("name").expect("model name")), name);
+        }
+    }
+
+    #[test]
+    fn omp_models_yaml_official_numeric_display_names_parse_as_strings() {
+        let settings = Settings::default();
+        let providers = client_export_test_providers();
+
+        let text = omp_models_yml_text(&settings, &providers, "openai/gpt-5.5").unwrap();
+        let document: serde_yaml::Value = serde_yaml::from_str(&text).unwrap();
+
+        let models = document
+            .get("providers")
+            .and_then(|providers| providers.get("codexhub-openai"))
+            .and_then(|provider| provider.get("models"))
+            .and_then(|models| models.as_sequence())
+            .expect("official models");
+        // The official source is environment-dependent (local subscription
+        // cache vs static fallback), so the hermetic invariant is that every
+        // emitted official id/name parses back as a YAML string, whatever the
+        // concrete catalog is. Deterministic numeric-name coverage lives in
+        // the custom-provider fixture test above.
+        assert!(!models.is_empty());
+        for model in models {
+            yaml_string(model.get("id").expect("model id"));
+            yaml_string(model.get("name").expect("model name"));
+        }
     }
 
     #[test]
@@ -6599,7 +6701,7 @@ mod tests {
             omp_models_yml_text(&settings, &providers, "ollama-cloud/nemotron-3-nano:30b").unwrap();
 
         assert!(text.contains("codexhub-ollama-cloud:"));
-        assert!(text.contains("id: nemotron-3-nano:30b"));
+        assert!(text.contains("id: \"nemotron-3-nano:30b\""));
         assert!(!text.contains("contextWindow:"));
     }
 
@@ -7644,12 +7746,11 @@ mod tests {
         assert!(config.contains("  vision: codexhub-openai/gpt-5.5"));
         let models = fs::read_to_string(&models_path).unwrap();
         assert!(models.contains("providers:\n  codexhub-openai:"));
-        assert!(models.contains("baseUrl: http://127.0.0.1:9099/v1/providers/openai"));
+        assert!(models.contains("baseUrl: \"http://127.0.0.1:9099/v1/providers/openai\""));
         assert!(models.contains("api: openai-responses"));
-        assert!(models.contains("apiKey: codexhub-proxy"));
-        assert!(models.contains("id: gpt-5.5"));
-        assert!(models.contains("id: gpt-5.5-fast"));
-        assert!(models.contains("id: gpt-5.4-fast"));
+        assert!(models.contains("apiKey: \"codexhub-proxy\""));
+        assert!(models.contains("id: \"gpt-5.5\""));
+        assert!(models.contains("id: \"gpt-5.5-fast\""));
     }
 
     #[test]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "CodexHub",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "identifier": "com.codexhub.app",
   "build": {
     "frontendDist": "../frontend/dist",

--- a/tests/test_release_channel_scripts.py
+++ b/tests/test_release_channel_scripts.py
@@ -20,7 +20,7 @@ def test_official_transport_wheel_is_pinned_and_packaged():
 
 
 def test_release_version_is_consistent_across_manifests():
-    expected = "0.1.5"
+    expected = "0.1.6"
     tauri = json.loads((ROOT / "src-tauri" / "tauri.conf.json").read_text(encoding="utf-8"))
     cargo = tomllib.loads((ROOT / "src-tauri" / "Cargo.toml").read_text(encoding="utf-8"))
     cargo_lock = tomllib.loads((ROOT / "src-tauri" / "Cargo.lock").read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary
- `yaml_scalar` no longer emits values unquoted based on a character allowlist: every OMP `models.yml` string field (model id, model name, base URL, API key) is now always emitted as a double-quoted YAML scalar (JSON-compatible escaping), so numeric-looking names like `5.5`/`5.4`, booleans, nulls, timestamps, anchors, and collection syntax all round-trip as strings. Fixes OMP 17.0.1 schema rejection (`providers.codexhub-openai.models.*.name: must be a string (was a number)`) and the resulting session-only fallback.
- New typed round-trip tests parse the emitted document with serde_yaml and assert OMP-facing field types (not substring presence): a hostile-fixture provider covering numbers/exponents/booleans/nulls/dates/anchors/collections, plus an all-strings invariant over the official provider.
- Set candidate version `0.1.6` across the six version fields (tauri.conf.json, Cargo.toml, Cargo.lock, frontend package manifests ×2) and the release-channel contract pin.

## Test adjustments (pre-existing non-hermetic tests)
- `omp_models_export_all_active_gateway_models` and `omp_apply_writes_models_yml_and_model_roles_with_backup` previously asserted catalog-dependent model IDs (`gpt-5.4-fast`). Those tests read the machine's local Codex subscription cache, so they fail on any machine whose cache lacks that model (verified failing on clean `dev` HEAD on a machine with a changed cache; CI runners without a cache use the static fallback and pass). The cache-dependent assertions were removed; quoting/format assertions and hermetic typed coverage (new tests) remain. Follow-up issue to be filed for a proper official-catalog injection seam.

## Verification
- `cargo test --locked omp_`: 8/8 (including the two new typed round-trip tests)
- `cargo test --locked` / strict clippy / `git diff --check` / release-channel Python tests: see CI
- Manual: portable Windows build produced from this branch for user acceptance testing of the OMP managed route

Closes #155
