### PR TITLE
fix: make cross-language atomic lock ownership and stale recovery safe (#149)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,12 @@ jobs:
           python-version: '3.13'
 
       - name: Set up Rust stable
-        run: rustup toolchain install stable --profile minimal
+        run: rustup toolchain install stable --profile minimal --component clippy
+
+      - name: Lint safe_file with clippy for Linux
+        env:
+          CARGO_MANIFEST_DIR: ${{ github.workspace }}/src-tauri
+        run: rustup run stable clippy-driver --edition=2021 --test src-tauri/src/safe_file.rs -o safe-file-linux-lint -D warnings
 
       - name: Compile safe_file test harness for Linux
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,31 @@ jobs:
             cargo build --release --locked
           }
 
+  rust-safe-file-linux:
+    name: Rust safe_file Linux compile and tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Set up Rust stable
+        run: rustup toolchain install stable --profile minimal
+
+      - name: Compile safe_file test harness for Linux
+        env:
+          CARGO_MANIFEST_DIR: ${{ github.workspace }}/src-tauri
+        run: rustc +stable --edition=2021 --test src-tauri/src/safe_file.rs -o safe-file-linux-tests
+
+      - name: Run safe_file Linux tests
+        env:
+          PYTHONPATH: ${{ github.workspace }}/src-python
+        run: ./safe-file-linux-tests
+
   release-flavor-contract:
     name: Release flavor contract
     runs-on: windows-latest

--- a/docs/agents/ci.md
+++ b/docs/agents/ci.md
@@ -6,8 +6,10 @@ GitHub Actions runs the required PR validation for branches targeting `dev` and 
 
 - Python tests: `python -m pytest -q`
 - Frontend build and UI contract: `npm ci`, `npm run build`, `npm run test:ui-contract` in `frontend/`
-- Rust tests: `cargo test --locked` in `src-tauri/`
+- Rust tests (normal and debug flavors): `cargo test --locked` in `src-tauri/`, plus a release-optimized flavor build
 - Rust clippy: `cargo clippy --locked --all-targets -- -D warnings` in `src-tauri/`
+- Release flavor contract: portable-build dry-run parity for the normal and debug flavors
+- Rust safe_file Linux compile and tests: standalone `rustc --test` compile of `src-tauri/src/safe_file.rs` on Ubuntu, a `clippy-driver -D warnings` lint of the same file, and the resulting cross-language test binary. This job exists because `safe_file.rs` contains `cfg(unix)` FFI that the Windows-only Rust jobs never compile; it must stay free of crate dependencies so the standalone compile keeps working.
 
 The Rust jobs create a temporary `src-tauri/resources/python/.ci-placeholder` file during CI because Tauri's resource glob requires at least one runtime Python resource file. The placeholder is not committed.
 

--- a/docs/agents/verification-policy.md
+++ b/docs/agents/verification-policy.md
@@ -53,10 +53,12 @@ not block PR, merge, or release under the current policy.
 
 ## CI authority
 
-GitHub Actions runs all four repository jobs for every PR to `dev` or `main`
-regardless of local verification class. Local risk selection reduces duplicate
-work; it does not weaken CI. When CI is unavailable and a merge must proceed,
-reproduce the full fallback in `docs/agents/ci.md`.
+GitHub Actions runs every repository job for every PR to `dev` or `main`
+regardless of local verification class (Python tests, frontend build and UI
+contract, Rust tests for both flavors, Rust clippy, release flavor contract,
+and the safe_file Linux compile/lint/tests). Local risk selection reduces
+duplicate work; it does not weaken CI. When CI is unavailable and a merge must
+proceed, reproduce the full fallback in `docs/agents/ci.md`.
 
 Existing active work migrates incrementally: retain already completed full
 suites and formal reviews, do not restart a Worker, and verify only later

--- a/src-python/atomic_io.py
+++ b/src-python/atomic_io.py
@@ -12,7 +12,20 @@ from typing import Callable, Iterator
 
 LOCK_WAIT_TIMEOUT_SECONDS = 10.0
 LOCK_RETRY_DELAY_SECONDS = 0.025
+# Versioned lock record. Anything else is fail-closed:
+# - unknown/future versions -> never recovered (fail closed);
+# - legacy pid/timestamp records -> recovered only when the PID is provably
+#   dead, otherwise fail closed;
+# - mixed-version caveat: binaries older than this protocol may still reclaim
+#   or unlink a protocol lock file (they classify anything non-legacy as
+#   stale); old binaries cannot be patched, so upgrades must drain running
+#   old processes before relying on overlap protection.
+# Crash-recovery bound: a holder death releases its OS byte lock, so a new
+# owner enters within LOCK_WAIT_TIMEOUT_SECONDS.
 LOCK_PROTOCOL = "codexhub-atomic-lock=1\n"
+# Win32 FILE_ATTRIBUTE_REPARSE_POINT; read via getattr so it stays zero on
+# non-Windows platforms where the attribute never appears.
+_FILE_ATTRIBUTE_REPARSE_POINT = 0x400
 _TEST_LOCK_HOOK: Callable[[str], None] | None = None
 
 
@@ -172,7 +185,7 @@ def _validate_lock_stat(metadata: os.stat_result) -> None:
         not stat.S_ISREG(metadata.st_mode)
         or metadata.st_nlink != 1
         or reparse_tag
-        or file_attributes & 0x400
+        or file_attributes & _FILE_ATTRIBUTE_REPARSE_POINT
     ):
         raise OSError("atomic write lock is not a regular single-link file")
 
@@ -327,14 +340,14 @@ def _pid_is_definitely_dead(pid: int) -> bool:
     if os.name == "nt":
         # A process that cannot be opened is deliberately treated as live or
         # unknown. This gives up recovery rather than risking an overlap.
-        handle = _KERNEL32.OpenProcess(0x1000, False, pid)
+        handle = _KERNEL32.OpenProcess(_PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
         if not handle:
             return False
         try:
             exit_code = wintypes.DWORD()
             if not _KERNEL32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
                 return False
-            return exit_code.value != 259  # STILL_ACTIVE
+            return exit_code.value != _STILL_ACTIVE
         finally:
             _KERNEL32.CloseHandle(handle)
     try:
@@ -353,6 +366,20 @@ def _pid_is_definitely_dead(pid: int) -> bool:
 if os.name == "nt":
     import msvcrt
     from ctypes import wintypes
+
+    _GENERIC_READ_WRITE = 0xC0000000
+    _SHARE_READ_WRITE_DELETE = 0x00000007
+    _FILE_FLAG_OPEN_REPARSE_POINT = 0x00200000
+    _CREATE_NEW = 1
+    _OPEN_EXISTING = 3
+    _ERROR_FILE_NOT_FOUND = 2
+    _ERROR_SHARING_VIOLATION = 32
+    _ERROR_LOCK_VIOLATION = 33
+    _ERROR_FILE_EXISTS = 80
+    _STILL_ACTIVE = 259
+    _PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+    _LOCKFILE_FAIL_IMMEDIATELY = 0x00000001
+    _LOCKFILE_EXCLUSIVE_LOCK = 0x00000002
 
     class _OVERLAPPED(ctypes.Structure):
         _fields_ = [("Internal", ctypes.c_size_t), ("InternalHigh", ctypes.c_size_t), ("Offset", ctypes.c_ulong), ("OffsetHigh", ctypes.c_ulong), ("hEvent", ctypes.c_void_p)]
@@ -382,19 +409,19 @@ if os.name == "nt":
     def _open_lock_file_windows(lock_path: Path, *, created: bool) -> int:
         handle = _KERNEL32.CreateFileW(
             str(lock_path),
-            0xC0000000,
-            0x00000007,
+            _GENERIC_READ_WRITE,
+            _SHARE_READ_WRITE_DELETE,
             None,
-            1 if created else 3,
-            0x00200000,
+            _CREATE_NEW if created else _OPEN_EXISTING,
+            _FILE_FLAG_OPEN_REPARSE_POINT,
             None,
         )
         invalid = ctypes.c_void_p(-1).value
         if handle in (None, invalid):
             error = ctypes.get_last_error()
-            if created and error == 80:
+            if created and error == _ERROR_FILE_EXISTS:
                 raise FileExistsError(error, "lock already exists")
-            if not created and error == 2:
+            if not created and error == _ERROR_FILE_NOT_FOUND:
                 raise FileNotFoundError(error, "lock disappeared")
             raise OSError("failed to open atomic write lock")
         return msvcrt.open_osfhandle(handle, os.O_RDWR | getattr(os, "O_BINARY", 0))
@@ -402,9 +429,9 @@ if os.name == "nt":
     def _try_lock_windows(fd: int) -> bool:
         overlapped = _OVERLAPPED()
         handle = wintypes.HANDLE(msvcrt.get_osfhandle(fd))
-        if _KERNEL32.LockFileEx(handle, 0x00000002 | 0x00000001, 0, 1, 0, ctypes.byref(overlapped)):
+        if _KERNEL32.LockFileEx(handle, _LOCKFILE_EXCLUSIVE_LOCK | _LOCKFILE_FAIL_IMMEDIATELY, 0, 1, 0, ctypes.byref(overlapped)):
             return True
-        if ctypes.get_last_error() in (33, 32):  # LOCK_VIOLATION/SHARING_VIOLATION
+        if ctypes.get_last_error() in (_ERROR_LOCK_VIOLATION, _ERROR_SHARING_VIOLATION):
             return False
         raise OSError("failed to acquire atomic write lock")
 

--- a/src-python/atomic_io.py
+++ b/src-python/atomic_io.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import contextlib
+import ctypes
 import errno
 import os
+import stat
 import time
 import uuid
 from pathlib import Path
@@ -10,42 +12,173 @@ from typing import Callable, Iterator
 
 LOCK_WAIT_TIMEOUT_SECONDS = 10.0
 LOCK_RETRY_DELAY_SECONDS = 0.025
-LOCK_STALE_AFTER_SECONDS = 60.0
+LOCK_PROTOCOL = "codexhub-atomic-lock=1\n"
+_TEST_LOCK_HOOK: Callable[[str], None] | None = None
+
+
+def _set_test_lock_hook(hook: Callable[[str], None] | None) -> None:
+    global _TEST_LOCK_HOOK
+    _TEST_LOCK_HOOK = hook
+
+
+def _notify_test_lock(event: str) -> None:
+    if _TEST_LOCK_HOOK is not None:
+        _TEST_LOCK_HOOK(event)
 
 
 @contextlib.contextmanager
-def file_lock_for(path: Path) -> Iterator[None]:
-    """Acquire a simple cross-process lock file for a target path."""
+def file_lock_for(path: Path) -> Iterator[Callable[[], None]]:
+    """Hold the cross-language advisory lock and its namespace guard."""
     lock_path = path.with_name(f"{path.name}.lock")
+    namespace_path = lock_path.with_name(f"{lock_path.name}.guard")
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     started = time.monotonic()
-    fd: int | None = None
-    while fd is None:
-        try:
-            fd = os.open(lock_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL)
-        except FileExistsError:
-            if _lock_is_stale(lock_path):
-                _remove_lock_file_best_effort(lock_path)
-                continue
-            if time.monotonic() - started >= LOCK_WAIT_TIMEOUT_SECONDS:
-                raise TimeoutError(f"timed out waiting for file lock {lock_path}")
-            time.sleep(LOCK_RETRY_DELAY_SECONDS)
-        except OSError as exc:
-            if exc.errno in (errno.EEXIST, errno.EACCES):
-                if _lock_is_stale(lock_path):
-                    _remove_lock_file_best_effort(lock_path)
-                    continue
-                if time.monotonic() - started >= LOCK_WAIT_TIMEOUT_SECONDS:
-                    raise TimeoutError(f"timed out waiting for file lock {lock_path}") from exc
-                time.sleep(LOCK_RETRY_DELAY_SECONDS)
-                continue
-            raise
+    namespace_fd = _acquire_namespace_guard(lock_path, started)
+
+    def verify_namespace() -> None:
+        _verify_lock_identity(namespace_path, namespace_fd)
+
     try:
-        os.write(fd, f"pid={os.getpid()}\nacquired_at_millis={_current_millis()}\n".encode("ascii"))
-        yield
+        while True:
+            if time.monotonic() - started >= LOCK_WAIT_TIMEOUT_SECONDS:
+                raise TimeoutError("timed out waiting for atomic write lock")
+            try:
+                fd, created = _open_lock_file(lock_path)
+            except (FileExistsError, FileNotFoundError):
+                _retry_after_failure(started)
+                continue
+            except OSError as exc:
+                raise OSError("failed to open atomic write lock") from exc
+
+            acquired = False
+            retry = False
+            try:
+                acquired = _try_lock_exclusive(fd)
+                if acquired:
+                    _verify_lock_identity(lock_path, fd)
+                    state = _read_lock_state(fd)
+                    if created:
+                        if state != "empty":
+                            raise TimeoutError("atomic write lock is unavailable")
+                        _write_protocol(fd)
+                    elif state == "protocol" or state == "dead-legacy":
+                        _write_protocol(fd)
+                    elif state == "empty":
+                        retry = True
+                    else:
+                        raise TimeoutError("atomic write lock is unavailable")
+                    if not retry:
+                        verify_namespace()
+                        _verify_lock_identity(lock_path, fd)
+                        yield verify_namespace
+                        verify_namespace()
+                        return
+            finally:
+                try:
+                    if acquired:
+                        _unlock(fd)
+                finally:
+                    os.close(fd)
+
+            _retry_after_failure(started)
     finally:
+        try:
+            _unlock(namespace_fd)
+        finally:
+            os.close(namespace_fd)
+
+
+def _acquire_namespace_guard(lock_path: Path, started: float) -> int:
+    guard_path = lock_path.with_name(f"{lock_path.name}.guard")
+    while True:
+        if time.monotonic() - started >= LOCK_WAIT_TIMEOUT_SECONDS:
+            raise TimeoutError("timed out waiting for atomic write lock")
+        try:
+            fd, _ = _open_lock_file(guard_path)
+        except (FileExistsError, FileNotFoundError):
+            _retry_after_failure(started)
+            continue
+        except OSError as exc:
+            raise OSError("failed to open atomic write lock") from exc
+        _notify_test_lock("attempt")
+        try:
+            if _try_lock_exclusive(fd):
+                _verify_lock_identity(guard_path, fd)
+                _notify_test_lock("acquired")
+                return fd
+            _notify_test_lock("blocked")
+        except Exception:
+            os.close(fd)
+            raise
         os.close(fd)
-        _remove_lock_file_best_effort(lock_path)
+        _retry_after_failure(started)
+
+
+def _retry_after_failure(started: float) -> None:
+    remaining = LOCK_WAIT_TIMEOUT_SECONDS - (time.monotonic() - started)
+    if remaining <= 0:
+        raise TimeoutError("timed out waiting for atomic write lock")
+    time.sleep(min(LOCK_RETRY_DELAY_SECONDS, remaining))
+
+
+def _open_lock_file(lock_path: Path) -> tuple[int, bool]:
+    """Open one regular, single-link lock artifact without following links."""
+    try:
+        existing_stat = os.lstat(lock_path)
+    except FileNotFoundError:
+        if os.name == "nt":
+            fd = _open_lock_file_windows(lock_path, created=True)
+        else:
+            flags = os.O_RDWR | os.O_CREAT | os.O_EXCL
+            nofollow = getattr(os, "O_NOFOLLOW", 0)
+            fd = os.open(lock_path, flags | nofollow, 0o600)
+        try:
+            _validate_lock_stat(os.fstat(fd))
+        except Exception:
+            os.close(fd)
+            raise
+        return fd, True
+
+    _validate_lock_stat(existing_stat)
+    if os.name == "nt":
+        fd = _open_lock_file_windows(lock_path, created=False)
+    else:
+        flags = os.O_RDWR | getattr(os, "O_NOFOLLOW", 0)
+        fd = os.open(lock_path, flags)
+    try:
+        opened_stat = os.fstat(fd)
+        _validate_lock_stat(opened_stat)
+        if not _same_file(existing_stat, opened_stat):
+            raise OSError("atomic write lock path changed")
+    except Exception:
+        os.close(fd)
+        raise
+    return fd, False
+
+
+def _verify_lock_identity(lock_path: Path, fd: int) -> None:
+    path_stat = os.lstat(lock_path)
+    _validate_lock_stat(path_stat)
+    opened_stat = os.fstat(fd)
+    _validate_lock_stat(opened_stat)
+    if not _same_file(path_stat, opened_stat):
+        raise OSError("atomic write lock path changed")
+
+
+def _validate_lock_stat(metadata: os.stat_result) -> None:
+    reparse_tag = getattr(metadata, "st_reparse_tag", 0)
+    file_attributes = getattr(metadata, "st_file_attributes", 0)
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or metadata.st_nlink != 1
+        or reparse_tag
+        or file_attributes & 0x400
+    ):
+        raise OSError("atomic write lock is not a regular single-link file")
+
+
+def _same_file(left: os.stat_result, right: os.stat_result) -> bool:
+    return (left.st_dev, left.st_ino) == (right.st_dev, right.st_ino)
 
 
 def atomic_write_text(path: Path, text: str, *, encoding: str = "utf-8", mode: int | None = None) -> None:
@@ -54,7 +187,8 @@ def atomic_write_text(path: Path, text: str, *, encoding: str = "utf-8", mode: i
 
 def atomic_write_bytes(path: Path, data: bytes, *, mode: int | None = None) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    with file_lock_for(path):
+    with file_lock_for(path) as verify_namespace:
+        verify_namespace()
         _atomic_write_bytes_unlocked(path, data, mode=mode)
 
 
@@ -66,14 +200,16 @@ def atomic_read_or_create_text(
     mode: int | None = None,
 ) -> str:
     path.parent.mkdir(parents=True, exist_ok=True)
-    with file_lock_for(path):
+    with file_lock_for(path) as verify_namespace:
+        verify_namespace()
         try:
             raw = path.read_text(encoding=encoding).strip()
-            if raw:
-                return raw
-        except OSError:
-            pass
+        except FileNotFoundError:
+            raw = ""
+        if raw:
+            return raw
         text = create_text()
+        verify_namespace()
         _atomic_write_bytes_unlocked(path, text.encode(encoding), mode=mode)
         return text
 
@@ -96,15 +232,191 @@ def _atomic_write_bytes_unlocked(path: Path, data: bytes, *, mode: int | None = 
         raise
 
 
-def _remove_lock_file_best_effort(lock_path: Path) -> None:
-    for _ in range(50):
+def _try_lock_exclusive(fd: int) -> bool:
+    if os.name == "nt":
+        return _try_lock_windows(fd)
+    import fcntl
+
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return True
+    except OSError as exc:
+        if exc.errno in (errno.EACCES, errno.EAGAIN):
+            return False
+        raise
+
+
+def _unlock(fd: int) -> None:
+    if os.name == "nt":
+        _unlock_windows(fd)
+        return
+    import fcntl
+
+    fcntl.flock(fd, fcntl.LOCK_UN)
+
+
+def _read_lock_state(fd: int) -> str:
+    os.lseek(fd, 0, os.SEEK_SET)
+    chunks: list[bytes] = []
+    while True:
+        chunk = os.read(fd, 4096)
+        if not chunk:
+            break
+        chunks.append(chunk)
+    return _classify_lock_bytes(b"".join(chunks))
+
+
+def _classify_lock_bytes(data: bytes) -> str:
+    if not data:
+        return "empty"
+    try:
+        text = data.decode("ascii")
+    except UnicodeDecodeError:
+        return "unknown"
+    if data in (b"codexhub-atomic-lock=1\n", b"codexhub-atomic-lock=1\r\n"):
+        return "protocol"
+    legacy = _parse_legacy_pid(text)
+    if legacy is None:
+        return "unknown"
+    return "dead-legacy" if _pid_is_definitely_dead(legacy) else "live-legacy"
+
+
+def _write_protocol(fd: int) -> None:
+    os.lseek(fd, 0, os.SEEK_SET)
+    os.ftruncate(fd, 0)
+    os.write(fd, LOCK_PROTOCOL.encode("ascii"))
+    os.fsync(fd)
+
+
+def _parse_legacy_pid(text: str) -> int | None:
+    """Parse exactly the former two-line record with a bounded PID."""
+    if "\r\n" in text:
+        if not text.endswith("\r\n") or "\r" in text[:-2].replace("\r\n", ""):
+            return None
+        lines = text[:-2].split("\r\n")
+    else:
+        if not text.endswith("\n") or "\r" in text:
+            return None
+        lines = text[:-1].split("\n")
+    if len(lines) != 2:
+        return None
+
+    values: dict[str, str] = {}
+    for line in lines:
+        key, separator, value = line.partition("=")
+        if not separator or key in values:
+            return None
+        values[key] = value
+    if set(values) != {"pid", "acquired_at_millis"}:
+        return None
+    if not all("0" <= char <= "9" for char in values["pid"]):
+        return None
+    if not all("0" <= char <= "9" for char in values["acquired_at_millis"]):
+        return None
+    try:
+        pid = int(values["pid"])
+        timestamp = int(values["acquired_at_millis"])
+    except ValueError:
+        return None
+    if not 0 < pid <= 2_147_483_647 or timestamp > 2**128 - 1:
+        return None
+    return pid
+
+
+def _pid_is_definitely_dead(pid: int) -> bool:
+    if os.name == "nt":
+        # A process that cannot be opened is deliberately treated as live or
+        # unknown. This gives up recovery rather than risking an overlap.
+        handle = _KERNEL32.OpenProcess(0x1000, False, pid)
+        if not handle:
+            return False
         try:
-            lock_path.unlink()
-            return
-        except FileNotFoundError:
-            return
-        except OSError:
-            time.sleep(0.01)
+            exit_code = wintypes.DWORD()
+            if not _KERNEL32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
+                return False
+            return exit_code.value != 259  # STILL_ACTIVE
+        finally:
+            _KERNEL32.CloseHandle(handle)
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return True
+    except PermissionError:
+        return False
+    except (OverflowError, ValueError):
+        return False
+    except OSError as exc:
+        return exc.errno == errno.ESRCH
+    return False
+
+
+if os.name == "nt":
+    import msvcrt
+    from ctypes import wintypes
+
+    class _OVERLAPPED(ctypes.Structure):
+        _fields_ = [("Internal", ctypes.c_size_t), ("InternalHigh", ctypes.c_size_t), ("Offset", ctypes.c_ulong), ("OffsetHigh", ctypes.c_ulong), ("hEvent", ctypes.c_void_p)]
+
+    _KERNEL32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    _KERNEL32.LockFileEx.argtypes = [wintypes.HANDLE, wintypes.DWORD, wintypes.DWORD, wintypes.DWORD, wintypes.DWORD, ctypes.POINTER(_OVERLAPPED)]
+    _KERNEL32.LockFileEx.restype = wintypes.BOOL
+    _KERNEL32.UnlockFileEx.argtypes = [wintypes.HANDLE, wintypes.DWORD, wintypes.DWORD, wintypes.DWORD, ctypes.POINTER(_OVERLAPPED)]
+    _KERNEL32.UnlockFileEx.restype = wintypes.BOOL
+    _KERNEL32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+    _KERNEL32.OpenProcess.restype = wintypes.HANDLE
+    _KERNEL32.GetExitCodeProcess.argtypes = [wintypes.HANDLE, ctypes.POINTER(wintypes.DWORD)]
+    _KERNEL32.GetExitCodeProcess.restype = wintypes.BOOL
+    _KERNEL32.CloseHandle.argtypes = [wintypes.HANDLE]
+    _KERNEL32.CloseHandle.restype = wintypes.BOOL
+    _KERNEL32.CreateFileW.argtypes = [
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        ctypes.c_void_p,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.HANDLE,
+    ]
+    _KERNEL32.CreateFileW.restype = wintypes.HANDLE
+
+    def _open_lock_file_windows(lock_path: Path, *, created: bool) -> int:
+        handle = _KERNEL32.CreateFileW(
+            str(lock_path),
+            0xC0000000,
+            0x00000007,
+            None,
+            1 if created else 3,
+            0x00200000,
+            None,
+        )
+        invalid = ctypes.c_void_p(-1).value
+        if handle in (None, invalid):
+            error = ctypes.get_last_error()
+            if created and error == 80:
+                raise FileExistsError(error, "lock already exists")
+            if not created and error == 2:
+                raise FileNotFoundError(error, "lock disappeared")
+            raise OSError("failed to open atomic write lock")
+        return msvcrt.open_osfhandle(handle, os.O_RDWR | getattr(os, "O_BINARY", 0))
+
+    def _try_lock_windows(fd: int) -> bool:
+        overlapped = _OVERLAPPED()
+        handle = wintypes.HANDLE(msvcrt.get_osfhandle(fd))
+        if _KERNEL32.LockFileEx(handle, 0x00000002 | 0x00000001, 0, 1, 0, ctypes.byref(overlapped)):
+            return True
+        if ctypes.get_last_error() in (33, 32):  # LOCK_VIOLATION/SHARING_VIOLATION
+            return False
+        raise OSError("failed to acquire atomic write lock")
+
+    def _unlock_windows(fd: int) -> None:
+        overlapped = _OVERLAPPED()
+        handle = wintypes.HANDLE(msvcrt.get_osfhandle(fd))
+        if not _KERNEL32.UnlockFileEx(handle, 0, 1, 0, ctypes.byref(overlapped)):
+            raise OSError("failed to release atomic write lock")
+else:
+    # Imported only where available; keeping the Windows implementation free
+    # of this import makes the module importable on both platforms.
+    msvcrt = None  # type: ignore[assignment]
 
 
 def _unique_temp_path(path: Path) -> Path:
@@ -123,30 +435,3 @@ def _fsync_directory_best_effort(path: Path) -> None:
         os.fsync(fd)
     finally:
         os.close(fd)
-
-
-def _current_millis() -> int:
-    return int(time.time() * 1000)
-
-
-def _lock_is_stale(lock_path: Path) -> bool:
-    try:
-        text = lock_path.read_text(encoding="utf-8", errors="replace")
-    except OSError:
-        return False
-    acquired_at = _parse_lock_acquired_at_millis(text)
-    if acquired_at is None:
-        return True
-    age_seconds = max(0.0, (_current_millis() - acquired_at) / 1000)
-    return age_seconds >= LOCK_STALE_AFTER_SECONDS
-
-
-def _parse_lock_acquired_at_millis(text: str) -> int | None:
-    for line in text.splitlines():
-        key, separator, value = line.partition("=")
-        if separator and key.strip() == "acquired_at_millis":
-            try:
-                return int(value.strip())
-            except ValueError:
-                return None
-    return None

--- a/src-tauri/src/app_updates.rs
+++ b/src-tauri/src/app_updates.rs
@@ -979,6 +979,8 @@ mod tests {
         serde_json::to_string(&manifest).expect("serialize flavor manifest")
     }
 
+    use crate::lock_test_fixtures::write_dead_legacy_lock;
+
     fn stale_lock_path(path: &std::path::Path) -> std::path::PathBuf {
         path.with_file_name(format!(
             "{}.lock",
@@ -986,31 +988,6 @@ mod tests {
                 .and_then(|name| name.to_str())
                 .unwrap_or("pending-update")
         ))
-    }
-
-    /// Keeps the dead child's handle open so the PID stays resolvable on
-    /// Windows for the test duration; reaps the (already exited) child on drop.
-    struct DeadChildGuard(std::process::Child);
-
-    impl Drop for DeadChildGuard {
-        fn drop(&mut self) {
-            let _ = self.0.wait();
-        }
-    }
-
-    /// Write a legacy record whose PID is provably dead (recoverable).
-    /// The returned guard must stay alive for the test duration: dropping its
-    /// handle would make the dead PID unresolvable on Windows.
-    fn write_dead_legacy_lock(lock: &std::path::Path) -> DeadChildGuard {
-        let mut child = std::process::Command::new("python")
-            .arg("-c")
-            .arg("pass")
-            .spawn()
-            .expect("python is required for stale lock fixtures");
-        let pid = child.id();
-        assert!(child.wait().expect("wait dead child").success());
-        fs::write(lock, format!("pid={pid}\nacquired_at_millis=0\n")).expect("write stale lock");
-        DeadChildGuard(child)
     }
 
     fn unique_pending_update_path(name: &str) -> std::path::PathBuf {

--- a/src-tauri/src/app_updates.rs
+++ b/src-tauri/src/app_updates.rs
@@ -944,11 +944,11 @@ mod tests {
     fn pending_update_write_recovers_stale_atomic_lock() {
         let path = unique_pending_update_path("stale-lock");
         let lock = stale_lock_path(&path);
-        fs::write(&lock, "pid=0\nacquired_at_millis=0\n").expect("write stale lock");
+        let _dead_child = write_dead_legacy_lock(&lock);
 
         write_pending_update(&path, "0.1.1").expect("write pending update");
 
-        assert!(!lock.exists());
+        assert_eq!(fs::read_to_string(&lock).expect("lock text"), "codexhub-atomic-lock=1\n");
         assert_eq!(
             read_pending_update(&path)
                 .expect("read pending update")
@@ -986,6 +986,31 @@ mod tests {
                 .and_then(|name| name.to_str())
                 .unwrap_or("pending-update")
         ))
+    }
+
+    /// Keeps the dead child's handle open so the PID stays resolvable on
+    /// Windows for the test duration; reaps the (already exited) child on drop.
+    struct DeadChildGuard(std::process::Child);
+
+    impl Drop for DeadChildGuard {
+        fn drop(&mut self) {
+            let _ = self.0.wait();
+        }
+    }
+
+    /// Write a legacy record whose PID is provably dead (recoverable).
+    /// The returned guard must stay alive for the test duration: dropping its
+    /// handle would make the dead PID unresolvable on Windows.
+    fn write_dead_legacy_lock(lock: &std::path::Path) -> DeadChildGuard {
+        let mut child = std::process::Command::new("python")
+            .arg("-c")
+            .arg("pass")
+            .spawn()
+            .expect("python is required for stale lock fixtures");
+        let pid = child.id();
+        assert!(child.wait().expect("wait dead child").success());
+        fs::write(lock, format!("pid={pid}\nacquired_at_millis=0\n")).expect("write stale lock");
+        DeadChildGuard(child)
     }
 
     fn unique_pending_update_path(name: &str) -> std::path::PathBuf {

--- a/src-tauri/src/lock_test_fixtures.rs
+++ b/src-tauri/src/lock_test_fixtures.rs
@@ -1,0 +1,31 @@
+//! Shared fixtures for stale-lock recovery tests.
+//!
+//! Kept out of `safe_file.rs` because that file must compile standalone via
+//! `rustc --test` in the safe_file Linux CI job; it keeps its own inline copy.
+
+use std::{fs, path::Path};
+
+/// Keeps the dead child's handle open so the PID stays resolvable on
+/// Windows for the test duration; reaps the (already exited) child on drop.
+pub(crate) struct DeadChildGuard(std::process::Child);
+
+impl Drop for DeadChildGuard {
+    fn drop(&mut self) {
+        let _ = self.0.wait();
+    }
+}
+
+/// Write a legacy record whose PID is provably dead (recoverable).
+/// The returned guard must stay alive for the test duration: dropping its
+/// handle would make the dead PID unresolvable on Windows.
+pub(crate) fn write_dead_legacy_lock(lock: &Path) -> DeadChildGuard {
+    let mut child = std::process::Command::new("python")
+        .arg("-c")
+        .arg("pass")
+        .spawn()
+        .expect("python is required for stale lock fixtures");
+    let pid = child.id();
+    assert!(child.wait().expect("wait dead child").success());
+    fs::write(lock, format!("pid={pid}\nacquired_at_millis=0\n")).expect("write stale lock");
+    DeadChildGuard(child)
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -12,6 +12,8 @@ mod gateway;
 mod gateway_lifecycle;
 mod gateway_transaction;
 mod history;
+#[cfg(test)]
+mod lock_test_fixtures;
 mod models;
 mod openai_usage;
 mod official_refresh;

--- a/src-tauri/src/openai_usage.rs
+++ b/src-tauri/src/openai_usage.rs
@@ -1786,6 +1786,8 @@ mod tests {
         fs::write(path, serde_json::to_string(&cache).unwrap()).unwrap();
     }
 
+    use crate::lock_test_fixtures::write_dead_legacy_lock;
+
     fn stale_lock_path(path: &Path) -> PathBuf {
         path.with_file_name(format!(
             "{}.lock",
@@ -1793,31 +1795,6 @@ mod tests {
                 .and_then(|name| name.to_str())
                 .unwrap_or("cache")
         ))
-    }
-
-    /// Keeps the dead child's handle open so the PID stays resolvable on
-    /// Windows for the test duration; reaps the (already exited) child on drop.
-    struct DeadChildGuard(std::process::Child);
-
-    impl Drop for DeadChildGuard {
-        fn drop(&mut self) {
-            let _ = self.0.wait();
-        }
-    }
-
-    /// Write a legacy record whose PID is provably dead (recoverable).
-    /// The returned guard must stay alive for the test duration: dropping its
-    /// handle would make the dead PID unresolvable on Windows.
-    fn write_dead_legacy_lock(lock: &Path) -> DeadChildGuard {
-        let mut child = std::process::Command::new("python")
-            .arg("-c")
-            .arg("pass")
-            .spawn()
-            .expect("python is required for stale lock fixtures");
-        let pid = child.id();
-        assert!(child.wait().expect("wait dead child").success());
-        fs::write(lock, format!("pid={pid}\nacquired_at_millis=0\n")).expect("write stale lock");
-        DeadChildGuard(child)
     }
 
     fn temp_root(name: &str) -> PathBuf {

--- a/src-tauri/src/openai_usage.rs
+++ b/src-tauri/src/openai_usage.rs
@@ -1676,7 +1676,7 @@ mod tests {
         let root = temp_root("openai-usage-stale-lock");
         let cache_path = root.join("usage-cache.json");
         let lock = stale_lock_path(&cache_path);
-        fs::write(&lock, "pid=0\nacquired_at_millis=0\n").expect("write stale lock");
+        let _dead_child = write_dead_legacy_lock(&lock);
         let usage: CodexAccountUsageResponse = serde_json::from_str(
             r#"{
               "summary": { "lifetimeTokens": 84 },
@@ -1693,7 +1693,7 @@ mod tests {
 
         write_usage_cache(&cache_path, &cache).expect("write usage cache");
 
-        assert!(!lock.exists());
+        assert_eq!(fs::read_to_string(&lock).expect("lock text"), "codexhub-atomic-lock=1\n");
         let written = fs::read_to_string(&cache_path).expect("cache text");
         assert!(written.contains(r#""fetched_at":10300"#));
         assert!(written.contains("2026-07-07"));
@@ -1793,6 +1793,31 @@ mod tests {
                 .and_then(|name| name.to_str())
                 .unwrap_or("cache")
         ))
+    }
+
+    /// Keeps the dead child's handle open so the PID stays resolvable on
+    /// Windows for the test duration; reaps the (already exited) child on drop.
+    struct DeadChildGuard(std::process::Child);
+
+    impl Drop for DeadChildGuard {
+        fn drop(&mut self) {
+            let _ = self.0.wait();
+        }
+    }
+
+    /// Write a legacy record whose PID is provably dead (recoverable).
+    /// The returned guard must stay alive for the test duration: dropping its
+    /// handle would make the dead PID unresolvable on Windows.
+    fn write_dead_legacy_lock(lock: &Path) -> DeadChildGuard {
+        let mut child = std::process::Command::new("python")
+            .arg("-c")
+            .arg("pass")
+            .spawn()
+            .expect("python is required for stale lock fixtures");
+        let pid = child.id();
+        assert!(child.wait().expect("wait dead child").success());
+        fs::write(lock, format!("pid={pid}\nacquired_at_millis=0\n")).expect("write stale lock");
+        DeadChildGuard(child)
     }
 
     fn temp_root(name: &str) -> PathBuf {

--- a/src-tauri/src/proxy.rs
+++ b/src-tauri/src/proxy.rs
@@ -3507,11 +3507,11 @@ model_catalog_json = "model-catalogs/codex-proxy-official-ollama.json"
         let paths = test_paths(&root);
         fs::create_dir_all(paths.proxy_dir()).unwrap();
         let lock = stale_lock_path(&paths.pid_path());
-        fs::write(&lock, "pid=0\nacquired_at_millis=0\n").expect("write stale lock");
+        let _dead_child = write_dead_legacy_lock(&lock);
 
         write_pid(&paths, 42, 4555, &paths.proxy_script_path()).expect("write pid");
 
-        assert!(!lock.exists());
+        assert_eq!(fs::read_to_string(&lock).expect("lock text"), "codexhub-atomic-lock=1\n");
         assert_eq!(read_pid(&paths).expect("read pid"), Some(42));
     }
 
@@ -4418,6 +4418,31 @@ time.sleep(10)
                 .and_then(|name| name.to_str())
                 .unwrap_or("pid")
         ))
+    }
+
+    /// Keeps the dead child's handle open so the PID stays resolvable on
+    /// Windows for the test duration; reaps the (already exited) child on drop.
+    struct DeadChildGuard(std::process::Child);
+
+    impl Drop for DeadChildGuard {
+        fn drop(&mut self) {
+            let _ = self.0.wait();
+        }
+    }
+
+    /// Write a legacy record whose PID is provably dead (recoverable).
+    /// The returned guard must stay alive for the test duration: dropping its
+    /// handle would make the dead PID unresolvable on Windows.
+    fn write_dead_legacy_lock(lock: &Path) -> DeadChildGuard {
+        let mut child = std::process::Command::new("python")
+            .arg("-c")
+            .arg("pass")
+            .spawn()
+            .expect("python is required for stale lock fixtures");
+        let pid = child.id();
+        assert!(child.wait().expect("wait dead child").success());
+        fs::write(lock, format!("pid={pid}\nacquired_at_millis=0\n")).expect("write stale lock");
+        DeadChildGuard(child)
     }
 
     fn free_port() -> u16 {

--- a/src-tauri/src/proxy.rs
+++ b/src-tauri/src/proxy.rs
@@ -4411,6 +4411,8 @@ time.sleep(10)
         path
     }
 
+    use crate::lock_test_fixtures::write_dead_legacy_lock;
+
     fn stale_lock_path(path: &Path) -> PathBuf {
         path.with_file_name(format!(
             "{}.lock",
@@ -4418,31 +4420,6 @@ time.sleep(10)
                 .and_then(|name| name.to_str())
                 .unwrap_or("pid")
         ))
-    }
-
-    /// Keeps the dead child's handle open so the PID stays resolvable on
-    /// Windows for the test duration; reaps the (already exited) child on drop.
-    struct DeadChildGuard(std::process::Child);
-
-    impl Drop for DeadChildGuard {
-        fn drop(&mut self) {
-            let _ = self.0.wait();
-        }
-    }
-
-    /// Write a legacy record whose PID is provably dead (recoverable).
-    /// The returned guard must stay alive for the test duration: dropping its
-    /// handle would make the dead PID unresolvable on Windows.
-    fn write_dead_legacy_lock(lock: &Path) -> DeadChildGuard {
-        let mut child = std::process::Command::new("python")
-            .arg("-c")
-            .arg("pass")
-            .spawn()
-            .expect("python is required for stale lock fixtures");
-        let pid = child.id();
-        assert!(child.wait().expect("wait dead child").success());
-        fs::write(lock, format!("pid={pid}\nacquired_at_millis=0\n")).expect("write stale lock");
-        DeadChildGuard(child)
     }
 
     fn free_port() -> u16 {

--- a/src-tauri/src/safe_file.rs
+++ b/src-tauri/src/safe_file.rs
@@ -528,20 +528,13 @@ fn lock_state(text: &str) -> LockState {
 /// Parse only the exact legacy record. Timestamp-only metadata is unsafe: its
 /// wall-clock age cannot prove that a former owner has stopped writing.
 fn parse_legacy_pid(text: &str) -> Option<i64> {
-    let lines: Vec<&str> = if let Some(body) = text.strip_suffix("\r\n") {
-        if body.split("\r\n").any(|line| line.contains('\r')) {
-            return None;
-        }
-        body.split("\r\n").collect()
-    } else if let Some(body) = text.strip_suffix('\n') {
-        if body.contains('\r') {
-            return None;
-        }
-        body.split('\n').collect()
-    } else {
-        return None;
+    let crlf_body = text.strip_suffix("\r\n");
+    let (body, separator) = match crlf_body {
+        Some(body) => (body, "\r\n"),
+        None => (text.strip_suffix('\n')?, "\n"),
     };
-    if lines.len() != 2 {
+    let lines: Vec<&str> = body.split(separator).collect();
+    if lines.iter().any(|line| line.contains('\r')) || lines.len() != 2 {
         return None;
     }
 

--- a/src-tauri/src/safe_file.rs
+++ b/src-tauri/src/safe_file.rs
@@ -937,7 +937,14 @@ mod tests {
 
         let result = lock.verify_namespace_identity();
 
-        assert!(result.unwrap_err().contains("path changed"));
+        // Rejection must fail closed; the message differs by platform:
+        // Windows still resolves the delete-pending handle (identity mismatch),
+        // while Linux reports the unlinked handle's zero link count first.
+        let error = result.unwrap_err();
+        assert!(
+            error.contains("path changed") || error.contains("not a regular single-link file"),
+            "unexpected error: {error}"
+        );
         drop(lock);
     }
 

--- a/src-tauri/src/safe_file.rs
+++ b/src-tauri/src/safe_file.rs
@@ -1,26 +1,54 @@
 use std::{
     fs::{self, File, OpenOptions},
-    io::Write,
+    io::{Read, Seek, SeekFrom, Write},
     path::{Path, PathBuf},
     thread,
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
+#[cfg(test)]
+use std::cell::RefCell;
+
+#[cfg(test)]
+type TestPreOpenHook = Box<dyn Fn(&Path)>;
+
+#[cfg(test)]
+thread_local! {
+    static TEST_PRE_OPEN_EXISTING_HOOK: RefCell<Option<TestPreOpenHook>> = RefCell::new(None);
+}
+
+#[cfg(test)]
+fn install_test_pre_open_hook(hook: impl Fn(&Path) + 'static) {
+    TEST_PRE_OPEN_EXISTING_HOOK.with(|slot| *slot.borrow_mut() = Some(Box::new(hook)));
+}
+
+#[cfg(test)]
+fn clear_test_pre_open_hook() {
+    TEST_PRE_OPEN_EXISTING_HOOK.with(|slot| *slot.borrow_mut() = None);
+}
+
+#[cfg(test)]
+fn invoke_test_pre_open_hook(path: &Path) {
+    TEST_PRE_OPEN_EXISTING_HOOK.with(|slot| {
+        if let Some(hook) = slot.borrow().as_ref() {
+            hook(path);
+        }
+    });
+}
+
 const LOCK_WAIT_TIMEOUT: Duration = Duration::from_secs(10);
 const LOCK_RETRY_DELAY: Duration = Duration::from_millis(25);
-const LOCK_STALE_AFTER: Duration = Duration::from_secs(60);
+const LOCK_PROTOCOL: &str = "codexhub-atomic-lock=1\n";
 
 pub(crate) fn write_text_atomic(path: &Path, text: &str) -> Result<(), String> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).map_err(|error| {
-            format!(
-                "failed to create file directory {}: {error}",
-                parent.display()
-            )
+            format!("failed to create file directory {}: {error}", parent.display())
         })?;
     }
 
-    let _lock = FileLock::acquire(path)?;
+    let lock = FileLock::acquire(path)?;
+    lock.verify_namespace_identity()?;
     let temp_path = unique_temp_path(path);
     let mut temp_file = File::create(&temp_path)
         .map_err(|error| format!("failed to write temp file {}: {error}", temp_path.display()))?;
@@ -33,22 +61,20 @@ pub(crate) fn write_text_atomic(path: &Path, text: &str) -> Result<(), String> {
         })?;
     drop(temp_file);
 
+    lock.verify_namespace_identity()
+        .inspect_err(|_| {
+            let _ = fs::remove_file(&temp_path);
+        })?;
     fs::rename(&temp_path, path).map_err(|error| {
         let _ = fs::remove_file(&temp_path);
-        format!(
-            "failed to move temp file {} to {}: {error}",
-            temp_path.display(),
-            path.display()
-        )
+        format!("failed to move temp file {} to {}: {error}", temp_path.display(), path.display())
     })
 }
 
 fn unique_temp_path(path: &Path) -> PathBuf {
     path.with_file_name(format!(
         ".{}.{}.{}.tmp-codexhub",
-        path.file_name()
-            .and_then(|name| name.to_str())
-            .unwrap_or("file"),
+        path.file_name().and_then(|name| name.to_str()).unwrap_or("file"),
         std::process::id(),
         timestamp_millis()
     ))
@@ -57,143 +83,1155 @@ fn unique_temp_path(path: &Path) -> PathBuf {
 fn lock_path(path: &Path) -> PathBuf {
     path.with_file_name(format!(
         "{}.lock",
-        path.file_name()
-            .and_then(|name| name.to_str())
-            .unwrap_or("file")
+        path.file_name().and_then(|name| name.to_str()).unwrap_or("file")
     ))
 }
 
 fn timestamp_millis() -> u128 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|duration| duration.as_millis())
-        .unwrap_or_default()
+    SystemTime::now().duration_since(UNIX_EPOCH).map(|duration| duration.as_millis()).unwrap_or_default()
 }
 
+#[cfg(target_os = "linux")]
+const LOCK_NOFOLLOW: i32 = 0x20000;
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"))]
+const LOCK_NOFOLLOW: i32 = 0x100;
+#[cfg(all(unix, not(any(target_os = "linux", target_os = "android", target_os = "macos", target_os = "ios", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"))))]
+const LOCK_NOFOLLOW: i32 = 0x100;
+
+fn open_lock_file(path: &Path, create_new: bool) -> std::io::Result<File> {
+    let mut options = OpenOptions::new();
+    options.read(true).write(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(LOCK_NOFOLLOW);
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::OpenOptionsExt;
+        options.share_mode(0x00000007).custom_flags(0x00200000);
+    }
+    if create_new {
+        options.create_new(true).open(path)
+    } else {
+        options.open(path)
+    }
+}
+
+fn namespace_lock_path(primary: &Path) -> PathBuf {
+    primary.with_file_name(format!("{}.guard", primary.file_name().and_then(|name| name.to_str()).unwrap_or("file")))
+}
+
+fn acquire_namespace_guard(path: &Path, started: &Instant, hook: Option<&dyn Fn(&'static str)>) -> Result<File, String> {
+    loop {
+        let file = match open_lock_file(path, true) {
+            Ok(file) => file,
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                let metadata = match fs::symlink_metadata(path) {
+                    Ok(metadata) => metadata,
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                        retry_lock(started)?;
+                        continue;
+                    }
+                    Err(_) => return Err("failed to open atomic write lock".to_owned()),
+                };
+                validate_lock_metadata(&metadata)?;
+                let pre_open_identity = lock_path_identity(path, &metadata)?;
+                #[cfg(test)]
+                invoke_test_pre_open_hook(path);
+                match open_lock_file(path, false) {
+                    Ok(file) => {
+                        let opened_identity = lock_file_identity(&file)?;
+                        if opened_identity != pre_open_identity {
+                            return Err("atomic write lock path changed".to_owned());
+                        }
+                        file
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                        retry_lock(started)?;
+                        continue;
+                    }
+                    Err(_) => return Err("failed to open atomic write lock".to_owned()),
+                }
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                retry_lock(started)?;
+                continue;
+            }
+            Err(_) => return Err("failed to open atomic write lock".to_owned()),
+        };
+        let metadata = file
+            .metadata()
+            .map_err(|_| "failed to open atomic write lock".to_owned())?;
+        validate_lock_metadata(&metadata)?;
+        validate_lock_handle(&file)?;
+        if let Some(hook) = hook {
+            hook("attempt");
+        }
+        match try_lock_exclusive(&file) {
+            Ok(true) => {
+                if let Err(error) = verify_lock_identity(path, &file) {
+                    let _ = unlock(&file);
+                    return Err(error);
+                }
+                if let Some(hook) = hook {
+                    hook("acquired");
+                }
+                return Ok(file);
+            }
+            Ok(false) => {
+                if let Some(hook) = hook {
+                    hook("blocked");
+                }
+            }
+            Err(()) => return Err("failed to acquire atomic write lock".to_owned()),
+        }
+        drop(file);
+        retry_lock(started)?;
+    }
+}
+
+///
+/// Python uses fcntl.flock/LockFileEx for exactly the same one-byte lock.  We
+/// never delete this file: process death releases the held lock, and the next
+/// owner overwrites the versioned metadata while holding it.
 struct FileLock {
-    path: PathBuf,
+    namespace_path: PathBuf,
+    namespace: File,
+    file: File,
+    locked: bool,
+    namespace_locked: bool,
 }
 
 impl FileLock {
     fn acquire(target: &Path) -> Result<Self, String> {
+        Self::acquire_inner(target, None)
+    }
+
+    #[cfg(test)]
+    fn acquire_with_hook(target: &Path, hook: &dyn Fn(&'static str)) -> Result<Self, String> {
+        Self::acquire_inner(target, Some(hook))
+    }
+
+    fn acquire_inner(target: &Path, hook: Option<&dyn Fn(&'static str)>) -> Result<Self, String> {
         let path = lock_path(target);
+        let namespace_path = namespace_lock_path(&path);
         let started = Instant::now();
+        let namespace = acquire_namespace_guard(&namespace_path, &started, hook)?;
         loop {
-            match OpenOptions::new().write(true).create_new(true).open(&path) {
-                Ok(mut file) => {
-                    let _ = writeln!(
-                        file,
-                        "pid={}\nacquired_at_millis={}",
-                        std::process::id(),
-                        timestamp_millis()
-                    );
-                    return Ok(Self { path });
+            let (mut file, created) = match open_lock_file(&path, true) {
+                Ok(file) => {
+                    let metadata = file
+                        .metadata()
+                        .map_err(|_| "failed to open atomic write lock".to_owned())?;
+                    validate_lock_metadata(&metadata)?;
+                    validate_lock_handle(&file)?;
+                    (file, true)
                 }
                 Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
-                    if lock_is_stale(&path) {
-                        let _ = fs::remove_file(&path);
-                        continue;
+                    let metadata = match fs::symlink_metadata(&path) {
+                        Ok(metadata) => metadata,
+                        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                            retry_lock(&started)?;
+                            continue;
+                        }
+                        Err(_) => return Err("failed to open atomic write lock".to_owned()),
+                    };
+                    validate_lock_metadata(&metadata)?;
+                    let pre_open_identity = lock_path_identity(&path, &metadata)?;
+                    #[cfg(test)]
+                    invoke_test_pre_open_hook(&path);
+                    let file = match open_lock_file(&path, false) {
+                        Ok(file) => file,
+                        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                            retry_lock(&started)?;
+                            continue;
+                        }
+                        Err(_) => return Err("failed to open atomic write lock".to_owned()),
+                    };
+                    let opened_metadata = file
+                        .metadata()
+                        .map_err(|_| "failed to open atomic write lock".to_owned())?;
+                    validate_lock_metadata(&opened_metadata)?;
+                    validate_lock_handle(&file)?;
+                    if lock_file_identity(&file)? != pre_open_identity {
+                        return Err("atomic write lock path changed".to_owned());
                     }
-                    if started.elapsed() >= LOCK_WAIT_TIMEOUT {
-                        return Err(format!(
-                            "timed out waiting for file lock {}",
-                            path.display()
-                        ));
+                    (file, false)
+                }
+                Err(_) => return Err("failed to open atomic write lock".to_owned()),
+            };
+
+            match try_lock_exclusive(&file) {
+                Ok(true) => {
+                    if let Err(error) = verify_lock_identity(&path, &file) {
+                        let _ = unlock(&file);
+                        return Err(error);
                     }
-                    thread::sleep(LOCK_RETRY_DELAY);
+                    match prepare_lock_metadata(&mut file, created) {
+                        Ok(()) => {
+                            if let Err(error) = verify_lock_identity(&path, &file) {
+                                let _ = unlock(&file);
+                                return Err(error);
+                            }
+                            return Ok(Self {
+                                namespace_path: namespace_path.clone(),
+                                namespace,
+                                file,
+                                locked: true,
+                                namespace_locked: true,
+                            });
+                        }
+                        Err(LockMetadataError::Transient) => {
+                            let _ = unlock(&file);
+                        }
+                        Err(LockMetadataError::Unrecoverable) => {
+                            let _ = unlock(&file);
+                            return Err("atomic write lock is unavailable".to_owned());
+                        }
+                        Err(LockMetadataError::Io) => {
+                            let _ = unlock(&file);
+                            return Err("failed to prepare atomic write lock".to_owned());
+                        }
+                    }
                 }
-                Err(error) => {
-                    return Err(format!(
-                        "failed to create file lock {}: {error}",
-                        path.display()
-                    ))
-                }
+                Ok(false) => {}
+                Err(()) => return Err("failed to acquire atomic write lock".to_owned()),
+            }
+
+            retry_lock(&started)?;
+        }
+    }
+
+    fn verify_namespace_identity(&self) -> Result<(), String> {
+        verify_lock_identity(&self.namespace_path, &self.namespace)
+    }
+
+    fn release(&mut self) -> Result<(), String> {
+        let mut first_error = None;
+        if self.locked {
+            if unlock(&self.file).is_err() {
+                first_error = Some("failed to release atomic write lock".to_owned());
+            } else {
+                self.locked = false;
             }
         }
+        if self.namespace_locked {
+            if unlock(&self.namespace).is_err() && first_error.is_none() {
+                first_error = Some("failed to release atomic write namespace".to_owned());
+            }
+            self.namespace_locked = false;
+        }
+        first_error.map_or(Ok(()), Err)
     }
 }
 
-fn lock_is_stale(path: &Path) -> bool {
-    let Ok(text) = fs::read_to_string(path) else {
-        return false;
-    };
-    let Some(acquired_at) = parse_lock_acquired_at_millis(&text) else {
-        return true;
-    };
-    let now = timestamp_millis();
-    now.saturating_sub(acquired_at) >= LOCK_STALE_AFTER.as_millis()
-}
-
-fn parse_lock_acquired_at_millis(text: &str) -> Option<u128> {
-    text.lines().find_map(|line| {
-        let (key, value) = line.split_once('=')?;
-        if key.trim() != "acquired_at_millis" {
-            return None;
-        }
-        value.trim().parse::<u128>().ok()
-    })
+fn retry_lock(started: &Instant) -> Result<(), String> {
+    let elapsed = started.elapsed();
+    if elapsed >= LOCK_WAIT_TIMEOUT {
+        return Err("timed out waiting for atomic write lock".to_owned());
+    }
+    thread::sleep(LOCK_RETRY_DELAY.min(LOCK_WAIT_TIMEOUT - elapsed));
+    Ok(())
 }
 
 impl Drop for FileLock {
     fn drop(&mut self) {
-        let _ = fs::remove_file(&self.path);
+        let _ = self.release();
     }
+}
+
+enum LockMetadataError {
+    Transient,
+    Unrecoverable,
+    Io,
+}
+
+fn validate_lock_metadata(metadata: &fs::Metadata) -> Result<(), String> {
+    if !metadata.file_type().is_file() {
+        return Err("atomic write lock is not a regular single-link file".to_owned());
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        if metadata.nlink() != 1 {
+            return Err("atomic write lock is not a regular single-link file".to_owned());
+        }
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt;
+        if metadata.file_attributes() & 0x400 != 0 {
+            return Err("atomic write lock is not a regular single-link file".to_owned());
+        }
+    }
+    Ok(())
+}
+
+#[cfg(not(windows))]
+fn validate_lock_handle(_file: &File) -> Result<(), String> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn lock_file_identity(file: &File) -> Result<(u64, u64), String> {
+    use std::os::unix::fs::MetadataExt;
+    let metadata = file
+        .metadata()
+        .map_err(|_| "atomic write lock path changed".to_owned())?;
+    validate_lock_metadata(&metadata)?;
+    Ok((metadata.dev(), metadata.ino()))
+}
+
+#[cfg(unix)]
+fn lock_path_identity(_path: &Path, metadata: &fs::Metadata) -> Result<(u64, u64), String> {
+    use std::os::unix::fs::MetadataExt;
+    Ok((metadata.dev(), metadata.ino()))
+}
+
+#[cfg(windows)]
+fn lock_path_identity(path: &Path, _metadata: &fs::Metadata) -> Result<(u32, u64), String> {
+    let file = open_lock_file(path, false).map_err(|_| "atomic write lock path changed".to_owned())?;
+    lock_file_identity(&file)
+}
+
+#[cfg(windows)]
+fn lock_file_identity(file: &File) -> Result<(u32, u64), String> {
+    use std::os::windows::io::AsRawHandle;
+    let mut information = ByHandleFileInformation::default();
+    let result = unsafe { GetFileInformationByHandle(file.as_raw_handle(), &mut information) };
+    if result == 0 || information.number_of_links != 1 || information.file_attributes & 0x400 != 0 {
+        return Err("atomic write lock is not a regular single-link file".to_owned());
+    }
+    let index = (u64::from(information.file_index_high) << 32) | u64::from(information.file_index_low);
+    Ok((information.volume_serial_number, index))
+}
+
+#[cfg(windows)]
+fn validate_lock_handle(file: &File) -> Result<(), String> {
+    lock_file_identity(file).map(|_| ())
+}
+
+#[cfg(unix)]
+fn verify_lock_identity(path: &Path, file: &File) -> Result<(), String> {
+    use std::os::unix::fs::MetadataExt;
+    let path_metadata = fs::symlink_metadata(path)
+        .map_err(|_| "atomic write lock path changed".to_owned())?;
+    validate_lock_metadata(&path_metadata)?;
+    let file_metadata = file
+        .metadata()
+        .map_err(|_| "atomic write lock path changed".to_owned())?;
+    validate_lock_metadata(&file_metadata)?;
+    if path_metadata.dev() != file_metadata.dev() || path_metadata.ino() != file_metadata.ino() {
+        return Err("atomic write lock path changed".to_owned());
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn verify_lock_identity(path: &Path, file: &File) -> Result<(), String> {
+    let path_metadata = fs::symlink_metadata(path)
+        .map_err(|_| "atomic write lock path changed".to_owned())?;
+    validate_lock_metadata(&path_metadata)?;
+    let path_file = open_lock_file(path, false)
+        .map_err(|_| "atomic write lock path changed".to_owned())?;
+    let path_identity = lock_file_identity(&path_file)
+        .map_err(|_| "atomic write lock path changed".to_owned())?;
+    let file_identity = lock_file_identity(file)
+        .map_err(|_| "atomic write lock path changed".to_owned())?;
+    if path_identity != file_identity {
+        return Err("atomic write lock path changed".to_owned());
+    }
+    Ok(())
+}
+
+fn prepare_lock_metadata(file: &mut File, created: bool) -> Result<(), LockMetadataError> {
+    let mut text = String::new();
+    file.seek(SeekFrom::Start(0)).map_err(|_| LockMetadataError::Io)?;
+    match file.read_to_string(&mut text) {
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::InvalidData => {
+            return Err(LockMetadataError::Unrecoverable)
+        }
+        Err(_) => return Err(LockMetadataError::Io),
+    }
+    let recoverable = match lock_state(&text) {
+        LockState::Protocol | LockState::DeadLegacy => true,
+        LockState::Empty if created => true,
+        LockState::Empty => return Err(LockMetadataError::Transient),
+        LockState::LiveLegacy | LockState::Unknown => false,
+    };
+    if !recoverable {
+        return Err(LockMetadataError::Unrecoverable);
+    }
+    file.set_len(0).map_err(|_| LockMetadataError::Io)?;
+    file.seek(SeekFrom::Start(0)).map_err(|_| LockMetadataError::Io)?;
+    file.write_all(LOCK_PROTOCOL.as_bytes()).map_err(|_| LockMetadataError::Io)?;
+    file.sync_all().map_err(|_| LockMetadataError::Io)
+}
+
+enum LockState {
+    Empty,
+    Protocol,
+    DeadLegacy,
+    LiveLegacy,
+    Unknown,
+}
+
+fn lock_state(text: &str) -> LockState {
+    if text.is_empty() {
+        return LockState::Empty;
+    }
+    if matches!(text, "codexhub-atomic-lock=1\n" | "codexhub-atomic-lock=1\r\n") {
+        return LockState::Protocol;
+    }
+    match parse_legacy_pid(text) {
+        Some(pid) if pid_is_definitely_dead(pid) => LockState::DeadLegacy,
+        Some(_) => LockState::LiveLegacy,
+        None => LockState::Unknown,
+    }
+}
+
+/// Parse only the exact legacy record. Timestamp-only metadata is unsafe: its
+/// wall-clock age cannot prove that a former owner has stopped writing.
+fn parse_legacy_pid(text: &str) -> Option<i64> {
+    let lines: Vec<&str> = if let Some(body) = text.strip_suffix("\r\n") {
+        if body.split("\r\n").any(|line| line.contains('\r')) {
+            return None;
+        }
+        body.split("\r\n").collect()
+    } else if let Some(body) = text.strip_suffix('\n') {
+        if body.contains('\r') {
+            return None;
+        }
+        body.split('\n').collect()
+    } else {
+        return None;
+    };
+    if lines.len() != 2 {
+        return None;
+    }
+
+    let mut pid = None;
+    let mut timestamp = None;
+    for line in lines {
+        let (key, value) = line.split_once('=')?;
+        match key {
+            "pid" if pid.is_none() => pid = parse_legacy_pid_value(value),
+            "acquired_at_millis" if timestamp.is_none() => {
+                timestamp = parse_decimal_u128(value)
+            }
+            _ => return None,
+        }
+    }
+    pid.zip(timestamp).map(|(pid, _)| pid)
+}
+
+fn parse_legacy_pid_value(value: &str) -> Option<i64> {
+    let parsed = parse_decimal_u128(value)?;
+    (1..=i32::MAX as u128).contains(&parsed).then_some(parsed as i64)
+}
+
+fn parse_decimal_u128(value: &str) -> Option<u128> {
+    if value.is_empty() || !value.bytes().all(|byte| byte.is_ascii_digit()) {
+        return None;
+    }
+    value.parse::<u128>().ok()
+}
+
+#[cfg(unix)]
+fn pid_is_definitely_dead(pid: i64) -> bool {
+    if pid <= 0 {
+        return true;
+    }
+    // kill(pid, 0) cannot signal the process. EPERM means it exists but is not
+    // ours, so it is deliberately not reclaimed.
+    let result = unsafe { kill(pid as i32, 0) };
+    result != 0 && std::io::Error::last_os_error().raw_os_error() == Some(3)
+}
+
+#[cfg(windows)]
+fn pid_is_definitely_dead(pid: i64) -> bool {
+    if pid <= 0 || pid > u32::MAX as i64 {
+        return true;
+    }
+    unsafe {
+        let handle = OpenProcess(0x1000, 0, pid as u32);
+        if handle.is_null() {
+            return false; // Access-denied and unknown are fail-safe.
+        }
+        let mut code = 0;
+        let result = GetExitCodeProcess(handle, &mut code);
+        CloseHandle(handle);
+        result != 0 && code != 259
+    }
+}
+
+#[cfg(unix)]
+fn try_lock_exclusive(file: &File) -> Result<bool, ()> {
+    use std::os::fd::AsRawFd;
+    let result = unsafe { flock(file.as_raw_fd(), 2 | 4) }; // LOCK_EX | LOCK_NB
+    if result == 0 {
+        Ok(true)
+    } else if matches!(std::io::Error::last_os_error().kind(), std::io::ErrorKind::WouldBlock) {
+        Ok(false)
+    } else {
+        Err(())
+    }
+}
+
+#[cfg(unix)]
+fn unlock(file: &File) -> std::io::Result<()> {
+    use std::os::fd::AsRawFd;
+    if unsafe { flock(file.as_raw_fd(), 8) } == 0 { Ok(()) } else { Err(std::io::Error::last_os_error()) }
+}
+
+#[cfg(windows)]
+fn try_lock_exclusive(file: &File) -> Result<bool, ()> {
+    use std::os::windows::io::AsRawHandle;
+    let mut overlapped = Overlapped::default();
+    let result = unsafe { LockFileEx(file.as_raw_handle(), 0x2 | 0x1, 0, 1, 0, &mut overlapped) };
+    if result != 0 { Ok(true) }
+    else if matches!(std::io::Error::last_os_error().raw_os_error(), Some(32 | 33)) { Ok(false) }
+    else { Err(()) }
+}
+
+#[cfg(windows)]
+fn unlock(file: &File) -> std::io::Result<()> {
+    use std::os::windows::io::AsRawHandle;
+    let mut overlapped = Overlapped::default();
+    if unsafe { UnlockFileEx(file.as_raw_handle(), 0, 1, 0, &mut overlapped) } != 0 { Ok(()) }
+    else { Err(std::io::Error::last_os_error()) }
+}
+
+#[cfg(unix)]
+unsafe extern "C" {
+    fn flock(fd: i32, operation: i32) -> i32;
+    fn kill(pid: i32, signal: i32) -> i32;
+}
+
+#[cfg(windows)]
+#[repr(C)]
+#[derive(Default)]
+struct ByHandleFileInformation {
+    file_attributes: u32,
+    creation_time_low: u32,
+    creation_time_high: u32,
+    last_access_time_low: u32,
+    last_access_time_high: u32,
+    last_write_time_low: u32,
+    last_write_time_high: u32,
+    volume_serial_number: u32,
+    file_size_high: u32,
+    file_size_low: u32,
+    number_of_links: u32,
+    file_index_high: u32,
+    file_index_low: u32,
+}
+#[cfg(windows)]
+#[repr(C)]
+#[derive(Default)]
+struct Overlapped {
+    internal: usize,
+    internal_high: usize,
+    offset: u32,
+    offset_high: u32,
+    event: *mut std::ffi::c_void,
+}
+
+#[cfg(windows)]
+#[link(name = "kernel32")]
+unsafe extern "system" {
+    fn GetFileInformationByHandle(handle: *mut std::ffi::c_void, information: *mut ByHandleFileInformation) -> i32;
+    fn LockFileEx(handle: *mut std::ffi::c_void, flags: u32, reserved: u32, low: u32, high: u32, overlapped: *mut Overlapped) -> i32;
+    fn UnlockFileEx(handle: *mut std::ffi::c_void, reserved: u32, low: u32, high: u32, overlapped: *mut Overlapped) -> i32;
+    fn OpenProcess(access: u32, inherit: i32, pid: u32) -> *mut std::ffi::c_void;
+    fn GetExitCodeProcess(handle: *mut std::ffi::c_void, code: *mut u32) -> i32;
+    fn CloseHandle(handle: *mut std::ffi::c_void) -> i32;
 }
 
 #[cfg(test)]
 mod tests {
-    use super::write_text_atomic;
-    use std::{fs, path::PathBuf, time::SystemTime};
+    use super::{
+        install_test_pre_open_hook, lock_state, parse_legacy_pid, write_text_atomic, FileLock, LockState,
+        LOCK_PROTOCOL,
+    };
+    use std::{
+        fs,
+        io::{BufRead, Read, Write},
+        path::{Path, PathBuf},
+        process::{Command, Stdio},
+        sync::mpsc,
+        thread,
+        time::{Duration, SystemTime},
+    };
 
     fn test_root(name: &str) -> PathBuf {
-        std::env::temp_dir().join(format!(
-            "codexhub-safe-file-{name}-{}",
-            SystemTime::now()
-                .duration_since(SystemTime::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ))
+        std::env::temp_dir().join(format!("codexhub-safe-file-{name}-{}", SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_nanos()))
     }
 
-    #[test]
-    fn write_text_atomic_does_not_clobber_existing_stale_temp_file() {
-        let root = test_root("stale-temp");
-        fs::create_dir_all(&root).unwrap();
-        let target = root.join("config.toml");
-        let stale_temp = target.with_extension("tmp-codexhub");
-        fs::write(&target, "old").unwrap();
-        fs::write(&stale_temp, "stale-temp").unwrap();
-
-        write_text_atomic(&target, "new").unwrap();
-
-        assert_eq!(fs::read_to_string(&target).unwrap(), "new");
-        assert_eq!(fs::read_to_string(&stale_temp).unwrap(), "stale-temp");
-    }
 
     #[test]
-    fn write_text_atomic_overwrites_existing_target() {
-        let root = test_root("overwrite-existing");
-        fs::create_dir_all(&root).unwrap();
-        let target = root.join("usage-cache.json");
-        fs::write(&target, "old").unwrap();
-
-        write_text_atomic(&target, "new").unwrap();
-
-        assert_eq!(fs::read_to_string(&target).unwrap(), "new");
-    }
-
-    #[test]
-    fn write_text_atomic_recovers_stale_lock_file() {
-        let root = test_root("stale-lock");
+    fn write_text_atomic_keeps_persistent_versioned_lock() {
+        let root = test_root("lock-protocol");
         fs::create_dir_all(&root).unwrap();
         let target = root.join("providers.toml");
-        let lock = root.join("providers.toml.lock");
-        fs::write(&target, "old").unwrap();
-        fs::write(&lock, "pid=0\nacquired_at_millis=0\n").unwrap();
+        write_text_atomic(&target, "new").unwrap();
+        assert_eq!(fs::read_to_string(root.join("providers.toml.lock")).unwrap(), "codexhub-atomic-lock=1\n");
+    }
+
+    #[test]
+    fn legacy_recovery_is_never_based_on_age() {
+        assert!(matches!(lock_state("pid=0\nacquired_at_millis=0\n"), LockState::Unknown));
+        assert!(matches!(lock_state("acquired_at_millis=0\n"), LockState::Unknown));
+        assert!(matches!(lock_state("not-a-lock\n"), LockState::Unknown));
+    }
+
+    #[test]
+    fn parser_accepts_only_the_shared_protocol_and_legacy_shape() {
+        assert!(matches!(lock_state("codexhub-atomic-lock=1\n"), LockState::Protocol));
+        assert!(matches!(lock_state("codexhub-atomic-lock=1\r\n"), LockState::Protocol));
+        assert_eq!(parse_legacy_pid("pid=1\r\nacquired_at_millis=0\r\n"), Some(1));
+        assert_eq!(parse_legacy_pid("pid=1\nacquired_at_millis=340282366920938463463374607431768211456\n"), None);
+        assert!(matches!(lock_state("codexhub-atomic-lock=1"), LockState::Unknown));
+        assert!(matches!(lock_state("codexhub-atomic-lock=2\n"), LockState::Unknown));
+        assert!(matches!(lock_state("codexhub-atomic-lock=1\nextra=value\n"), LockState::Unknown));
+        assert!(matches!(lock_state("pid=1\npid=2\nacquired_at_millis=0\n"), LockState::Unknown));
+        assert!(matches!(lock_state("pid=-1\nacquired_at_millis=0\n"), LockState::Unknown));
+        assert!(matches!(lock_state("pid=999999999999999999999999\nacquired_at_millis=0\n"), LockState::Unknown));
+    }
+
+    #[test]
+    fn existing_empty_lock_fails_closed() {
+        let root = test_root("empty-lock");
+        fs::create_dir_all(&root).unwrap();
+        let target = root.join("settings.json");
+        let lock = root.join("settings.json.lock");
+        fs::write(&lock, b"").unwrap();
+
+        let error = write_text_atomic(&target, "new").unwrap_err();
+
+        assert!(error.contains("timed out") || error.contains("unavailable"));
+        assert_eq!(fs::read(&lock).unwrap(), b"");
+    }
+
+    #[test]
+    fn dead_legacy_lock_is_recovered_without_unlinking_its_inode() {
+        let root = test_root("dead-legacy");
+        fs::create_dir_all(&root).unwrap();
+        let target = root.join("settings.json");
+        let lock = root.join("settings.json.lock");
+        let mut child = Command::new("python").arg("-c").arg("pass").spawn().unwrap();
+        let dead_pid = child.id();
+        assert!(child.wait().unwrap().success());
+        fs::write(&lock, format!("pid={dead_pid}\nacquired_at_millis=0\n")).unwrap();
+        let mut original = fs::File::open(&lock).unwrap();
 
         write_text_atomic(&target, "new").unwrap();
 
         assert_eq!(fs::read_to_string(&target).unwrap(), "new");
-        assert!(!lock.exists());
+        let mut original_text = String::new();
+        original.read_to_string(&mut original_text).unwrap();
+        assert_eq!(original_text, LOCK_PROTOCOL);
+        assert_eq!(fs::read_to_string(&lock).unwrap(), LOCK_PROTOCOL);
+    }
+
+    #[test]
+    fn unknown_legacy_and_future_locks_fail_closed() {
+        let root = test_root("unknown-lock");
+        fs::create_dir_all(&root).unwrap();
+        let target = root.join("settings.json");
+        let lock = root.join("settings.json.lock");
+        for metadata in [
+            "acquired_at_millis=0\n",
+            "not-a-lock\n",
+            "codexhub-atomic-lock=2\n",
+            "codexhub-atomic-lock=1\nextra=value\n",
+            "pid=0\nacquired_at_millis=0\n",
+        ] {
+            fs::write(&lock, metadata).unwrap();
+            let error = write_text_atomic(&target, "new").unwrap_err();
+            assert!(error.contains("unavailable"));
+        }
+    }
+
+    #[test]
+    fn hard_link_lock_is_rejected_by_production_entrypoint() {
+        let root = test_root("hard-link-lock");
+        fs::create_dir_all(&root).unwrap();
+        let target = root.join("settings.json");
+        let victim = root.join("victim");
+        let lock = root.join("settings.json.lock");
+        fs::write(&victim, "do not modify").unwrap();
+        if fs::hard_link(&victim, &lock).is_err() {
+            return;
+        }
+
+        let error = write_text_atomic(&target, "new").unwrap_err();
+
+        assert!(error.contains("atomic write lock"));
+        assert_eq!(fs::read_to_string(&victim).unwrap(), "do not modify");
+        assert!(!target.exists());
+    }
+
+    #[test]
+    fn invalid_utf8_lock_is_rejected_by_production_entrypoint() {
+        let root = test_root("invalid-utf8-lock");
+        fs::create_dir_all(&root).unwrap();
+        let target = root.join("settings.json");
+        let lock = root.join("settings.json.lock");
+        fs::write(&lock, b"pid=1\nacquired_at_millis=0\n\xff").unwrap();
+
+        let error = write_text_atomic(&target, "new").unwrap_err();
+
+        assert_eq!(error, "atomic write lock is unavailable");
+        assert!(!target.exists());
+        assert!(fs::read(&lock).unwrap().ends_with(b"\xff"));
+    }
+
+    #[test]
+    fn existing_primary_replacement_between_metadata_and_open_is_rejected() {
+        let root = test_root("primary-pre-open-replacement");
+        fs::create_dir_all(&root).unwrap();
+        let target = root.join("settings.json");
+        let lock = root.join("settings.json.lock");
+        let guard = root.join("settings.json.lock.guard");
+        let replacement = root.join("replacement.lock");
+        fs::write(&guard, LOCK_PROTOCOL).unwrap();
+        fs::write(&lock, LOCK_PROTOCOL).unwrap();
+        fs::write(&replacement, LOCK_PROTOCOL).unwrap();
+        let replaced = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let replaced_for_hook = replaced.clone();
+        let lock_for_hook = lock.clone();
+        let replacement_for_hook = replacement.clone();
+        install_test_pre_open_hook(move |path| {
+            if path == lock_for_hook.as_path() && !replaced_for_hook.swap(true, std::sync::atomic::Ordering::SeqCst) {
+                fs::remove_file(&lock_for_hook).unwrap();
+                fs::rename(&replacement_for_hook, &lock_for_hook).unwrap();
+            }
+        });
+
+        let result = FileLock::acquire(&target);
+        super::clear_test_pre_open_hook();
+
+        assert!(replaced.load(std::sync::atomic::Ordering::SeqCst));
+        match result {
+            Err(error) => assert!(error.contains("path changed")),
+            Ok(_) => panic!("replacement was accepted"),
+        }
+        assert!(!target.exists());
+        assert_eq!(fs::read_to_string(&lock).unwrap(), LOCK_PROTOCOL);
+    }
+
+    #[test]
+    fn existing_guard_replacement_between_metadata_and_open_is_rejected() {
+        let root = test_root("guard-pre-open-replacement");
+        fs::create_dir_all(&root).unwrap();
+        let target = root.join("settings.json");
+        let lock = root.join("settings.json.lock");
+        let guard = root.join("settings.json.lock.guard");
+        let replacement = root.join("replacement.guard");
+        fs::write(&guard, LOCK_PROTOCOL).unwrap();
+        fs::write(&lock, LOCK_PROTOCOL).unwrap();
+        fs::write(&replacement, LOCK_PROTOCOL).unwrap();
+        let replaced = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let replaced_for_hook = replaced.clone();
+        let guard_for_hook = guard.clone();
+        let replacement_for_hook = replacement.clone();
+        install_test_pre_open_hook(move |path| {
+            if path == guard_for_hook.as_path() && !replaced_for_hook.swap(true, std::sync::atomic::Ordering::SeqCst) {
+                fs::remove_file(&guard_for_hook).unwrap();
+                fs::rename(&replacement_for_hook, &guard_for_hook).unwrap();
+            }
+        });
+
+        let result = FileLock::acquire(&target);
+        super::clear_test_pre_open_hook();
+
+        assert!(replaced.load(std::sync::atomic::Ordering::SeqCst));
+        match result {
+            Err(error) => assert!(error.contains("path changed")),
+            Ok(_) => panic!("replacement was accepted"),
+        }
+        assert!(!target.exists());
+        assert_eq!(fs::read_to_string(&guard).unwrap(), LOCK_PROTOCOL);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn write_text_atomic_rejects_directory_junction_lock_without_changes() {
+        use std::os::windows::fs::MetadataExt;
+
+        let root = test_root("directory-junction-lock");
+        fs::create_dir_all(&root).unwrap();
+        let target = root.join("settings.json");
+        let victim = root.join("victim");
+        let lock = root.join("settings.json.lock");
+        let guard = root.join("settings.json.lock.guard");
+        fs::create_dir_all(&victim).unwrap();
+        let victim_file = victim.join("sentinel");
+        fs::write(&victim_file, "do not modify").unwrap();
+        fs::write(&target, "old").unwrap();
+        let status = std::process::Command::new("cmd")
+            .args(["/C", "mklink", "/J", &lock.to_string_lossy(), &victim.to_string_lossy()])
+            .status()
+            .unwrap();
+        assert!(status.success(), "CI must provide a directory junction fixture");
+        let before = fs::symlink_metadata(&lock).unwrap();
+
+        let error = write_text_atomic(&target, "new").unwrap_err();
+
+        let after = fs::symlink_metadata(&lock).unwrap();
+        assert!(error.contains("atomic write lock"));
+        assert_eq!(fs::read_to_string(&target).unwrap(), "old");
+        assert_eq!(fs::read_to_string(&victim_file).unwrap(), "do not modify");
+        assert_eq!(before.file_attributes(), after.file_attributes());
+        assert!(!target.with_file_name(".settings.json").exists());
+        let _ = fs::remove_file(&guard);
+    }
+
+    #[test]
+    fn guard_replacement_after_acquire_is_rejected_before_writer_operation() {
+        let root = test_root("guard-replacement-after-acquire");
+        fs::create_dir_all(&root).unwrap();
+        let target = root.join("settings.json");
+        let guard = root.join("settings.json.lock.guard");
+        let lock = FileLock::acquire(&target).unwrap();
+        fs::remove_file(&guard).unwrap();
+        fs::write(&guard, LOCK_PROTOCOL).unwrap();
+
+        let result = lock.verify_namespace_identity();
+
+        assert!(result.unwrap_err().contains("path changed"));
+        drop(lock);
+    }
+
+    struct PythonHolder {
+        child: std::process::Child,
+        stdin: std::process::ChildStdin,
+        events: mpsc::Receiver<String>,
+    }
+
+    fn python_holder(target: &Path) -> PythonHolder {
+        let source = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../src-python");
+        let script = "import pathlib, sys; from atomic_io import file_lock_for; target = pathlib.Path(sys.argv[1]);\nwith file_lock_for(target):\n    print('ready', flush=True);\n    if sys.stdin.readline().strip() != 'release': raise SystemExit(2);\n    print('released', flush=True)";
+        let mut child = Command::new("python")
+            .env("PYTHONPATH", source)
+            .arg("-c")
+            .arg(script)
+            .arg(target)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .expect("python is required for the cross-language lock tests");
+        let stdin = child.stdin.take().unwrap();
+        let stdout = child.stdout.take().unwrap();
+        let (events_tx, events_rx) = mpsc::channel();
+        thread::spawn(move || {
+            for line in std::io::BufReader::new(stdout).lines() {
+                let Ok(line) = line else { break };
+                if events_tx.send(line).is_err() {
+                    break;
+                }
+            }
+        });
+        PythonHolder { child, stdin, events: events_rx }
+    }
+
+    fn expect_handshake(events: &mpsc::Receiver<String>, expected: &str) {
+        assert_eq!(events.recv_timeout(Duration::from_secs(10)).unwrap(), expected);
+    }
+
+    #[test]
+    fn python_holder_blocks_rust_contender_until_handshake_release() {
+        let root = test_root("python-holder-rust-contender");
+        fs::create_dir_all(&root).unwrap();
+        let target = root.join("shared.json");
+        let lock_path = target.with_file_name("shared.json.lock");
+        let mut holder = python_holder(&target);
+        expect_handshake(&holder.events, "ready");
+
+        let (events_tx, events_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let (replacement_verified_tx, replacement_verified_rx) = mpsc::channel();
+        let (done_tx, done_rx) = mpsc::channel();
+        let contender = target.clone();
+        thread::spawn(move || {
+            let hook = |event: &'static str| {
+                events_tx.send(event.to_owned()).unwrap();
+                if event == "blocked" {
+                    replacement_verified_rx.recv_timeout(Duration::from_secs(10)).unwrap();
+                    events_tx.send("replacement-verified".to_owned()).unwrap();
+                }
+            };
+            let lock = FileLock::acquire_with_hook(&contender, &hook).unwrap();
+            done_tx.send(()).unwrap();
+            release_rx.recv_timeout(Duration::from_secs(10)).unwrap();
+            drop(lock);
+        });
+        expect_handshake(&events_rx, "attempt");
+        expect_handshake(&events_rx, "blocked");
+        fs::remove_file(&lock_path).unwrap();
+        fs::write(&lock_path, LOCK_PROTOCOL).unwrap();
+        replacement_verified_tx.send(()).unwrap();
+        expect_handshake(&events_rx, "replacement-verified");
+        holder.stdin.write_all(b"release\n").unwrap();
+        holder.stdin.flush().unwrap();
+        expect_handshake(&holder.events, "released");
+        assert!(holder.child.wait().unwrap().success());
+        expect_handshake(&events_rx, "attempt");
+        expect_handshake(&events_rx, "acquired");
+        release_tx.send(()).unwrap();
+        done_rx.recv_timeout(Duration::from_secs(10)).unwrap();
+        assert!(!target.exists());
+    }
+
+    #[test]
+    fn rust_holder_blocks_python_contender_until_handshake_release() {
+        let root = test_root("rust-holder-python-contender");
+        fs::create_dir_all(&root).unwrap();
+        let target = root.join("shared.json");
+        let source = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../src-python");
+        let script = "import pathlib, sys; from atomic_io import _set_test_lock_hook, atomic_write_text; target = pathlib.Path(sys.argv[1]); _set_test_lock_hook(lambda event: print(event, flush=True)); atomic_write_text(target, 'python'); print('entered', flush=True)";
+        let lock = FileLock::acquire(&target).unwrap();
+        let mut child = Command::new("python")
+            .env("PYTHONPATH", source)
+            .arg("-c")
+            .arg(script)
+            .arg(&target)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .unwrap();
+        let stdout = child.stdout.take().unwrap();
+        let (events_tx, events_rx) = mpsc::channel();
+        thread::spawn(move || {
+            for line in std::io::BufReader::new(stdout).lines() {
+                let Ok(line) = line else { break };
+                if events_tx.send(line).is_err() {
+                    break;
+                }
+            }
+        });
+        expect_handshake(&events_rx, "attempt");
+        expect_handshake(&events_rx, "blocked");
+        drop(lock);
+        expect_handshake(&events_rx, "attempt");
+        expect_handshake(&events_rx, "acquired");
+        expect_handshake(&events_rx, "entered");
+        assert!(child.wait().unwrap().success());
+        assert_eq!(fs::read_to_string(target).unwrap(), "python");
+    }
+
+    #[test]
+    fn killed_python_holder_releases_protocol_lock_for_rust_recovery() {
+        let root = test_root("killed-python-holder");
+        fs::create_dir_all(&root).unwrap();
+        let target = root.join("shared.json");
+        let mut holder = python_holder(&target);
+        expect_handshake(&holder.events, "ready");
+        holder.child.kill().unwrap();
+        holder.child.wait().unwrap();
+        write_text_atomic(&target, "recovered").unwrap();
+        assert_eq!(fs::read_to_string(target).unwrap(), "recovered");
+    }
+
+    fn recv_until(events: &mpsc::Receiver<String>, expected: &str) {
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        loop {
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            assert!(!remaining.is_zero(), "timed out waiting for {expected}");
+            let event = events.recv_timeout(remaining).unwrap();
+            if event == expected {
+                return;
+            }
+        }
+    }
+
+    #[test]
+    fn live_legacy_lock_is_never_reclaimed() {
+        let root = test_root("live-legacy");
+        fs::create_dir_all(&root).unwrap();
+        let target = root.join("settings.json");
+        let lock = root.join("settings.json.lock");
+        let metadata = format!("pid={}\nacquired_at_millis=0\n", std::process::id());
+        fs::write(&lock, &metadata).unwrap();
+
+        let error = write_text_atomic(&target, "new").unwrap_err();
+
+        assert!(error.contains("unavailable"));
+        assert_eq!(fs::read_to_string(&lock).unwrap(), metadata);
+        assert!(!target.exists());
+    }
+
+    #[test]
+    fn release_is_idempotent_and_protocol_instance_persists() {
+        let root = test_root("release-idempotent");
+        fs::create_dir_all(&root).unwrap();
+        let target = root.join("settings.json");
+        let mut lock = FileLock::acquire(&target).unwrap();
+        lock.release().unwrap();
+        lock.release().unwrap();
+        assert_eq!(fs::read_to_string(root.join("settings.json.lock")).unwrap(), LOCK_PROTOCOL);
+    }
+
+    #[test]
+    fn release_after_external_replacement_keeps_replacement_instance() {
+        let root = test_root("release-external-replacement");
+        fs::create_dir_all(&root).unwrap();
+        let target = root.join("settings.json");
+        let lock_path = root.join("settings.json.lock");
+        let lock = FileLock::acquire(&target).unwrap();
+        fs::remove_file(&lock_path).unwrap();
+        fs::write(&lock_path, LOCK_PROTOCOL).unwrap();
+        // The owner's release operates on its own handle and never unlinks, so
+        // the external replacement instance survives untouched.
+        drop(lock);
+        assert_eq!(fs::read_to_string(&lock_path).unwrap(), LOCK_PROTOCOL);
+    }
+
+    #[test]
+    fn protocol_lock_carries_no_age_metadata_and_contender_stays_blocked() {
+        let root = test_root("no-age-metadata");
+        fs::create_dir_all(&root).unwrap();
+        let target = root.join("settings.json");
+        // The persisted record carries no timestamp: age alone can never
+        // authorize a second writer, however long the first one holds.
+        write_text_atomic(&target, "seed").unwrap();
+        assert_eq!(fs::read_to_string(root.join("settings.json.lock")).unwrap(), LOCK_PROTOCOL);
+        fs::remove_file(&target).unwrap();
+
+        let lock = FileLock::acquire(&target).unwrap();
+        let (events_tx, events_rx) = mpsc::channel();
+        let contender_target = target.clone();
+        let contender = thread::spawn(move || {
+            let hook = |event: &'static str| events_tx.send(event.to_owned()).unwrap();
+            FileLock::acquire_with_hook(&contender_target, &hook).unwrap()
+        });
+        expect_handshake(&events_rx, "attempt");
+        expect_handshake(&events_rx, "blocked");
+        drop(lock);
+        recv_until(&events_rx, "acquired");
+        contender.join().unwrap();
+    }
+
+    #[test]
+    fn same_language_ab_c_choreography_keeps_single_owner() {
+        let root = test_root("ab-c-choreography");
+        fs::create_dir_all(&root).unwrap();
+        let target = root.join("settings.json");
+        let lock_path = root.join("settings.json.lock");
+
+        // A holds first.
+        let a_lock = FileLock::acquire(&target).unwrap();
+
+        // B waits and is provably blocked while A holds the namespace guard.
+        let (b_events_tx, b_events_rx) = mpsc::channel();
+        let (b_release_tx, b_release_rx) = mpsc::channel();
+        let (b_done_tx, b_done_rx) = mpsc::channel();
+        let b_target = target.clone();
+        thread::spawn(move || {
+            let hook = |event: &'static str| b_events_tx.send(event.to_owned()).unwrap();
+            let lock = FileLock::acquire_with_hook(&b_target, &hook).unwrap();
+            b_events_tx.send("b-inside".to_owned()).unwrap();
+            b_release_rx.recv_timeout(Duration::from_secs(10)).unwrap();
+            drop(lock);
+            b_done_tx.send(()).unwrap();
+        });
+        expect_handshake(&b_events_rx, "attempt");
+        expect_handshake(&b_events_rx, "blocked");
+
+        drop(a_lock);
+        // A's release operates on its own handle: the instance B is about to
+        // own survives, so B legitimately follows A.
+        assert_eq!(fs::read_to_string(&lock_path).unwrap(), LOCK_PROTOCOL);
+        recv_until(&b_events_rx, "acquired");
+        recv_until(&b_events_rx, "b-inside");
+
+        // C cannot overlap B's critical section; it waits for B's release.
+        let (c_events_tx, c_events_rx) = mpsc::channel();
+        let (c_done_tx, c_done_rx) = mpsc::channel();
+        let c_target = target.clone();
+        let c_handle = thread::spawn(move || {
+            let hook = |event: &'static str| c_events_tx.send(event.to_owned()).unwrap();
+            let lock = FileLock::acquire_with_hook(&c_target, &hook).unwrap();
+            drop(lock);
+            c_done_tx.send(()).unwrap();
+        });
+        expect_handshake(&c_events_rx, "attempt");
+        expect_handshake(&c_events_rx, "blocked");
+        assert!(c_done_rx.recv_timeout(Duration::from_millis(200)).is_err());
+
+        b_release_tx.send(()).unwrap();
+        b_done_rx.recv_timeout(Duration::from_secs(10)).unwrap();
+        recv_until(&c_events_rx, "acquired");
+        c_done_rx.recv_timeout(Duration::from_secs(10)).unwrap();
+        c_handle.join().unwrap();
+        assert_eq!(fs::read_to_string(&lock_path).unwrap(), LOCK_PROTOCOL);
+    }
+
+    #[test]
+    fn simultaneous_rust_python_acquisition_produces_exactly_one_owner() {
+        let root = test_root("simultaneous-rust-python");
+        fs::create_dir_all(&root).unwrap();
+        let target = root.join("shared.json");
+        let log = root.join("order.log");
+        fs::write(&log, "").unwrap();
+        let source = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../src-python");
+        let rounds = 5;
+        let script = "import pathlib, sys, time; from atomic_io import file_lock_for; target = pathlib.Path(sys.argv[1]); log = pathlib.Path(sys.argv[2]);\nfor _ in range(5):\n    with file_lock_for(target):\n        with log.open('a', encoding='ascii') as stream:\n            stream.write('START-P\\n'); stream.flush(); time.sleep(0.05); stream.write('END-P\\n')\nprint('done', flush=True)";
+        let mut child = Command::new("python")
+            .env("PYTHONPATH", &source)
+            .arg("-c")
+            .arg(script)
+            .arg(&target)
+            .arg(&log)
+            .stdout(Stdio::null())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .expect("python is required for the cross-language lock tests");
+
+        let rust_log = log.clone();
+        let rust_target = target.clone();
+        let worker = thread::spawn(move || {
+            for _ in 0..rounds {
+                let lock = FileLock::acquire(&rust_target).unwrap();
+                {
+                    let mut stream = fs::OpenOptions::new().append(true).open(&rust_log).unwrap();
+                    stream.write_all(b"START-R\n").unwrap();
+                    stream.flush().unwrap();
+                    thread::sleep(Duration::from_millis(50));
+                    stream.write_all(b"END-R\n").unwrap();
+                }
+                drop(lock);
+            }
+        });
+        worker.join().unwrap();
+        assert!(child.wait().unwrap().success());
+
+        let content = fs::read_to_string(&log).unwrap();
+        let mut open: Option<&str> = None;
+        let mut python_rounds = 0;
+        let mut rust_rounds = 0;
+        for line in content.lines() {
+            if let Some(owner) = line.strip_prefix("START-") {
+                assert!(open.is_none(), "overlapping critical sections at {line}");
+                open = Some(owner);
+            } else if let Some(owner) = line.strip_prefix("END-") {
+                assert_eq!(open.take(), Some(owner), "mismatched END marker");
+                match owner {
+                    "P" => python_rounds += 1,
+                    "R" => rust_rounds += 1,
+                    _ => panic!("unexpected owner {owner}"),
+                }
+            } else {
+                panic!("unexpected log line {line}");
+            }
+        }
+        assert!(open.is_none());
+        assert_eq!(python_rounds, 5);
+        assert_eq!(rust_rounds, rounds);
     }
 }

--- a/src-tauri/src/safe_file.rs
+++ b/src-tauri/src/safe_file.rs
@@ -38,7 +38,38 @@ fn invoke_test_pre_open_hook(path: &Path) {
 
 const LOCK_WAIT_TIMEOUT: Duration = Duration::from_secs(10);
 const LOCK_RETRY_DELAY: Duration = Duration::from_millis(25);
+// Versioned lock record. Anything else is fail-closed:
+// - unknown/future versions -> never recovered (fail closed);
+// - legacy pid/timestamp records -> recovered only when the PID is provably
+//   dead, otherwise fail closed;
+// - mixed-version caveat: binaries older than this protocol may still reclaim
+//   or unlink a protocol lock file (they classify anything non-legacy as
+//   stale); old binaries cannot be patched, so upgrades must drain running
+//   old processes before relying on overlap protection.
+// Crash-recovery bound: a holder death releases its OS byte lock, so a new
+// owner enters within LOCK_WAIT_TIMEOUT.
 const LOCK_PROTOCOL: &str = "codexhub-atomic-lock=1\n";
+
+#[cfg(windows)]
+mod win32 {
+    pub(crate) const SHARE_READ_WRITE_DELETE: u32 = 0x00000007;
+    pub(crate) const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x00200000;
+    pub(crate) const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x400;
+    pub(crate) const LOCKFILE_FAIL_IMMEDIATELY: u32 = 0x1;
+    pub(crate) const LOCKFILE_EXCLUSIVE_LOCK: u32 = 0x2;
+    pub(crate) const ERROR_SHARING_VIOLATION: i32 = 32;
+    pub(crate) const ERROR_LOCK_VIOLATION: i32 = 33;
+    pub(crate) const STILL_ACTIVE: u32 = 259;
+    pub(crate) const PROCESS_QUERY_LIMITED_INFORMATION: u32 = 0x1000;
+}
+
+#[cfg(unix)]
+mod flock_op {
+    pub(crate) const LOCK_EX: i32 = 2;
+    pub(crate) const LOCK_NB: i32 = 4;
+    pub(crate) const LOCK_UN: i32 = 8;
+    pub(crate) const ESRCH: i32 = 3;
+}
 
 pub(crate) fn write_text_atomic(path: &Path, text: &str) -> Result<(), String> {
     if let Some(parent) = path.parent() {
@@ -109,7 +140,9 @@ fn open_lock_file(path: &Path, create_new: bool) -> std::io::Result<File> {
     #[cfg(windows)]
     {
         use std::os::windows::fs::OpenOptionsExt;
-        options.share_mode(0x00000007).custom_flags(0x00200000);
+        options
+            .share_mode(win32::SHARE_READ_WRITE_DELETE)
+            .custom_flags(win32::FILE_FLAG_OPEN_REPARSE_POINT);
     }
     if create_new {
         options.create_new(true).open(path)
@@ -361,7 +394,7 @@ fn validate_lock_metadata(metadata: &fs::Metadata) -> Result<(), String> {
     #[cfg(windows)]
     {
         use std::os::windows::fs::MetadataExt;
-        if metadata.file_attributes() & 0x400 != 0 {
+        if metadata.file_attributes() & win32::FILE_ATTRIBUTE_REPARSE_POINT != 0 {
             return Err("atomic write lock is not a regular single-link file".to_owned());
         }
     }
@@ -400,7 +433,7 @@ fn lock_file_identity(file: &File) -> Result<(u32, u64), String> {
     use std::os::windows::io::AsRawHandle;
     let mut information = ByHandleFileInformation::default();
     let result = unsafe { GetFileInformationByHandle(file.as_raw_handle(), &mut information) };
-    if result == 0 || information.number_of_links != 1 || information.file_attributes & 0x400 != 0 {
+    if result == 0 || information.number_of_links != 1 || information.file_attributes & win32::FILE_ATTRIBUTE_REPARSE_POINT != 0 {
         return Err("atomic write lock is not a regular single-link file".to_owned());
     }
     let index = (u64::from(information.file_index_high) << 32) | u64::from(information.file_index_low);
@@ -547,7 +580,7 @@ fn pid_is_definitely_dead(pid: i64) -> bool {
     // kill(pid, 0) cannot signal the process. EPERM means it exists but is not
     // ours, so it is deliberately not reclaimed.
     let result = unsafe { kill(pid as i32, 0) };
-    result != 0 && std::io::Error::last_os_error().raw_os_error() == Some(3)
+    result != 0 && std::io::Error::last_os_error().raw_os_error() == Some(flock_op::ESRCH)
 }
 
 #[cfg(windows)]
@@ -556,21 +589,21 @@ fn pid_is_definitely_dead(pid: i64) -> bool {
         return true;
     }
     unsafe {
-        let handle = OpenProcess(0x1000, 0, pid as u32);
+        let handle = OpenProcess(win32::PROCESS_QUERY_LIMITED_INFORMATION, 0, pid as u32);
         if handle.is_null() {
             return false; // Access-denied and unknown are fail-safe.
         }
         let mut code = 0;
         let result = GetExitCodeProcess(handle, &mut code);
         CloseHandle(handle);
-        result != 0 && code != 259
+        result != 0 && code != win32::STILL_ACTIVE
     }
 }
 
 #[cfg(unix)]
 fn try_lock_exclusive(file: &File) -> Result<bool, ()> {
     use std::os::fd::AsRawFd;
-    let result = unsafe { flock(file.as_raw_fd(), 2 | 4) }; // LOCK_EX | LOCK_NB
+    let result = unsafe { flock(file.as_raw_fd(), flock_op::LOCK_EX | flock_op::LOCK_NB) };
     if result == 0 {
         Ok(true)
     } else if matches!(std::io::Error::last_os_error().kind(), std::io::ErrorKind::WouldBlock) {
@@ -583,16 +616,25 @@ fn try_lock_exclusive(file: &File) -> Result<bool, ()> {
 #[cfg(unix)]
 fn unlock(file: &File) -> std::io::Result<()> {
     use std::os::fd::AsRawFd;
-    if unsafe { flock(file.as_raw_fd(), 8) } == 0 { Ok(()) } else { Err(std::io::Error::last_os_error()) }
+    if unsafe { flock(file.as_raw_fd(), flock_op::LOCK_UN) } == 0 { Ok(()) } else { Err(std::io::Error::last_os_error()) }
 }
 
 #[cfg(windows)]
 fn try_lock_exclusive(file: &File) -> Result<bool, ()> {
     use std::os::windows::io::AsRawHandle;
     let mut overlapped = Overlapped::default();
-    let result = unsafe { LockFileEx(file.as_raw_handle(), 0x2 | 0x1, 0, 1, 0, &mut overlapped) };
+    let result = unsafe {
+        LockFileEx(
+            file.as_raw_handle(),
+            win32::LOCKFILE_EXCLUSIVE_LOCK | win32::LOCKFILE_FAIL_IMMEDIATELY,
+            0,
+            1,
+            0,
+            &mut overlapped,
+        )
+    };
     if result != 0 { Ok(true) }
-    else if matches!(std::io::Error::last_os_error().raw_os_error(), Some(32 | 33)) { Ok(false) }
+    else if matches!(std::io::Error::last_os_error().raw_os_error(), Some(code) if code == win32::ERROR_SHARING_VIOLATION || code == win32::ERROR_LOCK_VIOLATION) { Ok(false) }
     else { Err(()) }
 }
 

--- a/tests/lock_fixtures.py
+++ b/tests/lock_fixtures.py
@@ -1,0 +1,20 @@
+"""Shared fixtures for stale-lock recovery tests."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+
+def write_dead_legacy_lock(lock_path: Path) -> subprocess.Popen:
+    """Write a legacy record whose PID is provably dead (recoverable).
+
+    The returned process must stay referenced for the test duration: closing
+    its handle would make the dead PID unresolvable on Windows.
+    """
+    child = subprocess.Popen([os.environ.get("PYTHON", "python"), "-c", "pass"])
+    child_pid = child.pid
+    assert child.wait(timeout=5) == 0
+    lock_path.write_text(f"pid={child_pid}\nacquired_at_millis=0\n", encoding="utf-8")
+    return child

--- a/tests/test_atomic_io.py
+++ b/tests/test_atomic_io.py
@@ -1,11 +1,14 @@
 import os
 import stat
+import subprocess
 import threading
+import time
 from pathlib import Path
 
 import pytest
 
-from atomic_io import atomic_read_or_create_text, atomic_write_text
+import atomic_io
+from atomic_io import _classify_lock_bytes, _parse_legacy_pid, atomic_read_or_create_text, atomic_write_text, file_lock_for
 
 
 def test_atomic_write_text_replaces_existing_file(tmp_path: Path) -> None:
@@ -32,15 +35,19 @@ def test_atomic_write_text_keeps_existing_file_when_replace_fails(tmp_path: Path
     assert target.read_text(encoding="utf-8") == "old"
 
 
-def test_atomic_write_text_recovers_stale_lock_file(tmp_path: Path) -> None:
+def test_atomic_write_text_recovers_provably_dead_legacy_lock_without_unlinking(tmp_path: Path) -> None:
     target = tmp_path / "catalog.json"
     target.write_text("old", encoding="utf-8")
-    target.with_name("catalog.json.lock").write_text("pid=0\nacquired_at_millis=0\n", encoding="utf-8")
+    lock = target.with_name("catalog.json.lock")
+    child = subprocess.Popen([os.environ.get("PYTHON", "python"), "-c", "pass"])
+    child_pid = child.pid
+    assert child.wait(timeout=5) == 0
+    lock.write_text(f"pid={child_pid}\nacquired_at_millis=0\n", encoding="utf-8")
 
     atomic_write_text(target, "new", encoding="utf-8")
 
     assert target.read_text(encoding="utf-8") == "new"
-    assert not target.with_name("catalog.json.lock").exists()
+    assert lock.read_text(encoding="ascii") == "codexhub-atomic-lock=1\n"
 
 
 @pytest.mark.skipif(os.name == "nt", reason="Windows private ACLs are documented separately")
@@ -90,3 +97,447 @@ def test_atomic_read_or_create_text_returns_single_winning_value_under_concurren
     assert len(set(results)) == 1
     assert target.read_text(encoding="utf-8") == results[0]
     assert counter == 1
+
+
+@pytest.mark.parametrize(
+    "error",
+    [PermissionError("denied"), IsADirectoryError("directory"), UnicodeDecodeError("utf-8", b"\\xff", 0, 1, "invalid")],
+)
+def test_atomic_read_or_create_text_propagates_read_errors_without_creating(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, error: OSError | UnicodeDecodeError
+) -> None:
+    target = tmp_path / "secret"
+    invoked = False
+
+    def fail_read(self: Path, *, encoding: str, errors: str | None = None) -> str:
+        raise error
+
+    def creator() -> str:
+        nonlocal invoked
+        invoked = True
+        return "created"
+
+    monkeypatch.setattr(Path, "read_text", fail_read)
+    with pytest.raises(type(error)):
+        atomic_read_or_create_text(target, creator)
+    assert not invoked
+
+
+def test_atomic_read_or_create_text_creates_only_for_missing_or_empty_content(tmp_path: Path) -> None:
+    target = tmp_path / "value"
+    calls = 0
+
+    def creator() -> str:
+        nonlocal calls
+        calls += 1
+        return "created"
+
+    assert atomic_read_or_create_text(target, creator) == "created"
+    target.write_text("   \n", encoding="utf-8")
+    assert atomic_read_or_create_text(target, creator) == "created"
+    target.write_text("existing\n", encoding="utf-8")
+    assert atomic_read_or_create_text(target, creator) == "existing"
+    assert calls == 2
+
+
+def test_legacy_timestamp_or_malformed_lock_fails_safely(tmp_path: Path) -> None:
+    target = tmp_path / "settings.json"
+    lock = target.with_name("settings.json.lock")
+    lock.write_text("acquired_at_millis=0\n", encoding="ascii")
+    with pytest.raises(TimeoutError, match="unavailable"):
+        atomic_write_text(target, "new")
+    lock.write_text("not-a-lock\n", encoding="ascii")
+    with pytest.raises(TimeoutError, match="unavailable"):
+        atomic_write_text(target, "new")
+
+
+def test_existing_empty_lock_fails_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    target = tmp_path / "settings.json"
+    lock = target.with_name("settings.json.lock")
+    lock.touch()
+    monkeypatch.setattr(atomic_io, "LOCK_WAIT_TIMEOUT_SECONDS", 0.01)
+    monkeypatch.setattr(atomic_io.time, "sleep", lambda _: None)
+
+    with pytest.raises(TimeoutError, match="unavailable|timed out"):
+        atomic_write_text(target, "new")
+
+    assert lock.read_bytes() == b""
+
+
+def test_dead_legacy_lock_is_recovered_without_unlinking_its_inode(tmp_path: Path) -> None:
+    target = tmp_path / "settings.json"
+    lock = target.with_name("settings.json.lock")
+    child = subprocess.Popen([os.environ.get("PYTHON", "python"), "-c", "pass"])
+    child_pid = child.pid
+    assert child.wait(timeout=5) == 0
+    lock.write_text(f"pid={child_pid}\nacquired_at_millis=0\n", encoding="ascii")
+    inode = lock.stat().st_ino
+
+    atomic_write_text(target, "new")
+
+    assert target.read_text(encoding="utf-8") == "new"
+    assert lock.stat().st_ino == inode
+    assert lock.read_text(encoding="ascii") == "codexhub-atomic-lock=1\n"
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        "acquired_at_millis=0\n",
+        "not-a-lock\n",
+        "codexhub-atomic-lock=2\n",
+        "codexhub-atomic-lock=1\nextra=value\n",
+        "pid=1\npid=2\nacquired_at_millis=0\n",
+        "pid=0\nacquired_at_millis=0\n",
+        "pid=-1\nacquired_at_millis=0\n",
+        "pid=999999999999999999999999\nacquired_at_millis=0\n",
+    ],
+)
+def test_legacy_and_future_lock_metadata_fails_closed(tmp_path: Path, metadata: str) -> None:
+    target = tmp_path / "settings.json"
+    target.with_name("settings.json.lock").write_text(metadata, encoding="ascii")
+
+    with pytest.raises(TimeoutError, match="unavailable"):
+        atomic_write_text(target, "new")
+
+
+def test_lock_symlink_is_rejected_without_modifying_target(tmp_path: Path) -> None:
+    target = tmp_path / "settings.json"
+    victim = tmp_path / "victim"
+    lock = target.with_name("settings.json.lock")
+    victim.write_text("do not modify", encoding="ascii")
+    try:
+        lock.symlink_to(victim)
+    except (OSError, NotImplementedError) as error:
+        if os.environ.get("CI", "").lower() == "true":
+            pytest.fail(f"CI must provide a symlink/reparse fixture: {error}")
+        pytest.skip("symlinks are unavailable locally")
+
+    with pytest.raises(OSError, match="atomic write lock") as raised:
+        atomic_write_text(target, "new")
+
+    assert "settings.json.lock" not in str(raised.value)
+    assert victim.read_text(encoding="ascii") == "do not modify"
+
+
+def test_lock_hardlink_is_rejected_without_modifying_target(tmp_path: Path) -> None:
+    target = tmp_path / "settings.json"
+    victim = tmp_path / "victim"
+    lock = target.with_name("settings.json.lock")
+    victim.write_text("do not modify", encoding="ascii")
+    try:
+        os.link(victim, lock)
+    except (OSError, NotImplementedError):
+        pytest.skip("hard links are unavailable")
+
+    with pytest.raises(OSError, match="atomic write lock") as raised:
+        atomic_write_text(target, "new")
+
+    assert "settings.json.lock" not in str(raised.value)
+    assert victim.read_text(encoding="ascii") == "do not modify"
+
+
+def test_lock_identity_change_after_open_is_rejected(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    target = tmp_path / "settings.json"
+    lock = target.with_name("settings.json.lock")
+    lock.write_text("codexhub-atomic-lock=1\n", encoding="ascii")
+    replacement = tmp_path / "replacement.lock"
+    replacement.write_text("codexhub-atomic-lock=1\n", encoding="ascii")
+    real_lstat = atomic_io.os.lstat
+    calls = 0
+
+    def report_replaced_path(path: Path) -> os.stat_result:
+        nonlocal calls
+        if path == lock:
+            calls += 1
+            if calls == 2:
+                return real_lstat(replacement)
+        return real_lstat(path)
+
+    monkeypatch.setattr(atomic_io.os, "lstat", report_replaced_path)
+    with pytest.raises(OSError, match="atomic write lock"):
+        atomic_write_text(target, "new")
+
+    assert not target.exists()
+
+
+def test_empty_lock_is_retried_as_transient_until_protocol_is_ready(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    target = tmp_path / "settings.json"
+    lock = target.with_name("settings.json.lock")
+    lock.write_text("codexhub-atomic-lock=1\n", encoding="ascii")
+    reads = iter(["empty", "protocol"])
+    monkeypatch.setattr(atomic_io, "_read_lock_state", lambda _: next(reads))
+    monkeypatch.setattr(atomic_io.time, "sleep", lambda _: None)
+
+    atomic_write_text(target, "new")
+
+    assert target.read_text(encoding="utf-8") == "new"
+
+
+def test_lock_path_churn_obeys_deadline_and_backoff(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    target = tmp_path / "settings.json"
+    clock = iter([0.0, 0.0, 0.0, 2.0])
+    sleeps: list[float] = []
+    calls = 0
+    monkeypatch.setattr(atomic_io, "LOCK_WAIT_TIMEOUT_SECONDS", 1.0)
+    monkeypatch.setattr(atomic_io.time, "monotonic", lambda: next(clock))
+    monkeypatch.setattr(atomic_io.time, "sleep", sleeps.append)
+
+    def churn(_: Path) -> tuple[int, bool]:
+        nonlocal calls
+        calls += 1
+        if calls > 1:
+            raise AssertionError("retry did not honor deadline")
+        raise FileNotFoundError()
+
+    monkeypatch.setattr(atomic_io, "_open_lock_file", churn)
+
+    with pytest.raises(TimeoutError, match="timed out waiting"):
+        atomic_write_text(target, "new")
+
+    assert sleeps
+
+
+def test_lock_release_is_idempotent_and_coordination_file_persists(tmp_path: Path) -> None:
+    target = tmp_path / "settings.json"
+    with file_lock_for(target):
+        pass
+    with file_lock_for(target):
+        pass
+    assert target.with_name("settings.json.lock").read_text(encoding="ascii") == "codexhub-atomic-lock=1\n"
+
+
+@pytest.mark.parametrize(
+    ("data", "expected"),
+    [
+        (b"codexhub-atomic-lock=1\n", "protocol"),
+        (b"codexhub-atomic-lock=1\r\n", "protocol"),
+        (b"codexhub-atomic-lock=1", "unknown"),
+        (b"codexhub-atomic-lock=2\n", "unknown"),
+        (b"codexhub-atomic-lock=1\nextra=value\n", "unknown"),
+        (b"pid=0\nacquired_at_millis=0\n", "unknown"),
+        (b"pid=-1\nacquired_at_millis=0\n", "unknown"),
+        (b"pid=999999999999999999999999\nacquired_at_millis=0\n", "unknown"),
+        (b"pid=1\npid=2\nacquired_at_millis=0\n", "unknown"),
+        (b"pid=1\nacquired_at_millis=0\xff\n", "unknown"),
+    ],
+)
+def test_python_parser_uses_the_shared_protocol_classification(data: bytes, expected: str) -> None:
+    assert _classify_lock_bytes(data) == expected
+
+
+def test_python_parser_rejects_timestamp_outside_shared_u128_range() -> None:
+    assert _parse_legacy_pid("pid=1\nacquired_at_millis=340282366920938463463374607431768211456\n") is None
+
+
+
+
+def test_python_production_path_rejects_invalid_utf8_lock_without_writing(tmp_path: Path) -> None:
+    target = tmp_path / "settings.json"
+    lock = target.with_name("settings.json.lock")
+    lock.write_bytes(b"pid=1\nacquired_at_millis=0\n\xff")
+
+    with pytest.raises(TimeoutError, match="unavailable") as raised:
+        atomic_write_text(target, "new")
+
+    assert str(raised.value) == "atomic write lock is unavailable"
+    assert not target.exists()
+    assert lock.read_bytes().endswith(b"\xff")
+
+
+def test_guard_replacement_after_acquire_is_rejected_by_writer(tmp_path: Path) -> None:
+    target = tmp_path / "settings.json"
+    guard = target.with_name("settings.json.lock.guard")
+
+    def replace_guard_after_acquire(event: str) -> None:
+        if event == "acquired":
+            guard.unlink()
+            guard.write_text("codexhub-atomic-lock=1\n", encoding="ascii")
+
+    atomic_io._set_test_lock_hook(replace_guard_after_acquire)
+    try:
+        with pytest.raises(OSError, match="atomic write lock"):
+            atomic_write_text(target, "new")
+    finally:
+        atomic_io._set_test_lock_hook(None)
+
+    assert not target.exists()
+    assert guard.read_text(encoding="ascii") == "codexhub-atomic-lock=1\n"
+
+
+def _readline_with_watchdog(stream: object, timeout: float = 30.0) -> str:
+    result: list[str] = []
+    error: list[BaseException] = []
+
+    def read_line() -> None:
+        try:
+            result.append(stream.readline())  # type: ignore[attr-defined]
+        except BaseException as exc:  # pragma: no cover - only used for broken pipes
+            error.append(exc)
+
+    reader = threading.Thread(target=read_line, daemon=True)
+    reader.start()
+    reader.join(timeout)
+    if reader.is_alive():
+        pytest.fail("subprocess handshake watchdog expired")
+    if error:
+        raise error[0]
+    return result[0]
+
+
+def test_live_legacy_lock_is_never_reclaimed(tmp_path: Path) -> None:
+    target = tmp_path / "settings.json"
+    lock = target.with_name("settings.json.lock")
+    metadata = f"pid={os.getpid()}\nacquired_at_millis=0\n"
+    lock.write_text(metadata, encoding="ascii")
+
+    with pytest.raises(TimeoutError, match="unavailable"):
+        atomic_write_text(target, "new")
+
+    assert lock.read_text(encoding="ascii") == metadata
+    assert not target.exists()
+
+
+def test_held_lock_stays_exclusive_beyond_former_age_threshold(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    target = tmp_path / "settings.json"
+    entered = threading.Event()
+    release = threading.Event()
+
+    def holder() -> None:
+        with file_lock_for(target):
+            entered.set()
+            release.wait(10)
+
+    thread = threading.Thread(target=holder)
+    thread.start()
+    assert entered.wait(10)
+    # Backdate both artifacts far beyond the former 60-second staleness rule.
+    ancient = time.time() - 3600
+    os.utime(target.with_name("settings.json.lock"), (ancient, ancient))
+    os.utime(target.with_name("settings.json.lock.guard"), (ancient, ancient))
+
+    monkeypatch.setattr(atomic_io, "LOCK_WAIT_TIMEOUT_SECONDS", 0.2)
+    monkeypatch.setattr(atomic_io.time, "sleep", lambda _: None)
+    with pytest.raises(TimeoutError, match="timed out"):
+        atomic_write_text(target, "new")
+
+    release.set()
+    thread.join(10)
+    assert not target.exists()
+
+
+def test_same_language_ab_c_choreography_keeps_single_owner(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A holds; B waits and legitimately follows A; C cannot overlap B."""
+    target = tmp_path / "settings.json"
+    lock = target.with_name("settings.json.lock")
+    a_acquired = threading.Event()
+    a_release = threading.Event()
+    b_events: list[str] = []
+    b_acquired = threading.Event()
+    b_release = threading.Event()
+
+    def a_worker() -> None:
+        with file_lock_for(target):
+            a_acquired.set()
+            a_release.wait(10)
+
+    def b_worker() -> None:
+        def hook(event: str) -> None:
+            b_events.append(event)
+            if event == "acquired":
+                b_acquired.set()
+
+        atomic_io._set_test_lock_hook(hook)
+        with file_lock_for(target):
+            b_release.wait(10)
+
+    thread_a = threading.Thread(target=a_worker)
+    thread_b = threading.Thread(target=b_worker)
+    thread_a.start()
+    assert a_acquired.wait(10)
+    thread_b.start()
+    # B is provably blocked while A holds the namespace guard.
+    deadline = time.monotonic() + 10
+    while "blocked" not in b_events and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert "blocked" in b_events
+
+    a_release.set()
+    thread_a.join(10)
+    # A's release must not remove the instance B is about to own.
+    assert lock.read_text(encoding="ascii") == "codexhub-atomic-lock=1\n"
+    assert b_acquired.wait(10)
+    atomic_io._set_test_lock_hook(None)
+
+    # C times out instead of overlapping B's critical section.
+    monkeypatch.setattr(atomic_io, "LOCK_WAIT_TIMEOUT_SECONDS", 0.2)
+    monkeypatch.setattr(atomic_io.time, "sleep", lambda _: None)
+    with pytest.raises(TimeoutError, match="timed out"):
+        atomic_write_text(target, "c")
+    assert not target.exists()
+
+    b_release.set()
+    thread_b.join(10)
+    # After B legitimately releases, C enters and the protocol instance persists.
+    atomic_write_text(target, "c")
+    assert target.read_text(encoding="utf-8") == "c"
+    assert lock.read_text(encoding="ascii") == "codexhub-atomic-lock=1\n"
+
+
+def test_release_after_external_replacement_keeps_replacement_instance(tmp_path: Path) -> None:
+    target = tmp_path / "settings.json"
+    lock = target.with_name("settings.json.lock")
+    with file_lock_for(target):
+        try:
+            lock.unlink()
+            lock.write_text("codexhub-atomic-lock=1\n", encoding="ascii")
+        except PermissionError as error:
+            if os.environ.get("CI", "").lower() == "true":
+                pytest.fail(f"CI must provide an unlink/recreate fixture: {error}")
+            pytest.skip("platform denied unlinking an open lock artifact")
+    # The owner's release operates on its own handle and never unlinks, so the
+    # external replacement instance survives untouched.
+    assert lock.read_text(encoding="ascii") == "codexhub-atomic-lock=1\n"
+
+
+def test_real_unlink_recreate_cannot_overlap_guarded_contender(tmp_path: Path) -> None:
+    target = tmp_path / "shared.json"
+    lock = target.with_name("shared.json.lock")
+    source = str(Path(__file__).resolve().parents[1] / "src-python")
+    python = os.environ.get("PYTHON", "python")
+    holder_script = "import pathlib, sys; from atomic_io import file_lock_for; target = pathlib.Path(sys.argv[1]);\nwith file_lock_for(target):\n    print('held', flush=True);\n    if sys.stdin.readline().strip() != 'release': raise SystemExit(2);\n    print('released', flush=True)"
+    contender_script = "import pathlib, sys; from atomic_io import _set_test_lock_hook, atomic_write_text; target = pathlib.Path(sys.argv[1]); state = {'phase': 0};\ndef hook(event):\n    if event == 'attempt' and state['phase'] == 0:\n        print('attempt', flush=True); state['phase'] = 1\n    elif event == 'blocked' and state['phase'] == 1:\n        print('blocked', flush=True); state['phase'] = 2;\n        if sys.stdin.readline().strip() != 'replacement-verified': raise SystemExit(3)\n        print('replacement-verified', flush=True)\n    elif event == 'acquired':\n        print('acquired', flush=True)\n_set_test_lock_hook(hook); atomic_write_text(target, 'contender'); print('entered', flush=True)"
+    holder = subprocess.Popen([python, "-c", holder_script, str(target)], env={**os.environ, "PYTHONPATH": source}, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    contender = None
+    try:
+        assert holder.stdout is not None
+        assert holder.stdin is not None
+        assert _readline_with_watchdog(holder.stdout).strip() == "held"
+        contender = subprocess.Popen([python, "-c", contender_script, str(target)], env={**os.environ, "PYTHONPATH": source}, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        assert contender.stdout is not None
+        assert contender.stdin is not None
+        assert _readline_with_watchdog(contender.stdout).strip() == "attempt"
+        assert _readline_with_watchdog(contender.stdout).strip() == "blocked"
+        try:
+            lock.unlink()
+            lock.write_text("codexhub-atomic-lock=1\n", encoding="ascii")
+        except PermissionError as error:
+            if os.environ.get("CI", "").lower() == "true":
+                pytest.fail(f"CI must provide an unlink/recreate race fixture: {error}")
+            pytest.skip("platform denied unlinking an open lock artifact")
+        contender.stdin.write("replacement-verified\n")
+        contender.stdin.flush()
+        assert _readline_with_watchdog(contender.stdout).strip() == "replacement-verified"
+        holder.stdin.write("release\n")
+        holder.stdin.flush()
+        assert _readline_with_watchdog(holder.stdout).strip() == "released"
+        assert _readline_with_watchdog(contender.stdout).strip() == "acquired"
+        assert _readline_with_watchdog(contender.stdout).strip() == "entered"
+    finally:
+        if holder.poll() is None:
+            holder.kill()
+        holder.wait()
+        if contender is not None:
+            if contender.poll() is None:
+                contender.kill()
+            contender.wait()

--- a/tests/test_atomic_io.py
+++ b/tests/test_atomic_io.py
@@ -9,6 +9,7 @@ import pytest
 
 import atomic_io
 from atomic_io import _classify_lock_bytes, _parse_legacy_pid, atomic_read_or_create_text, atomic_write_text, file_lock_for
+from lock_fixtures import write_dead_legacy_lock
 
 
 def test_atomic_write_text_replaces_existing_file(tmp_path: Path) -> None:
@@ -39,10 +40,7 @@ def test_atomic_write_text_recovers_provably_dead_legacy_lock_without_unlinking(
     target = tmp_path / "catalog.json"
     target.write_text("old", encoding="utf-8")
     lock = target.with_name("catalog.json.lock")
-    child = subprocess.Popen([os.environ.get("PYTHON", "python"), "-c", "pass"])
-    child_pid = child.pid
-    assert child.wait(timeout=5) == 0
-    lock.write_text(f"pid={child_pid}\nacquired_at_millis=0\n", encoding="utf-8")
+    _dead_child = write_dead_legacy_lock(lock)
 
     atomic_write_text(target, "new", encoding="utf-8")
 
@@ -167,10 +165,7 @@ def test_existing_empty_lock_fails_closed(tmp_path: Path, monkeypatch: pytest.Mo
 def test_dead_legacy_lock_is_recovered_without_unlinking_its_inode(tmp_path: Path) -> None:
     target = tmp_path / "settings.json"
     lock = target.with_name("settings.json.lock")
-    child = subprocess.Popen([os.environ.get("PYTHON", "python"), "-c", "pass"])
-    child_pid = child.pid
-    assert child.wait(timeout=5) == 0
-    lock.write_text(f"pid={child_pid}\nacquired_at_millis=0\n", encoding="ascii")
+    _dead_child = write_dead_legacy_lock(lock)
     inode = lock.stat().st_ino
 
     atomic_write_text(target, "new")

--- a/tests/test_bucket_sync.py
+++ b/tests/test_bucket_sync.py
@@ -1,8 +1,23 @@
+import os
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
 
 from bucket_sync import sync_dir
+
+
+def write_dead_legacy_lock(lock_path: Path) -> subprocess.Popen:
+    """Write a legacy record whose PID is provably dead (recoverable).
+
+    The returned process must stay referenced for the test duration: closing
+    its handle would make the dead PID unresolvable on Windows.
+    """
+    child = subprocess.Popen([os.environ.get("PYTHON", "python"), "-c", "pass"])
+    child_pid = child.pid
+    assert child.wait(timeout=5) == 0
+    lock_path.write_text(f"pid={child_pid}\nacquired_at_millis=0\n", encoding="utf-8")
+    return child
 
 
 class BucketSyncTests(unittest.TestCase):
@@ -85,13 +100,13 @@ class BucketSyncTests(unittest.TestCase):
             target = destination / "session.jsonl"
             target.write_bytes(b"a\nb\n")
             lock_path = target.with_name("session.jsonl.lock")
-            lock_path.write_text("pid=0\nacquired_at_millis=0\n", encoding="utf-8")
+            _dead_child = write_dead_legacy_lock(lock_path)
 
             counts = sync_dir(source, destination)
 
             self.assertEqual(target.read_bytes(), b"a\nb\nc\n")
             self.assertEqual(counts, {"merged": 1})
-            self.assertFalse(lock_path.exists())
+            self.assertEqual(lock_path.read_text(encoding="ascii"), "codexhub-atomic-lock=1\n")
 
     def test_non_jsonl_overwrite_recovers_stale_atomic_lock(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -104,13 +119,13 @@ class BucketSyncTests(unittest.TestCase):
             target = destination / "state.json"
             target.write_bytes(b'{"old":true}\n')
             lock_path = target.with_name("state.json.lock")
-            lock_path.write_text("pid=0\nacquired_at_millis=0\n", encoding="utf-8")
+            _dead_child = write_dead_legacy_lock(lock_path)
 
             counts = sync_dir(source, destination)
 
             self.assertEqual(target.read_bytes(), b'{"new":true}\n')
             self.assertEqual(counts, {"overwritten": 1})
-            self.assertFalse(lock_path.exists())
+            self.assertEqual(lock_path.read_text(encoding="ascii"), "codexhub-atomic-lock=1\n")
 
 
 if __name__ == "__main__":

--- a/tests/test_bucket_sync.py
+++ b/tests/test_bucket_sync.py
@@ -1,23 +1,9 @@
-import os
-import subprocess
 import tempfile
 import unittest
 from pathlib import Path
 
 from bucket_sync import sync_dir
-
-
-def write_dead_legacy_lock(lock_path: Path) -> subprocess.Popen:
-    """Write a legacy record whose PID is provably dead (recoverable).
-
-    The returned process must stay referenced for the test duration: closing
-    its handle would make the dead PID unresolvable on Windows.
-    """
-    child = subprocess.Popen([os.environ.get("PYTHON", "python"), "-c", "pass"])
-    child_pid = child.pid
-    assert child.wait(timeout=5) == 0
-    lock_path.write_text(f"pid={child_pid}\nacquired_at_millis=0\n", encoding="utf-8")
-    return child
+from lock_fixtures import write_dead_legacy_lock
 
 
 class BucketSyncTests(unittest.TestCase):

--- a/tests/test_codex_auth.py
+++ b/tests/test_codex_auth.py
@@ -2,6 +2,7 @@ import base64
 import json
 import os
 import stat
+import subprocess
 import tempfile
 import time
 import unittest
@@ -10,6 +11,19 @@ from unittest.mock import patch
 
 import codex_auth
 from codex_auth import CodexAuthError
+
+
+def write_dead_legacy_lock(lock_path: Path) -> subprocess.Popen:
+    """Write a legacy record whose PID is provably dead (recoverable).
+
+    The returned process must stay referenced for the test duration: closing
+    its handle would make the dead PID unresolvable on Windows.
+    """
+    child = subprocess.Popen([os.environ.get("PYTHON", "python"), "-c", "pass"])
+    child_pid = child.pid
+    assert child.wait(timeout=5) == 0
+    lock_path.write_text(f"pid={child_pid}\nacquired_at_millis=0\n", encoding="utf-8")
+    return child
 
 
 def _make_jwt(payload: dict) -> str:
@@ -180,14 +194,14 @@ class RefreshTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             path = _make_auth_json(Path(tmp), access_token=old_token, refresh_token="rt.orig")
             lock_path = path.with_name("auth.json.lock")
-            lock_path.write_text("pid=0\nacquired_at_millis=0\n", encoding="utf-8")
+            _dead_child = write_dead_legacy_lock(lock_path)
             auth_data = json.loads(path.read_text(encoding="utf-8"))
             fake = _FakeResponse({"access_token": new_token, "refresh_token": "rt.fresh"})
 
             with patch("codex_auth.urlopen", return_value=fake):
                 codex_auth.refresh(auth_data, path)
 
-            self.assertFalse(lock_path.exists())
+            self.assertEqual(lock_path.read_text(encoding="ascii"), "codexhub-atomic-lock=1\n")
             self.assertEqual(json.loads(path.read_text(encoding="utf-8"))["tokens"]["access_token"], new_token)
             if os.name != "nt":
                 self.assertEqual(stat.S_IMODE(path.stat().st_mode), 0o600)

--- a/tests/test_codex_auth.py
+++ b/tests/test_codex_auth.py
@@ -2,7 +2,6 @@ import base64
 import json
 import os
 import stat
-import subprocess
 import tempfile
 import time
 import unittest
@@ -11,19 +10,7 @@ from unittest.mock import patch
 
 import codex_auth
 from codex_auth import CodexAuthError
-
-
-def write_dead_legacy_lock(lock_path: Path) -> subprocess.Popen:
-    """Write a legacy record whose PID is provably dead (recoverable).
-
-    The returned process must stay referenced for the test duration: closing
-    its handle would make the dead PID unresolvable on Windows.
-    """
-    child = subprocess.Popen([os.environ.get("PYTHON", "python"), "-c", "pass"])
-    child_pid = child.pid
-    assert child.wait(timeout=5) == 0
-    lock_path.write_text(f"pid={child_pid}\nacquired_at_millis=0\n", encoding="utf-8")
-    return child
+from lock_fixtures import write_dead_legacy_lock
 
 
 def _make_jwt(payload: dict) -> str:

--- a/tests/test_global_state_repair.py
+++ b/tests/test_global_state_repair.py
@@ -1,11 +1,26 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
+import subprocess
 import tempfile
 import unittest
 
 from global_state_repair import repair_global_state
+
+
+def write_dead_legacy_lock(lock_path: Path) -> subprocess.Popen:
+    """Write a legacy record whose PID is provably dead (recoverable).
+
+    The returned process must stay referenced for the test duration: closing
+    its handle would make the dead PID unresolvable on Windows.
+    """
+    child = subprocess.Popen([os.environ.get("PYTHON", "python"), "-c", "pass"])
+    child_pid = child.pid
+    assert child.wait(timeout=5) == 0
+    lock_path.write_text(f"pid={child_pid}\nacquired_at_millis=0\n", encoding="utf-8")
+    return child
 
 
 class GlobalStateRepairTests(unittest.TestCase):
@@ -70,12 +85,12 @@ class GlobalStateRepairTests(unittest.TestCase):
             backup_path = tmp / "backup" / ".codex-global-state.json"
             state_path.write_text(json.dumps(original), encoding="utf-8")
             lock_path = state_path.with_name(".codex-global-state.json.lock")
-            lock_path.write_text("pid=0\nacquired_at_millis=0\n", encoding="utf-8")
+            _dead_child = write_dead_legacy_lock(lock_path)
 
             result = repair_global_state(state_path, backup_path)
 
             self.assertTrue(result["changed"])
-            self.assertFalse(lock_path.exists())
+            self.assertEqual(lock_path.read_text(encoding="ascii"), "codexhub-atomic-lock=1\n")
             self.assertNotIn(
                 "selected-remote-host-id",
                 json.loads(state_path.read_text(encoding="utf-8")),

--- a/tests/test_global_state_repair.py
+++ b/tests/test_global_state_repair.py
@@ -1,26 +1,12 @@
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
-import subprocess
 import tempfile
 import unittest
 
 from global_state_repair import repair_global_state
-
-
-def write_dead_legacy_lock(lock_path: Path) -> subprocess.Popen:
-    """Write a legacy record whose PID is provably dead (recoverable).
-
-    The returned process must stay referenced for the test duration: closing
-    its handle would make the dead PID unresolvable on Windows.
-    """
-    child = subprocess.Popen([os.environ.get("PYTHON", "python"), "-c", "pass"])
-    child_pid = child.pid
-    assert child.wait(timeout=5) == 0
-    lock_path.write_text(f"pid={child_pid}\nacquired_at_millis=0\n", encoding="utf-8")
-    return child
+from lock_fixtures import write_dead_legacy_lock
 
 
 class GlobalStateRepairTests(unittest.TestCase):

--- a/tests/test_history_consolidate.py
+++ b/tests/test_history_consolidate.py
@@ -1,12 +1,27 @@
 from __future__ import annotations
 
 import json
+import os
 import sqlite3
+import subprocess
 import tempfile
 from pathlib import Path
 import unittest
 
 from history_consolidate import merge_global_state, official_main
+
+
+def write_dead_legacy_lock(lock_path: Path) -> subprocess.Popen:
+    """Write a legacy record whose PID is provably dead (recoverable).
+
+    The returned process must stay referenced for the test duration: closing
+    its handle would make the dead PID unresolvable on Windows.
+    """
+    child = subprocess.Popen([os.environ.get("PYTHON", "python"), "-c", "pass"])
+    child_pid = child.pid
+    assert child.wait(timeout=5) == 0
+    lock_path.write_text(f"pid={child_pid}\nacquired_at_millis=0\n", encoding="utf-8")
+    return child
 
 
 def write_session(path: Path, thread_id: str, provider: str, markers: list[str]) -> None:
@@ -128,7 +143,7 @@ class HistoryConsolidateTests(unittest.TestCase):
             official.mkdir(parents=True)
             active_state_path = active / ".codex-global-state.json"
             lock_path = active_state_path.with_name(".codex-global-state.json.lock")
-            lock_path.write_text("pid=0\nacquired_at_millis=0\n", encoding="utf-8")
+            _dead_child = write_dead_legacy_lock(lock_path)
             (official / ".codex-global-state.json").write_text(
                 json.dumps(
                     {
@@ -151,7 +166,7 @@ class HistoryConsolidateTests(unittest.TestCase):
             self.assertEqual(state["remote-connection-auto-connect-by-host-id"], {})
             self.assertNotIn("selected-remote-host-id", state["electron-persisted-atom-state"])
             self.assertEqual(state["electron-persisted-atom-state"]["remote-connection-auto-connect-by-host-id"], {})
-            self.assertFalse(lock_path.exists())
+            self.assertEqual(lock_path.read_text(encoding="ascii"), "codexhub-atomic-lock=1\n")
 
 
 if __name__ == "__main__":

--- a/tests/test_history_consolidate.py
+++ b/tests/test_history_consolidate.py
@@ -1,27 +1,13 @@
 from __future__ import annotations
 
 import json
-import os
 import sqlite3
-import subprocess
 import tempfile
 from pathlib import Path
 import unittest
 
 from history_consolidate import merge_global_state, official_main
-
-
-def write_dead_legacy_lock(lock_path: Path) -> subprocess.Popen:
-    """Write a legacy record whose PID is provably dead (recoverable).
-
-    The returned process must stay referenced for the test duration: closing
-    its handle would make the dead PID unresolvable on Windows.
-    """
-    child = subprocess.Popen([os.environ.get("PYTHON", "python"), "-c", "pass"])
-    child_pid = child.pid
-    assert child.wait(timeout=5) == 0
-    lock_path.write_text(f"pid={child_pid}\nacquired_at_millis=0\n", encoding="utf-8")
-    return child
+from lock_fixtures import write_dead_legacy_lock
 
 
 def write_session(path: Path, thread_id: str, provider: str, markers: list[str]) -> None:

--- a/tests/test_history_overlay.py
+++ b/tests/test_history_overlay.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from contextlib import redirect_stdout
 import io
 import json
+import os
 import sqlite3
+import subprocess
 import tempfile
 from pathlib import Path
 import unittest
@@ -25,6 +27,19 @@ from history_overlay import (
     restore_official_history_from_unified,
     restore_repair_backups,
 )
+
+
+def write_dead_legacy_lock(lock_path: Path) -> subprocess.Popen:
+    """Write a legacy record whose PID is provably dead (recoverable).
+
+    The returned process must stay referenced for the test duration: closing
+    its handle would make the dead PID unresolvable on Windows.
+    """
+    child = subprocess.Popen([os.environ.get("PYTHON", "python"), "-c", "pass"])
+    child_pid = child.pid
+    assert child.wait(timeout=5) == 0
+    lock_path.write_text(f"pid={child_pid}\nacquired_at_millis=0\n", encoding="utf-8")
+    return child
 
 
 class HistoryOverlayTests(unittest.TestCase):
@@ -67,12 +82,12 @@ class HistoryOverlayTests(unittest.TestCase):
             ledger_path = backup_root / "ledger.json"
             backup_root.mkdir(parents=True)
             ledger_lock_path = ledger_path.with_name("ledger.json.lock")
-            ledger_lock_path.write_text("pid=0\nacquired_at_millis=0\n", encoding="utf-8")
+            _dead_child = write_dead_legacy_lock(ledger_lock_path)
             ledger = apply_history_overlay(codex_dir, backup_root, ledger_path)
 
             self.assertEqual(len(ledger["state"][0]["thread_ids"]), 1)
             self.assertEqual(len(ledger["jsonl"]), 1)
-            self.assertFalse(ledger_lock_path.exists())
+            self.assertEqual(ledger_lock_path.read_text(encoding="ascii"), "codexhub-atomic-lock=1\n")
             connection = sqlite3.connect(db_path)
             try:
                 providers = dict(connection.execute("SELECT id, model_provider FROM threads"))

--- a/tests/test_history_overlay.py
+++ b/tests/test_history_overlay.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 from contextlib import redirect_stdout
 import io
 import json
-import os
 import sqlite3
-import subprocess
 import tempfile
 from pathlib import Path
 import unittest
@@ -27,19 +25,7 @@ from history_overlay import (
     restore_official_history_from_unified,
     restore_repair_backups,
 )
-
-
-def write_dead_legacy_lock(lock_path: Path) -> subprocess.Popen:
-    """Write a legacy record whose PID is provably dead (recoverable).
-
-    The returned process must stay referenced for the test duration: closing
-    its handle would make the dead PID unresolvable on Windows.
-    """
-    child = subprocess.Popen([os.environ.get("PYTHON", "python"), "-c", "pass"])
-    child_pid = child.pid
-    assert child.wait(timeout=5) == 0
-    lock_path.write_text(f"pid={child_pid}\nacquired_at_millis=0\n", encoding="utf-8")
-    return child
+from lock_fixtures import write_dead_legacy_lock
 
 
 class HistoryOverlayTests(unittest.TestCase):

--- a/tests/test_proxy_event_logging.py
+++ b/tests/test_proxy_event_logging.py
@@ -5,6 +5,7 @@ import json
 import os
 import sqlite3
 import stat
+import subprocess
 import tempfile
 import threading
 from pathlib import Path
@@ -13,6 +14,19 @@ from unittest.mock import patch
 from urllib.error import URLError
 
 import codex_proxy
+
+
+def write_dead_legacy_lock(lock_path: Path) -> subprocess.Popen:
+    """Write a legacy record whose PID is provably dead (recoverable).
+
+    The returned process must stay referenced for the test duration: closing
+    its handle would make the dead PID unresolvable on Windows.
+    """
+    child = subprocess.Popen([os.environ.get("PYTHON", "python"), "-c", "pass"])
+    child_pid = child.pid
+    assert child.wait(timeout=5) == 0
+    lock_path.write_text(f"pid={child_pid}\nacquired_at_millis=0\n", encoding="utf-8")
+    return child
 
 
 class ProxyEventLoggingTests(TestCase):
@@ -188,12 +202,12 @@ class ProxyEventLoggingTests(TestCase):
             secret_path = proxy_telemetry.telemetry_secret_path(codex_home)
             secret_path.parent.mkdir(parents=True)
             lock_path = secret_path.with_name("telemetry-secret.lock")
-            lock_path.write_text("pid=0\nacquired_at_millis=0\n", encoding="utf-8")
+            _dead_child = write_dead_legacy_lock(lock_path)
 
             digest = proxy_telemetry.telemetry_hmac(codex_home, b"test", b"payload")
 
             self.assertEqual(len(digest), 64)
-            self.assertFalse(lock_path.exists())
+            self.assertEqual(lock_path.read_text(encoding="ascii"), "codexhub-atomic-lock=1\n")
             self.assertTrue(secret_path.read_text(encoding="utf-8").strip())
             if os.name != "nt":
                 self.assertEqual(stat.S_IMODE(secret_path.stat().st_mode), 0o600)

--- a/tests/test_proxy_event_logging.py
+++ b/tests/test_proxy_event_logging.py
@@ -5,7 +5,6 @@ import json
 import os
 import sqlite3
 import stat
-import subprocess
 import tempfile
 import threading
 from pathlib import Path
@@ -14,19 +13,7 @@ from unittest.mock import patch
 from urllib.error import URLError
 
 import codex_proxy
-
-
-def write_dead_legacy_lock(lock_path: Path) -> subprocess.Popen:
-    """Write a legacy record whose PID is provably dead (recoverable).
-
-    The returned process must stay referenced for the test duration: closing
-    its handle would make the dead PID unresolvable on Windows.
-    """
-    child = subprocess.Popen([os.environ.get("PYTHON", "python"), "-c", "pass"])
-    child_pid = child.pid
-    assert child.wait(timeout=5) == 0
-    lock_path.write_text(f"pid={child_pid}\nacquired_at_millis=0\n", encoding="utf-8")
-    return child
+from lock_fixtures import write_dead_legacy_lock
 
 
 class ProxyEventLoggingTests(TestCase):


### PR DESCRIPTION
## Summary

Closes #149. The #23 timestamp lock protocol let a stale reclaim cascade into overlapping writers: writer B removed writer A's lock path after 60 s, A's cleanup then unconditionally removed B's lock path, and C could enter while B was still writing — in either language. Age alone could also reclaim a valid long-running owner. Separately, `atomic_read_or_create_text` caught every `OSError` and created/replaced values on permission, disk, or decoding failures.

**New ownership-safe contract** (one versioned protocol, both languages):

- Persistent `<target>.lock` coordination file plus a `<target>.lock.guard` namespace guard; no lock-path unlink anywhere, no age-based reclaim.
- Ownership is a held OS one-byte advisory lock (`LockFileEx` on Windows, `flock` on Unix); process death releases it, so crash recovery needs no metadata heuristic. Crash-recovery bound: a new owner enters within the 10 s acquisition timeout.
- Versioned cross-language metadata `codexhub-atomic-lock=1`; legacy `pid`/`acquired_at_millis` records are recovered only when the PID is provably dead; live/unknown/malformed state fails closed. Mixed-version caveat and recovery bound are documented at the protocol constant in both languages (old binaries cannot be patched and may still reclaim a protocol lock file; upgrades must drain old processes).
- Reparse-point/hard-link/identity-change attacks fail closed: no-follow opens, single-link regular-file validation, and path-vs-handle identity re-verification at acquire and before every write.
- `atomic_read_or_create_text` catches only `FileNotFoundError`; permission/disk/path-type/decoding errors propagate without invoking the creator (callers audited: `proxy_telemetry` and `worker_binding_signing` both intend causal propagation; no plumbing changes needed).

## Verification

- `python -m pytest -q tests/test_atomic_io.py` — 43 passed, 1 skipped
- `cargo test --locked safe_file` — 21 passed (includes real-process cross-language tests)
- `python -m pytest -q` — 1270 passed, 1 skipped, 327 subtests (full suite)
- `cargo test --locked` — 376 passed; 6 failures = the identical pre-existing host-dependent set verified on the base commit (they read live `~/.codex` state; CI is green). The known load-flaky inspection test failed once, passed on rerun.
- `cargo clippy --locked --all-targets -- -D warnings` — clean
- Standalone `rustc --edition=2021 --test src-tauri/src/safe_file.rs` compile — clean (CI Linux job contract)
- `git diff --check` — clean; `python scripts/report_quality_gates.py` — report-only, no blocking findings
- Independent review: Standards + Spec axes; all actionable findings closed in the review-delta commit (CI docs updated for the new Linux job + clippy-driver lint step, test-fixture dedup into `lock_test_fixtures.rs`/`tests/lock_fixtures.py`, named FFI constants, protocol/mixed-version/recovery-bound comments)

## Acceptance evidence highlights

- A/B/C: same-language choreography tests in both languages prove A's release cannot remove B's instance and C cannot overlap B; structural guarantee: zero unlink calls on lock paths in either implementation.
- Cross-language: real-process tests for Python-holder/Rust-contender, Rust-holder/Python-contender, killed-Python-holder recovery, and simultaneous acquisition producing exactly one owner (paired START/END log markers).
- Long hold: the protocol record carries no timestamp (asserted); a held lock with artifacts backdated past the former 60 s rule still blocks contenders (Python utime test).
- Legacy: provably-dead PID recovery without inode unlink; live-owner legacy never reclaimed; malformed/future/unknown fail closed in both parsers.
- Release: idempotent (double-release test) and harmless after external replacement (replacement instance survives release untouched).

## Notes

- The `rust-safe-file-linux` CI job compiles and lints the `cfg(unix)` FFI that Windows-only Rust jobs never see; `safe_file.rs` must remain crate-dependency-free (documented in `docs/agents/ci.md` and in `lock_test_fixtures.rs`).
- Same-language A/B/C choreography uses threads holding independent OS handles (LockFileEx/flock serialize across in-process handles); real-process coverage is provided by the cross-language and unlink/recreate fixtures.
- Stale-lock caller fixtures (bucket_sync, codex_auth, global_state_repair, history_consolidate, history_overlay, proxy_telemetry, app_updates, openai_usage, proxy pid) were aligned to the new contract: recoverable dead-PID legacy records, and the lock file now persists with protocol metadata instead of being deleted.