### PR TITLE
Fix reusable workspace-bound real-client E2E

### DIFF
--- a/config/providers.toml
+++ b/config/providers.toml
@@ -42,6 +42,8 @@ name = "Volcengine"
 base_url = "https://ark.cn-beijing.volces.com/api/coding/v3"
 api_key = "{env:VOLCENGINE_API_KEY}"
 display_prefix = "Volc"
+upstream_format = "responses"
+available_upstream_formats = ["responses"]
 sort_order = 2
 enabled = true
 

--- a/docs/agents/real-client-e2e.md
+++ b/docs/agents/real-client-e2e.md
@@ -81,12 +81,26 @@ Use a new output directory for every invocation. Before launch it contains:
     config/
       gateway.json
       host-environment.json
+    gui-seed/
+      desktop-luna/
+      desktop-volc/
+      zcode-luna/
+      zcode-volc/
 ```
 
 `isolated/work` must not exist before invocation. The runner verifies the
 output/isolation ancestors are canonical and non-reparse, rejects any stale or
 linked work root, creates the directory once without `-Force`, and verifies it
 is empty before any executable probe or launch.
+
+`isolated/gui-seed` is the invocation-local staging location for an
+operator-controlled durable seed stored outside all run output directories.
+Before launch, copy each of the four named case directories from that durable
+seed into this location. Never copy a prior run's `isolated/work`. The runner
+accepts only canonical, non-reparse, independently copied seed files and
+normalizes or discards client runtime state before it creates the fresh case
+roots. Keep the durable seed private; it contains dedicated-account browser
+login state and is never uploaded.
 
 `profile.json` contains only readiness assertions and no account identifier:
 
@@ -105,9 +119,12 @@ root; it is never discovered or copied from the current user's Codex home. It
 must use `chatgpt` mode and contain non-empty access and refresh tokens.
 `volc.json` has schema
 `codexhub.real-client-volc.v1` and one non-empty `api_key`. `gateway.json` has
-schema `codexhub.real-client-gateway.v1`, a loopback `listen_port`, and a
-dedicated `gateway_client_key`. These secret-bearing inputs remain under
-`isolated/` and are never uploaded.
+schema `codexhub.real-client-gateway.v1`, a loopback `listen_port` below the
+Windows dynamic client range (`1024`–`49151`), and a dedicated
+`gateway_client_key`. Preflight must also be able to bind that port
+exclusively; a bound outbound socket is rejected even when it is not a
+listener. These secret-bearing inputs remain under `isolated/` and are never
+uploaded.
 
 Build the runnable, release-optimized Debug portable from the exact candidate
 SHA. A plain `cargo build` or `src-tauri/target/debug/codexhub.exe` is not a
@@ -259,6 +276,17 @@ one successful read-only read tool, emit the named sentinel once, and finish
 once. The compatibility-baseline client parsers consume their real JSONL
 contracts; accepting a newer version never relaxes these shapes:
 
+- every automated prompt names `./sentinel.txt` explicitly instead of asking
+  the model to discover an unnamed file;
+- Codex CLI receives the prompt once through stdin and binds the case root with
+  `-C`;
+- OpenCode binds the case root with `--dir`, uses a fixed title, and runs
+  `--pure`;
+- Pi enables only the built-in `read` tool and disables context files,
+  extensions, skills, and prompt templates;
+- OMP binds the case root with `--cwd`, enables only `read`, disables title
+  generation, extensions, skills, and rules, and does not persist a session.
+
 - Codex CLI `0.144.5`: `thread.started`, `item.completed` command/agent
   items, and `turn.completed`; the read command must explicitly report
   `status = completed` and integer `exit_code = 0`;
@@ -272,8 +300,9 @@ contracts; accepting a newer version never relaxes these shapes:
   contradictory ordering, and duplicate/missing agent ends fail closed.
 
 OMP's `17.0.3` compatibility baseline is launched through its one-shot JSON interface as
-`omp --print --mode json --model <selector> <prompt>`. It has no `run`
-subcommand, and `--format` is not a supported launch flag.
+`omp --print --mode json --model <selector> --no-session --no-title --tools
+read --no-extensions --no-skills --no-rules --cwd <case-root> <prompt>`. It
+has no `run` subcommand, and `--format` is not a supported launch flag.
 
 Completed/final assistant messages prove the exact sentinel content but are
 not relabeled as stream deltas. Streaming is proven separately from correlated
@@ -418,6 +447,17 @@ powershell -NoProfile -File scripts/Run-RealClientE2E.ps1 `
 
 6. Wait for the template and four case-local GUI launches (Desktop Luna/Volc
    and ZCode Luna/Volc). Each launch consumes its own #194-applied root.
+   Reusable Desktop GUI seeds preserve the browser profile and a normalized
+   allowlist of completed-onboarding state. The normalized `.codex` state
+   never copies project history, remote installation or host identity, session
+   databases, unknown fields, or stale workspace paths; browser-profile data
+   remains the dedicated-account login boundary.
+   Reusable ZCode GUI seeds preserve network/login state and durable UI
+   preferences, but the runner discards task databases and browser
+   local/session/IndexedDB state before launch. It also rewrites
+   `recentProjects` and `lastWorkspaceSession` to the fresh case root. This
+   prevents a copied task from silently resolving relative tools against an
+   older run while retaining the operator's completed setup.
    Complete and finalize the four GUI cases as described above while the
    runner is waiting.
 7. Confirm exit `0`, summary outcome `passed`, all twelve cases passed, and the

--- a/scripts/Run-RealClientE2E.ps1
+++ b/scripts/Run-RealClientE2E.ps1
@@ -884,6 +884,25 @@ function Test-LoopbackListener {
     }
 }
 
+function Test-LoopbackPortBindable {
+    param([int]$Port)
+    $listener = [System.Net.Sockets.TcpListener]::new(
+        [System.Net.IPAddress]::Loopback,
+        $Port
+    )
+    try {
+        $listener.Server.ExclusiveAddressUse = $true
+        $listener.Start()
+        return $true
+    }
+    catch {
+        return $false
+    }
+    finally {
+        $listener.Stop()
+    }
+}
+
 function Test-GatewayHealth {
     param([int]$Port)
     $response = $null
@@ -1114,10 +1133,33 @@ function Invoke-CandidateOfficialBootstrap {
 function Get-ClientArguments {
     param([string]$Client, [string]$Model, [string]$WorkRoot, [string]$Prompt)
     switch ($Client) {
-        'codex-cli' { return @('exec', '--ephemeral', '--json', '--skip-git-repo-check', '-C', $WorkRoot, '-m', $Model, '-s', 'read-only', $Prompt) }
-        'opencode' { return @('run', '--format', 'json', '--model', $Model, $Prompt) }
-        'pi' { return @('--print', '--mode', 'json', '--model', $Model, '--no-session', $Prompt) }
-        'omp' { return @('--print', '--mode', 'json', '--model', $Model, $Prompt) }
+        'codex-cli' {
+            return @(
+                'exec', '--ephemeral', '--json', '--skip-git-repo-check',
+                '-C', $WorkRoot, '-m', $Model, '-s', 'read-only', '-'
+            )
+        }
+        'opencode' {
+            return @(
+                'run', '--format', 'json', '--model', $Model,
+                '--dir', $WorkRoot, '--title', 'codexhub-real-client-e2e',
+                '--pure', $Prompt
+            )
+        }
+        'pi' {
+            return @(
+                '--print', '--mode', 'json', '--model', $Model, '--no-session',
+                '--tools', 'read', '--no-context-files', '--no-extensions',
+                '--no-skills', '--no-prompt-templates', $Prompt
+            )
+        }
+        'omp' {
+            return @(
+                '--print', '--mode', 'json', '--model', $Model, '--no-session',
+                '--no-title', '--tools', 'read', '--no-extensions', '--no-skills',
+                '--no-rules', '--cwd', $WorkRoot, $Prompt
+            )
+        }
         default { return @() }
     }
 }
@@ -1377,7 +1419,7 @@ function Invoke-ClientAttempt {
     $sentinel = "SENTINEL:codexhub-real-client-e2e:$($Case.case_id)"
     $sentinelPath = Join-Path $CaseRoot 'sentinel.txt'
     [System.IO.File]::WriteAllText($sentinelPath, $sentinel, $script:Utf8NoBom)
-    $prompt = "Read the sentinel file once with one read-only tool call, then stream exactly $sentinel and stop."
+    $prompt = "Read ./sentinel.txt once with exactly one read-only tool call, then stream exactly $sentinel and stop."
     $arguments = @(Get-ClientArguments -Client $Case.client -Model $LaunchModel -WorkRoot $CaseRoot -Prompt $prompt)
     $environment = @{
         CODEXHUB_E2E_CASE = $Case.case_id
@@ -2218,6 +2260,178 @@ function Publish-ManagedClientTargets {
     }
 }
 
+function Test-ZCodeGuiSeedTransientPath {
+    param(
+        [string]$RelativeRoot,
+        [string]$RelativePath
+    )
+    $candidate = (($RelativeRoot.TrimEnd('\') + '\' + $RelativePath.TrimStart('\')) -replace '/', '\')
+    foreach ($transientRoot in @(
+        '.zcode\cli\db',
+        '.zcode\cli\log',
+        '.zcode\cli\rollout',
+        '.zcode\v2\logs',
+        'appdata\roaming\ZCode\session\IndexedDB',
+        'appdata\roaming\ZCode\session\Local Storage',
+        'appdata\roaming\ZCode\session\Session Storage'
+    )) {
+        if ($candidate.Equals($transientRoot, [System.StringComparison]::OrdinalIgnoreCase) -or
+            $candidate.StartsWith($transientRoot + '\', [System.StringComparison]::OrdinalIgnoreCase)) {
+            return $true
+        }
+    }
+    return $candidate.Equals(
+        '.zcode\v2\tasks-index.sqlite',
+        [System.StringComparison]::OrdinalIgnoreCase
+    ) -or $candidate.Equals(
+        '.zcode\v2\tasks-index.sqlite-shm',
+        [System.StringComparison]::OrdinalIgnoreCase
+    ) -or $candidate.Equals(
+        '.zcode\v2\tasks-index.sqlite-wal',
+        [System.StringComparison]::OrdinalIgnoreCase
+    )
+}
+
+function Test-DesktopGuiSeedAllowedPath {
+    param(
+        [string]$RelativeRoot,
+        [string]$RelativePath
+    )
+    if ($RelativeRoot.Equals(
+        'browser-profile',
+        [System.StringComparison]::OrdinalIgnoreCase
+    )) {
+        return $true
+    }
+    $candidate = (($RelativeRoot.TrimEnd('\') + '\' + $RelativePath.TrimStart('\')) -replace '/', '\')
+    return $candidate.Equals(
+        '.codex\.codex-global-state.json',
+        [System.StringComparison]::OrdinalIgnoreCase
+    )
+}
+
+function Normalize-DesktopGuiSeedState {
+    param([string]$CaseRoot)
+    $statePath = Join-Path $CaseRoot '.codex\.codex-global-state.json'
+    if (-not (Test-Path -LiteralPath $statePath -PathType Leaf)) {
+        return
+    }
+    try {
+        $source = Get-Content -LiteralPath $statePath -Raw -Encoding UTF8 |
+            ConvertFrom-Json -ErrorAction Stop
+        $firstSeen = Get-JsonProperty $source 'desktop-first-seen-at-ms' $null
+        if (($firstSeen -isnot [int] -and $firstSeen -isnot [long]) -or
+            [int64]$firstSeen -le 0) {
+            throw 'preflight_gui_seed_invalid'
+        }
+        $sourceAtom = Get-JsonProperty $source 'electron-persisted-atom-state'
+        if ($null -eq $sourceAtom -or
+            (Get-JsonProperty $sourceAtom 'electron:onboarding-primary-runtime-install-ready' $false) -ne $true) {
+            throw 'preflight_gui_seed_invalid'
+        }
+        $atom = [ordered]@{
+            'chatgpt-migration-announcement-completed-v1' = (
+                (Get-JsonProperty $sourceAtom 'chatgpt-migration-announcement-completed-v1' $false) -eq $true
+            )
+            'chatgpt-update-downloaded-announcement-seen-v1' = (
+                (Get-JsonProperty $sourceAtom 'chatgpt-update-downloaded-announcement-seen-v1' $false) -eq $true
+            )
+            'desktop-link-default-destination' = if (
+                [string](Get-JsonProperty $sourceAtom 'desktop-link-default-destination' '') -ceq 'in-app-browser'
+            ) { 'in-app-browser' } else { '' }
+            'electron:onboarding-primary-runtime-install-ready' = $true
+        }
+        $allowedMigrations = @(
+            '2026-07-13-string-based-remote-projects',
+            '2026-07-13-automation-project-targets',
+            '2026-07-13-local-projects',
+            '2026-07-13-remap-legacy-automation-project-targets',
+            '2026-07-13-clear-legacy-browser-download-history',
+            '2026-07-14-repair-metadata-local-projects'
+        )
+        $migrations = @(
+            Get-JsonProperty $source 'electron-completed-local-data-migration-ids' @() |
+                ForEach-Object { [string]$_ } |
+                Where-Object { $_ -cin $allowedMigrations } |
+                Select-Object -Unique
+        )
+        $normalized = [ordered]@{
+            'desktop-first-seen-at-ms' = [int64]$firstSeen
+            'electron-persisted-atom-state' = $atom
+            'electron-completed-local-data-migration-ids' = $migrations
+            'local-projects' = [ordered]@{}
+            'remote-project-connection-backfill-completed' = (
+                (Get-JsonProperty $source 'remote-project-connection-backfill-completed' $false) -eq $true
+            )
+            'electron-remote-control-config-migration-completed' = (
+                (Get-JsonProperty $source 'electron-remote-control-config-migration-completed' $false) -eq $true
+            )
+            'electron-internal-update-cdn-enabled' = (
+                (Get-JsonProperty $source 'electron-internal-update-cdn-enabled' $false) -eq $true
+            )
+            'electron-openai-mcp-form-elicitations-enabled' = (
+                (Get-JsonProperty $source 'electron-openai-mcp-form-elicitations-enabled' $false) -eq $true
+            )
+        }
+        Write-JsonFile -Path $statePath -Value $normalized
+        $readback = Get-Content -LiteralPath $statePath -Raw -Encoding UTF8 |
+            ConvertFrom-Json -ErrorAction Stop
+        $readbackNames = @($readback.PSObject.Properties.Name | Sort-Object)
+        $expectedReadbackNames = @(
+            'desktop-first-seen-at-ms',
+            'electron-completed-local-data-migration-ids',
+            'electron-internal-update-cdn-enabled',
+            'electron-openai-mcp-form-elicitations-enabled',
+            'electron-persisted-atom-state',
+            'electron-remote-control-config-migration-completed',
+            'local-projects',
+            'remote-project-connection-backfill-completed'
+        ) | Sort-Object
+        if (($readbackNames -join ',') -cne ($expectedReadbackNames -join ',') -or
+            (Get-JsonProperty (Get-JsonProperty $readback 'electron-persisted-atom-state') 'electron:onboarding-primary-runtime-install-ready' $false) -ne $true) {
+            throw 'preflight_gui_seed_invalid'
+        }
+    }
+    catch {
+        throw 'preflight_gui_seed_invalid'
+    }
+}
+
+function Normalize-ZCodeGuiSeedSettings {
+    param([string]$CaseRoot)
+    $settingPath = Join-Path $CaseRoot '.zcode\v2\setting.json'
+    if (-not (Test-Path -LiteralPath $settingPath -PathType Leaf)) {
+        return
+    }
+    try {
+        $setting = Get-Content -LiteralPath $settingPath -Raw -Encoding UTF8 | ConvertFrom-Json -ErrorAction Stop
+        $setting | Add-Member -NotePropertyName 'recentProjects' -NotePropertyValue @($CaseRoot) -Force
+        $setting | Add-Member -NotePropertyName 'lastWorkspaceSession' -NotePropertyValue @(
+            [pscustomobject]@{
+                kind = 'local'
+                workspacePath = $CaseRoot
+            }
+        ) -Force
+        $setting | Add-Member -NotePropertyName 'lastActiveTabIndex' -NotePropertyValue 0 -Force
+        [System.IO.File]::WriteAllText(
+            $settingPath,
+            (($setting | ConvertTo-Json -Depth 20) + [System.Environment]::NewLine),
+            $script:Utf8NoBom
+        )
+        $readback = Get-Content -LiteralPath $settingPath -Raw -Encoding UTF8 | ConvertFrom-Json -ErrorAction Stop
+        if (@($readback.recentProjects).Count -ne 1 -or
+            [string]$readback.recentProjects[0] -cne $CaseRoot -or
+            @($readback.lastWorkspaceSession).Count -ne 1 -or
+            [string]$readback.lastWorkspaceSession[0].kind -cne 'local' -or
+            [string]$readback.lastWorkspaceSession[0].workspacePath -cne $CaseRoot) {
+            throw 'preflight_gui_seed_invalid'
+        }
+    }
+    catch {
+        throw 'preflight_gui_seed_invalid'
+    }
+}
+
 function Copy-GuiStateSeed {
     param(
         [string]$SeedCaseRoot,
@@ -2226,7 +2440,7 @@ function Copy-GuiStateSeed {
         [string]$IsolationRoot
     )
     $relativeRoots = if ($Client -ceq 'desktop') {
-        @('browser-profile')
+        @('browser-profile', '.codex')
     }
     elseif ($Client -ceq 'zcode') {
         @('.zcode', 'appdata')
@@ -2276,6 +2490,14 @@ function Copy-GuiStateSeed {
                     throw 'preflight_gui_seed_invalid'
                 }
                 $relative = $itemPath.Substring($sourcePrefix.Length)
+                if ($Client -ceq 'desktop' -and
+                    -not (Test-DesktopGuiSeedAllowedPath -RelativeRoot $relativeRoot -RelativePath $relative)) {
+                    continue
+                }
+                if ($Client -ceq 'zcode' -and
+                    (Test-ZCodeGuiSeedTransientPath -RelativeRoot $relativeRoot -RelativePath $relative)) {
+                    continue
+                }
                 $destination = Join-Path $destinationRoot $relative
                 if ($item.PSIsContainer) {
                     $directoryCount += 1
@@ -2296,6 +2518,12 @@ function Copy-GuiStateSeed {
                     throw 'preflight_gui_seed_invalid'
                 }
             }
+        }
+        if ($Client -ceq 'zcode') {
+            Normalize-ZCodeGuiSeedSettings -CaseRoot $CaseRoot
+        }
+        elseif ($Client -ceq 'desktop') {
+            Normalize-DesktopGuiSeedState -CaseRoot $CaseRoot
         }
     }
     catch {
@@ -2619,7 +2847,10 @@ if ([string]$script:GatewayConfig.schema -cne 'codexhub.real-client-gateway.v1' 
     [string]$script:GatewayConfig.gateway_client_key -notmatch '^\S{16,}$') {
     throw 'preflight_gateway_config_invalid'
 }
-if (Test-LoopbackListener -Port ([int]$script:GatewayConfig.listen_port)) {
+if ([int]$script:GatewayConfig.listen_port -ge 49152) {
+    throw 'preflight_gateway_port_unsafe'
+}
+if (-not (Test-LoopbackPortBindable -Port ([int]$script:GatewayConfig.listen_port))) {
     throw 'preflight_gateway_port_in_use'
 }
 $script:AccountAuthPath = $accountAuthPath

--- a/scripts/Run-RealClientE2E.ps1
+++ b/scripts/Run-RealClientE2E.ps1
@@ -732,7 +732,10 @@ function New-IsolatedStartInfo {
     $startInfo.RedirectStandardOutput = $true
     $startInfo.RedirectStandardError = $true
     $startInfo.EnvironmentVariables.Clear()
-    foreach ($name in @('SystemRoot', 'WINDIR', 'ComSpec', 'PATH', 'PATHEXT')) {
+    foreach ($name in @(
+        'SystemRoot', 'WINDIR', 'ComSpec', 'PATH', 'PATHEXT',
+        'USERNAME', 'USERDOMAIN'
+    )) {
         $value = [System.Environment]::GetEnvironmentVariable($name)
         if ($value) {
             $startInfo.EnvironmentVariables[$name] = $value
@@ -1833,6 +1836,81 @@ function Get-DesktopInstallationMetadata {
     }
 }
 
+function Copy-DesktopApplicationPayload {
+    param(
+        [string]$Executable,
+        [string]$WorkRoot,
+        [string]$IsolationRoot
+    )
+    try {
+        $sourceExecutable = (Resolve-Path -LiteralPath $Executable -ErrorAction Stop).Path
+        $sourceRoot = (Resolve-Path -LiteralPath (Split-Path -Parent $sourceExecutable) -ErrorAction Stop).Path.TrimEnd('\')
+        $sourcePrefix = $sourceRoot + '\'
+        if (-not $sourceExecutable.StartsWith($sourcePrefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+            throw 'preflight_desktop_payload_invalid'
+        }
+        $items = @(Get-ChildItem -LiteralPath $sourceRoot -Recurse -Force -ErrorAction Stop)
+        $files = @($items | Where-Object { -not $_.PSIsContainer })
+        $directories = @($items | Where-Object { $_.PSIsContainer })
+        if ($files.Count -eq 0 -or $files.Count -gt 20000 -or $directories.Count -gt 5000) {
+            throw 'preflight_desktop_payload_invalid'
+        }
+        $totalBytes = [uint64]0
+        foreach ($item in $items) {
+            $linkType = if ($item.PSObject.Properties['LinkType']) { [string]$item.LinkType } else { '' }
+            $isReparsePoint = ($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0
+            $isAllowedAppxHardLink = -not $item.PSIsContainer -and $linkType -ceq 'HardLink'
+            if ($isReparsePoint -or ($linkType -and -not $isAllowedAppxHardLink)) {
+                throw 'preflight_desktop_payload_invalid'
+            }
+            $itemPath = [System.IO.Path]::GetFullPath($item.FullName)
+            if (-not $itemPath.StartsWith($sourcePrefix, [System.StringComparison]::OrdinalIgnoreCase) -or
+                -not (Resolve-Path -LiteralPath $itemPath -ErrorAction Stop).Path.Equals(
+                    $itemPath,
+                    [System.StringComparison]::OrdinalIgnoreCase
+                )) {
+                throw 'preflight_desktop_payload_invalid'
+            }
+            if (-not $item.PSIsContainer) {
+                $totalBytes += [uint64]$item.Length
+                if ($totalBytes -gt 4GB) {
+                    throw 'preflight_desktop_payload_invalid'
+                }
+            }
+        }
+
+        $destinationRoot = Join-Path $WorkRoot 'desktop-app'
+        if (Test-Path -LiteralPath $destinationRoot) {
+            throw 'preflight_desktop_payload_invalid'
+        }
+        [void](New-Item -ItemType Directory -Path $destinationRoot)
+        Assert-CanonicalNonReparseDirectory -Path $destinationRoot -Failure 'preflight_desktop_payload_invalid'
+        foreach ($directory in $directories) {
+            $relative = $directory.FullName.Substring($sourcePrefix.Length)
+            [void](New-Item -ItemType Directory -Force -Path (Join-Path $destinationRoot $relative))
+        }
+        foreach ($file in $files) {
+            $relative = $file.FullName.Substring($sourcePrefix.Length)
+            $destination = Join-Path $destinationRoot $relative
+            [void](New-Item -ItemType Directory -Force -Path (Split-Path -Parent $destination))
+            Copy-Item -LiteralPath $file.FullName -Destination $destination
+            if ((Get-Sha256 -Path $file.FullName) -cne (Get-Sha256 -Path $destination)) {
+                throw 'preflight_desktop_payload_invalid'
+            }
+        }
+        $manifestRelative = $sourceExecutable.Substring($sourcePrefix.Length)
+        $stagedExecutable = Join-Path $destinationRoot $manifestRelative
+        Assert-IsolatedRegularFile -Path $stagedExecutable -IsolationRoot $IsolationRoot
+        return $stagedExecutable
+    }
+    catch {
+        if ($_.Exception.Message -ceq 'preflight_desktop_payload_invalid') {
+            throw
+        }
+        throw 'preflight_desktop_payload_invalid'
+    }
+}
+
 function Get-ZCodeInstallationMetadata {
     param([string]$Executable)
     if ($script:WindowsInstallMetadata) {
@@ -2140,6 +2218,94 @@ function Publish-ManagedClientTargets {
     }
 }
 
+function Copy-GuiStateSeed {
+    param(
+        [string]$SeedCaseRoot,
+        [string]$CaseRoot,
+        [string]$Client,
+        [string]$IsolationRoot
+    )
+    $relativeRoots = if ($Client -ceq 'desktop') {
+        @('browser-profile')
+    }
+    elseif ($Client -ceq 'zcode') {
+        @('.zcode', 'appdata')
+    }
+    else {
+        throw 'preflight_gui_seed_invalid'
+    }
+    try {
+        Assert-CanonicalNonReparseDirectory -Path $SeedCaseRoot -Failure 'preflight_gui_seed_invalid'
+        $resolvedIsolation = (Resolve-Path -LiteralPath $IsolationRoot -ErrorAction Stop).Path.TrimEnd('\')
+        $resolvedSeedCase = (Resolve-Path -LiteralPath $SeedCaseRoot -ErrorAction Stop).Path.TrimEnd('\')
+        if (-not $resolvedSeedCase.StartsWith(
+            $resolvedIsolation + '\',
+            [System.StringComparison]::OrdinalIgnoreCase
+        )) {
+            throw 'preflight_gui_seed_invalid'
+        }
+
+        $fileCount = 0
+        $directoryCount = 0
+        [uint64]$totalBytes = 0
+        foreach ($relativeRoot in $relativeRoots) {
+            $sourceRoot = Join-Path $resolvedSeedCase $relativeRoot
+            if (-not (Test-Path -LiteralPath $sourceRoot -PathType Container)) {
+                continue
+            }
+            Assert-CanonicalNonReparseDirectory -Path $sourceRoot -Failure 'preflight_gui_seed_invalid'
+            $resolvedSourceRoot = (Resolve-Path -LiteralPath $sourceRoot -ErrorAction Stop).Path.TrimEnd('\')
+            $sourcePrefix = $resolvedSourceRoot + '\'
+            $destinationRoot = Join-Path $CaseRoot $relativeRoot
+            if (Test-Path -LiteralPath $destinationRoot) {
+                throw 'preflight_gui_seed_invalid'
+            }
+            [void](New-Item -ItemType Directory -Path $destinationRoot)
+
+            foreach ($item in @(Get-ChildItem -LiteralPath $resolvedSourceRoot -Recurse -Force -ErrorAction Stop)) {
+                $linkType = if ($item.PSObject.Properties['LinkType']) { [string]$item.LinkType } else { '' }
+                if (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0 -or $linkType) {
+                    throw 'preflight_gui_seed_invalid'
+                }
+                $itemPath = [System.IO.Path]::GetFullPath($item.FullName)
+                if (-not $itemPath.StartsWith($sourcePrefix, [System.StringComparison]::OrdinalIgnoreCase) -or
+                    -not (Resolve-Path -LiteralPath $itemPath -ErrorAction Stop).Path.Equals(
+                        $itemPath,
+                        [System.StringComparison]::OrdinalIgnoreCase
+                    )) {
+                    throw 'preflight_gui_seed_invalid'
+                }
+                $relative = $itemPath.Substring($sourcePrefix.Length)
+                $destination = Join-Path $destinationRoot $relative
+                if ($item.PSIsContainer) {
+                    $directoryCount += 1
+                    if ($directoryCount -gt 10000) {
+                        throw 'preflight_gui_seed_invalid'
+                    }
+                    [void](New-Item -ItemType Directory -Force -Path $destination)
+                    continue
+                }
+                $fileCount += 1
+                $totalBytes += [uint64]$item.Length
+                if ($fileCount -gt 50000 -or $totalBytes -gt 2GB) {
+                    throw 'preflight_gui_seed_invalid'
+                }
+                [void](New-Item -ItemType Directory -Force -Path (Split-Path -Parent $destination))
+                Copy-Item -LiteralPath $itemPath -Destination $destination
+                if ((Get-Sha256 -Path $itemPath) -cne (Get-Sha256 -Path $destination)) {
+                    throw 'preflight_gui_seed_invalid'
+                }
+            }
+        }
+    }
+    catch {
+        if ($_.Exception.Message -ceq 'preflight_gui_seed_invalid') {
+            throw
+        }
+        throw 'preflight_gui_seed_invalid'
+    }
+}
+
 function Initialize-ClientConfiguration {
     param(
         [string]$Client,
@@ -2227,6 +2393,8 @@ id = "volc"
 name = "Volcengine"
 base_url = "https://ark.cn-beijing.volces.com/api/coding/v3"
 api_key = "{env:VOLCENGINE_API_KEY}"
+upstream_format = "responses"
+available_upstream_formats = ["responses"]
 enabled = true
 
   [[providers.models]]
@@ -2337,6 +2505,7 @@ $accountPath = Join-Path $isolationRoot 'account\profile.json'
 $accountAuthPath = Join-Path $isolationRoot 'account\auth.json'
 $credentialPath = Join-Path $isolationRoot 'credentials\volc.json'
 $configRoot = Join-Path $isolationRoot 'config'
+$guiSeedRoot = Join-Path $isolationRoot 'gui-seed'
 $workRoot = Join-Path $isolationRoot 'work'
 $gatewayConfigPath = Join-Path $configRoot 'gateway.json'
 $manualEvidencePath = Join-Path $OutputDirectory 'manual-evidence.json'
@@ -2489,6 +2658,10 @@ foreach ($versionTarget in @(
     $actualVersions[$versionTarget.key] = Get-NativeClientVersion -Client $versionTarget.client -Executable $executables[$versionTarget.client] -Minimum $script:MinimumVersions[$versionTarget.key] -ProbeRoot (Join-Path $workRoot "version-$($versionTarget.client)")
     $script:ObservedVersions[$versionTarget.key] = $actualVersions[$versionTarget.key]
 }
+$desktopLaunchExecutable = Copy-DesktopApplicationPayload `
+    -Executable $executables.desktop `
+    -WorkRoot $workRoot `
+    -IsolationRoot $isolationRoot
 [void](New-Item -ItemType Directory -Path $artifactRoot)
 [void](New-Item -ItemType Directory -Path (Join-Path $artifactRoot 'cases'))
 
@@ -2574,6 +2747,12 @@ try {
             Join-Path $workRoot $case.case_id
         }
         [void](New-Item -ItemType Directory -Path $caseRoot -Force)
+        if ($case.client -in @('desktop', 'zcode')) {
+            $seedCaseRoot = Join-Path $guiSeedRoot $case.case_id
+            if (Test-Path -LiteralPath $seedCaseRoot -PathType Container) {
+                Copy-GuiStateSeed -SeedCaseRoot $seedCaseRoot -CaseRoot $caseRoot -Client $case.client -IsolationRoot $isolationRoot
+            }
+        }
         $caseConfigurations[$case.case_id] = Initialize-ClientConfiguration -Client $case.client -CaseRoot $caseRoot -Model $case.gateway_model -CatalogPath $candidateCatalogPath
     }
     [void](Initialize-ClientConfiguration -Client 'desktop' -CaseRoot $candidateRoot -Model 'gpt-5.6-luna' -CatalogPath $candidateCatalogPath)
@@ -2610,13 +2789,14 @@ try {
         [void]$manualSentinelPaths.Add($guiSentinelPath)
         $guiArguments = if ($guiClient -ceq 'desktop') {
             $desktopUserDataRoot = Join-Path $guiCaseRoot 'browser-profile'
-            [void](New-Item -ItemType Directory -Path $desktopUserDataRoot)
-            @("--user-data-dir=$desktopUserDataRoot", '--no-first-run')
+            [void](New-Item -ItemType Directory -Force -Path $desktopUserDataRoot)
+            @("--user-data-dir=$desktopUserDataRoot", '--no-first-run', $guiCaseRoot)
         }
         else {
-            @()
+            @($guiCaseRoot)
         }
-        $guiProcess = Start-IsolatedProcess -Executable $executables[$guiClient] -Arguments $guiArguments -CaseRoot $guiCaseRoot -Environment @{
+        $guiExecutable = if ($guiClient -ceq 'desktop') { $desktopLaunchExecutable } else { $executables[$guiClient] }
+        $guiProcess = Start-IsolatedProcess -Executable $guiExecutable -Arguments $guiArguments -CaseRoot $guiCaseRoot -Environment @{
             CODEXHUB_E2E_GUI_CLIENT = $guiClient
             CODEXHUB_E2E_CASES = $guiCase.case_id
             CODEXHUB_E2E_MODELS = $guiCase.canonical_model

--- a/tests/fixtures/real_client_e2e/fake-client-desktop-argv.cmd
+++ b/tests/fixtures/real_client_e2e/fake-client-desktop-argv.cmd
@@ -1,5 +1,7 @@
 @echo off
-if /I "%CODEXHUB_E2E_GUI_CLIENT%"=="desktop" (
+if not "%CODEXHUB_E2E_GUI_CLIENT%"=="" (
   <nul set /p "=%*">"%CODEXHUB_E2E_GUI_LAUNCH_MARKER%.argv"
+  <nul set /p "=%~f0">"%CODEXHUB_E2E_GUI_LAUNCH_MARKER%.executable"
+  <nul set /p "=%USERNAME%|%USERDOMAIN%">"%CODEXHUB_E2E_GUI_LAUNCH_MARKER%.identity"
 )
 call "%~dp0fake-client-real-contract.cmd" %*

--- a/tests/fixtures/real_client_e2e/fake-client-workspace-argv.cmd
+++ b/tests/fixtures/real_client_e2e/fake-client-workspace-argv.cmd
@@ -1,0 +1,39 @@
+@echo off
+setlocal EnableDelayedExpansion
+if defined CODEXHUB_E2E_VERSION_PROBE goto delegate
+if defined CODEXHUB_E2E_GUI_CLIENT goto delegate
+if not defined CODEXHUB_E2E_CASE exit /b 30
+
+if "%CODEXHUB_E2E_CLIENT%"=="codex-cli" (
+  set /p "PROMPT_INPUT="
+  echo(!PROMPT_INPUT! | findstr.exe /l /c:"./sentinel.txt" >nul || exit /b 31
+  echo %* | findstr.exe /l /c:"-C %CD%" >nul || exit /b 32
+  for %%A in (%*) do set "LAST_ARG=%%~A"
+  if not "!LAST_ARG!"=="-" exit /b 33
+) else if "%CODEXHUB_E2E_CLIENT%"=="opencode" (
+  echo %* | findstr.exe /l /c:"./sentinel.txt" >nul || exit /b 31
+  echo %* | findstr.exe /l /c:"--dir %CD%" >nul || exit /b 34
+  echo %* | findstr.exe /l /c:"--title codexhub-real-client-e2e" >nul || exit /b 35
+  echo %* | findstr.exe /l /c:"--pure" >nul || exit /b 36
+) else if "%CODEXHUB_E2E_CLIENT%"=="pi" (
+  echo %* | findstr.exe /l /c:"./sentinel.txt" >nul || exit /b 31
+  echo %* | findstr.exe /l /c:"--tools read" >nul || exit /b 37
+  echo %* | findstr.exe /l /c:"--no-context-files" >nul || exit /b 38
+  echo %* | findstr.exe /l /c:"--no-extensions" >nul || exit /b 39
+  echo %* | findstr.exe /l /c:"--no-skills" >nul || exit /b 40
+  echo %* | findstr.exe /l /c:"--no-prompt-templates" >nul || exit /b 41
+) else if "%CODEXHUB_E2E_CLIENT%"=="omp" (
+  echo %* | findstr.exe /l /c:"./sentinel.txt" >nul || exit /b 31
+  echo %* | findstr.exe /l /c:"--cwd %CD%" >nul || exit /b 42
+  echo %* | findstr.exe /l /c:"--tools read" >nul || exit /b 43
+  echo %* | findstr.exe /l /c:"--no-title" >nul || exit /b 44
+  echo %* | findstr.exe /l /c:"--no-extensions" >nul || exit /b 45
+  echo %* | findstr.exe /l /c:"--no-skills" >nul || exit /b 46
+  echo %* | findstr.exe /l /c:"--no-rules" >nul || exit /b 47
+) else (
+  exit /b 48
+)
+
+:delegate
+call "%~dp0fake-client-real-contract.cmd"
+exit /b %errorlevel%

--- a/tests/test_providers_config.py
+++ b/tests/test_providers_config.py
@@ -23,6 +23,13 @@ from providers_config import (
 
 
 class ProvidersConfigTests(unittest.TestCase):
+    def test_bundled_volc_declares_responses_as_its_only_upstream_format(self):
+        providers = load_providers(DEFAULT_PROVIDERS_PATH)
+        volc = next(provider for provider in providers if provider.id == "volc")
+
+        self.assertEqual(volc.upstream_format, "responses")
+        self.assertEqual(volc.available_upstream_formats, ("responses",))
+
     def test_bundled_ollama_glm_uses_the_only_deferred_core_model_override(self):
         providers = load_providers(DEFAULT_PROVIDERS_PATH)
         ollama = next(provider for provider in providers if provider.id == "ollama-cloud")

--- a/tests/test_real_client_e2e.py
+++ b/tests/test_real_client_e2e.py
@@ -1743,8 +1743,229 @@ def test_desktop_gui_cases_use_distinct_case_local_user_data_directories(tmp_pat
         assert arguments.count("--user-data-dir=") == 1
         assert str(expected_profile).casefold() in arguments.casefold()
         assert "--no-first-run" in arguments
+        expected_workspace = work / "gui-desktop" / case_id
+        assert arguments.rstrip('"').casefold().endswith(
+            str(expected_workspace).casefold()
+        )
         observed[case_id] = arguments
     assert observed["desktop-luna"] != observed["desktop-volc"]
+
+
+def test_zcode_gui_cases_open_their_case_local_workspaces(tmp_path):
+    result = _run(
+        tmp_path,
+        client_fakes={"ZCodePath": "fake-client-desktop-argv.cmd"},
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    work = tmp_path / "output" / "isolated" / "work"
+    for case_id in ("zcode-luna", "zcode-volc"):
+        arguments = (
+            work / f"gui-{case_id}.launched.argv"
+        ).read_text(encoding="ascii").strip()
+        expected_workspace = work / "gui-zcode" / case_id
+        assert arguments.rstrip('"').casefold().endswith(
+            str(expected_workspace).casefold()
+        )
+
+
+def test_candidate_runtime_declares_volc_native_responses_route(tmp_path):
+    result = _run(tmp_path)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    providers = (
+        tmp_path
+        / "output"
+        / "isolated"
+        / "work"
+        / "candidate"
+        / "runtime"
+        / "proxy"
+        / "config"
+        / "providers.toml"
+    ).read_text(encoding="utf-8")
+    assert 'upstream_format = "responses"' in providers
+    assert 'available_upstream_formats = ["responses"]' in providers
+
+
+def test_gui_cases_copy_reusable_state_into_fresh_isolated_roots(tmp_path):
+    seeded_files = {
+        "desktop-luna/browser-profile/Preferences": "desktop-luna-state",
+        "desktop-volc/browser-profile/Preferences": "desktop-volc-state",
+        "zcode-luna/.zcode/v2/setting.json": "zcode-luna-state",
+        "zcode-volc/.zcode/v2/setting.json": "zcode-volc-state",
+    }
+
+    def seed_gui_state(_output, isolation, _debug):
+        seed_root = isolation / "gui-seed"
+        for relative, value in seeded_files.items():
+            path = seed_root / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(value, encoding="utf-8")
+
+    result = _run(tmp_path, mutate=seed_gui_state)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    work = tmp_path / "output" / "isolated" / "work"
+    for relative, value in seeded_files.items():
+        case_id, case_relative = relative.split("/", 1)
+        client = "desktop" if case_id.startswith("desktop-") else "zcode"
+        source = tmp_path / "output" / "isolated" / "gui-seed" / relative
+        copied = work / f"gui-{client}" / case_id / case_relative
+        assert copied.read_text(encoding="utf-8") == value
+        assert copied.stat().st_ino != source.stat().st_ino
+
+
+def test_gui_state_seed_rejects_hardlinked_files(tmp_path):
+    external = tmp_path / "external-gui-state"
+    external.write_text("must not be imported", encoding="utf-8")
+
+    def seed_hardlink(_output, isolation, _debug):
+        seed = (
+            isolation
+            / "gui-seed"
+            / "desktop-luna"
+            / "browser-profile"
+            / "Preferences"
+        )
+        seed.parent.mkdir(parents=True)
+        os.link(external, seed)
+
+    result = _run(
+        tmp_path,
+        mutate=seed_hardlink,
+        finalize_manual=False,
+    )
+
+    assert result.returncode != 0
+    summary = json.loads((tmp_path / "output" / "summary.json").read_text())
+    assert summary["failure_classification"] == "preflight_gui_seed_invalid"
+
+
+def test_desktop_gui_preserves_windows_identity_for_sandbox_acl_setup(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("USERNAME", "e2e-current-user")
+    monkeypatch.setenv("USERDOMAIN", "e2e-current-domain")
+
+    result = _run(
+        tmp_path,
+        client_fakes={"CodexDesktopPath": "fake-client-desktop-argv.cmd"},
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    work = tmp_path / "output" / "isolated" / "work"
+    for case_id in ("desktop-luna", "desktop-volc"):
+        identity = (work / f"gui-{case_id}.launched.identity").read_text(
+            encoding="ascii"
+        )
+        assert identity == "e2e-current-user|e2e-current-domain"
+
+
+def test_desktop_gui_launches_from_invocation_local_manifest_payload(tmp_path):
+    source_executable = FIXTURES / "fake-client-desktop-argv.cmd"
+
+    result = _run(
+        tmp_path,
+        client_fakes={"CodexDesktopPath": source_executable.name},
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    work = tmp_path / "output" / "isolated" / "work"
+    staged_root = work / "desktop-app"
+    staged_executable = staged_root / source_executable.name
+    assert staged_executable.read_bytes() == source_executable.read_bytes()
+    assert staged_executable.stat().st_ino != source_executable.stat().st_ino
+    for case_id in ("desktop-luna", "desktop-volc"):
+        launch_path = (
+            work / f"gui-{case_id}.launched.executable"
+        ).read_text(encoding="ascii")
+        assert Path(launch_path).resolve() == staged_executable.resolve()
+        assert Path(launch_path).resolve().is_relative_to(staged_root.resolve())
+
+
+def test_desktop_payload_hardlinks_are_copied_as_independent_files(tmp_path):
+    payload = b"appx deployment hardlink payload"
+    desktop_root = tmp_path / "desktop-install"
+    desktop_root.mkdir()
+    desktop_executable = desktop_root / "CodexDesktop.cmd"
+    shutil.copyfile(FIXTURES / "fake-client-desktop-argv.cmd", desktop_executable)
+    shutil.copyfile(
+        FIXTURES / "fake-client-real-contract.cmd",
+        desktop_root / "fake-client-real-contract.cmd",
+    )
+    source = desktop_root / "shared-runtime.bin"
+    linked = desktop_root / "shared-runtime-copy.bin"
+    source.write_bytes(payload)
+    os.link(source, linked)
+    assert source.stat().st_ino == linked.stat().st_ino
+
+    def bind_payload_root(_output, isolation, _debug):
+        metadata_path = isolation / "config" / "windows-install-metadata.json"
+        metadata = json.loads(metadata_path.read_text())
+        metadata["desktop"]["install_location"] = str(desktop_root.resolve())
+        metadata_path.write_text(json.dumps(metadata), encoding="utf-8")
+
+    result = _run(
+        tmp_path,
+        client_fakes={"CodexDesktopPath": desktop_executable},
+        mutate=bind_payload_root,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    staged_root = tmp_path / "output" / "isolated" / "work" / "desktop-app"
+    staged_source = staged_root / "shared-runtime.bin"
+    staged_link = staged_root / "shared-runtime-copy.bin"
+    assert staged_source.read_bytes() == payload
+    assert staged_link.read_bytes() == payload
+    assert staged_source.stat().st_ino != source.stat().st_ino
+    assert staged_link.stat().st_ino != linked.stat().st_ino
+    assert staged_source.stat().st_ino != staged_link.stat().st_ino
+
+
+def test_desktop_payload_reparse_points_fail_before_gui_launch(tmp_path):
+    external = tmp_path / "external-desktop-state"
+    external.mkdir()
+    (external / "must-not-be-copied.txt").write_text("host state", encoding="utf-8")
+
+    def add_payload_junction(_output, _isolation, _debug):
+        desktop_root = tmp_path / "Program Files" / "OpenAI Codex"
+        result = subprocess.run(
+            [
+                "cmd.exe",
+                "/d",
+                "/c",
+                "mklink",
+                "/J",
+                str(desktop_root / "linked-host-state"),
+                str(external),
+            ],
+            text=True,
+            capture_output=True,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    result = _run(
+        tmp_path,
+        authoritative_paths_with_spaces=True,
+        mutate=add_payload_junction,
+        finalize_manual=False,
+        manual_timeout_seconds=1,
+    )
+
+    assert result.returncode != 0
+    summary = json.loads((tmp_path / "output" / "summary.json").read_text())
+    assert summary["failure_classification"] == "preflight_desktop_payload_invalid"
+    assert not (tmp_path / "output" / "manual-evidence.template.json").exists()
+    assert not (
+        tmp_path
+        / "output"
+        / "isolated"
+        / "work"
+        / "desktop-app"
+        / "linked-host-state"
+        / "must-not-be-copied.txt"
+    ).exists()
 
 
 def test_ambient_host_session_environment_never_reaches_candidate_or_clients(

--- a/tests/test_real_client_e2e.py
+++ b/tests/test_real_client_e2e.py
@@ -993,6 +993,21 @@ def test_omp_17_0_3_uses_print_json_one_shot_arguments(tmp_path):
     assert [case["outcome"] for case in omp_cases] == ["passed", "passed"]
 
 
+def test_automated_clients_bind_fresh_workspace_and_minimal_read_only_context(tmp_path):
+    result = _run(tmp_path, fake="fake-client-workspace-argv.cmd")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    summary = json.loads(
+        (tmp_path / "output" / "summary.json").read_text(encoding="utf-8-sig")
+    )
+    automated = [
+        case
+        for case in summary["cases"]
+        if case["case_id"].startswith(("codex-cli", "opencode", "pi", "omp"))
+    ]
+    assert [case["outcome"] for case in automated] == ["passed"] * 8
+
+
 def test_windows_client_state_paths_are_isolated_per_case(tmp_path):
     result = _run(tmp_path, fake="fake-client-isolation.cmd")
 
@@ -1792,8 +1807,8 @@ def test_gui_cases_copy_reusable_state_into_fresh_isolated_roots(tmp_path):
     seeded_files = {
         "desktop-luna/browser-profile/Preferences": "desktop-luna-state",
         "desktop-volc/browser-profile/Preferences": "desktop-volc-state",
-        "zcode-luna/.zcode/v2/setting.json": "zcode-luna-state",
-        "zcode-volc/.zcode/v2/setting.json": "zcode-volc-state",
+        "zcode-luna/.zcode/v2/telemetry-state.json": "zcode-luna-state",
+        "zcode-volc/.zcode/v2/telemetry-state.json": "zcode-volc-state",
     }
 
     def seed_gui_state(_output, isolation, _debug):
@@ -1814,6 +1829,186 @@ def test_gui_cases_copy_reusable_state_into_fresh_isolated_roots(tmp_path):
         copied = work / f"gui-{client}" / case_id / case_relative
         assert copied.read_text(encoding="utf-8") == value
         assert copied.stat().st_ino != source.stat().st_ino
+
+
+def test_desktop_gui_seed_preserves_onboarding_without_stale_identity_or_history(
+    tmp_path,
+):
+    stale_workspace = (
+        r"D:\Workstation\CodexHub-real-client-e2e\runs\old-run"
+        r"\isolated\work\gui-desktop\desktop-luna"
+    )
+    allowed_migrations = [
+        "2026-07-13-string-based-remote-projects",
+        "2026-07-13-local-projects",
+    ]
+
+    def seed_gui_state(_output, isolation, _debug):
+        for case_id in ("desktop-luna", "desktop-volc"):
+            codex_root = isolation / "gui-seed" / case_id / ".codex"
+            codex_root.mkdir(parents=True)
+            (codex_root / ".codex-global-state.json").write_text(
+                json.dumps(
+                    {
+                        "desktop-first-seen-at-ms": 1_784_822_624_226,
+                        "electron-persisted-atom-state": {
+                            "chatgpt-migration-announcement-completed-v1": True,
+                            "chatgpt-update-downloaded-announcement-seen-v1": True,
+                            "desktop-link-default-destination": "in-app-browser",
+                            "electron:onboarding-primary-runtime-install-ready": True,
+                            "unsafe-workspace": stale_workspace,
+                        },
+                        "electron-completed-local-data-migration-ids": [
+                            *allowed_migrations,
+                            stale_workspace,
+                        ],
+                        "local-projects": {
+                            "stale": {"path": stale_workspace},
+                        },
+                        "remote-project-connection-backfill-completed": True,
+                        "electron-local-remote-control-installation-id": "stale-installation",
+                        "electron-remote-control-config-migration-completed": True,
+                        "electron-internal-update-cdn-enabled": False,
+                        "electron-openai-mcp-form-elicitations-enabled": False,
+                        "selected-remote-host-id": "stale-host",
+                        "unexpected-secret": "must-not-copy",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (codex_root / "state_5.sqlite").write_text(
+                stale_workspace,
+                encoding="utf-8",
+            )
+
+    result = _run(tmp_path, mutate=seed_gui_state)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    work = tmp_path / "output" / "isolated" / "work" / "gui-desktop"
+    for case_id in ("desktop-luna", "desktop-volc"):
+        source = (
+            tmp_path
+            / "output"
+            / "isolated"
+            / "gui-seed"
+            / case_id
+            / ".codex"
+            / ".codex-global-state.json"
+        )
+        case_codex = work / case_id / ".codex"
+        copied = case_codex / ".codex-global-state.json"
+        state = json.loads(copied.read_text(encoding="utf-8-sig"))
+        assert state == {
+            "desktop-first-seen-at-ms": 1_784_822_624_226,
+            "electron-persisted-atom-state": {
+                "chatgpt-migration-announcement-completed-v1": True,
+                "chatgpt-update-downloaded-announcement-seen-v1": True,
+                "desktop-link-default-destination": "in-app-browser",
+                "electron:onboarding-primary-runtime-install-ready": True,
+            },
+            "electron-completed-local-data-migration-ids": allowed_migrations,
+            "local-projects": {},
+            "remote-project-connection-backfill-completed": True,
+            "electron-remote-control-config-migration-completed": True,
+            "electron-internal-update-cdn-enabled": False,
+            "electron-openai-mcp-form-elicitations-enabled": False,
+        }
+        assert stale_workspace not in copied.read_text(encoding="utf-8")
+        assert copied.stat().st_ino != source.stat().st_ino
+        assert not (case_codex / "state_5.sqlite").exists()
+        assert (case_codex / "config.toml").is_file()
+        assert (case_codex / "auth.json").is_file()
+
+
+def test_zcode_gui_seed_preserves_login_state_without_stale_workspace_state(tmp_path):
+    stale_workspace = (
+        r"D:\Workstation\CodexHub-real-client-e2e\runs\old-run"
+        r"\isolated\work\gui-zcode\zcode-luna"
+    )
+
+    def seed_gui_state(_output, isolation, _debug):
+        case_root = isolation / "gui-seed" / "zcode-luna"
+        setting = case_root / ".zcode" / "v2" / "setting.json"
+        setting.parent.mkdir(parents=True)
+        setting.write_text(
+            json.dumps(
+                {
+                    "recentProjects": [stale_workspace],
+                    "lastWorkspaceSession": [
+                        {"kind": "local", "workspacePath": stale_workspace}
+                    ],
+                    "settingsSyncFirstRunPromptHandled": True,
+                }
+            ),
+            encoding="utf-8",
+        )
+        transient_files = (
+            case_root / ".zcode" / "v2" / "tasks-index.sqlite",
+            case_root / ".zcode" / "cli" / "db" / "db.sqlite",
+            case_root
+            / "appdata"
+            / "roaming"
+            / "ZCode"
+            / "session"
+            / "Local Storage"
+            / "leveldb"
+            / "000003.log",
+        )
+        for path in transient_files:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(stale_workspace, encoding="utf-8")
+        cookie = (
+            case_root
+            / "appdata"
+            / "roaming"
+            / "ZCode"
+            / "session"
+            / "Network"
+            / "Cookies"
+        )
+        cookie.parent.mkdir(parents=True)
+        cookie.write_text("reusable-login-state", encoding="utf-8")
+
+    result = _run(tmp_path, mutate=seed_gui_state)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    case_root = (
+        tmp_path
+        / "output"
+        / "isolated"
+        / "work"
+        / "gui-zcode"
+        / "zcode-luna"
+    )
+    setting = json.loads(
+        (case_root / ".zcode" / "v2" / "setting.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert setting["recentProjects"] == [str(case_root)]
+    assert setting["lastWorkspaceSession"] == [
+        {"kind": "local", "workspacePath": str(case_root)}
+    ]
+    assert setting["settingsSyncFirstRunPromptHandled"] is True
+    assert not (case_root / ".zcode" / "v2" / "tasks-index.sqlite").exists()
+    assert not (case_root / ".zcode" / "cli" / "db").exists()
+    assert not (
+        case_root
+        / "appdata"
+        / "roaming"
+        / "ZCode"
+        / "session"
+        / "Local Storage"
+    ).exists()
+    assert (
+        case_root
+        / "appdata"
+        / "roaming"
+        / "ZCode"
+        / "session"
+        / "Network"
+        / "Cookies"
+    ).read_text(encoding="utf-8") == "reusable-login-state"
 
 
 def test_gui_state_seed_rejects_hardlinked_files(tmp_path):
@@ -2264,6 +2459,42 @@ def test_preexisting_gateway_listener_is_rejected_before_candidate_or_gui(tmp_pa
     assert result.returncode != 0
     summary = json.loads((tmp_path / "output" / "summary.json").read_text())
     assert summary["failure_classification"] == "preflight_gateway_port_in_use"
+    assert not (tmp_path / "output" / "manual-evidence.template.json").exists()
+
+
+def test_preexisting_bound_non_listener_port_is_rejected_before_candidate_or_gui(tmp_path):
+    reservation = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    reservation.setsockopt(socket.SOL_SOCKET, socket.SO_EXCLUSIVEADDRUSE, 1)
+    reservation.bind(("127.0.0.1", 19190))
+    try:
+        result = _run(tmp_path, finalize_manual=False)
+    finally:
+        reservation.close()
+
+    assert result.returncode != 0
+    summary = json.loads((tmp_path / "output" / "summary.json").read_text())
+    assert summary["failure_classification"] == "preflight_gateway_port_in_use"
+    assert not (tmp_path / "output" / "manual-evidence.template.json").exists()
+
+
+def test_dynamic_client_port_is_rejected_before_candidate_or_gui(tmp_path):
+    def use_dynamic_client_port(_output, isolation, _debug):
+        (isolation / "config" / "gateway.json").write_text(
+            json.dumps(
+                {
+                    "schema": "codexhub.real-client-gateway.v1",
+                    "listen_port": 55000,
+                    "gateway_client_key": "fixture-gateway-private-key",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    result = _run(tmp_path, mutate=use_dynamic_client_port, finalize_manual=False)
+
+    assert result.returncode != 0
+    summary = json.loads((tmp_path / "output" / "summary.json").read_text())
+    assert summary["failure_classification"] == "preflight_gateway_port_unsafe"
     assert not (tmp_path / "output" / "manual-evidence.template.json").exists()
 
 


### PR DESCRIPTION
Closes #218.

## What changed
- binds all four automated clients to their fresh case workspace and trims ambient context/tool discovery;
- preserves dedicated Desktop login plus allowlisted onboarding state, while keeping stale Codex identity/history/runtime out of new cases;
- preserves reusable ZCode login/preferences while discarding task/session/browser transient state and rewriting workspace bindings;
- rejects occupied and Windows dynamic-range Gateway ports before candidate launch;
- documents durable four-case GUI seed staging.

## Why
The release E2E repeatedly required GUI setup and produced automated failures from ambient workspaces rather than the case-local sentinel contract.

## Local verification
- exact local candidate review: Standards pass; Spec pass; no blockers
- affected E2E matrix: 7 passed
- seed-focused matrix: 4 passed
- Desktop onboarding regression: 1 passed
- prior runner module on the pre-seed delta: 131 passed
- prior repository Python suite on the pre-seed delta: 1425 passed, 1 skipped, 332 subtests passed
- PowerShell parse: clean
- git diff --check: clean
- report-only quality gates: 0 parse errors; existing findings only

The four successful GUI cases from the local R36 run are retained as manual evidence. This PR does not claim a final 12/12 qualification; dev is the requested human validation target before any main release merge.