### PR TITLE
fix(gateway): preserve explicit chat reasoning controls to responses upstreams (#164)

### DIFF
--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -2126,6 +2126,7 @@ def choose_upstream(model_id: str) -> dict[str, Any]:
             ),
             "reports_cached_input_tokens": bool(external_model.get("reports_cached_input_tokens")),
             "supports_developer_role": bool(external_model.get("supports_developer_role", True)),
+            "supported_reasoning_levels": tuple(external_model.get("supported_reasoning_levels") or ()),
             "input_modalities": tuple(external_model.get("input_modalities") or ("text",)),
         }
 
@@ -2171,6 +2172,42 @@ def _reasoning_param_is_unsupported(upstream_name: Any, requested_model: Any, up
     return False
 
 
+def _request_carries_reasoning_control(payload: Mapping[str, Any]) -> bool:
+    effort = payload.get("reasoning_effort")
+    if isinstance(effort, str) and effort:
+        return True
+    reasoning = payload.get("reasoning")
+    if isinstance(reasoning, str) and reasoning:
+        return True
+    if isinstance(reasoning, Mapping) and reasoning:
+        return True
+    template_kwargs = payload.get("chat_template_kwargs")
+    if isinstance(template_kwargs, Mapping):
+        template_effort = template_kwargs.get("reasoning_effort")
+        if isinstance(template_effort, str) and template_effort:
+            return True
+    return False
+
+
+def _reasoning_policy_for_request(
+    inbound_payload: Any,
+    upstream: Mapping[str, Any] | None,
+    model: str | None,
+) -> str | None:
+    if not isinstance(inbound_payload, Mapping) or not isinstance(upstream, Mapping):
+        return None
+    if _request_carries_reasoning_control(inbound_payload):
+        return "explicit"
+    levels = upstream.get("supported_reasoning_levels")
+    if not levels and model:
+        candidate = generated_catalog_by_slug().get(canonical_model_id(model))
+        if isinstance(candidate, Mapping):
+            levels = candidate.get("supported_reasoning_levels")
+    if levels:
+        return "provider-default"
+    return None
+
+
 def _validate_reasoning_effort_for_upstream(
     payload: Any,
     upstream: Mapping[str, Any],
@@ -2184,6 +2221,9 @@ def _validate_reasoning_effort_for_upstream(
         requested_efforts.append(reasoning.get("effort"))
     elif isinstance(reasoning, str):
         requested_efforts.append(reasoning)
+    template_kwargs = payload.get("chat_template_kwargs")
+    if isinstance(template_kwargs, Mapping):
+        requested_efforts.append(template_kwargs.get("reasoning_effort"))
     is_ultra = any(
         isinstance(effort, str) and effort.strip().lower() == "ultra" for effort in requested_efforts
     )
@@ -8120,6 +8160,8 @@ def transparent_request_body(
                 changed = True
             if official_responses_backend and _normalize_responses_string_input(next_payload):
                 changed = True
+            if upstream_name == "ollama_cloud" and _apply_ollama_reasoning_effort_alias(next_payload):
+                changed = True
             if changed:
                 return json.dumps(next_payload, ensure_ascii=True, separators=(",", ":")).encode("utf-8")
         return body
@@ -8149,6 +8191,8 @@ def transparent_request_body(
     if _normalize_responses_message_input_items(next_payload):
         changed = True
     if upstream_is_third_party and _rewrite_internal_input_items(next_payload):
+        changed = True
+    if upstream_name == "ollama_cloud" and _apply_ollama_reasoning_effort_alias(next_payload):
         changed = True
     if not changed:
         return body
@@ -8781,22 +8825,28 @@ def compatible_request_body(
         changed = True
 
     if upstream_name == "ollama_cloud":
-        reasoning = payload.get("reasoning")
-        if isinstance(reasoning, dict):
-            effort = reasoning.get("effort")
-            replacement = OLLAMA_REASONING_EFFORT_ALIASES.get(effort) if isinstance(effort, str) else None
-            if replacement is not None:
-                reasoning["effort"] = replacement
-                changed = True
-        else:
-            replacement = OLLAMA_REASONING_EFFORT_ALIASES.get(reasoning) if isinstance(reasoning, str) else None
-            if replacement is not None:
-                payload["reasoning"] = replacement
-                changed = True
+        if _apply_ollama_reasoning_effort_alias(payload):
+            changed = True
 
     if not changed:
         return body
     return json.dumps(payload, ensure_ascii=True, separators=(",", ":")).encode("utf-8")
+
+
+def _apply_ollama_reasoning_effort_alias(payload: dict[str, Any]) -> bool:
+    reasoning = payload.get("reasoning")
+    if isinstance(reasoning, dict):
+        effort = reasoning.get("effort")
+        replacement = OLLAMA_REASONING_EFFORT_ALIASES.get(effort) if isinstance(effort, str) else None
+        if replacement is not None:
+            reasoning["effort"] = replacement
+            return True
+        return False
+    replacement = OLLAMA_REASONING_EFFORT_ALIASES.get(reasoning) if isinstance(reasoning, str) else None
+    if replacement is not None:
+        payload["reasoning"] = replacement
+        return True
+    return False
 
 
 APPLY_PATCH_FUNCTION_NAME = "apply_patch"
@@ -12393,9 +12443,11 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 request_kind = RETRY_REQUEST_MAIN_GENERATION
                 proxy_request_context = _event_context_with_request_kind(request_context, request_kind)
             vision_proxy_policy = vision_proxy_policy_for_route(route_decision, behavior_profile)
+            reasoning_policy = _reasoning_policy_for_request(inbound_payload, upstream, model)
             route_policy_event_fields = {
                 **_route_decision_event_fields(route_decision),
                 "vision_proxy_policy": vision_proxy_policy,
+                **({"reasoning_policy": reasoning_policy} if reasoning_policy else {}),
             }
             proxy_request_context = {
                 **proxy_request_context,

--- a/src-python/protocol_translation.py
+++ b/src-python/protocol_translation.py
@@ -749,15 +749,35 @@ def chat_completions_request_to_responses_body(
             "max_output_tokens",
             "reasoning",
             "reasoning_effort",
+            "chat_template_kwargs",
+            "stream_options",
             "n",
         },
         "Chat Completions request",
     )
-    if payload.get("reasoning") is not None or payload.get("reasoning_effort") is not None:
+    template_reasoning_effort = _chat_template_reasoning_effort(payload.get("chat_template_kwargs"))
+    _require_representable_stream_options(payload.get("stream_options"))
+    direct_reasoning_effort = _chat_reasoning_effort(payload)
+    reasoning_control_present = (
+        payload.get("reasoning") is not None or payload.get("reasoning_effort") is not None
+    )
+    if reasoning_control_present and direct_reasoning_effort is None:
         raise UnsupportedProtocolTranslationError(
             "unsupported_protocol_semantics",
             "Cannot translate Chat Completions reasoning controls to Responses without a proven equivalent.",
         )
+    if (
+        direct_reasoning_effort is not None
+        and template_reasoning_effort is not None
+        and direct_reasoning_effort != template_reasoning_effort
+    ):
+        raise UnsupportedProtocolTranslationError(
+            "unsupported_protocol_semantics",
+            "Cannot translate conflicting Chat Completions reasoning controls to Responses without losing intent.",
+        )
+    effective_reasoning_effort = (
+        direct_reasoning_effort if direct_reasoning_effort is not None else template_reasoning_effort
+    )
     if "n" in payload and payload.get("n") not in (None, 1):
         raise UnsupportedProtocolTranslationError(
             "unsupported_protocol_semantics",
@@ -797,8 +817,61 @@ def chat_completions_request_to_responses_body(
     tool_choice = chat_tool_choice_to_responses_tool_choice(payload.get("tool_choice"))
     if tool_choice is not None:
         responses_payload["tool_choice"] = tool_choice
+    if effective_reasoning_effort is not None:
+        responses_payload["reasoning"] = {"effort": effective_reasoning_effort}
 
     return json.dumps(responses_payload, ensure_ascii=True, separators=(",", ":")).encode("utf-8")
+
+
+def _chat_template_reasoning_effort(value: Any) -> str | None:
+    if value is None:
+        return None
+    if (
+        not isinstance(value, Mapping)
+        or set(value.keys()) != {"reasoning_effort"}
+        or not isinstance(value.get("reasoning_effort"), str)
+        or not value["reasoning_effort"]
+    ):
+        raise UnsupportedProtocolTranslationError(
+            "unsupported_protocol_semantics",
+            "Cannot translate Chat Completions chat_template_kwargs fields without losing them; only chat_template_kwargs.reasoning_effort is supported.",
+        )
+    return value["reasoning_effort"]
+
+
+def _require_representable_stream_options(value: Any) -> None:
+    if value is None:
+        return
+    # stream_options.include_usage is representable by construction: the
+    # Responses stream always carries usage and the reverse adapter re-injects
+    # include_usage for streaming Chat Completions callers.
+    if (
+        not isinstance(value, Mapping)
+        or set(value.keys()) != {"include_usage"}
+        or not isinstance(value.get("include_usage"), bool)
+    ):
+        raise UnsupportedProtocolTranslationError(
+            "unsupported_protocol_semantics",
+            "Cannot translate Chat Completions stream_options fields without losing them; only stream_options.include_usage is supported.",
+        )
+
+
+def _chat_reasoning_effort(payload: Mapping[str, Any]) -> str | None:
+    reasoning = payload.get("reasoning")
+    if isinstance(reasoning, str):
+        return reasoning or None
+    if isinstance(reasoning, Mapping):
+        if (
+            set(reasoning.keys()) == {"effort"}
+            and isinstance(reasoning.get("effort"), str)
+            and reasoning["effort"]
+        ):
+            return reasoning["effort"]
+        return None
+    effort = payload.get("reasoning_effort")
+    if isinstance(effort, str) and effort:
+        return effort
+    return None
 
 
 def _chat_completion_message_output(

--- a/tests/test_chat_completions_gateway.py
+++ b/tests/test_chat_completions_gateway.py
@@ -1329,6 +1329,153 @@ class ChatCompletionsEndpointTests(unittest.TestCase):
         ]
         self.assertEqual(marker_events, [])
 
+    def _ollama_glm_external_model(self):
+        return {
+            "alias": "ollama-cloud/glm-5.2",
+            "provider_alias": "ollama-cloud",
+            "upstream_name": "ollama_cloud",
+            "display_prefix": "Ollama",
+            "base_url": "https://ollama.example.test/v1",
+            "api_key": "ollama-test-token",
+            "upstream_model": "glm-5.2",
+            "upstream_format": "responses",
+            "supported_reasoning_levels": ("low", "high", "xhigh", "max"),
+            "default_reasoning_level": "max",
+            "priority_base": 200,
+            "context_window": 131072,
+            "max_output_tokens": 8192,
+            "input_modalities": ("text",),
+            "context_source": "providers_toml",
+            "max_output_source": "providers_toml",
+        }
+
+    def _run_ollama_chat_request(self, payload_fields):
+        policy = codex_proxy.load_policy(codex_proxy.POLICY_PATH)
+        external_model = self._ollama_glm_external_model()
+        body = json.dumps(
+            {
+                "model": "glm-5.2",
+                "messages": [{"role": "user", "content": "hi"}],
+                "stream": False,
+                **payload_fields,
+            }
+        ).encode("utf-8")
+        handler = self._make_handler(body, path="/v1/providers/ollama-cloud/chat/completions")
+        upstream_body = json.dumps({
+            "id": "resp_reasoning",
+            "object": "response",
+            "status": "completed",
+            "model": "glm-5.2",
+            "output": [{
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "Hi"}],
+            }],
+        }).encode("utf-8")
+        with (
+            patch(
+                "codex_proxy.generated_catalog_slugs",
+                return_value={"gpt-5.5", "ollama-cloud/glm-5.2"},
+            ),
+            patch(
+                "codex_proxy.generated_catalog_by_slug",
+                return_value={
+                    "gpt-5.5": {"slug": "gpt-5.5"},
+                    "ollama-cloud/glm-5.2": {
+                        "slug": "ollama-cloud/glm-5.2",
+                        "input_modalities": ["text"],
+                        "supported_reasoning_levels": ["low", "high", "xhigh", "max"],
+                    },
+                },
+            ),
+            patch(
+                "codex_proxy.load_policy",
+                return_value=replace(
+                    policy,
+                    allowed_provider_models=policy.allowed_provider_models + ("ollama-cloud/glm-5.2",),
+                ),
+            ),
+            patch("codex_proxy.resolve_external_model_alias", return_value=external_model),
+            patch("codex_proxy.urlopen", return_value=_FakeJsonResponse(upstream_body)) as mock_urlopen,
+        ):
+            CodexProxyHandler.do_POST(handler)
+        return handler, mock_urlopen
+
+    def test_chat_template_reasoning_effort_reaches_ollama_upstream_as_responses_reasoning(self):
+        handler, mock_urlopen = self._run_ollama_chat_request({
+            "chat_template_kwargs": {"reasoning_effort": "max"},
+            "stream_options": {"include_usage": True},
+        })
+        self.assertEqual(handler._fake.status, 200)
+        sent_payload = json.loads(mock_urlopen.call_args.args[0].data)
+        self.assertEqual(sent_payload["reasoning"], {"effort": "max"})
+        self.assertNotIn("chat_template_kwargs", sent_payload)
+        self.assertNotIn("stream_options", sent_payload)
+
+    def test_chat_template_reasoning_effort_high_stays_distinct_for_ollama(self):
+        handler, mock_urlopen = self._run_ollama_chat_request({
+            "chat_template_kwargs": {"reasoning_effort": "high"},
+        })
+        self.assertEqual(handler._fake.status, 200)
+        sent_payload = json.loads(mock_urlopen.call_args.args[0].data)
+        self.assertEqual(sent_payload["reasoning"], {"effort": "high"})
+
+    def test_chat_template_reasoning_effort_xhigh_aliases_to_max_for_ollama(self):
+        handler, mock_urlopen = self._run_ollama_chat_request({
+            "chat_template_kwargs": {"reasoning_effort": "xhigh"},
+        })
+        self.assertEqual(handler._fake.status, 200)
+        sent_payload = json.loads(mock_urlopen.call_args.args[0].data)
+        self.assertEqual(sent_payload["reasoning"], {"effort": "max"})
+
+    def test_unmappable_chat_template_kwargs_fails_closed_400(self):
+        handler, mock_urlopen = self._run_ollama_chat_request({
+            "chat_template_kwargs": {"enable_thinking": True},
+        })
+        self.assertEqual(handler._fake.status, 400)
+        mock_urlopen.assert_not_called()
+        self.assertIn(b"chat_template_kwargs", b"".join(handler.wfile.writes))
+
+    def test_stream_options_with_extra_keys_fails_closed_400(self):
+        handler, mock_urlopen = self._run_ollama_chat_request({
+            "chat_template_kwargs": {"reasoning_effort": "max"},
+            "stream_options": {"include_usage": True, "chunk_delimiter": "\n"},
+        })
+        self.assertEqual(handler._fake.status, 400)
+        mock_urlopen.assert_not_called()
+
+    def test_ultra_reasoning_effort_via_chat_template_kwargs_rejected_400(self):
+        handler, mock_urlopen = self._run_ollama_chat_request({
+            "chat_template_kwargs": {"reasoning_effort": "ultra"},
+        })
+        self.assertEqual(handler._fake.status, 400)
+        mock_urlopen.assert_not_called()
+        self.assertIn(b"ultra", b"".join(handler.wfile.writes))
+
+    def test_reasoning_policy_marks_provider_default_when_control_omitted(self):
+        handler, mock_urlopen = self._run_ollama_chat_request({})
+        self.assertEqual(handler._fake.status, 200)
+        request_start = next(
+            call.kwargs
+            for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] == "request_start"
+        )
+        self.assertEqual(request_start["reasoning_policy"], "provider-default")
+        sent_payload = json.loads(mock_urlopen.call_args.args[0].data)
+        self.assertNotIn("reasoning", sent_payload)
+
+    def test_reasoning_policy_marks_explicit_when_control_present(self):
+        handler, _mock_urlopen = self._run_ollama_chat_request({
+            "chat_template_kwargs": {"reasoning_effort": "max"},
+        })
+        self.assertEqual(handler._fake.status, 200)
+        request_start = next(
+            call.kwargs
+            for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] == "request_start"
+        )
+        self.assertEqual(request_start["reasoning_policy"], "explicit")
+
     def test_explicit_third_party_standard_chat_route_is_transparent_metered(self):
         policy = codex_proxy.load_policy(codex_proxy.POLICY_PATH)
         external_model = {

--- a/tests/test_chat_completions_gateway.py
+++ b/tests/test_chat_completions_gateway.py
@@ -1396,6 +1396,8 @@ class ChatCompletionsEndpointTests(unittest.TestCase):
                 ),
             ),
             patch("codex_proxy.resolve_external_model_alias", return_value=external_model),
+            patch("codex_proxy.ollama_cloud_alias_upstream_model", return_value=None),
+            patch("codex_proxy.ollama_cloud_runtime_upstream", return_value=None),
             patch("codex_proxy.urlopen", return_value=_FakeJsonResponse(upstream_body)) as mock_urlopen,
         ):
             CodexProxyHandler.do_POST(handler)

--- a/tests/test_protocol_translation.py
+++ b/tests/test_protocol_translation.py
@@ -227,6 +227,71 @@ class ProtocolTranslationTests(unittest.TestCase):
             protocol_translation.chat_completion_to_response_body(body)
         self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
 
+    def test_chat_template_reasoning_effort_translates_to_responses_reasoning(self):
+        body = json.dumps(
+            {
+                "model": "glm-5.2",
+                "messages": [{"role": "user", "content": "hi"}],
+                "chat_template_kwargs": {"reasoning_effort": "max"},
+                "stream": True,
+                "stream_options": {"include_usage": True},
+            }
+        ).encode("utf-8")
+        translated = json.loads(protocol_translation.chat_completions_request_to_responses_body(body))
+        self.assertEqual(translated["reasoning"], {"effort": "max"})
+        self.assertNotIn("chat_template_kwargs", translated)
+        self.assertNotIn("stream_options", translated)
+        self.assertTrue(translated["stream"])
+
+    def test_chat_reasoning_controls_translate_to_responses_effort(self):
+        for payload, expected in (
+            ({"reasoning_effort": "high"}, {"effort": "high"}),
+            ({"reasoning": "xhigh"}, {"effort": "xhigh"}),
+            ({"reasoning": {"effort": "low"}}, {"effort": "low"}),
+        ):
+            with self.subTest(payload=payload):
+                body = json.dumps(
+                    {
+                        "model": "glm-5.2",
+                        "messages": [{"role": "user", "content": "hi"}],
+                        **payload,
+                    }
+                ).encode("utf-8")
+                translated = json.loads(protocol_translation.chat_completions_request_to_responses_body(body))
+                self.assertEqual(translated["reasoning"], expected)
+
+    def test_conflicting_chat_reasoning_controls_fail_closed(self):
+        body = json.dumps(
+            {
+                "model": "glm-5.2",
+                "messages": [{"role": "user", "content": "hi"}],
+                "reasoning_effort": "high",
+                "chat_template_kwargs": {"reasoning_effort": "max"},
+            }
+        ).encode("utf-8")
+        with self.assertRaises(protocol_translation.UnsupportedProtocolTranslationError) as raised:
+            protocol_translation.chat_completions_request_to_responses_body(body)
+        self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
+
+    def test_unmappable_chat_template_kwargs_and_stream_options_fail_closed(self):
+        for extra in (
+            {"chat_template_kwargs": {"enable_thinking": True}},
+            {"chat_template_kwargs": {"reasoning_effort": "max", "enable_thinking": False}},
+            {"stream_options": {"include_usage": True, "chunk_delimiter": "\n"}},
+            {"reasoning": {"effort": "high", "summary": "auto"}},
+        ):
+            with self.subTest(extra=extra):
+                body = json.dumps(
+                    {
+                        "model": "glm-5.2",
+                        "messages": [{"role": "user", "content": "hi"}],
+                        **extra,
+                    }
+                ).encode("utf-8")
+                with self.assertRaises(protocol_translation.UnsupportedProtocolTranslationError) as raised:
+                    protocol_translation.chat_completions_request_to_responses_body(body)
+                self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
+
     def test_chat_completion_chunking_rejects_lossy_message_semantics(self):
         for message in (
             {"role": "assistant", "content": None, "refusal": "I cannot help with that."},
@@ -646,7 +711,7 @@ class ProtocolTranslationTests(unittest.TestCase):
     def test_chat_semantic_fields_without_responses_equivalents_fail_closed(self):
         payloads = {
             "reasoning": {
-                "reasoning_effort": "high",
+                "reasoning": {"effort": "high", "summary": "auto"},
                 "messages": [{"role": "user", "content": "Hello"}],
             },
             "refusal": {


### PR DESCRIPTION
## Summary

Closes #164. ZCode's `openai-compatible` GLM-5.2 route sends `chat_template_kwargs.reasoning_effort` plus `stream_options`; the Chat Completions→Responses translation rejected both fields (and every effort-shaped reasoning control) before upstream execution, leaving no auditable route that preserves an explicit reasoning choice.

- **Translation**: effort-shaped chat reasoning controls — `reasoning_effort`, string `reasoning`, sole-effort `reasoning` objects, and `chat_template_kwargs.reasoning_effort` — now translate to Responses `reasoning.effort`. Unmappable controls (extra `chat_template_kwargs` keys, non-effort `reasoning` fields) and conflicting duplicates still fail closed with precise `unsupported_protocol_semantics` diagnostics. `stream_options.include_usage` is accepted as representable by construction (the reverse adapter re-injects it for streaming callers).
- **Alias parity**: the Ollama `xhigh`→`max` alias now also applies on provider-scoped transparent fallback sends, not just the full compatibility path.
- **Validation**: `chat_template_kwargs.reasoning_effort` is checked against the third-party `ultra` boundary before translation (deterministic 400).
- **Omission policy**: request telemetry carries an auditable `reasoning_policy` marker — `explicit` when a control is present, `provider-default` when a reasoning-capable model (server-side catalog) receives none. Catalog `default_reasoning_level` is never injected as a wire default.

## Verification

- `python -m pytest -q` — 1226 passed, 1 skipped (full suite)
- `git diff --check` — clean; `python scripts/report_quality_gates.py` — report-only, no new findings
- No live provider calls: deterministic request-capture fixtures prove final upstream payloads

New coverage:

- Route level (`tests/test_chat_completions_gateway.py`): `max`/`high`/`xhigh` via `chat_template_kwargs` reach the Ollama Responses upstream as `reasoning.effort` (`xhigh`→`max` alias); unmappable `chat_template_kwargs` / extra `stream_options` keys / `ultra` fail closed 400; `reasoning_policy` marker asserts `provider-default` vs `explicit`.
- Translation level (`tests/test_protocol_translation.py`): effort mapping for all three control shapes, conflict rejection, unmappable-control rejection.
- Updated `test_chat_semantic_fields_without_responses_equivalents_fail_closed`: the fail-closed fixture now uses a genuinely unmappable reasoning control (`effort` + `summary`), matching the narrowed translation contract.

## Notes

- Stacked on #173 (#154) → #172 (#168) → #170 (#169); rebase as those land.
- The companion export-side work (advertising the levels that make ZCode emit these controls) is #154 in the same stack.
