### PR TITLE
Issue #205: candidate catalog bootstrap before managed-client config

### DIFF
--- a/docs/agents/real-client-e2e.md
+++ b/docs/agents/real-client-e2e.md
@@ -150,13 +150,23 @@ escape, reparse points or junctions, hard links, and an over-bound tree fail
 closed. This lookup is generic: operators and the runner must not infer a
 client-specific candidate source directory from the target name.
 
-Before `refresh-models`, candidate startup, or any client/GUI launch, the
-runner contract-probes the actual passed `-ManagedClientConfigBuild` for
-Codex, OpenCode, ZCode, Pi, and OMP across both Official and Volc selections.
-Each probe performs preview/apply/readback in the final case-local root; those
-verified roots are then reused for the corresponding client launch. Thus the
-probe detects candidate #194 CLI schema drift without a second materialization
-or host-state fallback. Codex apply requires the six production fields
+The runner first invokes the candidate's production `refresh-models` command
+with the isolated `CODEXHUB_RUNTIME_HOME`, isolated
+`CODEXHUB_CODEX_TARGET_HOME`, dedicated auth input, and the exact
+version-verified Codex CLI path. This publishes the candidate-managed Official
+catalog and resolved context budget without discovering or copying a host
+catalog, session, or configuration. Operators must not seed this state by hand
+or hard-code a context limit.
+
+After `refresh-models` succeeds, the runner contract-probes the actual passed
+`-ManagedClientConfigBuild` for Codex, OpenCode, ZCode, Pi, and OMP across both
+Official and Volc selections. Each probe performs `preview`/`apply`/`readback`
+in the final case-local root, passing the candidate-published Official catalog
+via `--catalog-path` for any `openai/gpt-5.6-luna` selection. The verified roots
+are then reused for the corresponding client launch. Thus the probe detects
+candidate #194 CLI schema drift and verifies that the candidate-managed catalog
+drives Official model resolution without a second materialization or host-state
+fallback. Codex apply requires the six production fields
 `gateway_lifecycle`, `message`, `mode`, `proxy_build`, `proxy_port`, and
 `proxy_running`. `history_sync_status` and `history_sync_message` are the only
 optional keys and may be omitted, null, or bounded safe strings; all other
@@ -184,13 +194,7 @@ the same exact portable candidate executable and SHA may be supplied for both
 roles. The summary and human template record both bindings.
 
 Before launching Desktop or ZCode, the runner also requires the configured
-loopback port to be unused. It first invokes the candidate's production
-`refresh-models` command with the isolated `CODEXHUB_RUNTIME_HOME`, isolated
-`CODEXHUB_CODEX_TARGET_HOME`, dedicated auth input, and the exact
-version-verified Codex CLI path. This publishes the candidate-managed Official
-catalog and resolved context budget without discovering or copying a host
-catalog, session, or configuration. Operators must not seed this state by hand
-or hard-code a context limit.
+loopback port to be unused.
 
 Pass the real Codex CLI executable to `-CodexCliPath`. Do not pass an
 OpenCodex-style shim that locates another executable relative to the current
@@ -198,13 +202,13 @@ user's `%APPDATA%`: the runner intentionally replaces `%APPDATA%` with the
 fresh case-local directory, so such host-state indirection fails closed rather
 than weakening isolation.
 
-After that bootstrap, the runner starts the candidate in a kill-on-close
-Windows Job Object and waits for a successful `/health` response plus the
-isolated diagnostics path. Bootstrap and readiness share one 30-second budget
-(or the smaller `-TimeoutSeconds` value); bootstrap does not receive a second
-timeout window. A context-budget publication failure is classified as
-`candidate_gateway_bootstrap_failed_context_budget`; other bootstrap failures
-and timeouts use `candidate_gateway_bootstrap_failed` and
+After the `refresh-models` bootstrap, the runner starts the candidate in a
+kill-on-close Windows Job Object and waits for a successful `/health` response
+plus the isolated diagnostics path. Bootstrap and readiness share one 30-second
+budget (or the smaller `-TimeoutSeconds` value); bootstrap does not receive a
+second timeout window. A missing or stale Official catalog after `refresh-models`
+is classified as `candidate_gateway_bootstrap_failed_context_budget`; other
+bootstrap failures and timeouts use `candidate_gateway_bootstrap_failed` and
 `candidate_gateway_bootstrap_timeout`. A missing Python lifecycle, listener,
 usable health response, or diagnostics path after bootstrap fails before any
 GUI launch with a stable `candidate_gateway_startup_failed_*` classification.

--- a/scripts/Run-RealClientE2E.ps1
+++ b/scripts/Run-RealClientE2E.ps1
@@ -337,7 +337,7 @@ function Set-RunnerPhase {
     if (-not $script:WatchdogStatePath) {
         return
     }
-    if ($Phase -notin @('preflight', 'client_materialization', 'candidate_startup', 'manual_evidence', 'automated_cases', 'summary')) {
+    if ($Phase -notin @('preflight', 'client_materialization', 'candidate_startup', 'candidate_gateway_ready', 'manual_evidence', 'automated_cases', 'summary')) {
         throw 'internal_runner_phase_invalid'
     }
     [System.IO.File]::WriteAllText($script:WatchdogStatePath, $Phase, $script:Utf8NoBom)
@@ -1907,9 +1907,10 @@ function Invoke-ManagedClientConfigVerb {
         [string]$Client,
         [string]$Root,
         [string]$Model,
-        [string]$SettingsPath,
-        [string]$ProvidersPath,
-        [string]$ProcessRoot
+        [string]$SettingsPath = $script:ManagedClientSettingsPath,
+        [string]$ProvidersPath = $script:ManagedClientProvidersPath,
+        [string]$ProcessRoot,
+        [string]$CatalogPath = ''
     )
     $arguments = @(
         'managed-client-config', $Verb,
@@ -1919,6 +1920,9 @@ function Invoke-ManagedClientConfigVerb {
         '--settings-path', $SettingsPath,
         '--providers-path', $ProvidersPath
     )
+    if ($CatalogPath) {
+        $arguments += @('--catalog-path', $CatalogPath)
+    }
     $result = Invoke-IsolatedProcess -Executable $script:ManagedClientConfigBuild -Arguments $arguments -CaseRoot $ProcessRoot -Environment @{
         CODEXHUB_E2E_MATERIALIZER_LOG = $script:ManagedClientConfigLogPath
     } -StandardInput '' -ProcessTimeoutSeconds 30
@@ -2081,7 +2085,8 @@ function Initialize-ClientConfiguration {
         [string]$CaseRoot,
         [string]$Model,
         [string]$SettingsPath = $script:ManagedClientSettingsPath,
-        [string]$ProvidersPath = $script:ManagedClientProvidersPath
+        [string]$ProvidersPath = $script:ManagedClientProvidersPath,
+        [string]$CatalogPath = ''
     )
     $managedClient = if ($Client -in @('desktop', 'codex-cli')) { 'codex' } else { $Client }
     $previewRoot = Join-Path $CaseRoot 'managed-preview'
@@ -2089,14 +2094,14 @@ function Initialize-ClientConfiguration {
     if ((Test-Path -LiteralPath $previewRoot) -or (Test-Path -LiteralPath $applyRoot)) {
         throw 'client_configuration_materializer_root_not_fresh'
     }
-    $preview = Invoke-ManagedClientConfigVerb -Verb 'preview' -Client $managedClient -Root $previewRoot -Model $Model -SettingsPath $SettingsPath -ProvidersPath $ProvidersPath -ProcessRoot $CaseRoot
+    $preview = Invoke-ManagedClientConfigVerb -Verb 'preview' -Client $managedClient -Root $previewRoot -Model $Model -SettingsPath $SettingsPath -ProvidersPath $ProvidersPath -ProcessRoot $CaseRoot -CatalogPath $CatalogPath
     if ($managedClient -ceq 'codex') {
         Assert-ManagedClientOutputKeys -Value $preview -Required @('client_id', 'selector', 'model', 'route_protocol', 'target_names', 'overlay_args_relative')
     }
     else {
         Assert-ManagedClientOutputKeys -Value $preview -Required @('client_id', 'selector', 'model', 'route_protocol', 'target_names', 'next_redacted')
     }
-    $apply = Invoke-ManagedClientConfigVerb -Verb 'apply' -Client $managedClient -Root $applyRoot -Model $Model -SettingsPath $SettingsPath -ProvidersPath $ProvidersPath -ProcessRoot $CaseRoot
+    $apply = Invoke-ManagedClientConfigVerb -Verb 'apply' -Client $managedClient -Root $applyRoot -Model $Model -SettingsPath $SettingsPath -ProvidersPath $ProvidersPath -ProcessRoot $CaseRoot -CatalogPath $CatalogPath
     if ($managedClient -ceq 'codex') {
         Assert-ManagedClientOutputKeys -Value $apply -Required @('mode', 'proxy_running', 'proxy_port', 'proxy_build', 'message', 'gateway_lifecycle') -Optional @('history_sync_status', 'history_sync_message')
         if ([string](Get-JsonProperty $apply 'mode' '') -cne 'custom') {
@@ -2109,7 +2114,7 @@ function Initialize-ClientConfiguration {
             throw 'client_configuration_materializer_contradiction'
         }
     }
-    $readback = Invoke-ManagedClientConfigVerb -Verb 'readback' -Client $managedClient -Root $applyRoot -Model $Model -SettingsPath $SettingsPath -ProvidersPath $ProvidersPath -ProcessRoot $CaseRoot
+    $readback = Invoke-ManagedClientConfigVerb -Verb 'readback' -Client $managedClient -Root $applyRoot -Model $Model -SettingsPath $SettingsPath -ProvidersPath $ProvidersPath -ProcessRoot $CaseRoot -CatalogPath $CatalogPath
     Assert-ManagedClientOutputKeys -Value $readback -Required @('client_id', 'ok', 'selector', 'model', 'route_protocol')
     if ((Get-JsonProperty $readback 'ok' $false) -ne $true -or
         [string](Get-JsonProperty $preview 'client_id' '') -cne $managedClient -or
@@ -2460,18 +2465,6 @@ try {
     $candidateRoot = Join-Path $workRoot 'candidate'
     [void](New-Item -ItemType Directory -Force -Path $candidateRoot)
     Initialize-CandidateRuntime -CandidateRoot $candidateRoot
-    $caseConfigurations = @{}
-    foreach ($case in @($manualCases) + @($automatedCases)) {
-        $caseRoot = if ($case.client -in @('desktop', 'zcode')) {
-            Join-Path (Join-Path $workRoot ("gui-" + $case.client)) $case.case_id
-        }
-        else {
-            Join-Path $workRoot $case.case_id
-        }
-        [void](New-Item -ItemType Directory -Path $caseRoot -Force)
-        $caseConfigurations[$case.case_id] = Initialize-ClientConfiguration -Client $case.client -CaseRoot $caseRoot -Model $case.gateway_model
-    }
-    [void](Initialize-ClientConfiguration -Client 'desktop' -CaseRoot $candidateRoot -Model 'gpt-5.6-luna')
     $candidateEnvironment = @{
         CODEXHUB_E2E_CANDIDATE_SHA = $CandidateSha
         CODEXHUB_E2E_GATEWAY_PORT = [string]$script:GatewayConfig.listen_port
@@ -2487,6 +2480,26 @@ try {
     $candidateStartupBudgetMilliseconds = [Math]::Min($TimeoutSeconds, 30) * 1000
     $candidateStartupStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
     [void](Invoke-CandidateOfficialBootstrap -Executable $DebugBuild -CandidateRoot $candidateRoot -Environment $candidateEnvironment -TimeoutSeconds $TimeoutSeconds)
+    $candidateCatalogPath = Join-Path $script:CandidateRuntimeRoot 'proxy\model-catalogs\codexhub-model-catalog.json'
+    if (-not (Test-Path -LiteralPath $candidateCatalogPath -PathType Leaf)) {
+        $candidateStartupStopwatch.Stop()
+        Write-CandidateStartupDiagnostic -FailureClassification 'candidate_gateway_bootstrap_failed_context_budget' -DurationMilliseconds [int]$candidateStartupStopwatch.ElapsedMilliseconds -PortableResourcesReady $true -CandidateRunning $false -PythonChildSeen $false -ListenerSeen $false -HealthReady $false -DiagnosticsReady (Test-Path -LiteralPath $script:DiagnosticsPath -PathType Leaf)
+        throw 'candidate_gateway_bootstrap_failed_context_budget'
+    }
+    $caseConfigurations = @{}
+    foreach ($case in @($manualCases) + @($automatedCases)) {
+        $caseRoot = if ($case.client -in @('desktop', 'zcode')) {
+            Join-Path (Join-Path $workRoot ("gui-" + $case.client)) $case.case_id
+        }
+        else {
+            Join-Path $workRoot $case.case_id
+        }
+        [void](New-Item -ItemType Directory -Path $caseRoot -Force)
+        $caseConfigurations[$case.case_id] = Initialize-ClientConfiguration -Client $case.client -CaseRoot $caseRoot -Model $case.gateway_model -CatalogPath $candidateCatalogPath
+    }
+    [void](Initialize-ClientConfiguration -Client 'desktop' -CaseRoot $candidateRoot -Model 'gpt-5.6-luna' -CatalogPath $candidateCatalogPath)
+    $candidateStartupStopwatch.Stop()
+    $candidateStartupStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
     $remainingStartupMilliseconds = $candidateStartupBudgetMilliseconds - [int]$candidateStartupStopwatch.ElapsedMilliseconds
     if ($remainingStartupMilliseconds -le 0) {
         $candidateStartupStopwatch.Stop()

--- a/scripts/Run-RealClientE2E.ps1
+++ b/scripts/Run-RealClientE2E.ps1
@@ -44,6 +44,7 @@ param(
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
 
 try {
 Add-Type -TypeDefinition @'

--- a/tests/fixtures/real_client_e2e/fake-debug-build-bad-health.cmd
+++ b/tests/fixtures/real_client_e2e/fake-debug-build-bad-health.cmd
@@ -1,5 +1,12 @@
 @echo off
-if /I "%~1"=="refresh-models" exit /b 0
+setlocal EnableDelayedExpansion
+if /I "%~1"=="refresh-models" (
+  set "catalog=%CODEXHUB_RUNTIME_HOME%\proxy\model-catalogs"
+  if not exist "!catalog!" mkdir "!catalog!"
+  powershell -NoProfile -Command "Set-Content -LiteralPath '!catalog!\codexhub-model-catalog.json' -Value '{`\"candidate-managed`\": true}' -NoNewline"
+  if errorlevel 1 exit /b 37
+  exit /b 0
+)
 if not "%~1"=="" exit /b 39
 if not defined CODEXHUB_RUNTIME_HOME exit /b 22
 if not exist "%CODEXHUB_RUNTIME_HOME%\proxy\settings.json" exit /b 26

--- a/tests/fixtures/real_client_e2e/fake-debug-build-bad-health.cmd
+++ b/tests/fixtures/real_client_e2e/fake-debug-build-bad-health.cmd
@@ -3,7 +3,7 @@ setlocal EnableDelayedExpansion
 if /I "%~1"=="refresh-models" (
   set "catalog=%CODEXHUB_RUNTIME_HOME%\proxy\model-catalogs"
   if not exist "!catalog!" mkdir "!catalog!"
-  powershell -NoProfile -Command "Set-Content -LiteralPath '!catalog!\codexhub-model-catalog.json' -Value '{`\"candidate-managed`\": true}' -NoNewline"
+  python.exe "%~dp0write-catalog.py" "!catalog!\codexhub-model-catalog.json"
   if errorlevel 1 exit /b 37
   exit /b 0
 )

--- a/tests/fixtures/real_client_e2e/fake-debug-build-contract-probe.cmd
+++ b/tests/fixtures/real_client_e2e/fake-debug-build-contract-probe.cmd
@@ -1,12 +1,19 @@
 @echo off
+setlocal EnableDelayedExpansion
 if not defined CODEXHUB_E2E_CONTRACT_PROBE_LOG exit /b 50
-python.exe "%~dp0validate-managed-client-contract-probe.py" "%CODEXHUB_E2E_CONTRACT_PROBE_LOG%"
-if errorlevel 1 exit /b 51
-if /I "%~1"=="refresh-models" exit /b 0
+if /I "%~1"=="refresh-models" (
+  set "catalog=%CODEXHUB_RUNTIME_HOME%\proxy\model-catalogs"
+  if not exist "!catalog!" mkdir "!catalog!"
+  powershell -NoProfile -Command "Set-Content -LiteralPath '!catalog!\codexhub-model-catalog.json' -Value '{`\"candidate-managed`\": true}' -NoNewline"
+  if errorlevel 1 exit /b 37
+  exit /b 0
+)
 if not "%~1"=="" exit /b 39
 if not defined CODEXHUB_E2E_CANDIDATE_SHA exit /b 21
 if not defined CODEXHUB_RUNTIME_HOME exit /b 22
 if not defined CODEXHUB_CODEX_TARGET_HOME exit /b 23
 if not defined CODEX_PROXY_GATEWAY_CLIENT_KEY exit /b 24
 if not defined VOLCENGINE_API_KEY exit /b 25
+python.exe "%~dp0validate-managed-client-contract-probe.py" "%CODEXHUB_E2E_CONTRACT_PROBE_LOG%"
+if errorlevel 1 exit /b 51
 python.exe "%~dp0fake-debug-gateway.py" --port %CODEXHUB_E2E_GATEWAY_PORT%

--- a/tests/fixtures/real_client_e2e/fake-debug-build-contract-probe.cmd
+++ b/tests/fixtures/real_client_e2e/fake-debug-build-contract-probe.cmd
@@ -4,7 +4,7 @@ if not defined CODEXHUB_E2E_CONTRACT_PROBE_LOG exit /b 50
 if /I "%~1"=="refresh-models" (
   set "catalog=%CODEXHUB_RUNTIME_HOME%\proxy\model-catalogs"
   if not exist "!catalog!" mkdir "!catalog!"
-  powershell -NoProfile -Command "Set-Content -LiteralPath '!catalog!\codexhub-model-catalog.json' -Value '{`\"candidate-managed`\": true}' -NoNewline"
+  python.exe "%~dp0write-catalog.py" "!catalog!\codexhub-model-catalog.json"
   if errorlevel 1 exit /b 37
   exit /b 0
 )

--- a/tests/fixtures/real_client_e2e/fake-debug-build-exit.cmd
+++ b/tests/fixtures/real_client_e2e/fake-debug-build-exit.cmd
@@ -1,4 +1,11 @@
 @echo off
-if /I "%~1"=="refresh-models" exit /b 0
+setlocal EnableDelayedExpansion
+if /I "%~1"=="refresh-models" (
+  set "catalog=%CODEXHUB_RUNTIME_HOME%\proxy\model-catalogs"
+  if not exist "!catalog!" mkdir "!catalog!"
+  powershell -NoProfile -Command "Set-Content -LiteralPath '!catalog!\codexhub-model-catalog.json' -Value '{`\"candidate-managed`\": true}' -NoNewline"
+  if errorlevel 1 exit /b 37
+  exit /b 0
+)
 if not "%~1"=="" exit /b 39
 exit /b 31

--- a/tests/fixtures/real_client_e2e/fake-debug-build-exit.cmd
+++ b/tests/fixtures/real_client_e2e/fake-debug-build-exit.cmd
@@ -3,7 +3,7 @@ setlocal EnableDelayedExpansion
 if /I "%~1"=="refresh-models" (
   set "catalog=%CODEXHUB_RUNTIME_HOME%\proxy\model-catalogs"
   if not exist "!catalog!" mkdir "!catalog!"
-  powershell -NoProfile -Command "Set-Content -LiteralPath '!catalog!\codexhub-model-catalog.json' -Value '{`\"candidate-managed`\": true}' -NoNewline"
+  python.exe "%~dp0write-catalog.py" "!catalog!\codexhub-model-catalog.json"
   if errorlevel 1 exit /b 37
   exit /b 0
 )

--- a/tests/fixtures/real_client_e2e/fake-debug-build-no-listener.cmd
+++ b/tests/fixtures/real_client_e2e/fake-debug-build-no-listener.cmd
@@ -1,5 +1,12 @@
 @echo off
-if /I "%~1"=="refresh-models" exit /b 0
+setlocal EnableDelayedExpansion
+if /I "%~1"=="refresh-models" (
+  set "catalog=%CODEXHUB_RUNTIME_HOME%\proxy\model-catalogs"
+  if not exist "!catalog!" mkdir "!catalog!"
+  powershell -NoProfile -Command "Set-Content -LiteralPath '!catalog!\codexhub-model-catalog.json' -Value '{`\"candidate-managed`\": true}' -NoNewline"
+  if errorlevel 1 exit /b 37
+  exit /b 0
+)
 if not "%~1"=="" exit /b 39
 if not defined CODEXHUB_RUNTIME_HOME exit /b 22
 if not exist "%CODEXHUB_RUNTIME_HOME%\proxy\settings.json" exit /b 26

--- a/tests/fixtures/real_client_e2e/fake-debug-build-no-listener.cmd
+++ b/tests/fixtures/real_client_e2e/fake-debug-build-no-listener.cmd
@@ -3,7 +3,7 @@ setlocal EnableDelayedExpansion
 if /I "%~1"=="refresh-models" (
   set "catalog=%CODEXHUB_RUNTIME_HOME%\proxy\model-catalogs"
   if not exist "!catalog!" mkdir "!catalog!"
-  powershell -NoProfile -Command "Set-Content -LiteralPath '!catalog!\codexhub-model-catalog.json' -Value '{`\"candidate-managed`\": true}' -NoNewline"
+  python.exe "%~dp0write-catalog.py" "!catalog!\codexhub-model-catalog.json"
   if errorlevel 1 exit /b 37
   exit /b 0
 )

--- a/tests/fixtures/real_client_e2e/fake-debug-build-official-bootstrap.cmd
+++ b/tests/fixtures/real_client_e2e/fake-debug-build-official-bootstrap.cmd
@@ -37,5 +37,9 @@ if exist "%~f0.bootstrap-fail" (
 if exist "%~f0.bootstrap-slow" (
   ping.exe 127.0.0.1 -n 4 >nul
 )
+set "catalog=%CODEXHUB_RUNTIME_HOME%\proxy\model-catalogs"
+if not exist "%catalog%" mkdir "%catalog%"
+  powershell -NoProfile -Command "Set-Content -LiteralPath \"%catalog%\codexhub-model-catalog.json\" -Value '{`\"candidate-managed`\": true}' -NoNewline"
+if errorlevel 1 exit /b 37
 >"%budget%" echo candidate-managed-safe-budget
 exit /b 0

--- a/tests/fixtures/real_client_e2e/fake-debug-build-official-bootstrap.cmd
+++ b/tests/fixtures/real_client_e2e/fake-debug-build-official-bootstrap.cmd
@@ -39,7 +39,7 @@ if exist "%~f0.bootstrap-slow" (
 )
 set "catalog=%CODEXHUB_RUNTIME_HOME%\proxy\model-catalogs"
 if not exist "%catalog%" mkdir "%catalog%"
-  powershell -NoProfile -Command "Set-Content -LiteralPath \"%catalog%\codexhub-model-catalog.json\" -Value '{`\"candidate-managed`\": true}' -NoNewline"
+python.exe "%~dp0write-catalog.py" "%catalog%\codexhub-model-catalog.json"
 if errorlevel 1 exit /b 37
 >"%budget%" echo candidate-managed-safe-budget
 exit /b 0

--- a/tests/fixtures/real_client_e2e/fake-debug-build.cmd
+++ b/tests/fixtures/real_client_e2e/fake-debug-build.cmd
@@ -3,7 +3,7 @@ setlocal EnableDelayedExpansion
 if /I "%~1"=="refresh-models" (
   set "catalog=%CODEXHUB_RUNTIME_HOME%\proxy\model-catalogs"
   if not exist "!catalog!" mkdir "!catalog!"
-  powershell -NoProfile -Command "Set-Content -LiteralPath '!catalog!\codexhub-model-catalog.json' -Value '{`\"candidate-managed`\": true}' -NoNewline"
+  python.exe "%~dp0write-catalog.py" "!catalog!\codexhub-model-catalog.json"
   if errorlevel 1 exit /b 37
   exit /b 0
 )

--- a/tests/fixtures/real_client_e2e/fake-debug-build.cmd
+++ b/tests/fixtures/real_client_e2e/fake-debug-build.cmd
@@ -1,5 +1,12 @@
 @echo off
-if /I "%~1"=="refresh-models" exit /b 0
+setlocal EnableDelayedExpansion
+if /I "%~1"=="refresh-models" (
+  set "catalog=%CODEXHUB_RUNTIME_HOME%\proxy\model-catalogs"
+  if not exist "!catalog!" mkdir "!catalog!"
+  powershell -NoProfile -Command "Set-Content -LiteralPath '!catalog!\codexhub-model-catalog.json' -Value '{`\"candidate-managed`\": true}' -NoNewline"
+  if errorlevel 1 exit /b 37
+  exit /b 0
+)
 if not "%~1"=="" exit /b 39
 if not defined CODEXHUB_E2E_CANDIDATE_SHA exit /b 21
 if not defined CODEXHUB_RUNTIME_HOME exit /b 22

--- a/tests/fixtures/real_client_e2e/fake-managed-client-config.py
+++ b/tests/fixtures/real_client_e2e/fake-managed-client-config.py
@@ -43,12 +43,14 @@ def parse_args(argv: list[str]) -> tuple[str, dict[str, str]]:
     return argv[1], parsed
 
 
-def selection(client: str, model: str) -> tuple[str, str]:
+def selection(client: str, model: str, catalog_path: str | None) -> tuple[str, str]:
     if client == "codex":
         return f"custom/{model}", "responses"
     provider, model_id = model.split("/", 1)
     selector = f"codexhub-{provider}/{model_id}"
     protocol = "responses" if provider == "openai" else "chat_completions"
+    if model_id == "gpt-5.6-luna" and catalog_path is None:
+        fail("openai/gpt-5.6-luna requires candidate catalog", 11)
     return selector, protocol
 
 
@@ -205,13 +207,15 @@ def main() -> None:
     client = args["--client"]
     model = args["--model"]
     root = Path(args["--root"])
+    catalog_path = args.get("--catalog-path")
     if not root.is_absolute():
         fail("root must be absolute")
     mode = os.environ.get("CODEXHUB_E2E_MATERIALIZER_MODE", "ok")
     if mode == "failure":
         fail("materializer failed with fixture-gateway-private-key", 9)
     root.mkdir(parents=True, exist_ok=True)
-    selector, protocol = selection(client, model)
+    _, model_id = model.split("/", 1) if "/" in model else ("", model)
+    selector, protocol = selection(client, model, catalog_path)
     if verb == "apply":
         write_targets(root, client, model, mode)
         (root / ".fake-managed-state.json").write_text(
@@ -289,6 +293,10 @@ def main() -> None:
         result = base | {"ok": True}
     if mode == "unsafe-output":
         result["api_key"] = "fixture-gateway-private-key"
+    if catalog_path and model_id == "gpt-5.6-luna" and (
+        not Path(catalog_path).is_file() or "candidate-managed" not in Path(catalog_path).read_text(encoding="utf-8")
+    ):
+        fail("candidate catalog missing or stale")
     print(json.dumps(result))
 
 

--- a/tests/fixtures/real_client_e2e/validate-managed-client-contract-probe.py
+++ b/tests/fixtures/real_client_e2e/validate-managed-client-contract-probe.py
@@ -24,6 +24,9 @@ def main(path: Path) -> None:
             for row in rows
             if (row["client"], row["model"]) == pair
         } == {"preview", "apply", "readback"}
+    for row in rows:
+        if row["client"] in ("opencode", "zcode", "pi", "omp") and row["model"] == "openai/gpt-5.6-luna":
+            assert "--catalog-path" in row["flags"], row
 
 
 if __name__ == "__main__":

--- a/tests/fixtures/real_client_e2e/write-catalog.py
+++ b/tests/fixtures/real_client_e2e/write-catalog.py
@@ -1,0 +1,15 @@
+import json
+from pathlib import Path
+import sys
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        raise SystemExit(1)
+    target = Path(sys.argv[1])
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text('{"candidate-managed": true}', encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_real_client_e2e.py
+++ b/tests/test_real_client_e2e.py
@@ -499,8 +499,7 @@ def test_runner_invokes_candidate_materializer_for_every_managed_client(tmp_path
             "readback",
         }
     assert all(
-        item["flags"]
-        == ["--client", "--model", "--providers-path", "--root", "--settings-path"]
+        "--catalog-path" in item["flags"]
         for item in invocations
     )
     assert all(

--- a/tests/test_real_client_e2e.py
+++ b/tests/test_real_client_e2e.py
@@ -205,6 +205,7 @@ def _prepare_run(
         FIXTURES / "validate-managed-client-contract-probe.py",
         tmp_path / "validate-managed-client-contract-probe.py",
     )
+    shutil.copyfile(FIXTURES / "write-catalog.py", tmp_path / "write-catalog.py")
     portable_files = (
         "config/providers.toml",
         "src-python/codex_proxy.py",


### PR DESCRIPTION
<!-- orchestrator:delivery:v1 -->
```json
{
  "contract_sha256": "4e88e312eb133f5cd904d21c69cfa41a07b8fecc8706c5b5ebd2077b7de9c7f0",
  "candidate_sha": "920622159483fd5f0c139a1ad24acfbae0a5cf8b",
  "changed_paths": [
    "docs/agents/real-client-e2e.md",
    "scripts/Run-RealClientE2E.ps1",
    "tests/fixtures/real_client_e2e/fake-debug-build-bad-health.cmd",
    "tests/fixtures/real_client_e2e/fake-debug-build-contract-probe.cmd",
    "tests/fixtures/real_client_e2e/fake-debug-build-exit.cmd",
    "tests/fixtures/real_client_e2e/fake-debug-build-no-listener.cmd",
    "tests/fixtures/real_client_e2e/fake-debug-build-official-bootstrap.cmd",
    "tests/fixtures/real_client_e2e/fake-debug-build.cmd",
    "tests/fixtures/real_client_e2e/fake-managed-client-config.py",
    "tests/fixtures/real_client_e2e/validate-managed-client-contract-probe.py",
    "tests/fixtures/real_client_e2e/write-catalog.py",
    "tests/test_real_client_e2e.py"
  ],
  "tdd": {
    "red": "Initial full real-client E2E run under pytest confirmed the host-catalog discovery failure and materializer ordering failure before source edits.",
    "green": "Reworked fixture catalog writes to use a neutral write-catalog.py invoked from each fake-debug-build script, added the fixture to the test copy step, set ProgressPreference='SilentlyContinue' in the runner, and re-ran 111 tests green in 683.63s.",
    "refactor": "Reduced PowerShell Set-Content duplication across fixtures by centralizing catalog creation in tests/fixtures/real_client_e2e/write-catalog.py."
  },
  "verification": [
    "Local: python -m pytest -q tests/test_real_client_e2e.py => 111 passed in 683.63s",
    "CI: https://github.com/NOirBRight/CodexHub/actions/runs/29963931641 all jobs green at candidate SHA 920622159483fd5f0c139a1ad24acfbae0a5cf8b"
  ],
  "deviations": [],
  "risks": []
}
```
