### PR TITLE
fix(gateway): preserve transparent Responses tool history (#193)

### DIFF
--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -653,6 +653,8 @@ TOOL_SEARCH_EXPLICIT_FUNCTION_TOOL = {
 TOOL_SEARCH_EMPTY_MISS_BOUND = 2
 TOOL_SEARCH_UNAVAILABLE_QUERY_CLASSIFICATION = "identical_exact_query"
 TOOL_SEARCH_UNAVAILABLE_STATUS = "unavailable"
+EXCESSIVE_TOOL_LOOP_BOUND = 3
+EXCESSIVE_TOOL_LOOP_ERROR_CODE = "excessive_tool_loop"
 BROWSER_CONTEXT_MARKERS = (
     "# in app browser",
     "# browser comments",
@@ -6730,6 +6732,59 @@ def _compatible_internal_message(item: Mapping[str, Any]) -> dict[str, str] | No
     return _compatible_tool_message(item)
 
 
+def _is_standard_responses_function_call(item: Mapping[str, Any]) -> bool:
+    return (
+        item.get("type") == "function_call"
+        and isinstance(item.get("call_id"), str)
+        and bool(item["call_id"])
+        and isinstance(item.get("name"), str)
+        and bool(item["name"])
+        and "arguments" in item
+        and not item.get("namespace")
+        and WORKER_REQUESTED_BINDING_FIELD not in item
+        and _multi_agent_function_call_name(item) is None
+        and _node_repl_function_call_name(item) is None
+        and not _is_mcp_or_codex_app_function_call(item)
+    )
+
+
+def _excessive_transparent_responses_tool_loop_count(payload: Mapping[str, Any]) -> int | None:
+    input_items = payload.get("input")
+    if not isinstance(input_items, list):
+        return None
+
+    pending_calls: dict[str, tuple[str, str]] = {}
+    previous_pair: tuple[str, str, str] | None = None
+    repeated_count = 0
+    for item in input_items:
+        if not isinstance(item, Mapping):
+            previous_pair = None
+            repeated_count = 0
+            continue
+        if _is_standard_responses_function_call(item):
+            if item.get("status") == "completed":
+                pending_calls[item["call_id"]] = (
+                    item["name"],
+                    json.dumps(item["arguments"], ensure_ascii=True, separators=(",", ":"), sort_keys=True),
+                )
+            else:
+                previous_pair = None
+                repeated_count = 0
+            continue
+        if item.get("type") == "function_call_output" and isinstance(item.get("call_id"), str):
+            call = pending_calls.pop(item["call_id"], None)
+            if call is not None and "output" in item:
+                pair = call + (json.dumps(item["output"], ensure_ascii=True, separators=(",", ":"), sort_keys=True),)
+                repeated_count = repeated_count + 1 if pair == previous_pair else 1
+                previous_pair = pair
+                if repeated_count >= EXCESSIVE_TOOL_LOOP_BOUND:
+                    return repeated_count
+                continue
+        previous_pair = None
+        repeated_count = 0
+    return None
+
+
 def _multi_agent_discovery_output_item(item: Mapping[str, Any]) -> dict[str, Any]:
     rewritten = dict(item)
     rewritten["tools"] = MULTI_AGENT_DISCOVERY_TOOLS
@@ -6742,6 +6797,7 @@ def _rewrite_internal_input_items(
     payload: dict[str, Any],
     event_context: Mapping[str, Any] | None = None,
     upstream_name: str | None = None,
+    preserve_standard_function_history: bool = False,
 ) -> bool:
     input_items = payload.get("input")
     if not isinstance(input_items, list):
@@ -6753,10 +6809,19 @@ def _rewrite_internal_input_items(
     multi_agent_search_call_ids: set[str] = set()
     multi_agent_calls_by_call_id: dict[str, tuple[str, dict[str, Any] | None]] = {}
     node_repl_call_ids: set[str] = set()
+    preserved_standard_call_ids: set[str] = set()
     for item in input_items:
         item_type = item.get("type") if isinstance(item, dict) else None
+        call_id = item.get("call_id") if isinstance(item, dict) else None
+        if preserve_standard_function_history and isinstance(item, dict):
+            if _is_standard_responses_function_call(item):
+                preserved_standard_call_ids.add(item["call_id"])
+                rewritten_items.append(item)
+                continue
+            if item_type == "function_call_output" and call_id in preserved_standard_call_ids:
+                rewritten_items.append(item)
+                continue
         if isinstance(item_type, str) and item_type in INTERNAL_INPUT_ITEM_TYPES:
-            call_id = item.get("call_id")
             if item_type == "function_call" and isinstance(call_id, str):
                 if _node_repl_function_call_name(item) is not None:
                     node_repl_call_ids.add(call_id)
@@ -8333,7 +8398,10 @@ def transparent_request_body(
                 changed = True
             if official_responses_backend and _sanitize_unsupported_compaction_input_items(next_payload):
                 changed = True
-            if upstream_is_third_party and _rewrite_internal_input_items(next_payload):
+            if upstream_is_third_party and _rewrite_internal_input_items(
+                next_payload,
+                preserve_standard_function_history=True,
+            ):
                 changed = True
             if official_responses_backend and "max_output_tokens" in next_payload:
                 del next_payload["max_output_tokens"]
@@ -8376,7 +8444,10 @@ def transparent_request_body(
         changed = True
     if _normalize_responses_message_input_items(next_payload):
         changed = True
-    if upstream_is_third_party and _rewrite_internal_input_items(next_payload):
+    if upstream_is_third_party and _rewrite_internal_input_items(
+        next_payload,
+        preserve_standard_function_history=True,
+    ):
         changed = True
     if upstream_name == "ollama_cloud" and _apply_ollama_reasoning_effort_alias(next_payload):
         changed = True
@@ -12898,6 +12969,17 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         schemas_rewritten=tool_schema_rewrites,
                         **proxy_request_context,
                     )
+                if is_transparent_same_format and inbound_format == "responses":
+                    repeated_count = _excessive_transparent_responses_tool_loop_count(
+                        _safe_json_mapping(body) or {}
+                    )
+                    if repeated_count is not None:
+                        raise UpstreamProtocolTranslationError(
+                            UnsupportedProtocolTranslationError(
+                                EXCESSIVE_TOOL_LOOP_ERROR_CODE,
+                                f"Repeated successful function calls exceeded the bound of {EXCESSIVE_TOOL_LOOP_BOUND}.",
+                            )
+                        )
             else:
                 compatibility_upstream = upstream
                 if upstream_format == "auto":

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -6785,6 +6785,53 @@ def _excessive_transparent_responses_tool_loop_count(payload: Mapping[str, Any])
     return None
 
 
+def _excessive_transparent_chat_tool_loop_count(payload: Mapping[str, Any]) -> int | None:
+    messages = payload.get("messages")
+    if not isinstance(messages, list):
+        return None
+
+    previous_pair: tuple[str, str, str] | None = None
+    repeated_count = 0
+    index = 0
+    while index < len(messages) - 1:
+        message = messages[index]
+        result = messages[index + 1]
+        tool_calls = message.get("tool_calls") if isinstance(message, Mapping) else None
+        if (
+            not isinstance(tool_calls, list)
+            or len(tool_calls) != 1
+            or not isinstance(result, Mapping)
+            or message.get("role") != "assistant"
+            or result.get("role") != "tool"
+        ):
+            previous_pair = None
+            repeated_count = 0
+            index += 1
+            continue
+        call = tool_calls[0]
+        function = call.get("function") if isinstance(call, Mapping) else None
+        if (
+            not isinstance(function, Mapping)
+            or call.get("type") != "function"
+            or not isinstance(call.get("id"), str)
+            or call["id"] != result.get("tool_call_id")
+            or not isinstance(function.get("name"), str)
+            or not isinstance(function.get("arguments"), str)
+            or not isinstance(result.get("content"), str)
+        ):
+            previous_pair = None
+            repeated_count = 0
+            index += 1
+            continue
+        pair = (function["name"], function["arguments"], result["content"])
+        repeated_count = repeated_count + 1 if pair == previous_pair else 1
+        previous_pair = pair
+        if repeated_count >= EXCESSIVE_TOOL_LOOP_BOUND:
+            return repeated_count
+        index += 2
+    return None
+
+
 def _multi_agent_discovery_output_item(item: Mapping[str, Any]) -> dict[str, Any]:
     rewritten = dict(item)
     rewritten["tools"] = MULTI_AGENT_DISCOVERY_TOOLS
@@ -12969,9 +13016,14 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         schemas_rewritten=tool_schema_rewrites,
                         **proxy_request_context,
                     )
-                if is_transparent_same_format and inbound_format == "responses":
-                    repeated_count = _excessive_transparent_responses_tool_loop_count(
-                        _safe_json_mapping(body) or {}
+                if upstream_name != "official" and is_transparent_same_format:
+                    transparent_payload = _safe_json_mapping(body) or {}
+                    repeated_count = (
+                        _excessive_transparent_responses_tool_loop_count(transparent_payload)
+                        if inbound_format == "responses"
+                        else _excessive_transparent_chat_tool_loop_count(transparent_payload)
+                        if inbound_format == "chat_completions"
+                        else None
                     )
                     if repeated_count is not None:
                         raise UpstreamProtocolTranslationError(

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -705,6 +705,83 @@ class RoutingTests(unittest.TestCase):
         self.assertEqual(result["output"][0]["content"][0]["text"], "hello")
         self.assertEqual(dict(fake.headers).get("Content-Type"), "application/json")
 
+    def test_opencode_volc_transparent_responses_preserves_standard_function_history(self):
+        input_items = [
+            {"type": "message", "role": "user", "content": "Calculate 2 + 2."},
+            {
+                "id": "fc_calc_1",
+                "type": "function_call",
+                "status": "completed",
+                "call_id": "call_calc_1",
+                "name": "calculator",
+                "arguments": '{"expression":"2+2"}',
+            },
+            {"type": "function_call_output", "call_id": "call_calc_1", "output": "4"},
+        ]
+        body = json.dumps(
+            {
+                "model": "glm-5.2",
+                "input": input_items,
+                "tools": [{"type": "function", "name": "calculator", "parameters": {"type": "object"}}],
+                "stream": False,
+            }
+        ).encode("utf-8")
+        handler, fake = post_handler(
+            "/v1/providers/volc/responses",
+            body,
+            headers={"X-Codex-Client-Id": "opencode"},
+        )
+
+        with patch(
+            "codex_proxy._open_upstream_response",
+            return_value=FakeContextResponse(b'{"id":"resp_volc","output":[]}'),
+        ) as open_upstream:
+            CodexProxyHandler.do_POST(handler)
+
+        request = open_upstream.call_args.args[0]
+        self.assertEqual(request.full_url, "https://ark.example.test/v1/responses")
+        sent_payload = json.loads(request.data)
+        self.assertEqual(sent_payload["model"], "glm-5.2")
+        self.assertEqual(sent_payload["input"], input_items)
+        self.assertEqual(fake.status, 200)
+
+    def test_opencode_volc_transparent_responses_bounds_repeated_successful_function_calls(self):
+        input_items = [{"type": "message", "role": "user", "content": "Calculate 2 + 2."}]
+        for index in range(3):
+            call_id = f"call_calc_{index}"
+            input_items.extend(
+                [
+                    {
+                        "type": "function_call",
+                        "status": "completed",
+                        "call_id": call_id,
+                        "name": "calculator",
+                        "arguments": '{"expression":"2+2"}',
+                    },
+                    {"type": "function_call_output", "call_id": call_id, "output": "4"},
+                ]
+            )
+        body = json.dumps(
+            {"model": "glm-5.2", "input": input_items, "stream": False}
+        ).encode("utf-8")
+        handler, fake = post_handler(
+            "/v1/providers/volc/responses",
+            body,
+            headers={"X-Codex-Client-Id": "opencode"},
+        )
+
+        with patch(
+            "codex_proxy._open_upstream_response",
+            return_value=FakeContextResponse(b'{"id":"resp_unexpected","output":[]}'),
+        ) as open_upstream:
+            CodexProxyHandler.do_POST(handler)
+
+        self.assertEqual(fake.status, 400)
+        open_upstream.assert_not_called()
+        payload = json.loads(b"".join(fake.wfile.writes))
+        self.assertEqual(payload["codexhub_error"]["details"]["error"], "excessive_tool_loop")
+        self.assertFalse(payload["codexhub_error"]["retryable"])
+
     def test_third_party_app_official_chat_completions_uses_lightweight_responses_fallback(self):
         body = json.dumps(
             {

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -705,67 +705,94 @@ class RoutingTests(unittest.TestCase):
         self.assertEqual(result["output"][0]["content"][0]["text"], "hello")
         self.assertEqual(dict(fake.headers).get("Content-Type"), "application/json")
 
-    def test_opencode_volc_transparent_responses_preserves_standard_function_history(self):
-        input_items = [
-            {"type": "message", "role": "user", "content": "Calculate 2 + 2."},
+    def test_opencode_volc_transparent_chat_preserves_standard_tool_history(self):
+        messages = [
+            {"role": "user", "content": "Calculate 2 + 2."},
             {
-                "id": "fc_calc_1",
-                "type": "function_call",
-                "status": "completed",
-                "call_id": "call_calc_1",
-                "name": "calculator",
-                "arguments": '{"expression":"2+2"}',
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_calc_1",
+                        "type": "function",
+                        "function": {"name": "calculator", "arguments": '{"expression":"2+2"}'},
+                    }
+                ],
             },
-            {"type": "function_call_output", "call_id": "call_calc_1", "output": "4"},
+            {"role": "tool", "tool_call_id": "call_calc_1", "content": "4"},
+        ]
+        tools = [
+            {"type": "function", "function": {"name": "calculator", "parameters": {"type": "object"}}}
         ]
         body = json.dumps(
             {
                 "model": "glm-5.2",
-                "input": input_items,
-                "tools": [{"type": "function", "name": "calculator", "parameters": {"type": "object"}}],
+                "messages": messages,
+                "tools": tools,
                 "stream": False,
             }
         ).encode("utf-8")
+        self.external_model["upstream_format"] = "chat_completions"
         handler, fake = post_handler(
-            "/v1/providers/volc/responses",
+            "/v1/providers/volc/chat/completions",
             body,
             headers={"X-Codex-Client-Id": "opencode"},
         )
 
-        with patch(
-            "codex_proxy._open_upstream_response",
-            return_value=FakeContextResponse(b'{"id":"resp_volc","output":[]}'),
-        ) as open_upstream:
+        with (
+            patch(
+                "codex_proxy._chat_completions_request_to_responses_body",
+                side_effect=AssertionError("converted to Responses"),
+            ),
+            patch(
+                "codex_proxy._responses_request_to_chat_completion_body",
+                side_effect=AssertionError("converted from Responses"),
+            ),
+            patch(
+                "codex_proxy.compatible_request_body",
+                side_effect=AssertionError("compatibility adapter ran"),
+            ),
+            patch(
+                "codex_proxy._open_upstream_response",
+                return_value=FakeContextResponse(b'{"id":"chatcmpl_volc","choices":[]}'),
+            ) as open_upstream,
+        ):
             CodexProxyHandler.do_POST(handler)
 
         request = open_upstream.call_args.args[0]
-        self.assertEqual(request.full_url, "https://ark.example.test/v1/responses")
+        self.assertEqual(request.full_url, "https://ark.example.test/v1/chat/completions")
         sent_payload = json.loads(request.data)
         self.assertEqual(sent_payload["model"], "glm-5.2")
-        self.assertEqual(sent_payload["input"], input_items)
+        self.assertEqual(sent_payload["messages"], messages)
+        self.assertEqual(sent_payload["tools"], tools)
         self.assertEqual(fake.status, 200)
 
-    def test_opencode_volc_transparent_responses_bounds_repeated_successful_function_calls(self):
-        input_items = [{"type": "message", "role": "user", "content": "Calculate 2 + 2."}]
+    def test_opencode_volc_transparent_chat_bounds_repeated_successful_tool_calls(self):
+        messages = [{"role": "user", "content": "Calculate 2 + 2."}]
         for index in range(3):
             call_id = f"call_calc_{index}"
-            input_items.extend(
+            messages.extend(
                 [
                     {
-                        "type": "function_call",
-                        "status": "completed",
-                        "call_id": call_id,
-                        "name": "calculator",
-                        "arguments": '{"expression":"2+2"}',
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": call_id,
+                                "type": "function",
+                                "function": {"name": "calculator", "arguments": '{"expression":"2+2"}'},
+                            }
+                        ],
                     },
-                    {"type": "function_call_output", "call_id": call_id, "output": "4"},
+                    {"role": "tool", "tool_call_id": call_id, "content": "4"},
                 ]
             )
         body = json.dumps(
-            {"model": "glm-5.2", "input": input_items, "stream": False}
+            {"model": "glm-5.2", "messages": messages, "stream": False}
         ).encode("utf-8")
+        self.external_model["upstream_format"] = "chat_completions"
         handler, fake = post_handler(
-            "/v1/providers/volc/responses",
+            "/v1/providers/volc/chat/completions",
             body,
             headers={"X-Codex-Client-Id": "opencode"},
         )


### PR DESCRIPTION
<!-- orchestrator:delivery:v1 -->
```json
{"contract_sha256":"1ff14dbee06ecd94fb43a834b557450b186b62b69343c35bf0718549dbf1e46f","candidate_sha":"69b71bd5876207909c12cc560bf1279c61e2995f","changed_paths":["src-python/codex_proxy.py","tests/test_routing.py"],"tdd":{"red":"python -m pytest -q tests/test_routing.py -k opencode_volc_transparent_chat failed because the repeated successful Chat tool-call history reached the upstream and returned 200.","green":"python -m pytest -q tests/test_routing.py -k opencode_volc_transparent_chat: 2 passed.","refactor":"python -m pytest -q tests/test_routing.py tests/test_chat_completions_gateway.py: 564 passed, 134 subtests passed."},"verification":["python -m pytest -q tests/test_routing.py tests/test_chat_completions_gateway.py: 564 passed, 134 subtests passed","python -m pytest -q: 1403 passed, 1 skipped, 332 subtests passed","git diff --check: passed","python scripts/report_quality_gates.py: report-only completed with pre-existing findings"],"deviations":["Production managed-client preview proved OpenCode Volc uses route_protocol chat_completions, so the transparent loop boundary was reworked from the superseded Responses-only path to the actual Chat path."],"risks":["Exact-SHA Actions, bounded heavy review, and the Coordinator-owned final E2E remain pending for this new candidate."]}
```