### PR TITLE
Pass isolated Codex auth to E2E bootstrap

### DIFF
--- a/scripts/Run-RealClientE2E.ps1
+++ b/scripts/Run-RealClientE2E.ps1
@@ -2481,6 +2481,15 @@ try {
     $candidateRoot = Join-Path $workRoot 'candidate'
     [void](New-Item -ItemType Directory -Force -Path $candidateRoot)
     Initialize-CandidateRuntime -CandidateRoot $candidateRoot
+    $candidateAuthPath = Join-Path $script:CandidateCodexRoot 'auth.json'
+    if (Test-Path -LiteralPath $candidateAuthPath) {
+        throw 'candidate_gateway_bootstrap_failed'
+    }
+    Copy-Item -LiteralPath $script:AccountAuthPath -Destination $candidateAuthPath
+    Assert-IsolatedRegularFile -Path $candidateAuthPath -IsolationRoot $isolationRoot
+    if ((Get-Sha256 -Path $script:AccountAuthPath) -cne (Get-Sha256 -Path $candidateAuthPath)) {
+        throw 'candidate_gateway_bootstrap_failed'
+    }
     $candidateEnvironment = @{
         CODEXHUB_E2E_CANDIDATE_SHA = $CandidateSha
         CODEXHUB_E2E_GATEWAY_PORT = [string]$script:GatewayConfig.listen_port

--- a/tests/fixtures/real_client_e2e/fake-debug-build-official-bootstrap.cmd
+++ b/tests/fixtures/real_client_e2e/fake-debug-build-official-bootstrap.cmd
@@ -9,6 +9,7 @@ if /I not "%USERPROFILE%"=="%CD%" exit /b 24
 if /I not "%APPDATA%"=="%CD%\appdata\roaming" exit /b 25
 if /I not "%LOCALAPPDATA%"=="%CD%\appdata\local" exit /b 26
 if /I not "%CODEX_HOME%"=="%CODEXHUB_CODEX_TARGET_HOME%" exit /b 27
+if not exist "%CODEXHUB_CODEX_TARGET_HOME%\auth.json" exit /b 38
 if defined CODEXHUB_HOST_SESSION exit /b 28
 if defined OPENAI_API_KEY exit /b 29
 set "budget=%CODEXHUB_RUNTIME_HOME%\proxy\official-context-budget.ready"

--- a/tests/test_real_client_e2e.py
+++ b/tests/test_real_client_e2e.py
@@ -2003,6 +2003,12 @@ def test_candidate_bootstraps_official_context_budget_before_gateway_start(tmp_p
     )
 
     assert result.returncode == 0, result.stdout + result.stderr
+    isolated_auth = tmp_path / "output" / "isolated" / "account" / "auth.json"
+    candidate_auth = (
+        tmp_path / "output" / "isolated" / "work" / "candidate" / ".codex" / "auth.json"
+    )
+    assert candidate_auth.read_bytes() == isolated_auth.read_bytes()
+    assert candidate_auth.stat().st_ino != isolated_auth.stat().st_ino
     candidate_proxy = (
         tmp_path / "output" / "isolated" / "work" / "candidate" / "runtime" / "proxy"
     )


### PR DESCRIPTION
Fixes #213

The final real-client runner now copies the already validated invocation-local Codex auth into the fresh candidate Codex target home before candidate refresh-models. It rejects a pre-existing destination, revalidates isolation, and checks byte identity without discovering or reusing host Codex state.

A zero-model-request reproduction proved this is the missing boundary: the prior final portable failed without the dedicated auth and published the native Luna cache and nonzero context budgets with the same isolated auth copied. The full twelve-case GUI qualification remains intentionally blocked until this exact fix passes CI, review, merge, rebuild, and the bootstrap-only probe.

<!-- orchestrator:delivery:v1 -->
```json
{"candidate_sha":"59e3bf22ec17254a4fe72a29a7bdbec051903fbf","changed_paths":["scripts/Run-RealClientE2E.ps1","tests/fixtures/real_client_e2e/fake-debug-build-official-bootstrap.cmd","tests/test_real_client_e2e.py"],"contract_sha256":"cd06a1e9ba517bc84470e2cc9da2387ea9a6fb3cc2912fc8e1d34cf3a9bc5a08","deviations":[],"risks":["The exact merged portable must still pass the standalone bootstrap-only probe before the one final visible twelve-case qualification."],"tdd":{"red":"The focused candidate bootstrap test failed in 3.02 seconds when the fixture required candidate auth and the runner had not copied it.","green":"The focused test passed after the runner installed a byte-identical independent auth file before refresh-models; the four-test bootstrap group passed in 50.99 seconds.","refactor":"Reused the existing validated account-auth path, candidate Codex root, isolation validator, and SHA helper; no host discovery, credential serializer, or second bootstrap path was introduced."},"verification":["The focused regression and four-test bootstrap group passed.","PowerShell parsing reported zero errors.","git diff --check passed.","The report-only quality gate completed with zero parse errors and only existing findings.","A standalone zero-model-request probe on the prior final portable proved the isolated auth copy changes bootstrap from failure with zero budgets to success with Luna budgets 272000, 258400, and 244800."]}
```
