### PR TITLE
fix(gateway): normalize boolean tool schemas on transparent routes (#175)

### DIFF
--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -8225,6 +8225,95 @@ def _rewrite_transparent_developer_role_messages(
     return json.dumps(next_payload, ensure_ascii=True, separators=(",", ":")).encode("utf-8"), rewritten
 
 
+# JSON Schema positions whose values are themselves schemas (or maps/lists of
+# schemas). Value positions such as ``default``, ``enum``, ``const``, or
+# ``examples`` must never be rewritten, so normalization is schema-aware rather
+# than a blind recursive boolean replacement.
+_TOOL_SCHEMA_MAP_KEYS = ("properties", "patternProperties", "$defs", "defs", "definitions", "dependentSchemas")
+_TOOL_SCHEMA_SINGLE_KEYS = (
+    "items",
+    "additionalItems",
+    "additionalProperties",
+    "contains",
+    "propertyNames",
+    "if",
+    "then",
+    "else",
+    "not",
+    "unevaluatedItems",
+    "unevaluatedProperties",
+    "contentSchema",
+)
+_TOOL_SCHEMA_LIST_KEYS = ("allOf", "anyOf", "oneOf", "prefixItems")
+
+
+def _normalize_tool_json_schema(node: Any, state: dict[str, int]) -> Any:
+    """Replace boolean subschemas with equivalent object forms.
+
+    ``true`` and ``{}`` accept any instance; ``false`` and ``{"not": {}}``
+    accept none. Some upstreams (for example Moonshot-flavored validators)
+    reject boolean property schemas outright, so transparent routes normalize
+    them without changing validation semantics.
+    """
+    if isinstance(node, bool):
+        state["rewritten"] += 1
+        return {} if node else {"not": {}}
+    if not isinstance(node, dict):
+        return node
+    next_node = dict(node)
+    for key in _TOOL_SCHEMA_MAP_KEYS:
+        value = next_node.get(key)
+        if isinstance(value, dict):
+            next_node[key] = {
+                name: _normalize_tool_json_schema(subschema, state) if isinstance(subschema, (dict, bool)) else subschema
+                for name, subschema in value.items()
+            }
+    for key in _TOOL_SCHEMA_SINGLE_KEYS:
+        value = next_node.get(key)
+        if isinstance(value, (dict, bool)):
+            next_node[key] = _normalize_tool_json_schema(value, state)
+        elif isinstance(value, list):
+            next_node[key] = [
+                _normalize_tool_json_schema(item, state) if isinstance(item, (dict, bool)) else item
+                for item in value
+            ]
+    for key in _TOOL_SCHEMA_LIST_KEYS:
+        value = next_node.get(key)
+        if isinstance(value, list):
+            next_node[key] = [
+                _normalize_tool_json_schema(item, state) if isinstance(item, (dict, bool)) else item
+                for item in value
+            ]
+    return next_node
+
+
+def _normalize_transparent_tool_schema_booleans(body: bytes) -> tuple[bytes, int]:
+    payload = _safe_json_mapping(body)
+    if payload is None:
+        return body, 0
+    tools = payload.get("tools")
+    if not isinstance(tools, list):
+        return body, 0
+    state = {"rewritten": 0}
+    next_tools: list[Any] = []
+    for tool in tools:
+        if isinstance(tool, dict):
+            function = tool.get("function")
+            if isinstance(function, dict):
+                parameters = function.get("parameters")
+                if isinstance(parameters, (dict, bool)):
+                    parameters = _normalize_tool_json_schema(parameters, state)
+                    function = {**function, "parameters": parameters}
+                    tool = {**tool, "function": function}
+        next_tools.append(tool)
+    if not state["rewritten"]:
+        return body, 0
+    next_payload = dict(payload)
+    next_payload["tools"] = next_tools
+    return json.dumps(next_payload, ensure_ascii=True, separators=(",", ":")).encode("utf-8"), state["rewritten"]
+
+
+
 def _is_raw_provider_probe_context(event_context: Mapping[str, Any] | None) -> bool:
     return bool((event_context or {}).get("raw_provider_probe"))
 
@@ -12570,6 +12659,17 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         upstream=upstream_name,
                         inbound_format=inbound_format,
                         messages_rewritten=developer_role_rewrites,
+                        **proxy_request_context,
+                    )
+                body, tool_schema_rewrites = _normalize_transparent_tool_schema_booleans(body)
+                if tool_schema_rewrites:
+                    write_proxy_event(
+                        "tool_schema_boolean_normalized",
+                        request_id=request_id,
+                        model=model_canonical,
+                        upstream=upstream_name,
+                        inbound_format=inbound_format,
+                        schemas_rewritten=tool_schema_rewrites,
                         **proxy_request_context,
                     )
             else:

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -8230,7 +8230,7 @@ def _rewrite_transparent_developer_role_messages(
 # ``examples`` must never be rewritten, so normalization is schema-aware rather
 # than a blind recursive boolean replacement.
 _TOOL_SCHEMA_MAP_KEYS = ("properties", "patternProperties", "$defs", "defs", "definitions", "dependentSchemas")
-_TOOL_SCHEMA_SINGLE_KEYS = (
+_TOOL_SCHEMA_VALUE_KEYS = (
     "items",
     "additionalItems",
     "additionalProperties",
@@ -8245,6 +8245,13 @@ _TOOL_SCHEMA_SINGLE_KEYS = (
     "contentSchema",
 )
 _TOOL_SCHEMA_LIST_KEYS = ("allOf", "anyOf", "oneOf", "prefixItems")
+
+
+def _normalize_tool_json_schema_items(value: list[Any], state: dict[str, int]) -> list[Any]:
+    return [
+        _normalize_tool_json_schema(item, state) if isinstance(item, (dict, bool)) else item
+        for item in value
+    ]
 
 
 def _normalize_tool_json_schema(node: Any, state: dict[str, int]) -> Any:
@@ -8268,22 +8275,16 @@ def _normalize_tool_json_schema(node: Any, state: dict[str, int]) -> Any:
                 name: _normalize_tool_json_schema(subschema, state) if isinstance(subschema, (dict, bool)) else subschema
                 for name, subschema in value.items()
             }
-    for key in _TOOL_SCHEMA_SINGLE_KEYS:
+    for key in _TOOL_SCHEMA_VALUE_KEYS:
         value = next_node.get(key)
         if isinstance(value, (dict, bool)):
             next_node[key] = _normalize_tool_json_schema(value, state)
         elif isinstance(value, list):
-            next_node[key] = [
-                _normalize_tool_json_schema(item, state) if isinstance(item, (dict, bool)) else item
-                for item in value
-            ]
+            next_node[key] = _normalize_tool_json_schema_items(value, state)
     for key in _TOOL_SCHEMA_LIST_KEYS:
         value = next_node.get(key)
         if isinstance(value, list):
-            next_node[key] = [
-                _normalize_tool_json_schema(item, state) if isinstance(item, (dict, bool)) else item
-                for item in value
-            ]
+            next_node[key] = _normalize_tool_json_schema_items(value, state)
     return next_node
 
 
@@ -8311,7 +8312,6 @@ def _normalize_transparent_tool_schema_booleans(body: bytes) -> tuple[bytes, int
     next_payload = dict(payload)
     next_payload["tools"] = next_tools
     return json.dumps(next_payload, ensure_ascii=True, separators=(",", ":")).encode("utf-8"), state["rewritten"]
-
 
 
 def _is_raw_provider_probe_context(event_context: Mapping[str, Any] | None) -> bool:
@@ -12661,6 +12661,10 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         messages_rewritten=developer_role_rewrites,
                         **proxy_request_context,
                     )
+                # Unconditional by design: rewriting boolean JSON Schemas to
+                # their equivalent object forms is semantics-preserving for
+                # every upstream, and intolerant validators (e.g. Moonshot)
+                # fail closed without it. No provider capability gate.
                 body, tool_schema_rewrites = _normalize_transparent_tool_schema_booleans(body)
                 if tool_schema_rewrites:
                     write_proxy_event(

--- a/tests/test_chat_completions_gateway.py
+++ b/tests/test_chat_completions_gateway.py
@@ -1329,6 +1329,186 @@ class ChatCompletionsEndpointTests(unittest.TestCase):
         ]
         self.assertEqual(marker_events, [])
 
+    def _kimi_transparent_external_model(self):
+        return {
+            "alias": "kimi/k3",
+            "provider_alias": "kimi",
+            "upstream_name": "kimi",
+            "display_prefix": "Kimi",
+            "base_url": "https://api.kimi.example.test/coding",
+            "api_key": "kimi-test-token",
+            "upstream_model": "k3",
+            "upstream_format": "chat_completions",
+            "priority_base": 200,
+            "context_window": 1048576,
+            "max_output_tokens": 32768,
+            "input_modalities": ("text", "image"),
+            "context_source": "providers_toml",
+            "max_output_source": "providers_toml",
+        }
+
+    def _run_kimi_transparent_chat(self, body: bytes, response_id: str):
+        policy = codex_proxy.load_policy(codex_proxy.POLICY_PATH)
+        handler = self._make_handler(body, path="/v1/providers/kimi/chat/completions")
+        upstream_body = json.dumps({
+            "id": response_id,
+            "object": "chat.completion",
+            "model": "k3",
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": "Hi"},
+                "finish_reason": "stop",
+            }],
+        }).encode("utf-8")
+
+        with (
+            patch(
+                "codex_proxy.generated_catalog_slugs",
+                return_value={"gpt-5.5", "kimi/k3"},
+            ),
+            patch(
+                "codex_proxy.generated_catalog_by_slug",
+                return_value={
+                    "gpt-5.5": {"slug": "gpt-5.5"},
+                    "kimi/k3": {"slug": "kimi/k3"},
+                },
+            ),
+            patch(
+                "codex_proxy.load_policy",
+                return_value=replace(
+                    policy,
+                    allowed_provider_models=policy.allowed_provider_models + ("kimi/k3",),
+                ),
+            ),
+            patch(
+                "codex_proxy.resolve_external_model_alias",
+                return_value=self._kimi_transparent_external_model(),
+            ),
+            patch("codex_proxy.urlopen", return_value=_FakeJsonResponse(upstream_body)) as mock_urlopen,
+        ):
+            CodexProxyHandler.do_POST(handler)
+        return handler, mock_urlopen
+
+    def _tool_schema_marker_events(self):
+        return [
+            call.kwargs
+            for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] == "tool_schema_boolean_normalized"
+        ]
+
+    def test_provider_scoped_transparent_chat_normalizes_boolean_tool_schemas(self):
+        body = json.dumps({
+            "model": "k3",
+            "messages": [{"role": "user", "content": "plan something"}],
+            "stream": False,
+            "tools": [{
+                "type": "function",
+                "function": {
+                    "name": "task",
+                    "description": "manage tasks",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "tasks": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "task": {"type": "string"},
+                                        "outputSchema": True,
+                                        "blocked": False,
+                                        "mode": {
+                                            "type": "string",
+                                            "default": True,
+                                            "enum": ["fast", True],
+                                        },
+                                    },
+                                    "required": ["task"],
+                                },
+                            },
+                        },
+                    },
+                },
+            }],
+        }).encode("utf-8")
+
+        handler, mock_urlopen = self._run_kimi_transparent_chat(body, "chatcmpl_schema_normalized")
+
+        sent_payload = json.loads(mock_urlopen.call_args.args[0].data)
+        item_properties = sent_payload["tools"][0]["function"]["parameters"]["properties"]["tasks"]["items"]["properties"]
+        self.assertEqual(item_properties["outputSchema"], {})
+        self.assertEqual(item_properties["blocked"], {"not": {}})
+        # Value positions are not schemas and must stay untouched.
+        self.assertIs(item_properties["mode"]["default"], True)
+        self.assertEqual(item_properties["mode"]["enum"], ["fast", True])
+        self.assertEqual(handler._fake.status, 200)
+        marker_events = self._tool_schema_marker_events()
+        self.assertEqual(len(marker_events), 1)
+        self.assertEqual(marker_events[0]["upstream"], "kimi")
+        self.assertEqual(marker_events[0]["schemas_rewritten"], 2)
+
+    def test_provider_scoped_transparent_chat_normalizes_nested_boolean_tool_schemas(self):
+        body = json.dumps({
+            "model": "k3",
+            "messages": [{"role": "user", "content": "deep"}],
+            "stream": False,
+            "tools": [{
+                "type": "function",
+                "function": {
+                    "name": "deep",
+                    "parameters": {
+                        "type": "object",
+                        "$defs": {"anything": True},
+                        "properties": {
+                            "combo": {
+                                "allOf": [True, {"type": "string"}],
+                                "anyOf": [{"type": "number"}],
+                            },
+                            "extra": {"additionalProperties": False},
+                        },
+                    },
+                },
+            }],
+        }).encode("utf-8")
+
+        handler, mock_urlopen = self._run_kimi_transparent_chat(body, "chatcmpl_schema_nested")
+
+        sent_payload = json.loads(mock_urlopen.call_args.args[0].data)
+        params = sent_payload["tools"][0]["function"]["parameters"]
+        self.assertEqual(params["$defs"]["anything"], {})
+        self.assertEqual(params["properties"]["combo"]["allOf"][0], {})
+        self.assertEqual(params["properties"]["combo"]["allOf"][1], {"type": "string"})
+        self.assertEqual(params["properties"]["combo"]["anyOf"][0], {"type": "number"})
+        self.assertEqual(params["properties"]["extra"]["additionalProperties"], {"not": {}})
+        self.assertEqual(handler._fake.status, 200)
+        marker_events = self._tool_schema_marker_events()
+        self.assertEqual(len(marker_events), 1)
+        self.assertEqual(marker_events[0]["schemas_rewritten"], 3)
+
+    def test_provider_scoped_transparent_chat_preserves_object_only_tool_schemas(self):
+        tool_parameters = {
+            "type": "object",
+            "properties": {
+                "path": {"type": "string", "description": "file path"},
+                "flag": {"type": "boolean", "default": True},
+            },
+            "required": ["path"],
+            "additionalProperties": {"type": "string"},
+        }
+        body = json.dumps({
+            "model": "k3",
+            "messages": [{"role": "user", "content": "read a file"}],
+            "stream": False,
+            "tools": [{"type": "function", "function": {"name": "read", "parameters": tool_parameters}}],
+        }).encode("utf-8")
+
+        handler, mock_urlopen = self._run_kimi_transparent_chat(body, "chatcmpl_schema_passthrough")
+
+        sent_payload = json.loads(mock_urlopen.call_args.args[0].data)
+        self.assertEqual(sent_payload["tools"][0]["function"]["parameters"], tool_parameters)
+        self.assertEqual(handler._fake.status, 200)
+        self.assertEqual(self._tool_schema_marker_events(), [])
+
     def _ollama_glm_external_model(self):
         return {
             "alias": "ollama-cloud/glm-5.2",

--- a/tests/test_chat_completions_gateway.py
+++ b/tests/test_chat_completions_gateway.py
@@ -1509,6 +1509,30 @@ class ChatCompletionsEndpointTests(unittest.TestCase):
         self.assertEqual(handler._fake.status, 200)
         self.assertEqual(self._tool_schema_marker_events(), [])
 
+    def test_normalize_tool_schema_booleans_ignores_non_tool_booleans(self):
+        body = json.dumps({
+            "model": "k3",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": True,
+            "metadata": {"flag": True, "nested": {"off": False}},
+        }).encode("utf-8")
+
+        next_body, rewritten = codex_proxy._normalize_transparent_tool_schema_booleans(body)
+
+        self.assertEqual(rewritten, 0)
+        self.assertEqual(next_body, body)
+
+    def test_normalize_tool_schema_booleans_without_tools_is_byte_identical(self):
+        body = json.dumps({
+            "model": "k3",
+            "messages": [{"role": "user", "content": "hi"}],
+        }).encode("utf-8")
+
+        next_body, rewritten = codex_proxy._normalize_transparent_tool_schema_booleans(body)
+
+        self.assertEqual(rewritten, 0)
+        self.assertIs(next_body, body)
+
     def _ollama_glm_external_model(self):
         return {
             "alias": "ollama-cloud/glm-5.2",


### PR DESCRIPTION
## Summary

Closes #175. OMP (pi-mono) requests with tools failed against the managed Kimi provider with HTTP 400 (`tools.function.parameters is not a valid moonshot flavored json schema … property schema for 'outputSchema' must be an object`). OMP's `task` tool declares `"outputSchema": true` — a boolean JSON Schema, valid per spec but rejected by Moonshot's flavored validator. The transparent route forwarded tool parameter schemas verbatim.

- New `_normalize_transparent_tool_schema_booleans` on the transparent same-format/lightweight-fallback path: boolean subschemas inside `tools[*].function.parameters` are rewritten to equivalent object forms — `true` → `{}` and `false` → `{"not": {}}` — recursing through `properties`/`items`/`additionalProperties`/`patternProperties`/`\`/combinators and the other schema-position keys.
- **Unconditional by design** (documented at the call site): the rewrite is semantics-preserving for every upstream, so no provider capability gate is needed and Kimi is fixed without manual config. This resolves the issue's open decision in favor of unconditional normalization.
- Schema-aware traversal: value positions (`default`, `enum`, `const`, `examples`) are never touched.
- Requests without boolean schemas return the original body byte-identical (early return, no re-serialization).
- Telemetry marker `tool_schema_boolean_normalized` with counts only (`schemas_rewritten`), mirroring the style of `developer_role_rewrite_applied` while using an event name specific to this rewrite.

## Verification

- `python -m pytest -q` — 1231 passed, 1 skipped, 327 subtests (full suite)
- `git diff --check` — clean; `python scripts/report_quality_gates.py` — report-only, no new findings
- Python-only change; Rust/frontend untouched
- Independent review: Standards axis — no blocking findings (judgement-call duplication/name items fixed in the follow-up commit); Spec axis — decision documentation, non-tool-payload and byte-identical coverage gaps fixed in the follow-up commit

New regression coverage:

- `test_provider_scoped_transparent_chat_normalizes_boolean_tool_schemas` (OMP `task`-shaped schema; `true`/`false` normalized; `default`/`enum` booleans untouched; marker count)
- `test_provider_scoped_transparent_chat_normalizes_nested_boolean_tool_schemas` (`\`/`allOf`/`anyOf`/`additionalProperties` depth)
- `test_provider_scoped_transparent_chat_preserves_object_only_tool_schemas` (no rewrite, no marker)
- `test_normalize_tool_schema_booleans_ignores_non_tool_booleans` / `test_normalize_tool_schema_booleans_without_tools_is_byte_identical` (byte-identical passthrough)

## Notes

- Manual OMP end-to-end evidence (per issue acceptance: `task` tool request with image attached succeeds against managed Kimi) to be captured on the next release-candidate portable, same as #168/#169.
- Intentionally traverses a broader schema-position vocabulary than the issue's minimal list (`definitions`, `dependentSchemas`, `contains`, `if`/`then`/`else`, `prefixItems` etc.) so other clients' boolean subschemas are covered by the same semantics-preserving rule.