### PR TITLE
Fix bounded upstream SSE reader lifecycle

### DIFF
--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -12977,6 +12977,200 @@ class _GatewayDownstreamStreamCommit:
         }
 
 
+class _UpstreamSseReaderLifecycle:
+    """Owns one upstream SSE reader thread, a bounded queue, and deterministic close/join.
+
+    This lifecycle is the single owner of the thread that reads raw SSE lines from
+    an upstream response. It uses a bounded queue (capacity 32) so a slow or stalled
+    downstream cannot create unbounded buffering. The producer observes close while
+    waiting on a full queue; the consumer observes close while waiting on an empty
+    queue. Close is idempotent and wakes both sides. Join is bounded and classifies a
+    non-terminating reader without hiding it.
+    """
+
+    QUEUE_CAPACITY = 32
+    PRODUCER_PUT_TIMEOUT_SECONDS = 0.05
+    CONSUMER_POLL_TIMEOUT_SECONDS = 0.1
+    JOIN_TIMEOUT_SECONDS = 1.0
+
+    def __init__(
+        self,
+        response: Any,
+        *,
+        admission: GatewayRequestAdmission | None = None,
+        cancellation_requested: Callable[[], bool] | None = None,
+        thread_name: str = "codex-proxy-sse-reader",
+    ) -> None:
+        self._response = response
+        self._queue: queue.Queue[tuple[str, Any]] = queue.Queue(maxsize=self.QUEUE_CAPACITY)
+        self._closed = threading.Event()
+        self._close_lock = threading.Lock()
+        self._thread: threading.Thread | None = None
+        self._thread_name = thread_name
+        self._cancellation_requested = (
+            (lambda: admission.cancelled) if admission is not None else cancellation_requested
+        )
+        self._started = False
+        self._response_closed = False
+        self._join_outcome: str | None = None
+        if admission is not None:
+            admission.attach_upstream_transport(self)
+
+    @property
+    def closed(self) -> bool:
+        return self._closed.is_set()
+
+    @property
+    def queue_depth(self) -> int:
+        return self._queue.qsize()
+
+    @property
+    def reader_alive(self) -> bool:
+        thread = self._thread
+        return thread is not None and thread.is_alive()
+
+    @property
+    def join_outcome(self) -> str | None:
+        return self._join_outcome
+
+    def _cancelled(self) -> bool:
+        if self._closed.is_set():
+            return True
+        cancellation_requested = self._cancellation_requested
+        if cancellation_requested is None:
+            return False
+        try:
+            return bool(cancellation_requested())
+        except Exception:
+            return False
+
+    def start(self) -> None:
+        """Start the reader thread idempotently."""
+        with self._close_lock:
+            if self._started or self._closed.is_set():
+                return
+            self._started = True
+            thread = threading.Thread(target=self._read_upstream, name=self._thread_name, daemon=True)
+            self._thread = thread
+        thread.start()
+
+    def _read_upstream(self) -> None:
+        """Producer loop: read lines and enqueue them with bounded backpressure."""
+        response = self._response
+        try:
+            while not self._cancelled():
+                try:
+                    line = response.readline()
+                except BaseException as exc:
+                    if not self._cancelled():
+                        self._enqueue(("error", exc))
+                    return
+                if not self._enqueue(("line", line)):
+                    return
+                if not line:
+                    return
+        finally:
+            self.close()
+
+    def _enqueue(self, item: tuple[str, Any]) -> bool:
+        """Enqueue one item, respecting close/cancellation. Returns False if closed."""
+        while not self._cancelled():
+            try:
+                self._queue.put(item, timeout=self.PRODUCER_PUT_TIMEOUT_SECONDS)
+                return True
+            except queue.Full:
+                continue
+        return False
+
+    def get(self, timeout: float | None = None) -> tuple[str, Any]:
+        """Get one queued item.
+
+        Raises ``queue.Empty`` on timeout. The caller should check :attr:`closed`
+        to distinguish a transient empty queue from a closed lifecycle.
+        """
+        self.start()
+        if timeout is not None:
+            try:
+                return self._queue.get(timeout=max(0.0, timeout))
+            except queue.Empty:
+                if self._cancelled():
+                    return "line", b""
+                raise
+        while True:
+            try:
+                return self._queue.get(timeout=self.CONSUMER_POLL_TIMEOUT_SECONDS)
+            except queue.Empty:
+                if self._cancelled():
+                    return "line", b""
+
+    def readline(self) -> bytes:
+        """Read one upstream SSE line.
+
+        Returns ``b""`` when the lifecycle is closed. Raises the stored upstream
+        exception when the reader encountered an error.
+        """
+        self.start()
+        while True:
+            kind, value = self.get()
+            if kind == "error":
+                raise value
+            return value
+
+    def iter_lines(self):
+        """Yield raw upstream SSE lines until EOF or close."""
+        try:
+            while True:
+                line = self.readline()
+                yield line
+                if not line:
+                    return
+        finally:
+            self.close()
+
+    def shorten_terminal_drain_timeout(self, timeout_seconds: float) -> None:
+        """Forward the existing pooled-response terminal drain optimization."""
+        shorten = getattr(self._response, "shorten_terminal_drain_timeout", None)
+        if callable(shorten):
+            shorten(timeout_seconds)
+
+    def close(self) -> None:
+        """Close the lifecycle idempotently and wake both producer and consumer."""
+        with self._close_lock:
+            self._closed.set()
+            should_close_response = not self._response_closed
+            self._response_closed = True
+        if should_close_response:
+            close = getattr(self._response, "close", None)
+            if callable(close):
+                try:
+                    close()
+                except Exception:
+                    pass
+
+    def join(self, timeout: float = JOIN_TIMEOUT_SECONDS) -> tuple[bool, str | None]:
+        """Join the reader thread for at most ``timeout`` seconds.
+
+        Returns ``(joined, outcome)``. A started reader receives a sanitized
+        termination classification; ``outcome`` is ``None`` only when no reader
+        was started. Once a join timeout is observed, that classification remains
+        retained even if a later join observes termination.
+        """
+        thread = self._thread
+        if thread is None:
+            return True, None
+        bounded_timeout = min(self.JOIN_TIMEOUT_SECONDS, max(0.0, timeout))
+        thread.join(timeout=bounded_timeout)
+        if thread.is_alive():
+            outcome = "upstream_sse_reader_thread_did_not_terminate"
+            if self._join_outcome != outcome:
+                logger.warning("upstream SSE reader join ended with %s", outcome)
+            self._join_outcome = outcome
+            return False, self._join_outcome
+        if self._join_outcome is None:
+            self._join_outcome = "upstream_sse_reader_thread_terminated"
+        return True, self._join_outcome
+
+
 class CodexProxyHandler(BaseHTTPRequestHandler):
     protocol_version = "HTTP/1.1"
 
@@ -14801,113 +14995,93 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
         model_event_timeout_seconds = model_event_sse_idle_timeout_seconds()
         transport_idle_guard_enabled = transport_timeout_seconds > 0
         model_event_idle_guard_enabled = model_event_timeout_seconds > 0 and line_resets_idle_timeout is not None
-        if (
-            admission is None
-            and keepalive_interval <= 0
-            and not transport_idle_guard_enabled
-            and not model_event_idle_guard_enabled
-        ):
+
+        lifecycle = _UpstreamSseReaderLifecycle(
+            response,
+            admission=admission,
+        )
+        request_scoped_seam = _handler_downstream_stream_commit(self)
+        if request_scoped_seam is not None:
+            request_scoped_seam.attach_upstream_response(lifecycle)
+        lifecycle.start()
+        try:
+            stream_started_at = time.monotonic()
+            last_transport_at = stream_started_at
+            last_model_event_at = stream_started_at
+            last_keepalive_at = stream_started_at
+
+            def raise_idle_timeout(timeout_seconds: float, phase: str) -> None:
+                lifecycle.close()
+                raise UpstreamStreamIdleTimeoutError(timeout_seconds, phase=phase)
+
             while True:
                 raise_if_shutdown_requested()
-                line = response.readline()
-                observe_line(line)
-                yield line
-                if not line:
-                    return
-
-        lines: queue.Queue[tuple[str, bytes | BaseException]] = queue.Queue()
-
-        def read_upstream_lines() -> None:
-            try:
-                while True:
-                    line = response.readline()
-                    lines.put(("line", line))
-                    if not line:
-                        return
-            except BaseException as exc:
-                lines.put(("error", exc))
-
-        threading.Thread(target=read_upstream_lines, name="codex-proxy-sse-reader", daemon=True).start()
-        stream_started_at = time.monotonic()
-        last_transport_at = stream_started_at
-        last_model_event_at = stream_started_at
-        last_keepalive_at = stream_started_at
-
-        def close_response_for_idle_timeout() -> None:
-            close = getattr(response, "close", None)
-            if callable(close):
-                try:
-                    close()
-                except Exception:
-                    pass
-
-        def raise_idle_timeout(timeout_seconds: float, phase: str) -> None:
-            close_response_for_idle_timeout()
-            raise UpstreamStreamIdleTimeoutError(timeout_seconds, phase=phase)
-
-        while True:
-            raise_if_shutdown_requested()
-            now = time.monotonic()
-            timeout_seconds: float | None = None
-            if keepalive_interval > 0:
-                timeout_seconds = max(0.001, keepalive_interval - (now - last_keepalive_at))
-            if transport_idle_guard_enabled:
-                remaining_idle = transport_timeout_seconds - (now - last_transport_at)
-                if remaining_idle <= 0:
-                    raise_idle_timeout(transport_timeout_seconds, "transport")
-                timeout_seconds = (
-                    remaining_idle
-                    if timeout_seconds is None
-                    else max(0.001, min(timeout_seconds, remaining_idle))
-                )
-            if model_event_idle_guard_enabled:
-                remaining_idle = model_event_timeout_seconds - (now - last_model_event_at)
-                if remaining_idle <= 0:
-                    raise_idle_timeout(model_event_timeout_seconds, "model_event")
-                timeout_seconds = (
-                    remaining_idle
-                    if timeout_seconds is None
-                    else max(0.001, min(timeout_seconds, remaining_idle))
-                )
-            if admission is not None:
-                timeout_seconds = (
-                    0.1
-                    if timeout_seconds is None
-                    else max(0.001, min(timeout_seconds, 0.1))
-                )
-
-            try:
-                if timeout_seconds is None:
-                    kind, value = lines.get()
-                else:
-                    kind, value = lines.get(timeout=timeout_seconds)
-            except queue.Empty:
-                raise_if_shutdown_requested()
                 now = time.monotonic()
-                if transport_idle_guard_enabled and (now - last_transport_at) >= transport_timeout_seconds:
-                    raise_idle_timeout(transport_timeout_seconds, "transport")
-                if model_event_idle_guard_enabled and (now - last_model_event_at) >= model_event_timeout_seconds:
-                    raise_idle_timeout(model_event_timeout_seconds, "model_event")
+                timeout_seconds: float | None = None
                 if keepalive_interval > 0:
-                    if not self._write_sse_keepalive():
-                        close_response_for_idle_timeout()
-                        raise DownstreamKeepaliveFailedError(
-                            "downstream keepalive write failed"
-                        )
-                    last_keepalive_at = time.monotonic()
-                continue
-            if kind == "error":
-                raise_if_shutdown_requested()
-                raise value
-            if isinstance(value, bytes) and value:
-                now = time.monotonic()
-                last_transport_at = now
-                if model_event_idle_guard_enabled and line_resets_idle_timeout is not None and line_resets_idle_timeout(value):
-                    last_model_event_at = now
-                observe_line(value)
-            yield value
-            if not value:
-                return
+                    timeout_seconds = max(0.001, keepalive_interval - (now - last_keepalive_at))
+                if transport_idle_guard_enabled:
+                    remaining_idle = transport_timeout_seconds - (now - last_transport_at)
+                    if remaining_idle <= 0:
+                        raise_idle_timeout(transport_timeout_seconds, "transport")
+                    timeout_seconds = (
+                        remaining_idle
+                        if timeout_seconds is None
+                        else max(0.001, min(timeout_seconds, remaining_idle))
+                    )
+                if model_event_idle_guard_enabled:
+                    remaining_idle = model_event_timeout_seconds - (now - last_model_event_at)
+                    if remaining_idle <= 0:
+                        raise_idle_timeout(model_event_timeout_seconds, "model_event")
+                    timeout_seconds = (
+                        remaining_idle
+                        if timeout_seconds is None
+                        else max(0.001, min(timeout_seconds, remaining_idle))
+                    )
+                if admission is not None:
+                    timeout_seconds = (
+                        0.1
+                        if timeout_seconds is None
+                        else max(0.001, min(timeout_seconds, 0.1))
+                    )
+
+                try:
+                    if timeout_seconds is None:
+                        kind, value = lifecycle.get()
+                    else:
+                        kind, value = lifecycle.get(timeout=timeout_seconds)
+                except queue.Empty:
+                    raise_if_shutdown_requested()
+                    if lifecycle.closed:
+                        return
+                    now = time.monotonic()
+                    if transport_idle_guard_enabled and (now - last_transport_at) >= transport_timeout_seconds:
+                        raise_idle_timeout(transport_timeout_seconds, "transport")
+                    if model_event_idle_guard_enabled and (now - last_model_event_at) >= model_event_timeout_seconds:
+                        raise_idle_timeout(model_event_timeout_seconds, "model_event")
+                    if keepalive_interval > 0:
+                        if not self._write_sse_keepalive():
+                            lifecycle.close()
+                            raise DownstreamKeepaliveFailedError(
+                                "downstream keepalive write failed"
+                            )
+                        last_keepalive_at = time.monotonic()
+                    continue
+                if kind == "error":
+                    raise_if_shutdown_requested()
+                    raise value
+                if isinstance(value, bytes) and value:
+                    now = time.monotonic()
+                    last_transport_at = now
+                    if model_event_idle_guard_enabled and line_resets_idle_timeout is not None and line_resets_idle_timeout(value):
+                        last_model_event_at = now
+                    observe_line(value)
+                yield value
+                if not value:
+                    return
+        finally:
+            lifecycle.close()
+            lifecycle.join(timeout=_UpstreamSseReaderLifecycle.JOIN_TIMEOUT_SECONDS)
 
     def _write_sse_error_event(self, upstream_name: str, exc: BaseException) -> None:
         self._write_sse_event(
@@ -15179,12 +15353,17 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 return status
             return _handle_cancellation()
 
+        lifecycle = _UpstreamSseReaderLifecycle(
+            response,
+            admission=admission,
+        )
+        seam.attach_upstream_response(lifecycle)
         try:
             while True:
                 result = _observed_cancellation()
                 if result is not None:
                     return result
-                line = response.readline()
+                line = lifecycle.readline()
                 result = _observed_cancellation()
                 if result is not None:
                     return result
@@ -15270,6 +15449,9 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 synthetic_terminal_write_detail=synthetic_terminal_write_detail,
             )
             return 502
+        finally:
+            lifecycle.close()
+            lifecycle.join(timeout=_UpstreamSseReaderLifecycle.JOIN_TIMEOUT_SECONDS)
 
         self.close_connection = True
         sse_fields = seam.stats()
@@ -15536,13 +15718,18 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
             pending_lines.clear()
             return True
 
+        lifecycle = _UpstreamSseReaderLifecycle(
+            response,
+            admission=admission,
+        )
+        seam.attach_upstream_response(lifecycle)
         try:
             while True:
                 result = _observed_cancellation()
                 if result is not None:
                     return result
                 try:
-                    line = response.readline()
+                    line = lifecycle.readline()
                 except (IncompleteRead, TimeoutError, OSError, URLError) as exc:
                     result = _observed_cancellation()
                     if result is not None:
@@ -15658,6 +15845,9 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
             # Stream error events are intentionally raised without sending headers
             # so the caller can retry. The seam owns any bytes already committed.
             raise
+        finally:
+            lifecycle.close()
+            lifecycle.join(timeout=_UpstreamSseReaderLifecycle.JOIN_TIMEOUT_SECONDS)
 
     def _relay_upstream_response(
         self,

--- a/tests/test_proxy_shutdown.py
+++ b/tests/test_proxy_shutdown.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import inspect
 import json
 from pathlib import Path
 import tempfile
 import threading
+import time
 from http.client import HTTPConnection
 from http.server import ThreadingHTTPServer
 from types import SimpleNamespace
@@ -13,6 +15,51 @@ from urllib.request import Request
 import codex_proxy
 import pytest
 from codex_proxy import CodexProxyHandler
+
+
+class _LifecycleResponse:
+    def __init__(self, lines: list[bytes | BaseException]) -> None:
+        self._lines = list(lines)
+        self.close_calls = 0
+
+    def readline(self) -> bytes:
+        value = self._lines.pop(0)
+        if isinstance(value, BaseException):
+            raise value
+        return value
+
+    def close(self) -> None:
+        self.close_calls += 1
+
+
+class _ProducingResponse:
+    def __init__(self) -> None:
+        self.close_calls = 0
+        self.read_calls = 0
+        self.closed = threading.Event()
+
+    def readline(self) -> bytes:
+        self.read_calls += 1
+        return f"data: {self.read_calls}\n\n".encode()
+
+    def close(self) -> None:
+        self.close_calls += 1
+        self.closed.set()
+
+
+class _NonTerminatingResponse:
+    def __init__(self) -> None:
+        self.close_calls = 0
+        self.entered = threading.Event()
+        self.release = threading.Event()
+
+    def readline(self) -> bytes:
+        self.entered.set()
+        self.release.wait()
+        return b""
+
+    def close(self) -> None:
+        self.close_calls += 1
 
 
 def _run_server_with_event_writer_result(writer_result):
@@ -33,6 +80,126 @@ def _run_server_with_event_writer_result(writer_result):
             codex_proxy.run_server("127.0.0.1", 8080)
 
     return server, writer, warning
+
+
+def test_upstream_sse_reader_queue_is_exactly_32_and_full_queue_cancellation_is_bounded() -> None:
+    controller = codex_proxy.GatewayShutdownController()
+    admission = controller.admit()
+    assert admission is not None
+    response = _ProducingResponse()
+    lifecycle = codex_proxy._UpstreamSseReaderLifecycle(response, admission=admission)
+    full_queue_put_entered = threading.Event()
+    queue_put = lifecycle._queue.put
+
+    def observe_full_queue_put(item, block=True, timeout=None):
+        if lifecycle._queue.full():
+            full_queue_put_entered.set()
+        return queue_put(item, block=block, timeout=timeout)
+
+    with patch.object(lifecycle._queue, "put", side_effect=observe_full_queue_put):
+        lifecycle.start()
+        assert full_queue_put_entered.wait(timeout=1.0)
+
+        assert lifecycle.QUEUE_CAPACITY == 32
+        assert lifecycle.queue_depth == 32
+        assert response.read_calls == 33
+        assert lifecycle.reader_alive
+
+        started_at = time.monotonic()
+        assert controller.close_admission() == 1
+        joined, outcome = lifecycle.join(timeout=1.0)
+
+        assert time.monotonic() - started_at < 1.0
+        assert joined is True
+        assert outcome == "upstream_sse_reader_thread_terminated"
+        assert lifecycle.queue_depth == 32
+        assert lifecycle.reader_alive is False
+        assert response.close_calls == 1
+    controller.complete(admission)
+
+
+def test_upstream_sse_reader_closes_once_on_normal_eof_and_preserves_order() -> None:
+    response = _LifecycleResponse([b"data: first\n\n", b"data: second\n\n", b""])
+    lifecycle = codex_proxy._UpstreamSseReaderLifecycle(response)
+
+    assert list(lifecycle.iter_lines()) == [
+        b"data: first\n\n",
+        b"data: second\n\n",
+        b"",
+    ]
+    lifecycle.close()
+    joined, outcome = lifecycle.join()
+
+    assert joined is True
+    assert outcome == "upstream_sse_reader_thread_terminated"
+    assert response.close_calls == 1
+    assert lifecycle.reader_alive is False
+
+
+def test_upstream_sse_reader_closes_once_and_wakes_consumer_on_upstream_error() -> None:
+    response = _LifecycleResponse([OSError("synthetic upstream failure")])
+    lifecycle = codex_proxy._UpstreamSseReaderLifecycle(response)
+
+    with pytest.raises(OSError, match="synthetic upstream failure"):
+        lifecycle.readline()
+    lifecycle.close()
+    joined, outcome = lifecycle.join()
+
+    assert joined is True
+    assert outcome == "upstream_sse_reader_thread_terminated"
+    assert response.close_calls == 1
+    assert lifecycle.reader_alive is False
+
+
+def test_upstream_sse_reader_repeated_close_wakes_unstarted_consumer_without_starting_reader() -> None:
+    response = _LifecycleResponse([b"must not be read"])
+    lifecycle = codex_proxy._UpstreamSseReaderLifecycle(response)
+
+    lifecycle.close()
+    lifecycle.close()
+
+    assert lifecycle.readline() == b""
+    assert lifecycle.join() == (True, None)
+    assert response.close_calls == 1
+    assert response._lines == [b"must not be read"]
+
+
+def test_upstream_sse_reader_join_is_capped_at_one_second_and_timeout_is_classified() -> None:
+    response = _NonTerminatingResponse()
+    lifecycle = codex_proxy._UpstreamSseReaderLifecycle(response)
+    lifecycle.start()
+    assert response.entered.wait(timeout=1.0)
+    lifecycle.close()
+
+    started_at = time.monotonic()
+    with patch.object(codex_proxy.logger, "warning") as warning:
+        joined, outcome = lifecycle.join(timeout=10.0)
+    elapsed = time.monotonic() - started_at
+
+    assert joined is False
+    assert outcome == "upstream_sse_reader_thread_did_not_terminate"
+    assert lifecycle.join_outcome == outcome
+    assert elapsed <= 1.1
+    warning.assert_called_once_with("upstream SSE reader join ended with %s", outcome)
+    assert response.close_calls == 1
+
+    response.release.set()
+    joined_after_release, retained_outcome = lifecycle.join(timeout=1.0)
+    assert joined_after_release is True
+    assert retained_outcome == outcome
+    assert lifecycle.reader_alive is False
+
+
+def test_upstream_sse_reader_scope_audit_keeps_bounded_queue_and_thread_in_one_owner() -> None:
+    lifecycle_source = inspect.getsource(codex_proxy._UpstreamSseReaderLifecycle)
+    module_source = inspect.getsource(codex_proxy)
+
+    assert "QUEUE_CAPACITY = 32" in lifecycle_source
+    assert "queue.Queue(maxsize=self.QUEUE_CAPACITY)" in lifecycle_source
+    assert "self._queue.put(item, timeout=self.PRODUCER_PUT_TIMEOUT_SECONDS)" in lifecycle_source
+    assert "self._queue.put(item)" not in lifecycle_source
+    assert module_source.count('"codex-proxy-sse-reader"') == 1
+    assert "target=self._read_upstream" in lifecycle_source
 
 
 def test_shutdown_endpoint_stops_server() -> None:

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -140,12 +140,18 @@ class FakeSseResponse:
             "Content-Length": "999",
         }
         self.lines = list(lines)
+        self.closed = False
+        self.close_call_count = 0
 
     def readline(self):
         line = self.lines.pop(0)
         if isinstance(line, BaseException):
             raise line
         return line
+
+    def close(self):
+        self.close_call_count += 1
+        self.closed = True
 
     def __enter__(self):
         return self
@@ -167,6 +173,19 @@ class FakeDelayedSseResponse(FakeSseResponse):
         return super().readline()
 
 
+class FakeConcurrentSseResponse(FakeSseResponse):
+    def __init__(self, lines, barrier):
+        super().__init__(lines)
+        self.barrier = barrier
+        self.readline_calls = 0
+
+    def readline(self):
+        self.readline_calls += 1
+        if self.readline_calls == 1:
+            self.barrier.wait(timeout=2)
+        return super().readline()
+
+
 class FakeSequencedDelayedSseResponse(FakeSseResponse):
     def __init__(self, items):
         super().__init__([])
@@ -182,6 +201,7 @@ class FakeSequencedDelayedSseResponse(FakeSseResponse):
         return line
 
     def close(self):
+        self.close_call_count += 1
         self.closed = True
 
 
@@ -2639,6 +2659,112 @@ class RoutingTests(unittest.TestCase):
                 for call in write_event.call_args_list
             )
         )
+
+    def test_four_concurrent_official_and_third_party_responses_chat_streams_complete_independently(self):
+        barrier = threading.Barrier(4)
+        response_events = [
+            b'data: {"type":"response.created","response":{"id":"resp_concurrent","model":"gpt-5.5"}}\n\n',
+            b'data: {"type":"response.output_text.delta","delta":"sentinel"}\n\n',
+            b'data: {"type":"response.completed","response":{"id":"resp_concurrent","status":"completed"}}\n\n',
+            b"",
+        ]
+        chat_events = [
+            b'data: {"id":"chatcmpl_concurrent","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"sentinel"},"finish_reason":"stop"}]}\n\n',
+            b"data: [DONE]\n\n",
+            b"",
+        ]
+        cases = [
+            {
+                "name": "official_responses",
+                "upstream_name": "official",
+                "upstream_format": "responses",
+                "inbound_format": "responses",
+                "behavior_profile": codex_proxy.BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH,
+                "lines": response_events,
+                "terminal": b"response.completed",
+            },
+            {
+                "name": "official_chat",
+                "upstream_name": "official",
+                "upstream_format": "responses",
+                "inbound_format": "chat_completions",
+                "behavior_profile": None,
+                "lines": response_events,
+                "terminal": b"data: [DONE]",
+            },
+            {
+                "name": "third_party_responses",
+                "upstream_name": "volcengine",
+                "upstream_format": "responses",
+                "inbound_format": "responses",
+                "behavior_profile": codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+                "lines": response_events,
+                "terminal": b"response.completed",
+            },
+            {
+                "name": "third_party_chat",
+                "upstream_name": "ollama_cloud",
+                "upstream_format": "chat_completions",
+                "inbound_format": "chat_completions",
+                "behavior_profile": codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+                "lines": chat_events,
+                "terminal": b"data: [DONE]",
+            },
+        ]
+        results = {}
+        failures = []
+        result_lock = threading.Lock()
+
+        def relay(case):
+            handler = FakeHandler()
+            response = FakeConcurrentSseResponse(case["lines"], barrier)
+            admission = codex_proxy.GatewayRequestAdmission()
+            previous = codex_proxy._activate_gateway_request(admission)
+            try:
+                status = CodexProxyHandler._relay_upstream_response(
+                    handler,
+                    response,
+                    case["upstream_name"],
+                    request_id=f"req-{case['name']}",
+                    model="openai/gpt-5.5",
+                    upstream_format=case["upstream_format"],
+                    inbound_format=case["inbound_format"],
+                    caller_stream=True,
+                    behavior_profile=case["behavior_profile"],
+                    usage_capture={},
+                )
+                with result_lock:
+                    results[case["name"]] = (
+                        status,
+                        b"".join(handler.wfile.writes),
+                        response.close_call_count,
+                    )
+            except BaseException as exc:
+                with result_lock:
+                    failures.append(exc)
+            finally:
+                codex_proxy._restore_gateway_request(previous)
+
+        threads = [
+            threading.Thread(target=relay, args=(case,), name=f"relay-{case['name']}")
+            for case in cases
+        ]
+        started_at = time.monotonic()
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=2)
+
+        self.assertLess(time.monotonic() - started_at, 2)
+        self.assertFalse([thread.name for thread in threads if thread.is_alive()])
+        self.assertEqual(failures, [])
+        self.assertEqual(set(results), {case["name"] for case in cases})
+        for case in cases:
+            status, body, close_call_count = results[case["name"]]
+            self.assertEqual(status, 200, case["name"])
+            self.assertEqual(body.count(case["terminal"]), 1, case["name"])
+            self.assertIn(b"sentinel", body, case["name"])
+            self.assertEqual(close_call_count, 1, case["name"])
 
     def test_upstream_http_error_emits_request_complete_with_status(self):
         body = json.dumps({"model": "volc/glm-5.2", "messages": [{"role": "user", "content": "hi"}], "stream": False}).encode("utf-8")
@@ -6993,6 +7119,7 @@ class RoutingTests(unittest.TestCase):
         self.assertEqual(handler.wfile.writes, lines[:-1])
         self.assertGreaterEqual(handler.wfile.flush_count, 3)
         self.assertTrue(handler.close_connection)
+        self.assertEqual(response.close_call_count, 1)
 
     def test_sse_relay_keeps_downstream_alive_while_waiting_for_upstream_line(self):
         handler = FakeHandler()
@@ -7047,6 +7174,7 @@ class RoutingTests(unittest.TestCase):
 
         self.assertEqual(status, 499)
         self.assertTrue(handler.close_connection)
+        self.assertEqual(response.close_call_count, 1)
         closed_event = next(
             call.kwargs
             for call in write_event.call_args_list
@@ -9033,6 +9161,7 @@ class RoutingTests(unittest.TestCase):
         event_kwargs = matching_events[-1].kwargs
         self.assertEqual(event_kwargs["stream_idle_timeout_seconds"], 0.02)
         self.assertEqual(event_kwargs["stream_idle_phase"], "model_event")
+        self.assertEqual(response.close_call_count, 1)
 
     def test_responses_sse_passthrough_aborts_on_transport_idle_timeout(self):
         handler = FakeHandler()
@@ -9076,6 +9205,7 @@ class RoutingTests(unittest.TestCase):
         event_kwargs = matching_events[-1].kwargs
         self.assertEqual(event_kwargs["stream_idle_timeout_seconds"], 0.01)
         self.assertEqual(event_kwargs["stream_idle_phase"], "transport")
+        self.assertEqual(response.close_call_count, 1)
 
     def test_responses_sse_passthrough_aborts_after_output_model_event_idle_timeout(self):
         handler = FakeHandler()
@@ -9126,6 +9256,7 @@ class RoutingTests(unittest.TestCase):
         self.assertEqual(event_kwargs["stream_idle_timeout_seconds"], 0.02)
         self.assertEqual(event_kwargs["stream_idle_phase"], "model_event")
         self.assertTrue(event_kwargs["downstream_output_started"])
+        self.assertEqual(response.close_call_count, 1)
 
     def test_responses_sse_function_call_argument_deltas_keep_idle_timer_alive(self):
         handler = FakeHandler()


### PR DESCRIPTION
Closes #19

## What changed

- Route every upstream SSE reader through one lifecycle owner with an exact 32-entry queue.
- Make full-queue producer backpressure cancellable by downstream close and Gateway shutdown.
- Close upstream responses idempotently across EOF, errors, idle timeout, protocol/handler exit, and cancellation.
- Bound reader joins to one second and retain a sanitized non-termination classification.
- Preserve successful stream ordering, keepalive and idle-timeout semantics, terminal handling, and downstream-close 499 behavior.
- Add deterministic lifecycle, bounded-backpressure, shutdown, scope-audit, and four-route concurrency coverage.

## Validation

- Focused routing/chat/shutdown: 628 passed, 134 subtests passed
- Protocol translation: 60 passed, 112 subtests passed
- Corrected blocked-producer regression: 25 consecutive passes
- Final shutdown module: 20 passed
- `git diff --check`: passed
- Report-only quality gate: parse_errors=0
- Exact-local Standards and strict Spec reviews: pass

Real-client qualification remains owned by #227.

<!-- orchestrator:delivery:v1 -->
```json
{"contract_sha256":"1cf75e684ea9f177b65b3765647adbd61e86d853d428e24933d88d7bd43b4db4","candidate_sha":"f03d5df14d9abc788ed1840074e1d43cb74a53b4","changed_paths":["src-python/codex_proxy.py","tests/test_proxy_shutdown.py","tests/test_routing.py"],"tdd":{"red":"Inherited lifecycle implementation lacked deterministic bounded queue/lifecycle acceptance; exact-capacity blocked-producer coverage exposed the missing seam, and review reproduced the initial test synchronization race.","green":"Focused routing/chat/shutdown passed 628 tests plus 134 subtests; protocol translation passed 60 plus 112 subtests; corrected blocked-producer test passed 25 consecutive runs and test_proxy_shutdown.py passed 20/20.","refactor":"Centralized all three SSE reader sites behind one bounded lifecycle owner; final delta only made capacity-32 synchronization deterministic and aligned the join outcome docstring."},"verification":["focused routing/chat/shutdown: 628 passed, 134 subtests passed","protocol translation: 60 passed, 112 subtests passed","corrected blocked-producer test: 25 consecutive passes","test_proxy_shutdown.py: 20 passed","git diff --check: passed","report_quality_gates: report-only, parse_errors=0","exact-local Standards review: pass","exact-local strict Spec review: pass"],"deviations":["Per explicit user verification correction, interrupted repo-wide pytest attempts are superseded process evidence; the Worker gate is the exact affected matrix and the frozen PR SHA receives the single complete CI run."],"risks":["Exact-SHA CI is pending; real-client qualification remains owned by Issue #227."]}
```