### PR TITLE
Fix #143: cancel active Gateway work on lifecycle stop

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -597,6 +597,9 @@ export default function App() {
 
   const startAppUpdateInstall = useCallback(
     async (source: "settings" | "toast" = "settings") => {
+      if (!window.confirm(t("runtime.gatewayRetirementWarning"))) {
+        return;
+      }
       const toastId = updateAvailableToastId.current;
       if (toastId) {
         dismissToast(toastId);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -933,8 +933,11 @@ export default function App() {
   const runRuntimeAction = useCallback(async (
     label: string,
     action: () => Promise<AppStatus>,
-    options?: { toast?: boolean },
+    options?: { toast?: boolean; warnBeforeGatewayRetirement?: boolean },
   ) => {
+    if (options?.warnBeforeGatewayRetirement && !window.confirm(t("runtime.gatewayRetirementWarning"))) {
+      return;
+    }
     setBusy(label);
     const toastId =
       options?.toast === false
@@ -975,6 +978,9 @@ export default function App() {
     setBusy("settings");
     try {
       const restartGateway = shouldRestartGateway(settings, next, gatewayStatus);
+      if (restartGateway && !window.confirm(t("runtime.gatewayRetirementWarning"))) {
+        return t("runtime.gatewayRetirementCancelled");
+      }
       if (settings && next.auto_start_software !== settings.auto_start_software) {
         if (next.auto_start_software) {
           await api.setAutostart(true);
@@ -1035,13 +1041,16 @@ export default function App() {
   const openSettings = useCallback(() => setSettingsOpen(true), []);
   const closeSettings = useCallback(() => setSettingsOpen(false), []);
   const startProxy = useCallback(() => runRuntimeAction("start", api.startProxy), [runRuntimeAction]);
-  const stopProxy = useCallback(() => runRuntimeAction("stop", api.stopProxy), [runRuntimeAction]);
+  const stopProxy = useCallback(
+    () => runRuntimeAction("stop", api.stopProxy, { warnBeforeGatewayRetirement: true }),
+    [runRuntimeAction],
+  );
   const startProxyQuiet = useCallback(
     () => runRuntimeAction("start", api.startProxy, { toast: false }),
     [runRuntimeAction],
   );
   const stopProxyQuiet = useCallback(
-    () => runRuntimeAction("stop", api.stopProxy, { toast: false }),
+    () => runRuntimeAction("stop", api.stopProxy, { toast: false, warnBeforeGatewayRetirement: true }),
     [runRuntimeAction],
   );
   const updateProvidersCache = useCallback(

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -60,6 +60,8 @@ const enUS = {
     closeToTray: "Close to tray",
     debugDiagnostics: "Debug diagnostics",
     gatewayHint: "Gateway is the local OpenAI-compatible server in front of Hub",
+    gatewayRetirementWarning: "Active Codex Tasks may be interrupted. Continue?",
+    gatewayRetirementCancelled: "Gateway action cancelled before interrupting active Codex Tasks.",
     maximizeOrRestore: "Maximize or restore",
     minimize: "Minimize",
     proxyRunning: "Proxy running",

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -60,6 +60,8 @@ const zhCN = {
     closeToTray: "最小化到托盘",
     debugDiagnostics: "调试诊断",
     gatewayHint: "Gateway 是 Hub 前面的本地 OpenAI 兼容服务",
+    gatewayRetirementWarning: "活跃的 Codex 任务可能会被中断。是否继续？",
+    gatewayRetirementCancelled: "Gateway 操作已取消，活跃的 Codex 任务未被中断。",
     maximizeOrRestore: "最大化或还原",
     minimize: "最小化",
     proxyRunning: "代理运行中",

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -738,6 +738,164 @@ PROXY_TEXT_LOG_PATH = RUNTIME_PROXY_DIR / "codex-proxy.log"
 GATEWAY_EVENT_QUEUE_MAX_RECORDS = _env_positive_int("CODEX_GATEWAY_EVENT_QUEUE_MAX_RECORDS", 4096)
 GATEWAY_EVENT_QUEUE_MAX_BYTES = _env_positive_int("CODEX_GATEWAY_EVENT_QUEUE_MAX_BYTES", 4 * 1024 * 1024)
 GATEWAY_EVENT_WRITER_SHUTDOWN_TIMEOUT_SECONDS = 5.0
+GATEWAY_USER_REQUESTED_SHUTDOWN_BUDGET_SECONDS = 2.0
+USER_REQUESTED_SHUTDOWN_OUTCOME = "user_requested_shutdown"
+
+
+class GatewayUserRequestedShutdown(RuntimeError):
+    """Raised in a request worker after the local Gateway begins retirement."""
+
+
+class GatewayRequestAdmission:
+    """One admitted Gateway request and the upstream transport it may cancel."""
+
+    def __init__(self) -> None:
+        self._cancelled = threading.Event()
+        self._lock = threading.Lock()
+        self._upstream_transport: Any | None = None
+
+    @property
+    def cancelled(self) -> bool:
+        return self._cancelled.is_set()
+
+    def attach_upstream_transport(self, transport: Any) -> None:
+        with self._lock:
+            self._upstream_transport = transport
+            cancelled = self._cancelled.is_set()
+        if cancelled:
+            self._close_upstream_transport(transport)
+
+    def cancel(self) -> None:
+        self._cancelled.set()
+        with self._lock:
+            transport = self._upstream_transport
+        if transport is not None:
+            self._close_upstream_transport(transport)
+
+    def raise_if_cancelled(self) -> None:
+        if self.cancelled:
+            raise GatewayUserRequestedShutdown(USER_REQUESTED_SHUTDOWN_OUTCOME)
+
+    @staticmethod
+    def _close_upstream_transport(transport: Any) -> None:
+        close = getattr(transport, "close", None)
+        if callable(close):
+            try:
+                close()
+            except Exception:
+                pass
+
+
+class GatewayShutdownController:
+    """Authenticated local control-plane state for Gateway retirement."""
+
+    def __init__(
+        self,
+        *,
+        clock: Callable[[], float] = time.monotonic,
+        shutdown_budget_seconds: float = GATEWAY_USER_REQUESTED_SHUTDOWN_BUDGET_SECONDS,
+    ) -> None:
+        self._clock = clock
+        self._shutdown_budget_seconds = max(0.0, shutdown_budget_seconds)
+        self._lock = threading.Lock()
+        self._admission_open = True
+        self._shutdown_started_at: float | None = None
+        self._active: set[GatewayRequestAdmission] = set()
+        self._active_drained = threading.Event()
+        self._active_drained.set()
+
+    def admit(self) -> GatewayRequestAdmission | None:
+        with self._lock:
+            if not self._admission_open:
+                return None
+            admission = GatewayRequestAdmission()
+            self._active.add(admission)
+            self._active_drained.clear()
+            return admission
+
+    def complete(self, admission: GatewayRequestAdmission) -> None:
+        with self._lock:
+            self._active.discard(admission)
+            if not self._active:
+                self._active_drained.set()
+
+    def close_admission(self) -> int:
+        with self._lock:
+            self._admission_open = False
+            if self._shutdown_started_at is None:
+                self._shutdown_started_at = self._clock()
+            active = tuple(self._active)
+        for admission in active:
+            admission.cancel()
+        return len(active)
+
+    def remaining_shutdown_budget_seconds(self) -> float:
+        with self._lock:
+            started_at = self._shutdown_started_at
+        if started_at is None:
+            return self._shutdown_budget_seconds
+        return max(0.0, self._shutdown_budget_seconds - (self._clock() - started_at))
+
+    def wait_for_active_requests(self) -> bool:
+        return self._active_drained.wait(timeout=self.remaining_shutdown_budget_seconds())
+
+
+GATEWAY_SHUTDOWN_CONTROLLER = GatewayShutdownController()
+_GATEWAY_REQUEST_ADMISSION = threading.local()
+
+
+def _gateway_shutdown_controller_for_handler(handler: Any) -> GatewayShutdownController:
+    server = getattr(handler, "server", None)
+    controller = getattr(server, "gateway_shutdown_controller", None)
+    return controller if isinstance(controller, GatewayShutdownController) else GATEWAY_SHUTDOWN_CONTROLLER
+
+
+def _activate_gateway_request(admission: GatewayRequestAdmission) -> GatewayRequestAdmission | None:
+    previous = getattr(_GATEWAY_REQUEST_ADMISSION, "current", None)
+    _GATEWAY_REQUEST_ADMISSION.current = admission
+    return previous if isinstance(previous, GatewayRequestAdmission) else None
+
+
+def _restore_gateway_request(previous: GatewayRequestAdmission | None) -> None:
+    if previous is None:
+        try:
+            del _GATEWAY_REQUEST_ADMISSION.current
+        except AttributeError:
+            pass
+        return
+    _GATEWAY_REQUEST_ADMISSION.current = previous
+
+
+def _active_gateway_request() -> GatewayRequestAdmission | None:
+    current = getattr(_GATEWAY_REQUEST_ADMISSION, "current", None)
+    return current if isinstance(current, GatewayRequestAdmission) else None
+
+
+def user_requested_shutdown_payload(inbound_format: str) -> dict[str, Any]:
+    message = "Gateway stopped because the user requested shutdown."
+    codexhub_error = _codexhub_error_payload(
+        source="gateway",
+        message=message,
+        status=503,
+        error=USER_REQUESTED_SHUTDOWN_OUTCOME,
+        error_type=USER_REQUESTED_SHUTDOWN_OUTCOME,
+        failure_class=RETRY_FAILURE_PERMANENT,
+    )
+    if inbound_format == "chat_completions":
+        return {
+            "error": {
+                "message": message,
+                "type": USER_REQUESTED_SHUTDOWN_OUTCOME,
+                "code": USER_REQUESTED_SHUTDOWN_OUTCOME,
+                "status": 503,
+            },
+            "codexhub_error": codexhub_error,
+        }
+    return {
+        "error": USER_REQUESTED_SHUTDOWN_OUTCOME,
+        "detail": message,
+        "codexhub_error": codexhub_error,
+    }
 
 
 def _gateway_event_writer_recovery_record(
@@ -12283,7 +12441,15 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 self._send_json(401, _local_gateway_auth_error_payload())
                 self.close_connection = True
                 return
-            self._send_json(200, {"ok": True, "message": "shutdown scheduled"})
+            controller = _gateway_shutdown_controller_for_handler(self)
+            controller.close_admission()
+            self._send_json(
+                200,
+                {
+                    "ok": True,
+                    "outcome": USER_REQUESTED_SHUTDOWN_OUTCOME,
+                },
+            )
             self.close_connection = True
             threading.Thread(target=self.server.shutdown, daemon=True).start()
             return

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -776,6 +776,9 @@ class GatewayRequestAdmission:
         if self.cancelled:
             raise GatewayUserRequestedShutdown(USER_REQUESTED_SHUTDOWN_OUTCOME)
 
+    def wait_for_cancellation(self, timeout: float) -> bool:
+        return self._cancelled.wait(timeout=max(0.0, timeout))
+
     @staticmethod
     def _close_upstream_transport(transport: Any) -> None:
         close = getattr(transport, "close", None)
@@ -836,6 +839,11 @@ class GatewayShutdownController:
             return self._shutdown_budget_seconds
         return max(0.0, self._shutdown_budget_seconds - (self._clock() - started_at))
 
+    @property
+    def shutdown_requested(self) -> bool:
+        with self._lock:
+            return self._shutdown_started_at is not None
+
     def wait_for_active_requests(self) -> bool:
         return self._active_drained.wait(timeout=self.remaining_shutdown_budget_seconds())
 
@@ -871,6 +879,15 @@ def _active_gateway_request() -> GatewayRequestAdmission | None:
     return current if isinstance(current, GatewayRequestAdmission) else None
 
 
+def _sleep_for_retry_with_gateway_cancellation(delay_seconds: float) -> None:
+    admission = _active_gateway_request()
+    if admission is None:
+        time.sleep(delay_seconds)
+        return
+    if admission.wait_for_cancellation(delay_seconds):
+        admission.raise_if_cancelled()
+
+
 def user_requested_shutdown_payload(inbound_format: str) -> dict[str, Any]:
     message = "Gateway stopped because the user requested shutdown."
     codexhub_error = _codexhub_error_payload(
@@ -892,10 +909,21 @@ def user_requested_shutdown_payload(inbound_format: str) -> dict[str, Any]:
             "codexhub_error": codexhub_error,
         }
     return {
+        "type": USER_REQUESTED_SHUTDOWN_OUTCOME,
         "error": USER_REQUESTED_SHUTDOWN_OUTCOME,
         "detail": message,
         "codexhub_error": codexhub_error,
     }
+
+
+def _record_user_requested_shutdown() -> None:
+    write_proxy_event(
+        "request_cancelled",
+        shutdown_outcome=USER_REQUESTED_SHUTDOWN_OUTCOME,
+        status=503,
+        error=USER_REQUESTED_SHUTDOWN_OUTCOME,
+        detail="Gateway shutdown requested by user",
+    )
 
 
 def _gateway_event_writer_recovery_record(
@@ -11822,6 +11850,8 @@ def _typed_error_code(
 ) -> str:
     if error_type == "gateway_auth_error":
         return "gateway.auth"
+    if error_type == USER_REQUESTED_SHUTDOWN_OUTCOME:
+        return "gateway.user_requested_shutdown"
     if error_type in {"invalid_request_error", "validation_error"}:
         return "provider.request"
     if error_code in {"UpstreamProtocolError", "upstream_stream_incomplete", "upstream_stream_idle_timeout"}:
@@ -12243,6 +12273,9 @@ def _open_upstream_response(
     diagnostic_model = _diagnostic_context_value(event_context, "model")
     attempt = 1
     while True:
+        admission = _active_gateway_request()
+        if admission is not None:
+            admission.raise_if_cancelled()
         attempt_started_at = time.monotonic()
         try:
             response = _open_upstream_once(
@@ -12250,6 +12283,9 @@ def _open_upstream_response(
                 upstream_name=upstream_name,
                 timeout=timeout,
             )
+            if admission is not None:
+                admission.attach_upstream_transport(response)
+                admission.raise_if_cancelled()
             elapsed_ms = int(max(0.0, time.monotonic() - attempt_started_at) * 1000)
             connection_disposition = _diagnostic_connection_disposition(response)
             # A returned response proves this Gateway attempt reached response
@@ -12288,6 +12324,8 @@ def _open_upstream_response(
             )
             return response
         except (HTTPError, IncompleteRead, OSError, URLError) as exc:
+            if admission is not None:
+                admission.raise_if_cancelled()
             elapsed_ms = int(max(0.0, time.monotonic() - attempt_started_at) * 1000)
             connection_disposition = _diagnostic_error_connection_disposition(exc)
             try:
@@ -12373,7 +12411,7 @@ def _open_upstream_response(
                         failure_class=failure_class,
                 )
             )
-            time.sleep(delay_seconds)
+            _sleep_for_retry_with_gateway_cancellation(delay_seconds)
             attempt += 1
 
 
@@ -12502,6 +12540,16 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
             self._send_json(401, _local_gateway_auth_error_payload())
             self.close_connection = True
             return
+        shutdown_controller = _gateway_shutdown_controller_for_handler(self)
+        admission = shutdown_controller.admit()
+        if admission is None:
+            _record_user_requested_shutdown()
+            self._send_user_requested_shutdown_outcome(
+                inbound_format=inbound_format,
+                downstream_sse_started=False,
+            )
+            return
+        previous_admission = _activate_gateway_request(admission)
         request_kind = RETRY_REQUEST_MAIN_GENERATION
         proxy_request_context = _event_context_with_request_kind(request_context, request_kind)
         raw_provider_probe = raw_provider_probe_requested(self.headers, self.path)
@@ -12525,7 +12573,15 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
         request_start_written = False
         write_request_start_once: Callable[[Mapping[str, Any]], None] | None = None
 
+        def send_user_requested_shutdown() -> None:
+            _record_user_requested_shutdown()
+            self._send_user_requested_shutdown_outcome(
+                inbound_format=inbound_format,
+                downstream_sse_started=downstream_sse_started,
+            )
+
         try:
+            admission.raise_if_cancelled()
             content_length = int(self.headers.get("Content-Length", "0"))
             if content_length < 0:
                 raise ValueError("Content-Length must be non-negative")
@@ -13088,6 +13144,9 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                             LifecycleEmptyFinalResponseError,
                             LifecycleFinalFormatResponseError,
                         ) as exc:
+                            active_request = _active_gateway_request()
+                            if active_request is not None:
+                                active_request.raise_if_cancelled()
                             lifecycle_retry = isinstance(
                                 exc,
                                 (LifecycleEmptyFinalResponseError, LifecycleFinalFormatResponseError),
@@ -13165,7 +13224,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                                     failure_phase="stream_body" if stream_failure else None,
                                 )
                             )
-                            time.sleep(delay_seconds)
+                            _sleep_for_retry_with_gateway_cancellation(delay_seconds)
                             relay_attempt += 1
                             continue
                         relay_attempt += 1
@@ -13227,7 +13286,12 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 **usage_capture,
                 **proxy_request_context,
             )
+        except GatewayUserRequestedShutdown:
+            send_user_requested_shutdown()
         except CompactEmptyResponseError as exc:
+            if admission.cancelled:
+                send_user_requested_shutdown()
+                return
             detail = safe_upstream_error_detail(exc)
             write_proxy_event(
                 "request_error",
@@ -13266,6 +13330,9 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 error_type="compact_empty_response",
             )
         except (LifecycleEmptyFinalResponseError, LifecycleFinalFormatResponseError) as exc:
+            if admission.cancelled:
+                send_user_requested_shutdown()
+                return
             detail = safe_upstream_error_detail(exc)
             error_code = (
                 "lifecycle_empty_final_response"
@@ -13308,6 +13375,9 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 error_type=error_code,
             )
         except ImageProxyError as exc:
+            if admission.cancelled:
+                send_user_requested_shutdown()
+                return
             if not request_start_written and callable(write_request_start_once):
                 fallback_request_observability = {
                     **caller_request_observability,
@@ -13351,6 +13421,9 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 error_type="image_proxy_error",
             )
         except UpstreamProtocolTranslationError as exc:
+            if admission.cancelled:
+                send_user_requested_shutdown()
+                return
             detail = str(exc)
             error_code = exc.cause.code
             is_apply_patch_adapter_error = error_code == APPLY_PATCH_ADAPTER_ERROR_CODE
@@ -13430,6 +13503,9 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 error_type=json_error_type,
             )
         except ValueError as exc:
+            if admission.cancelled:
+                send_user_requested_shutdown()
+                return
             write_proxy_event(
                 "request_error",
                 request_id=request_id,
@@ -13457,6 +13533,9 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 error_type="invalid_request_error",
             )
         except HTTPError as exc:
+            if admission.cancelled:
+                send_user_requested_shutdown()
+                return
             if downstream_sse_started:
                 self._write_downstream_sse_error(
                     inbound_format=inbound_format,
@@ -13528,6 +13607,9 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 **proxy_request_context,
             )
         except IncompleteRead as exc:
+            if admission.cancelled:
+                send_user_requested_shutdown()
+                return
             detail = safe_upstream_error_detail(exc)
             write_proxy_event(
                 "request_error",
@@ -13559,6 +13641,9 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 detail=detail,
             )
         except (OSError, URLError) as exc:
+            if admission.cancelled:
+                send_user_requested_shutdown()
+                return
             detail = safe_upstream_error_detail(exc)
             write_proxy_event(
                 "request_error",
@@ -13590,6 +13675,9 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 detail=detail,
             )
         except Exception as exc:
+            if admission.cancelled:
+                send_user_requested_shutdown()
+                return
             detail = safe_upstream_error_detail(exc)
             logger.exception("unexpected proxy error request_id=%s", request_id)
             write_proxy_event(
@@ -13621,6 +13709,9 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 exc=exc,
                 detail=detail,
             )
+        finally:
+            _restore_gateway_request(previous_admission)
+            shutdown_controller.complete(admission)
 
     def _send_local_responses_no_content(self) -> None:
         request_id = uuid.uuid4().hex[:12]
@@ -13896,6 +13987,30 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
             )
             self._safe_send_json(502, {"error": type(exc).__name__, "detail": detail}, request_id)
 
+    def _send_user_requested_shutdown_outcome(
+        self,
+        *,
+        inbound_format: str,
+        downstream_sse_started: bool,
+    ) -> None:
+        payload = user_requested_shutdown_payload(inbound_format)
+        try:
+            if downstream_sse_started:
+                if inbound_format == "chat_completions":
+                    self.wfile.write(
+                        b"data: "
+                        + json.dumps(payload, ensure_ascii=True, separators=(",", ":")).encode("utf-8")
+                        + b"\n\n"
+                    )
+                    self.wfile.flush()
+                else:
+                    self._write_sse_event("error", payload)
+            else:
+                self._send_json(503, payload)
+        except OSError:
+            pass
+        self.close_connection = True
+
     def _send_json(self, status: int, payload: dict[str, Any]) -> None:
         body = _json_response_bytes(payload)
         self.send_response(status)
@@ -13937,6 +14052,12 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
         line_resets_idle_timeout: Callable[[bytes], bool] | None = None,
         on_line: Callable[[bytes], None] | None = None,
     ) -> Any:
+        admission = _active_gateway_request()
+
+        def raise_if_shutdown_requested() -> None:
+            if admission is not None:
+                admission.raise_if_cancelled()
+
         def observe_line(line: bytes) -> None:
             if not line or on_line is None:
                 return
@@ -13950,8 +14071,14 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
         model_event_timeout_seconds = model_event_sse_idle_timeout_seconds()
         transport_idle_guard_enabled = transport_timeout_seconds > 0
         model_event_idle_guard_enabled = model_event_timeout_seconds > 0 and line_resets_idle_timeout is not None
-        if keepalive_interval <= 0 and not transport_idle_guard_enabled and not model_event_idle_guard_enabled:
+        if (
+            admission is None
+            and keepalive_interval <= 0
+            and not transport_idle_guard_enabled
+            and not model_event_idle_guard_enabled
+        ):
             while True:
+                raise_if_shutdown_requested()
                 line = response.readline()
                 observe_line(line)
                 yield line
@@ -13989,6 +14116,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
             raise UpstreamStreamIdleTimeoutError(timeout_seconds, phase=phase)
 
         while True:
+            raise_if_shutdown_requested()
             now = time.monotonic()
             timeout_seconds: float | None = None
             if keepalive_interval > 0:
@@ -14011,6 +14139,12 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                     if timeout_seconds is None
                     else max(0.001, min(timeout_seconds, remaining_idle))
                 )
+            if admission is not None:
+                timeout_seconds = (
+                    0.1
+                    if timeout_seconds is None
+                    else max(0.001, min(timeout_seconds, 0.1))
+                )
 
             try:
                 if timeout_seconds is None:
@@ -14018,6 +14152,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 else:
                     kind, value = lines.get(timeout=timeout_seconds)
             except queue.Empty:
+                raise_if_shutdown_requested()
                 now = time.monotonic()
                 if transport_idle_guard_enabled and (now - last_transport_at) >= transport_timeout_seconds:
                     raise_idle_timeout(transport_timeout_seconds, "transport")
@@ -14028,6 +14163,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                     last_keepalive_at = time.monotonic()
                 continue
             if kind == "error":
+                raise_if_shutdown_requested()
                 raise value
             if isinstance(value, bytes) and value:
                 now = time.monotonic()
@@ -16129,18 +16265,38 @@ def run_server(host: str, port: int) -> None:
         force=True,
     )
     server = ThreadingHTTPServer((host, port), CodexProxyHandler)
+    server.daemon_threads = True
+    shutdown_controller = GatewayShutdownController()
+    server.gateway_shutdown_controller = shutdown_controller
     logger.info("serving Codex proxy on %s:%s", host, port)
     try:
         server.serve_forever()
     finally:
+        server.server_close()
+        if shutdown_controller.shutdown_requested:
+            shutdown_controller.wait_for_active_requests()
+            flush_timeout = min(
+                GATEWAY_EVENT_WRITER_SHUTDOWN_TIMEOUT_SECONDS,
+                shutdown_controller.remaining_shutdown_budget_seconds(),
+            )
+        else:
+            flush_timeout = GATEWAY_EVENT_WRITER_SHUTDOWN_TIMEOUT_SECONDS
         writer_result = GATEWAY_EVENT_WRITER.shutdown(
-            timeout=GATEWAY_EVENT_WRITER_SHUTDOWN_TIMEOUT_SECONDS,
+            timeout=flush_timeout,
         )
         if not writer_result.completed:
             logger.warning("Gateway event writer shutdown ended with %s", writer_result.outcome)
         try:
             diagnostic_shutdown = getattr(GATEWAY_DIAGNOSTIC_RECORDER, "shutdown", None)
-            if callable(diagnostic_shutdown) and not diagnostic_shutdown(GATEWAY_EVENT_WRITER_SHUTDOWN_TIMEOUT_SECONDS):
+            diagnostic_timeout = (
+                min(
+                    GATEWAY_EVENT_WRITER_SHUTDOWN_TIMEOUT_SECONDS,
+                    shutdown_controller.remaining_shutdown_budget_seconds(),
+                )
+                if shutdown_controller.shutdown_requested
+                else GATEWAY_EVENT_WRITER_SHUTDOWN_TIMEOUT_SECONDS
+            )
+            if callable(diagnostic_shutdown) and not diagnostic_shutdown(diagnostic_timeout):
                 logger.warning("Gateway diagnostic recorder shutdown did not drain")
         except Exception:
             logger.warning("Gateway diagnostic recorder shutdown failed")

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -755,13 +755,13 @@ fn run_tray_action(app: &AppHandle, id: &str) {
             );
         }
         TRAY_START_GATEWAY => {
-            run_tray_lifecycle_action(app, "Start Gateway", start_proxy);
+            run_tray_lifecycle_action(app, "Start Gateway", start_proxy, false);
         }
         TRAY_STOP_GATEWAY => {
-            run_tray_lifecycle_action(app, "Stop Gateway", stop_proxy);
+            run_tray_lifecycle_action(app, "Stop Gateway", stop_proxy, true);
         }
         TRAY_RESTART_GATEWAY => {
-            run_tray_lifecycle_action(app, "Restart Gateway", restart_proxy);
+            run_tray_lifecycle_action(app, "Restart Gateway", restart_proxy, true);
         }
         TRAY_EXIT => app.exit(0),
         _ => {}
@@ -777,9 +777,15 @@ fn run_tray_lifecycle_action(
     app: &AppHandle,
     action: &'static str,
     work: fn() -> Result<AppStatus, String>,
+    retires_gateway: bool,
 ) {
     let toast_id = next_tray_toast_id();
-    emit_tray_toast(app, tray_loading_toast(toast_id.clone(), action));
+    let loading_toast = if retires_gateway {
+        tray_retiring_gateway_loading_toast(toast_id.clone(), action)
+    } else {
+        tray_loading_toast(toast_id.clone(), action)
+    };
+    emit_tray_toast(app, loading_toast);
     let app = app.clone();
     std::mem::drop(tauri::async_runtime::spawn_blocking(move || {
         let result = work();
@@ -797,6 +803,14 @@ fn tray_loading_toast(id: String, action: &str) -> TrayToast {
     TrayToast {
         id,
         text: format!("{action}..."),
+        tone: "loading".to_string(),
+    }
+}
+
+fn tray_retiring_gateway_loading_toast(id: String, action: &str) -> TrayToast {
+    TrayToast {
+        id,
+        text: format!("{action}: active Codex Tasks may be interrupted. {action}..."),
         tone: "loading".to_string(),
     }
 }
@@ -1112,7 +1126,10 @@ fn main() {
 
 #[cfg(test)]
 mod tests {
-    use super::{start_gateway_after_startup, tray_loading_toast, tray_toast_for, AppStatus};
+    use super::{
+        start_gateway_after_startup, tray_loading_toast, tray_retiring_gateway_loading_toast,
+        tray_toast_for, AppStatus,
+    };
     use std::cell::Cell;
 
     #[test]
@@ -1133,6 +1150,11 @@ mod tests {
         let loading = tray_loading_toast("same-toast".to_string(), "Start Gateway");
         assert_eq!(loading.id, "same-toast");
         assert_eq!(loading.tone, "loading");
+
+        let retiring = tray_retiring_gateway_loading_toast("same-toast".to_string(), "Stop Gateway");
+        assert_eq!(retiring.id, loading.id);
+        assert_eq!(retiring.tone, "loading");
+        assert!(retiring.text.contains("active Codex Tasks may be interrupted"));
 
         let success = tray_toast_for("same-toast".to_string(), "Start Gateway", Ok(status()));
         assert_eq!(success.id, loading.id);

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -808,10 +808,21 @@ fn tray_loading_toast(id: String, action: &str) -> TrayToast {
 }
 
 fn tray_retiring_gateway_loading_toast(id: String, action: &str) -> TrayToast {
+    let locale = config::get_settings()
+        .map(|settings| settings.locale)
+        .unwrap_or_default();
     TrayToast {
         id,
-        text: format!("{action}: active Codex Tasks may be interrupted. {action}..."),
+        text: format!("{} {action}...", gateway_retirement_warning_for_locale(&locale)),
         tone: "loading".to_string(),
+    }
+}
+
+fn gateway_retirement_warning_for_locale(locale: &str) -> &'static str {
+    if locale == "zh-CN" {
+        "活跃的 Codex 任务可能会被中断。"
+    } else {
+        "Active Codex Tasks may be interrupted."
     }
 }
 
@@ -1127,8 +1138,8 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::{
-        start_gateway_after_startup, tray_loading_toast, tray_retiring_gateway_loading_toast,
-        tray_toast_for, AppStatus,
+        gateway_retirement_warning_for_locale, start_gateway_after_startup, tray_loading_toast,
+        tray_retiring_gateway_loading_toast, tray_toast_for, AppStatus,
     };
     use std::cell::Cell;
 
@@ -1154,7 +1165,10 @@ mod tests {
         let retiring = tray_retiring_gateway_loading_toast("same-toast".to_string(), "Stop Gateway");
         assert_eq!(retiring.id, loading.id);
         assert_eq!(retiring.tone, "loading");
-        assert!(retiring.text.contains("active Codex Tasks may be interrupted"));
+        assert_eq!(
+            gateway_retirement_warning_for_locale("zh-CN"),
+            "活跃的 Codex 任务可能会被中断。"
+        );
 
         let success = tray_toast_for("same-toast".to_string(), "Start Gateway", Ok(status()));
         assert_eq!(success.id, loading.id);

--- a/src-tauri/src/proxy.rs
+++ b/src-tauri/src/proxy.rs
@@ -94,7 +94,9 @@ where
 }
 
 pub fn stop() -> Result<AppStatus, String> {
-    let backend = ProxyLifecycleBackend::runtime()?;
+    let backend = ProxyLifecycleBackend::runtime_with_session_owned_identity(
+        gateway_lifecycle().session_owned_identity(),
+    )?;
     gateway_lifecycle().stop(&backend)
 }
 
@@ -102,7 +104,9 @@ pub fn restart_after<Prepare>(prepare: Prepare) -> Result<AppStatus, String>
 where
     Prepare: FnOnce() -> Result<(), String>,
 {
-    let backend = ProxyLifecycleBackend::runtime()?;
+    let backend = ProxyLifecycleBackend::runtime_with_session_owned_identity(
+        gateway_lifecycle().session_owned_identity(),
+    )?;
     gateway_lifecycle()
         .restart(&backend, prepare)
         .map(|snapshot| snapshot.status)
@@ -185,14 +189,22 @@ impl ProxyPaths {
 struct ProxyLifecycleBackend {
     paths: ProxyPaths,
     lifecycle_gate_path: PathBuf,
+    session_owned_identity: Option<GatewayIdentity>,
 }
 
 impl ProxyLifecycleBackend {
     fn runtime() -> Result<Self, String> {
+        Self::runtime_with_session_owned_identity(None)
+    }
+
+    fn runtime_with_session_owned_identity(
+        session_owned_identity: Option<GatewayIdentity>,
+    ) -> Result<Self, String> {
         let paths = ProxyPaths::runtime()?;
         Ok(Self {
             lifecycle_gate_path: paths.lifecycle_gate_path(),
             paths,
+            session_owned_identity,
         })
     }
 }
@@ -240,7 +252,7 @@ impl GatewayLifecycleBackend for ProxyLifecycleBackend {
     }
 
     fn stop(&self) -> Result<AppStatus, String> {
-        stop_with_paths(&self.paths)
+        stop_session_owned_with_paths(&self.paths, self.session_owned_identity.as_ref())
     }
 
     fn can_reuse(&self, snapshot: &GatewayLifecycleSnapshot) -> bool {
@@ -1087,6 +1099,337 @@ fn clean_up_failed_start(
         inspector,
         &SystemChildTerminator,
     )
+}
+
+const USER_REQUESTED_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
+const USER_REQUESTED_SHUTDOWN_POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+trait ShutdownClock {
+    fn elapsed(&self) -> Duration;
+    fn sleep(&self, duration: Duration);
+}
+
+struct SystemShutdownClock {
+    started_at: Instant,
+}
+
+impl SystemShutdownClock {
+    fn new() -> Self {
+        Self {
+            started_at: Instant::now(),
+        }
+    }
+}
+
+impl ShutdownClock for SystemShutdownClock {
+    fn elapsed(&self) -> Duration {
+        self.started_at.elapsed()
+    }
+
+    fn sleep(&self, duration: Duration) {
+        if !duration.is_zero() {
+            thread::sleep(duration);
+        }
+    }
+}
+
+struct ShutdownBudget<'a> {
+    clock: &'a dyn ShutdownClock,
+}
+
+impl<'a> ShutdownBudget<'a> {
+    fn new(clock: &'a dyn ShutdownClock) -> Self {
+        Self { clock }
+    }
+
+    fn remaining(&self) -> Duration {
+        USER_REQUESTED_SHUTDOWN_TIMEOUT.saturating_sub(self.clock.elapsed())
+    }
+
+    fn cap(&self, maximum: Duration) -> Duration {
+        self.remaining().min(maximum)
+    }
+
+    fn sleep_to_next_poll(&self) -> bool {
+        let wait = self.remaining().min(USER_REQUESTED_SHUTDOWN_POLL_INTERVAL);
+        if wait.is_zero() {
+            return false;
+        }
+        self.clock.sleep(wait);
+        true
+    }
+}
+
+fn stop_session_owned_with_paths(
+    paths: &ProxyPaths,
+    session_owned_identity: Option<&GatewayIdentity>,
+) -> Result<AppStatus, String> {
+    let clock = SystemShutdownClock::new();
+    stop_session_owned_with_paths_and_controls(
+        paths,
+        session_owned_identity,
+        &SystemProcessKiller,
+        &SystemProcessInspector,
+        &SystemListenerInspector,
+        &request_shutdown_with_timeout,
+        &health_with_timeout,
+        &clock,
+    )
+}
+
+fn stop_session_owned_with_paths_and_controls(
+    paths: &ProxyPaths,
+    session_owned_identity: Option<&GatewayIdentity>,
+    killer: &dyn ProcessKiller,
+    inspector: &dyn ProcessInspector,
+    listener_inspector: &dyn ListenerInspector,
+    shutdown_request: &dyn Fn(u16, &str, Duration) -> Result<(), String>,
+    health_probe: &dyn Fn(u16, Duration) -> Result<Option<HealthResponse>, String>,
+    clock: &dyn ShutdownClock,
+) -> Result<AppStatus, String> {
+    let budget = ShutdownBudget::new(clock);
+    let settings = read_settings(paths)?;
+    let mode = read_mode(paths)?;
+    let pid_record = read_pid_record(paths)?;
+    let lifecycle_port = pid_record
+        .as_ref()
+        .map(|record| record.expected_port(settings.proxy_port))
+        .unwrap_or(settings.proxy_port);
+    let was_running = gateway_running_with_budget(lifecycle_port, health_probe, &budget)?;
+
+    let Some(pid_record) = pid_record else {
+        if was_running {
+            return Err(format!(
+                "Gateway health responds on port {lifecycle_port}, but no managed PID identity exists; refusing to send shutdown to the external listener"
+            ));
+        }
+        return stopped_gateway_status(mode, lifecycle_port, "Gateway is not running".to_string());
+    };
+
+    match verify_proxy_process(&pid_record, paths, lifecycle_port, inspector)? {
+        VerifiedProxyProcess::Missing { pid } => {
+            remove_pid(paths)?;
+            return stopped_gateway_status(
+                mode,
+                lifecycle_port,
+                format!("Removed stale Gateway PID {pid}; user-requested shutdown found no live process"),
+            );
+        }
+        VerifiedProxyProcess::Mismatch { pid, reason } => {
+            remove_pid(paths)?;
+            return Err(format!(
+                "Gateway user-requested shutdown refused because managed PID {pid} ownership could not be verified ({reason}); removed stale identity"
+            ));
+        }
+        VerifiedProxyProcess::Unknown { pid, reason } => {
+            return Err(format!(
+                "Gateway user-requested shutdown could not inspect managed PID {pid} ({reason}); preserved durable ownership"
+            ));
+        }
+        VerifiedProxyProcess::Verified { pid } if was_running => {
+            verify_listener_owner(pid, lifecycle_port, listener_inspector, "before shutdown")?;
+            let timeout = budget.cap(SHUTDOWN_TIMEOUT);
+            if !timeout.is_zero() {
+                let _ = shutdown_request(lifecycle_port, &settings.gateway_client_key, timeout);
+            }
+        }
+        VerifiedProxyProcess::Verified { .. } => {}
+    }
+
+    let listener_stopped = if was_running {
+        wait_for_listener_stop_with_budget(lifecycle_port, health_probe, &budget)?
+    } else {
+        true
+    };
+    let process_stopped = if listener_stopped {
+        wait_for_managed_process_stop_with_budget(
+            &pid_record,
+            paths,
+            lifecycle_port,
+            inspector,
+            &budget,
+        )?
+    } else {
+        false
+    };
+
+    if process_stopped {
+        remove_pid(paths)?;
+        return stopped_gateway_status(
+            mode,
+            lifecycle_port,
+            "Gateway stopped gracefully after user-requested shutdown".to_string(),
+        );
+    }
+
+    let pid = force_kill_session_owned_gateway_at_deadline(
+        paths,
+        &pid_record,
+        session_owned_identity,
+        lifecycle_port,
+        killer,
+        inspector,
+        listener_inspector,
+    )?;
+    log::warn!(
+        "Gateway user_requested_shutdown force-close issued for the current-session PID {pid}"
+    );
+
+    match verify_proxy_process(&pid_record, paths, lifecycle_port, inspector)? {
+        VerifiedProxyProcess::Missing { .. } => {}
+        VerifiedProxyProcess::Verified { pid } => {
+            return Err(format!(
+                "Gateway user-requested shutdown force-close reached its two-second budget, but PID {pid} is still running"
+            ));
+        }
+        VerifiedProxyProcess::Mismatch { pid, reason } => {
+            return Err(format!(
+                "Gateway PID {pid} changed identity after user-requested force-close ({reason}); preserved durable ownership"
+            ));
+        }
+        VerifiedProxyProcess::Unknown { pid, reason } => {
+            return Err(format!(
+                "Gateway PID {pid} could not be inspected after user-requested force-close ({reason}); preserved durable ownership"
+            ));
+        }
+    }
+    remove_pid(paths)?;
+    stopped_gateway_status(
+        mode,
+        lifecycle_port,
+        format!("Gateway PID {pid} stopped after user-requested shutdown"),
+    )
+}
+
+fn stopped_gateway_status(mode: String, port: u16, message: String) -> Result<AppStatus, String> {
+    Ok(AppStatus {
+        mode,
+        proxy_running: false,
+        proxy_port: port,
+        proxy_build: None,
+        message,
+        gateway_lifecycle: GatewayLifecyclePhase::Stopped,
+        history_sync_status: None,
+        history_sync_message: None,
+    })
+}
+
+fn gateway_running_with_budget(
+    port: u16,
+    health_probe: &dyn Fn(u16, Duration) -> Result<Option<HealthResponse>, String>,
+    budget: &ShutdownBudget<'_>,
+) -> Result<bool, String> {
+    let timeout = budget.cap(HEALTH_TIMEOUT);
+    if timeout.is_zero() {
+        return Ok(false);
+    }
+    Ok(health_probe(port, timeout)?
+        .as_ref()
+        .map(HealthResponse::is_running)
+        .unwrap_or(false))
+}
+
+fn wait_for_listener_stop_with_budget(
+    port: u16,
+    health_probe: &dyn Fn(u16, Duration) -> Result<Option<HealthResponse>, String>,
+    budget: &ShutdownBudget<'_>,
+) -> Result<bool, String> {
+    loop {
+        if !gateway_running_with_budget(port, health_probe, budget)? {
+            return Ok(true);
+        }
+        if !budget.sleep_to_next_poll() {
+            return Ok(false);
+        }
+    }
+}
+
+fn wait_for_managed_process_stop_with_budget(
+    record: &ProxyPidRecord,
+    paths: &ProxyPaths,
+    port: u16,
+    inspector: &dyn ProcessInspector,
+    budget: &ShutdownBudget<'_>,
+) -> Result<bool, String> {
+    loop {
+        match verify_proxy_process(record, paths, port, inspector)? {
+            VerifiedProxyProcess::Missing { .. } => return Ok(true),
+            VerifiedProxyProcess::Verified { .. } => {}
+            VerifiedProxyProcess::Mismatch { pid, reason } => {
+                return Err(format!(
+                    "Gateway PID {pid} changed identity while waiting for user-requested shutdown ({reason}); preserved durable ownership"
+                ));
+            }
+            VerifiedProxyProcess::Unknown { pid, reason } => {
+                return Err(format!(
+                    "Gateway PID {pid} could not be inspected while waiting for user-requested shutdown ({reason}); preserved durable ownership"
+                ));
+            }
+        }
+        if !budget.sleep_to_next_poll() {
+            return Ok(false);
+        }
+    }
+}
+
+fn force_kill_session_owned_gateway_at_deadline(
+    paths: &ProxyPaths,
+    record: &ProxyPidRecord,
+    session_owned_identity: Option<&GatewayIdentity>,
+    port: u16,
+    killer: &dyn ProcessKiller,
+    inspector: &dyn ProcessInspector,
+    listener_inspector: &dyn ListenerInspector,
+) -> Result<u32, String> {
+    let Some(session_owned_identity) = session_owned_identity else {
+        return Err(
+            "Gateway user-requested shutdown refused force-close because #139 has no current-session identity"
+                .to_string(),
+        );
+    };
+    let Some(record_identity) = record.gateway_identity() else {
+        return Err(
+            "Gateway user-requested shutdown refused force-close because the durable PID record has no verifiable current-session identity"
+                .to_string(),
+        );
+    };
+    if &record_identity != session_owned_identity {
+        return Err(
+            "Gateway user-requested shutdown refused force-close because the durable Gateway identity no longer matches #139's current-session identity"
+                .to_string(),
+        );
+    }
+
+    let pid = match verify_proxy_process(record, paths, port, inspector)? {
+        VerifiedProxyProcess::Verified { pid } => pid,
+        VerifiedProxyProcess::Missing { pid } => {
+            remove_pid(paths)?;
+            return Err(format!(
+                "managed Gateway PID {pid} disappeared before user-requested force-close; preserved truthful reconciliation"
+            ));
+        }
+        VerifiedProxyProcess::Mismatch { pid, reason } => {
+            return Err(format!(
+                "managed Gateway PID {pid} ownership could not be verified before user-requested force-close: {reason}"
+            ));
+        }
+        VerifiedProxyProcess::Unknown { pid, reason } => {
+            return Err(format!(
+                "managed Gateway PID {pid} inspection is unavailable before user-requested force-close ({reason}); preserved durable ownership"
+            ));
+        }
+    };
+
+    let listener_pid = listener_inspector.listening_pid(port)?;
+    if let Some(listener_pid) = listener_pid {
+        if listener_pid != pid {
+            return Err(format!(
+                "exact managed Gateway PID {pid} does not own the current listener on port {port} immediately before user-requested force-close (PID {listener_pid}); refusing destructive action"
+            ));
+        }
+    }
+    killer.kill(pid)?;
+    Ok(pid)
 }
 
 fn stop_with_paths(paths: &ProxyPaths) -> Result<AppStatus, String> {
@@ -2167,8 +2510,12 @@ fn config_value_uses_managed_catalog(value: &str) -> bool {
 }
 
 fn health(port: u16) -> Result<Option<HealthResponse>, String> {
+    health_with_timeout(port, HEALTH_TIMEOUT)
+}
+
+fn health_with_timeout(port: u16, timeout: Duration) -> Result<Option<HealthResponse>, String> {
     let client = reqwest::blocking::Client::builder()
-        .timeout(HEALTH_TIMEOUT)
+        .timeout(timeout)
         .build()
         .map_err(|error| format!("failed to build HTTP client: {error}"))?;
     let url = format!("http://127.0.0.1:{port}/health");
@@ -2185,8 +2532,16 @@ fn health(port: u16) -> Result<Option<HealthResponse>, String> {
 }
 
 fn request_shutdown(port: u16, gateway_client_key: &str) -> Result<(), String> {
+    request_shutdown_with_timeout(port, gateway_client_key, SHUTDOWN_TIMEOUT)
+}
+
+fn request_shutdown_with_timeout(
+    port: u16,
+    gateway_client_key: &str,
+    timeout: Duration,
+) -> Result<(), String> {
     let client = reqwest::blocking::Client::builder()
-        .timeout(SHUTDOWN_TIMEOUT)
+        .timeout(timeout)
         .build()
         .map_err(|error| format!("failed to build HTTP client: {error}"))?;
     let url = format!("http://127.0.0.1:{port}/shutdown");
@@ -2970,7 +3325,8 @@ mod tests {
         force_kill_after_graceful_timeout, kill_process, read_pid, read_pid_record,
         reconciled_snapshot_with_controls,
         start_with_paths, start_with_paths_and_controls, start_with_paths_and_waiter,
-        status_with_paths, stop_with_paths, stop_with_paths_and_controls, verify_proxy_command_line,
+        status_with_paths, stop_session_owned_with_paths_and_controls, stop_with_paths,
+        stop_with_paths_and_controls, verify_proxy_command_line, ShutdownClock,
         write_pid, ChildTerminator, InspectedProcess, ListenerInspector, ProcessInfo,
         ProcessInspector, ProcessKiller, ProxyLifecycleBackend, ProxyPaths, ProxyPidMetadata,
         ProxyPidRecord, StartupOutcome, VerifiedProxyProcess, DEBUG_DIAGNOSTIC_BOOTSTRAP,
@@ -2990,7 +3346,7 @@ mod tests {
     use std::process::Stdio;
     use std::collections::VecDeque;
     use std::sync::{
-        atomic::{AtomicU32, Ordering},
+        atomic::{AtomicBool, AtomicU32, Ordering},
         Arc,
     };
     use std::thread;
@@ -3701,6 +4057,95 @@ model_catalog_json = "model-catalogs/codex-proxy-official-ollama.json"
     }
 
     #[test]
+    fn session_shutdown_uses_one_two_second_budget_and_refuses_replaced_identity() {
+        let root = temp_root("session-shutdown-replaced-identity");
+        let paths = test_paths(&root);
+        let port = free_port();
+        let pid = 12_345;
+        write_settings(&paths, port);
+        write_pid(&paths, pid, port, &paths.proxy_script_path()).expect("write pid");
+        let record = read_pid_record(&paths)
+            .expect("read pid record")
+            .expect("managed pid record");
+        let current_identity = record.gateway_identity().expect("managed Gateway identity");
+        let replaced_identity = GatewayIdentity {
+            pid: pid + 1,
+            ..current_identity
+        };
+        let clock = FakeShutdownClock::default();
+        let request_timeouts = RefCell::new(Vec::new());
+        let killer = RecordingKiller::default();
+        let inspector = RecordingInspector::new(fake_proxy_process(&paths, port));
+        let listener = FixedListenerInspector::new(Some(pid));
+
+        let error = stop_session_owned_with_paths_and_controls(
+            &paths,
+            Some(&replaced_identity),
+            &killer,
+            &inspector,
+            &listener,
+            &|_port, _key, timeout| {
+                request_timeouts.borrow_mut().push(timeout);
+                Ok(())
+            },
+            &|_port, _timeout| Ok(Some(healthy_response())),
+            &clock,
+        )
+        .expect_err("replaced identity must never be force-killed");
+
+        assert!(error.contains("current-session identity"), "{error}");
+        assert_eq!(request_timeouts.borrow().as_slice(), &[Duration::from_millis(800)]);
+        assert_eq!(clock.elapsed(), Duration::from_secs(2));
+        assert!(killer.killed.borrow().is_empty());
+        assert_eq!(read_pid(&paths).expect("pid preserved"), Some(pid));
+    }
+
+    #[test]
+    fn session_shutdown_force_kills_only_the_exact_owned_identity_at_the_deadline() {
+        let root = temp_root("session-shutdown-owned-identity");
+        let paths = test_paths(&root);
+        let port = free_port();
+        let pid = 12_345;
+        write_settings(&paths, port);
+        write_pid(&paths, pid, port, &paths.proxy_script_path()).expect("write pid");
+        let record = read_pid_record(&paths)
+            .expect("read pid record")
+            .expect("managed pid record");
+        let current_identity = record.gateway_identity().expect("managed Gateway identity");
+        let clock = FakeShutdownClock::default();
+        let alive = Arc::new(AtomicBool::new(true));
+        let listener_pid = Arc::new(AtomicU32::new(pid));
+        let killer = KillAwareKiller::new(Arc::clone(&alive), Arc::clone(&listener_pid));
+        let inspector = KillAwareInspector::new(Arc::clone(&alive), fake_proxy_process(&paths, port));
+        let listener = AtomicListenerInspector::new(listener_pid);
+
+        let status = stop_session_owned_with_paths_and_controls(
+            &paths,
+            Some(&current_identity),
+            &killer,
+            &inspector,
+            &listener,
+            &|_port, _key, timeout| {
+                assert_eq!(timeout, Duration::from_millis(800));
+                Ok(())
+            },
+            &|_port, _timeout| {
+                Ok(alive
+                    .load(Ordering::SeqCst)
+                    .then(healthy_response))
+            },
+            &clock,
+        )
+        .expect("exact session-owned Gateway should be force-stopped at deadline");
+
+        assert!(!status.proxy_running);
+        assert!(status.message.contains("user-requested shutdown"));
+        assert_eq!(killer.killed.borrow().as_slice(), &[pid]);
+        assert_eq!(clock.elapsed(), Duration::from_secs(2));
+        assert_eq!(read_pid(&paths).expect("pid removed"), None);
+    }
+
+    #[test]
     fn start_timeout_error_includes_captured_stdout_and_stderr() {
         let root = temp_root("start-timeout-output");
         let paths = test_paths(&root);
@@ -4300,6 +4745,7 @@ time.sleep(10)
             let backend = ProxyLifecycleBackend {
                 lifecycle_gate_path: paths.lifecycle_gate_path(),
                 paths: paths.clone(),
+                session_owned_identity: None,
             };
             let coordinator = crate::gateway_lifecycle::GatewayLifecycleCoordinator::new();
 
@@ -4620,6 +5066,73 @@ time.sleep(10)
         fn kill(&self, pid: u32) -> Result<(), String> {
             self.killed.borrow_mut().push(pid);
             Ok(())
+        }
+    }
+
+    #[derive(Default)]
+    struct FakeShutdownClock {
+        elapsed: RefCell<Duration>,
+    }
+
+    impl FakeShutdownClock {
+        fn elapsed_value(&self) -> Duration {
+            *self.elapsed.borrow()
+        }
+    }
+
+    impl ShutdownClock for FakeShutdownClock {
+        fn elapsed(&self) -> Duration {
+            self.elapsed_value()
+        }
+
+        fn sleep(&self, duration: Duration) {
+            *self.elapsed.borrow_mut() += duration;
+        }
+    }
+
+    struct KillAwareKiller {
+        killed: RefCell<Vec<u32>>,
+        alive: Arc<AtomicBool>,
+        listener_pid: Arc<AtomicU32>,
+    }
+
+    impl KillAwareKiller {
+        fn new(alive: Arc<AtomicBool>, listener_pid: Arc<AtomicU32>) -> Self {
+            Self {
+                killed: RefCell::new(Vec::new()),
+                alive,
+                listener_pid,
+            }
+        }
+    }
+
+    impl ProcessKiller for KillAwareKiller {
+        fn kill(&self, pid: u32) -> Result<(), String> {
+            self.killed.borrow_mut().push(pid);
+            self.alive.store(false, Ordering::SeqCst);
+            self.listener_pid.store(0, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    struct KillAwareInspector {
+        alive: Arc<AtomicBool>,
+        running: InspectedProcess,
+    }
+
+    impl KillAwareInspector {
+        fn new(alive: Arc<AtomicBool>, running: InspectedProcess) -> Self {
+            Self { alive, running }
+        }
+    }
+
+    impl ProcessInspector for KillAwareInspector {
+        fn inspect(&self, _pid: u32) -> Result<InspectedProcess, String> {
+            if self.alive.load(Ordering::SeqCst) {
+                Ok(self.running.clone())
+            } else {
+                Ok(InspectedProcess::Missing)
+            }
         }
     }
 

--- a/src-tauri/src/proxy.rs
+++ b/src-tauri/src/proxy.rs
@@ -1160,34 +1160,41 @@ impl<'a> ShutdownBudget<'a> {
     }
 }
 
+struct UserRequestedShutdownControls<'a> {
+    killer: &'a dyn ProcessKiller,
+    inspector: &'a dyn ProcessInspector,
+    listener_inspector: &'a dyn ListenerInspector,
+    shutdown_request: &'a dyn Fn(u16, &str, Duration) -> Result<(), String>,
+    health_probe: &'a dyn Fn(u16, Duration) -> Result<Option<HealthResponse>, String>,
+    clock: &'a dyn ShutdownClock,
+}
+
 fn stop_session_owned_with_paths(
     paths: &ProxyPaths,
     session_owned_identity: Option<&GatewayIdentity>,
 ) -> Result<AppStatus, String> {
     let clock = SystemShutdownClock::new();
+    let controls = UserRequestedShutdownControls {
+        killer: &SystemProcessKiller,
+        inspector: &SystemProcessInspector,
+        listener_inspector: &SystemListenerInspector,
+        shutdown_request: &request_shutdown_with_timeout,
+        health_probe: &health_with_timeout,
+        clock: &clock,
+    };
     stop_session_owned_with_paths_and_controls(
         paths,
         session_owned_identity,
-        &SystemProcessKiller,
-        &SystemProcessInspector,
-        &SystemListenerInspector,
-        &request_shutdown_with_timeout,
-        &health_with_timeout,
-        &clock,
+        &controls,
     )
 }
 
 fn stop_session_owned_with_paths_and_controls(
     paths: &ProxyPaths,
     session_owned_identity: Option<&GatewayIdentity>,
-    killer: &dyn ProcessKiller,
-    inspector: &dyn ProcessInspector,
-    listener_inspector: &dyn ListenerInspector,
-    shutdown_request: &dyn Fn(u16, &str, Duration) -> Result<(), String>,
-    health_probe: &dyn Fn(u16, Duration) -> Result<Option<HealthResponse>, String>,
-    clock: &dyn ShutdownClock,
+    controls: &UserRequestedShutdownControls<'_>,
 ) -> Result<AppStatus, String> {
-    let budget = ShutdownBudget::new(clock);
+    let budget = ShutdownBudget::new(controls.clock);
     let settings = read_settings(paths)?;
     let mode = read_mode(paths)?;
     let pid_record = read_pid_record(paths)?;
@@ -1195,7 +1202,7 @@ fn stop_session_owned_with_paths_and_controls(
         .as_ref()
         .map(|record| record.expected_port(settings.proxy_port))
         .unwrap_or(settings.proxy_port);
-    let was_running = gateway_running_with_budget(lifecycle_port, health_probe, &budget)?;
+    let was_running = gateway_running_with_budget(lifecycle_port, controls.health_probe, &budget)?;
 
     let Some(pid_record) = pid_record else {
         if was_running {
@@ -1206,7 +1213,7 @@ fn stop_session_owned_with_paths_and_controls(
         return stopped_gateway_status(mode, lifecycle_port, "Gateway is not running".to_string());
     };
 
-    match verify_proxy_process(&pid_record, paths, lifecycle_port, inspector)? {
+    match verify_proxy_process(&pid_record, paths, lifecycle_port, controls.inspector)? {
         VerifiedProxyProcess::Missing { pid } => {
             remove_pid(paths)?;
             return stopped_gateway_status(
@@ -1227,17 +1234,26 @@ fn stop_session_owned_with_paths_and_controls(
             ));
         }
         VerifiedProxyProcess::Verified { pid } if was_running => {
-            verify_listener_owner(pid, lifecycle_port, listener_inspector, "before shutdown")?;
+            verify_listener_owner(
+                pid,
+                lifecycle_port,
+                controls.listener_inspector,
+                "before shutdown",
+            )?;
             let timeout = budget.cap(SHUTDOWN_TIMEOUT);
             if !timeout.is_zero() {
-                let _ = shutdown_request(lifecycle_port, &settings.gateway_client_key, timeout);
+                let _ = (controls.shutdown_request)(
+                    lifecycle_port,
+                    &settings.gateway_client_key,
+                    timeout,
+                );
             }
         }
         VerifiedProxyProcess::Verified { .. } => {}
     }
 
     let listener_stopped = if was_running {
-        wait_for_listener_stop_with_budget(lifecycle_port, health_probe, &budget)?
+        wait_for_listener_stop_with_budget(lifecycle_port, controls.health_probe, &budget)?
     } else {
         true
     };
@@ -1246,7 +1262,7 @@ fn stop_session_owned_with_paths_and_controls(
             &pid_record,
             paths,
             lifecycle_port,
-            inspector,
+            controls.inspector,
             &budget,
         )?
     } else {
@@ -1267,15 +1283,15 @@ fn stop_session_owned_with_paths_and_controls(
         &pid_record,
         session_owned_identity,
         lifecycle_port,
-        killer,
-        inspector,
-        listener_inspector,
+        controls.killer,
+        controls.inspector,
+        controls.listener_inspector,
     )?;
     log::warn!(
         "Gateway user_requested_shutdown force-close issued for the current-session PID {pid}"
     );
 
-    match verify_proxy_process(&pid_record, paths, lifecycle_port, inspector)? {
+    match verify_proxy_process(&pid_record, paths, lifecycle_port, controls.inspector)? {
         VerifiedProxyProcess::Missing { .. } => {}
         VerifiedProxyProcess::Verified { pid } => {
             return Err(format!(
@@ -3326,7 +3342,8 @@ mod tests {
         reconciled_snapshot_with_controls,
         start_with_paths, start_with_paths_and_controls, start_with_paths_and_waiter,
         status_with_paths, stop_session_owned_with_paths_and_controls, stop_with_paths,
-        stop_with_paths_and_controls, verify_proxy_command_line, ShutdownClock,
+        stop_with_paths_and_controls, verify_proxy_command_line, GatewayIdentity, ShutdownClock,
+        UserRequestedShutdownControls,
         write_pid, ChildTerminator, InspectedProcess, ListenerInspector, ProcessInfo,
         ProcessInspector, ProcessKiller, ProxyLifecycleBackend, ProxyPaths, ProxyPidMetadata,
         ProxyPidRecord, StartupOutcome, VerifiedProxyProcess, DEBUG_DIAGNOSTIC_BOOTSTRAP,
@@ -4077,19 +4094,24 @@ model_catalog_json = "model-catalogs/codex-proxy-official-ollama.json"
         let killer = RecordingKiller::default();
         let inspector = RecordingInspector::new(fake_proxy_process(&paths, port));
         let listener = FixedListenerInspector::new(Some(pid));
+        let shutdown_request = |_port: u16, _key: &str, timeout: Duration| -> Result<(), String> {
+            request_timeouts.borrow_mut().push(timeout);
+            Ok(())
+        };
+        let health_probe = |_port, _timeout| Ok(Some(healthy_response()));
+        let controls = UserRequestedShutdownControls {
+            killer: &killer,
+            inspector: &inspector,
+            listener_inspector: &listener,
+            shutdown_request: &shutdown_request,
+            health_probe: &health_probe,
+            clock: &clock,
+        };
 
         let error = stop_session_owned_with_paths_and_controls(
             &paths,
             Some(&replaced_identity),
-            &killer,
-            &inspector,
-            &listener,
-            &|_port, _key, timeout| {
-                request_timeouts.borrow_mut().push(timeout);
-                Ok(())
-            },
-            &|_port, _timeout| Ok(Some(healthy_response())),
-            &clock,
+            &controls,
         )
         .expect_err("replaced identity must never be force-killed");
 
@@ -4118,23 +4140,28 @@ model_catalog_json = "model-catalogs/codex-proxy-official-ollama.json"
         let killer = KillAwareKiller::new(Arc::clone(&alive), Arc::clone(&listener_pid));
         let inspector = KillAwareInspector::new(Arc::clone(&alive), fake_proxy_process(&paths, port));
         let listener = AtomicListenerInspector::new(listener_pid);
+        let shutdown_request = |_port: u16, _key: &str, timeout: Duration| -> Result<(), String> {
+            assert_eq!(timeout, Duration::from_millis(800));
+            Ok(())
+        };
+        let health_probe = |_port, _timeout| {
+            Ok(alive
+                .load(Ordering::SeqCst)
+                .then(healthy_response))
+        };
+        let controls = UserRequestedShutdownControls {
+            killer: &killer,
+            inspector: &inspector,
+            listener_inspector: &listener,
+            shutdown_request: &shutdown_request,
+            health_probe: &health_probe,
+            clock: &clock,
+        };
 
         let status = stop_session_owned_with_paths_and_controls(
             &paths,
             Some(&current_identity),
-            &killer,
-            &inspector,
-            &listener,
-            &|_port, _key, timeout| {
-                assert_eq!(timeout, Duration::from_millis(800));
-                Ok(())
-            },
-            &|_port, _timeout| {
-                Ok(alive
-                    .load(Ordering::SeqCst)
-                    .then(healthy_response))
-            },
-            &clock,
+            &controls,
         )
         .expect("exact session-owned Gateway should be force-stopped at deadline");
 

--- a/src-tauri/src/proxy.rs
+++ b/src-tauri/src/proxy.rs
@@ -1287,6 +1287,13 @@ fn stop_session_owned_with_paths_and_controls(
         controls.inspector,
         controls.listener_inspector,
     )?;
+    let Some(pid) = pid else {
+        return stopped_gateway_status(
+            mode,
+            lifecycle_port,
+            "Gateway stopped during user-requested shutdown close budget".to_string(),
+        );
+    };
     log::warn!(
         "Gateway user_requested_shutdown force-close issued for the current-session PID {pid}"
     );
@@ -1396,7 +1403,7 @@ fn force_kill_session_owned_gateway_at_deadline(
     killer: &dyn ProcessKiller,
     inspector: &dyn ProcessInspector,
     listener_inspector: &dyn ListenerInspector,
-) -> Result<u32, String> {
+) -> Result<Option<u32>, String> {
     let Some(session_owned_identity) = session_owned_identity else {
         return Err(
             "Gateway user-requested shutdown refused force-close because #139 has no current-session identity"
@@ -1420,9 +1427,10 @@ fn force_kill_session_owned_gateway_at_deadline(
         VerifiedProxyProcess::Verified { pid } => pid,
         VerifiedProxyProcess::Missing { pid } => {
             remove_pid(paths)?;
-            return Err(format!(
-                "managed Gateway PID {pid} disappeared before user-requested force-close; preserved truthful reconciliation"
-            ));
+            log::info!(
+                "Gateway user_requested_shutdown found current-session PID {pid} already stopped at the close deadline"
+            );
+            return Ok(None);
         }
         VerifiedProxyProcess::Mismatch { pid, reason } => {
             return Err(format!(
@@ -1445,7 +1453,7 @@ fn force_kill_session_owned_gateway_at_deadline(
         }
     }
     killer.kill(pid)?;
-    Ok(pid)
+    Ok(Some(pid))
 }
 
 fn stop_with_paths(paths: &ProxyPaths) -> Result<AppStatus, String> {
@@ -4169,6 +4177,38 @@ model_catalog_json = "model-catalogs/codex-proxy-official-ollama.json"
         assert!(status.message.contains("user-requested shutdown"));
         assert_eq!(killer.killed.borrow().as_slice(), &[pid]);
         assert_eq!(clock.elapsed(), Duration::from_secs(2));
+        assert_eq!(read_pid(&paths).expect("pid removed"), None);
+    }
+
+    #[test]
+    fn session_shutdown_deadline_reconciles_an_already_stopped_current_identity() {
+        let root = temp_root("session-shutdown-deadline-already-stopped");
+        let paths = test_paths(&root);
+        let port = free_port();
+        let pid = 12_345;
+        write_settings(&paths, port);
+        write_fake_proxy_script(&paths, "print('test')");
+        write_pid(&paths, pid, port, &paths.proxy_script_path()).expect("write pid");
+        let record = read_pid_record(&paths)
+            .expect("read pid record")
+            .expect("managed pid record");
+        let current_identity = record.gateway_identity().expect("managed Gateway identity");
+        let killer = RecordingKiller::default();
+        let inspector = RecordingInspector::new(InspectedProcess::Missing);
+
+        let outcome = super::force_kill_session_owned_gateway_at_deadline(
+            &paths,
+            &record,
+            Some(&current_identity),
+            port,
+            &killer,
+            &inspector,
+            &FixedListenerInspector::new(None),
+        )
+        .expect("an already-stopped current-session Gateway is reconciled without force kill");
+
+        assert_eq!(outcome, None);
+        assert!(killer.killed.borrow().is_empty());
         assert_eq!(read_pid(&paths).expect("pid removed"), None);
     }
 

--- a/tests/test_proxy_shutdown.py
+++ b/tests/test_proxy_shutdown.py
@@ -36,7 +36,9 @@ def _run_server_with_event_writer_result(writer_result):
 
 
 def test_shutdown_endpoint_stops_server() -> None:
+    controller = codex_proxy.GatewayShutdownController()
     server = ThreadingHTTPServer(("127.0.0.1", 0), CodexProxyHandler)
+    server.gateway_shutdown_controller = controller
     thread = threading.Thread(target=server.serve_forever)
     thread.start()
 
@@ -201,6 +203,23 @@ def test_request_racing_admission_closure_never_opens_or_retries_upstream_work()
                     timeout=30,
                 )
         open_upstream.assert_not_called()
+    finally:
+        codex_proxy._restore_gateway_request(previous)
+        controller.complete(admission)
+
+
+def test_cancelled_admission_interrupts_retry_wait_without_sleep() -> None:
+    controller = codex_proxy.GatewayShutdownController()
+    admission = controller.admit()
+    assert admission is not None
+    previous = codex_proxy._activate_gateway_request(admission)
+
+    try:
+        controller.close_admission()
+        with patch.object(codex_proxy.time, "sleep") as sleep:
+            with pytest.raises(codex_proxy.GatewayUserRequestedShutdown):
+                codex_proxy._sleep_for_retry_with_gateway_cancellation(30.0)
+        sleep.assert_not_called()
     finally:
         codex_proxy._restore_gateway_request(previous)
         controller.complete(admission)

--- a/tests/test_proxy_shutdown.py
+++ b/tests/test_proxy_shutdown.py
@@ -109,6 +109,18 @@ def test_closing_admission_cancels_every_active_upstream_transport() -> None:
     assert controller.admit() is None
 
 
+def test_transport_attached_after_admission_closes_is_cancelled_without_upstream_work() -> None:
+    controller = codex_proxy.GatewayShutdownController()
+    admission = controller.admit()
+    assert admission is not None
+
+    controller.close_admission()
+    late_transport = Mock()
+    admission.attach_upstream_transport(late_transport)
+
+    late_transport.close.assert_called_once_with()
+
+
 def test_shutdown_budget_is_shared_by_many_active_requests() -> None:
     now = [10.0]
     controller = codex_proxy.GatewayShutdownController(
@@ -262,6 +274,26 @@ def test_active_request_receives_a_sanitized_user_requested_shutdown_outcome() -
             server.shutdown()
         server.server_close()
         server_thread.join(timeout=2)
+
+
+def test_downstream_already_closed_does_not_hide_user_requested_shutdown_cleanup() -> None:
+    class BrokenStream:
+        def write(self, _payload: bytes) -> None:
+            raise BrokenPipeError("downstream already closed")
+
+        def flush(self) -> None:
+            raise BrokenPipeError("downstream already closed")
+
+    handler = object.__new__(CodexProxyHandler)
+    handler.wfile = BrokenStream()
+    handler.close_connection = False
+
+    handler._send_user_requested_shutdown_outcome(
+        inbound_format="responses",
+        downstream_sse_started=True,
+    )
+
+    assert handler.close_connection is True
 
 
 def test_run_server_uses_the_remaining_shared_shutdown_budget_for_flush() -> None:

--- a/tests/test_proxy_shutdown.py
+++ b/tests/test_proxy_shutdown.py
@@ -58,6 +58,83 @@ def test_shutdown_endpoint_stops_server() -> None:
         thread.join(timeout=2)
 
 
+def test_shutdown_endpoint_closes_admission_and_reports_user_requested_shutdown() -> None:
+    controller = codex_proxy.GatewayShutdownController()
+    server = ThreadingHTTPServer(("127.0.0.1", 0), CodexProxyHandler)
+    server.gateway_shutdown_controller = controller
+    thread = threading.Thread(target=server.serve_forever)
+    thread.start()
+
+    try:
+        host, port = server.server_address
+        connection = HTTPConnection(host, port, timeout=2)
+        connection.request("POST", "/shutdown")
+        response = connection.getresponse()
+        payload = json.loads(response.read().decode("utf-8"))
+        connection.close()
+
+        assert response.status == 200
+        assert payload == {
+            "ok": True,
+            "outcome": "user_requested_shutdown",
+        }
+        assert controller.admit() is None
+
+        thread.join(timeout=2)
+        assert not thread.is_alive()
+    finally:
+        if thread.is_alive():
+            server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def test_closing_admission_cancels_every_active_upstream_transport() -> None:
+    controller = codex_proxy.GatewayShutdownController()
+    official_request = controller.admit()
+    third_party_request = controller.admit()
+    assert official_request is not None
+    assert third_party_request is not None
+
+    official_transport = Mock()
+    third_party_transport = Mock()
+    official_request.attach_upstream_transport(official_transport)
+    third_party_request.attach_upstream_transport(third_party_transport)
+
+    assert controller.close_admission() == 2
+    official_transport.close.assert_called_once_with()
+    third_party_transport.close.assert_called_once_with()
+    assert controller.admit() is None
+
+
+def test_shutdown_budget_is_shared_by_many_active_requests() -> None:
+    now = [10.0]
+    controller = codex_proxy.GatewayShutdownController(
+        clock=lambda: now[0],
+        shutdown_budget_seconds=2.0,
+    )
+    active = [controller.admit() for _ in range(3)]
+    assert all(active)
+
+    assert controller.close_admission() == 3
+    now[0] = 11.25
+    assert controller.remaining_shutdown_budget_seconds() == 0.75
+
+    now[0] = 12.0
+    assert controller.remaining_shutdown_budget_seconds() == 0.0
+
+
+def test_user_requested_shutdown_outcome_is_sanitized_for_every_downstream_format() -> None:
+    for inbound_format in ("responses", "chat_completions"):
+        payload = codex_proxy.user_requested_shutdown_payload(inbound_format)
+        serialized = json.dumps(payload).lower()
+
+        assert "user_requested_shutdown" in serialized
+        assert "prompt" not in serialized
+        assert "task" not in serialized
+        assert "bearer" not in serialized
+
+
 def test_run_server_drains_the_event_writer_when_the_server_exits() -> None:
     server, writer, warning = _run_server_with_event_writer_result(
         SimpleNamespace(completed=True, outcome="drained"),

--- a/tests/test_proxy_shutdown.py
+++ b/tests/test_proxy_shutdown.py
@@ -258,6 +258,21 @@ def test_active_request_receives_a_sanitized_user_requested_shutdown_outcome() -
     client_thread = threading.Thread(target=post_active_request)
     try:
         with (
+            patch.object(
+                codex_proxy,
+                "upstream_headers",
+                return_value={"Authorization": "Bearer test-token"},
+            ) as build_upstream_headers,
+            patch.object(
+                codex_proxy,
+                "codex_access_token",
+                side_effect=AssertionError("shutdown cancellation must not read Codex auth"),
+            ) as access_token,
+            patch.object(
+                codex_proxy,
+                "codex_account_id",
+                side_effect=AssertionError("shutdown cancellation must not read Codex auth"),
+            ) as account_id,
             patch.object(codex_proxy, "_open_upstream_response", side_effect=wait_for_shutdown) as open_upstream,
             patch.object(codex_proxy, "write_proxy_event") as write_event,
         ):
@@ -279,6 +294,9 @@ def test_active_request_receives_a_sanitized_user_requested_shutdown_outcome() -
                 "payload": codex_proxy.user_requested_shutdown_payload("responses"),
             }
             assert open_upstream.call_count == 1
+            build_upstream_headers.assert_called_once()
+            access_token.assert_not_called()
+            account_id.assert_not_called()
             shutdown_event = next(
                 call.kwargs
                 for call in write_event.call_args_list

--- a/tests/test_proxy_shutdown.py
+++ b/tests/test_proxy_shutdown.py
@@ -8,8 +8,10 @@ from http.client import HTTPConnection
 from http.server import ThreadingHTTPServer
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
+from urllib.request import Request
 
 import codex_proxy
+import pytest
 from codex_proxy import CodexProxyHandler
 
 
@@ -133,6 +135,159 @@ def test_user_requested_shutdown_outcome_is_sanitized_for_every_downstream_forma
         assert "prompt" not in serialized
         assert "task" not in serialized
         assert "bearer" not in serialized
+
+
+def test_requests_arriving_after_admission_closure_never_open_an_upstream_transport() -> None:
+    controller = codex_proxy.GatewayShutdownController()
+    controller.close_admission()
+    server = ThreadingHTTPServer(("127.0.0.1", 0), CodexProxyHandler)
+    server.gateway_shutdown_controller = controller
+    thread = threading.Thread(target=server.serve_forever)
+    thread.start()
+
+    try:
+        host, port = server.server_address
+        connection = HTTPConnection(host, port, timeout=2)
+        with patch.object(
+            codex_proxy,
+            "_open_upstream_response",
+            side_effect=AssertionError("closed admission must not open upstream work"),
+        ) as open_upstream:
+            connection.request(
+                "POST",
+                "/v1/responses",
+                body=b'{"model":"gpt-5.6-terra","input":"must not reach upstream"}',
+                headers={"Content-Type": "application/json"},
+            )
+            response = connection.getresponse()
+            payload = json.loads(response.read().decode("utf-8"))
+        connection.close()
+
+        assert response.status == 503
+        assert payload == codex_proxy.user_requested_shutdown_payload("responses")
+        open_upstream.assert_not_called()
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def test_request_racing_admission_closure_never_opens_or_retries_upstream_work() -> None:
+    controller = codex_proxy.GatewayShutdownController()
+    admission = controller.admit()
+    assert admission is not None
+    previous = codex_proxy._activate_gateway_request(admission)
+
+    try:
+        controller.close_admission()
+        with patch.object(codex_proxy, "_open_upstream_once") as open_upstream:
+            with pytest.raises(codex_proxy.GatewayUserRequestedShutdown):
+                codex_proxy._open_upstream_response(
+                    Request("https://example.invalid/v1/responses", data=b"{}", method="POST"),
+                    upstream_name="official",
+                    upstream_format="responses",
+                    timeout=30,
+                )
+        open_upstream.assert_not_called()
+    finally:
+        codex_proxy._restore_gateway_request(previous)
+        controller.complete(admission)
+
+
+def test_active_request_receives_a_sanitized_user_requested_shutdown_outcome() -> None:
+    controller = codex_proxy.GatewayShutdownController()
+    server = ThreadingHTTPServer(("127.0.0.1", 0), CodexProxyHandler)
+    server.gateway_shutdown_controller = controller
+    server_thread = threading.Thread(target=server.serve_forever)
+    server_thread.start()
+    upstream_entered = threading.Event()
+    result: dict[str, object] = {}
+
+    def wait_for_shutdown(*_args, **_kwargs):
+        upstream_entered.set()
+        admission = codex_proxy._active_gateway_request()
+        assert admission is not None
+        assert admission.wait_for_cancellation(2.0)
+        admission.raise_if_cancelled()
+
+    def post_active_request() -> None:
+        host, port = server.server_address
+        connection = HTTPConnection(host, port, timeout=4)
+        connection.request(
+            "POST",
+            "/v1/responses",
+            body=b'{"model":"gpt-5.6-terra","input":"active request"}',
+            headers={"Content-Type": "application/json"},
+        )
+        response = connection.getresponse()
+        result["status"] = response.status
+        result["payload"] = json.loads(response.read().decode("utf-8"))
+        connection.close()
+
+    client_thread = threading.Thread(target=post_active_request)
+    try:
+        with (
+            patch.object(codex_proxy, "_open_upstream_response", side_effect=wait_for_shutdown) as open_upstream,
+            patch.object(codex_proxy, "write_proxy_event") as write_event,
+        ):
+            client_thread.start()
+            assert upstream_entered.wait(timeout=2)
+
+            host, port = server.server_address
+            shutdown_connection = HTTPConnection(host, port, timeout=2)
+            shutdown_connection.request("POST", "/shutdown")
+            shutdown_response = shutdown_connection.getresponse()
+            assert shutdown_response.status == 200
+            shutdown_response.read()
+            shutdown_connection.close()
+
+            client_thread.join(timeout=3)
+            assert not client_thread.is_alive()
+            assert result == {
+                "status": 503,
+                "payload": codex_proxy.user_requested_shutdown_payload("responses"),
+            }
+            assert open_upstream.call_count == 1
+            shutdown_event = next(
+                call.kwargs
+                for call in write_event.call_args_list
+                if call.args and call.args[0] == "request_cancelled"
+            )
+            assert shutdown_event["shutdown_outcome"] == "user_requested_shutdown"
+            assert "active request" not in repr(shutdown_event)
+    finally:
+        if client_thread.is_alive():
+            client_thread.join(timeout=1)
+        if server_thread.is_alive():
+            server.shutdown()
+        server.server_close()
+        server_thread.join(timeout=2)
+
+
+def test_run_server_uses_the_remaining_shared_shutdown_budget_for_flush() -> None:
+    now = [0.0]
+    controller = codex_proxy.GatewayShutdownController(
+        clock=lambda: now[0],
+        shutdown_budget_seconds=2.0,
+    )
+    controller.close_admission()
+    server = Mock()
+    writer = Mock()
+    writer.shutdown.return_value = SimpleNamespace(completed=True, outcome="drained")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with (
+            patch.object(codex_proxy, "PROXY_TEXT_LOG_PATH", Path(tmpdir) / "proxy.log"),
+            patch.object(codex_proxy.logging, "basicConfig"),
+            patch.object(codex_proxy.logging, "FileHandler"),
+            patch.object(codex_proxy.logging, "StreamHandler"),
+            patch.object(codex_proxy, "ThreadingHTTPServer", return_value=server),
+            patch.object(codex_proxy, "GatewayShutdownController", return_value=controller),
+            patch.object(codex_proxy, "GATEWAY_EVENT_WRITER", writer),
+        ):
+            codex_proxy.run_server("127.0.0.1", 8080)
+
+    writer.shutdown.assert_called_once_with(timeout=2.0)
 
 
 def test_run_server_drains_the_event_writer_when_the_server_exits() -> None:

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1262,12 +1262,12 @@ class RoutingTests(unittest.TestCase):
             patch("codex_proxy.codex_access_token", return_value="sub-token"),
             patch("codex_proxy.codex_account_id", return_value="acct-1"),
             patch("codex_proxy._open_upstream_response", side_effect=[interrupted, success]) as open_response,
-            patch("codex_proxy.time.sleep") as mock_sleep,
+            patch("codex_proxy._sleep_for_retry_with_gateway_cancellation") as mock_retry_wait,
         ):
             CodexProxyHandler.do_POST(handler)
 
         self.assertEqual(open_response.call_count, 2)
-        mock_sleep.assert_called_once()
+        mock_retry_wait.assert_called_once_with(2)
         self.assertEqual(fake.status, 200)
         downstream = b"".join(fake.wfile.writes)
         self.assertIn(b"response.completed", downstream)
@@ -1306,12 +1306,12 @@ class RoutingTests(unittest.TestCase):
             patch("codex_proxy.codex_access_token", return_value="sub-token"),
             patch("codex_proxy.codex_account_id", return_value="acct-1"),
             patch("codex_proxy._open_upstream_response", side_effect=[interrupted, unused_success]) as open_response,
-            patch("codex_proxy.time.sleep") as mock_sleep,
+            patch("codex_proxy._sleep_for_retry_with_gateway_cancellation") as mock_retry_wait,
         ):
             CodexProxyHandler.do_POST(handler)
 
         self.assertEqual(open_response.call_count, 1)
-        mock_sleep.assert_not_called()
+        mock_retry_wait.assert_not_called()
         downstream = b"".join(fake.wfile.writes)
         self.assertIn(b"response.created", downstream)
         self.assertIn(b"response.failed", downstream)
@@ -2047,12 +2047,12 @@ class RoutingTests(unittest.TestCase):
             patch("codex_proxy.codex_access_token", return_value="sub-token"),
             patch("codex_proxy.codex_account_id", return_value="acct-1"),
             patch("codex_proxy._official_urlopen", side_effect=[error, success]) as mock_urlopen,
-            patch("codex_proxy.time.sleep") as mock_sleep,
+            patch("codex_proxy._sleep_for_retry_with_gateway_cancellation") as mock_retry_wait,
         ):
             CodexProxyHandler.do_POST(handler)
 
         self.assertEqual(mock_urlopen.call_count, 1)
-        mock_sleep.assert_not_called()
+        mock_retry_wait.assert_not_called()
         event_names = [call.args[0] for call in self.write_proxy_event.call_args_list if call.args]
         self.assertNotIn("upstream_retry", event_names)
         self.assertNotIn("sse_retry_notice", event_names)
@@ -2088,12 +2088,12 @@ class RoutingTests(unittest.TestCase):
             patch("codex_proxy.codex_access_token", return_value="sub-token"),
             patch("codex_proxy.codex_account_id", return_value="acct-1"),
             patch("codex_proxy._official_urlopen", side_effect=[TimeoutError("connect timed out"), success]) as mock_urlopen,
-            patch("codex_proxy.time.sleep") as mock_sleep,
+            patch("codex_proxy._sleep_for_retry_with_gateway_cancellation") as mock_retry_wait,
         ):
             CodexProxyHandler.do_POST(handler)
 
         self.assertEqual(mock_urlopen.call_count, 2)
-        mock_sleep.assert_called_once()
+        mock_retry_wait.assert_called_once_with(2)
         retry_events = [
             call.kwargs
             for call in self.write_proxy_event.call_args_list
@@ -3244,12 +3244,12 @@ class RoutingTests(unittest.TestCase):
                 clear=False,
             ),
             patch("codex_proxy.urlopen", side_effect=[error, success]) as mock_urlopen,
-            patch("codex_proxy.time.sleep") as mock_sleep,
+            patch("codex_proxy._sleep_for_retry_with_gateway_cancellation") as mock_retry_wait,
         ):
             CodexProxyHandler.do_POST(handler)
 
         self.assertEqual(mock_urlopen.call_count, 2)
-        mock_sleep.assert_called_once_with(2)
+        mock_retry_wait.assert_called_once_with(2)
         self.assertEqual(fake.status, 200)
         written = b"".join(fake.wfile.writes)
         self.assertNotIn(b"event: codexhub.retry\n", written)
@@ -3303,12 +3303,12 @@ class RoutingTests(unittest.TestCase):
                 clear=False,
             ),
             patch("codex_proxy.urlopen", side_effect=[failed_stream, success]) as mock_urlopen,
-            patch("codex_proxy.time.sleep") as mock_sleep,
+            patch("codex_proxy._sleep_for_retry_with_gateway_cancellation") as mock_retry_wait,
         ):
             CodexProxyHandler.do_POST(handler)
 
         self.assertEqual(mock_urlopen.call_count, 2)
-        mock_sleep.assert_called_once_with(2)
+        mock_retry_wait.assert_called_once_with(2)
         self.assertEqual(fake.status, 200)
         written = b"".join(fake.wfile.writes)
         self.assertNotIn(b"event: codexhub.retry\n", written)
@@ -3374,12 +3374,12 @@ class RoutingTests(unittest.TestCase):
                 clear=False,
             ),
             patch("codex_proxy.urlopen", side_effect=[failed_stream, success]) as mock_urlopen,
-            patch("codex_proxy.time.sleep") as mock_sleep,
+            patch("codex_proxy._sleep_for_retry_with_gateway_cancellation") as mock_retry_wait,
         ):
             CodexProxyHandler.do_POST(handler)
 
         self.assertEqual(mock_urlopen.call_count, 2)
-        mock_sleep.assert_called_once_with(2)
+        mock_retry_wait.assert_called_once_with(2)
         self.assertEqual(fake.status, 200)
         written = b"".join(fake.wfile.writes)
         self.assertIn(b"resp_transparent_retry", written)
@@ -3445,12 +3445,12 @@ class RoutingTests(unittest.TestCase):
                 clear=False,
             ),
             patch("codex_proxy.urlopen", side_effect=[failed_stream, success]) as mock_urlopen,
-            patch("codex_proxy.time.sleep") as mock_sleep,
+            patch("codex_proxy._sleep_for_retry_with_gateway_cancellation") as mock_retry_wait,
         ):
             CodexProxyHandler.do_POST(handler)
 
         self.assertEqual(mock_urlopen.call_count, 2)
-        mock_sleep.assert_called_once_with(2)
+        mock_retry_wait.assert_called_once_with(2)
         self.assertEqual(fake.status, 200)
         written = b"".join(fake.wfile.writes)
         self.assertIn(b"resp_retry", written)
@@ -3513,12 +3513,12 @@ class RoutingTests(unittest.TestCase):
                 clear=False,
             ),
             patch("codex_proxy.urlopen", side_effect=[failed_stream, success]) as mock_urlopen,
-            patch("codex_proxy.time.sleep") as mock_sleep,
+            patch("codex_proxy._sleep_for_retry_with_gateway_cancellation") as mock_retry_wait,
         ):
             CodexProxyHandler.do_POST(handler)
 
         self.assertEqual(mock_urlopen.call_count, 2)
-        mock_sleep.assert_called_once_with(2)
+        mock_retry_wait.assert_called_once_with(2)
         self.assertEqual(fake.status, 200)
         written = b"".join(fake.wfile.writes)
         self.assertIn(b"resp_text_retry", written)
@@ -3585,12 +3585,12 @@ class RoutingTests(unittest.TestCase):
                 clear=False,
             ),
             patch("codex_proxy.urlopen", side_effect=[*failed_streams, success]) as mock_urlopen,
-            patch("codex_proxy.time.sleep") as mock_sleep,
+            patch("codex_proxy._sleep_for_retry_with_gateway_cancellation") as mock_retry_wait,
         ):
             CodexProxyHandler.do_POST(handler)
 
         self.assertEqual(mock_urlopen.call_count, 5)
-        self.assertEqual([call.args[0] for call in mock_sleep.call_args_list], [2, 2, 4, 6])
+        self.assertEqual([call.args[0] for call in mock_retry_wait.call_args_list], [2, 2, 4, 6])
         self.assertEqual(fake.status, 200)
         written = b"".join(fake.wfile.writes)
         self.assertIn(b"resp_text_retry", written)
@@ -3651,12 +3651,12 @@ class RoutingTests(unittest.TestCase):
                 clear=False,
             ),
             patch("codex_proxy.urlopen", side_effect=[empty_stream, success]) as mock_urlopen,
-            patch("codex_proxy.time.sleep") as mock_sleep,
+            patch("codex_proxy._sleep_for_retry_with_gateway_cancellation") as mock_retry_wait,
         ):
             CodexProxyHandler.do_POST(handler)
 
         self.assertEqual(mock_urlopen.call_count, 2)
-        mock_sleep.assert_called_once_with(2)
+        mock_retry_wait.assert_called_once_with(2)
         self.assertEqual(fake.status, 200)
         written = b"".join(fake.wfile.writes)
         self.assertIn(b"resp_visible", written)
@@ -3722,12 +3722,12 @@ class RoutingTests(unittest.TestCase):
                 clear=False,
             ),
             patch("codex_proxy.urlopen", side_effect=[*empty_streams, should_not_be_used]) as mock_urlopen,
-            patch("codex_proxy.time.sleep") as mock_sleep,
+            patch("codex_proxy._sleep_for_retry_with_gateway_cancellation") as mock_retry_wait,
         ):
             CodexProxyHandler.do_POST(handler)
 
         self.assertEqual(mock_urlopen.call_count, 2)
-        mock_sleep.assert_called_once_with(2)
+        mock_retry_wait.assert_called_once_with(2)
         self.assertEqual(fake.status, 200)
         written = b"".join(fake.wfile.writes)
         self.assertIn(b"upstream_empty_completed_response", written)
@@ -3799,12 +3799,12 @@ class RoutingTests(unittest.TestCase):
                 clear=False,
             ),
             patch("codex_proxy.urlopen", side_effect=[failed_stream]) as mock_urlopen,
-            patch("codex_proxy.time.sleep") as mock_sleep,
+            patch("codex_proxy._sleep_for_retry_with_gateway_cancellation") as mock_retry_wait,
         ):
             CodexProxyHandler.do_POST(handler)
 
         self.assertEqual(mock_urlopen.call_count, 1)
-        mock_sleep.assert_not_called()
+        mock_retry_wait.assert_not_called()
         self.assertEqual(fake.status, 200)
         written = b"".join(fake.wfile.writes)
         self.assertIn(b"resp_tool_reset", written)


### PR DESCRIPTION
## Scope

Implements the Issue #143 Gateway retirement contract from the carried candidate: close admission first, cancel active upstream work, best-effort deliver a sanitized `user_requested_shutdown` result, and enforce the bounded ownership-safe lifecycle path.

This attempt adds the adjudicated regression coverage only:

- isolates the shutdown-server fixture controller in `tests/test_proxy_shutdown.py` and verifies canceled admission interrupts the retry wait without a real sleep;
- updates `tests/test_routing.py` expectations to assert the cancellation-aware retry seam.

The `tests/test_routing.py` change is the orchestrator-approved, test-only hotset expansion. No production routing code changed outside the canonical hotset.

## Verification

- `cd src-tauri && cargo clippy --locked --all-targets -- -D warnings` — PASS.
- Sanitized, serialized `cargo test --locked` with fresh empty `CODEX_HOME` and `APPDATA`, `RUST_TEST_THREADS=1` — PASS, 389/389. An immediately preceding identical sanitized invocation returned exit 101 with no emitted runner output; the documented retry completed cleanly.
- `python -m pytest -q tests/test_proxy_shutdown.py` — PASS, 14 passed.
- `python -m pytest -q tests/test_proxy_shutdown.py tests/test_routing.py` — PASS, 475 passed and 124 subtests passed.
- `python -m pytest -q` — PASS, 1281 passed, 1 skipped, 327 subtests passed.
- Frontend build and UI-contract checks — prior carried-candidate evidence remains applicable because this attempt has no frontend delta: PASS, 141 checks.
- `python scripts/report_quality_gates.py` — exit 0, report-only, parse_errors 0 (existing findings reported non-blockingly).
- `git diff --check 23c82655842fe4886a28e9fe4b6ef513a4a283e3..HEAD` — PASS.

The Cargo verification deliberately redirects both `CODEX_HOME` and `APPDATA` to fresh empty directories to rule out this host's live-CODEX_HOME model-catalog contamination in excluded `gateway.rs` model-export tests.

## Packaged Windows Debug smoke

`cd src-tauri; CODEXHUB_BUILD_FLAVOR=debug; CARGO_TARGET_DIR=target/issue-143-smoke/build-5c21770; cargo tauri build --config target/issue-143-smoke/tauri.issue143smoke.conf.json --no-bundle --ci --debug --features debug-diagnostics` — PASS. The packaged Debug app from commit `5c217708` was then exercised in this worktree.

- Long-running Official Responses stream: accepted the pre-action interruption warning; delivered `user_requested_shutdown`; the active upstream stream disconnected; retiring listener removal was measured at **1671.051 ms** and the retiring PID was gone.
- Long-running third-party stream: used the UI Restart path; the original Gateway PID exited, one replacement PID owned the sole port-19099 listener, and the active third-party upstream stream disconnected.

Evidence retained in the worktree under `src-tauri/target/issue-143-smoke/traces-5c21770/`:
`02-stop-warning-before-accept.jpg`, `04-timed-official-user-requested-stopped.jpg`, `timed-official-stop-listener.json`, `official-client-timed.jsonl`, `upstream.jsonl`, `08-third-party-restart-warning.jpg`, `09-third-party-restart-reconciled.jpg`, `thirdparty-before-restart-identity.json`, and `thirdparty-after-restart-identity.json`.