### PR TITLE
Fix E2E catalog publication race

### DIFF
--- a/scripts/Run-RealClientE2E.ps1
+++ b/scripts/Run-RealClientE2E.ps1
@@ -2482,6 +2482,14 @@ try {
     $candidateStartupStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
     [void](Invoke-CandidateOfficialBootstrap -Executable $DebugBuild -CandidateRoot $candidateRoot -Environment $candidateEnvironment -TimeoutSeconds $TimeoutSeconds)
     $candidateCatalogPath = Join-Path $script:CandidateRuntimeRoot 'model-catalogs\codexhub-model-catalog.json'
+    $candidateCatalogDeadlineMilliseconds = [Math]::Min(
+        $candidateStartupBudgetMilliseconds,
+        [int]$candidateStartupStopwatch.ElapsedMilliseconds + 2000
+    )
+    while (-not (Test-Path -LiteralPath $candidateCatalogPath -PathType Leaf) -and
+        $candidateStartupStopwatch.ElapsedMilliseconds -lt $candidateCatalogDeadlineMilliseconds) {
+        Start-Sleep -Milliseconds 25
+    }
     if (-not (Test-Path -LiteralPath $candidateCatalogPath -PathType Leaf)) {
         $candidateStartupStopwatch.Stop()
         Write-CandidateStartupDiagnostic -FailureClassification 'candidate_gateway_bootstrap_failed_context_budget' -DurationMilliseconds ([int]$candidateStartupStopwatch.ElapsedMilliseconds) -PortableResourcesReady $true -CandidateRunning $false -PythonChildSeen $false -ListenerSeen $false -HealthReady $false -DiagnosticsReady (Test-Path -LiteralPath $script:DiagnosticsPath -PathType Leaf)

--- a/tests/fixtures/real_client_e2e/fake-debug-build-official-bootstrap-no-catalog.cmd
+++ b/tests/fixtures/real_client_e2e/fake-debug-build-official-bootstrap-no-catalog.cmd
@@ -1,0 +1,29 @@
+@echo off
+setlocal
+if not defined CODEXHUB_RUNTIME_HOME exit /b 21
+if not defined CODEXHUB_CODEX_TARGET_HOME exit /b 22
+if not defined CODEXHUB_CODEX_PATH exit /b 34
+if not exist "%CODEXHUB_CODEX_PATH%" exit /b 35
+if /I not "%HOME%"=="%CD%" exit /b 23
+if /I not "%USERPROFILE%"=="%CD%" exit /b 24
+if /I not "%APPDATA%"=="%CD%\appdata\roaming" exit /b 25
+if /I not "%LOCALAPPDATA%"=="%CD%\appdata\local" exit /b 26
+if /I not "%CODEX_HOME%"=="%CODEXHUB_CODEX_TARGET_HOME%" exit /b 27
+if defined CODEXHUB_HOST_SESSION exit /b 28
+if defined OPENAI_API_KEY exit /b 29
+set "budget=%CODEXHUB_RUNTIME_HOME%\proxy\official-context-budget.ready"
+set "invocations=%CODEXHUB_RUNTIME_HOME%\proxy\official-bootstrap-invocations.txt"
+if /I "%~1"=="refresh-models" goto refresh
+if not "%~1"=="" exit /b 30
+>>"%invocations%" echo start
+if not exist "%budget%" exit /b 31
+python.exe "%~dp0fake-debug-gateway.py" --port %CODEXHUB_E2E_GATEWAY_PORT%
+exit /b %errorlevel%
+
+:refresh
+if not "%~2"=="" exit /b 32
+>>"%invocations%" echo refresh-models
+set "catalog=%CODEXHUB_RUNTIME_HOME%\model-catalogs"
+if not exist "%catalog%" mkdir "%catalog%"
+>"%budget%" echo candidate-managed-safe-budget
+exit /b 0

--- a/tests/test_real_client_e2e.py
+++ b/tests/test_real_client_e2e.py
@@ -569,6 +569,48 @@ def test_candidate_publishes_catalog_at_production_runtime_root(tmp_path):
     ).exists()
 
 
+def test_candidate_waits_for_atomic_catalog_publication_within_startup_budget(
+    tmp_path,
+):
+    catalog_path = (
+        tmp_path
+        / "output"
+        / "isolated"
+        / "work"
+        / "candidate"
+        / "runtime"
+        / "model-catalogs"
+        / "codexhub-model-catalog.json"
+    )
+    published = threading.Event()
+
+    def publish_after_refresh_returns() -> None:
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline and not catalog_path.parent.is_dir():
+            time.sleep(0.01)
+        time.sleep(0.25)
+        catalog_path.parent.mkdir(parents=True, exist_ok=True)
+        catalog_path.write_text('{"candidate-managed": true}', encoding="utf-8")
+        published.set()
+
+    publisher = threading.Thread(target=publish_after_refresh_returns, daemon=True)
+    publisher.start()
+    try:
+        result = _run(
+            tmp_path,
+            debug_fake="fake-debug-build-official-bootstrap-no-catalog.cmd",
+        )
+    finally:
+        publisher.join(timeout=5)
+
+    assert published.is_set()
+    assert result.returncode == 0, result.stdout + result.stderr
+    summary = json.loads(
+        (tmp_path / "output" / "summary.json").read_text(encoding="utf-8-sig")
+    )
+    assert summary["outcome"] == "passed"
+
+
 def test_obsolete_proxy_subdir_catalog_fails_closed_before_clients_or_requests(
     tmp_path,
 ):


### PR DESCRIPTION
Fixes #209

<!-- orchestrator:delivery:v1 -->
```json
{"candidate_sha":"20d2e0ba61d3f3054686c0af5ddf15852bc0a4f1","changed_paths":["scripts/Run-RealClientE2E.ps1","tests/fixtures/real_client_e2e/fake-debug-build-official-bootstrap-no-catalog.cmd","tests/test_real_client_e2e.py"],"contract_sha256":"8c7ca3798d1e2cfb7a4a8801f8e58bb8ea4e3af505b1a162f78c6c991e71f9b7","deviations":[],"risks":[],"tdd":{"red":"A runner-level external delayed publisher reproduced candidate_gateway_bootstrap_failed_context_budget with zero cases in 2.80 seconds after refresh returned success.","green":"The runner now observes the production catalog for at most two seconds inside the existing startup stopwatch budget; delayed-publication, production-path, and obsolete-path tests pass.","refactor":"Kept the production runtime catalog path and existing fail-closed classification without changing routing, materialization, evidence, or retry contracts."},"verification":["Three focused real-client runner tests passed under the checked-in Windows watchdog: 3 passed, 113 deselected","PowerShell parser reported zero errors","git diff --check passed","python scripts/report_quality_gates.py completed with zero parse errors and report-only existing findings"]}
```