### PR TITLE
fix: isolate saved workspace roots during history consolidation (#151)

### DIFF
--- a/scripts/codex-mode.ps1
+++ b/scripts/codex-mode.ps1
@@ -12,6 +12,11 @@ param(
 
     [switch]$SkipUiStateRepair,
 
+    [switch]$DryRun,
+
+    [Alias('Apply')]
+    [switch]$ApplyWorkspaceRoots,
+
     [Alias('h')]
     [switch]$Help
 )
@@ -28,7 +33,9 @@ Usage:
   codex-mode.cmd history-status
   codex-mode.cmd history-custom
   codex-mode.cmd history-openai
-  codex-mode.cmd consolidate-official
+  codex-mode.cmd consolidate-official [-DryRun]
+  codex-mode.cmd repair-main [-DryRun]
+  codex-mode.cmd import-workspace-roots [-Apply]
 
 Single-history Codex mode switcher. It no longer copies sessions/state between
 mode-buckets. Normal switching rewrites config.toml and normalizes history
@@ -38,14 +45,19 @@ Modes:
   official             Switch live config to provider openai.
   proxy                Switch live config to provider custom through http://127.0.0.1:9099/v1.
   refresh              Refresh proxy model catalog only.
-  history-status       Count openai/custom provider labels in JSONL and state_5.sqlite.
+  history-status       Count openai/custom provider labels and report saved workspace roots separately.
   history-custom       Repair command: normalize live history labels openai -> custom.
   history-openai       Repair command: normalize live history labels custom -> openai.
   consolidate-official Restore the old official bucket as main line, then merge active-only tail.
+                       Saved workspace roots are preserved; -DryRun previews without writing.
+  repair-main          Alias for consolidate-official with the same saved-root policy.
+  import-workspace-roots
+                       Preview exact canonical/deduplicated source-only roots. Add -Apply only
+                       after reviewing the preview; applying creates a pre-write backup.
   status               Show active config, history summary, and proxy health.
 
 Safety:
-  Close Codex App before official/proxy/history/consolidate commands.
+  Close Codex App before official/proxy/history/consolidate/import-workspace-roots commands.
   -ForceCloseCodex is accepted for compatibility but intentionally ignored.
   Legacy mode-buckets are kept as backups and are not written by normal switching.
 '@ | Write-Host
@@ -613,7 +625,7 @@ function Invoke-ConsolidateOfficial {
     $stamp = Get-Date -Format 'yyyyMMddHHmmss'
     $backupRoot = Join-Path $ScriptDir "consolidate-official-$stamp"
     $targetProvider = Get-CurrentHistoryProvider
-    Invoke-Checked -FilePath 'python' -Arguments @(
+    $arguments = @(
         (Join-Path $ProxyDir 'history_consolidate.py'),
         'official-main',
         '--codex-dir',
@@ -625,7 +637,49 @@ function Invoke-ConsolidateOfficial {
         '--target-provider',
         $targetProvider
     )
-    Write-Host "Official bucket consolidated into active history using provider $targetProvider. Backup: $backupRoot"
+    if ($DryRun) {
+        $arguments += '--dry-run'
+    }
+    Invoke-Checked -FilePath 'python' -Arguments $arguments
+    if ($DryRun) {
+        Write-Host "Dry-run only; no active history or saved workspace roots were written."
+    }
+    else {
+        Write-Host "Official bucket consolidated into active history using provider $targetProvider. Backup: $backupRoot"
+    }
+}
+
+function Invoke-SavedWorkspaceRootImport {
+    Assert-CodexClosed
+
+    $sourceDir = Join-Path $CodexDir 'mode-buckets\official'
+    if (-not (Test-Path -LiteralPath $sourceDir)) {
+        throw "Official bucket not found: $sourceDir"
+    }
+
+    $stamp = Get-Date -Format 'yyyyMMddHHmmss'
+    $backupRoot = Join-Path $ScriptDir "import-workspace-roots-$stamp"
+    $arguments = @(
+        (Join-Path $ProxyDir 'history_consolidate.py'),
+        'import-saved-workspace-roots',
+        '--codex-dir',
+        $CodexDir,
+        '--source-dir',
+        $sourceDir,
+        '--backup-root',
+        $backupRoot,
+        '--preview'
+    )
+    if ($ApplyWorkspaceRoots) {
+        $arguments += '--apply'
+    }
+    Invoke-Checked -FilePath 'python' -Arguments $arguments
+    if ($ApplyWorkspaceRoots) {
+        Write-Host "Saved workspace roots imported after preview. Backup: $backupRoot"
+    }
+    else {
+        Write-Host 'Preview only; rerun with -Apply to import the displayed roots.'
+    }
 }
 
 function Show-ConfigSummary {
@@ -763,6 +817,7 @@ switch ($Mode) {
     'history-openai' { Invoke-HistoryOverlay -TargetProvider 'openai' }
     'consolidate-official' { Invoke-ConsolidateOfficial }
     'repair-main' { Invoke-ConsolidateOfficial }
+    'import-workspace-roots' { Invoke-SavedWorkspaceRootImport }
     default {
         Show-Usage
         throw "Unknown mode: $Mode"

--- a/src-python/history_consolidate.py
+++ b/src-python/history_consolidate.py
@@ -4,13 +4,15 @@ import argparse
 from collections import Counter
 from datetime import datetime, timezone
 import json
+import ntpath
 import os
+import posixpath
 from pathlib import Path
 import re
 import shutil
 import sqlite3
 import tempfile
-from typing import Any, Iterable
+from typing import Any
 
 from atomic_io import atomic_write_text
 
@@ -30,9 +32,9 @@ GLOBAL_STATE_THREAD_LIST_KEYS = (
     "pinned-thread-ids",
 )
 GLOBAL_STATE_LIST_UNION_KEYS = (
-    "electron-saved-workspace-roots",
     "project-order",
 )
+SAVED_WORKSPACE_ROOTS_KEY = "electron-saved-workspace-roots"
 ELECTRON_PERSISTED_THREAD_DICT_KEYS = (
     "heartbeat-thread-permissions-by-id",
 )
@@ -382,6 +384,101 @@ def merge_dict_missing(destination: dict[str, Any], source: dict[str, Any]) -> i
     return added
 
 
+def _uses_windows_path_semantics(value: str) -> bool:
+    return os.name == "nt" or bool(ntpath.splitdrive(value)[0]) or value.startswith(("\\\\", "//"))
+
+
+def canonicalize_workspace_root(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    if not value:
+        return None
+    if _uses_windows_path_semantics(value):
+        normalized = ntpath.normcase(ntpath.normpath(value.replace("/", "\\")))
+        return normalized.replace("\\", "/")
+    return posixpath.normpath(value)
+
+
+def canonicalize_workspace_roots(values: Any) -> list[str]:
+    if not isinstance(values, list):
+        return []
+    canonical: dict[str, str] = {}
+    for value in values:
+        normalized = canonicalize_workspace_root(value)
+        if normalized is not None:
+            canonical[normalized] = normalized
+    return [canonical[key] for key in sorted(canonical)]
+
+
+def _workspace_roots_from_state(state: dict[str, Any]) -> list[Any]:
+    values = state.get(SAVED_WORKSPACE_ROOTS_KEY)
+    return list(values) if isinstance(values, list) else []
+
+
+def preview_saved_workspace_roots(
+    active_state: dict[str, Any], source_state: dict[str, Any]
+) -> dict[str, Any]:
+    active_roots = _workspace_roots_from_state(active_state)
+    source_values = source_state.get(SAVED_WORKSPACE_ROOTS_KEY)
+    source_roots = canonicalize_workspace_roots(source_values)
+    active_keys = {
+        normalized
+        for value in active_roots
+        for normalized in [canonicalize_workspace_root(value)]
+        if normalized is not None
+    }
+    added_roots = [root for root in source_roots if root not in active_keys]
+    return {
+        "active_roots": active_roots,
+        "source_roots": source_roots,
+        "added_roots": added_roots,
+        "active_key_present": SAVED_WORKSPACE_ROOTS_KEY in active_state,
+        "source_key_present": SAVED_WORKSPACE_ROOTS_KEY in source_state,
+    }
+
+
+def _copy_owned_global_state(source: dict[str, Any], import_saved_workspace_roots: bool) -> dict[str, Any]:
+    copied: dict[str, Any] = {}
+    for key in GLOBAL_STATE_THREAD_DICT_KEYS:
+        if isinstance(source.get(key), dict):
+            copied[key] = source[key]
+    for key in GLOBAL_STATE_THREAD_LIST_KEYS + GLOBAL_STATE_LIST_UNION_KEYS:
+        if isinstance(source.get(key), list):
+            copied[key] = source[key]
+    if isinstance(source.get(REMOTE_AUTOCONNECT_KEY), dict):
+        copied[REMOTE_AUTOCONNECT_KEY] = source[REMOTE_AUTOCONNECT_KEY]
+
+    source_epa = source.get(ATOM_STATE_KEY)
+    if isinstance(source_epa, dict):
+        copied_epa: dict[str, Any] = {}
+        for key in ELECTRON_PERSISTED_THREAD_DICT_KEYS:
+            if isinstance(source_epa.get(key), dict):
+                copied_epa[key] = source_epa[key]
+        for key in ELECTRON_PERSISTED_LIST_KEYS:
+            if isinstance(source_epa.get(key), dict):
+                copied_epa[key] = source_epa[key]
+        if isinstance(source_epa.get(REMOTE_AUTOCONNECT_KEY), dict):
+            copied_epa[REMOTE_AUTOCONNECT_KEY] = source_epa[REMOTE_AUTOCONNECT_KEY]
+        if copied_epa:
+            copied[ATOM_STATE_KEY] = copied_epa
+
+    if import_saved_workspace_roots:
+        roots = canonicalize_workspace_roots(source.get(SAVED_WORKSPACE_ROOTS_KEY))
+        if roots:
+            copied[SAVED_WORKSPACE_ROOTS_KEY] = roots
+    return copied
+
+
+def _load_global_state(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    state = json.loads(path.read_text(encoding="utf-8-sig"))
+    if not isinstance(state, dict):
+        raise ValueError(f"global state must be an object: {path}")
+    return state
+
+
 def remove_remote_selection_values(container: dict[str, Any]) -> int:
     changed = 0
     for key in REMOTE_SELECTION_KEYS:
@@ -403,28 +500,44 @@ def sanitize_global_state_remote_selection(state: dict[str, Any]) -> int:
     return changed
 
 
-def merge_global_state(codex_dir: Path, source_dir: Path, backup_root: Path) -> dict[str, int | str]:
+def merge_global_state(
+    codex_dir: Path,
+    source_dir: Path,
+    backup_root: Path,
+    import_saved_workspace_roots: bool = False,
+) -> dict[str, Any]:
     source_path = source_dir / ".codex-global-state.json"
     active_path = codex_dir / ".codex-global-state.json"
     if not source_path.exists():
-        return {"skipped": "source-missing"}
+        preview = preview_saved_workspace_roots(_load_global_state(active_path), {})
+        preview["policy"] = "explicit-import" if import_saved_workspace_roots else "preserve-active"
+        preview["applied"] = False
+        return {"skipped": "source-missing", "saved_workspace_roots": preview}
+
+    source = _load_global_state(source_path)
+    preview = preview_saved_workspace_roots(_load_global_state(active_path), source)
+    preview["policy"] = "explicit-import" if import_saved_workspace_roots else "preserve-active"
+    preview["applied"] = False
     if not active_path.exists():
         active_path.parent.mkdir(parents=True, exist_ok=True)
-        source = json.loads(source_path.read_text(encoding="utf-8-sig"))
-        removed_remote_keys = sanitize_global_state_remote_selection(source) if isinstance(source, dict) else 0
+        removed_remote_keys = sanitize_global_state_remote_selection(source)
+        active = _copy_owned_global_state(source, import_saved_workspace_roots)
         atomic_write_text(
             active_path,
-            json.dumps(source, ensure_ascii=False, separators=(",", ":")) + "\n",
+            json.dumps(active, ensure_ascii=False, separators=(",", ":")) + "\n",
             encoding="utf-8",
         )
-        return {"copied": 1, "removed_remote_keys": removed_remote_keys}
+        preview["applied"] = import_saved_workspace_roots and bool(preview["added_roots"])
+        return {
+            "copied": 1,
+            "removed_remote_keys": removed_remote_keys,
+            "saved_workspace_roots": preview,
+        }
 
-    source = json.loads(source_path.read_text(encoding="utf-8-sig"))
-    active = json.loads(active_path.read_text(encoding="utf-8-sig"))
+    active = _load_global_state(active_path)
     changed = 0
     changed += sanitize_global_state_remote_selection(active)
-    if isinstance(source, dict):
-        sanitize_global_state_remote_selection(source)
+    sanitize_global_state_remote_selection(source)
 
     for key in GLOBAL_STATE_THREAD_DICT_KEYS:
         if isinstance(source.get(key), dict):
@@ -440,6 +553,13 @@ def merge_global_state(codex_dir: Path, source_dir: Path, backup_root: Path) -> 
             if new != old:
                 active[key] = new
                 changed += 1
+
+    if import_saved_workspace_roots and preview["added_roots"]:
+        old_roots = active.get(SAVED_WORKSPACE_ROOTS_KEY)
+        old_roots = list(old_roots) if isinstance(old_roots, list) else []
+        active[SAVED_WORKSPACE_ROOTS_KEY] = old_roots + preview["added_roots"]
+        changed += 1
+        preview["applied"] = True
 
     source_epa = source.get("electron-persisted-atom-state")
     active_epa = active.get("electron-persisted-atom-state")
@@ -475,7 +595,56 @@ def merge_global_state(codex_dir: Path, source_dir: Path, backup_root: Path) -> 
             json.dumps(active, ensure_ascii=False, separators=(",", ":")) + "\n",
             encoding="utf-8",
         )
-    return {"changed_fields": changed}
+    return {"changed_fields": changed, "saved_workspace_roots": preview}
+
+
+def import_saved_workspace_roots(
+    codex_dir: Path, source_dir: Path, backup_root: Path, apply: bool = False
+) -> dict[str, Any]:
+    active_path = codex_dir / ".codex-global-state.json"
+    source_path = source_dir / ".codex-global-state.json"
+    active = _load_global_state(active_path)
+    source = _load_global_state(source_path)
+    preview = preview_saved_workspace_roots(active, source)
+    result: dict[str, Any] = {
+        "preview": preview,
+        "applied": False,
+        "backup_root": str(backup_root),
+        "backup_created": False,
+    }
+    if not apply or not preview["added_roots"]:
+        return result
+
+    backup_root.mkdir(parents=True, exist_ok=True)
+    atomic_write_text(
+        backup_root / "meta.json",
+        json.dumps(
+            {
+                "created_at": utc_now_iso(),
+                "codex_dir": str(codex_dir),
+                "source_dir": str(source_dir),
+                "operation": "import-saved-workspace-roots",
+            },
+            indent=2,
+            ensure_ascii=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    if active_path.exists():
+        backup_file(active_path, codex_dir, backup_root, "active-before")
+        result["backup_created"] = True
+
+    updated = dict(active)
+    updated[SAVED_WORKSPACE_ROOTS_KEY] = preview["active_roots"] + preview["added_roots"]
+    active_path.parent.mkdir(parents=True, exist_ok=True)
+    atomic_write_text(
+        active_path,
+        json.dumps(updated, ensure_ascii=False, separators=(",", ":")) + "\n",
+        encoding="utf-8",
+    )
+    result["applied"] = True
+    return result
 
 
 def provider_counts_from_jsonl(codex_dir: Path) -> Counter[str]:
@@ -508,18 +677,50 @@ def provider_counts_from_state(codex_dir: Path) -> list[dict[str, Any]]:
 
 
 def status(codex_dir: Path) -> dict[str, Any]:
+    state = _load_global_state(codex_dir / ".codex-global-state.json")
+    saved_workspace_roots = preview_saved_workspace_roots(state, {})
+    saved_workspace_roots["canonical_active_roots"] = canonicalize_workspace_roots(
+        saved_workspace_roots["active_roots"]
+    )
     return {
         "codex_dir": str(codex_dir),
         "jsonl": dict(provider_counts_from_jsonl(codex_dir)),
         "state": provider_counts_from_state(codex_dir),
+        "saved_workspace_roots": saved_workspace_roots,
     }
 
 
-def official_main(codex_dir: Path, source_dir: Path, backup_root: Path, target_provider: str) -> dict[str, Any]:
+def official_main(
+    codex_dir: Path,
+    source_dir: Path,
+    backup_root: Path,
+    target_provider: str,
+    dry_run: bool = False,
+) -> dict[str, Any]:
     if target_provider not in PROVIDER_VALUES:
         raise ValueError(f"unsupported target provider: {target_provider}")
     if not source_dir.exists():
         raise FileNotFoundError(source_dir)
+
+    if dry_run:
+        with tempfile.TemporaryDirectory(prefix="history-consolidate-dry-run-") as temp_dir:
+            simulation_root = Path(temp_dir)
+            simulated_active = simulation_root / "active"
+            simulated_source = simulation_root / "source"
+            if codex_dir.exists():
+                shutil.copytree(codex_dir, simulated_active)
+            else:
+                simulated_active.mkdir(parents=True)
+            shutil.copytree(source_dir, simulated_source)
+            result = official_main(
+                simulated_active,
+                simulated_source,
+                simulation_root / "backup",
+                target_provider,
+            )
+        result["dry_run"] = True
+        result["backup_root"] = str(backup_root)
+        return result
 
     backup_root.mkdir(parents=True, exist_ok=True)
     meta = {
@@ -556,21 +757,69 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Consolidate Codex single-history provider buckets.")
     subparsers = parser.add_subparsers(dest="command", required=True)
 
-    status_parser = subparsers.add_parser("status")
+    status_parser = subparsers.add_parser(
+        "status", help="Report history/provider counts and saved workspace roots separately."
+    )
     status_parser.add_argument("--codex-dir", required=True, type=Path)
 
-    official_parser = subparsers.add_parser("official-main")
+    official_parser = subparsers.add_parser(
+        "official-main", help="Consolidate history without importing saved workspace roots."
+    )
     official_parser.add_argument("--codex-dir", required=True, type=Path)
     official_parser.add_argument("--source-dir", required=True, type=Path)
     official_parser.add_argument("--backup-root", required=True, type=Path)
     official_parser.add_argument("--target-provider", required=True, choices=sorted(PROVIDER_VALUES))
+    official_parser.add_argument(
+        "--dry-run", action="store_true", help="Preview history changes without writing active state."
+    )
+
+    import_parser = subparsers.add_parser(
+        "import-saved-workspace-roots",
+        help="Preview exact canonical saved-workspace additions; use --apply only after reviewing them.",
+    )
+    import_parser.add_argument("--codex-dir", required=True, type=Path)
+    import_parser.add_argument("--source-dir", required=True, type=Path)
+    import_parser.add_argument("--backup-root", required=True, type=Path)
+    import_parser.add_argument(
+        "--preview",
+        action="store_true",
+        required=True,
+        help="Required preview gate; exact additions are printed before any --apply write.",
+    )
+    import_parser.add_argument(
+        "--apply", action="store_true", help="Apply the reviewed additions and create a pre-write backup."
+    )
 
     args = parser.parse_args(argv)
     if args.command == "status":
         print_result(status(args.codex_dir))
         return 0
     if args.command == "official-main":
-        print_result(official_main(args.codex_dir, args.source_dir, args.backup_root, args.target_provider))
+        print_result(
+            official_main(
+                args.codex_dir,
+                args.source_dir,
+                args.backup_root,
+                args.target_provider,
+                dry_run=args.dry_run,
+            )
+        )
+        return 0
+    if args.command == "import-saved-workspace-roots":
+        preview = preview_saved_workspace_roots(
+            _load_global_state(args.codex_dir / ".codex-global-state.json"),
+            _load_global_state(args.source_dir / ".codex-global-state.json"),
+        )
+        print_result({"dry_run": True, "saved_workspace_roots": preview})
+        if args.apply:
+            print_result(
+                import_saved_workspace_roots(
+                    args.codex_dir,
+                    args.source_dir,
+                    args.backup_root,
+                    apply=True,
+                )
+            )
         return 0
     raise ValueError(args.command)
 

--- a/src-python/history_consolidate.py
+++ b/src-python/history_consolidate.py
@@ -438,36 +438,29 @@ def preview_saved_workspace_roots(
     }
 
 
-def _copy_owned_global_state(source: dict[str, Any], import_saved_workspace_roots: bool) -> dict[str, Any]:
-    copied: dict[str, Any] = {}
-    for key in GLOBAL_STATE_THREAD_DICT_KEYS:
-        if isinstance(source.get(key), dict):
-            copied[key] = source[key]
-    for key in GLOBAL_STATE_THREAD_LIST_KEYS + GLOBAL_STATE_LIST_UNION_KEYS:
-        if isinstance(source.get(key), list):
-            copied[key] = source[key]
-    if isinstance(source.get(REMOTE_AUTOCONNECT_KEY), dict):
-        copied[REMOTE_AUTOCONNECT_KEY] = source[REMOTE_AUTOCONNECT_KEY]
-
-    source_epa = source.get(ATOM_STATE_KEY)
-    if isinstance(source_epa, dict):
-        copied_epa: dict[str, Any] = {}
-        for key in ELECTRON_PERSISTED_THREAD_DICT_KEYS:
-            if isinstance(source_epa.get(key), dict):
-                copied_epa[key] = source_epa[key]
-        for key in ELECTRON_PERSISTED_LIST_KEYS:
-            if isinstance(source_epa.get(key), dict):
-                copied_epa[key] = source_epa[key]
-        if isinstance(source_epa.get(REMOTE_AUTOCONNECT_KEY), dict):
-            copied_epa[REMOTE_AUTOCONNECT_KEY] = source_epa[REMOTE_AUTOCONNECT_KEY]
-        if copied_epa:
-            copied[ATOM_STATE_KEY] = copied_epa
-
+def _copy_global_state_for_active(source: dict[str, Any], import_saved_workspace_roots: bool) -> dict[str, Any]:
+    copied = dict(source)
     if import_saved_workspace_roots:
         roots = canonicalize_workspace_roots(source.get(SAVED_WORKSPACE_ROOTS_KEY))
         if roots:
             copied[SAVED_WORKSPACE_ROOTS_KEY] = roots
+        else:
+            copied.pop(SAVED_WORKSPACE_ROOTS_KEY, None)
+    else:
+        copied.pop(SAVED_WORKSPACE_ROOTS_KEY, None)
     return copied
+
+
+def _copy_dry_run_inputs(source_dir: Path, destination_dir: Path) -> None:
+    destination_dir.mkdir(parents=True, exist_ok=True)
+    for name in SESSION_DIR_NAMES:
+        source_path = source_dir / name
+        if source_path.is_dir():
+            shutil.copytree(source_path, destination_dir / name)
+    for name in (".codex-global-state.json", STATE_DB_FILENAME):
+        source_path = source_dir / name
+        if source_path.is_file():
+            shutil.copy2(source_path, destination_dir / name)
 
 
 def _load_global_state(path: Path) -> dict[str, Any]:
@@ -521,7 +514,7 @@ def merge_global_state(
     if not active_path.exists():
         active_path.parent.mkdir(parents=True, exist_ok=True)
         removed_remote_keys = sanitize_global_state_remote_selection(source)
-        active = _copy_owned_global_state(source, import_saved_workspace_roots)
+        active = _copy_global_state_for_active(source, import_saved_workspace_roots)
         atomic_write_text(
             active_path,
             json.dumps(active, ensure_ascii=False, separators=(",", ":")) + "\n",
@@ -707,11 +700,8 @@ def official_main(
             simulation_root = Path(temp_dir)
             simulated_active = simulation_root / "active"
             simulated_source = simulation_root / "source"
-            if codex_dir.exists():
-                shutil.copytree(codex_dir, simulated_active)
-            else:
-                simulated_active.mkdir(parents=True)
-            shutil.copytree(source_dir, simulated_source)
+            _copy_dry_run_inputs(codex_dir, simulated_active)
+            _copy_dry_run_inputs(source_dir, simulated_source)
             result = official_main(
                 simulated_active,
                 simulated_source,

--- a/src-python/history_consolidate.py
+++ b/src-python/history_consolidate.py
@@ -438,16 +438,9 @@ def preview_saved_workspace_roots(
     }
 
 
-def _copy_global_state_for_active(source: dict[str, Any], import_saved_workspace_roots: bool) -> dict[str, Any]:
+def _copy_global_state_for_active(source: dict[str, Any]) -> dict[str, Any]:
     copied = dict(source)
-    if import_saved_workspace_roots:
-        roots = canonicalize_workspace_roots(source.get(SAVED_WORKSPACE_ROOTS_KEY))
-        if roots:
-            copied[SAVED_WORKSPACE_ROOTS_KEY] = roots
-        else:
-            copied.pop(SAVED_WORKSPACE_ROOTS_KEY, None)
-    else:
-        copied.pop(SAVED_WORKSPACE_ROOTS_KEY, None)
+    copied.pop(SAVED_WORKSPACE_ROOTS_KEY, None)
     return copied
 
 
@@ -461,6 +454,22 @@ def _copy_dry_run_inputs(source_dir: Path, destination_dir: Path) -> None:
         source_path = source_dir / name
         if source_path.is_file():
             shutil.copy2(source_path, destination_dir / name)
+
+    source_db_paths = sqlite_db_paths(source_dir)
+    for index, source_db_path in enumerate(source_db_paths[1:], start=1):
+        local_home = destination_dir / ".dry-run-sqlite-home" / str(index)
+        local_home.mkdir(parents=True, exist_ok=True)
+        local_db_path = local_home / STATE_DB_FILENAME
+        for suffix in ("", "-wal", "-shm"):
+            source_path = source_db_path.with_name(source_db_path.name + suffix)
+            if source_path.is_file():
+                shutil.copy2(source_path, local_db_path.with_name(local_db_path.name + suffix))
+    if len(source_db_paths) > 1:
+        sqlite_home = destination_dir / ".dry-run-sqlite-home" / "1"
+        (destination_dir / "config.toml").write_text(
+            f"sqlite_home = '{sqlite_home.as_posix()}'\n",
+            encoding="utf-8",
+        )
 
 
 def _load_global_state(path: Path) -> dict[str, Any]:
@@ -497,30 +506,28 @@ def merge_global_state(
     codex_dir: Path,
     source_dir: Path,
     backup_root: Path,
-    import_saved_workspace_roots: bool = False,
 ) -> dict[str, Any]:
     source_path = source_dir / ".codex-global-state.json"
     active_path = codex_dir / ".codex-global-state.json"
     if not source_path.exists():
         preview = preview_saved_workspace_roots(_load_global_state(active_path), {})
-        preview["policy"] = "explicit-import" if import_saved_workspace_roots else "preserve-active"
+        preview["policy"] = "preserve-active"
         preview["applied"] = False
         return {"skipped": "source-missing", "saved_workspace_roots": preview}
 
     source = _load_global_state(source_path)
     preview = preview_saved_workspace_roots(_load_global_state(active_path), source)
-    preview["policy"] = "explicit-import" if import_saved_workspace_roots else "preserve-active"
+    preview["policy"] = "preserve-active"
     preview["applied"] = False
     if not active_path.exists():
         active_path.parent.mkdir(parents=True, exist_ok=True)
         removed_remote_keys = sanitize_global_state_remote_selection(source)
-        active = _copy_global_state_for_active(source, import_saved_workspace_roots)
+        active = _copy_global_state_for_active(source)
         atomic_write_text(
             active_path,
             json.dumps(active, ensure_ascii=False, separators=(",", ":")) + "\n",
             encoding="utf-8",
         )
-        preview["applied"] = import_saved_workspace_roots and bool(preview["added_roots"])
         return {
             "copied": 1,
             "removed_remote_keys": removed_remote_keys,
@@ -546,13 +553,6 @@ def merge_global_state(
             if new != old:
                 active[key] = new
                 changed += 1
-
-    if import_saved_workspace_roots and preview["added_roots"]:
-        old_roots = active.get(SAVED_WORKSPACE_ROOTS_KEY)
-        old_roots = list(old_roots) if isinstance(old_roots, list) else []
-        active[SAVED_WORKSPACE_ROOTS_KEY] = old_roots + preview["added_roots"]
-        changed += 1
-        preview["applied"] = True
 
     source_epa = source.get("electron-persisted-atom-state")
     active_epa = active.get("electron-persisted-atom-state")

--- a/tests/test_history_consolidate.py
+++ b/tests/test_history_consolidate.py
@@ -288,8 +288,6 @@ class HistoryConsolidateTests(unittest.TestCase):
                         "selected-remote-host-id": "remote-ssh-discovered:am01s",
                         "remote-connection-auto-connect-by-host-id": {"remote-ssh-discovered:am01s": True},
                         "electron-saved-workspace-roots": ["C:/stale/project"],
-                        "skills": {"must-not-copy": True},
-                        "plugin-cache": {"must-not-copy": True},
                         "electron-persisted-atom-state": {
                             "selected-remote-host-id": "remote-ssh-discovered:am01s",
                             "remote-connection-auto-connect-by-host-id": {"remote-ssh-discovered:am01s": True},
@@ -298,6 +296,10 @@ class HistoryConsolidateTests(unittest.TestCase):
                 ),
                 encoding="utf-8",
             )
+            (official / "skills").mkdir()
+            (official / "skills" / "must-not-copy.md").write_text("skill data", encoding="utf-8")
+            (official / "plugins").mkdir()
+            (official / "plugins" / "must-not-copy.json").write_text("plugin data", encoding="utf-8")
 
             result = merge_global_state(active, official, root / "backup")
 
@@ -305,11 +307,11 @@ class HistoryConsolidateTests(unittest.TestCase):
             state = json.loads((active / ".codex-global-state.json").read_text(encoding="utf-8"))
             self.assertNotIn("selected-remote-host-id", state)
             self.assertNotIn("electron-saved-workspace-roots", state)
-            self.assertNotIn("skills", state)
-            self.assertNotIn("plugin-cache", state)
             self.assertEqual(state["remote-connection-auto-connect-by-host-id"], {})
             self.assertNotIn("selected-remote-host-id", state["electron-persisted-atom-state"])
             self.assertEqual(state["electron-persisted-atom-state"]["remote-connection-auto-connect-by-host-id"], {})
+            self.assertFalse((active / "skills").exists())
+            self.assertFalse((active / "plugins").exists())
             self.assertEqual(lock_path.read_text(encoding="ascii"), "codexhub-atomic-lock=1\n")
 
 

--- a/tests/test_history_consolidate.py
+++ b/tests/test_history_consolidate.py
@@ -6,7 +6,14 @@ import tempfile
 from pathlib import Path
 import unittest
 
-from history_consolidate import merge_global_state, official_main
+from history_consolidate import (
+    canonicalize_workspace_root,
+    import_saved_workspace_roots,
+    merge_global_state,
+    official_main,
+    preview_saved_workspace_roots,
+    status,
+)
 from lock_fixtures import write_dead_legacy_lock
 
 
@@ -77,6 +84,106 @@ class HistoryConsolidateTests(unittest.TestCase):
             self.assertEqual(state["electron-saved-workspace-roots"], ["C:/active/project"])
             self.assertEqual(state["project-order"], ["active-project", "official-project"])
 
+    def test_explicit_workspace_root_import_previews_canonical_deduplicated_additions_and_backups(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            active = root / ".codex"
+            official = root / "official"
+            active.mkdir(parents=True)
+            official.mkdir(parents=True)
+            active_roots = [r"C:\Users\Noir\Project", "C:/active/second"]
+            source_roots = [
+                r"c:\users\noir\project\.",
+                "C:/source/z/.",
+                "c:/source/A",
+                "C:/source/a/",
+                "C:/source/z",
+            ]
+            active_state = {"electron-saved-workspace-roots": active_roots, "project-order": ["active"]}
+            source_state = {"electron-saved-workspace-roots": source_roots, "project-order": ["official"]}
+            active_state_path = active / ".codex-global-state.json"
+            active_state_path.write_text(json.dumps(active_state), encoding="utf-8")
+            (official / ".codex-global-state.json").write_text(json.dumps(source_state), encoding="utf-8")
+
+            preview = preview_saved_workspace_roots(active_state, source_state)
+            expected_added = sorted(
+                {
+                    canonicalize_workspace_root(value)
+                    for value in source_roots
+                    if canonicalize_workspace_root(value) is not None
+                }
+                - {
+                    canonicalize_workspace_root(value)
+                    for value in active_roots
+                    if canonicalize_workspace_root(value) is not None
+                }
+            )
+            self.assertEqual(preview["active_roots"], active_roots)
+            self.assertEqual(preview["added_roots"], expected_added)
+
+            backup = root / "backup"
+            preview_result = import_saved_workspace_roots(active, official, backup)
+            self.assertFalse(preview_result["applied"])
+            self.assertFalse(backup.exists())
+
+            applied = import_saved_workspace_roots(active, official, backup, apply=True)
+            self.assertTrue(applied["applied"])
+            self.assertTrue(applied["backup_created"])
+            state = json.loads(active_state_path.read_text(encoding="utf-8"))
+            self.assertEqual(state["electron-saved-workspace-roots"], active_roots + expected_added)
+            backup_state = json.loads(
+                (backup / "active-before" / ".codex-global-state.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(backup_state, active_state)
+
+    def test_workspace_root_import_ignores_source_without_workspace_key_and_status_reports_active_roots(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            active = root / ".codex"
+            official = root / "official"
+            active.mkdir(parents=True)
+            official.mkdir(parents=True)
+            active_roots = ["C:/active/project"]
+            (active / ".codex-global-state.json").write_text(
+                json.dumps({"electron-saved-workspace-roots": active_roots}), encoding="utf-8"
+            )
+            (official / ".codex-global-state.json").write_text(
+                json.dumps({"project-order": ["official"]}), encoding="utf-8"
+            )
+
+            result = import_saved_workspace_roots(active, official, root / "backup", apply=True)
+
+            self.assertEqual(result["preview"]["added_roots"], [])
+            self.assertFalse(result["preview"]["source_key_present"])
+            self.assertEqual(
+                json.loads((active / ".codex-global-state.json").read_text(encoding="utf-8"))[
+                    "electron-saved-workspace-roots"
+                ],
+                active_roots,
+            )
+            self.assertFalse((root / "backup").exists())
+            self.assertEqual(status(active)["saved_workspace_roots"]["active_roots"], active_roots)
+
+    def test_official_main_dry_run_reports_saved_root_policy_without_writing(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            active = root / ".codex"
+            official = root / "official"
+            active.mkdir(parents=True)
+            official.mkdir(parents=True)
+            active_state = {"electron-saved-workspace-roots": ["C:/active/project"]}
+            source_state = {"electron-saved-workspace-roots": ["C:/official/project"]}
+            active_state_path = active / ".codex-global-state.json"
+            active_state_path.write_text(json.dumps(active_state), encoding="utf-8")
+            (official / ".codex-global-state.json").write_text(json.dumps(source_state), encoding="utf-8")
+
+            result = official_main(active, official, root / "backup", "custom", dry_run=True)
+
+            self.assertTrue(result["dry_run"])
+            self.assertFalse(result["global_state"]["saved_workspace_roots"]["applied"])
+            self.assertEqual(json.loads(active_state_path.read_text(encoding="utf-8")), active_state)
+            self.assertFalse((root / "backup").exists())
+
     def test_official_main_merges_source_branch_then_active_tail_and_normalizes_provider(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
@@ -95,11 +202,14 @@ class HistoryConsolidateTests(unittest.TestCase):
             active_state = {
                 "thread-workspace-root-hints": {"thread-c": "C:/active"},
                 "projectless-thread-ids": ["thread-c"],
+                "electron-saved-workspace-roots": ["C:/active/project"],
             }
             official_state = {
                 "thread-workspace-root-hints": {"thread-a": "C:/official", "thread-b": "C:/official"},
                 "projectless-thread-ids": ["thread-b"],
                 "selected-remote-host-id": "remote-ssh-discovered:am01s",
+                "electron-saved-workspace-roots": ["C:/official/stale-project"],
+                "skills": {"must-not-copy": True},
             }
             (active / ".codex-global-state.json").write_text(json.dumps(active_state), encoding="utf-8")
             (official / ".codex-global-state.json").write_text(json.dumps(official_state), encoding="utf-8")
@@ -124,8 +234,15 @@ class HistoryConsolidateTests(unittest.TestCase):
 
             state = json.loads((active / ".codex-global-state.json").read_text(encoding="utf-8"))
             self.assertEqual(state["thread-workspace-root-hints"]["thread-b"], "C:/official")
+            self.assertEqual(state["electron-saved-workspace-roots"], ["C:/active/project"])
+            self.assertNotIn("skills", state)
             self.assertNotIn("selected-remote-host-id", state)
             self.assertTrue((root / "backup" / "active-before").exists())
+            self.assertFalse(result["global_state"]["saved_workspace_roots"]["applied"])
+            self.assertEqual(
+                result["global_state"]["saved_workspace_roots"]["added_roots"],
+                ["c:/official/stale-project"],
+            )
 
     def test_official_main_inserts_source_threads_when_state_schema_order_differs(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -170,6 +287,9 @@ class HistoryConsolidateTests(unittest.TestCase):
                     {
                         "selected-remote-host-id": "remote-ssh-discovered:am01s",
                         "remote-connection-auto-connect-by-host-id": {"remote-ssh-discovered:am01s": True},
+                        "electron-saved-workspace-roots": ["C:/stale/project"],
+                        "skills": {"must-not-copy": True},
+                        "plugin-cache": {"must-not-copy": True},
                         "electron-persisted-atom-state": {
                             "selected-remote-host-id": "remote-ssh-discovered:am01s",
                             "remote-connection-auto-connect-by-host-id": {"remote-ssh-discovered:am01s": True},
@@ -184,6 +304,9 @@ class HistoryConsolidateTests(unittest.TestCase):
             self.assertEqual(result["copied"], 1)
             state = json.loads((active / ".codex-global-state.json").read_text(encoding="utf-8"))
             self.assertNotIn("selected-remote-host-id", state)
+            self.assertNotIn("electron-saved-workspace-roots", state)
+            self.assertNotIn("skills", state)
+            self.assertNotIn("plugin-cache", state)
             self.assertEqual(state["remote-connection-auto-connect-by-host-id"], {})
             self.assertNotIn("selected-remote-host-id", state["electron-persisted-atom-state"])
             self.assertEqual(state["electron-persisted-atom-state"]["remote-connection-auto-connect-by-host-id"], {})

--- a/tests/test_history_consolidate.py
+++ b/tests/test_history_consolidate.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import json
+import os
 import sqlite3
 import tempfile
 from pathlib import Path
 import unittest
+from unittest import mock
 
 from history_consolidate import (
     canonicalize_workspace_root,
@@ -182,6 +184,67 @@ class HistoryConsolidateTests(unittest.TestCase):
             self.assertTrue(result["dry_run"])
             self.assertFalse(result["global_state"]["saved_workspace_roots"]["applied"])
             self.assertEqual(json.loads(active_state_path.read_text(encoding="utf-8")), active_state)
+            self.assertFalse((root / "backup").exists())
+
+    def test_official_main_dry_run_does_not_write_external_env_sqlite_home(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            active = root / "active"
+            official = root / "official"
+            external = root / "external-sqlite"
+            active.mkdir(parents=True)
+            official.mkdir(parents=True)
+            external.mkdir(parents=True)
+            create_state(active / "state_5.sqlite", [("active", "custom", "active")])
+            create_state(official / "state_5.sqlite", [("source", "openai", "source")])
+            external_db = external / "state_5.sqlite"
+            create_state(external_db, [("external", "openai", "external")])
+            before = external_db.read_bytes()
+            before_sidecars = {
+                path.name: path.read_bytes()
+                for path in external.glob("state_5.sqlite-*")
+                if path.is_file()
+            }
+
+            with mock.patch.dict(os.environ, {"CODEX_SQLITE_HOME": str(external)}):
+                result = official_main(active, official, root / "backup", "custom", dry_run=True)
+
+            self.assertTrue(result["dry_run"])
+            self.assertEqual(external_db.read_bytes(), before)
+            self.assertEqual(
+                {
+                    path.name: path.read_bytes()
+                    for path in external.glob("state_5.sqlite-*")
+                    if path.is_file()
+                },
+                before_sidecars,
+            )
+            self.assertNotIn(str(external), json.dumps(result))
+            self.assertTrue(all(".dry-run-sqlite-home" in item["path"] for item in result["state"][1:]))
+            self.assertFalse((root / "backup").exists())
+
+    def test_official_main_dry_run_previews_source_sqlite_home_config_inside_simulation(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            active = root / "active"
+            official = root / "official"
+            source_sqlite_home = official / "sqlite-home"
+            active.mkdir(parents=True)
+            official.mkdir(parents=True)
+            source_sqlite_home.mkdir(parents=True)
+            create_state(active / "state_5.sqlite", [("active", "custom", "active")])
+            create_state(official / "state_5.sqlite", [("source", "openai", "source")])
+            create_state(source_sqlite_home / "state_5.sqlite", [("source-home", "openai", "source-home")])
+            config = f"sqlite_home = '{source_sqlite_home.as_posix()}'\n"
+            (active / "config.toml").write_text(config, encoding="utf-8")
+            (official / "config.toml").write_text(config, encoding="utf-8")
+
+            result = official_main(active, official, root / "backup", "custom", dry_run=True)
+
+            self.assertEqual(len(result["state"]), 2)
+            self.assertIn(".dry-run-sqlite-home", result["state"][1]["path"])
+            self.assertTrue(result["state"][1]["path"].endswith("state_5.sqlite"))
+            self.assertNotIn(str(source_sqlite_home), json.dumps(result))
             self.assertFalse((root / "backup").exists())
 
     def test_official_main_merges_source_branch_then_active_tail_and_normalizes_provider(self):

--- a/tests/test_history_consolidate.py
+++ b/tests/test_history_consolidate.py
@@ -42,6 +42,41 @@ def create_state_with_columns(path: Path, columns: list[str], rows: list[tuple[o
 
 
 class HistoryConsolidateTests(unittest.TestCase):
+    def test_default_global_merge_preserves_saved_workspace_roots_without_importing_source_roots(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            active = root / ".codex"
+            official = root / "official"
+            active.mkdir(parents=True)
+            official.mkdir(parents=True)
+            (active / ".codex-global-state.json").write_text(
+                json.dumps(
+                    {
+                        "electron-saved-workspace-roots": ["C:/active/project"],
+                        "project-order": ["active-project"],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (official / ".codex-global-state.json").write_text(
+                json.dumps(
+                    {
+                        "electron-saved-workspace-roots": [
+                            "C:/official/stale-project",
+                            "C:/active/project",
+                        ],
+                        "project-order": ["official-project"],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            merge_global_state(active, official, root / "backup")
+
+            state = json.loads((active / ".codex-global-state.json").read_text(encoding="utf-8"))
+            self.assertEqual(state["electron-saved-workspace-roots"], ["C:/active/project"])
+            self.assertEqual(state["project-order"], ["active-project", "official-project"])
+
     def test_official_main_merges_source_branch_then_active_tail_and_normalizes_provider(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)


### PR DESCRIPTION
## Scope

Closes #151 by separating Codex Desktop saved workspace roots from conversation/history consolidation.

- Removed `electron-saved-workspace-roots` from the default global-state list union. `official-main` and the `repair-main` wrapper path now preserve active roots without importing, removing, reordering, or unioning them.
- Added explicit `import-saved-workspace-roots --preview [--apply]` support with Windows path canonicalization, case/spelling deduplication, deterministic ordering, exact added-root preview, and pre-write backup.
- Added `status` and `official-main --dry-run` reporting that keeps saved-workspace entries separate from history/thread results. The dry-run copies only history-consolidation inputs, not unrelated directories.
- Added `codex-mode.ps1 import-workspace-roots -Apply` help and routing.
- Preserved unrelated global-state keys while ensuring the default path drops only the saved-root key when creating a missing active state; skills/plugins are not traversed or copied.

Changed paths are entirely within the Issue hotset:

- `src-python/history_consolidate.py`
- `tests/test_history_consolidate.py`
- `scripts/codex-mode.ps1`

## Verification

- `python -m pytest -q tests/test_history_consolidate.py` - 7 passed
- `python -m pytest -q` - 1274 passed, 1 skipped, 327 subtests passed
- `git diff --check` - passed
- `python scripts/report_quality_gates.py` - exit 0, report-only; parse_errors 0 and only existing repository-wide baseline findings
- `python -m py_compile src-python/history_consolidate.py` - passed
- PowerShell command help - passed

## Manual Windows fixture evidence

Executed from this worktree with one active root, multiple source-only roots, duplicate/case/spelling variants, and active/source thread history fixtures.

1. Default `official-main` output reported `applied: false`; the active root remained `C:/active/project`; source-only roots were not imported; thread markers were `common, official-main, active-tail` and SQLite threads were `thread-a/custom` and `thread-b/custom`.
2. Preview output listed exact canonical additions: `c:/source/a`, `c:/source/z`.
3. `import-saved-workspace-roots --preview --apply` reported `backup_created: true`.
4. Post-apply assertions confirmed roots were `[C:/active/project, c:/source/a, c:/source/z]`, the backup matched the post-default state, and thread/history markers and SQLite rows were unchanged after import.

Commits: recovery scaffold `599bc89`, implementation `1b6255a`, final dry-run/input-scope fix `0a9c851`.
