### PR TITLE
Fix Codex native cache publication race

### DIFF
--- a/scripts/Run-RealClientE2E.ps1
+++ b/scripts/Run-RealClientE2E.ps1
@@ -197,6 +197,7 @@ $script:MinimumVersions = [ordered]@{
     pi = '0.80.6'
     omp = '17.0.3'
 }
+$script:ObservedVersions = [ordered]@{}
 $script:MaximumCapturedCharacters = 65536
 $script:Utf8NoBom = [System.Text.UTF8Encoding]::new($false)
 $script:ProcessJobHandle = [IntPtr]::Zero
@@ -311,6 +312,19 @@ function Write-JsonFile {
     [System.IO.File]::WriteAllText($Path, $json + "`n", $script:Utf8NoBom)
 }
 
+function Get-ReportedClientVersions {
+    $reported = [ordered]@{}
+    foreach ($name in $script:MinimumVersions.Keys) {
+        $reported[$name] = if ($script:ObservedVersions.Contains($name)) {
+            [string]$script:ObservedVersions[$name]
+        }
+        else {
+            [string]$script:MinimumVersions[$name]
+        }
+    }
+    return $reported
+}
+
 function Get-FailureSummaryValue {
     param([string]$FailureClassification, [string[]]$Artifacts = @())
     return [ordered]@{
@@ -319,7 +333,7 @@ function Get-FailureSummaryValue {
         managed_client_config_sha = if ($ManagedClientConfigSha -match '^[0-9a-fA-F]{40}$') { $ManagedClientConfigSha.ToLowerInvariant() } else { $null }
         outcome = 'failed'
         failure_classification = $FailureClassification
-        pinned_versions = $script:MinimumVersions
+        pinned_versions = Get-ReportedClientVersions
         canonical_models = @('gpt-5.6-luna', 'volc/glm-5.2', 'codexhub-openai/gpt-5.6-luna', 'codexhub-volc/glm-5.2')
         counts = [ordered]@{
             case_count = 0
@@ -1078,7 +1092,7 @@ function Invoke-CandidateOfficialBootstrap {
 function Get-ClientArguments {
     param([string]$Client, [string]$Model, [string]$WorkRoot, [string]$Prompt)
     switch ($Client) {
-        'codex-cli' { return @('exec', '--ephemeral', '--json', '-C', $WorkRoot, '-m', $Model, '-s', 'read-only', '-a', 'never', $Prompt) }
+        'codex-cli' { return @('exec', '--ephemeral', '--json', '--skip-git-repo-check', '-C', $WorkRoot, '-m', $Model, '-s', 'read-only', $Prompt) }
         'opencode' { return @('run', '--format', 'json', '--model', $Model, $Prompt) }
         'pi' { return @('--print', '--mode', 'json', '--model', $Model, '--no-session', $Prompt) }
         'omp' { return @('--print', '--mode', 'json', '--model', $Model, $Prompt) }
@@ -2427,6 +2441,7 @@ foreach ($versionTarget in @(
     [pscustomobject]@{ client = 'omp'; key = 'omp' }
 )) {
     $actualVersions[$versionTarget.key] = Get-NativeClientVersion -Client $versionTarget.client -Executable $executables[$versionTarget.client] -Minimum $script:MinimumVersions[$versionTarget.key] -ProbeRoot (Join-Path $workRoot "version-$($versionTarget.client)")
+    $script:ObservedVersions[$versionTarget.key] = $actualVersions[$versionTarget.key]
 }
 [void](New-Item -ItemType Directory -Path $artifactRoot)
 [void](New-Item -ItemType Directory -Path (Join-Path $artifactRoot 'cases'))
@@ -2641,7 +2656,7 @@ catch {
         managed_client_config_sha = if ($ManagedClientConfigSha -match '^[0-9a-f]{40}$') { $ManagedClientConfigSha } else { $null }
         outcome = 'failed'
         failure_classification = $failureClassification
-        pinned_versions = $script:MinimumVersions
+        pinned_versions = Get-ReportedClientVersions
         canonical_models = @('gpt-5.6-luna', 'volc/glm-5.2', 'codexhub-openai/gpt-5.6-luna', 'codexhub-volc/glm-5.2')
         counts = [ordered]@{
             case_count = 0

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -18,6 +18,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 const DISCOVERY_TIMEOUT: Duration = Duration::from_secs(20);
 const MODEL_TEST_TIMEOUT: Duration = Duration::from_secs(8);
 const CODEX_APP_SERVER_MODEL_LIST_TIMEOUT: Duration = Duration::from_secs(8);
+const CODEX_APP_SERVER_CACHE_POLL_INTERVAL: Duration = Duration::from_millis(10);
 const GENERATED_CATALOG_FILE: &str = "codexhub-model-catalog.json";
 const LEGACY_GENERATED_CATALOG_FILE: &str = "codex-proxy-official-ollama.json";
 const RESOLVED_MODEL_LIMITS_JSON: &str = include_str!("../../config/resolved_model_limits.json");
@@ -359,8 +360,22 @@ fn refresh_official_models_direct_with_runner(
 fn read_codex_app_server_model_list() -> Result<Value, String> {
     let codex = find_codex_executable()?;
     let mut command = Command::new(&codex);
+    command.args(["app-server", "--stdio"]);
+    let cache_path = runtime_paths::codex_target_home_dir()?.join("models_cache.json");
+    read_codex_app_server_model_list_with_command(
+        command,
+        &cache_path,
+        CODEX_APP_SERVER_MODEL_LIST_TIMEOUT,
+    )
+}
+
+fn read_codex_app_server_model_list_with_command(
+    mut command: Command,
+    cache_path: &Path,
+    timeout: Duration,
+) -> Result<Value, String> {
+    let deadline = Instant::now() + timeout;
     command
-        .args(["app-server", "--stdio"])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::null());
@@ -413,20 +428,62 @@ fn read_codex_app_server_model_list() -> Result<Value, String> {
         &mut child,
         stdout,
         json!(2),
-        CODEX_APP_SERVER_MODEL_LIST_TIMEOUT,
+        deadline.saturating_duration_since(Instant::now()),
     )?;
-    kill_child(&mut child);
     if let Some(error) = message.get("error") {
         let message = error
             .get("message")
             .and_then(Value::as_str)
             .unwrap_or("request failed");
+        kill_child(&mut child);
         return Err(format!("codex app-server model list failed: {message}"));
     }
-    message
+    let result = message
         .get("result")
         .cloned()
-        .ok_or_else(|| "codex app-server model list response did not include a result".to_string())
+        .ok_or_else(|| "codex app-server model list response did not include a result".to_string());
+    let result = match result {
+        Ok(result) => result,
+        Err(error) => {
+            kill_child(&mut child);
+            return Err(error);
+        }
+    };
+    if !wait_for_native_model_cache_publication(cache_path, deadline) {
+        kill_child(&mut child);
+        return Err(
+            "codex app-server model list did not publish a readable native models cache before the refresh deadline"
+                .to_string(),
+        );
+    }
+    kill_child(&mut child);
+    Ok(result)
+}
+
+fn wait_for_native_model_cache_publication(cache_path: &Path, deadline: Instant) -> bool {
+    let mut previous = None;
+    loop {
+        let current = readable_native_model_cache(cache_path);
+        if current.is_some() && current == previous {
+            return true;
+        }
+        previous = current;
+
+        let now = Instant::now();
+        if now >= deadline {
+            return false;
+        }
+        thread::sleep(
+            CODEX_APP_SERVER_CACHE_POLL_INTERVAL.min(deadline.saturating_duration_since(now)),
+        );
+    }
+}
+
+fn readable_native_model_cache(cache_path: &Path) -> Option<Vec<u8>> {
+    let bytes = fs::read(cache_path).ok()?;
+    let payload: Value = serde_json::from_slice(&bytes).ok()?;
+    payload.get("models")?.as_array()?;
+    Some(bytes)
 }
 
 fn read_codex_app_server_value_response(
@@ -2411,7 +2468,7 @@ mod tests {
     use std::sync::mpsc::{self, Receiver};
     use std::sync::Mutex;
     use std::thread::{self, JoinHandle};
-    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+    use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
 
@@ -2430,6 +2487,100 @@ mod tests {
         assert_eq!(
             desktop_codex_exe_from_local_appdata(&root),
             Some(executable)
+        );
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn app_server_model_list_waits_for_delayed_atomic_native_cache_publication() {
+        let root = temp_root("app-server-delayed-cache");
+        let script = root.join("fake-codex-app-server.py");
+        let cache_path = root.join("codex-home").join("models_cache.json");
+        fs::create_dir_all(cache_path.parent().unwrap()).unwrap();
+        fs::write(
+            &script,
+            r#"import json
+import os
+from pathlib import Path
+import sys
+import time
+
+for line in sys.stdin:
+    message = json.loads(line)
+    if message.get("id") != 2:
+        continue
+    print(json.dumps({"id": 2, "result": {"data": []}}), flush=True)
+    time.sleep(0.15)
+    cache_path = Path(os.environ["FAKE_MODELS_CACHE"])
+    temporary_path = cache_path.with_suffix(".tmp")
+    temporary_path.write_text(
+        json.dumps({"fetched_at": "2026-07-23T00:00:00Z", "models": []}),
+        encoding="utf-8",
+    )
+    os.replace(temporary_path, cache_path)
+    time.sleep(10)
+"#,
+        )
+        .unwrap();
+        let mut command = std::process::Command::new(super::find_python());
+        command
+            .arg(&script)
+            .env("FAKE_MODELS_CACHE", &cache_path);
+
+        let result = super::read_codex_app_server_model_list_with_command(
+            command,
+            &cache_path,
+            Duration::from_secs(2),
+        )
+        .expect("model list response");
+
+        assert_eq!(result, json!({"data": []}));
+        assert!(
+            cache_path.is_file(),
+            "the app-server must remain alive until its atomic native cache publication is visible"
+        );
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn app_server_model_list_fails_closed_when_native_cache_is_never_published() {
+        let root = temp_root("app-server-missing-cache");
+        let script = root.join("fake-codex-app-server.py");
+        let cache_path = root.join("codex-home").join("models_cache.json");
+        fs::create_dir_all(cache_path.parent().unwrap()).unwrap();
+        fs::write(
+            &script,
+            r#"import json
+import sys
+import time
+
+for line in sys.stdin:
+    message = json.loads(line)
+    if message.get("id") != 2:
+        continue
+    print(json.dumps({"id": 2, "result": {"data": []}}), flush=True)
+    time.sleep(10)
+"#,
+        )
+        .unwrap();
+        let mut command = std::process::Command::new(super::find_python());
+        command.arg(&script);
+        let started = Instant::now();
+
+        let error = super::read_codex_app_server_model_list_with_command(
+            command,
+            &cache_path,
+            Duration::from_millis(500),
+        )
+        .expect_err("missing native cache publication must fail closed");
+
+        assert_eq!(
+            error,
+            "codex app-server model list did not publish a readable native models cache before the refresh deadline"
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "missing cache handling must remain bounded"
         );
         let _ = fs::remove_dir_all(root);
     }

--- a/tests/fixtures/real_client_e2e/fake-client-codex-0.145.0.cmd
+++ b/tests/fixtures/real_client_e2e/fake-client-codex-0.145.0.cmd
@@ -3,5 +3,7 @@ if defined CODEXHUB_E2E_VERSION_PROBE (
   echo codex-cli 0.145.0
   exit /b 0
 )
+echo(%*| findstr /C:"-a never" >nul && exit /b 21
+echo(%*| findstr /C:"--skip-git-repo-check" >nul || exit /b 22
 call "%~dp0fake-client-real-contract.cmd" %*
 exit /b %errorlevel%

--- a/tests/test_real_client_e2e.py
+++ b/tests/test_real_client_e2e.py
@@ -2053,6 +2053,7 @@ def test_candidate_context_budget_bootstrap_failure_is_bounded_and_sanitized(tmp
     result = _run(
         tmp_path,
         debug_fake="fake-debug-build-official-bootstrap.cmd",
+        client_fakes={"CodexCliPath": "fake-client-codex-0.145.0.cmd"},
         mutate=force_context_budget_failure,
         finalize_manual=False,
         timeout_seconds=1,
@@ -2069,6 +2070,7 @@ def test_candidate_context_budget_bootstrap_failure_is_bounded_and_sanitized(tmp
     )
     assert summary["counts"]["case_count"] == 0
     assert summary["artifacts"] == ["candidate-startup.json"]
+    assert summary["pinned_versions"]["codex_cli"] == "0.145.0"
     startup_path = tmp_path / "output" / "candidate-startup.json"
     startup = json.loads(startup_path.read_text())
     assert set(startup) == STARTUP_DIAGNOSTIC_KEYS


### PR DESCRIPTION
Fixes #211

This fixes the production teardown race that caused the fourth pre-case qualification failure. CodexHub now keeps the real Codex app-server alive, within its existing deadline, until the native model cache is readable and stable. It also uses the supported Codex 0.145 non-Git runner arguments and preserves detected versions in failure evidence.

The release-optimized Debug portable completed a fresh isolated bootstrap-only check with a fresh Luna context budget and zero model requests. The full twelve-case qualification has intentionally not been started on this intermediate SHA.

<!-- orchestrator:delivery:v1 -->
```json
{"candidate_sha":"24c9ec7c71cc20fdd69e4aa1631ddbc8d5ded93c","changed_paths":["scripts/Run-RealClientE2E.ps1","src-tauri/src/models.rs","tests/fixtures/real_client_e2e/fake-client-codex-0.145.0.cmd","tests/test_real_client_e2e.py"],"contract_sha256":"2c7527bde2e5424bb676c6ffebe7aabf79b393eb83a1f7c5936d556f3c9694fd","deviations":[],"risks":["The single final visible twelve-case qualification remains outstanding until this fix and Issue 193 are present on one final candidate."],"tdd":{"red":"The delayed atomic native-cache process test failed in 0.18 seconds because immediate app-server teardown prevented publication; the real Codex 0.145 runner fixture also rejected the obsolete arguments.","green":"The two native-cache process tests pass in 0.55 seconds, and the two focused runner tests pass with the supported Codex 0.145 arguments and actual-version evidence.","refactor":"Extracted the production app-server process seam and bounded readable-cache observation without creating another catalog authority or weakening freshness and context-budget checks."},"verification":["PowerShell parsing and git diff --check passed.","A fresh release-optimized Debug portable completed refresh-models in 7.88 seconds with Codex CLI 0.145.0, fresh Direct Official authority, Luna budgets 272000, 258400, and 244800, and zero model-request events.","The real Codex 0.145 binary rejected the removed approval argument and accepted the new read-only non-Git argument set without a model request.","No full twelve-case qualification was run on this intermediate candidate."]}
```
