### PR TITLE
Route third-party transparent streams through the downstream commit seam

### DIFF
--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -12533,16 +12533,46 @@ def _open_upstream_response(
             attempt += 1
 
 
+def _responses_synthetic_terminal_failure(
+    handler: CodexProxyHandler,
+    exc: BaseException,
+    *,
+    status: int,
+    response_id: str | None,
+    upstream_name: str,
+    model: str | None,
+) -> tuple[bool, str | None, str | None]:
+    """Write a Responses-format synthetic terminal failure event."""
+    try:
+        handler._write_sse_event(
+            "response.failed",
+            _responses_failed_event_for_stream_error(
+                upstream_name=upstream_name,
+                model=model,
+                status=status,
+                exc=exc,
+                response_id=response_id,
+            ),
+        )
+        return True, None, None
+    except OSError as write_exc:
+        return False, type(write_exc).__name__, safe_upstream_error_detail(write_exc)
+
+
 class _GatewayDownstreamStreamCommit:
-    """Owns downstream writes and terminal commitment for an Official Responses SSE stream.
+    """Owns downstream writes and terminal commitment for an SSE stream.
 
     The seam is the single owner of all bytes written to the downstream client for
-    an Official Responses passthrough stream: data events, terminal events, and
-    sanitized error events. It tracks whether a terminal event has been committed
-    to the downstream, classifies the close phase (before output, during an event,
-    or after terminal commitment), and hands off cancellation/closure to the owned
+    a passthrough SSE stream: data events, terminal events, and sanitized error
+    events. It tracks whether a terminal event has been committed to the
+    downstream, classifies the close phase (before output, during an event, or
+    after terminal commitment), and hands off cancellation/closure to the owned
     upstream response so that no later write, retry, fallback, or duplicate
     terminal can occur on this stream.
+
+    Protocol-specific observers (terminal detection, usage extraction, and
+    synthetic terminal formatting) are injected by the caller; the seam itself
+    owns only the lifecycle ledger and byte commitment.
     """
 
     def __init__(
@@ -12554,6 +12584,13 @@ class _GatewayDownstreamStreamCommit:
         model: str | None = None,
         request_id: str | None = None,
         inbound_format: str = "responses",
+        upstream_format: str = "responses",
+        usage_line_callback: Callable[[Mapping[str, Any], bytes], None] | None = None,
+        synthetic_terminal_failure_callback: Callable[
+            [CodexProxyHandler, BaseException, int, str | None, str, str | None],
+            tuple[bool, str | None, str | None],
+        ]
+        | None = None,
     ) -> None:
         self._handler = handler
         self._upstream_response = upstream_response
@@ -12561,6 +12598,17 @@ class _GatewayDownstreamStreamCommit:
         self._model = model
         self._request_id = request_id
         self._inbound_format = inbound_format
+        self._upstream_format = upstream_format
+        self._usage_line_callback = (
+            usage_line_callback
+            if usage_line_callback is not None
+            else _offer_official_passthrough_usage_line
+        )
+        self._synthetic_terminal_failure_callback = (
+            synthetic_terminal_failure_callback
+            if synthetic_terminal_failure_callback is not None
+            else _responses_synthetic_terminal_failure
+        )
         self._sse_stats = PassthroughSseSemanticStats()
         self._terminal_observed = False
         self._terminal_committed = False
@@ -12570,6 +12618,7 @@ class _GatewayDownstreamStreamCommit:
         self._lines_streamed = 0
         self._bytes_streamed = 0
         self._last_upstream_byte_at: float | None = None
+        self._last_write_error: OSError | None = None
 
     @property
     def terminal_committed(self) -> bool:
@@ -12638,19 +12687,23 @@ class _GatewayDownstreamStreamCommit:
         """Commit one upstream SSE line to the downstream stream.
 
         Returns True if the line was written (or was empty). Returns False if the
-        downstream stream is closed, in which case the caller must stop writing.
+        downstream stream is closed or a terminal event has already been committed,
+        in which case the caller must stop writing.
         """
         if self._downstream_closed:
             return False
         if not line:
             return True
+        if self._terminal_committed:
+            return False
         terminal_observed_now = self._observe_line(line)
         if terminal_observed_now:
             _observe_gateway_diagnostic("observe_terminal", self._request_id, forwarded=False)
         try:
             self._handler.wfile.write(line)
             self._handler.wfile.flush()
-        except OSError:
+        except OSError as write_exc:
+            self._last_write_error = write_exc
             self.close()
             return False
         self._downstream_output_started = True
@@ -12660,12 +12713,17 @@ class _GatewayDownstreamStreamCommit:
             self._terminal_committed = True
             _observe_gateway_diagnostic("observe_terminal", self._request_id, forwarded=True)
             self._record_terminal()
-        _offer_official_passthrough_usage_line(
+            # Terminal ledger is sealed: close the downstream side deterministically
+            # so no later upstream byte can be written or mislabeled as a disconnect.
+            # Upstream is left open so the caller can drain to the natural EOF.
+            self._downstream_closed = True
+            self._handler.close_connection = True
+        self._usage_line_callback(
             {
                 "request_id": self._request_id,
                 "model": self._model,
                 "upstream": self._upstream_name,
-                "upstream_format": "responses",
+                "upstream_format": self._upstream_format,
                 "inbound_format": self._inbound_format,
             },
             line,
@@ -12699,20 +12757,30 @@ class _GatewayDownstreamStreamCommit:
                 self._handler.wfile.flush()
                 self._sse_stats.finalize_pending()
             response_id = self._sse_stats.response_id
-            self._handler._write_sse_event(
-                "response.failed",
-                _responses_failed_event_for_stream_error(
-                    upstream_name=self._upstream_name,
-                    model=self._model,
-                    status=status,
-                    exc=exc,
-                    response_id=response_id,
-                ),
+            (
+                synthetic_terminal_event_sent,
+                synthetic_terminal_write_error,
+                synthetic_terminal_write_detail,
+            ) = self._synthetic_terminal_failure_callback(
+                self._handler,
+                exc,
+                status=status,
+                response_id=response_id,
+                upstream_name=self._upstream_name,
+                model=self._model,
             )
-            self._terminal_committed = True
-            return True, None, None
+            if synthetic_terminal_event_sent:
+                self._terminal_committed = True
+            return (
+                synthetic_terminal_event_sent,
+                synthetic_terminal_write_error,
+                synthetic_terminal_write_detail,
+            )
         except OSError as write_exc:
             return False, type(write_exc).__name__, safe_upstream_error_detail(write_exc)
+
+    def last_write_error(self) -> OSError | None:
+        return self._last_write_error
 
     def counters(self) -> dict[str, Any]:
         return {
@@ -14748,22 +14816,12 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 send_downstream_headers_once()
                 _observe_gateway_diagnostic("observe_sse_line", request_id, len(line))
                 if not seam.commit_data(line):
-                    close_phase = seam.close_phase
-                    if close_phase == "after_terminal":
-                        _emit_stream_closed(
-                            status_code=499,
-                            error="OSError",
-                            detail=f"downstream_client_closed ({close_phase})",
-                            failure_phase="downstream_write",
-                            failure_side="downstream_write",
-                            failure_class="downstream_client_closed",
-                            client_disconnected=True,
-                            synthetic_terminal_event_sent=False,
-                            synthetic_terminal_event_type=None,
-                            synthetic_terminal_write_error=None,
-                            synthetic_terminal_write_detail=None,
-                        )
+                    if seam.terminal_committed:
+                        # Terminal ledger is sealed; suppress the post-terminal
+                        # upstream line without writing or mislabeling it as a
+                        # downstream client disconnect.
                         return status
+                    close_phase = seam.close_phase
                     _emit_stream_closed(
                         status_code=499,
                         error="OSError",
@@ -14862,8 +14920,8 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
             upstream_format=upstream_format,
             inbound_format=inbound_format,
         )
-
-        headers_sent = headers_already_sent
+        admission = _active_gateway_request()
+        headers_sent = bool(headers_already_sent)
 
         def send_downstream_headers_once() -> None:
             nonlocal headers_sent
@@ -14879,48 +14937,286 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
             if is_event_stream and mark_downstream_sse_started is not None:
                 mark_downstream_sse_started()
 
+        # Transparent Chat Completions streams preserve the existing protocol
+        # convention of closing on interruption without a synthetic terminal error
+        # frame; the seam still prevents duplicate terminals and later writes.
+        def _no_synthetic_terminal_failure(
+            _handler: CodexProxyHandler,
+            _exc: BaseException,
+            *,
+            status: int,
+            response_id: str | None,
+            upstream_name: str,
+            model: str | None,
+        ) -> tuple[bool, str | None, str | None]:
+            return False, None, None
+
+        synthetic_terminal_failure = (
+            _responses_synthetic_terminal_failure
+            if inbound_format == "responses"
+            else _no_synthetic_terminal_failure
+        )
+
+        seam = _GatewayDownstreamStreamCommit(
+            self,
+            response,
+            upstream_name,
+            model=model,
+            request_id=request_id,
+            inbound_format=inbound_format,
+            upstream_format=upstream_format,
+            usage_line_callback=lambda context, line: _offer_usage_observed_sse_line(
+                context, line, upstream_format=upstream_format
+            ),
+            synthetic_terminal_failure_callback=synthetic_terminal_failure,
+        )
+        _capture_usage(usage_capture, None, missing_reason="async_usage_pending")
+
         if not (defer_stream_errors and is_event_stream and not headers_already_sent):
             send_downstream_headers_once()
 
-        _capture_usage(usage_capture, None, missing_reason="async_usage_pending")
-        if is_event_stream:
-            pending_lines: list[bytes] = []
+        def _last_upstream_byte_age_ms(now: float, last_at: float | None) -> int | None:
+            return None if last_at is None else int(max(0.0, now - last_at) * 1000)
 
-            def transparent_error_event(payload: Mapping[str, Any]) -> UpstreamStreamErrorEvent | None:
-                if upstream_format == "responses" and _responses_stream_error_type(payload) is not None:
-                    return UpstreamStreamErrorEvent(payload)
-                if upstream_format == "chat_completions" and _chat_stream_error_detail(payload) is not None:
-                    return UpstreamStreamErrorEvent(payload)
+        def _emit_stream_closed(
+            *,
+            status_code: int,
+            error: str,
+            detail: str,
+            failure_phase: str,
+            failure_side: str,
+            failure_class: str,
+            client_disconnected: bool,
+            synthetic_terminal_event_sent: bool,
+            synthetic_terminal_event_type: str | None,
+            synthetic_terminal_write_error: str | None,
+            synthetic_terminal_write_detail: str | None,
+        ) -> None:
+            close_phase = seam.close_phase
+            counters = seam.counters()
+            now = time.monotonic()
+            write_proxy_event(
+                "transparent_stream_closed",
+                request_id=request_id,
+                model=model,
+                upstream=upstream_name,
+                status=status_code,
+                upstream_format=upstream_format,
+                inbound_format=inbound_format,
+                error=error,
+                detail=detail,
+                failure_phase=failure_phase,
+                failure_side=failure_side,
+                failure_class=failure_class,
+                client_disconnected=client_disconnected,
+                synthetic_terminal_event_sent=synthetic_terminal_event_sent,
+                synthetic_terminal_event_type=synthetic_terminal_event_type,
+                synthetic_terminal_write_error=synthetic_terminal_write_error,
+                synthetic_terminal_write_detail=synthetic_terminal_write_detail,
+                lines_streamed=counters["lines_streamed"],
+                bytes_streamed=counters["bytes_streamed"],
+                last_upstream_byte_age_ms=_last_upstream_byte_age_ms(
+                    now, counters["last_upstream_byte_at"]
+                ),
+                headers_sent_downstream=headers_sent,
+                downstream_sse_started=headers_sent,
+                close_phase=close_phase,
+                **seam.stats(),
+            )
+
+        def _handle_cancellation() -> int:
+            seam.cancel()
+            _emit_stream_closed(
+                status_code=503,
+                error="GatewayUserRequestedShutdown",
+                detail="request cancelled by gateway shutdown",
+                failure_phase="upstream_read",
+                failure_side="upstream_read",
+                failure_class="gateway_shutdown",
+                client_disconnected=False,
+                synthetic_terminal_event_sent=False,
+                synthetic_terminal_event_type=None,
+                synthetic_terminal_write_error=None,
+                synthetic_terminal_write_detail=None,
+            )
+            return 503
+
+        def _observed_cancellation() -> int | None:
+            """Return a status if cancellation was observed, honoring terminal commitment."""
+            if admission is None or not admission.cancelled:
                 return None
+            if seam.terminal_committed:
+                sse_fields = seam.stats()
+                if usage_capture is not None:
+                    usage_capture.update(sse_fields)
+                return status
+            return _handle_cancellation()
 
-            def write_transparent_line(line: bytes) -> None:
-                self.wfile.write(line)
-                self.wfile.flush()
-                _offer_usage_observed_sse_line(
-                    usage_context,
-                    line,
+        if not is_event_stream:
+            body = b""
+            try:
+                while True:
+                    result = _observed_cancellation()
+                    if result is not None:
+                        return result
+                    chunk = response.read(65536)
+                    result = _observed_cancellation()
+                    if result is not None:
+                        return result
+                    if not chunk:
+                        break
+                    body += chunk
+            except (IncompleteRead, TimeoutError, OSError, URLError) as exc:
+                if seam.terminal_committed:
+                    return status
+                if admission is not None and admission.cancelled:
+                    return _handle_cancellation()
+                self.close_connection = True
+                write_proxy_event(
+                    "transparent_body_read_failed",
+                    request_id=request_id,
+                    model=model,
+                    upstream=upstream_name,
+                    status=502,
                     upstream_format=upstream_format,
+                    inbound_format=inbound_format,
+                    error=type(exc).__name__,
+                    detail=safe_upstream_error_detail(exc),
                 )
+                return 502
 
+            self.wfile.write(body)
+            self.wfile.flush()
+            _offer_usage_observed_body(usage_context, body)
+            self.close_connection = True
+            return status
+
+        pending_lines: list[bytes] = []
+
+        def transparent_error_event(payload: Mapping[str, Any]) -> UpstreamStreamErrorEvent | None:
+            if upstream_format == "responses" and _responses_stream_error_type(payload) is not None:
+                return UpstreamStreamErrorEvent(payload)
+            if upstream_format == "chat_completions" and _chat_stream_error_detail(payload) is not None:
+                return UpstreamStreamErrorEvent(payload)
+            return None
+
+        def _commit_pending_lines() -> bool:
+            """Commit buffered pending lines through the seam. Returns True on success."""
+            for pending_line in pending_lines:
+                if not seam.commit_data(pending_line):
+                    return False
+            pending_lines.clear()
+            return True
+
+        def _handle_write_failure() -> int:
+            """Emit downstream_stream_closed using the actual OSError when available.
+
+            If commit_data returned False because the terminal was already
+            committed, no client disconnect occurred; just return success.
+            """
+            close_phase = seam.close_phase
+            write_error = seam.last_write_error()
+            if write_error is None and seam.terminal_committed:
+                # Stopped only because a terminal event was already committed.
+                return status
+            exc = write_error if write_error is not None else OSError("downstream closed")
+            event_fields = _public_event_context(event_context)
+            for key in (
+                "request_id",
+                "model",
+                "upstream",
+                "status",
+                "upstream_format",
+                "inbound_format",
+                "error",
+                "detail",
+            ):
+                event_fields.pop(key, None)
+            write_proxy_event(
+                "downstream_stream_closed",
+                request_id=request_id,
+                model=model,
+                upstream=upstream_name,
+                status=status,
+                upstream_format=upstream_format,
+                inbound_format=inbound_format,
+                error=type(exc).__name__,
+                detail=safe_upstream_error_detail(exc),
+                close_phase=close_phase,
+                **event_fields,
+            )
+            return status
+
+        try:
             while True:
+                result = _observed_cancellation()
+                if result is not None:
+                    return result
                 try:
                     line = response.readline()
                 except (IncompleteRead, TimeoutError, OSError, URLError) as exc:
+                    result = _observed_cancellation()
+                    if result is not None:
+                        return result
+                    if seam.terminal_committed:
+                        sse_fields = seam.stats()
+                        if usage_capture is not None:
+                            usage_capture.update(sse_fields)
+                        return status
                     if defer_stream_errors and not headers_sent:
                         raise UpstreamStreamInterruptedError(exc) from exc
-                    self.close_connection = True
-                    write_proxy_event(
-                        "transparent_stream_closed",
-                        request_id=request_id,
-                        model=model,
-                        upstream=upstream_name,
-                        status=502,
-                        upstream_format=upstream_format,
-                        inbound_format=inbound_format,
+                    if seam.downstream_closed:
+                        _emit_stream_closed(
+                            status_code=499,
+                            error=type(exc).__name__,
+                            detail=safe_upstream_error_detail(exc),
+                            failure_phase="stream_body",
+                            failure_side="upstream_read",
+                            failure_class="downstream_client_closed",
+                            client_disconnected=True,
+                            synthetic_terminal_event_sent=False,
+                            synthetic_terminal_event_type=None,
+                            synthetic_terminal_write_error=None,
+                            synthetic_terminal_write_detail=None,
+                        )
+                        return 499
+                    (
+                        synthetic_terminal_event_sent,
+                        synthetic_terminal_write_error,
+                        synthetic_terminal_write_detail,
+                    ) = seam.commit_terminal_failure(exc, status=502)
+                    sse_fields = seam.stats()
+                    if usage_capture is not None:
+                        usage_capture.update(sse_fields)
+                        usage_capture["synthetic_terminal_event_sent"] = synthetic_terminal_event_sent
+                        if synthetic_terminal_event_sent:
+                            usage_capture["synthetic_terminal_event_type"] = (
+                                "response.failed" if inbound_format == "responses" else "chat.error"
+                            )
+                        if synthetic_terminal_write_error is not None:
+                            usage_capture["synthetic_terminal_write_error"] = synthetic_terminal_write_error
+                    synthetic_terminal_event_type = None
+                    if synthetic_terminal_event_sent:
+                        synthetic_terminal_event_type = (
+                            "response.failed" if inbound_format == "responses" else "chat.error"
+                        )
+                    _emit_stream_closed(
+                        status_code=502,
                         error=type(exc).__name__,
                         detail=safe_upstream_error_detail(exc),
+                        failure_phase="stream_body",
+                        failure_side="upstream_read",
+                        failure_class="upstream_stream_interrupted",
+                        client_disconnected=False,
+                        synthetic_terminal_event_sent=synthetic_terminal_event_sent,
+                        synthetic_terminal_event_type=synthetic_terminal_event_type,
+                        synthetic_terminal_write_error=synthetic_terminal_write_error,
+                        synthetic_terminal_write_detail=synthetic_terminal_write_detail,
                     )
                     return 502
+                result = _observed_cancellation()
+                if result is not None:
+                    return result
                 if not line:
                     break
                 _observe_gateway_diagnostic("observe_sse_line", request_id, len(line))
@@ -14948,102 +15244,25 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                     if not release_pending:
                         continue
                     send_downstream_headers_once()
-                    try:
-                        for pending_line in pending_lines:
-                            write_transparent_line(pending_line)
-                    except OSError as exc:
-                        self.close_connection = True
-                        event_fields = _public_event_context(event_context)
-                        for key in (
-                            "request_id",
-                            "model",
-                            "upstream",
-                            "status",
-                            "upstream_format",
-                            "inbound_format",
-                            "error",
-                            "detail",
-                        ):
-                            event_fields.pop(key, None)
-                        write_proxy_event(
-                            "downstream_stream_closed",
-                            request_id=request_id,
-                            model=model,
-                            upstream=upstream_name,
-                            status=status,
-                            upstream_format=upstream_format,
-                            inbound_format=inbound_format,
-                            error=type(exc).__name__,
-                            detail=safe_upstream_error_detail(exc),
-                            **event_fields,
-                        )
-                        return status
-                    pending_lines.clear()
+                    if not _commit_pending_lines():
+                        return _handle_write_failure()
                     continue
-                try:
-                    send_downstream_headers_once()
-                    write_transparent_line(line)
-                except OSError as exc:
-                    self.close_connection = True
-                    event_fields = _public_event_context(event_context)
-                    for key in (
-                        "request_id",
-                        "model",
-                        "upstream",
-                        "status",
-                        "upstream_format",
-                        "inbound_format",
-                        "error",
-                        "detail",
-                    ):
-                        event_fields.pop(key, None)
-                    write_proxy_event(
-                        "downstream_stream_closed",
-                        request_id=request_id,
-                        model=model,
-                        upstream=upstream_name,
-                        status=status,
-                        upstream_format=upstream_format,
-                        inbound_format=inbound_format,
-                        error=type(exc).__name__,
-                        detail=safe_upstream_error_detail(exc),
-                        **event_fields,
-                    )
-                    return status
+                send_downstream_headers_once()
+                if not seam.commit_data(line):
+                    return _handle_write_failure()
             if pending_lines and not headers_sent:
                 send_downstream_headers_once()
-                for pending_line in pending_lines:
-                    write_transparent_line(pending_line)
+                if not _commit_pending_lines():
+                    return _handle_write_failure()
             self.close_connection = True
+            sse_fields = seam.stats()
+            if usage_capture is not None:
+                usage_capture.update(sse_fields)
             return status
-
-        body = b""
-        try:
-            while True:
-                chunk = response.read(65536)
-                if not chunk:
-                    break
-                body += chunk
-        except (IncompleteRead, TimeoutError, OSError, URLError) as exc:
-            self.close_connection = True
-            write_proxy_event(
-                "transparent_body_read_failed",
-                request_id=request_id,
-                model=model,
-                upstream=upstream_name,
-                status=502,
-                upstream_format=upstream_format,
-                inbound_format=inbound_format,
-                error=type(exc).__name__,
-                detail=safe_upstream_error_detail(exc),
-            )
-            return 502
-
-        self.wfile.write(body)
-        self.wfile.flush()
-        _offer_usage_observed_body(usage_context, body)
-        self.close_connection = True
-        return status
+        except UpstreamStreamErrorEvent:
+            # Stream error events are intentionally raised without sending headers
+            # so the caller can retry. The seam owns any bytes already committed.
+            raise
 
     def _relay_upstream_response(
         self,

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -2734,7 +2734,11 @@ def _decode_sse_metadata_value(value: bytes) -> str | None:
 
 
 class PassthroughSseSemanticStats:
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        terminal_observer: Callable[[str | None, bytes, Any], bool] | None = None,
+    ) -> None:
         self.events_streamed = 0
         self.json_events_streamed = 0
         self.terminal_event_seen = False
@@ -2746,6 +2750,9 @@ class PassthroughSseSemanticStats:
         self.response_id: str | None = None
         self.event_type_counts: dict[str, int] = {}
         self.event_types_truncated = False
+        self._terminal_observer = (
+            terminal_observer if terminal_observer is not None else _responses_terminal_observer
+        )
         self._event_name: str | None = None
         self._data_lines: list[bytes] = []
 
@@ -2809,7 +2816,6 @@ class PassthroughSseSemanticStats:
         payload: Any = None
         if data == b"[DONE]":
             self.done_sentinel_seen = True
-            self.terminal_event_seen = True
             event_type = event_type or "[DONE]"
         elif data:
             try:
@@ -2821,23 +2827,25 @@ class PassthroughSseSemanticStats:
                 payload_type = payload.get("type")
                 if isinstance(payload_type, str) and payload_type:
                     event_type = payload_type
-                if _responses_event_commits_downstream_output(payload, "official"):
-                    self.downstream_output_seen = True
-                response = payload.get("response")
-                if isinstance(response, Mapping):
-                    response_id = response.get("id")
-                    if isinstance(response_id, str) and response_id:
-                        self.response_id = response_id
+                if self._terminal_observer is _responses_terminal_observer:
+                    if _responses_event_commits_downstream_output(payload, "official"):
+                        self.downstream_output_seen = True
+                    response = payload.get("response")
+                    if isinstance(response, Mapping):
+                        response_id = response.get("id")
+                        if isinstance(response_id, str) and response_id:
+                            self.response_id = response_id
 
         if event_type is None:
             return
         self.last_event_type = event_type
         self._record_event_type(event_type)
-        if event_type.startswith("response."):
-            self.response_event_seen = True
-        if event_type == "response.completed":
-            self.completed_event_seen = True
-        if event_type in RESPONSES_TERMINAL_EVENT_TYPES:
+        if self._terminal_observer is _responses_terminal_observer:
+            if event_type.startswith("response."):
+                self.response_event_seen = True
+            if event_type == "response.completed":
+                self.completed_event_seen = True
+        if self._terminal_observer(event_name, data, payload):
             self.terminal_event_seen = True
 
     def _record_event_type(self, event_type: str) -> None:
@@ -2856,6 +2864,32 @@ RESPONSES_TERMINAL_EVENT_TYPES = {
     "response.incomplete",
     "error",
 }
+
+
+def _responses_terminal_observer(
+    event_name: str | None,
+    data: bytes,
+    payload: Any,
+) -> bool:
+    """Responses protocol terminal predicate: [DONE] or known terminal types."""
+    if data == b"[DONE]":
+        return True
+    event_type = event_name
+    if isinstance(payload, Mapping):
+        payload_type = payload.get("type")
+        if isinstance(payload_type, str) and payload_type:
+            event_type = payload_type
+    return event_type in RESPONSES_TERMINAL_EVENT_TYPES
+
+
+def _chat_terminal_observer(
+    event_name: str | None,
+    data: bytes,
+    payload: Any,
+) -> bool:
+    """Chat Completions protocol terminal predicate: only the [DONE] sentinel."""
+    del event_name, payload
+    return data == b"[DONE]"
 
 
 def _responses_events_have_terminal(events: list[Mapping[str, Any]]) -> bool:
@@ -12585,6 +12619,7 @@ class _GatewayDownstreamStreamCommit:
         request_id: str | None = None,
         inbound_format: str = "responses",
         upstream_format: str = "responses",
+        terminal_observer: Callable[[str | None, bytes, Any], bool] | None = None,
         usage_line_callback: Callable[[Mapping[str, Any], bytes], None] | None = None,
         synthetic_terminal_failure_callback: Callable[
             [CodexProxyHandler, BaseException, int, str | None, str, str | None],
@@ -12604,12 +12639,8 @@ class _GatewayDownstreamStreamCommit:
             if usage_line_callback is not None
             else _offer_official_passthrough_usage_line
         )
-        self._synthetic_terminal_failure_callback = (
-            synthetic_terminal_failure_callback
-            if synthetic_terminal_failure_callback is not None
-            else _responses_synthetic_terminal_failure
-        )
-        self._sse_stats = PassthroughSseSemanticStats()
+        self._synthetic_terminal_failure_callback = synthetic_terminal_failure_callback
+        self._sse_stats = PassthroughSseSemanticStats(terminal_observer=terminal_observer)
         self._terminal_observed = False
         self._terminal_committed = False
         self._downstream_closed = False
@@ -12744,13 +12775,16 @@ class _GatewayDownstreamStreamCommit:
         available.
 
         Returns (sent, write_error_name, write_error_detail). No event is written
-        if the stream is already closed or a terminal has already been committed,
-        which prevents duplicate terminals and fallback writes.
+        if the stream is already closed, a terminal has already been committed,
+        or no synthetic terminal failure callback is configured, which prevents
+        duplicate terminals and fallback writes.
         """
         if self._downstream_closed or self._terminal_committed:
             return False, None, None
         self._downstream_closed = True
         self._handler.close_connection = True
+        if self._synthetic_terminal_failure_callback is None:
+            return False, None, None
         try:
             if self._sse_stats.has_pending_event():
                 self._handler.wfile.write(b"\n")
@@ -14720,6 +14754,8 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
             model=model,
             request_id=request_id,
             inbound_format=inbound_format,
+            terminal_observer=_responses_terminal_observer,
+            synthetic_terminal_failure_callback=_responses_synthetic_terminal_failure,
         )
         _capture_usage(usage_capture, None, missing_reason="async_official_passthrough")
 
@@ -14937,25 +14973,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
             if is_event_stream and mark_downstream_sse_started is not None:
                 mark_downstream_sse_started()
 
-        # Transparent Chat Completions streams preserve the existing protocol
-        # convention of closing on interruption without a synthetic terminal error
-        # frame; the seam still prevents duplicate terminals and later writes.
-        def _no_synthetic_terminal_failure(
-            _handler: CodexProxyHandler,
-            _exc: BaseException,
-            *,
-            status: int,
-            response_id: str | None,
-            upstream_name: str,
-            model: str | None,
-        ) -> tuple[bool, str | None, str | None]:
-            return False, None, None
-
-        synthetic_terminal_failure = (
-            _responses_synthetic_terminal_failure
-            if inbound_format == "responses"
-            else _no_synthetic_terminal_failure
-        )
+        chat_mode = inbound_format == "chat_completions"
 
         seam = _GatewayDownstreamStreamCommit(
             self,
@@ -14965,10 +14983,15 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
             request_id=request_id,
             inbound_format=inbound_format,
             upstream_format=upstream_format,
+            terminal_observer=(
+                _chat_terminal_observer if chat_mode else _responses_terminal_observer
+            ),
             usage_line_callback=lambda context, line: _offer_usage_observed_sse_line(
                 context, line, upstream_format=upstream_format
             ),
-            synthetic_terminal_failure_callback=synthetic_terminal_failure,
+            synthetic_terminal_failure_callback=(
+                _responses_synthetic_terminal_failure if not chat_mode else None
+            ),
         )
         _capture_usage(usage_capture, None, missing_reason="async_usage_pending")
 

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -2171,10 +2171,8 @@ class RoutingTests(unittest.TestCase):
         self.assertTrue(event["headers_sent_downstream"])
         self.assertTrue(event["downstream_sse_started"])
 
-    def test_official_passthrough_downstream_close_after_terminal_returns_success(self):
+    def test_official_passthrough_suppresses_post_terminal_write_and_returns_success(self):
         fake = FakeHandler()
-        # created line (0), completed/terminal line (1), in_progress line (2) -> fail after terminal
-        fake.wfile = FakeWFile(fail_on_write=lambda _data, index: index == 2)
         response = FakeSseResponse(
             [
                 b'data: {"type":"response.created","response":{"id":"resp_1"}}\n\n',
@@ -2184,25 +2182,34 @@ class RoutingTests(unittest.TestCase):
             ]
         )
 
-        status = CodexProxyHandler._relay_upstream_response(
-            fake,
-            response,
-            "official",
-            request_id="req-close-after-terminal",
-            model="openai/gpt-5.5",
-            upstream_format="responses",
-            inbound_format="responses",
-            caller_stream=True,
-            behavior_profile=codex_proxy.BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH,
-            usage_capture={},
-        )
+        with patch("codex_proxy.write_proxy_event") as write_event:
+            status = CodexProxyHandler._relay_upstream_response(
+                fake,
+                response,
+                "official",
+                request_id="req-close-after-terminal",
+                model="openai/gpt-5.5",
+                upstream_format="responses",
+                inbound_format="responses",
+                caller_stream=True,
+                behavior_profile=codex_proxy.BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH,
+                usage_capture={},
+            )
 
         body = b"".join(fake.wfile.writes)
         self.assertEqual(status, 200)
         self.assertIn(b"response.created", body)
         self.assertIn(b"response.completed", body)
         self.assertNotIn(b"response.failed", body)
+        self.assertNotIn(b"response.in_progress", body)
         self.assertTrue(fake.close_connection)
+        # Suppression after terminal must not be logged as a downstream disconnect.
+        self.assertFalse(
+            any(
+                call.args and call.args[0] == "official_passthrough_stream_closed"
+                for call in write_event.call_args_list
+            )
+        )
 
     def test_official_passthrough_stream_commit_seam_classifies_before_output(self):
         fake = FakeHandler()
@@ -2350,6 +2357,64 @@ class RoutingTests(unittest.TestCase):
                 for call in write_event.call_args_list
             )
         )
+
+    def test_stream_commit_seam_prevents_write_after_terminal_commitment(self):
+        fake = FakeHandler()
+        response = FakeSseResponse(
+            [
+                b'data: {"type":"response.completed","response":{"id":"resp_1","status":"completed"}}\n\n',
+                b'data: {"type":"response.in_progress","response":{"id":"resp_1"}}\n\n',
+                b"",
+            ]
+        )
+
+        status = CodexProxyHandler._relay_upstream_response(
+            fake,
+            response,
+            "official",
+            request_id="req-no-write-after-terminal",
+            model="openai/gpt-5.5",
+            upstream_format="responses",
+            inbound_format="responses",
+            caller_stream=True,
+            behavior_profile=codex_proxy.BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH,
+            usage_capture={},
+        )
+
+        body = b"".join(fake.wfile.writes)
+        self.assertEqual(status, 200)
+        self.assertIn(b"response.completed", body)
+        self.assertNotIn(b"response.in_progress", body)
+
+    def test_stream_commit_seam_preserves_chat_done_after_finish_reason(self):
+        fake = FakeHandler()
+        response = FakeSseResponse(
+            [
+                b'data: {"id":"chatcmpl_1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n',
+                b"\n",
+                b"data: [DONE]\n",
+                b"\n",
+                b"",
+            ]
+        )
+
+        status = CodexProxyHandler._relay_upstream_response(
+            fake,
+            response,
+            "ollama_cloud",
+            request_id="req-chat-done-after-finish",
+            model="ollama-cloud/glm-5.2",
+            upstream_format="chat_completions",
+            inbound_format="chat_completions",
+            caller_stream=True,
+            behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+            usage_capture={},
+        )
+
+        body = b"".join(fake.wfile.writes)
+        self.assertEqual(status, 200)
+        self.assertIn(b'"finish_reason":"stop"', body)
+        self.assertIn(b"data: [DONE]", body)
 
     def test_official_passthrough_cancellation_closes_upstream_and_reader(self):
         fake = FakeHandler()
@@ -9349,7 +9414,39 @@ class RoutingTests(unittest.TestCase):
         event_names = [call.args[0] for call in self.write_proxy_event.call_args_list if call.args]
         self.assertNotIn("transparent_stream_closed", event_names)
 
-    def test_transparent_chat_stream_commit_writes_synthetic_terminal_on_interruption(self):
+    def test_transparent_responses_stream_commit_suppresses_post_terminal_line(self):
+        handler = FakeHandler()
+        response = FakeSseResponse(
+            [
+                b'data: {"type":"response.created","response":{"id":"resp_1"}}\n\n',
+                b'data: {"type":"response.completed","response":{"id":"resp_1","status":"completed"}}\n\n',
+                b'data: {"type":"response.in_progress","response":{"id":"resp_1"}}\n\n',
+                b"",
+            ]
+        )
+
+        status = CodexProxyHandler._relay_upstream_response(
+            handler,
+            response,
+            "volcengine",
+            request_id="req_transparent_post_terminal_suppress",
+            model="volc/glm-5.2",
+            upstream_format="responses",
+            inbound_format="responses",
+            caller_stream=True,
+            behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+        )
+
+        data = b"".join(handler.wfile.writes)
+        self.assertEqual(status, 200)
+        self.assertIn(b"response.completed", data)
+        self.assertNotIn(b"response.in_progress", data)
+        self.assertTrue(handler.close_connection)
+        event_names = [call.args[0] for call in self.write_proxy_event.call_args_list if call.args]
+        self.assertNotIn("transparent_stream_closed", event_names)
+        self.assertNotIn("downstream_stream_closed", event_names)
+
+    def test_transparent_chat_stream_commit_closes_without_synthetic_terminal_on_interruption(self):
         handler = FakeHandler()
         chunks = [
             {
@@ -9378,15 +9475,68 @@ class RoutingTests(unittest.TestCase):
         data = b"".join(handler.wfile.writes)
         self.assertEqual(status, 502)
         self.assertIn(b"data: ", data)
-        self.assertIn(b'"error"', data)
+        self.assertNotIn(b'"error"', data)
         self.assertNotIn(b"event: response.failed", data)
+        self.assertNotIn(b"data: [DONE]", data)
         event_names = [call.args[0] for call in self.write_proxy_event.call_args_list if call.args]
         self.assertIn("transparent_stream_closed", event_names)
         closed_event = next(
             call.kwargs for call in self.write_proxy_event.call_args_list
             if call.args and call.args[0] == "transparent_stream_closed"
         )
-        self.assertTrue(closed_event["synthetic_terminal_event_sent"])
+        self.assertFalse(closed_event["synthetic_terminal_event_sent"])
+        self.assertEqual(closed_event["failure_class"], "upstream_stream_interrupted")
+
+    def test_transparent_responses_cancellation_closes_upstream_and_reader(self):
+        handler = FakeHandler()
+        response = FakeCancellableSseResponse(
+            [
+                (0.5, b'data: {"type":"response.created","response":{"id":"resp_1"}}\n\n'),
+            ]
+        )
+        admission = codex_proxy.GatewayRequestAdmission()
+        admission.attach_upstream_transport(response)
+        previous = codex_proxy._activate_gateway_request(admission)
+
+        def cancel_soon() -> None:
+            time.sleep(0.05)
+            admission.cancel()
+
+        try:
+            thread = threading.Thread(target=cancel_soon)
+            thread.start()
+            with patch("codex_proxy.write_proxy_event") as write_event:
+                status = CodexProxyHandler._relay_transparent_upstream_response(
+                    handler,
+                    response,
+                    "volcengine",
+                    request_id="req-transparent-cancel",
+                    model="volc/glm-5.2",
+                    upstream_format="responses",
+                    inbound_format="responses",
+                    defer_stream_errors=True,
+                )
+            thread.join(timeout=1)
+        finally:
+            codex_proxy._restore_gateway_request(previous)
+
+        body = b"".join(handler.wfile.writes)
+        self.assertEqual(status, 503)
+        self.assertEqual(body, b"")
+        self.assertTrue(handler.close_connection)
+        self.assertFalse(handler.headers_ended)
+        self.assertGreaterEqual(response.close_call_count, 1)
+        closed_event = next(
+            call.kwargs
+            for call in write_event.call_args_list
+            if call.args and call.args[0] == "transparent_stream_closed"
+        )
+        self.assertEqual(closed_event["status"], 503)
+        self.assertEqual(closed_event["failure_class"], "gateway_shutdown")
+        self.assertFalse(closed_event["client_disconnected"])
+        self.assertEqual(closed_event["close_phase"], "before_output")
+        self.assertFalse(closed_event["synthetic_terminal_event_sent"])
+        self.assertFalse(closed_event["downstream_sse_started"])
 
     def test_transparent_chat_stream_commit_treats_done_as_terminal(self):
         handler = FakeHandler()

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -9487,6 +9487,71 @@ class RoutingTests(unittest.TestCase):
         self.assertFalse(closed_event["synthetic_terminal_event_sent"])
         self.assertEqual(closed_event["failure_class"], "upstream_stream_interrupted")
 
+    def test_transparent_chat_ignores_responses_type_in_extension_field(self):
+        handler = FakeHandler()
+        chunks = [
+            {
+                "id": "chatcmpl_1",
+                "object": "chat.completion.chunk",
+                "type": "response.completed",
+                "choices": [{"index": 0, "delta": {"content": "ok"}, "finish_reason": None}],
+            },
+            {
+                "id": "chatcmpl_1",
+                "object": "chat.completion.chunk",
+                "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+            },
+        ]
+        response = FakeSseResponse(
+            [f"data: {json.dumps(chunk)}\n\n".encode("utf-8") for chunk in chunks]
+            + [b"data: [DONE]\n\n", b""]
+        )
+
+        status = CodexProxyHandler._relay_upstream_response(
+            handler,
+            response,
+            "ollama_cloud",
+            request_id="req_chat_extension_type",
+            model="ollama-cloud/glm-5.2",
+            upstream_format="chat_completions",
+            inbound_format="chat_completions",
+            caller_stream=True,
+            behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+        )
+
+        data = b"".join(handler.wfile.writes)
+        self.assertEqual(status, 200)
+        self.assertIn(b'"type": "response.completed"', data)
+        self.assertIn(b'"finish_reason": "stop"', data)
+        self.assertIn(b"data: [DONE]", data)
+        self.assertNotIn(b"event: response.failed", data)
+        self.assertNotIn(b'"error"', data)
+
+    def test_transparent_chat_interruption_preserves_exact_bytes_without_framing(self):
+        handler = FakeHandler()
+        line = b'data: {"id":"chatcmpl_1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":null}]}\n'
+        response = FakeSseResponse([line, URLError("connection reset")])
+
+        status = CodexProxyHandler._relay_upstream_response(
+            handler,
+            response,
+            "ollama_cloud",
+            request_id="req_chat_exact_interrupt",
+            model="ollama-cloud/glm-5.2",
+            upstream_format="chat_completions",
+            inbound_format="chat_completions",
+            caller_stream=True,
+            behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+        )
+
+        data = b"".join(handler.wfile.writes)
+        self.assertEqual(status, 502)
+        self.assertEqual(data, line)
+        self.assertNotIn(b"event: response.failed", data)
+        self.assertNotIn(b'"error"', data)
+        # No extra blank-line separator from a no-op synthetic terminal.
+        self.assertFalse(data.endswith(b"\n\n"))
+
     def test_transparent_responses_cancellation_closes_upstream_and_reader(self):
         handler = FakeHandler()
         response = FakeCancellableSseResponse(

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -9284,6 +9284,142 @@ class RoutingTests(unittest.TestCase):
             codex_proxy.RETRY_FAILURE_PROVIDER_OVERLOADED,
         )
 
+    def test_transparent_responses_stream_commit_writes_synthetic_terminal_on_interruption(self):
+        handler = FakeHandler()
+        response = FakeSseResponse(
+            [
+                b'data: {"type":"response.created","response":{"id":"resp_1","model":"glm-5.2"}}\n\n',
+                URLError("connection reset"),
+            ]
+        )
+
+        status = CodexProxyHandler._relay_upstream_response(
+            handler,
+            response,
+            "volcengine",
+            request_id="req_transparent_responses_interrupt",
+            model="volc/glm-5.2",
+            upstream_format="responses",
+            inbound_format="responses",
+            caller_stream=True,
+            behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+        )
+
+        data = b"".join(handler.wfile.writes)
+        self.assertEqual(status, 502)
+        self.assertIn(b"response.created", data)
+        self.assertIn(b"event: response.failed", data)
+        self.assertIn(b'"type":"response.failed"', data)
+        self.assertIn(b'"upstream":"volcengine"', data)
+        event_names = [call.args[0] for call in self.write_proxy_event.call_args_list if call.args]
+        self.assertIn("transparent_stream_closed", event_names)
+        closed_event = next(
+            call.kwargs for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] == "transparent_stream_closed"
+        )
+        self.assertTrue(closed_event["synthetic_terminal_event_sent"])
+        self.assertEqual(closed_event["synthetic_terminal_event_type"], "response.failed")
+
+    def test_transparent_responses_stream_commit_ignores_interruption_after_terminal(self):
+        handler = FakeHandler()
+        response = FakeSseResponse(
+            [
+                b'data: {"type":"response.created","response":{"id":"resp_1"}}\n\n',
+                b'data: {"type":"response.completed","response":{"id":"resp_1","status":"completed"}}\n\n',
+                URLError("connection reset"),
+            ]
+        )
+
+        status = CodexProxyHandler._relay_upstream_response(
+            handler,
+            response,
+            "volcengine",
+            request_id="req_transparent_responses_terminal",
+            model="volc/glm-5.2",
+            upstream_format="responses",
+            inbound_format="responses",
+            caller_stream=True,
+            behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+        )
+
+        data = b"".join(handler.wfile.writes)
+        self.assertEqual(status, 200)
+        self.assertIn(b"response.completed", data)
+        self.assertNotIn(b"response.failed", data)
+        event_names = [call.args[0] for call in self.write_proxy_event.call_args_list if call.args]
+        self.assertNotIn("transparent_stream_closed", event_names)
+
+    def test_transparent_chat_stream_commit_writes_synthetic_terminal_on_interruption(self):
+        handler = FakeHandler()
+        chunks = [
+            {
+                "id": "chatcmpl_1",
+                "object": "chat.completion.chunk",
+                "choices": [{"index": 0, "delta": {"content": "ok"}, "finish_reason": None}],
+            },
+        ]
+        response = FakeSseResponse(
+            [f"data: {json.dumps(chunk)}\n\n".encode("utf-8") for chunk in chunks]
+            + [URLError("connection reset")]
+        )
+
+        status = CodexProxyHandler._relay_upstream_response(
+            handler,
+            response,
+            "ollama_cloud",
+            request_id="req_transparent_chat_interrupt",
+            model="ollama-cloud/glm-5.2",
+            upstream_format="chat_completions",
+            inbound_format="chat_completions",
+            caller_stream=True,
+            behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+        )
+
+        data = b"".join(handler.wfile.writes)
+        self.assertEqual(status, 502)
+        self.assertIn(b"data: ", data)
+        self.assertIn(b'"error"', data)
+        self.assertNotIn(b"event: response.failed", data)
+        event_names = [call.args[0] for call in self.write_proxy_event.call_args_list if call.args]
+        self.assertIn("transparent_stream_closed", event_names)
+        closed_event = next(
+            call.kwargs for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] == "transparent_stream_closed"
+        )
+        self.assertTrue(closed_event["synthetic_terminal_event_sent"])
+
+    def test_transparent_chat_stream_commit_treats_done_as_terminal(self):
+        handler = FakeHandler()
+        chunks = [
+            {
+                "id": "chatcmpl_1",
+                "object": "chat.completion.chunk",
+                "choices": [{"index": 0, "delta": {"content": "ok"}, "finish_reason": "stop"}],
+            },
+        ]
+        response = FakeSseResponse(
+            [f"data: {json.dumps(chunk)}\n\n".encode("utf-8") for chunk in chunks]
+            + [b"data: [DONE]\n", b""]
+        )
+
+        status = CodexProxyHandler._relay_upstream_response(
+            handler,
+            response,
+            "ollama_cloud",
+            request_id="req_transparent_chat_done",
+            model="ollama-cloud/glm-5.2",
+            upstream_format="chat_completions",
+            inbound_format="chat_completions",
+            caller_stream=True,
+            behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+        )
+
+        data = b"".join(handler.wfile.writes)
+        self.assertEqual(status, 200)
+        self.assertIn(b"data: [DONE]", data)
+        self.assertNotIn(b"response.failed", data)
+        self.assertNotIn(b'"error"', data)
+
     def test_responses_sse_incomplete_custom_tool_input_defers_without_body(self):
         handler = FakeHandler()
         response = FakeSseResponse(


### PR DESCRIPTION
<!-- orchestrator:delivery:v1 -->
```json
{"contract_sha256":"7548c929c6c7a250925e2ea317c2fda91a713354f2ab72ad27e942e9605fa396","candidate_sha":"717c27254f6597373ce354c8288346da2c796069","changed_paths":["src-python/codex_proxy.py","tests/test_routing.py"],"tdd":{"red":"Focused comparative regressions first proved missing lifecycle ownership for same-format transparent Responses/Chat. Exact-local review then exposed two additional REDs: a Chat extension field type=response.completed suppressed later finish/DONE bytes, and an interrupted partial Chat event gained an extra blank-line separator.","green":"Third-party Native Responses and same-format transparent Chat/Responses now share the downstream lifecycle/byte-commit seam. Injected protocol predicates keep Responses terminal events Responses-owned and seal Chat only at DONE; Chat interruption has no synthetic terminal or framing byte, while Responses retains response.failed synthesis.","refactor":"Generalized the Issue #221 seam with explicit upstream format, usage observer, terminal observer, synthetic-terminal policy and actual write-error state. Parsing/conversion remains route-owned and a terminal-sealed refusal is distinct from downstream OSError telemetry."},"verification":["focused RED/GREEN lifecycle and exact-wire regressions failed before their fixes and pass on the candidate","python -m pytest -q tests/test_routing.py tests/test_chat_completions_gateway.py tests/test_proxy_event_logging.py tests/test_proxy_shutdown.py: 612 passed, 134 subtests passed in 27.01s","python -m pytest -q: 1445 passed, 1 skipped, 332 subtests passed in 1055.56s (0:17:35); exit 0 and stderr empty","git diff --check: clean","python scripts/report_quality_gates.py: report-only, no new changed-path finding","exact-local-SHA Standards review: pass, no blockers","exact-local-SHA Spec review: pass, no blockers"],"deviations":[],"risks":["PassthroughSseSemanticStats uses the injected canonical terminal predicate both for sealing and for protocol-specific diagnostic fields; the only production call sites explicitly install the Responses or Chat predicate.","Request-level diagnostics, converted SSE routes, keepalives and remaining framing helpers intentionally remain outside this slice and are preflighted for Issue #223."]}
```

Closes #222
