### PR TITLE
Fix Codex catalog upgrade schema

### DIFF
--- a/src-python/catalog_sync.py
+++ b/src-python/catalog_sync.py
@@ -1231,6 +1231,7 @@ def build_official_proxy_model(
         apply_official_model_defaults(model, slug)
     normalize_official_responses_lite_opt_in(model)
     apply_pinned_official_catalog_metadata(model, slug)
+    normalize_official_upgrade_for_codex(model)
     limits = RESOLVED_MODEL_LIMITS.get(("openai", slug))
     if limits is not None and limits.max_output_tokens is not None:
         model.setdefault("max_output_tokens", limits.max_output_tokens)
@@ -1269,6 +1270,28 @@ def build_official_proxy_model(
     )
     model["codex_proxy_metadata"] = proxy_metadata
     return model
+
+
+def normalize_official_upgrade_for_codex(model: dict[str, Any]) -> None:
+    upgrade = model.get("upgrade")
+    if not isinstance(upgrade, str) or not upgrade:
+        return
+
+    upgrade_info = model.get("upgradeInfo")
+    if not isinstance(upgrade_info, dict):
+        upgrade_info = model.get("upgrade_info")
+    migration_markdown = ""
+    if isinstance(upgrade_info, dict):
+        raw_markdown = upgrade_info.get("migrationMarkdown")
+        if not isinstance(raw_markdown, str):
+            raw_markdown = upgrade_info.get("migration_markdown")
+        if isinstance(raw_markdown, str):
+            migration_markdown = raw_markdown
+
+    model["upgrade"] = {
+        "model": upgrade,
+        "migration_markdown": migration_markdown,
+    }
 
 
 def official_model_index(official_models: Iterable[dict[str, Any]]) -> dict[str, dict[str, Any]]:

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -763,6 +763,10 @@ gateway_exported = true
       "input_modalities": ["text", "image"],
       "supported_reasoning_levels": ["medium"],
       "default_reasoning_level": "medium",
+      "upgrade": {
+        "model": "gpt-cli-catalog-next",
+        "migration_markdown": "Switch to the next CLI catalog model."
+      },
       "enabled": true,
       "gateway_exported": true,
       "codex_proxy_metadata": {
@@ -1020,7 +1024,7 @@ gateway_exported = true
             let (settings_path, providers_path) = write_settings_and_providers(&root);
             let catalog_path = write_candidate_official_catalog(&root);
 
-            for client_id in ["opencode", "zcode", "pi", "omp"] {
+            for client_id in ["codex", "opencode", "zcode", "pi", "omp"] {
                 let preview_root = root.join(format!("{client_id}-preview"));
                 let apply_root = root.join(format!("{client_id}-apply"));
                 for (verb, isolated) in [
@@ -1051,6 +1055,23 @@ gateway_exported = true
                     );
                 }
             }
+
+            let codex_staged_catalog = root
+                .join("codex-apply")
+                .join("runtime")
+                .join("model-catalogs")
+                .join("codexhub-model-catalog.json");
+            let staged: serde_json::Value = serde_json::from_str(
+                &fs::read_to_string(codex_staged_catalog).expect("staged Codex catalog"),
+            )
+            .expect("staged Codex catalog JSON");
+            assert_eq!(
+                staged["models"][0]["upgrade"],
+                serde_json::json!({
+                    "model": "gpt-cli-catalog-next",
+                    "migration_markdown": "Switch to the next CLI catalog model."
+                })
+            );
         }
 
         #[test]

--- a/tests/test_catalog_sync.py
+++ b/tests/test_catalog_sync.py
@@ -265,7 +265,7 @@ class CatalogSyncTests(unittest.TestCase):
         self.assertIn("gpt-5.6-current", known)
         self.assertNotIn("gpt-5.6-stale", known)
 
-    def test_official_catalog_preserves_app_cli_metadata_without_generic_defaults(self):
+    def test_official_catalog_preserves_app_metadata_and_projects_cli_upgrade_schema(self):
         official = [
             {
                 "slug": "gpt-5.6-sol",
@@ -287,7 +287,12 @@ class CatalogSyncTests(unittest.TestCase):
                 "use_responses_lite": True,
                 "availability": {"plan": "plus"},
                 "upgrade": "gpt-5.7-sol",
-                "upgrade_info": {"message": "Upgrade available"},
+                "upgradeInfo": {
+                    "model": "gpt-5.7-sol",
+                    "upgradeCopy": None,
+                    "modelLink": None,
+                    "migrationMarkdown": "Switch to GPT-5.7 Sol.\n",
+                },
                 "comp_hash": "3000",
             }
         ]
@@ -311,8 +316,15 @@ class CatalogSyncTests(unittest.TestCase):
         self.assertEqual(model["slug"], "gpt-5.6-sol")
         self.assertEqual(model["display_name"], "5.6 Sol")
         for key, value in official[0].items():
-            if key not in {"slug", "display_name"}:
+            if key not in {"slug", "display_name", "upgrade"}:
                 self.assertEqual(model[key], value, key)
+        self.assertEqual(
+            model["upgrade"],
+            {
+                "model": "gpt-5.7-sol",
+                "migration_markdown": "Switch to GPT-5.7 Sol.\n",
+            },
+        )
         self.assertEqual(model["shell_type"], "shell_command")
         self.assertEqual(model["supports_parallel_tool_calls"], True)
         self.assertEqual(model["default_reasoning_level"], "medium")
@@ -325,6 +337,26 @@ class CatalogSyncTests(unittest.TestCase):
             model["codex_proxy_metadata"]["official_context_budget"]["source"],
             "current_direct_official",
         )
+
+    def test_official_catalog_preserves_native_cli_upgrade_schema(self):
+        native_upgrade = {
+            "model": "gpt-5.7-sol",
+            "migration_markdown": "Switch to GPT-5.7 Sol.\n",
+        }
+        catalog = build_codex_catalog(
+            [
+                {
+                    "slug": "gpt-5.6-sol",
+                    "display_name": "GPT-5.6-Sol",
+                    "upgrade": native_upgrade,
+                }
+            ],
+            [],
+            self.policy,
+            "0.145.0",
+        )
+
+        self.assertEqual(catalog["models"][0]["upgrade"], native_upgrade)
 
     def test_official_catalog_backfills_pinned_planner_metadata_per_model(self):
         official = [


### PR DESCRIPTION
Fixes #202

This frozen candidate fixes the Codex 0.145 startup failure caused by string-valued `upgrade` fields in the generated Official model catalog. The existing catalog generator now projects the app-server upgrade DTO into Codex's native `ModelInfoUpgrade` object while preserving `upgradeInfo` and already-native objects.

All development verification and the exact-local-SHA combined review completed before this single push. GitHub Actions is only the final exact-SHA merge backstop. The final twelve-case real-client qualification remains a separate release gate after this fix is merged into `dev`.

<!-- orchestrator:delivery:v1 -->
```json
{
  "candidate_sha": "e429fe58abd441d99493a3cce913a6fa7d656c48",
  "changed_paths": [
    "src-python/catalog_sync.py",
    "src-tauri/src/cli.rs",
    "tests/test_catalog_sync.py"
  ],
  "contract_sha256": "ca9ab92b4524d76a6cf77ed7eadf7703c0c69d7be9683000f2393e30b84db59c",
  "deviations": [],
  "risks": [
    "The final twelve-case real-client qualification and four human Desktop/ZCode GUI confirmations remain the 0.1.7 release gate after this fix merges into dev."
  ],
  "tdd": {
    "red": "A fresh generated catalog made codex features list fail before any request with invalid type string, expected struct ModelInfoUpgrade; the regression fixtures reproduced both app-server string and native object forms.",
    "green": "The existing generator now emits native upgrade objects, preserves upgradeInfo and native objects, and the Codex external-catalog preview/apply/readback matrix plus the installed Codex parser all pass.",
    "refactor": "Normalization stays at the existing catalog boundary and reuses existing staging and serializers; no GUI, authentication, routing, sandbox, provider selection, or second catalog generator was introduced."
  },
  "verification": [
    "The exact catalog suite passed 57 tests and 42 subtests; the complete Python suite passed 1411 tests with 1 skipped and 332 subtests.",
    "The deterministic complete Rust suite passed 458 of 458 single-threaded and clippy was clean.",
    "Codex managed-client preview, apply, and readback all exited 0 against fresh isolated roots.",
    "A fresh exact-SHA bootstrap exited 0; the generated catalog contained zero string upgrades and two native upgrade objects; codex features list exited 0.",
    "git diff --check and report-only quality gates passed with zero parse errors.",
    "The bounded exact-local-SHA spec and standards reviews passed with no blockers before this single push."
  ]
}
```