### PR TITLE
Fix isolated candidate catalog import

### DIFF
--- a/scripts/Run-RealClientE2E.ps1
+++ b/scripts/Run-RealClientE2E.ps1
@@ -1070,23 +1070,42 @@ function Invoke-CandidateOfficialBootstrap {
         [hashtable]$Environment,
         [int]$TimeoutSeconds
     )
-    $result = Invoke-IsolatedProcess -Executable $Executable -Arguments @('refresh-models') -CaseRoot $CandidateRoot -Environment $Environment -StandardInput '' -ProcessTimeoutSeconds ([Math]::Min($TimeoutSeconds, 30))
-    if ($result.timed_out) {
-        Write-CandidateStartupDiagnostic -FailureClassification 'candidate_gateway_bootstrap_timeout' -DurationMilliseconds $result.duration_ms -PortableResourcesReady $true -CandidateRunning $false -PythonChildSeen $false -ListenerSeen $false -HealthReady $false -DiagnosticsReady (Test-Path -LiteralPath $script:DiagnosticsPath -PathType Leaf)
-        throw 'candidate_gateway_bootstrap_timeout'
-    }
-    if ($result.exit_code -ne 0) {
+    $budgetMilliseconds = [Math]::Min($TimeoutSeconds, 30) * 1000
+    $bootstrapStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+    for ($attempt = 1; $attempt -le 2; $attempt++) {
+        $remainingMilliseconds = $budgetMilliseconds - [int]$bootstrapStopwatch.ElapsedMilliseconds
+        if ($remainingMilliseconds -le 0) {
+            $bootstrapStopwatch.Stop()
+            Write-CandidateStartupDiagnostic -FailureClassification 'candidate_gateway_bootstrap_timeout' -DurationMilliseconds $budgetMilliseconds -PortableResourcesReady $true -CandidateRunning $false -PythonChildSeen $false -ListenerSeen $false -HealthReady $false -DiagnosticsReady (Test-Path -LiteralPath $script:DiagnosticsPath -PathType Leaf)
+            throw 'candidate_gateway_bootstrap_timeout'
+        }
+        $processTimeoutSeconds = [Math]::Max(1, [Math]::Floor($remainingMilliseconds / 1000))
+        $result = Invoke-IsolatedProcess -Executable $Executable -Arguments @('refresh-models') -CaseRoot $CandidateRoot -Environment $Environment -StandardInput '' -ProcessTimeoutSeconds $processTimeoutSeconds
+        if ($result.timed_out) {
+            $bootstrapStopwatch.Stop()
+            Write-CandidateStartupDiagnostic -FailureClassification 'candidate_gateway_bootstrap_timeout' -DurationMilliseconds ([Math]::Min($budgetMilliseconds, [int]$bootstrapStopwatch.ElapsedMilliseconds)) -PortableResourcesReady $true -CandidateRunning $false -PythonChildSeen $false -ListenerSeen $false -HealthReady $false -DiagnosticsReady (Test-Path -LiteralPath $script:DiagnosticsPath -PathType Leaf)
+            throw 'candidate_gateway_bootstrap_timeout'
+        }
+        if ($result.exit_code -eq 0) {
+            $bootstrapStopwatch.Stop()
+            return $result
+        }
         $boundedOutput = [string]$result.stdout + "`n" + [string]$result.stderr
+        $transientNativeCacheTimeout = $boundedOutput -match '(?i)codex app-server model list did not publish a readable native models cache before the refresh deadline'
+        $remainingAfterAttempt = $budgetMilliseconds - [int]$bootstrapStopwatch.ElapsedMilliseconds
+        if ($attempt -eq 1 -and $transientNativeCacheTimeout -and $remainingAfterAttempt -gt 1000) {
+            continue
+        }
         $failure = if ($boundedOutput -match '(?i)published Official catalog contains no safe resolved context budget|current Official context snapshot is unavailable') {
             'candidate_gateway_bootstrap_failed_context_budget'
         }
         else {
             'candidate_gateway_bootstrap_failed'
         }
-        Write-CandidateStartupDiagnostic -FailureClassification $failure -DurationMilliseconds $result.duration_ms -PortableResourcesReady $true -CandidateRunning $false -PythonChildSeen $false -ListenerSeen $false -HealthReady $false -DiagnosticsReady (Test-Path -LiteralPath $script:DiagnosticsPath -PathType Leaf)
+        $bootstrapStopwatch.Stop()
+        Write-CandidateStartupDiagnostic -FailureClassification $failure -DurationMilliseconds ([Math]::Min($budgetMilliseconds, [int]$bootstrapStopwatch.ElapsedMilliseconds)) -PortableResourcesReady $true -CandidateRunning $false -PythonChildSeen $false -ListenerSeen $false -HealthReady $false -DiagnosticsReady (Test-Path -LiteralPath $script:DiagnosticsPath -PathType Leaf)
         throw $failure
     }
-    return $result
 }
 
 function Get-ClientArguments {
@@ -1786,10 +1805,31 @@ function Get-DesktopInstallationMetadata {
         throw 'preflight_desktop_executable_unbound'
     }
     $package = $bound[0]
+    $manifest = Get-AppxPackageManifest -Package $package -ErrorAction Stop
+    $applications = @($manifest.Package.Applications.Application | Where-Object {
+        [string]$_.EntryPoint -ceq 'Windows.FullTrustApplication'
+    })
+    if ($applications.Count -ne 1) {
+        throw 'preflight_desktop_executable_unbound'
+    }
+    $manifestRelativeExecutable = ([string]$applications[0].Executable).Replace('/', '\')
+    if (-not $manifestRelativeExecutable -or
+        [System.IO.Path]::IsPathRooted($manifestRelativeExecutable) -or
+        @($manifestRelativeExecutable -split '\\' | Where-Object { $_ -in @('', '.', '..') }).Count -gt 0) {
+        throw 'preflight_desktop_executable_unbound'
+    }
+    $manifestExecutable = [System.IO.Path]::GetFullPath(
+        (Join-Path ([string]$package.InstallLocation) $manifestRelativeExecutable)
+    )
+    if (-not (Test-Path -LiteralPath $manifestExecutable -PathType Leaf) -or
+        -not (Test-ExecutableBoundToInstallLocation -Executable $manifestExecutable -InstallLocation ([string]$package.InstallLocation))) {
+        throw 'preflight_desktop_executable_unbound'
+    }
     return [pscustomobject]@{
         package_name = [string]$package.Name
         package_version = [string]$package.Version
         install_location = [string]$package.InstallLocation
+        manifest_executable = $manifestExecutable
     }
 }
 
@@ -1853,6 +1893,12 @@ function Get-NativeClientVersion {
             throw 'preflight_desktop_version_mismatch'
         }
         if (-not (Test-ExecutableBoundToInstallLocation -Executable $Executable -InstallLocation ([string]$metadata.install_location))) {
+            throw 'preflight_desktop_executable_unbound'
+        }
+        $manifestExecutable = ([string](Get-JsonProperty -Value $metadata -Name 'manifest_executable' -Default '')).Trim()
+        if (-not $manifestExecutable -or
+            -not (Test-Path -LiteralPath $manifestExecutable -PathType Leaf) -or
+            (Resolve-Path -LiteralPath $Executable).Path -cne (Resolve-Path -LiteralPath $manifestExecutable).Path) {
             throw 'preflight_desktop_executable_unbound'
         }
         return $packageVersion
@@ -2361,7 +2407,7 @@ if ($TestWindowsInstallMetadataFixture) {
     Assert-IsolatedRegularFile -Path $TestWindowsInstallMetadataFixture -IsolationRoot $isolationRoot
     $script:WindowsInstallMetadata = Read-JsonObject -Path $TestWindowsInstallMetadataFixture -Failure 'preflight_windows_install_metadata_invalid'
     Assert-ExactJsonProperties -Value $script:WindowsInstallMetadata -Names @('schema', 'desktop', 'zcode') -Failure 'preflight_windows_install_metadata_invalid'
-    Assert-ExactJsonProperties -Value $script:WindowsInstallMetadata.desktop -Names @('package_name', 'package_version', 'install_location', 'executable_product_version') -Failure 'preflight_windows_install_metadata_invalid'
+    Assert-ExactJsonProperties -Value $script:WindowsInstallMetadata.desktop -Names @('package_name', 'package_version', 'install_location', 'manifest_executable', 'executable_product_version') -Failure 'preflight_windows_install_metadata_invalid'
     $zcodeFixtureProperties = @('DisplayName', 'DisplayVersion', 'Publisher', 'DisplayIcon', 'UninstallString', 'ExecutableProductVersion')
     if ($null -ne $script:WindowsInstallMetadata.zcode.PSObject.Properties['InstallLocation']) {
         $zcodeFixtureProperties += 'InstallLocation'
@@ -2562,7 +2608,15 @@ try {
         $guiSentinelPath = Join-Path $guiCaseRoot 'sentinel.txt'
         [System.IO.File]::WriteAllText($guiSentinelPath, "SENTINEL:codexhub-real-client-e2e:$($guiCase.case_id)", $script:Utf8NoBom)
         [void]$manualSentinelPaths.Add($guiSentinelPath)
-        $guiProcess = Start-IsolatedProcess -Executable $executables[$guiClient] -Arguments @() -CaseRoot $guiCaseRoot -Environment @{
+        $guiArguments = if ($guiClient -ceq 'desktop') {
+            $desktopUserDataRoot = Join-Path $guiCaseRoot 'browser-profile'
+            [void](New-Item -ItemType Directory -Path $desktopUserDataRoot)
+            @("--user-data-dir=$desktopUserDataRoot", '--no-first-run')
+        }
+        else {
+            @()
+        }
+        $guiProcess = Start-IsolatedProcess -Executable $executables[$guiClient] -Arguments $guiArguments -CaseRoot $guiCaseRoot -Environment @{
             CODEXHUB_E2E_GUI_CLIENT = $guiClient
             CODEXHUB_E2E_CASES = $guiCase.case_id
             CODEXHUB_E2E_MODELS = $guiCase.canonical_model

--- a/src-python/config_overlay.py
+++ b/src-python/config_overlay.py
@@ -618,7 +618,7 @@ def _selected_model_is_official(selected_model: str | None) -> bool:
 
 
 def build_overlay(
-    catalog_value: str,
+    catalog_value: str | None,
     owner: str,
     context_budget: tuple[int, int] | None = None,
 ) -> str:
@@ -626,8 +626,9 @@ def build_overlay(
         MARKER_BEGIN,
         f"# owner = {owner}",
         f'model_provider = "{PROXY_PROVIDER_ID}"',
-        f"model_catalog_json = {toml_literal(catalog_value)}",
     ]
+    if catalog_value is not None:
+        lines.append(f"model_catalog_json = {toml_literal(catalog_value)}")
     if context_budget is not None:
         context_window, auto_compact_token_limit = context_budget
         lines.extend(
@@ -712,7 +713,7 @@ def insert_provider_section(text: str, provider_section: str) -> str:
 def apply_overlay(
     config_path: Path,
     backup_path: Path,
-    catalog_path: Path,
+    catalog_path: Path | None,
     base_url: str,
     owner: str = "release",
     takeover: bool = False,
@@ -749,7 +750,7 @@ def apply_overlay(
         cleaned = strip_top_level_keys(cleaned, CONTEXT_GUARD_KEYS)
     cleaned = set_feature_flags(cleaned, PROXY_FEATURE_FLAGS)
     updated = build_overlay(
-        catalog_config_value(config_path, catalog_path),
+        catalog_config_value(config_path, catalog_path) if catalog_path is not None else None,
         owner,
         context_budget,
     ) + cleaned.lstrip()
@@ -799,7 +800,7 @@ def main(argv: list[str] | None = None) -> int:
     apply_parser = subparsers.add_parser("apply")
     apply_parser.add_argument("--config", required=True, type=Path)
     apply_parser.add_argument("--backup", required=True, type=Path)
-    apply_parser.add_argument("--catalog", required=True, type=Path)
+    apply_parser.add_argument("--catalog", type=Path)
     apply_parser.add_argument("--base-url", required=True)
     apply_parser.add_argument("--owner", choices=["release", "beta"], default="release")
     apply_parser.add_argument("--takeover", action="store_true")

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -412,12 +412,17 @@ fn run_codex_managed_client_config(
     } else {
         gateway::validate_isolated_root(&request.root)?
     };
-    let (_settings, _providers, paths, _staged_catalog_path) =
+    let (_settings, _providers, paths, staged_catalog_path) =
         load_settings_and_providers(request, isolated.root())?;
     let model = request.model.clone().unwrap_or_else(|| "gpt-5.5".to_string());
     match request.verb.as_str() {
         "preview" => {
-            let preview = config::preview_codex_config_isolated(&paths, "custom", &model)?;
+            let preview = config::preview_codex_config_isolated(
+                &paths,
+                "custom",
+                &model,
+                staged_catalog_path.as_deref(),
+            )?;
             Ok(serde_json::to_value(&preview).map_err(|error| error.to_string())?)
         }
         "apply" => {
@@ -427,8 +432,15 @@ fn run_codex_managed_client_config(
                 .map(Path::to_path_buf)
                 .unwrap_or_else(config::find_python);
             let runner = config::ProcessCommandRunner;
-            let status =
-                config::apply_codex_config_isolated(&paths, "custom", false, &model, &python, &runner)?;
+            let status = config::apply_codex_config_isolated(
+                &paths,
+                "custom",
+                false,
+                &model,
+                staged_catalog_path.as_deref(),
+                &python,
+                &runner,
+            )?;
             Ok(serde_json::to_value(&status).map_err(|error| error.to_string())?)
         }
         "readback" => {
@@ -918,6 +930,57 @@ gateway_exported = true
             // "custom/gpt-5.6-luna". This CLI test ensures the dispatch path
             // that wires ConfigPaths + populate_isolated_repo_resources does
             // not regress for Codex preview.
+        }
+
+        #[test]
+        fn managed_client_config_codex_volc_without_catalog_never_writes_dangling_catalog_reference()
+        {
+            let root = temp_root("mcc-codex-volc-no-catalog");
+            let (settings_path, providers_path) = write_settings_and_providers(&root);
+            let isolated = root.join("isolated");
+            let common_args = [
+                "--client",
+                "codex",
+                "--root",
+                isolated.to_str().unwrap(),
+                "--settings-path",
+                settings_path.to_str().unwrap(),
+                "--providers-path",
+                providers_path.to_str().unwrap(),
+                "--model",
+                "volc/glm-5.2",
+            ];
+
+            let apply_args = std::iter::once("managed-client-config")
+                .chain(std::iter::once("apply"))
+                .chain(common_args)
+                .map(str::to_string)
+                .collect::<Vec<_>>();
+            assert_eq!(run(&apply_args), 0, "Codex Volc apply should succeed");
+
+            let readback_args = std::iter::once("managed-client-config")
+                .chain(std::iter::once("readback"))
+                .chain(common_args)
+                .map(str::to_string)
+                .collect::<Vec<_>>();
+            assert_eq!(run(&readback_args), 0, "Codex Volc readback should succeed");
+
+            let config_path = isolated.join("codex-target").join("config.toml");
+            let config_text = fs::read_to_string(&config_path).unwrap();
+            assert!(
+                !config_text
+                    .lines()
+                    .any(|line| line.trim_start().starts_with("model_catalog_json")),
+                "Codex config must not reference a catalog when --catalog-path was omitted:\n{config_text}"
+            );
+            assert!(
+                !isolated
+                    .join("runtime")
+                    .join("model-catalogs")
+                    .join("codexhub-model-catalog.json")
+                    .exists(),
+                "Volc apply without --catalog-path must not synthesize an Official catalog"
+            );
         }
 
         // F6: table-driven all-client CLI dispatch. Every supported client

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -1,8 +1,12 @@
 use crate::{
-    autostart, catalog, config, gateway, history, models, proxy, AppStatus, Provider, Settings,
+    autostart, catalog, config, gateway, history, models, proxy, AppStatus, Model, Provider,
+    Settings, UpstreamFormat,
 };
 use serde::Serialize;
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
+
+const MAX_MANAGED_CLIENT_CATALOG_BYTES: u64 = 16 * 1024 * 1024;
 
 pub fn run(args: &[String]) -> i32 {
     match args.first().map(String::as_str) {
@@ -201,7 +205,15 @@ fn run_managed_client_config(args: &[String]) -> i32 {
 fn load_settings_and_providers(
     request: &ManagedClientConfigRequest,
     isolated_root: &Path,
-) -> Result<(Settings, Vec<Provider>, config::ConfigPaths), String> {
+) -> Result<
+    (
+        Settings,
+        Vec<Provider>,
+        config::ConfigPaths,
+        Option<PathBuf>,
+    ),
+    String,
+> {
     // The isolated ConfigPaths resolves settings/providers/catalog/targets
     // beneath the supplied root using existing production parsers. We seed
     // the isolated runtime dir with the caller-supplied settings/providers
@@ -218,6 +230,7 @@ fn load_settings_and_providers(
     // discovery. Native clients (opencode/zcode/pi/omp) do not read from
     // the repo tree, so this is harmless for them.
     config::populate_isolated_repo_resources(&paths)?;
+    let staged_catalog_path = stage_candidate_catalog(request.catalog_path.as_deref(), &paths)?;
     // Seed settings.json from the caller-supplied path if provided.
     if let Some(settings_path) = &request.settings_path {
         let text = std::fs::read_to_string(settings_path)
@@ -235,9 +248,125 @@ fn load_settings_and_providers(
             format!("failed to write isolated providers: {error}")
         })?;
     }
-    let settings = config::get_settings_from_paths(&paths)?;
-    let providers = config::get_providers_from_paths(&paths)?;
-    Ok((settings, providers, paths))
+    let mut settings = config::get_settings_from_paths(&paths)?;
+    let mut providers = config::get_providers_from_paths(&paths)?;
+
+    // The isolated CLI must never discover Official models from the current
+    // user's runtime. An explicit candidate catalog is imported below as the
+    // authoritative OpenAI provider; without one, only the supplied provider
+    // configuration is available.
+    let include_candidate_official_models = settings.include_official_models;
+    settings.include_official_models = false;
+    if include_candidate_official_models {
+        if let Some(catalog_path) = staged_catalog_path.as_deref() {
+            let official_models = models::read_official_catalog_models(catalog_path)
+                .map_err(|_| "candidate catalog is malformed".to_string())?;
+            if official_models.is_empty() {
+                return Err("candidate catalog has no Official models".to_string());
+            }
+            providers.retain(|provider| provider.id != "openai");
+            providers.push(candidate_official_provider(official_models));
+        }
+    }
+
+    Ok((settings, providers, paths, staged_catalog_path))
+}
+
+fn stage_candidate_catalog(
+    source_path: Option<&Path>,
+    paths: &config::ConfigPaths,
+) -> Result<Option<PathBuf>, String> {
+    let Some(source_path) = source_path else {
+        return Ok(None);
+    };
+    let source_bytes = read_bounded_single_link_file(source_path)
+        .map_err(|_| "candidate catalog source is not a regular single-link file".to_string())?;
+    let staged_path = paths.generated_catalog_path_for_cli();
+    let parent = staged_path
+        .parent()
+        .ok_or_else(|| "candidate catalog target has no parent".to_string())?;
+    std::fs::create_dir_all(parent)
+        .map_err(|_| "failed to create isolated candidate catalog directory".to_string())?;
+
+    if staged_path.exists() {
+        let staged_bytes = read_bounded_single_link_file(&staged_path)
+            .map_err(|_| "isolated candidate catalog is not a regular single-link file".to_string())?;
+        if staged_bytes != source_bytes {
+            return Err("isolated candidate catalog contradicts supplied source".to_string());
+        }
+    } else {
+        let mut staged = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&staged_path)
+            .map_err(|_| "failed to create isolated candidate catalog".to_string())?;
+        staged
+            .write_all(&source_bytes)
+            .and_then(|_| staged.sync_all())
+            .map_err(|_| "failed to write isolated candidate catalog".to_string())?;
+        drop(staged);
+        let staged_bytes = read_bounded_single_link_file(&staged_path)
+            .map_err(|_| "isolated candidate catalog is not a regular single-link file".to_string())?;
+        if staged_bytes != source_bytes {
+            return Err("isolated candidate catalog copy verification failed".to_string());
+        }
+    }
+    Ok(Some(staged_path))
+}
+
+fn read_bounded_single_link_file(path: &Path) -> Result<Vec<u8>, String> {
+    let path_metadata = std::fs::symlink_metadata(path)
+        .map_err(|error| format!("failed to inspect input: {error}"))?;
+    if !path_metadata.file_type().is_file() || path_metadata.file_type().is_symlink() {
+        return Err("input is not a regular file".to_string());
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt;
+        const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x400;
+        if path_metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+            return Err("input is a reparse point".to_string());
+        }
+    }
+    let canonical = std::fs::canonicalize(path)
+        .map_err(|error| format!("failed to canonicalize input: {error}"))?;
+    gateway::reject_hard_link(&canonical)?;
+    let file = std::fs::File::open(&canonical)
+        .map_err(|error| format!("failed to open input: {error}"))?;
+    let metadata = file
+        .metadata()
+        .map_err(|error| format!("failed to inspect open input: {error}"))?;
+    if !metadata.is_file() || metadata.len() > MAX_MANAGED_CLIENT_CATALOG_BYTES {
+        return Err("input is not a bounded regular file".to_string());
+    }
+    let mut bytes = Vec::with_capacity(metadata.len() as usize);
+    file.take(MAX_MANAGED_CLIENT_CATALOG_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|error| format!("failed to read input: {error}"))?;
+    if bytes.len() as u64 > MAX_MANAGED_CLIENT_CATALOG_BYTES {
+        return Err("input exceeds the size bound".to_string());
+    }
+    Ok(bytes)
+}
+
+fn candidate_official_provider(models: Vec<Model>) -> Provider {
+    Provider {
+        id: "openai".to_string(),
+        name: "OpenAI".to_string(),
+        base_url: "https://api.openai.com/v1".to_string(),
+        api_key: None,
+        upstream_format: Some(UpstreamFormat::Responses),
+        available_upstream_formats: Some(vec![UpstreamFormat::Responses]),
+        tool_protocol: None,
+        tool_surface_strategy: None,
+        reports_cached_input_tokens: None,
+        supports_developer_role: Some(true),
+        display_prefix: Some("openai/".to_string()),
+        sort_order: Some(0),
+        enabled: true,
+        locked: true,
+        models,
+    }
 }
 
 fn run_native_managed_client_config(
@@ -248,13 +377,14 @@ fn run_native_managed_client_config(
     } else {
         gateway::validate_isolated_root(&request.root)?
     };
-    let (settings, providers, _paths) = load_settings_and_providers(request, isolated.root())?;
+    let (settings, providers, _paths, staged_catalog_path) =
+        load_settings_and_providers(request, isolated.root())?;
     let input = gateway::IsolatedClientApplyInput {
         client_id: request.client.clone(),
         model: request.model.clone(),
         settings,
         providers,
-        catalog_path: request.catalog_path.clone(),
+        catalog_path: staged_catalog_path,
         backup_subdir: request.backup_subdir.clone(),
     };
     match request.verb.as_str() {
@@ -282,7 +412,8 @@ fn run_codex_managed_client_config(
     } else {
         gateway::validate_isolated_root(&request.root)?
     };
-    let (_settings, _providers, paths) = load_settings_and_providers(request, isolated.root())?;
+    let (_settings, _providers, paths, _staged_catalog_path) =
+        load_settings_and_providers(request, isolated.root())?;
     let model = request.model.clone().unwrap_or_else(|| "gpt-5.5".to_string());
     match request.verb.as_str() {
         "preview" => {
@@ -607,6 +738,34 @@ gateway_exported = true
             (settings_path, providers_path)
         }
 
+        fn write_candidate_official_catalog(root: &Path) -> PathBuf {
+            let catalog_path = root.join("candidate-catalog.json");
+            fs::write(
+                &catalog_path,
+                r#"{
+  "models": [
+    {
+      "slug": "gpt-cli-catalog-only",
+      "display_name": "CLI Catalog Only",
+      "context_window": 272000,
+      "input_modalities": ["text", "image"],
+      "supported_reasoning_levels": ["medium"],
+      "default_reasoning_level": "medium",
+      "enabled": true,
+      "gateway_exported": true,
+      "codex_proxy_metadata": {
+        "provider": "openai",
+        "upstream_name": "official",
+        "upstream_model": "gpt-cli-catalog-only"
+      }
+    }
+  ]
+}"#,
+            )
+            .unwrap();
+            catalog_path
+        }
+
         #[test]
         fn managed_client_config_unknown_verb_returns_usage_error() {
             let root = temp_root("mcc-unknown-verb");
@@ -790,6 +949,73 @@ gateway_exported = true
                     "preview should succeed for client {client_id}"
                 );
             }
+        }
+
+        #[test]
+        fn managed_client_config_native_matrix_imports_external_catalog_into_fresh_roots() {
+            let root = temp_root("mcc-external-catalog");
+            let (settings_path, providers_path) = write_settings_and_providers(&root);
+            let catalog_path = write_candidate_official_catalog(&root);
+
+            for client_id in ["opencode", "zcode", "pi", "omp"] {
+                let preview_root = root.join(format!("{client_id}-preview"));
+                let apply_root = root.join(format!("{client_id}-apply"));
+                for (verb, isolated) in [
+                    ("preview", preview_root.as_path()),
+                    ("apply", apply_root.as_path()),
+                    ("readback", apply_root.as_path()),
+                ] {
+                    let args = vec![
+                        "managed-client-config".to_string(),
+                        verb.to_string(),
+                        "--client".to_string(),
+                        client_id.to_string(),
+                        "--root".to_string(),
+                        isolated.to_string_lossy().to_string(),
+                        "--settings-path".to_string(),
+                        settings_path.to_string_lossy().to_string(),
+                        "--providers-path".to_string(),
+                        providers_path.to_string_lossy().to_string(),
+                        "--catalog-path".to_string(),
+                        catalog_path.to_string_lossy().to_string(),
+                        "--model".to_string(),
+                        "openai/gpt-cli-catalog-only".to_string(),
+                    ];
+                    assert_eq!(
+                        run(&args),
+                        0,
+                        "{verb} should import the candidate catalog for {client_id}"
+                    );
+                }
+            }
+        }
+
+        #[test]
+        fn managed_client_config_rejects_hardlinked_external_catalog() {
+            let root = temp_root("mcc-hardlinked-catalog");
+            let (settings_path, providers_path) = write_settings_and_providers(&root);
+            let catalog_path = write_candidate_official_catalog(&root);
+            let linked_catalog_path = root.join("linked-candidate-catalog.json");
+            fs::hard_link(&catalog_path, &linked_catalog_path).unwrap();
+            let isolated = root.join("isolated");
+            let args = vec![
+                "managed-client-config".to_string(),
+                "preview".to_string(),
+                "--client".to_string(),
+                "zcode".to_string(),
+                "--root".to_string(),
+                isolated.to_string_lossy().to_string(),
+                "--settings-path".to_string(),
+                settings_path.to_string_lossy().to_string(),
+                "--providers-path".to_string(),
+                providers_path.to_string_lossy().to_string(),
+                "--catalog-path".to_string(),
+                linked_catalog_path.to_string_lossy().to_string(),
+                "--model".to_string(),
+                "openai/gpt-cli-catalog-only".to_string(),
+            ];
+
+            assert_eq!(run(&args), 1, "linked catalog input must fail closed");
         }
     }
 }

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -169,6 +169,13 @@ impl ConfigPaths {
         self.runtime_providers_path()
     }
 
+    /// CLI accessor for the isolated generated catalog path. The caller may
+    /// import an explicitly supplied candidate catalog here only after the
+    /// fresh isolated root has been validated.
+    pub(crate) fn generated_catalog_path_for_cli(&self) -> PathBuf {
+        self.generated_catalog_path()
+    }
+
     pub(crate) fn settings_path(&self) -> PathBuf {
         self.proxy_dir().join("settings.json")
     }

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -858,6 +858,27 @@ fn switch_mode_with_paths_takeover_as_owner(
     python: &Path,
     runner: &dyn CommandRunner,
 ) -> Result<AppStatus, String> {
+    let catalog_path = paths.generated_catalog_path();
+    switch_mode_with_paths_takeover_as_owner_and_catalog(
+        current_app_owner,
+        mode,
+        force_takeover,
+        paths,
+        Some(&catalog_path),
+        python,
+        runner,
+    )
+}
+
+fn switch_mode_with_paths_takeover_as_owner_and_catalog(
+    current_app_owner: crate::app_flavor::RoutingOwner,
+    mode: &str,
+    force_takeover: bool,
+    paths: &ConfigPaths,
+    catalog_path: Option<&Path>,
+    python: &Path,
+    runner: &dyn CommandRunner,
+) -> Result<AppStatus, String> {
     if mode != "official" && mode != "custom" {
         return Err(format!(
             "unsupported mode: {mode}; expected official or custom"
@@ -918,8 +939,14 @@ fn switch_mode_with_paths_takeover_as_owner(
                 .config_backup_path_for_owner(current_app_owner)
                 .to_string_lossy()
                 .into_owned(),
-            "--catalog".to_string(),
-            paths.generated_catalog_path().to_string_lossy().into_owned(),
+        ];
+        if let Some(catalog_path) = catalog_path {
+            args.extend([
+                "--catalog".to_string(),
+                catalog_path.to_string_lossy().into_owned(),
+            ]);
+        }
+        args.extend([
             "--base-url".to_string(),
             format!("http://127.0.0.1:{}", settings.proxy_port),
             "--gateway-key".to_string(),
@@ -929,7 +956,7 @@ fn switch_mode_with_paths_takeover_as_owner(
                 crate::app_flavor::RoutingOwner::Beta => "beta".to_string(),
                 _ => "release".to_string(),
             },
-        ];
+        ]);
         if force_takeover && target_owner != Some(current_app_owner) {
             args.push("--takeover".to_string());
         }
@@ -1230,6 +1257,7 @@ pub(crate) fn preview_codex_config_isolated(
     paths: &ConfigPaths,
     mode: &str,
     model: &str,
+    catalog_path: Option<&Path>,
 ) -> Result<IsolatedCodexPreview, String> {
     if mode != "custom" && mode != "official" {
         return Err(format!("unsupported Codex mode: {mode}"));
@@ -1242,7 +1270,8 @@ pub(crate) fn preview_codex_config_isolated(
         .to_string()];
     // Build the overlay args that apply would invoke, expressed as relative
     // tokens so the structured output never leaks absolute paths.
-    let overlay_args_relative = build_codex_overlay_args_relative(paths, mode, model);
+    let overlay_args_relative =
+        build_codex_overlay_args_relative(paths, mode, model, catalog_path);
     Ok(IsolatedCodexPreview {
         client_id: "codex".to_string(),
         selector: format!("{CODEX_OVERLAY_PROVIDER_ID}/{model}"),
@@ -1258,16 +1287,18 @@ pub(crate) fn apply_codex_config_isolated(
     mode: &str,
     force_takeover: bool,
     model: &str,
+    catalog_path: Option<&Path>,
     python: &Path,
     runner: &dyn CommandRunner,
 ) -> Result<crate::AppStatus, String> {
     let _ = model; // The overlay derives the selected model from config.toml.
     let current_app_owner = crate::app_flavor::current().routing_owner();
-    switch_mode_with_paths_takeover_as_owner(
+    switch_mode_with_paths_takeover_as_owner_and_catalog(
         current_app_owner,
         mode,
         force_takeover,
         paths,
+        catalog_path,
         python,
         runner,
     )
@@ -1389,7 +1420,12 @@ fn parse_toml_string_value(value: &str) -> Option<String> {
     }
 }
 
-fn build_codex_overlay_args_relative(paths: &ConfigPaths, mode: &str, _model: &str) -> Vec<String> {
+fn build_codex_overlay_args_relative(
+    paths: &ConfigPaths,
+    mode: &str,
+    _model: &str,
+    catalog_path: Option<&Path>,
+) -> Vec<String> {
     // The structured preview reports the overlay *shape* using relative tokens
     // so absolute paths never leak. The actual apply path resolves them
     // through `switch_mode_with_paths_takeover_as_owner`.
@@ -1405,22 +1441,24 @@ fn build_codex_overlay_args_relative(paths: &ConfigPaths, mode: &str, _model: &s
         .and_then(|name| name.to_str())
         .unwrap_or("config.toml.release.backup")
         .to_string();
-    let catalog_name = paths
-        .generated_catalog_path()
-        .file_name()
-        .and_then(|name| name.to_str())
-        .unwrap_or("codexhub-model-catalog.json")
-        .to_string();
     let command = if mode == "official" { "restore" } else { "apply" };
-    vec![
+    let mut args = vec![
         command.to_string(),
         "--config".to_string(),
         config_name,
         "--backup".to_string(),
         backup_name,
-        "--catalog".to_string(),
-        catalog_name,
-    ]
+    ];
+    if mode == "custom" && catalog_path.is_some() {
+        let catalog_name = paths
+            .generated_catalog_path()
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("codexhub-model-catalog.json")
+            .to_string();
+        args.extend(["--catalog".to_string(), catalog_name]);
+    }
+    args
 }
 
 #[cfg(test)]
@@ -2968,7 +3006,14 @@ base_url = "https://ark.cn-beijing.volces.com/api/coding/v3"
         fn codex_preview_under_isolated_root_reports_relative_target_and_no_secret() {
             let root = temp_root("codex-preview-isolated");
             let paths = isolated_paths(&root);
-            let preview = preview_codex_config_isolated(&paths, "custom", "gpt-5.6-luna").unwrap();
+            let catalog_path = paths.generated_catalog_path();
+            let preview = preview_codex_config_isolated(
+                &paths,
+                "custom",
+                "gpt-5.6-luna",
+                Some(&catalog_path),
+            )
+            .unwrap();
 
             assert_eq!(preview.client_id, "codex");
             // F4: the Codex preview now reports the real overlay provider/route
@@ -3003,9 +3048,17 @@ base_url = "https://ark.cn-beijing.volces.com/api/coding/v3"
             .unwrap();
             let runner = RecordingRunner::successful();
 
-            let result =
-                apply_codex_config_isolated(&paths, "custom", false, "gpt-5.6-luna", Path::new("python-test"), &runner)
-                    .unwrap();
+            let catalog_path = paths.generated_catalog_path();
+            let result = apply_codex_config_isolated(
+                &paths,
+                "custom",
+                false,
+                "gpt-5.6-luna",
+                Some(&catalog_path),
+                Path::new("python-test"),
+                &runner,
+            )
+            .unwrap();
             assert_eq!(result.mode, "custom");
 
             let commands = runner.commands.borrow();

--- a/src-tauri/src/gateway.rs
+++ b/src-tauri/src/gateway.rs
@@ -1074,7 +1074,7 @@ fn gateway_client_config_write_lock() -> &'static Mutex<()> {
 /// owned by exactly one path beneath the isolated root; a hard link means a
 /// second name elsewhere owns the same inode, which breaks the single-owner
 /// namespace invariant the readback verifier is responsible for.
-fn reject_hard_link(path: &Path) -> Result<(), String> {
+pub(crate) fn reject_hard_link(path: &Path) -> Result<(), String> {
     #[cfg(unix)]
     {
         use std::os::unix::fs::MetadataExt;
@@ -2165,7 +2165,12 @@ fn official_model_disabled(settings: &Settings, id: &str) -> bool {
 }
 
 fn gateway_models_from_config(settings: &Settings, providers: &[Provider]) -> Vec<GatewayModel> {
-    gateway_models_from_sources(settings, providers, official_models(settings))
+    let official_source_models = if settings.include_official_models {
+        official_models(settings)
+    } else {
+        Vec::new()
+    };
+    gateway_models_from_sources(settings, providers, official_source_models)
 }
 
 fn gateway_models_from_sources(

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -1890,6 +1890,24 @@ fn generate_catalog_with_runner(
 }
 
 fn read_catalog_models(path: &Path) -> Result<Vec<Model>, String> {
+    read_catalog_models_matching(path, |_| true)
+}
+
+pub(crate) fn read_official_catalog_models(path: &Path) -> Result<Vec<Model>, String> {
+    read_catalog_models_matching(path, |item| {
+        item.get("codex_proxy_metadata")
+            .and_then(Value::as_object)
+            .is_some_and(|metadata| {
+                metadata.get("provider").and_then(Value::as_str) == Some("openai")
+                    && metadata.get("upstream_name").and_then(Value::as_str) == Some("official")
+            })
+    })
+}
+
+fn read_catalog_models_matching(
+    path: &Path,
+    include: impl Fn(&Value) -> bool,
+) -> Result<Vec<Model>, String> {
     let text = fs::read_to_string(path)
         .map_err(|error| format!("failed to read catalog JSON {}: {error}", path.display()))?;
     let payload: Value = serde_json::from_str(&text)
@@ -1907,6 +1925,9 @@ fn read_catalog_models(path: &Path) -> Result<Vec<Model>, String> {
     let mut seen = HashSet::new();
     let mut models = Vec::new();
     for item in items {
+        if !include(item) {
+            continue;
+        }
         let Some(model) = catalog_model_from_item(item) else {
             continue;
         };

--- a/tests/fixtures/real_client_e2e/fake-client-desktop-argv.cmd
+++ b/tests/fixtures/real_client_e2e/fake-client-desktop-argv.cmd
@@ -1,0 +1,5 @@
+@echo off
+if /I "%CODEXHUB_E2E_GUI_CLIENT%"=="desktop" (
+  <nul set /p "=%*">"%CODEXHUB_E2E_GUI_LAUNCH_MARKER%.argv"
+)
+call "%~dp0fake-client-real-contract.cmd" %*

--- a/tests/fixtures/real_client_e2e/fake-debug-build-official-bootstrap.cmd
+++ b/tests/fixtures/real_client_e2e/fake-debug-build-official-bootstrap.cmd
@@ -35,6 +35,11 @@ if exist "%~f0.bootstrap-fail" (
   >&2 echo published Official catalog contains no safe resolved context budget
   exit /b 33
 )
+if exist "%~f0.bootstrap-fail-once" if not exist "%CODEXHUB_RUNTIME_HOME%\proxy\bootstrap-fail-once.seen" (
+  >"%CODEXHUB_RUNTIME_HOME%\proxy\bootstrap-fail-once.seen" echo seen
+  >&2 echo codex app-server model list did not publish a readable native models cache before the refresh deadline; failed to publish a degraded safe snapshot: published Official catalog contains no safe resolved context budget
+  exit /b 39
+)
 if exist "%~f0.bootstrap-slow" (
   ping.exe 127.0.0.1 -n 4 >nul
 )

--- a/tests/fixtures/real_client_e2e/windows-install-metadata.template.json
+++ b/tests/fixtures/real_client_e2e/windows-install-metadata.template.json
@@ -4,6 +4,7 @@
     "package_name": "OpenAI.Codex",
     "package_version": "26.715.8383.0",
     "install_location": "__FIXTURE_INSTALL_LOCATION__",
+    "manifest_executable": "__FIXTURE_MANIFEST_EXECUTABLE__",
     "executable_product_version": "1.2026.1704.0"
   },
   "zcode": {

--- a/tests/test_real_client_e2e.py
+++ b/tests/test_real_client_e2e.py
@@ -286,8 +286,6 @@ def _run(
         shutil.copyfile(FIXTURES / debug_fake, debug_build)
     if materializer_fake is not None:
         shutil.copyfile(FIXTURES / materializer_fake, materializer_build)
-    if mutate is not None:
-        mutate(output, isolation, debug_build)
     fake_path = FIXTURES / fake
     executable_arguments = {
         "CodexDesktopPath": fake_path,
@@ -353,6 +351,14 @@ def _run(
         metadata_path.write_text(json.dumps(metadata), encoding="utf-8")
         executable_arguments["CodexDesktopPath"] = desktop_path
         executable_arguments["ZCodePath"] = zcode_path
+    metadata_path = isolation / "config" / "windows-install-metadata.json"
+    metadata = json.loads(metadata_path.read_text())
+    metadata["desktop"]["manifest_executable"] = str(
+        Path(executable_arguments["CodexDesktopPath"]).resolve()
+    )
+    metadata_path.write_text(json.dumps(metadata), encoding="utf-8")
+    if mutate is not None:
+        mutate(output, isolation, debug_build)
     command = [
         _powershell(),
         "-NoProfile",
@@ -1697,6 +1703,50 @@ def test_passed_executables_must_be_bound_to_authoritative_install_locations(tmp
     assert not (tmp_path / "output" / "manual-evidence.template.json").exists()
 
 
+def test_desktop_executable_must_match_appx_manifest_entry(tmp_path):
+    def bind_manifest_to_different_executable(_output, isolation, _debug):
+        path = isolation / "config" / "windows-install-metadata.json"
+        metadata = json.loads(path.read_text())
+        metadata["desktop"]["manifest_executable"] = str(
+            (FIXTURES / "fake-client-isolation.cmd").resolve()
+        )
+        path.write_text(json.dumps(metadata), encoding="utf-8")
+
+    result = _run(
+        tmp_path,
+        mutate=bind_manifest_to_different_executable,
+        finalize_manual=False,
+    )
+
+    assert result.returncode != 0
+    summary = json.loads((tmp_path / "output" / "summary.json").read_text())
+    assert (
+        summary["failure_classification"]
+        == "preflight_desktop_executable_unbound"
+    )
+    assert not (tmp_path / "output" / "manual-evidence.template.json").exists()
+
+
+def test_desktop_gui_cases_use_distinct_case_local_user_data_directories(tmp_path):
+    result = _run(
+        tmp_path,
+        client_fakes={"CodexDesktopPath": "fake-client-desktop-argv.cmd"},
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    work = tmp_path / "output" / "isolated" / "work"
+    observed = {}
+    for case_id in ("desktop-luna", "desktop-volc"):
+        argument_log = work / f"gui-{case_id}.launched.argv"
+        arguments = argument_log.read_text(encoding="ascii").strip()
+        expected_profile = work / "gui-desktop" / case_id / "browser-profile"
+        assert arguments.count("--user-data-dir=") == 1
+        assert str(expected_profile).casefold() in arguments.casefold()
+        assert "--no-first-run" in arguments
+        observed[case_id] = arguments
+    assert observed["desktop-luna"] != observed["desktop-volc"]
+
+
 def test_ambient_host_session_environment_never_reaches_candidate_or_clients(
     tmp_path, monkeypatch
 ):
@@ -2091,6 +2141,37 @@ def test_candidate_context_budget_bootstrap_failure_is_bounded_and_sanitized(tmp
     assert "fixture-codex-access-token" not in serialized
     assert "fixture-volc-private-token" not in serialized
     assert not list((tmp_path / "output" / "isolated" / "work").glob("gui-*.launched"))
+
+
+def test_candidate_retries_transient_native_model_cache_timeout_within_shared_budget(
+    tmp_path,
+):
+    def fail_first_native_cache_publication(_output, _isolation, debug_build):
+        Path(f"{debug_build}.bootstrap-fail-once").write_text(
+            "fail once", encoding="ascii"
+        )
+
+    started = time.monotonic()
+    result = _run(
+        tmp_path,
+        debug_fake="fake-debug-build-official-bootstrap.cmd",
+        mutate=fail_first_native_cache_publication,
+        timeout_seconds=30,
+    )
+    elapsed = time.monotonic() - started
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert elapsed < 30
+    candidate_proxy = (
+        tmp_path / "output" / "isolated" / "work" / "candidate" / "runtime" / "proxy"
+    )
+    assert (
+        candidate_proxy / "official-bootstrap-invocations.txt"
+    ).read_text().splitlines() == [
+        "refresh-models",
+        "refresh-models",
+        "start",
+    ]
 
 
 def test_candidate_bootstrap_and_listener_share_one_startup_budget(tmp_path):


### PR DESCRIPTION
Fixes #215

This frozen candidate resolves both release-blocking boundaries found by the local R18 startup reproductions.

First, an explicit candidate Official catalog is validated and staged inside each fresh managed-client runtime before the production serializers consume it. Ambient Official discovery stays disabled and confinement remains fail closed. Second, a Volc Codex configuration with no explicit catalog now omits `model_catalog_json` instead of pointing Codex at a file that does not exist.

The same locally frozen SHA also hardens the GUI startup seam: AppX Desktop is bound to the unique `Windows.FullTrustApplication` executable, Desktop cases receive distinct case-local profiles, and the exact transient native-catalog timeout can retry only once within the existing shared 30-second budget.

All development validation was completed locally before the single push. GitHub Actions is now only the final exact-SHA merge backstop. The real 12-case qualification will run once, from a portable rebuilt from this exact commit, after CI succeeds.

<!-- orchestrator:delivery:v1 -->
```json
{
  "candidate_sha": "42f4057353cce5a66702e98148259550239938fb",
  "changed_paths": [
    "scripts/Run-RealClientE2E.ps1",
    "src-python/config_overlay.py",
    "src-tauri/src/cli.rs",
    "src-tauri/src/config.rs",
    "src-tauri/src/gateway.rs",
    "src-tauri/src/models.rs",
    "tests/fixtures/real_client_e2e/fake-client-desktop-argv.cmd",
    "tests/fixtures/real_client_e2e/fake-debug-build-official-bootstrap.cmd",
    "tests/fixtures/real_client_e2e/windows-install-metadata.template.json",
    "tests/test_real_client_e2e.py"
  ],
  "contract_sha256": "23405d037fcdd2669348179c3949507efb7a0f8a138b6094f68110874e91ac72",
  "deviations": [],
  "risks": [
    "The final twelve-case real-client qualification and four human Desktop/ZCode GUI confirmations remain the release gate after exact-SHA CI succeeds."
  ],
  "tdd": {
    "green": "The Volc no-catalog regression now omits model_catalog_json while Official explicit-catalog staging remains intact; AppX FullTrustApplication binding, case-local Desktop user-data-dir arguments, and the one-shot transient timeout retry all pass their focused tests.",
    "red": "The isolated Volc Codex apply/readback reproduction emitted model_catalog_json without an explicit catalog, leaving a nonexistent file reference that made Codex config/read and sandbox startup fail; runner regressions also captured AppX executable binding and per-case Desktop profile isolation.",
    "refactor": "Reused the production overlay and native serializers, existing isolated catalog staging, AppX manifest metadata, and shared 30-second startup budget; no ambient discovery, second serializer, fallback route, or secret/path disclosure was added."
  },
  "verification": [
    "Managed-client Rust tests passed 39 of 39 and isolated Codex tests passed 8 of 8.",
    "The affected runner/bootstrap/GUI-isolation matrix passed 16 of 16 and config_overlay passed 45 tests plus 5 subtests.",
    "The deterministic complete Rust suite passed 458 of 458 single-threaded and clippy was clean.",
    "The complete Python suite passed 1411 tests with 1 skipped and 332 subtests.",
    "PowerShell parsing, git diff --check, scope audit, secret scan, and report-only gates passed with zero parse errors.",
    "A local debug portable bootstrap verified Official staged catalog readback and Volc no-catalog readback without launching a real GUI.",
    "The bounded exact-local-SHA combined review passed with no blockers before this single push."
  ]
}
```
