### PR TITLE
Introduce a lossless event-boundary SSE assembler

### DIFF
--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -2754,13 +2754,11 @@ class PassthroughSseSemanticStats:
         if self._terminal_error is not None:
             return
         try:
-            events = self._assembler.feed(chunk)
+            self._assembler.feed(chunk, on_event=self._observe_event)
         except SseFrameTooLargeError as exc:
             self._terminal_error = exc
             self._eof_disposition = "size_limit"
             raise
-        for event in events:
-            self._observe_event(event)
 
     def finalize_pending(self) -> None:
         if self._eof_disposition is not None:

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -47,6 +47,7 @@ sys.path.insert(0, str(VENDORED_URLLIB3_WHEEL))
 
 import urllib3
 
+from sse_events import SseEvent, SseEventAssembler
 from protocol_translation import (
     ChatToResponsesStreamConverter,
     ResponsesToChatStreamConverter,
@@ -2718,21 +2719,6 @@ def _parse_sse_json_payload(line: bytes) -> dict[str, Any] | None:
 SSE_EVENT_TYPE_TELEMETRY_LIMIT = 64
 
 
-def _sse_field_value(line_without_ending: bytes, prefix: bytes) -> bytes:
-    value = line_without_ending[len(prefix) :]
-    if value.startswith(b" "):
-        value = value[1:]
-    return value
-
-
-def _decode_sse_metadata_value(value: bytes) -> str | None:
-    try:
-        text = value.decode("utf-8", errors="replace").strip()
-    except Exception:
-        return None
-    return text or None
-
-
 class PassthroughSseSemanticStats:
     def __init__(
         self,
@@ -2753,19 +2739,25 @@ class PassthroughSseSemanticStats:
         self._terminal_observer = (
             terminal_observer if terminal_observer is not None else _responses_terminal_observer
         )
-        self._event_name: str | None = None
-        self._data_lines: list[bytes] = []
+        self._assembler = SseEventAssembler()
+        self._eof_disposition: str | None = None
+        self._incomplete_bytes_discarded = 0
 
-    def observe_line(self, line: bytes) -> None:
-        for physical_line in line.splitlines(keepends=True):
-            self._observe_physical_line(physical_line)
+    def observe_bytes(self, chunk: bytes) -> None:
+        for event in self._assembler.feed(chunk):
+            self._observe_event(event)
 
     def finalize_pending(self) -> None:
-        if self._event_name is not None or self._data_lines:
-            self._finish_event()
+        if self._eof_disposition is not None:
+            return
+        termination = self._assembler.finish()
+        for event in termination.events:
+            self._observe_event(event)
+        self._eof_disposition = termination.disposition
+        self._incomplete_bytes_discarded = termination.discarded_bytes
 
     def has_pending_event(self) -> bool:
-        return self._event_name is not None or bool(self._data_lines)
+        return self._assembler.buffered_bytes > 0
 
     def fields(self) -> dict[str, Any]:
         event_types = sorted(self.event_type_counts)
@@ -2784,32 +2776,19 @@ class PassthroughSseSemanticStats:
             fields["sse_last_event_type"] = self.last_event_type
         if self.event_types_truncated:
             fields["sse_event_types_truncated"] = True
+        if self._eof_disposition == "incomplete":
+            fields["sse_eof_disposition"] = "incomplete"
+            fields["sse_incomplete_bytes_discarded"] = self._incomplete_bytes_discarded
         return fields
 
-    def _observe_physical_line(self, physical_line: bytes) -> None:
-        line = physical_line
-        for candidate in (b"\r\n", b"\n", b"\r"):
-            if line.endswith(candidate):
-                line = line[: -len(candidate)]
-                break
-        if line == b"":
-            self._finish_event()
+    def _observe_event(self, event: SseEvent) -> None:
+        event_name: str | None = None
+        if event.event is not None:
+            event_name = event.event.decode("utf-8", errors="replace").strip() or None
+        has_data_field = any(line.name == b"data" for line in event.lines)
+        if event_name is None and not has_data_field:
             return
-        if line.startswith(b":"):
-            return
-        if line.startswith(b"event:"):
-            self._event_name = _decode_sse_metadata_value(_sse_field_value(line, b"event:"))
-            return
-        if line.startswith(b"data:"):
-            self._data_lines.append(_sse_field_value(line, b"data:"))
-
-    def _finish_event(self) -> None:
-        if self._event_name is None and not self._data_lines:
-            return
-        event_name = self._event_name
-        data = b"\n".join(self._data_lines)
-        self._event_name = None
-        self._data_lines = []
+        data = event.data
 
         self.events_streamed += 1
         event_type = event_name
@@ -12801,7 +12780,7 @@ class _GatewayDownstreamStreamCommit:
     def _observe_line(self, line: bytes) -> bool:
         """Observe one raw SSE line and return True if it contains a terminal event."""
         self._last_upstream_byte_at = time.monotonic()
-        self._sse_stats.observe_line(line)
+        self._sse_stats.observe_bytes(line)
         if self._sse_stats.terminal_event_seen and not self._terminal_observed:
             self._terminal_observed = True
             return True
@@ -12933,7 +12912,7 @@ class _GatewayDownstreamStreamCommit:
             if self._sse_stats.has_pending_event():
                 self._handler.wfile.write(b"\n")
                 self._handler.wfile.flush()
-                self._sse_stats.finalize_pending()
+                self._sse_stats.observe_bytes(b"\n")
         except OSError as write_exc:
             self._last_write_error = write_exc
             self.close()

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -2756,8 +2756,8 @@ class PassthroughSseSemanticStats:
         self._eof_disposition = termination.disposition
         self._incomplete_bytes_discarded = termination.discarded_bytes
 
-    def has_pending_event(self) -> bool:
-        return self._assembler.buffered_bytes > 0
+    def pending_completion_bytes(self) -> bytes:
+        return self._assembler.completion_bytes()
 
     def fields(self) -> dict[str, Any]:
         event_types = sorted(self.event_type_counts)
@@ -12909,10 +12909,11 @@ class _GatewayDownstreamStreamCommit:
         if self._synthetic_terminal_failure_callback is None:
             return False, None, None
         try:
-            if self._sse_stats.has_pending_event():
-                self._handler.wfile.write(b"\n")
+            completion = self._sse_stats.pending_completion_bytes()
+            if completion:
+                self._handler.wfile.write(completion)
                 self._handler.wfile.flush()
-                self._sse_stats.observe_bytes(b"\n")
+                self._sse_stats.observe_bytes(completion)
         except OSError as write_exc:
             self._last_write_error = write_exc
             self.close()

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -47,7 +47,7 @@ sys.path.insert(0, str(VENDORED_URLLIB3_WHEEL))
 
 import urllib3
 
-from sse_events import SseEvent, SseEventAssembler
+from sse_events import SseEvent, SseEventAssembler, SseFrameTooLargeError
 from protocol_translation import (
     ChatToResponsesStreamConverter,
     ResponsesToChatStreamConverter,
@@ -2742,9 +2742,18 @@ class PassthroughSseSemanticStats:
         self._assembler = SseEventAssembler()
         self._eof_disposition: str | None = None
         self._incomplete_bytes_discarded = 0
+        self._terminal_error: SseFrameTooLargeError | None = None
 
     def observe_bytes(self, chunk: bytes) -> None:
-        for event in self._assembler.feed(chunk):
+        if self._terminal_error is not None:
+            return
+        try:
+            events = self._assembler.feed(chunk)
+        except SseFrameTooLargeError as exc:
+            self._terminal_error = exc
+            self._eof_disposition = "size_limit"
+            raise
+        for event in events:
             self._observe_event(event)
 
     def finalize_pending(self) -> None:
@@ -2757,6 +2766,8 @@ class PassthroughSseSemanticStats:
         self._incomplete_bytes_discarded = termination.discarded_bytes
 
     def pending_completion_bytes(self) -> bytes:
+        if self._terminal_error is not None:
+            return b""
         return self._assembler.completion_bytes()
 
     def fields(self) -> dict[str, Any]:
@@ -15375,7 +15386,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         synthetic_terminal_write_detail=None,
                     )
                     return 499
-        except (IncompleteRead, TimeoutError, OSError, URLError) as exc:
+        except (IncompleteRead, TimeoutError, OSError, URLError, SseFrameTooLargeError) as exc:
             if seam.terminal_committed:
                 sse_fields = seam.stats()
                 if usage_capture is not None:
@@ -15421,7 +15432,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 detail=safe_upstream_error_detail(exc),
                 failure_phase="stream_body",
                 failure_side="upstream_read",
-                failure_class="upstream_stream_interrupted",
+                failure_class=getattr(exc, "classification", "upstream_stream_interrupted"),
                 client_disconnected=False,
                 synthetic_terminal_event_sent=synthetic_terminal_event_sent,
                 synthetic_terminal_event_type="response.failed" if synthetic_terminal_event_sent else None,

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -47,7 +47,12 @@ sys.path.insert(0, str(VENDORED_URLLIB3_WHEEL))
 
 import urllib3
 
-from sse_events import SseEvent, SseEventAssembler, SseFrameTooLargeError
+from sse_events import (
+    DEFAULT_MAX_FRAME_BYTES,
+    SseEvent,
+    SseEventAssembler,
+    SseFrameTooLargeError,
+)
 from protocol_translation import (
     ChatToResponsesStreamConverter,
     ResponsesToChatStreamConverter,
@@ -2724,6 +2729,7 @@ class PassthroughSseSemanticStats:
         self,
         *,
         terminal_observer: Callable[[str | None, bytes, Any], bool] | None = None,
+        max_frame_bytes: int = DEFAULT_MAX_FRAME_BYTES,
     ) -> None:
         self.events_streamed = 0
         self.json_events_streamed = 0
@@ -2739,7 +2745,7 @@ class PassthroughSseSemanticStats:
         self._terminal_observer = (
             terminal_observer if terminal_observer is not None else _responses_terminal_observer
         )
-        self._assembler = SseEventAssembler()
+        self._assembler = SseEventAssembler(max_frame_bytes=max_frame_bytes)
         self._eof_disposition: str | None = None
         self._incomplete_bytes_discarded = 0
         self._terminal_error: SseFrameTooLargeError | None = None
@@ -12679,6 +12685,7 @@ class _GatewayDownstreamStreamCommit:
             tuple[bool, str | None, str | None],
         ]
         | None = None,
+        max_frame_bytes: int = DEFAULT_MAX_FRAME_BYTES,
     ) -> None:
         self._handler = handler
         self._upstream_response = upstream_response
@@ -12693,7 +12700,11 @@ class _GatewayDownstreamStreamCommit:
             else _offer_official_passthrough_usage_line
         )
         self._synthetic_terminal_failure_callback = synthetic_terminal_failure_callback
-        self._sse_stats = PassthroughSseSemanticStats(terminal_observer=terminal_observer)
+        self._max_frame_bytes = max_frame_bytes
+        self._sse_stats = PassthroughSseSemanticStats(
+            terminal_observer=terminal_observer,
+            max_frame_bytes=max_frame_bytes,
+        )
         self._terminal_observed = False
         self._terminal_committed = False
         self._downstream_closed = False
@@ -12732,7 +12743,10 @@ class _GatewayDownstreamStreamCommit:
         self._upstream_response = response
 
     def set_terminal_observer(self, terminal_observer: Callable[[str | None, bytes, Any], bool] | None) -> None:
-        self._sse_stats = PassthroughSseSemanticStats(terminal_observer=terminal_observer)
+        self._sse_stats = PassthroughSseSemanticStats(
+            terminal_observer=terminal_observer,
+            max_frame_bytes=self._max_frame_bytes,
+        )
 
     def set_usage_line_callback(self, usage_line_callback: Callable[[Mapping[str, Any], bytes], None] | None) -> None:
         self._usage_line_callback = (
@@ -15709,6 +15723,70 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
             pending_lines.clear()
             return True
 
+        def _handle_stream_failure(exc: BaseException) -> int:
+            result = _observed_cancellation()
+            if result is not None:
+                return result
+            if seam.terminal_committed:
+                sse_fields = seam.stats()
+                if usage_capture is not None:
+                    usage_capture.update(sse_fields)
+                return status
+            if defer_stream_errors and not headers_sent:
+                raise UpstreamStreamInterruptedError(exc) from exc
+            if seam.downstream_closed:
+                _emit_stream_closed(
+                    status_code=499,
+                    error=type(exc).__name__,
+                    detail=safe_upstream_error_detail(exc),
+                    failure_phase="stream_body",
+                    failure_side="upstream_read",
+                    failure_class="downstream_client_closed",
+                    client_disconnected=True,
+                    synthetic_terminal_event_sent=False,
+                    synthetic_terminal_event_type=None,
+                    synthetic_terminal_write_error=None,
+                    synthetic_terminal_write_detail=None,
+                )
+                return 499
+            (
+                synthetic_terminal_event_sent,
+                synthetic_terminal_write_error,
+                synthetic_terminal_write_detail,
+            ) = seam.commit_terminal_failure(exc, status=502)
+            if seam.downstream_closed and seam.last_write_error() is not None:
+                return _handle_write_failure()
+            sse_fields = seam.stats()
+            if usage_capture is not None:
+                usage_capture.update(sse_fields)
+                usage_capture["synthetic_terminal_event_sent"] = synthetic_terminal_event_sent
+                if synthetic_terminal_event_sent:
+                    usage_capture["synthetic_terminal_event_type"] = (
+                        "response.failed" if inbound_format == "responses" else "chat.error"
+                    )
+                if synthetic_terminal_write_error is not None:
+                    usage_capture["synthetic_terminal_write_error"] = synthetic_terminal_write_error
+            synthetic_terminal_event_type = None
+            if synthetic_terminal_event_sent:
+                synthetic_terminal_event_type = (
+                    "response.failed" if inbound_format == "responses" else "chat.error"
+                )
+            self.close_connection = True
+            _emit_stream_closed(
+                status_code=502,
+                error=type(exc).__name__,
+                detail=safe_upstream_error_detail(exc),
+                failure_phase="stream_body",
+                failure_side="upstream_read",
+                failure_class=getattr(exc, "classification", "upstream_stream_interrupted"),
+                client_disconnected=False,
+                synthetic_terminal_event_sent=synthetic_terminal_event_sent,
+                synthetic_terminal_event_type=synthetic_terminal_event_type,
+                synthetic_terminal_write_error=synthetic_terminal_write_error,
+                synthetic_terminal_write_detail=synthetic_terminal_write_detail,
+            )
+            return 502
+
         lifecycle = _UpstreamSseReaderLifecycle(
             response,
             admission=admission,
@@ -15722,68 +15800,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 try:
                     line = lifecycle.readline()
                 except (IncompleteRead, TimeoutError, OSError, URLError) as exc:
-                    result = _observed_cancellation()
-                    if result is not None:
-                        return result
-                    if seam.terminal_committed:
-                        sse_fields = seam.stats()
-                        if usage_capture is not None:
-                            usage_capture.update(sse_fields)
-                        return status
-                    if defer_stream_errors and not headers_sent:
-                        raise UpstreamStreamInterruptedError(exc) from exc
-                    if seam.downstream_closed:
-                        _emit_stream_closed(
-                            status_code=499,
-                            error=type(exc).__name__,
-                            detail=safe_upstream_error_detail(exc),
-                            failure_phase="stream_body",
-                            failure_side="upstream_read",
-                            failure_class="downstream_client_closed",
-                            client_disconnected=True,
-                            synthetic_terminal_event_sent=False,
-                            synthetic_terminal_event_type=None,
-                            synthetic_terminal_write_error=None,
-                            synthetic_terminal_write_detail=None,
-                        )
-                        return 499
-                    (
-                        synthetic_terminal_event_sent,
-                        synthetic_terminal_write_error,
-                        synthetic_terminal_write_detail,
-                    ) = seam.commit_terminal_failure(exc, status=502)
-                    if seam.downstream_closed and seam.last_write_error() is not None:
-                        return _handle_write_failure()
-                    sse_fields = seam.stats()
-                    if usage_capture is not None:
-                        usage_capture.update(sse_fields)
-                        usage_capture["synthetic_terminal_event_sent"] = synthetic_terminal_event_sent
-                        if synthetic_terminal_event_sent:
-                            usage_capture["synthetic_terminal_event_type"] = (
-                                "response.failed" if inbound_format == "responses" else "chat.error"
-                            )
-                        if synthetic_terminal_write_error is not None:
-                            usage_capture["synthetic_terminal_write_error"] = synthetic_terminal_write_error
-                    synthetic_terminal_event_type = None
-                    if synthetic_terminal_event_sent:
-                        synthetic_terminal_event_type = (
-                            "response.failed" if inbound_format == "responses" else "chat.error"
-                        )
-                    self.close_connection = True
-                    _emit_stream_closed(
-                        status_code=502,
-                        error=type(exc).__name__,
-                        detail=safe_upstream_error_detail(exc),
-                        failure_phase="stream_body",
-                        failure_side="upstream_read",
-                        failure_class="upstream_stream_interrupted",
-                        client_disconnected=False,
-                        synthetic_terminal_event_sent=synthetic_terminal_event_sent,
-                        synthetic_terminal_event_type=synthetic_terminal_event_type,
-                        synthetic_terminal_write_error=synthetic_terminal_write_error,
-                        synthetic_terminal_write_detail=synthetic_terminal_write_detail,
-                    )
-                    return 502
+                    return _handle_stream_failure(exc)
                 result = _observed_cancellation()
                 if result is not None:
                     return result
@@ -15832,6 +15849,8 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
             if usage_capture is not None:
                 usage_capture.update(sse_fields)
             return status
+        except SseFrameTooLargeError as exc:
+            return _handle_stream_failure(exc)
         except UpstreamStreamErrorEvent:
             # Stream error events are intentionally raised without sending headers
             # so the caller can retry. The seam owns any bytes already committed.

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -2748,15 +2748,13 @@ class PassthroughSseSemanticStats:
         self._assembler = SseEventAssembler(max_frame_bytes=max_frame_bytes)
         self._eof_disposition: str | None = None
         self._incomplete_bytes_discarded = 0
-        self._terminal_error: SseFrameTooLargeError | None = None
 
     def observe_bytes(self, chunk: bytes) -> None:
-        if self._terminal_error is not None:
+        if self._eof_disposition == "size_limit":
             return
         try:
             self._assembler.feed(chunk, on_event=self._observe_event)
-        except SseFrameTooLargeError as exc:
-            self._terminal_error = exc
+        except SseFrameTooLargeError:
             self._eof_disposition = "size_limit"
             raise
 
@@ -2770,7 +2768,7 @@ class PassthroughSseSemanticStats:
         self._incomplete_bytes_discarded = termination.discarded_bytes
 
     def pending_completion_bytes(self) -> bytes:
-        if self._terminal_error is not None:
+        if self._eof_disposition == "size_limit":
             return b""
         return self._assembler.completion_bytes()
 

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -12714,6 +12714,7 @@ class _GatewayDownstreamStreamCommit:
         self._bytes_streamed = 0
         self._last_upstream_byte_at: float | None = None
         self._last_write_error: OSError | None = None
+        self._last_successful_completion_bytes = b""
 
     @property
     def terminal_committed(self) -> bool:
@@ -12837,6 +12838,7 @@ class _GatewayDownstreamStreamCommit:
         self._downstream_output_started = True
         self._lines_streamed += 1
         self._bytes_streamed += len(line)
+        self._last_successful_completion_bytes = self._sse_stats.pending_completion_bytes()
         if terminal_observed_now:
             self._terminal_committed = True
             _observe_gateway_diagnostic("observe_terminal", self._request_id, forwarded=True)
@@ -12903,6 +12905,8 @@ class _GatewayDownstreamStreamCommit:
         self._downstream_output_started = True
         self._lines_streamed += 1
         self._bytes_streamed += len(data)
+        if observe:
+            self._last_successful_completion_bytes = self._sse_stats.pending_completion_bytes()
         if terminal_observed_now:
             self._terminal_committed = True
             _observe_gateway_diagnostic("observe_terminal", self._request_id, forwarded=True)
@@ -12934,11 +12938,17 @@ class _GatewayDownstreamStreamCommit:
         if self._synthetic_terminal_failure_callback is None:
             return False, None, None
         try:
-            completion = self._sse_stats.pending_completion_bytes()
+            size_limit_exceeded = isinstance(exc, SseFrameTooLargeError)
+            completion = (
+                self._last_successful_completion_bytes
+                if size_limit_exceeded
+                else self._sse_stats.pending_completion_bytes()
+            )
             if completion:
                 self._handler.wfile.write(completion)
                 self._handler.wfile.flush()
-                self._sse_stats.observe_bytes(completion)
+                if not size_limit_exceeded:
+                    self._sse_stats.observe_bytes(completion)
         except OSError as write_exc:
             self._last_write_error = write_exc
             self.close()

--- a/src-python/sse_events.py
+++ b/src-python/sse_events.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Callable
 
 
 __all__ = [
@@ -85,12 +86,17 @@ class SseEventAssembler:
     def buffered_bytes(self) -> int:
         return len(self._frame_raw) + len(self._buffer) - self._line_start
 
-    def feed(self, chunk: bytes) -> tuple[SseEvent, ...]:
+    def feed(
+        self,
+        chunk: bytes,
+        *,
+        on_event: Callable[[SseEvent], None] | None = None,
+    ) -> tuple[SseEvent, ...]:
         """Consume bytes and return every complete frame in their original order."""
         self._require_open()
         self._buffer.extend(chunk)
         try:
-            events = self._drain(eof=False)
+            events = self._drain(eof=False, on_event=on_event)
             self._check_size(self.buffered_bytes)
             self._compact_buffer()
             return events
@@ -155,7 +161,12 @@ class SseEventAssembler:
             discarded_bytes=discarded_bytes,
         )
 
-    def _drain(self, *, eof: bool) -> tuple[SseEvent, ...]:
+    def _drain(
+        self,
+        *,
+        eof: bool,
+        on_event: Callable[[SseEvent], None] | None = None,
+    ) -> tuple[SseEvent, ...]:
         events: list[SseEvent] = []
         while True:
             extracted = self._extract_line(eof=eof)
@@ -172,7 +183,10 @@ class SseEventAssembler:
                 self._check_size(len(self._frame_raw))
                 continue
             self._check_size(len(self._frame_raw))
-            events.append(self._complete_event())
+            event = self._complete_event()
+            events.append(event)
+            if on_event is not None:
+                on_event(event)
         return tuple(events)
 
     def _extract_line(self, *, eof: bool) -> tuple[bytes, bytes] | None:

--- a/src-python/sse_events.py
+++ b/src-python/sse_events.py
@@ -109,7 +109,7 @@ class SseEventAssembler:
             if self._at_stream_start and content.startswith(b"\xef\xbb\xbf"):
                 content = content[3:]
             if trailing_cr:
-                return b"" if not content else b"\r"
+                return b"\n" if not content else b"\r\n"
             if not content:
                 return b"\n"
             return b"\n\n"

--- a/src-python/sse_events.py
+++ b/src-python/sse_events.py
@@ -100,10 +100,18 @@ class SseEventAssembler:
             raise
 
     def completion_bytes(self) -> bytes:
-        """Return the minimal LF suffix that completes the pending frame."""
+        """Return the minimal suffix that completes the pending frame."""
         self._require_open()
-        partial_line_bytes = len(self._buffer) - self._line_start
-        if partial_line_bytes:
+        partial_line = bytes(self._buffer[self._line_start :])
+        if partial_line:
+            trailing_cr = partial_line.endswith(b"\r")
+            content = partial_line[:-1] if trailing_cr else partial_line
+            if self._at_stream_start and content.startswith(b"\xef\xbb\xbf"):
+                content = content[3:]
+            if trailing_cr:
+                return b"" if not content else b"\r"
+            if not content:
+                return b"\n"
             return b"\n\n"
         if self._frame_raw:
             return b"\n"

--- a/src-python/sse_events.py
+++ b/src-python/sse_events.py
@@ -14,6 +14,8 @@ __all__ = [
 ]
 
 DEFAULT_MAX_FRAME_BYTES = 16 * 1024 * 1024
+# Retry metadata remains raw regardless; the semantic integer is deliberately bounded.
+MAX_RETRY_MILLISECONDS = (1 << 63) - 1
 
 
 class SseAssemblerClosedError(RuntimeError):
@@ -72,6 +74,7 @@ class SseEventAssembler:
             raise ValueError("max_frame_bytes must be positive")
         self._max_frame_bytes = max_frame_bytes
         self._buffer = bytearray()
+        self._line_start = 0
         self._scan_offset = 0
         self._frame_raw = bytearray()
         self._lines: list[SseLine] = []
@@ -80,7 +83,7 @@ class SseEventAssembler:
 
     @property
     def buffered_bytes(self) -> int:
-        return len(self._frame_raw) + len(self._buffer)
+        return len(self._frame_raw) + len(self._buffer) - self._line_start
 
     def feed(self, chunk: bytes) -> tuple[SseEvent, ...]:
         """Consume bytes and return every complete frame in their original order."""
@@ -88,12 +91,23 @@ class SseEventAssembler:
         self._buffer.extend(chunk)
         try:
             events = self._drain(eof=False)
-            self._check_size()
+            self._check_size(self.buffered_bytes)
+            self._compact_buffer()
             return events
         except SseFrameTooLargeError:
             self._discard()
             self._closed_disposition = "size_limit"
             raise
+
+    def completion_bytes(self) -> bytes:
+        """Return the minimal LF suffix that completes the pending frame."""
+        self._require_open()
+        partial_line_bytes = len(self._buffer) - self._line_start
+        if partial_line_bytes:
+            return b"\n\n"
+        if self._frame_raw:
+            return b"\n"
+        return b""
 
     def finish(self) -> SseTermination:
         """Close at EOF and report complete final-CR events or discarded bytes."""
@@ -147,9 +161,9 @@ class SseEventAssembler:
                     content = content[3:]
             if content:
                 self._lines.append(_parse_line(content, raw_line))
-                self._check_size()
+                self._check_size(len(self._frame_raw))
                 continue
-            self._check_size()
+            self._check_size(len(self._frame_raw))
             events.append(self._complete_event())
         return tuple(events)
 
@@ -157,9 +171,9 @@ class SseEventAssembler:
         for index in range(self._scan_offset, len(self._buffer)):
             byte = self._buffer[index]
             if byte == 0x0A:
-                raw_line = bytes(self._buffer[: index + 1])
-                del self._buffer[: index + 1]
-                self._scan_offset = 0
+                raw_line = bytes(self._buffer[self._line_start : index + 1])
+                self._line_start = index + 1
+                self._scan_offset = self._line_start
                 return raw_line[:-1], raw_line
             if byte != 0x0D:
                 continue
@@ -167,9 +181,9 @@ class SseEventAssembler:
                 self._scan_offset = index
                 return None
             ending_size = 2 if index + 1 < len(self._buffer) and self._buffer[index + 1] == 0x0A else 1
-            raw_line = bytes(self._buffer[: index + ending_size])
-            del self._buffer[: index + ending_size]
-            self._scan_offset = 0
+            raw_line = bytes(self._buffer[self._line_start : index + ending_size])
+            self._line_start = index + ending_size
+            self._scan_offset = self._line_start
             return raw_line[:-ending_size], raw_line
         self._scan_offset = len(self._buffer)
         return None
@@ -179,11 +193,13 @@ class SseEventAssembler:
         data_values = [line.value for line in lines if line.name == b"data"]
         event_values = [line.value for line in lines if line.name == b"event"]
         id_values = [line.value for line in lines if line.name == b"id" and b"\0" not in line.value]
-        retry_values = [
-            int(line.value)
-            for line in lines
-            if line.name == b"retry" and line.value and line.value.isdigit()
-        ]
+        retry_values: list[int] = []
+        for line in lines:
+            if line.name != b"retry":
+                continue
+            retry = _parse_retry_milliseconds(line.value)
+            if retry is not None:
+                retry_values.append(retry)
         event = SseEvent(
             raw=bytes(self._frame_raw),
             lines=lines,
@@ -196,8 +212,7 @@ class SseEventAssembler:
         self._lines.clear()
         return event
 
-    def _check_size(self) -> None:
-        pending_bytes = self.buffered_bytes
+    def _check_size(self, pending_bytes: int) -> None:
         if pending_bytes > self._max_frame_bytes:
             raise SseFrameTooLargeError(
                 pending_bytes=pending_bytes,
@@ -206,9 +221,18 @@ class SseEventAssembler:
 
     def _discard(self) -> None:
         self._buffer.clear()
+        self._line_start = 0
         self._scan_offset = 0
         self._frame_raw.clear()
         self._lines.clear()
+
+    def _compact_buffer(self) -> None:
+        if self._line_start == 0:
+            return
+        consumed = self._line_start
+        self._buffer = self._buffer[consumed:]
+        self._line_start = 0
+        self._scan_offset -= consumed
 
     def _require_open(self) -> None:
         if self._closed_disposition is not None:
@@ -225,3 +249,17 @@ def _parse_line(content: bytes, raw: bytes) -> SseLine:
     if separator and value.startswith(b" "):
         value = value[1:]
     return SseLine(raw=raw, kind="field", name=name, value=value)
+
+
+def _parse_retry_milliseconds(value: bytes) -> int | None:
+    if not value:
+        return None
+    result = 0
+    for byte in value:
+        digit = byte - 0x30
+        if digit < 0 or digit > 9:
+            return None
+        if result > (MAX_RETRY_MILLISECONDS - digit) // 10:
+            return None
+        result = result * 10 + digit
+    return result

--- a/src-python/sse_events.py
+++ b/src-python/sse_events.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+__all__ = [
+    "DEFAULT_MAX_FRAME_BYTES",
+    "SseAssemblerClosedError",
+    "SseEvent",
+    "SseEventAssembler",
+    "SseFrameTooLargeError",
+    "SseLine",
+    "SseTermination",
+]
+
+DEFAULT_MAX_FRAME_BYTES = 16 * 1024 * 1024
+
+
+class SseAssemblerClosedError(RuntimeError):
+    def __init__(self, disposition: str) -> None:
+        self.disposition = disposition
+        super().__init__(f"SSE assembler is closed ({disposition})")
+
+
+class SseFrameTooLargeError(ValueError):
+    classification = "sse_frame_too_large"
+
+    def __init__(self, *, pending_bytes: int, max_frame_bytes: int) -> None:
+        self.pending_bytes = pending_bytes
+        self.max_frame_bytes = max_frame_bytes
+        super().__init__(
+            f"SSE frame exceeded byte limit "
+            f"(pending_bytes={pending_bytes}, max_frame_bytes={max_frame_bytes})"
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SseLine:
+    raw: bytes
+    kind: str
+    name: bytes | None
+    value: bytes
+
+
+@dataclass(frozen=True, slots=True)
+class SseEvent:
+    raw: bytes
+    lines: tuple[SseLine, ...]
+    data: bytes
+    event: bytes | None
+    id: bytes | None
+    retry: int | None
+
+
+@dataclass(frozen=True, slots=True)
+class SseTermination:
+    events: tuple[SseEvent, ...]
+    disposition: str
+    discarded_bytes: int
+
+
+class SseEventAssembler:
+    """Assemble lossless SSE frames from arbitrarily partitioned byte chunks.
+
+    ``feed`` emits a frame only after its blank-line boundary is complete.
+    ``finish`` resolves a final standalone CR, discards any other partial frame,
+    and permanently closes the assembler until ``reset`` is called.
+    """
+
+    def __init__(self, *, max_frame_bytes: int = DEFAULT_MAX_FRAME_BYTES) -> None:
+        if max_frame_bytes <= 0:
+            raise ValueError("max_frame_bytes must be positive")
+        self._max_frame_bytes = max_frame_bytes
+        self._buffer = bytearray()
+        self._scan_offset = 0
+        self._frame_raw = bytearray()
+        self._lines: list[SseLine] = []
+        self._at_stream_start = True
+        self._closed_disposition: str | None = None
+
+    @property
+    def buffered_bytes(self) -> int:
+        return len(self._frame_raw) + len(self._buffer)
+
+    def feed(self, chunk: bytes) -> tuple[SseEvent, ...]:
+        """Consume bytes and return every complete frame in their original order."""
+        self._require_open()
+        self._buffer.extend(chunk)
+        try:
+            events = self._drain(eof=False)
+            self._check_size()
+            return events
+        except SseFrameTooLargeError:
+            self._discard()
+            self._closed_disposition = "size_limit"
+            raise
+
+    def finish(self) -> SseTermination:
+        """Close at EOF and report complete final-CR events or discarded bytes."""
+        self._require_open()
+        events = self._drain(eof=True)
+        discarded_bytes = self.buffered_bytes
+        disposition = "incomplete" if discarded_bytes else "complete"
+        self._discard()
+        self._closed_disposition = disposition
+        return SseTermination(
+            events=events,
+            disposition=disposition,
+            discarded_bytes=discarded_bytes,
+        )
+
+    def cancel(self) -> SseTermination:
+        """Discard pending bytes and close without retaining or echoing payloads."""
+        self._require_open()
+        discarded_bytes = self.buffered_bytes
+        self._discard()
+        self._closed_disposition = "cancelled"
+        return SseTermination(
+            events=(),
+            disposition="cancelled",
+            discarded_bytes=discarded_bytes,
+        )
+
+    def reset(self) -> SseTermination:
+        """Discard pending state and reopen this instance at a new stream start."""
+        discarded_bytes = self.buffered_bytes
+        self._discard()
+        self._at_stream_start = True
+        self._closed_disposition = None
+        return SseTermination(
+            events=(),
+            disposition="reset",
+            discarded_bytes=discarded_bytes,
+        )
+
+    def _drain(self, *, eof: bool) -> tuple[SseEvent, ...]:
+        events: list[SseEvent] = []
+        while True:
+            extracted = self._extract_line(eof=eof)
+            if extracted is None:
+                break
+            content, raw_line = extracted
+            self._frame_raw.extend(raw_line)
+            if self._at_stream_start:
+                self._at_stream_start = False
+                if content.startswith(b"\xef\xbb\xbf"):
+                    content = content[3:]
+            if content:
+                self._lines.append(_parse_line(content, raw_line))
+                self._check_size()
+                continue
+            self._check_size()
+            events.append(self._complete_event())
+        return tuple(events)
+
+    def _extract_line(self, *, eof: bool) -> tuple[bytes, bytes] | None:
+        for index in range(self._scan_offset, len(self._buffer)):
+            byte = self._buffer[index]
+            if byte == 0x0A:
+                raw_line = bytes(self._buffer[: index + 1])
+                del self._buffer[: index + 1]
+                self._scan_offset = 0
+                return raw_line[:-1], raw_line
+            if byte != 0x0D:
+                continue
+            if index + 1 == len(self._buffer) and not eof:
+                self._scan_offset = index
+                return None
+            ending_size = 2 if index + 1 < len(self._buffer) and self._buffer[index + 1] == 0x0A else 1
+            raw_line = bytes(self._buffer[: index + ending_size])
+            del self._buffer[: index + ending_size]
+            self._scan_offset = 0
+            return raw_line[:-ending_size], raw_line
+        self._scan_offset = len(self._buffer)
+        return None
+
+    def _complete_event(self) -> SseEvent:
+        lines = tuple(self._lines)
+        data_values = [line.value for line in lines if line.name == b"data"]
+        event_values = [line.value for line in lines if line.name == b"event"]
+        id_values = [line.value for line in lines if line.name == b"id" and b"\0" not in line.value]
+        retry_values = [
+            int(line.value)
+            for line in lines
+            if line.name == b"retry" and line.value and line.value.isdigit()
+        ]
+        event = SseEvent(
+            raw=bytes(self._frame_raw),
+            lines=lines,
+            data=b"\n".join(data_values),
+            event=event_values[-1] if event_values else None,
+            id=id_values[-1] if id_values else None,
+            retry=retry_values[-1] if retry_values else None,
+        )
+        self._frame_raw.clear()
+        self._lines.clear()
+        return event
+
+    def _check_size(self) -> None:
+        pending_bytes = self.buffered_bytes
+        if pending_bytes > self._max_frame_bytes:
+            raise SseFrameTooLargeError(
+                pending_bytes=pending_bytes,
+                max_frame_bytes=self._max_frame_bytes,
+            )
+
+    def _discard(self) -> None:
+        self._buffer.clear()
+        self._scan_offset = 0
+        self._frame_raw.clear()
+        self._lines.clear()
+
+    def _require_open(self) -> None:
+        if self._closed_disposition is not None:
+            raise SseAssemblerClosedError(self._closed_disposition)
+
+
+def _parse_line(content: bytes, raw: bytes) -> SseLine:
+    if content.startswith(b":"):
+        value = content[1:]
+        if value.startswith(b" "):
+            value = value[1:]
+        return SseLine(raw=raw, kind="comment", name=None, value=value)
+    name, separator, value = content.partition(b":")
+    if separator and value.startswith(b" "):
+        value = value[1:]
+    return SseLine(raw=raw, kind="field", name=name, value=value)

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -9961,6 +9961,51 @@ class RoutingTests(unittest.TestCase):
         self.assertEqual(failed_payload["type"], "response.failed")
         self.assertNotIn(secret, body)
 
+    def test_transparent_responses_size_crossing_cr_preserves_response_id(self):
+        handler = FakeHandler()
+        response_id = "resp_size_crossing_cr"
+        handler._downstream_stream_commit = codex_proxy._GatewayDownstreamStreamCommit(
+            handler,
+            None,
+            "volcengine",
+            model="volc/glm-5.2",
+            request_id="req_transparent_responses_size_crossing_cr",
+            inbound_format="responses",
+            upstream_format="responses",
+            max_frame_bytes=128,
+        )
+        created_prefix = (
+            b'data: {"type":"response.created","response":{"id":"'
+            + response_id.encode("ascii")
+            + b'"}}\r'
+        )
+        secret = b"size-crossing-cr-secret"
+        crossing_chunk = b"\rdata: " + (b"x" * 128) + secret
+
+        status = CodexProxyHandler._relay_upstream_response(
+            handler,
+            FakeSseResponse([created_prefix, crossing_chunk, b""]),
+            "volcengine",
+            request_id="req_transparent_responses_size_crossing_cr",
+            model="volc/glm-5.2",
+            upstream_format="responses",
+            inbound_format="responses",
+            caller_stream=True,
+            behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+        )
+
+        body = b"".join(handler.wfile.writes)
+        events = SseEventAssembler().feed(body)
+        created_payload = json.loads(events[0].data)
+        failed_payload = json.loads(events[1].data)
+
+        self.assertEqual(status, 502)
+        self.assertEqual(len(events), 2)
+        self.assertEqual(created_payload["response"]["id"], response_id)
+        self.assertEqual(failed_payload["type"], "response.failed")
+        self.assertEqual(failed_payload["response"]["id"], response_id)
+        self.assertNotIn(secret, body)
+
     def test_transparent_responses_cr_completion_preserves_response_id_on_interruption(self):
         handler = FakeHandler()
         response_id = "resp_cr_boundary"

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -15,7 +15,7 @@ from urllib.error import HTTPError, URLError
 
 import catalog_sync
 import codex_proxy
-from sse_events import SseEventAssembler
+from sse_events import DEFAULT_MAX_FRAME_BYTES, SseEventAssembler
 from subagent_state import build_subagent_state
 from codex_proxy import (
     CodexProxyHandler,
@@ -2132,6 +2132,52 @@ class RoutingTests(unittest.TestCase):
         self.assertIn(b'"code":"URLError"', body)
         self.assertIn(b'"upstream":"official"', body)
         self.assertTrue(fake.close_connection)
+
+    def test_official_passthrough_size_limit_preserves_typed_terminal_failure(self):
+        fake = FakeHandler()
+        usage_capture = {}
+        secret = b"oversized-frame-secret"
+        prefix = b"data: "
+        oversized_frame = (
+            prefix
+            + (b"x" * (DEFAULT_MAX_FRAME_BYTES + 1 - len(prefix) - len(secret)))
+            + secret
+        )
+
+        with patch("codex_proxy.write_proxy_event") as write_event:
+            status = CodexProxyHandler._relay_upstream_response(
+                fake,
+                FakeSseResponse([oversized_frame, b""]),
+                "official",
+                request_id="req-size-limit",
+                model="gpt-5.5",
+                upstream_format="responses",
+                inbound_format="responses",
+                caller_stream=True,
+                behavior_profile=codex_proxy.BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH,
+                usage_capture=usage_capture,
+            )
+
+        body = b"".join(fake.wfile.writes)
+        events = SseEventAssembler().feed(body)
+        failed_payload = json.loads(events[0].data)
+        closed_event = next(
+            call.kwargs
+            for call in write_event.call_args_list
+            if call.args and call.args[0] == "official_passthrough_stream_closed"
+        )
+
+        self.assertEqual(status, 502)
+        self.assertEqual(len(events), 1)
+        self.assertEqual(failed_payload["type"], "response.failed")
+        self.assertEqual(
+            failed_payload["response"]["error"]["code"],
+            "SseFrameTooLargeError",
+        )
+        self.assertNotIn(secret, body)
+        self.assertEqual(closed_event["error"], "SseFrameTooLargeError")
+        self.assertEqual(closed_event["failure_class"], "sse_frame_too_large")
+        self.assertTrue(usage_capture["synthetic_terminal_event_sent"])
 
     def test_official_passthrough_closes_unterminated_data_before_synthetic_failure(self):
         fake = FakeHandler()

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -9956,10 +9956,40 @@ class RoutingTests(unittest.TestCase):
 
         self.assertEqual(status, 502)
         self.assertEqual(len(events), 2)
-        self.assertEqual(events[0].raw, completed_cr_event)
+        self.assertEqual(events[0].raw, completed_cr_event + b"\n")
         self.assertEqual(events[0].data, b"first")
         self.assertEqual(failed_payload["type"], "response.failed")
         self.assertNotIn(secret, body)
+
+    def test_transparent_responses_cr_completion_preserves_response_id_on_interruption(self):
+        handler = FakeHandler()
+        response_id = "resp_cr_boundary"
+        completed_cr_event = (
+            b'data: {"type":"response.created","response":{"id":"'
+            + response_id.encode("ascii")
+            + b'"}}\r\r'
+        )
+
+        status = CodexProxyHandler._relay_upstream_response(
+            handler,
+            FakeSseResponse([completed_cr_event, URLError("connection reset")]),
+            "volcengine",
+            request_id="req_transparent_responses_cr_interruption",
+            model="volc/glm-5.2",
+            upstream_format="responses",
+            inbound_format="responses",
+            caller_stream=True,
+            behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+        )
+
+        events = SseEventAssembler().feed(b"".join(handler.wfile.writes))
+        failed_payload = json.loads(events[1].data)
+
+        self.assertEqual(status, 502)
+        self.assertEqual(len(events), 2)
+        self.assertEqual(events[0].raw, completed_cr_event + b"\n")
+        self.assertEqual(failed_payload["type"], "response.failed")
+        self.assertEqual(failed_payload["response"]["id"], response_id)
 
     def test_transparent_responses_stream_commit_ignores_interruption_after_terminal(self):
         handler = FakeHandler()

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -9871,6 +9871,56 @@ class RoutingTests(unittest.TestCase):
         self.assertTrue(closed_event["synthetic_terminal_event_sent"])
         self.assertEqual(closed_event["synthetic_terminal_event_type"], "response.failed")
 
+    def test_transparent_responses_size_limit_writes_typed_synthetic_terminal(self):
+        handler = FakeHandler()
+        handler._downstream_stream_commit = codex_proxy._GatewayDownstreamStreamCommit(
+            handler,
+            None,
+            "volcengine",
+            model="volc/glm-5.2",
+            request_id="req_transparent_responses_size_limit",
+            inbound_format="responses",
+            upstream_format="responses",
+            max_frame_bytes=64,
+        )
+        secret = b"transparent-responses-secret"
+        usage_capture = {}
+
+        status = CodexProxyHandler._relay_upstream_response(
+            handler,
+            FakeSseResponse([b"data: " + (b"x" * 64) + secret, b""]),
+            "volcengine",
+            request_id="req_transparent_responses_size_limit",
+            model="volc/glm-5.2",
+            upstream_format="responses",
+            inbound_format="responses",
+            caller_stream=True,
+            behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+            usage_capture=usage_capture,
+        )
+
+        body = b"".join(handler.wfile.writes)
+        events = SseEventAssembler().feed(body)
+        failed_payload = json.loads(events[0].data)
+        closed_event = next(
+            call.kwargs
+            for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] == "transparent_stream_closed"
+        )
+
+        self.assertEqual(status, 502)
+        self.assertEqual(handler.status, 200)
+        self.assertEqual(len(events), 1)
+        self.assertEqual(failed_payload["type"], "response.failed")
+        self.assertEqual(
+            failed_payload["response"]["error"]["code"],
+            "SseFrameTooLargeError",
+        )
+        self.assertNotIn(secret, body)
+        self.assertEqual(closed_event["failure_class"], "sse_frame_too_large")
+        self.assertTrue(closed_event["synthetic_terminal_event_sent"])
+        self.assertTrue(usage_capture["synthetic_terminal_event_sent"])
+
     def test_transparent_responses_stream_commit_ignores_interruption_after_terminal(self):
         handler = FakeHandler()
         response = FakeSseResponse(
@@ -9972,6 +10022,49 @@ class RoutingTests(unittest.TestCase):
         )
         self.assertFalse(closed_event["synthetic_terminal_event_sent"])
         self.assertEqual(closed_event["failure_class"], "upstream_stream_interrupted")
+
+    def test_transparent_chat_size_limit_closes_without_synthetic_terminal(self):
+        handler = FakeHandler()
+        handler._downstream_stream_commit = codex_proxy._GatewayDownstreamStreamCommit(
+            handler,
+            None,
+            "ollama_cloud",
+            model="ollama-cloud/glm-5.2",
+            request_id="req_transparent_chat_size_limit",
+            inbound_format="chat_completions",
+            upstream_format="chat_completions",
+            max_frame_bytes=64,
+        )
+        secret = b"transparent-chat-secret"
+        usage_capture = {}
+
+        status = CodexProxyHandler._relay_upstream_response(
+            handler,
+            FakeSseResponse([b"data: " + (b"x" * 64) + secret, b""]),
+            "ollama_cloud",
+            request_id="req_transparent_chat_size_limit",
+            model="ollama-cloud/glm-5.2",
+            upstream_format="chat_completions",
+            inbound_format="chat_completions",
+            caller_stream=True,
+            behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+            usage_capture=usage_capture,
+        )
+
+        body = b"".join(handler.wfile.writes)
+        closed_event = next(
+            call.kwargs
+            for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] == "transparent_stream_closed"
+        )
+
+        self.assertEqual(status, 502)
+        self.assertEqual(handler.status, 200)
+        self.assertEqual(body, b"")
+        self.assertNotIn(secret, body)
+        self.assertEqual(closed_event["failure_class"], "sse_frame_too_large")
+        self.assertFalse(closed_event["synthetic_terminal_event_sent"])
+        self.assertFalse(usage_capture["synthetic_terminal_event_sent"])
 
     def test_transparent_chat_ignores_responses_type_in_extension_field(self):
         handler = FakeHandler()

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -15,6 +15,7 @@ from urllib.error import HTTPError, URLError
 
 import catalog_sync
 import codex_proxy
+from sse_events import SseEventAssembler
 from subagent_state import build_subagent_state
 from codex_proxy import (
     CodexProxyHandler,
@@ -2131,6 +2132,32 @@ class RoutingTests(unittest.TestCase):
         self.assertIn(b'"code":"URLError"', body)
         self.assertIn(b'"upstream":"official"', body)
         self.assertTrue(fake.close_connection)
+
+    def test_official_passthrough_closes_unterminated_data_before_synthetic_failure(self):
+        fake = FakeHandler()
+        partial = b'data: {"type":"response.created","response":{"id":"resp_partial"}}'
+
+        status = CodexProxyHandler._relay_upstream_response(
+            fake,
+            FakeSseResponse([partial, URLError("connection reset")]),
+            "official",
+            request_id="req-partial-before-failure",
+            model="gpt-5.5",
+            upstream_format="responses",
+            inbound_format="responses",
+            caller_stream=True,
+            behavior_profile=codex_proxy.BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH,
+            usage_capture={},
+        )
+
+        body = b"".join(fake.wfile.writes)
+        events = SseEventAssembler().feed(body)
+        self.assertEqual(status, 502)
+        self.assertEqual(
+            [json.loads(event.data)["type"] for event in events],
+            ["response.created", "response.failed"],
+        )
+        self.assertIn(partial + b"\n\nevent: response.failed\n", body)
 
     def test_official_passthrough_ignores_stream_error_after_completed_event(self):
         fake = FakeHandler()

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1902,6 +1902,75 @@ class RoutingTests(unittest.TestCase):
             ],
         )
 
+    def test_passthrough_semantics_wait_for_a_complete_sse_event(self):
+        stats = codex_proxy.PassthroughSseSemanticStats()
+
+        stats.observe_bytes(
+            b"event: response.completed\r\n"
+            b'data: {"type":"response.completed","response":{"id":"resp_complete"}}\r\n'
+        )
+
+        self.assertEqual(stats.fields()["sse_events_streamed"], 0)
+        self.assertEqual(stats.fields()["sse_json_events_streamed"], 0)
+        self.assertFalse(stats.terminal_event_seen)
+
+        stats.observe_bytes(b"\r\n")
+
+        self.assertEqual(stats.fields()["sse_events_streamed"], 1)
+        self.assertEqual(stats.fields()["sse_json_events_streamed"], 1)
+        self.assertTrue(stats.terminal_event_seen)
+        self.assertEqual(stats.response_id, "resp_complete")
+
+    def test_passthrough_semantics_report_and_discard_incomplete_eof(self):
+        stats = codex_proxy.PassthroughSseSemanticStats()
+        stats.observe_bytes(b'data: {"type":"response.completed"}\r\n')
+
+        stats.finalize_pending()
+        fields = stats.fields()
+
+        self.assertEqual(fields["sse_events_streamed"], 0)
+        self.assertEqual(fields["sse_json_events_streamed"], 0)
+        self.assertFalse(fields["sse_terminal_event_seen"])
+        self.assertEqual(fields["sse_eof_disposition"], "incomplete")
+        self.assertEqual(fields["sse_incomplete_bytes_discarded"], 37)
+
+    def test_official_passthrough_preserves_fragmented_metadata_event_bytes(self):
+        fake = FakeHandler()
+        usage_capture = {}
+        raw = (
+            b": keepalive \xff\r\n"
+            b"event: response.completed\r\n"
+            b'data: {"type":"response.completed",\r\n'
+            b'data: "response":{"id":"resp_chunked","status":"completed"}}\r\n'
+            b"id: 7\r\n"
+            b"\r\n"
+        )
+        split_points = (1, 13, 37, 64, len(raw) - 1)
+        chunks = [
+            raw[start:end]
+            for start, end in zip((0, *split_points), (*split_points, len(raw)))
+        ]
+
+        status = CodexProxyHandler._relay_upstream_response(
+            fake,
+            FakeSseResponse([*chunks, b""]),
+            "official",
+            request_id="req-fragmented-semantics",
+            model="gpt-5.5",
+            upstream_format="responses",
+            inbound_format="responses",
+            caller_stream=True,
+            behavior_profile=codex_proxy.BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH,
+            usage_capture=usage_capture,
+        )
+
+        self.assertEqual(status, 200)
+        self.assertEqual(b"".join(fake.wfile.writes), raw)
+        self.assertEqual(usage_capture["sse_events_streamed"], 1)
+        self.assertEqual(usage_capture["sse_json_events_streamed"], 1)
+        self.assertTrue(usage_capture["sse_terminal_event_seen"])
+        self.assertEqual(usage_capture["sse_last_event_type"], "response.completed")
+
     def test_official_http_passthrough_raw_relay_even_when_caller_stream_false(self):
         fake = FakeHandler()
         response = FakeSseResponse(

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -9923,6 +9923,44 @@ class RoutingTests(unittest.TestCase):
         self.assertTrue(closed_event["synthetic_terminal_event_sent"])
         self.assertTrue(usage_capture["synthetic_terminal_event_sent"])
 
+    def test_transparent_responses_size_limit_preserves_completed_cr_event_sequence(self):
+        handler = FakeHandler()
+        handler._downstream_stream_commit = codex_proxy._GatewayDownstreamStreamCommit(
+            handler,
+            None,
+            "volcengine",
+            model="volc/glm-5.2",
+            request_id="req_transparent_responses_cr_size_limit",
+            inbound_format="responses",
+            upstream_format="responses",
+            max_frame_bytes=64,
+        )
+        completed_cr_event = b"data: first\r\r"
+        secret = b"transparent-cr-secret"
+
+        status = CodexProxyHandler._relay_upstream_response(
+            handler,
+            FakeSseResponse([completed_cr_event, (b"x" * 64) + secret, b""]),
+            "volcengine",
+            request_id="req_transparent_responses_cr_size_limit",
+            model="volc/glm-5.2",
+            upstream_format="responses",
+            inbound_format="responses",
+            caller_stream=True,
+            behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+        )
+
+        body = b"".join(handler.wfile.writes)
+        events = SseEventAssembler().feed(body)
+        failed_payload = json.loads(events[1].data)
+
+        self.assertEqual(status, 502)
+        self.assertEqual(len(events), 2)
+        self.assertEqual(events[0].raw, completed_cr_event)
+        self.assertEqual(events[0].data, b"first")
+        self.assertEqual(failed_payload["type"], "response.failed")
+        self.assertNotIn(secret, body)
+
     def test_transparent_responses_stream_commit_ignores_interruption_after_terminal(self):
         handler = FakeHandler()
         response = FakeSseResponse(

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -9884,11 +9884,12 @@ class RoutingTests(unittest.TestCase):
             max_frame_bytes=64,
         )
         secret = b"transparent-responses-secret"
+        forwarded_prefix = b"data: " + (b"x" * 40)
         usage_capture = {}
 
         status = CodexProxyHandler._relay_upstream_response(
             handler,
-            FakeSseResponse([b"data: " + (b"x" * 64) + secret, b""]),
+            FakeSseResponse([forwarded_prefix, (b"y" * 24) + secret, b""]),
             "volcengine",
             request_id="req_transparent_responses_size_limit",
             model="volc/glm-5.2",
@@ -9901,7 +9902,7 @@ class RoutingTests(unittest.TestCase):
 
         body = b"".join(handler.wfile.writes)
         events = SseEventAssembler().feed(body)
-        failed_payload = json.loads(events[0].data)
+        failed_payload = json.loads(events[1].data)
         closed_event = next(
             call.kwargs
             for call in self.write_proxy_event.call_args_list
@@ -9910,7 +9911,8 @@ class RoutingTests(unittest.TestCase):
 
         self.assertEqual(status, 502)
         self.assertEqual(handler.status, 200)
-        self.assertEqual(len(events), 1)
+        self.assertEqual(len(events), 2)
+        self.assertEqual(events[0].raw, forwarded_prefix + b"\n\n")
         self.assertEqual(failed_payload["type"], "response.failed")
         self.assertEqual(
             failed_payload["response"]["error"]["code"],

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1,3 +1,4 @@
+import gc
 import os
 import gzip
 import io
@@ -7,6 +8,7 @@ import tempfile
 import threading
 import time
 import unittest
+import weakref
 from dataclasses import replace
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -15,7 +17,7 @@ from urllib.error import HTTPError, URLError
 
 import catalog_sync
 import codex_proxy
-from sse_events import DEFAULT_MAX_FRAME_BYTES, SseEventAssembler
+from sse_events import DEFAULT_MAX_FRAME_BYTES, SseEventAssembler, SseFrameTooLargeError
 from subagent_state import build_subagent_state
 from codex_proxy import (
     CodexProxyHandler,
@@ -1934,6 +1936,25 @@ class RoutingTests(unittest.TestCase):
         self.assertFalse(fields["sse_terminal_event_seen"])
         self.assertEqual(fields["sse_eof_disposition"], "incomplete")
         self.assertEqual(fields["sse_incomplete_bytes_discarded"], 37)
+
+    def test_passthrough_semantics_releases_size_limit_exception_traceback(self):
+        stats = codex_proxy.PassthroughSseSemanticStats(max_frame_bytes=8)
+
+        def capture_failure():
+            try:
+                stats.observe_bytes(b"data: private")
+            except SseFrameTooLargeError as exc:
+                return weakref.ref(exc)
+            self.fail("expected the frame size limit to fail closed")
+
+        failure_ref = capture_failure()
+        gc.collect()
+
+        self.assertIsNone(failure_ref())
+        self.assertEqual(stats.pending_completion_bytes(), b"")
+        stats.observe_bytes(b"data: ignored")
+        stats.finalize_pending()
+        self.assertEqual(stats.fields()["sse_events_streamed"], 0)
 
     def test_official_passthrough_preserves_fragmented_metadata_event_bytes(self):
         fake = FakeHandler()

--- a/tests/test_sse_events.py
+++ b/tests/test_sse_events.py
@@ -100,6 +100,16 @@ class SseEventAssemblerTests(unittest.TestCase):
         self.assertEqual(event.lines[-1].value, b"")
         self.assertEqual(tuple(line.raw for line in event.lines), tuple(raw.splitlines(keepends=True)[:-1]))
 
+    def test_oversized_numeric_retry_is_ignored_without_blocking_a_later_valid_value(self):
+        oversized_retry = b"9" * 5000
+        raw = b"retry:" + oversized_retry + b"\nretry: 1500\ndata: ok\n\n"
+
+        event = SseEventAssembler().feed(raw)[0]
+
+        self.assertEqual(event.raw, raw)
+        self.assertEqual(event.retry, 1500)
+        self.assertEqual(event.data, b"ok")
+
     def test_empty_events_are_emitted_and_multiple_frames_release_storage(self):
         assembler = SseEventAssembler()
 
@@ -141,6 +151,14 @@ class SseEventAssemblerTests(unittest.TestCase):
             assembler.feed(b"\n\n")
         self.assertEqual(closed.exception.disposition, "size_limit")
 
+    def test_size_limit_applies_to_each_frame_not_the_whole_input_chunk(self):
+        assembler = SseEventAssembler(max_frame_bytes=8)
+
+        events = assembler.feed(b"data:a\n\ndata:b\n\n")
+
+        self.assertEqual([event.data for event in events], [b"a", b"b"])
+        self.assertEqual(assembler.buffered_bytes, 0)
+
     def test_cancel_and_reset_have_bounded_deterministic_outcomes(self):
         assembler = SseEventAssembler()
         assembler.feed(b"data: secret")
@@ -167,6 +185,17 @@ class SseEventAssemblerTests(unittest.TestCase):
 
         self.assertEqual(len(events), 1)
         self.assertEqual(events[0].data, payload)
+        self.assertEqual(assembler.buffered_bytes, 0)
+
+    def test_many_short_lines_in_one_chunk_assemble_as_one_frame(self):
+        line_count = 8192
+        assembler = SseEventAssembler()
+
+        events = assembler.feed((b"data:x\n" * line_count) + b"\n")
+
+        self.assertEqual(len(events), 1)
+        self.assertEqual(len(events[0].lines), line_count)
+        self.assertEqual(events[0].data.count(b"\n"), line_count - 1)
         self.assertEqual(assembler.buffered_bytes, 0)
 
 

--- a/tests/test_sse_events.py
+++ b/tests/test_sse_events.py
@@ -133,6 +133,28 @@ class SseEventAssemblerTests(unittest.TestCase):
             assembler.feed(b"\r\n")
         self.assertEqual(raised.exception.disposition, "incomplete")
 
+    def test_completion_bytes_are_exact_across_line_endings_and_split_crlf(self):
+        cases = (
+            ("partial_line", (b"data: ok",), b"\n\n"),
+            ("lf_line", (b"data: ok\n",), b"\n"),
+            ("lf_event", (b"data: ok\n\n",), b""),
+            ("crlf_line", (b"data: ok\r\n",), b"\n"),
+            ("crlf_event", (b"data: ok\r\n\r\n",), b""),
+            ("cr_line", (b"data: ok\r",), b"\r"),
+            ("split_crlf_line", (b"data: ok\r", b"\n"), b"\n"),
+            ("cr_event", (b"data: ok\r\r",), b""),
+            ("split_consecutive_cr_event", (b"data: ok\r", b"\r"), b""),
+            ("empty_cr_event", (b"\r",), b""),
+        )
+
+        for name, chunks, expected in cases:
+            with self.subTest(name=name):
+                assembler = SseEventAssembler()
+                for chunk in chunks:
+                    assembler.feed(chunk)
+
+                self.assertEqual(assembler.completion_bytes(), expected)
+
     def test_size_limit_fails_closed_with_counts_only(self):
         self.assertEqual(DEFAULT_MAX_FRAME_BYTES, 16 * 1024 * 1024)
         assembler = SseEventAssembler(max_frame_bytes=12)

--- a/tests/test_sse_events.py
+++ b/tests/test_sse_events.py
@@ -140,11 +140,11 @@ class SseEventAssemblerTests(unittest.TestCase):
             ("lf_event", (b"data: ok\n\n",), b""),
             ("crlf_line", (b"data: ok\r\n",), b"\n"),
             ("crlf_event", (b"data: ok\r\n\r\n",), b""),
-            ("cr_line", (b"data: ok\r",), b"\r"),
+            ("cr_line", (b"data: ok\r",), b"\r\n"),
             ("split_crlf_line", (b"data: ok\r", b"\n"), b"\n"),
-            ("cr_event", (b"data: ok\r\r",), b""),
-            ("split_consecutive_cr_event", (b"data: ok\r", b"\r"), b""),
-            ("empty_cr_event", (b"\r",), b""),
+            ("cr_event", (b"data: ok\r\r",), b"\n"),
+            ("split_consecutive_cr_event", (b"data: ok\r", b"\r"), b"\n"),
+            ("empty_cr_event", (b"\r",), b"\n"),
         )
 
         for name, chunks, expected in cases:

--- a/tests/test_sse_events.py
+++ b/tests/test_sse_events.py
@@ -1,0 +1,174 @@
+import unittest
+
+from sse_events import (
+    DEFAULT_MAX_FRAME_BYTES,
+    SseAssemblerClosedError,
+    SseEventAssembler,
+    SseFrameTooLargeError,
+)
+
+
+class SseEventAssemblerTests(unittest.TestCase):
+    def test_complete_event_is_emitted_with_exact_raw_bytes(self):
+        assembler = SseEventAssembler()
+
+        self.assertEqual(assembler.feed(b"data: {\"type\":"), ())
+        events = assembler.feed(b"\"response.created\"}\r\n\r\n")
+
+        self.assertEqual(len(events), 1)
+        self.assertEqual(
+            events[0].raw,
+            b'data: {"type":"response.created"}\r\n\r\n',
+        )
+        self.assertEqual(events[0].data, b'{"type":"response.created"}')
+
+    def test_semantics_are_invariant_across_line_endings_and_chunk_boundaries(self):
+        for ending in (b"\n", b"\r\n", b"\r"):
+            raw = ending.join(
+                (
+                    b": keepalive",
+                    b"event: update",
+                    b"id:evt-7",
+                    b"retry: 1500",
+                    b"data:first",
+                    b"data: second",
+                    b"x-extension: opaque",
+                    b"",
+                    b"",
+                )
+            )
+            expected_line_kinds = (
+                "comment",
+                "field",
+                "field",
+                "field",
+                "field",
+                "field",
+                "field",
+            )
+            partitions = (
+                (raw,),
+                tuple(bytes((byte,)) for byte in raw),
+                (raw[:1], raw[1:]),
+                (raw[:-1], raw[-1:]),
+            )
+            if ending == b"\r\n":
+                split_crlf = raw.index(b"\r\n") + 1
+                partitions += ((raw[:split_crlf], raw[split_crlf:]),)
+
+            for chunks in partitions:
+                with self.subTest(ending=ending, chunk_lengths=tuple(map(len, chunks))):
+                    assembler = SseEventAssembler()
+                    events = ()
+                    for chunk in chunks:
+                        emitted = assembler.feed(chunk)
+                        self.assertFalse(events and emitted)
+                        events += emitted
+                    events += assembler.finish().events
+
+                    self.assertEqual(len(events), 1)
+                    event = events[0]
+                    self.assertEqual(event.raw, raw)
+                    self.assertEqual(event.data, b"first\nsecond")
+                    self.assertEqual(event.event, b"update")
+                    self.assertEqual(event.id, b"evt-7")
+                    self.assertEqual(event.retry, 1500)
+                    self.assertEqual(
+                        tuple(line.kind for line in event.lines),
+                        expected_line_kinds,
+                    )
+                    self.assertEqual(event.lines[-1].name, b"x-extension")
+                    self.assertEqual(event.lines[-1].value, b"opaque")
+
+    def test_bom_malformed_fields_and_invalid_utf8_remain_lossless(self):
+        raw = (
+            b"\xef\xbb\xbfdata:  first\r\n"
+            b"data:\xff\r\n"
+            b"id: ignored\0id\r\n"
+            b"retry: 12ms\r\n"
+            b"field-without-colon\r\n"
+            b"\r\n"
+        )
+
+        event = SseEventAssembler().feed(raw)[0]
+
+        self.assertEqual(event.raw, raw)
+        self.assertEqual(event.data, b" first\n\xff")
+        self.assertIsNone(event.id)
+        self.assertIsNone(event.retry)
+        self.assertEqual(event.lines[-1].name, b"field-without-colon")
+        self.assertEqual(event.lines[-1].value, b"")
+        self.assertEqual(tuple(line.raw for line in event.lines), tuple(raw.splitlines(keepends=True)[:-1]))
+
+    def test_empty_events_are_emitted_and_multiple_frames_release_storage(self):
+        assembler = SseEventAssembler()
+
+        events = assembler.feed(b"\n\ndata: one\n\ndata: two\n\n")
+
+        self.assertEqual([event.raw for event in events], [b"\n", b"\n", b"data: one\n\n", b"data: two\n\n"])
+        self.assertEqual([event.data for event in events], [b"", b"", b"one", b"two"])
+        self.assertEqual(assembler.buffered_bytes, 0)
+
+    def test_eof_discards_incomplete_frame_without_emitting_it(self):
+        assembler = SseEventAssembler()
+        self.assertEqual(assembler.feed(b"data: {\"type\":\"response.completed\"}\r\n"), ())
+
+        termination = assembler.finish()
+
+        self.assertEqual(termination.events, ())
+        self.assertEqual(termination.disposition, "incomplete")
+        self.assertEqual(termination.discarded_bytes, 37)
+        self.assertEqual(assembler.buffered_bytes, 0)
+        with self.assertRaises(SseAssemblerClosedError) as raised:
+            assembler.feed(b"\r\n")
+        self.assertEqual(raised.exception.disposition, "incomplete")
+
+    def test_size_limit_fails_closed_with_counts_only(self):
+        self.assertEqual(DEFAULT_MAX_FRAME_BYTES, 16 * 1024 * 1024)
+        assembler = SseEventAssembler(max_frame_bytes=12)
+        secret = b"data: SECRET"
+
+        with self.assertRaises(SseFrameTooLargeError) as raised:
+            assembler.feed(secret + b"!")
+
+        error = raised.exception
+        self.assertEqual(error.classification, "sse_frame_too_large")
+        self.assertEqual(error.pending_bytes, 13)
+        self.assertEqual(error.max_frame_bytes, 12)
+        self.assertNotIn("SECRET", str(error))
+        self.assertEqual(assembler.buffered_bytes, 0)
+        with self.assertRaises(SseAssemblerClosedError) as closed:
+            assembler.feed(b"\n\n")
+        self.assertEqual(closed.exception.disposition, "size_limit")
+
+    def test_cancel_and_reset_have_bounded_deterministic_outcomes(self):
+        assembler = SseEventAssembler()
+        assembler.feed(b"data: secret")
+
+        cancelled = assembler.cancel()
+        self.assertEqual(cancelled.disposition, "cancelled")
+        self.assertEqual(cancelled.discarded_bytes, 12)
+        self.assertEqual(cancelled.events, ())
+        with self.assertRaises(SseAssemblerClosedError):
+            assembler.feed(b"\n\n")
+
+        reset = assembler.reset()
+        self.assertEqual(reset.disposition, "reset")
+        self.assertEqual(reset.discarded_bytes, 0)
+        self.assertEqual(assembler.feed(b"data: ready\n\n")[0].data, b"ready")
+
+    def test_long_line_remains_chunk_invariant_under_one_byte_fragmentation(self):
+        payload = b"x" * (64 * 1024)
+        assembler = SseEventAssembler()
+
+        events = ()
+        for byte in b"data: " + payload + b"\n\n":
+            events += assembler.feed(bytes((byte,)))
+
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].data, payload)
+        self.assertEqual(assembler.buffered_bytes, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add one byte-oriented SSE event assembler with lossless raw frames and bounded semantic fields
- migrate passthrough semantic stats to observe only complete frames while preserving counters and response identity
- cover adversarial chunking, line endings, metadata, malformed fields, EOF, cancellation, reset, and the 16 MiB limit

Closes #224

<!-- orchestrator:delivery:v1 -->
```json
{"contract_sha256":"100801246f6796ceddd42c76beeb4d9bf614a267becd44d36c178239e7342622","candidate_sha":"11c56e2ad9bdb37a1906a50d5be1791d21139a01","changed_paths":["src-python/codex_proxy.py","src-python/sse_events.py","tests/test_routing.py","tests/test_sse_events.py"],"tdd":{"red":"Focused regressions exposed closed-assembler masking, transparent-route size-limit asymmetry, synthetic-terminal frame adhesion, CR completion identity loss, same-feed size-crossing identity loss, and retained size-error tracebacks.","green":"The frozen candidate passed the final affected matrix with 15 tests and 23 line-ending subtests while preserving typed failures, exact SSE event sequences, response identity, and bounded privacy behavior.","refactor":"The Gateway retains one SSE assembler, at most a completion suffix for recovery, and counts-only terminal state; rejected payloads and exception tracebacks are not retained."},"verification":["python -m pytest -q tests/test_sse_events.py tests/test_routing.py: 517 passed, 137 subtests passed before focused review deltas","python -m pytest -q tests/test_protocol_translation.py on the earlier reviewed candidate: 60 passed, 112 subtests passed","named affected SSE assembler and routing nodes on frozen candidate: 15 passed, 23 subtests passed","python -m py_compile src-python/codex_proxy.py src-python/sse_events.py tests/test_routing.py: passed","git diff --check: passed","independent Standards review: PASS on 11c56e2ad9bdb37a1906a50d5be1791d21139a01","independent strict Spec review: PASS on 11c56e2ad9bdb37a1906a50d5be1791d21139a01","python scripts/report_quality_gates.py: report-only baseline findings; no new named finding from this change","static assembler audit: one production SseEventAssembler definition and one Gateway consumer"],"deviations":[],"risks":[]}
```