### PR TITLE
Safely clean Windows autostart on uninstall

### DIFF
--- a/docs/agents/windows-autostart-smoke.md
+++ b/docs/agents/windows-autostart-smoke.md
@@ -25,3 +25,18 @@ For the portable case, enable autostart, exit CodexHub, move the executable,
 and reopen it. The toggle must load as disabled until autostart is enabled again
 at the new location. A subsequent real sign-out/sign-in must again produce
 exactly one process.
+
+## Packaged uninstall cleanup
+
+Run the focused uninstall harness in the clean Windows smoke VM for each
+packaged flavor. It installs and enables autostart, verifies owned cleanup while
+preserving an unrelated control task, reinstalls and checks one valid
+registration, then proves that an overwritten same-name mismatch is preserved:
+
+```powershell
+scripts/Test-WindowsAutostartUninstall.ps1 -Installer <path> -Flavor normal
+scripts/Test-WindowsAutostartUninstall.ps1 -Installer <path> -Flavor debug
+```
+
+The harness and installer diagnostics deliberately report only task disposition;
+they do not print the executable path or user identity.

--- a/docs/agents/windows-autostart-smoke.md
+++ b/docs/agents/windows-autostart-smoke.md
@@ -38,5 +38,11 @@ scripts/Test-WindowsAutostartUninstall.ps1 -Installer <path> -Flavor normal
 scripts/Test-WindowsAutostartUninstall.ps1 -Installer <path> -Flavor debug
 ```
 
+The normal and debug packages currently share the merged runtime identity
+(`CodexHub`, `CodexHubProxy`, and the CodexHub per-user install directory); the
+debug boundary is distinguished by its `_debug` installer artifact and compiled
+diagnostics capability. The harness selects and validates those flavor contracts
+explicitly rather than inferring identity from an environment variable.
+
 The harness and installer diagnostics deliberately report only task disposition;
 they do not print the executable path or user identity.

--- a/scripts/Run-Issue160VirtualBoxSmoke.ps1
+++ b/scripts/Run-Issue160VirtualBoxSmoke.ps1
@@ -1,0 +1,30 @@
+param(
+    [int]$LaunchTimeoutSeconds = 30,
+    [int]$InstallTimeoutSeconds = 180,
+    [switch]$RunUninstall,
+    [switch]$KeepAppRunning
+)
+
+$ErrorActionPreference = "Stop"
+$root = "\\VBOXSVR\CodexHubSmoke"
+if (-not $RunUninstall) { throw "Issue #160 smoke requires the uninstall boundary." }
+if ($KeepAppRunning) { throw "Issue #160 smoke cannot leave the app running." }
+$debugFlag = Join-Path $root "artifacts\issue160-debug.flag"
+$flavor = if (Test-Path -LiteralPath $debugFlag) { "debug" } else { "normal" }
+$installerName = if ($flavor -eq "debug") {
+    "CodexHub_0.1.6_debug_x64-setup.exe"
+} else {
+    "CodexHub_0.1.6_x64-setup.exe"
+}
+$installer = Join-Path $root "artifacts\$installerName"
+$deadline = [DateTime]::UtcNow.AddSeconds($LaunchTimeoutSeconds)
+while (-not (Test-Path -LiteralPath $installer) -and [DateTime]::UtcNow -lt $deadline) {
+    Start-Sleep -Milliseconds 250
+}
+if (-not (Test-Path -LiteralPath $installer)) { throw "Selected installer was not available." }
+
+& (Join-Path $root "scripts\Test-WindowsAutostartUninstall.ps1") `
+    -Installer $installer `
+    -Flavor $flavor `
+    -InstallTimeoutSeconds $InstallTimeoutSeconds
+exit $LASTEXITCODE

--- a/scripts/Test-WindowsAutostartUninstall.ps1
+++ b/scripts/Test-WindowsAutostartUninstall.ps1
@@ -1,18 +1,25 @@
 param(
-    [string]$Installer = "\\VBOXSVR\CodexHubSmoke\artifacts\CodexHub_0.1.6_x64-setup.exe",
+    [Parameter(Mandatory = $true)]
+    [string]$Installer,
     [ValidateSet("normal", "debug")]
     [string]$Flavor = "normal",
-    [int]$LaunchTimeoutSeconds = 30,
-    [int]$InstallTimeoutSeconds = 180,
-    [switch]$RunUninstall,
-    [switch]$KeepAppRunning
+    [int]$InstallTimeoutSeconds = 180
 )
 
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
-$taskName = "CodexHubProxy"
-$controlTaskName = "CodexHubUninstallControl"
+$flavorContract = switch ($Flavor) {
+    "normal" { @{ ProductName = "CodexHub"; TaskName = "CodexHubProxy"; InstallerSuffix = "_x64-setup.exe" } }
+    "debug" { @{ ProductName = "CodexHub"; TaskName = "CodexHubProxy"; InstallerSuffix = "_debug_x64-setup.exe" } }
+}
+$productName = $flavorContract.ProductName
+$taskName = $flavorContract.TaskName
+$controlTaskName = "${taskName}UninstallControl"
 $description = "CodexHub-owned per-user autostart"
+$installerName = [IO.Path]::GetFileName($Installer)
+if (-not $installerName.EndsWith($flavorContract.InstallerSuffix, [StringComparison]::OrdinalIgnoreCase)) {
+    throw "Installer artifact does not match the requested flavor."
+}
 
 function Get-Task([string]$Name) {
     $service = New-Object -ComObject "Schedule.Service"
@@ -55,7 +62,8 @@ function Register-ControlTask([string]$Name) {
 function Install-Candidate {
     $install = Start-Process -FilePath $Installer -ArgumentList "/S" -Wait -PassThru
     if ($install.ExitCode -ne 0) { throw "Installer failed for $Flavor flavor." }
-    $exe = Get-ChildItem "$env:LOCALAPPDATA\CodexHub" -Filter CodexHub.exe -Recurse |
+    $installRoot = Join-Path $env:LOCALAPPDATA $productName
+    $exe = Get-ChildItem $installRoot -Filter "$productName.exe" -Recurse |
         Select-Object -First 1 -ExpandProperty FullName
     if ([string]::IsNullOrWhiteSpace($exe)) { throw "Installed executable was not found." }
     return $exe

--- a/scripts/Test-WindowsAutostartUninstall.ps1
+++ b/scripts/Test-WindowsAutostartUninstall.ps1
@@ -1,0 +1,142 @@
+param(
+    [string]$Installer = "\\VBOXSVR\CodexHubSmoke\artifacts\CodexHub_0.1.6_x64-setup.exe",
+    [ValidateSet("normal", "debug")]
+    [string]$Flavor = "normal",
+    [int]$LaunchTimeoutSeconds = 30,
+    [int]$InstallTimeoutSeconds = 180,
+    [switch]$RunUninstall,
+    [switch]$KeepAppRunning
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+$taskName = "CodexHubProxy"
+$controlTaskName = "CodexHubUninstallControl"
+$description = "CodexHub-owned per-user autostart"
+
+function Get-Task([string]$Name) {
+    $service = New-Object -ComObject "Schedule.Service"
+    $service.Connect()
+    $folder = $service.GetFolder("\")
+    try { return $folder.GetTask($Name) }
+    catch {
+        if ($_.Exception.HResult -eq -2147024894) { return $null }
+        throw
+    }
+}
+
+function Remove-SmokeTask([string]$Name) {
+    $service = New-Object -ComObject "Schedule.Service"
+    $service.Connect()
+    $folder = $service.GetFolder("\")
+    try { $folder.DeleteTask($Name, 0) }
+    catch { if ($_.Exception.HResult -ne -2147024894) { throw } }
+}
+
+function Register-ControlTask([string]$Name) {
+    $service = New-Object -ComObject "Schedule.Service"
+    $service.Connect()
+    $folder = $service.GetFolder("\")
+    $sid = [Security.Principal.WindowsIdentity]::GetCurrent().User.Value
+    $definition = $service.NewTask(0)
+    $definition.RegistrationInfo.Description = "Unrelated uninstall smoke control"
+    $definition.Principal.UserId = $sid
+    $definition.Principal.LogonType = 3
+    $definition.Principal.RunLevel = 0
+    $trigger = $definition.Triggers.Create(9)
+    $trigger.Enabled = $true
+    $trigger.UserId = $sid
+    $action = $definition.Actions.Create(0)
+    $action.Path = "$env:WINDIR\System32\notepad.exe"
+    $action.WorkingDirectory = "$env:WINDIR\System32"
+    $null = $folder.RegisterTaskDefinition($Name, $definition, 6, $sid, $null, 3, $null)
+}
+
+function Install-Candidate {
+    $install = Start-Process -FilePath $Installer -ArgumentList "/S" -Wait -PassThru
+    if ($install.ExitCode -ne 0) { throw "Installer failed for $Flavor flavor." }
+    $exe = Get-ChildItem "$env:LOCALAPPDATA\CodexHub" -Filter CodexHub.exe -Recurse |
+        Select-Object -First 1 -ExpandProperty FullName
+    if ([string]::IsNullOrWhiteSpace($exe)) { throw "Installed executable was not found." }
+    return $exe
+}
+
+function Enable-Autostart([string]$Exe) {
+    $enable = Start-Process -FilePath $Exe -ArgumentList "set-autostart", "true" -Wait -PassThru
+    if ($enable.ExitCode -ne 0) { throw "Autostart enable failed." }
+}
+
+function Assert-OwnedTask([string]$Exe) {
+    $task = Get-Task $taskName
+    if ($null -eq $task) { throw "Owned registration is missing." }
+    [xml]$xml = $task.Xml
+    $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = $xml.Task.Principals.Principal
+    $trigger = $xml.Task.Triggers.LogonTrigger
+    $action = $xml.Task.Actions.Exec
+    $commandMatches = [StringComparer]::OrdinalIgnoreCase.Equals(
+        [IO.Path]::GetFullPath([string]$action.Command),
+        [IO.Path]::GetFullPath($Exe)
+    )
+    $workingMatches = [StringComparer]::OrdinalIgnoreCase.Equals(
+        [IO.Path]::GetFullPath([string]$action.WorkingDirectory),
+        [IO.Path]::GetDirectoryName([IO.Path]::GetFullPath($Exe))
+    )
+    $triggerMatches = [StringComparer]::OrdinalIgnoreCase.Equals([string]$trigger.UserId, $identity.User.Value) -or
+        [StringComparer]::OrdinalIgnoreCase.Equals([string]$trigger.UserId, $identity.Name)
+    $runLevelNode = $principal.SelectSingleNode("RunLevel")
+    $runLevel = if ($null -eq $runLevelNode) { "" } else { [string]$runLevelNode.InnerText }
+    $argumentsNode = $action.SelectSingleNode("Arguments")
+    $arguments = if ($null -eq $argumentsNode) { "" } else { [string]$argumentsNode.InnerText }
+    if ([string]$xml.Task.RegistrationInfo.Description -ne $description -or
+        -not $commandMatches -or -not $workingMatches -or
+        -not [string]::IsNullOrWhiteSpace($arguments) -or
+        [string]$principal.UserId -ne $identity.User.Value -or
+        [string]$principal.LogonType -ne "InteractiveToken" -or
+        (-not [string]::IsNullOrWhiteSpace($runLevel) -and $runLevel -ne "LeastPrivilege") -or
+        -not $triggerMatches) {
+        throw "Registration did not match the complete ownership contract."
+    }
+}
+
+function Uninstall-Candidate([string]$Exe) {
+    $uninstaller = Join-Path (Split-Path -Parent $Exe) "uninstall.exe"
+    $uninstall = Start-Process -FilePath $uninstaller -ArgumentList "/S" -Wait -PassThru
+    if ($uninstall.ExitCode -ne 0) { throw "Uninstaller failed." }
+    $deadline = [DateTime]::UtcNow.AddSeconds($InstallTimeoutSeconds)
+    while ((Test-Path -LiteralPath $Exe) -and [DateTime]::UtcNow -lt $deadline) {
+        Start-Sleep -Milliseconds 250
+    }
+    if (Test-Path -LiteralPath $Exe) { throw "Uninstaller did not complete in time." }
+}
+
+try {
+    Remove-SmokeTask $taskName
+    Remove-SmokeTask $controlTaskName
+    Register-ControlTask $controlTaskName
+
+    $exe = Install-Candidate
+    Enable-Autostart $exe
+    Assert-OwnedTask $exe
+    Uninstall-Candidate $exe
+    if ($null -ne (Get-Task $taskName)) { throw "Owned task survived uninstall." }
+    if ($null -eq (Get-Task $controlTaskName)) { throw "Unrelated control task was deleted." }
+    Write-Output "PASS: owned task removed; unrelated control task preserved."
+
+    $exe = Install-Candidate
+    Enable-Autostart $exe
+    Assert-OwnedTask $exe
+    Write-Output "PASS: reinstall created exactly one valid $Flavor registration."
+
+    Register-ControlTask $taskName
+    Uninstall-Candidate $exe
+    $mismatch = Get-Task $taskName
+    if ($null -eq $mismatch -or $mismatch.Xml -match [regex]::Escape($description)) {
+        throw "Same-name mismatched task was not preserved unchanged."
+    }
+    Write-Output "PASS: same-name mismatch preserved; diagnostics contain no executable path."
+}
+finally {
+    Remove-SmokeTask $taskName
+    Remove-SmokeTask $controlTaskName
+}

--- a/src-tauri/src/autostart.rs
+++ b/src-tauri/src/autostart.rs
@@ -226,23 +226,59 @@ fn remove_windows_autostart_for_uninstall(
     expected_exe: &Path,
     runner: &dyn CommandRunner,
 ) -> Result<String, String> {
-    let status = query_windows_autostart(expected_exe, runner)?;
-    if status.state == "missing" {
-        return Ok("No owned Windows autostart registration was present".to_string());
-    }
-    if !status.enabled {
-        return Err(
+    let program = Path::new("powershell.exe");
+    let args = windows_powershell_args(&windows_uninstall_cleanup_script(expected_exe));
+    let outcome = runner.run(program, &args).map_err(|_| {
+        "Windows uninstall autostart cleanup failed to start; registration preserved".to_string()
+    })?;
+    match outcome.code {
+        Some(0) => Ok("Owned Windows autostart registration absent or removed".to_string()),
+        Some(WINDOWS_UNINSTALL_PRESERVED_EXIT_CODE) => Err(
             "Windows autostart registration was preserved because ownership verification failed"
                 .to_string(),
-        );
+        ),
+        Some(code) => Err(format!(
+            "Windows uninstall autostart cleanup failed with exit code {code}; registration may be preserved"
+        )),
+        None => Err(
+            "Windows uninstall autostart cleanup ended without a status; registration may be preserved"
+                .to_string(),
+        ),
     }
+}
 
-    delete_windows_task(runner)?;
-    if query_windows_task(runner)?.is_some() {
-        return Err("Windows autostart cleanup failed readback verification".to_string());
-    }
+const WINDOWS_UNINSTALL_PRESERVED_EXIT_CODE: i32 = 3;
 
-    Ok("Owned Windows autostart registration removed".to_string())
+fn windows_uninstall_cleanup_script(expected_exe: &Path) -> String {
+    windows_uninstall_cleanup_script_with_prelude(expected_exe, &windows_scheduler_prelude())
+}
+
+fn windows_uninstall_cleanup_script_with_prelude(
+    expected_exe: &Path,
+    scheduler_prelude: &str,
+) -> String {
+    let task = powershell_literal(windows_task_name());
+    let expected_exe = powershell_literal(&expected_exe.to_string_lossy());
+    let description = powershell_literal(WINDOWS_TASK_DESCRIPTION);
+    format!(
+        "{}function Resolve-Sid($value){{if([string]::IsNullOrWhiteSpace($value)){{return $null}};try{{return ([Security.Principal.SecurityIdentifier]::new($value)).Value}}catch{{try{{return ([Security.Principal.NTAccount]::new($value)).Translate([Security.Principal.SecurityIdentifier]).Value}}catch{{return $null}}}}}};function Get-TaskOrNull{{try{{return $folder.GetTask({task})}}catch{{if($_.Exception.HResult -eq -2147024894){{return $null}};throw}}}};function Test-Owned($task){{try{{[xml]$xml=$task.Xml;$principals=@($xml.Task.Principals.Principal);$triggers=@($xml.Task.Triggers.LogonTrigger);$actions=@($xml.Task.Actions.Exec);if($principals.Count -ne 1 -or $triggers.Count -ne 1 -or $actions.Count -ne 1){{return $false}};$principal=$principals[0];$trigger=$triggers[0];$action=$actions[0];$principalSid=Resolve-Sid ([string]$principal.UserId);$triggerSid=Resolve-Sid ([string]$trigger.UserId);if($null -eq $principalSid -or $null -eq $triggerSid -or $principalSid -ne $triggerSid){{return $false}};$expected=[IO.Path]::GetFullPath({expected_exe});$command=[IO.Path]::GetFullPath([string]$action.Command);$working=[IO.Path]::GetFullPath([string]$action.WorkingDirectory);$arguments=[string]$action.Arguments;$runLevel=[string]$principal.RunLevel;$triggerEnabled=[string]$trigger.Enabled;$taskEnabled=[string]$xml.Task.Settings.Enabled;return $task.Path -eq ('\\'+{task}) -and [string]$xml.Task.RegistrationInfo.Description -eq {description} -and [StringComparer]::OrdinalIgnoreCase.Equals($command,$expected) -and [StringComparer]::OrdinalIgnoreCase.Equals($working,[IO.Path]::GetDirectoryName($expected)) -and [string]::IsNullOrWhiteSpace($arguments) -and [string]$principal.LogonType -eq 'InteractiveToken' -and ([string]::IsNullOrWhiteSpace($runLevel) -or $runLevel -eq 'LeastPrivilege') -and ([string]::IsNullOrWhiteSpace($triggerEnabled) -or $triggerEnabled -eq 'true') -and ([string]::IsNullOrWhiteSpace($taskEnabled) -or $taskEnabled -eq 'true')}}catch{{return $false}}}};$first=Get-TaskOrNull;if($null -eq $first){{exit 0}};if(-not (Test-Owned $first)){{exit 3}};$firstXml=$first.Xml;$second=Get-TaskOrNull;if($null -eq $second -or $second.Xml -cne $firstXml -or -not (Test-Owned $second)){{exit 3}};$folder.DeleteTask({task},0);if($null -ne (Get-TaskOrNull)){{exit 4}};exit 0",
+        scheduler_prelude,
+    )
+}
+
+#[cfg(test)]
+fn uninstall_owner_identity_matches(
+    principal: &str,
+    trigger: &str,
+    resolve_sid: impl Fn(&str) -> Option<String>,
+) -> bool {
+    let Some(principal_sid) = resolve_sid(principal) else {
+        return false;
+    };
+    let Some(trigger_sid) = resolve_sid(trigger) else {
+        return false;
+    };
+    windows_identity_equal(&principal_sid, &trigger_sid)
 }
 
 fn delete_windows_task(runner: &dyn CommandRunner) -> Result<(), String> {
@@ -935,49 +971,26 @@ mod tests {
     #[test]
     fn windows_uninstall_removes_only_fully_owned_task() {
         let exe = Path::new(r"C:\Program Files\CodexHub\CodexHub.exe");
-        let runner = RecordingRunner::sequence(vec![
-            Ok(command_outcome(
-                Some(0),
-                &windows_query_output(exe.to_str().unwrap()),
-                "",
-            )),
-            Ok(command_outcome(Some(0), "deleted", "")),
-            Ok(command_outcome(
-                Some(0),
-                super::WINDOWS_TASK_MISSING_MARKER,
-                "",
-            )),
-        ]);
+        let runner = RecordingRunner::sequence(vec![Ok(command_outcome(Some(0), "", ""))]);
 
         remove_windows_autostart_for_uninstall(exe, &runner).unwrap();
 
         assert_eq!(
             runner.commands.borrow().as_slice(),
-            &[
-                windows_query_command(),
-                windows_delete_command(),
-                windows_query_command(),
-            ]
+            &[windows_uninstall_cleanup_command(exe)]
         );
     }
 
     #[test]
     fn windows_uninstall_missing_task_is_idempotent() {
-        let runner = RecordingRunner::sequence(vec![Ok(command_outcome(
-            Some(0),
-            super::WINDOWS_TASK_MISSING_MARKER,
-            "",
-        ))]);
+        let runner = RecordingRunner::sequence(vec![Ok(command_outcome(Some(0), "", ""))]);
+        let exe = Path::new(r"C:\Program Files\CodexHub\CodexHub.exe");
 
-        remove_windows_autostart_for_uninstall(
-            Path::new(r"C:\Program Files\CodexHub\CodexHub.exe"),
-            &runner,
-        )
-        .unwrap();
+        remove_windows_autostart_for_uninstall(exe, &runner).unwrap();
 
         assert_eq!(
             runner.commands.borrow().as_slice(),
-            &[windows_query_command()]
+            &[windows_uninstall_cleanup_command(exe)]
         );
     }
 
@@ -989,8 +1002,8 @@ mod tests {
             r"C:\Program Files\CodexHub.old\CodexHub.exe",
         ] {
             let runner = RecordingRunner::sequence(vec![Ok(command_outcome(
-                Some(0),
-                &windows_query_output(task_exe),
+                Some(super::WINDOWS_UNINSTALL_PRESERVED_EXIT_CODE),
+                "",
                 "",
             ))]);
 
@@ -1002,7 +1015,7 @@ mod tests {
             );
             assert_eq!(
                 runner.commands.borrow().as_slice(),
-                &[windows_query_command()]
+                &[windows_uninstall_cleanup_command(installed)]
             );
             assert!(!error.contains(task_exe));
         }
@@ -1011,16 +1024,13 @@ mod tests {
     #[test]
     fn windows_uninstall_preserves_malformed_task_with_sanitized_diagnostic() {
         let runner = RecordingRunner::sequence(vec![Ok(command_outcome(
-            Some(0),
-            "CODEXHUB_CURRENT_SID=S-1-5-21-1000\nCODEXHUB_CURRENT_NAME=PRIVATE\\user\n<Task><Actions /></Task>",
+            Some(super::WINDOWS_UNINSTALL_PRESERVED_EXIT_CODE),
+            "",
             "",
         ))]);
+        let exe = Path::new(r"C:\Private\Secret\CodexHub.exe");
 
-        let error = remove_windows_autostart_for_uninstall(
-            Path::new(r"C:\Private\Secret\CodexHub.exe"),
-            &runner,
-        )
-        .unwrap_err();
+        let error = remove_windows_autostart_for_uninstall(exe, &runner).unwrap_err();
 
         assert_eq!(
             error,
@@ -1029,8 +1039,109 @@ mod tests {
         assert!(!error.contains("Private"));
         assert_eq!(
             runner.commands.borrow().as_slice(),
-            &[windows_query_command()]
+            &[windows_uninstall_cleanup_command(exe)]
         );
+    }
+
+    #[test]
+    fn windows_uninstall_cleanup_is_one_session_with_revalidation_before_delete() {
+        let script = super::windows_uninstall_cleanup_script(Path::new(
+            r"C:\Program Files\CodexHub\CodexHub.exe",
+        ));
+        let first_query = script.find("$first=Get-TaskOrNull").unwrap();
+        let second_query = script.find("$second=Get-TaskOrNull").unwrap();
+        let replacement_guard = script.find("$second.Xml -cne $firstXml").unwrap();
+        let delete = script.find("$folder.DeleteTask").unwrap();
+        let absence = script.rfind("Get-TaskOrNull").unwrap();
+
+        assert!(first_query < second_query);
+        assert!(second_query < replacement_guard);
+        assert!(replacement_guard < delete);
+        assert!(delete < absence);
+        assert_eq!(script.matches("$folder.DeleteTask").count(), 1);
+        assert!(!script.contains("WindowsIdentity]::GetCurrent"));
+    }
+
+    #[test]
+    fn windows_uninstall_identity_binds_principal_to_trigger_not_cleanup_user() {
+        let resolve = |identity: &str| match identity {
+            "ORIGINAL\\owner" | "S-1-5-21-2000" => Some("S-1-5-21-2000".to_string()),
+            "SYSTEM" => Some("S-1-5-18".to_string()),
+            _ => None,
+        };
+
+        assert!(super::uninstall_owner_identity_matches(
+            "S-1-5-21-2000",
+            "ORIGINAL\\owner",
+            resolve
+        ));
+        assert!(!super::uninstall_owner_identity_matches(
+            "SYSTEM",
+            "ORIGINAL\\owner",
+            resolve
+        ));
+        assert!(!super::uninstall_owner_identity_matches(
+            "unresolvable",
+            "ORIGINAL\\owner",
+            resolve
+        ));
+    }
+
+    #[test]
+    fn windows_uninstall_script_preserves_replacement_and_accepts_different_user_owner() {
+        let exe = Path::new(r"C:\Program Files\CodexHub\CodexHub.exe");
+        let owned = windows_task_xml(exe.to_str().unwrap())
+            .replace(
+                "<UserId>CODEXHUB-SMOKE\\smoke</UserId>",
+                "<UserId>S-1-5-21-2000</UserId>",
+            )
+            .replace("S-1-5-21-1000", "S-1-5-21-2000");
+        let replacement = owned.replace(super::WINDOWS_TASK_DESCRIPTION, "replacement");
+
+        assert_eq!(run_uninstall_script_fixture(exe, &[&owned, &owned]), 0);
+        assert_eq!(
+            run_uninstall_script_fixture(exe, &[&owned, &replacement]),
+            super::WINDOWS_UNINSTALL_PRESERVED_EXIT_CODE
+        );
+        assert_eq!(
+            run_uninstall_script_fixture(exe, &["<Task><Actions /></Task>"]),
+            super::WINDOWS_UNINSTALL_PRESERVED_EXIT_CODE
+        );
+    }
+
+    #[test]
+    fn windows_uninstall_launch_failure_is_sanitized_and_preserves_registration() {
+        let exe = Path::new(r"C:\Private\Owner\CodexHub.exe");
+        let runner = RecordingRunner::sequence(vec![Err(
+            "launch failed with secret credentials and C:\\Private\\Owner".to_string(),
+        )]);
+
+        let error = remove_windows_autostart_for_uninstall(exe, &runner).unwrap_err();
+
+        assert_eq!(
+            error,
+            "Windows uninstall autostart cleanup failed to start; registration preserved"
+        );
+        assert!(!error.contains("Private"));
+        assert_eq!(
+            runner.commands.borrow().as_slice(),
+            &[windows_uninstall_cleanup_command(exe)]
+        );
+    }
+
+    #[test]
+    fn nsis_cancellation_gate_and_launch_error_branch_precede_cleanup_success() {
+        let hook = include_str!("../windows/nsis-hooks.nsh");
+        let cancellation_gate = hook.find("!insertmacro CheckIfAppIsRunning").unwrap();
+        let clear_errors = hook.find("ClearErrors").unwrap();
+        let launch = hook.find("ExecWait").unwrap();
+        let launch_errors = hook.find("${If} ${Errors}").unwrap();
+        let success = hook.find("${ElseIf} $0 = 0").unwrap();
+
+        assert!(cancellation_gate < clear_errors);
+        assert!(clear_errors < launch);
+        assert!(launch < launch_errors);
+        assert!(launch_errors < success);
     }
 
     #[test]
@@ -1227,6 +1338,32 @@ mod tests {
             program: PathBuf::from("powershell.exe"),
             args: super::windows_powershell_args(&super::windows_delete_script()),
         }
+    }
+
+    fn windows_uninstall_cleanup_command(exe: &Path) -> RecordedCommand {
+        RecordedCommand {
+            program: PathBuf::from("powershell.exe"),
+            args: super::windows_powershell_args(&super::windows_uninstall_cleanup_script(exe)),
+        }
+    }
+
+    fn run_uninstall_script_fixture(exe: &Path, task_xml: &[&str]) -> i32 {
+        let mut prelude = "$ErrorActionPreference='Stop';$global:tasks=New-Object Collections.Queue;"
+            .to_string();
+        for xml in task_xml {
+            prelude.push_str(&format!(
+                "$global:tasks.Enqueue([pscustomobject]@{{Path={};Xml={}}});",
+                super::powershell_literal(&format!(r"\{}", super::windows_task_name())),
+                super::powershell_literal(xml),
+            ));
+        }
+        prelude.push_str("$folder=New-Object psobject;$folder|Add-Member ScriptMethod GetTask {if($global:tasks.Count -eq 0){return $null};return $global:tasks.Dequeue()};$folder|Add-Member ScriptMethod DeleteTask {$global:deleted=$true};");
+        let script = super::windows_uninstall_cleanup_script_with_prelude(exe, &prelude);
+        let outcome = std::process::Command::new("powershell.exe")
+            .args(super::windows_powershell_args(&script))
+            .output()
+            .expect("PowerShell fixture should start");
+        outcome.status.code().expect("PowerShell should return a code")
     }
 
     fn windows_query_command() -> RecordedCommand {

--- a/src-tauri/src/autostart.rs
+++ b/src-tauri/src/autostart.rs
@@ -41,6 +41,15 @@ pub fn remove_autostart() -> Result<String, String> {
     remove_autostart_with_dependencies(OperatingSystem::current(), &paths, &filesystem, &runner)
 }
 
+/// Removes the Windows task during package uninstall only when its complete
+/// registration still belongs to the executable being uninstalled.
+pub fn remove_autostart_for_uninstall() -> Result<String, String> {
+    let exe = std::env::current_exe().map_err(|_| {
+        "uninstall autostart cleanup could not resolve the installed executable".to_string()
+    })?;
+    remove_windows_autostart_for_uninstall(&exe, &ProcessCommandRunner)
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct AutostartStatus {
     pub enabled: bool,
@@ -211,6 +220,29 @@ fn remove_windows_autostart(runner: &dyn CommandRunner) -> Result<String, String
         "Autostart removed from Windows Task Scheduler task {}",
         windows_task_name()
     ))
+}
+
+fn remove_windows_autostart_for_uninstall(
+    expected_exe: &Path,
+    runner: &dyn CommandRunner,
+) -> Result<String, String> {
+    let status = query_windows_autostart(expected_exe, runner)?;
+    if status.state == "missing" {
+        return Ok("No owned Windows autostart registration was present".to_string());
+    }
+    if !status.enabled {
+        return Err(
+            "Windows autostart registration was preserved because ownership verification failed"
+                .to_string(),
+        );
+    }
+
+    delete_windows_task(runner)?;
+    if query_windows_task(runner)?.is_some() {
+        return Err("Windows autostart cleanup failed readback verification".to_string());
+    }
+
+    Ok("Owned Windows autostart registration removed".to_string())
 }
 
 fn delete_windows_task(runner: &dyn CommandRunner) -> Result<(), String> {
@@ -802,8 +834,8 @@ fn escape_xml(value: &str) -> String {
 mod tests {
     use super::{
         get_autostart_status_with_dependencies, remove_autostart_with_dependencies,
-        set_autostart_with_dependencies, AutostartFileSystem, AutostartPathProvider,
-        OperatingSystem,
+        remove_windows_autostart_for_uninstall, set_autostart_with_dependencies,
+        AutostartFileSystem, AutostartPathProvider, OperatingSystem,
     };
     use crate::config::{CommandOutcome, CommandRunner};
     use std::cell::RefCell;
@@ -897,6 +929,107 @@ mod tests {
         assert_eq!(
             runner.commands.borrow().as_slice(),
             &[windows_delete_command(), windows_query_command(),]
+        );
+    }
+
+    #[test]
+    fn windows_uninstall_removes_only_fully_owned_task() {
+        let exe = Path::new(r"C:\Program Files\CodexHub\CodexHub.exe");
+        let runner = RecordingRunner::sequence(vec![
+            Ok(command_outcome(
+                Some(0),
+                &windows_query_output(exe.to_str().unwrap()),
+                "",
+            )),
+            Ok(command_outcome(Some(0), "deleted", "")),
+            Ok(command_outcome(
+                Some(0),
+                super::WINDOWS_TASK_MISSING_MARKER,
+                "",
+            )),
+        ]);
+
+        remove_windows_autostart_for_uninstall(exe, &runner).unwrap();
+
+        assert_eq!(
+            runner.commands.borrow().as_slice(),
+            &[
+                windows_query_command(),
+                windows_delete_command(),
+                windows_query_command(),
+            ]
+        );
+    }
+
+    #[test]
+    fn windows_uninstall_missing_task_is_idempotent() {
+        let runner = RecordingRunner::sequence(vec![Ok(command_outcome(
+            Some(0),
+            super::WINDOWS_TASK_MISSING_MARKER,
+            "",
+        ))]);
+
+        remove_windows_autostart_for_uninstall(
+            Path::new(r"C:\Program Files\CodexHub\CodexHub.exe"),
+            &runner,
+        )
+        .unwrap();
+
+        assert_eq!(
+            runner.commands.borrow().as_slice(),
+            &[windows_query_command()]
+        );
+    }
+
+    #[test]
+    fn windows_uninstall_preserves_mismatched_and_replacement_path_tasks() {
+        let installed = Path::new(r"C:\Program Files\CodexHub\CodexHub.exe");
+        for task_exe in [
+            r"D:\Control\unrelated.exe",
+            r"C:\Program Files\CodexHub.old\CodexHub.exe",
+        ] {
+            let runner = RecordingRunner::sequence(vec![Ok(command_outcome(
+                Some(0),
+                &windows_query_output(task_exe),
+                "",
+            ))]);
+
+            let error = remove_windows_autostart_for_uninstall(installed, &runner).unwrap_err();
+
+            assert_eq!(
+                error,
+                "Windows autostart registration was preserved because ownership verification failed"
+            );
+            assert_eq!(
+                runner.commands.borrow().as_slice(),
+                &[windows_query_command()]
+            );
+            assert!(!error.contains(task_exe));
+        }
+    }
+
+    #[test]
+    fn windows_uninstall_preserves_malformed_task_with_sanitized_diagnostic() {
+        let runner = RecordingRunner::sequence(vec![Ok(command_outcome(
+            Some(0),
+            "CODEXHUB_CURRENT_SID=S-1-5-21-1000\nCODEXHUB_CURRENT_NAME=PRIVATE\\user\n<Task><Actions /></Task>",
+            "",
+        ))]);
+
+        let error = remove_windows_autostart_for_uninstall(
+            Path::new(r"C:\Private\Secret\CodexHub.exe"),
+            &runner,
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            error,
+            "Windows autostart registration was preserved because ownership verification failed"
+        );
+        assert!(!error.contains("Private"));
+        assert_eq!(
+            runner.commands.borrow().as_slice(),
+            &[windows_query_command()]
         );
     }
 

--- a/src-tauri/src/autostart.rs
+++ b/src-tauri/src/autostart.rs
@@ -1105,24 +1105,33 @@ mod tests {
             "</Triggers>",
             "<BootTrigger><Enabled>true</Enabled></BootTrigger></Triggers>",
         );
+        let unknown_action = owned.replace("<Exec>", "<UnknownAction>").replace(
+            "</Exec>",
+            "</UnknownAction>",
+        );
+        let unknown_trigger = owned
+            .replace("<LogonTrigger>", "<UnknownTrigger>")
+            .replace("</LogonTrigger>", "</UnknownTrigger>");
+        let malformed = "<Task><Actions /></Task>";
 
         assert_eq!(run_uninstall_script_fixture(exe, &[&owned, &owned]), (0, true));
         assert_eq!(
             run_uninstall_script_fixture(exe, &[&owned, &replacement]),
             (super::WINDOWS_UNINSTALL_PRESERVED_EXIT_CODE, false)
         );
-        assert_eq!(
-            run_uninstall_script_fixture(exe, &["<Task><Actions /></Task>"]),
-            (super::WINDOWS_UNINSTALL_PRESERVED_EXIT_CODE, false)
-        );
-        assert_eq!(
-            run_uninstall_script_fixture(exe, &[&extra_action]),
-            (super::WINDOWS_UNINSTALL_PRESERVED_EXIT_CODE, false)
-        );
-        assert_eq!(
-            run_uninstall_script_fixture(exe, &[&extra_trigger]),
-            (super::WINDOWS_UNINSTALL_PRESERVED_EXIT_CODE, false)
-        );
+        for (name, xml) in [
+            ("missing containers", malformed),
+            ("Exec plus ComHandler", extra_action.as_str()),
+            ("LogonTrigger plus BootTrigger", extra_trigger.as_str()),
+            ("unknown action element", unknown_action.as_str()),
+            ("unknown trigger element", unknown_trigger.as_str()),
+        ] {
+            assert_eq!(
+                run_uninstall_script_fixture(exe, &[xml, xml]),
+                (super::WINDOWS_UNINSTALL_PRESERVED_EXIT_CODE, false),
+                "{name} must preserve without deletion"
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/src/autostart.rs
+++ b/src-tauri/src/autostart.rs
@@ -261,7 +261,7 @@ fn windows_uninstall_cleanup_script_with_prelude(
     let expected_exe = powershell_literal(&expected_exe.to_string_lossy());
     let description = powershell_literal(WINDOWS_TASK_DESCRIPTION);
     format!(
-        "{}function Resolve-Sid($value){{if([string]::IsNullOrWhiteSpace($value)){{return $null}};try{{return ([Security.Principal.SecurityIdentifier]::new($value)).Value}}catch{{try{{return ([Security.Principal.NTAccount]::new($value)).Translate([Security.Principal.SecurityIdentifier]).Value}}catch{{return $null}}}}}};function Get-TaskOrNull{{try{{return $folder.GetTask({task})}}catch{{if($_.Exception.HResult -eq -2147024894){{return $null}};throw}}}};function Test-Owned($task){{try{{[xml]$xml=$task.Xml;$principals=@($xml.Task.Principals.Principal);$triggers=@($xml.Task.Triggers.LogonTrigger);$actions=@($xml.Task.Actions.Exec);if($principals.Count -ne 1 -or $triggers.Count -ne 1 -or $actions.Count -ne 1){{return $false}};$principal=$principals[0];$trigger=$triggers[0];$action=$actions[0];$principalSid=Resolve-Sid ([string]$principal.UserId);$triggerSid=Resolve-Sid ([string]$trigger.UserId);if($null -eq $principalSid -or $null -eq $triggerSid -or $principalSid -ne $triggerSid){{return $false}};$expected=[IO.Path]::GetFullPath({expected_exe});$command=[IO.Path]::GetFullPath([string]$action.Command);$working=[IO.Path]::GetFullPath([string]$action.WorkingDirectory);$arguments=[string]$action.Arguments;$runLevel=[string]$principal.RunLevel;$triggerEnabled=[string]$trigger.Enabled;$taskEnabled=[string]$xml.Task.Settings.Enabled;return $task.Path -eq ('\\'+{task}) -and [string]$xml.Task.RegistrationInfo.Description -eq {description} -and [StringComparer]::OrdinalIgnoreCase.Equals($command,$expected) -and [StringComparer]::OrdinalIgnoreCase.Equals($working,[IO.Path]::GetDirectoryName($expected)) -and [string]::IsNullOrWhiteSpace($arguments) -and [string]$principal.LogonType -eq 'InteractiveToken' -and ([string]::IsNullOrWhiteSpace($runLevel) -or $runLevel -eq 'LeastPrivilege') -and ([string]::IsNullOrWhiteSpace($triggerEnabled) -or $triggerEnabled -eq 'true') -and ([string]::IsNullOrWhiteSpace($taskEnabled) -or $taskEnabled -eq 'true')}}catch{{return $false}}}};$first=Get-TaskOrNull;if($null -eq $first){{exit 0}};if(-not (Test-Owned $first)){{exit 3}};$firstXml=$first.Xml;$second=Get-TaskOrNull;if($null -eq $second -or $second.Xml -cne $firstXml -or -not (Test-Owned $second)){{exit 3}};$folder.DeleteTask({task},0);if($null -ne (Get-TaskOrNull)){{exit 4}};exit 0",
+        "{}function Resolve-Sid($value){{if([string]::IsNullOrWhiteSpace($value)){{return $null}};try{{return ([Security.Principal.SecurityIdentifier]::new($value)).Value}}catch{{try{{return ([Security.Principal.NTAccount]::new($value)).Translate([Security.Principal.SecurityIdentifier]).Value}}catch{{return $null}}}}}};function Get-TaskOrNull{{try{{return $folder.GetTask({task})}}catch{{if($_.Exception.HResult -eq -2147024894){{return $null}};throw}}}};function Test-Owned($task){{try{{[xml]$xml=$task.Xml;$principalContainer=$xml.Task.Principals;$triggerContainer=$xml.Task.Triggers;$actionContainer=$xml.Task.Actions;if($null -eq $principalContainer -or $null -eq $triggerContainer -or $null -eq $actionContainer){{return $false}};$principals=@($principalContainer.ChildNodes|Where-Object{{$_.NodeType -eq [Xml.XmlNodeType]::Element}});$triggers=@($triggerContainer.ChildNodes|Where-Object{{$_.NodeType -eq [Xml.XmlNodeType]::Element}});$actions=@($actionContainer.ChildNodes|Where-Object{{$_.NodeType -eq [Xml.XmlNodeType]::Element}});if($principals.Count -ne 1 -or $principals[0].LocalName -ne 'Principal' -or $triggers.Count -ne 1 -or $triggers[0].LocalName -ne 'LogonTrigger' -or $actions.Count -ne 1 -or $actions[0].LocalName -ne 'Exec'){{return $false}};$principal=$principals[0];$trigger=$triggers[0];$action=$actions[0];$principalSid=Resolve-Sid ([string]$principal.UserId);$triggerSid=Resolve-Sid ([string]$trigger.UserId);if($null -eq $principalSid -or $null -eq $triggerSid -or $principalSid -ne $triggerSid){{return $false}};$expected=[IO.Path]::GetFullPath({expected_exe});$command=[IO.Path]::GetFullPath([string]$action.Command);$working=[IO.Path]::GetFullPath([string]$action.WorkingDirectory);$arguments=[string]$action.Arguments;$runLevel=[string]$principal.RunLevel;$triggerEnabled=[string]$trigger.Enabled;$taskEnabled=[string]$xml.Task.Settings.Enabled;return $task.Path -eq ('\\'+{task}) -and [string]$xml.Task.RegistrationInfo.Description -eq {description} -and [StringComparer]::OrdinalIgnoreCase.Equals($command,$expected) -and [StringComparer]::OrdinalIgnoreCase.Equals($working,[IO.Path]::GetDirectoryName($expected)) -and [string]::IsNullOrWhiteSpace($arguments) -and [string]$principal.LogonType -eq 'InteractiveToken' -and ([string]::IsNullOrWhiteSpace($runLevel) -or $runLevel -eq 'LeastPrivilege') -and ([string]::IsNullOrWhiteSpace($triggerEnabled) -or $triggerEnabled -eq 'true') -and ([string]::IsNullOrWhiteSpace($taskEnabled) -or $taskEnabled -eq 'true')}}catch{{return $false}}}};$first=Get-TaskOrNull;if($null -eq $first){{exit 0}};if(-not (Test-Owned $first)){{exit 3}};$firstXml=$first.Xml;$second=Get-TaskOrNull;if($null -eq $second -or $second.Xml -cne $firstXml -or -not (Test-Owned $second)){{exit 3}};$folder.DeleteTask({task},0);if($null -ne (Get-TaskOrNull)){{exit 4}};exit 0",
         scheduler_prelude,
     )
 }
@@ -1097,15 +1097,31 @@ mod tests {
             )
             .replace("S-1-5-21-1000", "S-1-5-21-2000");
         let replacement = owned.replace(super::WINDOWS_TASK_DESCRIPTION, "replacement");
+        let extra_action = owned.replace(
+            "</Actions>",
+            "<ComHandler><ClassId>{00000000-0000-0000-0000-000000000000}</ClassId></ComHandler></Actions>",
+        );
+        let extra_trigger = owned.replace(
+            "</Triggers>",
+            "<BootTrigger><Enabled>true</Enabled></BootTrigger></Triggers>",
+        );
 
-        assert_eq!(run_uninstall_script_fixture(exe, &[&owned, &owned]), 0);
+        assert_eq!(run_uninstall_script_fixture(exe, &[&owned, &owned]), (0, true));
         assert_eq!(
             run_uninstall_script_fixture(exe, &[&owned, &replacement]),
-            super::WINDOWS_UNINSTALL_PRESERVED_EXIT_CODE
+            (super::WINDOWS_UNINSTALL_PRESERVED_EXIT_CODE, false)
         );
         assert_eq!(
             run_uninstall_script_fixture(exe, &["<Task><Actions /></Task>"]),
-            super::WINDOWS_UNINSTALL_PRESERVED_EXIT_CODE
+            (super::WINDOWS_UNINSTALL_PRESERVED_EXIT_CODE, false)
+        );
+        assert_eq!(
+            run_uninstall_script_fixture(exe, &[&extra_action]),
+            (super::WINDOWS_UNINSTALL_PRESERVED_EXIT_CODE, false)
+        );
+        assert_eq!(
+            run_uninstall_script_fixture(exe, &[&extra_trigger]),
+            (super::WINDOWS_UNINSTALL_PRESERVED_EXIT_CODE, false)
         );
     }
 
@@ -1347,7 +1363,7 @@ mod tests {
         }
     }
 
-    fn run_uninstall_script_fixture(exe: &Path, task_xml: &[&str]) -> i32 {
+    fn run_uninstall_script_fixture(exe: &Path, task_xml: &[&str]) -> (i32, bool) {
         let mut prelude = "$ErrorActionPreference='Stop';$global:tasks=New-Object Collections.Queue;"
             .to_string();
         for xml in task_xml {
@@ -1357,13 +1373,16 @@ mod tests {
                 super::powershell_literal(xml),
             ));
         }
-        prelude.push_str("$folder=New-Object psobject;$folder|Add-Member ScriptMethod GetTask {if($global:tasks.Count -eq 0){return $null};return $global:tasks.Dequeue()};$folder|Add-Member ScriptMethod DeleteTask {$global:deleted=$true};");
+        prelude.push_str("$folder=New-Object psobject;$folder|Add-Member ScriptMethod GetTask {if($global:tasks.Count -eq 0){return $null};return $global:tasks.Dequeue()};$folder|Add-Member ScriptMethod DeleteTask {Write-Output 'CODEXHUB_DELETE_CALLED'};");
         let script = super::windows_uninstall_cleanup_script_with_prelude(exe, &prelude);
         let outcome = std::process::Command::new("powershell.exe")
             .args(super::windows_powershell_args(&script))
             .output()
             .expect("PowerShell fixture should start");
-        outcome.status.code().expect("PowerShell should return a code")
+        (
+            outcome.status.code().expect("PowerShell should return a code"),
+            String::from_utf8_lossy(&outcome.stdout).contains("CODEXHUB_DELETE_CALLED"),
+        )
     }
 
     fn windows_query_command() -> RecordedCommand {

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -25,6 +25,9 @@ pub fn run(args: &[String]) -> i32 {
             }
         },
         Some("remove-autostart") => print_result(autostart::remove_autostart()),
+        Some("cleanup-autostart-on-uninstall") => {
+            print_result(autostart::remove_autostart_for_uninstall())
+        }
         Some("app") | None => 0,
         Some("-h" | "--help" | "help") => {
             print_help();

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -41,7 +41,12 @@
       "icons/128x128@2x.png",
       "icons/icon.png",
       "icons/icon.ico"
-    ]
+    ],
+    "windows": {
+      "nsis": {
+        "installerHooks": "windows/nsis-hooks.nsh"
+      }
+    }
   },
   "plugins": {
     "updater": {

--- a/src-tauri/windows/nsis-hooks.nsh
+++ b/src-tauri/windows/nsis-hooks.nsh
@@ -1,8 +1,14 @@
 !macro NSIS_HOOK_PREUNINSTALL
   ; Updates replace the executable in place and must retain its registration.
   ${If} $UpdateMode <> 1
+    ; Tauri invokes its normal app-running gate after this hook. Invoke the same
+    ; gate here so interactive cancellation happens before persistent cleanup.
+    !insertmacro CheckIfAppIsRunning "${MAINBINARYNAME}.exe" "${PRODUCTNAME}"
+    ClearErrors
     ExecWait '"$INSTDIR\${MAINBINARYNAME}.exe" cleanup-autostart-on-uninstall' $0
-    ${If} $0 = 0
+    ${If} ${Errors}
+      DetailPrint "CodexHub autostart cleanup: command launch failed; registration preserved."
+    ${ElseIf} $0 = 0
       DetailPrint "CodexHub autostart cleanup: owned registration absent or removed."
     ${Else}
       ; Fail closed: uninstall continues, but any uncertain task is preserved.

--- a/src-tauri/windows/nsis-hooks.nsh
+++ b/src-tauri/windows/nsis-hooks.nsh
@@ -1,0 +1,12 @@
+!macro NSIS_HOOK_PREUNINSTALL
+  ; Updates replace the executable in place and must retain its registration.
+  ${If} $UpdateMode <> 1
+    ExecWait '"$INSTDIR\${MAINBINARYNAME}.exe" cleanup-autostart-on-uninstall' $0
+    ${If} $0 = 0
+      DetailPrint "CodexHub autostart cleanup: owned registration absent or removed."
+    ${Else}
+      ; Fail closed: uninstall continues, but any uncertain task is preserved.
+      DetailPrint "CodexHub autostart cleanup: registration preserved; ownership verification failed."
+    ${EndIf}
+  ${EndIf}
+!macroend


### PR DESCRIPTION
Closes #160

## Runtime implementation
- performs ownership verification, immediate second-read replacement detection, deletion, and absence confirmation inside one PowerShell/Task Scheduler COM process
- validates exact task identity, executable, working directory, description, settings, principal/trigger owner SID, and immediate XML child shape
- requires exactly one `Principal`, one total `LogonTrigger`, and one total `Exec`; missing, heterogeneous, unknown, malformed, mismatched, replaced, or identity-unresolvable registrations are preserved
- gates cleanup behind Tauri's app-running/cancellation check and handles NSIS launch errors explicitly

## Human-authorized test-only correction
Exact head `b1f48e816045dbc872c328e596e288971ae35c9d` changes tests only; runtime and package code are unchanged from `3dd1c51e71c9e458690f21da4ccedb08b86c79c6`.

The executable PowerShell oracle now enqueues two identical snapshots for every fail-closed shape case, preventing false success from an empty second-read queue. Each case asserts exactly `(exit code 3, delete_called=false)`:
- malformed XML / missing containers
- `Exec + ComHandler`
- `LogonTrigger + BootTrigger`
- distinct unknown action element
- distinct unknown trigger element

The corrected fixtures pass and exposed no runtime defect.

## Validation on exact test-only head
- focused uninstall suite: 8 passed
- corrected executable PowerShell fixture: passed
- `cargo clippy --locked --all-targets -- -D warnings`: passed
- `git diff --check`: passed
- `python scripts/report_quality_gates.py`: report-only baseline, no blocking result
- GitHub Actions run `29694262803`: **7/7 passed**

## Carried-forward exact runtime/package evidence
No rebuild or VM rerun was performed for the test-only head. The unchanged runtime/package bits retain the evidence built from `3dd1c51e71c9e458690f21da4ccedb08b86c79c6`:
- normal SHA-256 `ca7f08aa465718a259162ec3c468c910b8513e9a8f3e17458a8c973841c8707d`
- debug SHA-256 `d06876745a308df6aab1e465eb82e8abbbf9bbe7531de1903863273083555f19`
- normal and debug each passed owned cleanup, unrelated-control preservation, one-valid-registration reinstall, and same-name-mismatch preservation from independent `clean-os-ready` restores

The existing VM remains on snapshot `clean-os-ready` (`a5a3a247-b172-4c24-bce5-fa7639546a32`) in `saved` state. No credentials or private executable paths are included.