### PR TITLE
fix: count Kimi cached tokens

### DIFF
--- a/config/providers.toml
+++ b/config/providers.toml
@@ -4,6 +4,7 @@ name = "Ollama Cloud"
 base_url = "https://ollama.com/v1"
 api_key = "{env:OLLAMA_API_KEY}"
 display_prefix = "Ollama"
+# Set true only when an external provider returns truthful cached-input-token counts.
 reports_cached_input_tokens = false
 sort_order = 1
 enabled = true

--- a/frontend/scripts/ui-contract.test.mjs
+++ b/frontend/scripts/ui-contract.test.mjs
@@ -914,6 +914,14 @@ test("usage summary and chart use the same global time window", async () => {
   assert.match(tauriSource, /endTs/);
 });
 
+test("usage cache-hit gating includes Kimi and configured capable providers only", async () => {
+  const usageSource = await readFile(stackedUsagePath, "utf8");
+
+  assert.match(usageSource, /\["official", "openai", "official_openai", "kimi"\]/);
+  assert.match(usageSource, /provider\.reports_cached_input_tokens !== true/);
+  assert.match(usageSource, /eventReportsCacheUsage\(event, cacheCapableProviders\)/);
+});
+
 test("stacked usage chart uses neutral separators instead of misleading series outlines", async () => {
   const usageSource = await readFile(stackedUsagePath, "utf8");
   const svgSection = usageSource.match(/<svg[\s\S]*?<\/svg>/)?.[0] ?? "";

--- a/frontend/src/components/StackedUsageChartShell.tsx
+++ b/frontend/src/components/StackedUsageChartShell.tsx
@@ -1358,7 +1358,7 @@ function eventReportsCacheUsage(event: GatewayUsageEvent, cacheCapableProviders:
 }
 
 function cacheCapableProviderKeys(providers: Provider[]) {
-  const keys = new Set(["official", "openai", "official_openai"].map(cacheProviderKey));
+  const keys = new Set(["official", "openai", "official_openai", "kimi"].map(cacheProviderKey));
   for (const provider of providers) {
     if (provider.reports_cached_input_tokens !== true) {
       continue;

--- a/src-tauri/src/gateway.rs
+++ b/src-tauri/src/gateway.rs
@@ -7559,6 +7559,20 @@ mod tests {
     }
 
     #[test]
+    fn usage_summary_counts_cache_for_kimi_but_not_unflagged_external_providers() {
+        let text = [
+            r#"{"event":"request_complete","upstream":"kimi","model":"kimi/k3","status":200,"usage_source":"upstream_async","usage_input_tokens":100,"usage_cached_input_tokens":80,"usage_output_tokens":5}"#,
+            r#"{"event":"request_complete","upstream":"external","model":"external/k3","status":200,"usage_source":"upstream_async","usage_input_tokens":100,"usage_cached_input_tokens":90,"usage_output_tokens":5}"#,
+        ]
+        .join("\n");
+
+        let summary = read_usage_summary_from_text(&text);
+
+        assert_eq!(summary.cached_input_tokens, Some(80));
+        assert_eq!(summary.cache_hit_rate, Some(80.0));
+    }
+
+    #[test]
     fn usage_summary_estimates_cost_from_priced_token_usage() {
         let text = [
             r#"{"event":"request_complete","model":"openai/example","status":200,"duration_ms":120,"usage_source":"upstream","usage_input_tokens":10,"usage_output_tokens":4,"usage_cached_input_tokens":3}"#,

--- a/src-tauri/src/gateway/telemetry.rs
+++ b/src-tauri/src/gateway/telemetry.rs
@@ -1176,6 +1176,7 @@ fn cache_usage_capable_provider_aliases() -> HashSet<String> {
         cache_provider_key("official"),
         cache_provider_key("openai"),
         cache_provider_key("official_openai"),
+        cache_provider_key("kimi"),
     ]);
     if let Ok(providers) = config::get_providers() {
         for provider in providers {


### PR DESCRIPTION
## Summary
- classify the verified Kimi gateway alias as cache-capable in Rust telemetry and the frontend mirror
- preserve event-level overrides, configured external-provider opt-ins, official aliases, and the `openai/` model fallback
- document that external providers should opt in only when cached-input-token counts are truthful
- add Rust and frontend contract regression coverage for Kimi versus an unflagged external provider

Closes #171

## Checks
- PASS: `cargo test --locked usage_summary_counts_cache_for_kimi_but_not_unflagged_external_providers` (1 passed)
- PARTIAL/BASELINE: `cargo test --locked` (393 passed, 7 failed)
  - 6 existing catalog-sensitive tests expect `gpt-5.4`/`gpt-5.4-fast` while the current environment exposes `gpt-5.6-sol`: `gateway_client_sync_default_model_skips_disabled_default_model`, `opencode_apply_does_not_back_up_managed_config`, `opencode_config_exports_all_active_gateway_models`, `opencode_official_restore_survives_stable_then_beta_takeover`, `pi_config_exports_all_active_gateway_models`, `zcode_apply_writes_user_catalog_with_schema_safe_provider`
  - 1 existing timing-sensitive test exceeded its 3-second bound: `proxy::tests::post_spawn_inspection_timeout_cleans_up_gateway_without_leaking_output`
- PASS: `cargo clippy --locked --all-targets -- -D warnings`
- PASS: `npm run build`
- PASS: `npm run test:ui-contract` (142 passed)
- PASS: `git diff --check`
- REPORT ONLY: `python scripts/report_quality_gates.py` — 2 unused imports, 82 dead functions, 145 duplicate names, 0 parse errors; no finding introduced by this diff

## Out-of-scope findings
- The repository currently has broad pre-existing `cargo fmt --check` drift outside this issue's allowed hotset, so no unrelated formatting changes were made.
- The seven full Rust-suite failures listed above are unrelated to cache telemetry and were left unchanged.