### PR TITLE
fix(gateway): preserve export key order and emit OpenCode modalities (#176)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3512,6 +3512,7 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,6 +18,10 @@ tauri-plugin-single-instance = "2"
 tauri-plugin-shell = "2"
 tauri-plugin-updater = "2"
 serde = { version = "1", features = ["derive"] }
+# preserve_order is enabled crate-wide deliberately (#176): client exports
+# (OpenCode/Pi/ZCode) must emit keys in configured/catalog order rather than
+# BTreeMap alphabetical. All export maps are built from Vec iteration or
+# json! literals, so insertion order is deterministic everywhere.
 serde_json = { version = "1", features = ["preserve_order"] }
 toml = "0.8"
 dirs = "5"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,7 +18,7 @@ tauri-plugin-single-instance = "2"
 tauri-plugin-shell = "2"
 tauri-plugin-updater = "2"
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde_json = { version = "1", features = ["preserve_order"] }
 toml = "0.8"
 dirs = "5"
 reqwest = { version = "0.12", features = ["blocking", "json"] }

--- a/src-tauri/src/gateway.rs
+++ b/src-tauri/src/gateway.rs
@@ -4433,6 +4433,9 @@ fn opencode_config_text(
         for gateway_model in &group.models {
             let mut entry = json!({
                 "name": gateway_model.display_name,
+                "modalities": {
+                    "input": gateway_model.input_modalities,
+                },
             });
             if !gateway_model.supported_reasoning_levels.is_empty() {
                 let default_effort = gateway_model
@@ -6987,6 +6990,40 @@ mod tests {
                 },
             ],
         }]
+    }
+
+    #[test]
+    fn opencode_config_preserves_configured_reasoning_variant_order() {
+        let settings = Settings::default();
+        let providers = reasoning_contract_client_export_test_providers();
+        let text = opencode_config_text(&settings, &providers, "volc/glm-5.2").unwrap();
+
+        let variants_start = text.find("\"variants\"").expect("variants object");
+        let variants_text = &text[variants_start..];
+        let low = variants_text.find("\"low\"").expect("low variant");
+        let high = variants_text.find("\"high\"").expect("high variant");
+        let xhigh = variants_text.find("\"xhigh\"").expect("xhigh variant");
+        assert!(
+            low < high && high < xhigh,
+            "variants must follow the configured order (low, high, xhigh), got: {variants_text}"
+        );
+    }
+
+    #[test]
+    fn opencode_config_exports_configured_modalities_per_model() {
+        let settings = Settings::default();
+        let providers = reasoning_contract_client_export_test_providers();
+        let text = opencode_config_text(&settings, &providers, "volc/glm-5.2").unwrap();
+        let value: serde_json::Value = serde_json::from_str(&text).unwrap();
+
+        assert_eq!(
+            value.pointer("/provider/codexhub-volc/models/glm-5.2/modalities/input"),
+            Some(&serde_json::json!(["text", "image"]))
+        );
+        assert_eq!(
+            value.pointer("/provider/codexhub-volc/models/glm-5.2-flash/modalities/input"),
+            Some(&serde_json::json!(["text"]))
+        );
     }
 
     #[test]

--- a/src-tauri/src/gateway.rs
+++ b/src-tauri/src/gateway.rs
@@ -4421,6 +4421,15 @@ fn remove_zcode_v2_codexhub_provider(config_path: &Path) -> Result<bool, String>
     Ok(removed)
 }
 
+fn opencode_reasoning_variants(
+    supported_reasoning_levels: &[String],
+) -> Map<String, serde_json::Value> {
+    supported_reasoning_levels
+        .iter()
+        .map(|level| (level.clone(), json!({ "reasoningEffort": level.clone() })))
+        .collect::<Map<_, _>>()
+}
+
 fn opencode_config_text(
     settings: &Settings,
     providers: &[Provider],
@@ -4449,16 +4458,8 @@ fn opencode_config_text(
                     })
                     .cloned()
                     .unwrap_or_else(|| gateway_model.supported_reasoning_levels[0].clone());
-                let variants = gateway_model
-                    .supported_reasoning_levels
-                    .iter()
-                    .map(|level| {
-                        (
-                            level.clone(),
-                            json!({ "reasoningEffort": level.clone() }),
-                        )
-                    })
-                    .collect::<Map<_, _>>();
+                let variants =
+                    opencode_reasoning_variants(&gateway_model.supported_reasoning_levels);
                 if let Some(object) = entry.as_object_mut() {
                     object.insert("options".to_string(), json!({ "reasoningEffort": default_effort }));
                     object.insert("variants".to_string(), Value::Object(variants));
@@ -5306,8 +5307,9 @@ fn has_nonempty_payload(bytes: &[u8]) -> bool {
 mod tests {
     use super::{
         apply_opencode_config_with_paths, gateway_client_provider_groups_from_exported,
-        gateway_models_from_config, gateway_models_from_sources, official_models_from_metadata,
-        omp_models_yml_text, opencode_config_text, pi_models_text, pi_settings_text,
+        gateway_models_from_config, gateway_models_from_sources, official_gateway_reasoning_levels,
+        official_models_from_metadata, omp_models_yml_text, opencode_config_text,
+        opencode_reasoning_variants, pi_models_text, pi_settings_text,
         read_usage_events_from_sqlite_path, read_usage_events_from_text,
         read_usage_summary_from_sqlite_path_with_pricing, read_usage_summary_from_text,
         read_usage_summary_from_text_with_pricing, restore_latest_backup, runtime_proxy_dir,
@@ -6993,6 +6995,17 @@ mod tests {
     }
 
     #[test]
+    fn opencode_variants_preserve_official_catalog_reasoning_order() {
+        let variants = opencode_reasoning_variants(&official_gateway_reasoning_levels());
+        let keys: Vec<&str> = variants.keys().map(String::as_str).collect();
+        assert_eq!(
+            keys,
+            ["low", "medium", "high", "xhigh", "max"],
+            "official variants must follow catalog order, not alphabetical"
+        );
+    }
+
+    #[test]
     fn opencode_config_preserves_configured_reasoning_variant_order() {
         let settings = Settings::default();
         let providers = reasoning_contract_client_export_test_providers();
@@ -7023,6 +7036,12 @@ mod tests {
         assert_eq!(
             value.pointer("/provider/codexhub-volc/models/glm-5.2-flash/modalities/input"),
             Some(&serde_json::json!(["text"]))
+        );
+        // The projection has no output-modality source; omit rather than fabricate.
+        assert!(
+            value
+                .pointer("/provider/codexhub-volc/models/glm-5.2/modalities/output")
+                .is_none()
         );
     }
 


### PR DESCRIPTION
## Summary

Closes #176. Two OpenCode export defects on the 0.1.6 candidate:

1. **Reasoning variants exported alphabetically instead of configured order.** `supported_reasoning_levels = [low, medium, high, xhigh, max]` appeared as `high, low, max, medium, xhigh` in `opencode.json` because variants were collected into `serde_json::Map` (BTreeMap). Fixed by enabling `serde_json/preserve_order` crate-wide (decision recorded on the issue): all export maps are built from `Vec` iteration or `json!` literals, so insertion order is deterministic and every client export (OpenCode/Pi/ZCode) now emits keys in configured/catalog order.
2. **No `modalities` exported**, so OpenCode blocked image attachments client-side even for image-capable managed models. The export now emits `modalities.input` from the configured `input_modalities` projection (official `text+image`; external fail-closed `["text"]`, aligned with #168). `modalities.output` is omitted — the projection has no source for it (asserted by test, no fabrication).

Also extracts `opencode_reasoning_variants` so the official-catalog order path is deterministically testable without host `~/.codex` state.

## Verification

- `cargo test` — 358 passed; 6 failures = the identical pre-existing host-dependent set verified on the base commit (they read live `~/.codex` catalog state; CI is green). One additional base-set flake (`post_spawn_inspection_timeout`) observed once under load, passes in isolation.
- `cargo clippy --all-targets -- -D warnings` — clean
- `python -m pytest -q` — 1231 passed, 1 skipped (full suite)
- `npm ci && npm run build && npm run test:ui-contract` — 141 pass, 0 fail
- `git diff --check` — clean; `python scripts/report_quality_gates.py` — report-only, no new findings
- Independent review: Standards — no hard violations; global-feature documentation and blast-radius accounting added in the follow-up commit. Spec — official-order pin, `modalities.output` absence pin added in the follow-up commit.

New regression coverage:

- `opencode_config_preserves_configured_reasoning_variant_order` (external provider configured order)
- `opencode_variants_preserve_official_catalog_reasoning_order` (official catalog order, host-state independent)
- `opencode_config_exports_configured_modalities_per_model` (image-capable vs fail-closed text-only; `output` absent)

## Notes

- Manual OpenCode TUI evidence (variant order display; image attach on image-capable managed model) to be captured on the next release-candidate portable, same as #168/#169/#175.