### PR TITLE
Parse converted streams at complete SSE event boundaries

### DIFF
--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -13003,6 +13003,7 @@ class _GatewayDownstreamStreamCommit:
         self._last_upstream_byte_at: float | None = None
         self._last_write_error: OSError | None = None
         self._last_successful_completion_bytes = b""
+        self._headers_committed = False
         self._ensure_headers_committed_callback: Callable[[], bool] | None = None
 
     @property
@@ -13059,9 +13060,14 @@ class _GatewayDownstreamStreamCommit:
         self,
         callback: Callable[[], bool] | None,
     ) -> None:
-        self._ensure_headers_committed_callback = callback
+        self._ensure_headers_committed_callback = (
+            None if self._headers_committed else callback
+        )
 
     def _ensure_headers_committed_before_write(self) -> bool:
+        if self._headers_committed:
+            self._ensure_headers_committed_callback = None
+            return True
         callback = self._ensure_headers_committed_callback
         if callback is None:
             return True
@@ -13170,9 +13176,14 @@ class _GatewayDownstreamStreamCommit:
         """Authorize and record the sending of HTTP response headers.
 
         ``send_headers`` is called only when the stream is still open and no
-        terminal has been committed. Any OSError is captured, closes the owned
-        upstream work, and seals the downstream side.
+        terminal has been committed. A successful commit owns the one allowed
+        header block and disarms any deferred header callback. Later header
+        requests are successful no-ops. Any OSError is captured, closes the
+        owned upstream work, and seals the downstream side.
         """
+        if self._headers_committed:
+            self._ensure_headers_committed_callback = None
+            return True
         if self._downstream_closed or self._terminal_committed:
             return False
         try:
@@ -13181,6 +13192,8 @@ class _GatewayDownstreamStreamCommit:
             self._last_write_error = write_exc
             self.close()
             return False
+        self._headers_committed = True
+        self._ensure_headers_committed_callback = None
         return True
 
     def commit_sse_bytes(self, data: bytes, *, observe: bool = True) -> bool:

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -16336,10 +16336,20 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 event_context=event_context,
                 defer_stream_errors=defer_stream_errors,
             )
+        defer_verified_final_conversion_headers = (
+            is_event_stream
+            and caller_stream
+            and verified_source_format == "responses"
+            and want_chat_output
+            and behavior_profile != BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED
+        )
         defer_stream_headers = (
             is_event_stream
             and caller_stream
-            and lifecycle_empty_final_resample_enabled(event_context, request_kind)
+            and (
+                lifecycle_empty_final_resample_enabled(event_context, request_kind)
+                or defer_verified_final_conversion_headers
+            )
         )
 
         def finish_downstream_stream_closed(exc: OSError) -> int:
@@ -17176,6 +17186,10 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         stream_idle_phase=exc.phase,
                         detail=safe_upstream_error_detail(exc),
                     )
+                    if not send_downstream_response_headers_once():
+                        return finish_downstream_stream_closed(
+                            seam.last_write_error() or OSError("downstream closed")
+                        )
                     if not self._write_downstream_sse_error(
                         inbound_format=inbound_format,
                         upstream_name=upstream_name,
@@ -17205,6 +17219,10 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         error=type(exc).__name__,
                         detail=safe_upstream_error_detail(exc),
                     )
+                    if not send_downstream_response_headers_once():
+                        return finish_downstream_stream_closed(
+                            seam.last_write_error() or OSError("downstream closed")
+                        )
                     if not self._write_downstream_sse_error(
                         inbound_format=inbound_format,
                         upstream_name=upstream_name,
@@ -17238,6 +17256,10 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         upstream_format=upstream_format,
                         inbound_format=inbound_format,
                     )
+                    if not send_downstream_response_headers_once():
+                        return finish_downstream_stream_closed(
+                            seam.last_write_error() or OSError("downstream closed")
+                        )
                     if not self._write_downstream_sse_error(
                         inbound_format=inbound_format,
                         upstream_name=upstream_name,
@@ -17251,13 +17273,24 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                     _capture_usage(usage_capture, None, missing_reason="stream_incomplete")
                     return 502
 
+                try:
+                    converted_chat_chunks = _chat_completion_body_to_stream_chunks(
+                        _response_body_to_chat_completion_body(response_body)
+                    )
+                except UpstreamProtocolTranslationError:
+                    if verified_source_format is None:
+                        raise
+                    return finish_converted_sse_semantic_error(
+                        _verified_converted_sse_semantic_error(
+                            verified_source_format
+                        )
+                    )
+
                 if not send_downstream_response_headers_once():
                     return finish_downstream_stream_closed(
                         seam.last_write_error() or OSError("downstream closed")
                     )
-                for chunk in _chat_completion_body_to_stream_chunks(
-                    _response_body_to_chat_completion_body(response_body)
-                ):
+                for chunk in converted_chat_chunks:
                     if not self._write_sse_data(chunk):
                         return finish_downstream_stream_closed(
                             seam.last_write_error() or OSError("downstream closed")

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -2726,6 +2726,23 @@ class UpstreamSseSemanticError(ValueError):
     """A complete converted SSE frame is not valid source-protocol JSON."""
 
 
+def _verified_cross_protocol_source_format(
+    *,
+    behavior_profile: str | None,
+    upstream_format: str,
+    inbound_format: str,
+) -> str | None:
+    if upstream_format == inbound_format:
+        return None
+    if behavior_profile not in {
+        BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+        BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH,
+        BEHAVIOR_OFFICIAL_GATEWAY_COMPAT,
+    }:
+        return None
+    return upstream_format
+
+
 def _verified_converted_sse_semantic_error(
     source_format: str,
 ) -> UpstreamSseSemanticError:
@@ -2762,6 +2779,21 @@ def _validate_verified_converted_sse_payload(
             if not isinstance(details, Mapping):
                 invalid_shape()
             if any(type(count) is not int for count in details.values()):
+                invalid_shape()
+
+    def validate_error_envelope(error: Any) -> None:
+        if isinstance(error, str):
+            if not error:
+                invalid_shape()
+            return
+        if not isinstance(error, Mapping):
+            invalid_shape()
+        message = error.get("message")
+        if not isinstance(message, str) or not message:
+            invalid_shape()
+        if "code" in error:
+            code = error.get("code")
+            if code is not None and type(code) not in {str, int}:
                 invalid_shape()
 
     if source_format == "responses":
@@ -2840,6 +2872,14 @@ def _validate_verified_converted_sse_payload(
                         "output_tokens_details",
                     ),
                 )
+            if event_type == "response.failed":
+                if "error" not in response:
+                    invalid_shape()
+                validate_error_envelope(response.get("error"))
+        elif event_type == "error":
+            if "error" not in payload:
+                invalid_shape()
+            validate_error_envelope(payload.get("error"))
         elif event_type == "response.output_text.delta":
             if not isinstance(payload.get("delta"), str):
                 invalid_shape()
@@ -2854,17 +2894,25 @@ def _validate_verified_converted_sse_payload(
         }:
             validate_output_item(payload.get("item"))
         elif event_type == "response.function_call_arguments.delta":
-            if not isinstance(payload.get("delta"), str):
+            if (
+                not isinstance(payload.get("item_id"), str)
+                or not isinstance(payload.get("delta"), str)
+            ):
                 invalid_shape()
         elif event_type == "response.function_call_arguments.done":
-            if not isinstance(payload.get("arguments"), str):
+            if (
+                not isinstance(payload.get("item_id"), str)
+                or not isinstance(payload.get("arguments"), str)
+            ):
                 invalid_shape()
         return
     if source_format != "chat_completions":
         return
     choices = payload.get("choices")
-    if choices is None and "error" in payload:
-        return
+    if "error" in payload:
+        validate_error_envelope(payload.get("error"))
+        if choices is None:
+            return
     if not isinstance(choices, list):
         invalid_shape()
     if "usage" in payload:
@@ -16223,13 +16271,10 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
         buffer_sse_to_json = is_event_stream and not caller_stream
         buffered_json_response = False
         buffered_chat_sse_to_responses = False
-        verified_source_format = (
-            upstream_format
-            if (
-                behavior_profile == BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED
-                and upstream_format != inbound_format
-            )
-            else None
+        verified_source_format = _verified_cross_protocol_source_format(
+            behavior_profile=behavior_profile,
+            upstream_format=upstream_format,
+            inbound_format=inbound_format,
         )
         usage_context = _usage_observed_context(
             event_context,
@@ -16364,6 +16409,33 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
             _capture_usage(usage_capture, None, missing_reason="stream_protocol_error")
             return 502
 
+        def buffered_protocol_error_body(
+            exc: UpstreamSseSemanticError | SseFrameTooLargeError,
+        ) -> bytes:
+            write_proxy_event(
+                "upstream_stream_protocol_error",
+                request_id=request_id,
+                model=model,
+                upstream=upstream_name,
+                status=502,
+                upstream_format=upstream_format,
+                inbound_format=inbound_format,
+                error=type(exc).__name__,
+                detail=str(exc),
+            )
+            return json.dumps(
+                _json_error_payload_for_inbound_format(
+                    inbound_format=inbound_format,
+                    upstream_name=upstream_name,
+                    status=502,
+                    error="upstream_protocol_error",
+                    detail=str(exc),
+                    error_type="upstream_protocol_error",
+                ),
+                ensure_ascii=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+
         headers_sent = headers_already_sent
         if not is_event_stream or buffer_sse_to_json:
             converted_stream_failure = False
@@ -16372,33 +16444,6 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 events: list[Mapping[str, Any]] = []
                 chat_chunks: list[Mapping[str, Any] | str] = []
                 incomplete_frame = False
-
-                def buffered_protocol_error_body(
-                    exc: UpstreamSseSemanticError | SseFrameTooLargeError,
-                ) -> bytes:
-                    write_proxy_event(
-                        "upstream_stream_protocol_error",
-                        request_id=request_id,
-                        model=model,
-                        upstream=upstream_name,
-                        status=502,
-                        upstream_format=upstream_format,
-                        inbound_format=inbound_format,
-                        error=type(exc).__name__,
-                        detail=str(exc),
-                    )
-                    return json.dumps(
-                        _json_error_payload_for_inbound_format(
-                            inbound_format=inbound_format,
-                            upstream_name=upstream_name,
-                            status=502,
-                            error="upstream_protocol_error",
-                            detail=str(exc),
-                            error_type="upstream_protocol_error",
-                        ),
-                        ensure_ascii=True,
-                        separators=(",", ":"),
-                    ).encode("utf-8")
 
                 try:
                     for frame in self._iter_upstream_sse_events(
@@ -16494,43 +16539,62 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         raise UpstreamStreamInterruptedError(exc) from exc
                     raise
             upstream_body_for_usage = body
-            if converted_stream_failure:
-                pass
-            elif want_chat_output:
-                if upstream_format == "chat_completions":
-                    body = _response_body_to_chat_completion_body(
-                        compatible_response_body(
-                            _chat_completion_to_response_body(body),
+            try:
+                if converted_stream_failure:
+                    pass
+                elif want_chat_output:
+                    if upstream_format == "chat_completions":
+                        body = _response_body_to_chat_completion_body(
+                            compatible_response_body(
+                                _chat_completion_to_response_body(body),
+                                upstream_name,
+                                event_context=compatibility_event_context,
+                            )
+                        )
+                    else:
+                        # Upstream returned Responses format; convert to Chat Completions.
+                        if behavior_profile == BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED:
+                            body = _response_body_to_chat_completion_body(body)
+                        else:
+                            body = _response_body_to_chat_completion_body(
+                                compatible_response_body(
+                                    body,
+                                    upstream_name,
+                                    event_context=compatibility_event_context,
+                                )
+                            )
+                elif upstream_format == "chat_completions":
+                    if buffered_chat_sse_to_responses:
+                        converted_body = body
+                    else:
+                        converted_body = _chat_completion_to_response_body(
+                            body,
+                            repair=behavior_profile != BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+                        )
+                    if behavior_profile == BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED:
+                        body = converted_body
+                    else:
+                        body = compatible_response_body(
+                            converted_body,
                             upstream_name,
                             event_context=compatibility_event_context,
                         )
-                    )
-                else:
-                    # Upstream returned Responses format; convert to Chat Completions.
-                    if behavior_profile == BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED:
-                        body = _response_body_to_chat_completion_body(body)
-                    else:
-                        body = _response_body_to_chat_completion_body(
-                            compatible_response_body(body, upstream_name, event_context=compatibility_event_context)
-                        )
-            elif upstream_format == "chat_completions":
-                if buffered_chat_sse_to_responses:
-                    converted_body = body
-                else:
-                    converted_body = _chat_completion_to_response_body(
-                        body,
-                        repair=behavior_profile != BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
-                    )
-                if behavior_profile == BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED:
-                    body = converted_body
                 else:
                     body = compatible_response_body(
-                        converted_body,
+                        body,
                         upstream_name,
                         event_context=compatibility_event_context,
                     )
-            else:
-                body = compatible_response_body(body, upstream_name, event_context=compatibility_event_context)
+            except UpstreamProtocolTranslationError:
+                if not buffer_sse_to_json or verified_source_format is None:
+                    raise
+                status = 502
+                converted_stream_failure = True
+                body = buffered_protocol_error_body(
+                    _verified_converted_sse_semantic_error(
+                        verified_source_format
+                    )
+                )
             if status >= 400:
                 body = _with_codexhub_http_error(
                     body,
@@ -16754,7 +16818,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         line_ending = _sse_line_ending(frame.raw)
                         payload = _converted_sse_payload(
                             frame,
-                            verified_source_format="responses",
+                            verified_source_format=verified_source_format,
                         )
                         if payload is None or payload == "[DONE]":
                             continue
@@ -16913,7 +16977,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                     ):
                         payload = _converted_sse_payload(
                             frame,
-                            verified_source_format="chat_completions",
+                            verified_source_format=verified_source_format,
                         )
                         if payload is None:
                             continue
@@ -17077,7 +17141,10 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         on_chunk=observe_diagnostic_sse_line,
                     ):
                         line_ending = _sse_line_ending(frame.raw)
-                        event = _converted_sse_payload(frame)
+                        event = _converted_sse_payload(
+                            frame,
+                            verified_source_format=verified_source_format,
+                        )
                         if event is None or event == "[DONE]":
                             continue
                         events.append(event)
@@ -17220,7 +17287,10 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         on_chunk=observe_diagnostic_sse_line,
                     ):
                         line_ending = _sse_line_ending(frame.raw)
-                        payload = _converted_sse_payload(frame)
+                        payload = _converted_sse_payload(
+                            frame,
+                            verified_source_format=verified_source_format,
+                        )
                         if payload is None:
                             continue
                         if payload == "[DONE]":

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -2730,29 +2730,130 @@ def _validate_verified_converted_sse_payload(
     payload: Mapping[str, Any],
     source_format: str,
 ) -> None:
+    def invalid_shape() -> None:
+        source_label = (
+            "Responses" if source_format == "responses" else "Chat Completions"
+        )
+        raise UpstreamSseSemanticError(
+            f"Upstream returned a structurally invalid complete {source_label} SSE event."
+        )
+
     if source_format == "responses":
-        if (
-            payload.get("type") == "response.output_text.delta"
-            and not isinstance(payload.get("delta"), str)
-        ):
-            raise UpstreamSseSemanticError(
-                "Upstream returned a structurally invalid complete Responses SSE event."
-            )
+        def validate_output_item(item: Any) -> None:
+            if not isinstance(item, Mapping):
+                invalid_shape()
+            if not isinstance(item.get("type"), str):
+                invalid_shape()
+            if (
+                item.get("type") == "message"
+                and "content" in item
+                and not isinstance(item.get("content"), list)
+            ):
+                invalid_shape()
+            if item.get("type") == "function_call":
+                for field in ("call_id", "name", "arguments"):
+                    if field in item and not isinstance(item.get(field), str):
+                        invalid_shape()
+
+        event_type = payload.get("type")
+        if not isinstance(event_type, str):
+            invalid_shape()
+        if event_type in {
+            "response.created",
+            "response.completed",
+            "response.incomplete",
+            "response.failed",
+        }:
+            response = payload.get("response")
+            if not isinstance(response, Mapping):
+                invalid_shape()
+            for field in ("id", "model", "status"):
+                if field in response and not isinstance(response.get(field), str):
+                    invalid_shape()
+            if "output" in response:
+                output = response.get("output")
+                if not isinstance(output, list):
+                    invalid_shape()
+                for item in output:
+                    validate_output_item(item)
+            if "usage" in response and not isinstance(response.get("usage"), Mapping):
+                invalid_shape()
+        elif event_type == "response.output_text.delta":
+            if not isinstance(payload.get("delta"), str):
+                invalid_shape()
+        elif event_type in {
+            "response.content_part.added",
+            "response.content_part.done",
+        }:
+            if not isinstance(payload.get("part"), Mapping):
+                invalid_shape()
+        elif event_type in {
+            "response.output_item.added",
+            "response.output_item.done",
+        }:
+            validate_output_item(payload.get("item"))
+        elif event_type == "response.function_call_arguments.delta":
+            if not isinstance(payload.get("delta"), str):
+                invalid_shape()
+        elif event_type == "response.function_call_arguments.done":
+            if not isinstance(payload.get("arguments"), str):
+                invalid_shape()
         return
     if source_format != "chat_completions":
         return
     choices = payload.get("choices")
-    if not isinstance(choices, list):
+    if choices is None and "error" in payload:
         return
+    if not isinstance(choices, list):
+        invalid_shape()
+    if "usage" in payload and not isinstance(payload.get("usage"), Mapping):
+        invalid_shape()
+    for field in ("id", "object", "model"):
+        if field in payload and not isinstance(payload.get(field), str):
+            invalid_shape()
     for choice in choices:
-        if (
-            isinstance(choice, Mapping)
-            and "delta" in choice
-            and not isinstance(choice.get("delta"), Mapping)
-        ):
-            raise UpstreamSseSemanticError(
-                "Upstream returned a structurally invalid complete Chat Completions SSE event."
-            )
+        if not isinstance(choice, Mapping):
+            invalid_shape()
+        if "index" in choice and not isinstance(choice.get("index"), int):
+            invalid_shape()
+        if "delta" in choice and not isinstance(choice.get("delta"), Mapping):
+            invalid_shape()
+        delta = choice.get("delta")
+        if isinstance(delta, Mapping):
+            content = delta.get("content")
+            if content is not None and not isinstance(content, str):
+                invalid_shape()
+            tool_calls = delta.get("tool_calls")
+            if tool_calls is not None:
+                if not isinstance(tool_calls, list):
+                    invalid_shape()
+                for tool_call in tool_calls:
+                    if not isinstance(tool_call, Mapping):
+                        invalid_shape()
+                    if (
+                        "index" in tool_call
+                        and not isinstance(tool_call.get("index"), int)
+                    ):
+                        invalid_shape()
+                    for field in ("id", "type"):
+                        if (
+                            field in tool_call
+                            and not isinstance(tool_call.get(field), str)
+                        ):
+                            invalid_shape()
+                    function = tool_call.get("function")
+                    if function is not None:
+                        if not isinstance(function, Mapping):
+                            invalid_shape()
+                        for field in ("name", "arguments"):
+                            if (
+                                field in function
+                                and not isinstance(function.get(field), str)
+                            ):
+                                invalid_shape()
+        finish_reason = choice.get("finish_reason")
+        if finish_reason is not None and not isinstance(finish_reason, str):
+            invalid_shape()
 
 
 def _converted_sse_payload(
@@ -16157,6 +16258,14 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
         def finish_converted_sse_semantic_error(
             exc: UpstreamSseSemanticError | SseFrameTooLargeError,
         ) -> int:
+            if seam.terminal_committed:
+                self.close_connection = True
+                _capture_usage(
+                    usage_capture,
+                    None,
+                    missing_reason="async_usage_pending",
+                )
+                return status
             error_code = getattr(exc, "classification", "upstream_protocol_error")
             self.close_connection = True
             write_proxy_event(
@@ -16714,7 +16823,6 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         event_resets_idle_timeout=_chat_sse_event_resets_idle_timeout,
                         on_chunk=observe_diagnostic_sse_line,
                     ):
-                        line_ending = _sse_line_ending(frame.raw)
                         payload = _converted_sse_payload(
                             frame,
                             verified_source_format="chat_completions",

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -2726,32 +2726,87 @@ class UpstreamSseSemanticError(ValueError):
     """A complete converted SSE frame is not valid source-protocol JSON."""
 
 
+def _verified_converted_sse_semantic_error(
+    source_format: str,
+) -> UpstreamSseSemanticError:
+    source_label = (
+        "Responses" if source_format == "responses" else "Chat Completions"
+    )
+    return UpstreamSseSemanticError(
+        f"Upstream returned a structurally invalid complete {source_label} SSE event."
+    )
+
+
 def _validate_verified_converted_sse_payload(
     payload: Mapping[str, Any],
     source_format: str,
 ) -> None:
     def invalid_shape() -> None:
-        source_label = (
-            "Responses" if source_format == "responses" else "Chat Completions"
-        )
-        raise UpstreamSseSemanticError(
-            f"Upstream returned a structurally invalid complete {source_label} SSE event."
-        )
+        raise _verified_converted_sse_semantic_error(source_format)
+
+    def validate_usage(
+        usage: Any,
+        *,
+        token_fields: tuple[str, ...],
+        detail_fields: tuple[str, ...],
+    ) -> None:
+        if not isinstance(usage, Mapping):
+            invalid_shape()
+        for field in token_fields:
+            if field in usage and type(usage.get(field)) is not int:
+                invalid_shape()
+        for field in detail_fields:
+            if field not in usage:
+                continue
+            details = usage.get(field)
+            if not isinstance(details, Mapping):
+                invalid_shape()
+            if any(type(count) is not int for count in details.values()):
+                invalid_shape()
 
     if source_format == "responses":
+        def validate_content_part(part: Any) -> None:
+            if not isinstance(part, Mapping):
+                invalid_shape()
+            part_type = part.get("type")
+            if not isinstance(part_type, str):
+                invalid_shape()
+            if part_type in {"input_text", "output_text", "text"}:
+                if not isinstance(part.get("text"), str):
+                    invalid_shape()
+                if (
+                    "annotations" in part
+                    and not isinstance(part.get("annotations"), list)
+                ):
+                    invalid_shape()
+            elif part_type == "input_image":
+                if not isinstance(part.get("image_url"), str):
+                    invalid_shape()
+                if (
+                    "detail" in part
+                    and not isinstance(part.get("detail"), str)
+                ):
+                    invalid_shape()
+
         def validate_output_item(item: Any) -> None:
             if not isinstance(item, Mapping):
                 invalid_shape()
             if not isinstance(item.get("type"), str):
                 invalid_shape()
-            if (
-                item.get("type") == "message"
-                and "content" in item
-                and not isinstance(item.get("content"), list)
-            ):
-                invalid_shape()
+            for field in ("id", "status"):
+                if field in item and not isinstance(item.get(field), str):
+                    invalid_shape()
+            if item.get("type") == "message":
+                if "role" in item and not isinstance(item.get("role"), str):
+                    invalid_shape()
+                if "content" in item:
+                    content = item.get("content")
+                    if not isinstance(content, list):
+                        invalid_shape()
+                    for part in content:
+                        validate_content_part(part)
             if item.get("type") == "function_call":
-                for field in ("call_id", "name", "arguments"):
+                for field in ("call_id", "namespace", "name", "arguments"):
                     if field in item and not isinstance(item.get(field), str):
                         invalid_shape()
 
@@ -2776,8 +2831,15 @@ def _validate_verified_converted_sse_payload(
                     invalid_shape()
                 for item in output:
                     validate_output_item(item)
-            if "usage" in response and not isinstance(response.get("usage"), Mapping):
-                invalid_shape()
+            if "usage" in response:
+                validate_usage(
+                    response.get("usage"),
+                    token_fields=("input_tokens", "output_tokens", "total_tokens"),
+                    detail_fields=(
+                        "input_tokens_details",
+                        "output_tokens_details",
+                    ),
+                )
         elif event_type == "response.output_text.delta":
             if not isinstance(payload.get("delta"), str):
                 invalid_shape()
@@ -2785,8 +2847,7 @@ def _validate_verified_converted_sse_payload(
             "response.content_part.added",
             "response.content_part.done",
         }:
-            if not isinstance(payload.get("part"), Mapping):
-                invalid_shape()
+            validate_content_part(payload.get("part"))
         elif event_type in {
             "response.output_item.added",
             "response.output_item.done",
@@ -2806,15 +2867,22 @@ def _validate_verified_converted_sse_payload(
         return
     if not isinstance(choices, list):
         invalid_shape()
-    if "usage" in payload and not isinstance(payload.get("usage"), Mapping):
-        invalid_shape()
+    if "usage" in payload:
+        validate_usage(
+            payload.get("usage"),
+            token_fields=("prompt_tokens", "completion_tokens", "total_tokens"),
+            detail_fields=(
+                "prompt_tokens_details",
+                "completion_tokens_details",
+            ),
+        )
     for field in ("id", "object", "model"):
         if field in payload and not isinstance(payload.get(field), str):
             invalid_shape()
     for choice in choices:
         if not isinstance(choice, Mapping):
             invalid_shape()
-        if "index" in choice and not isinstance(choice.get("index"), int):
+        if "index" in choice and type(choice.get("index")) is not int:
             invalid_shape()
         if "delta" in choice and not isinstance(choice.get("delta"), Mapping):
             invalid_shape()
@@ -2832,7 +2900,7 @@ def _validate_verified_converted_sse_payload(
                         invalid_shape()
                     if (
                         "index" in tool_call
-                        and not isinstance(tool_call.get("index"), int)
+                        and type(tool_call.get("index")) is not int
                     ):
                         invalid_shape()
                     for field in ("id", "type"):
@@ -16304,6 +16372,34 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 events: list[Mapping[str, Any]] = []
                 chat_chunks: list[Mapping[str, Any] | str] = []
                 incomplete_frame = False
+
+                def buffered_protocol_error_body(
+                    exc: UpstreamSseSemanticError | SseFrameTooLargeError,
+                ) -> bytes:
+                    write_proxy_event(
+                        "upstream_stream_protocol_error",
+                        request_id=request_id,
+                        model=model,
+                        upstream=upstream_name,
+                        status=502,
+                        upstream_format=upstream_format,
+                        inbound_format=inbound_format,
+                        error=type(exc).__name__,
+                        detail=str(exc),
+                    )
+                    return json.dumps(
+                        _json_error_payload_for_inbound_format(
+                            inbound_format=inbound_format,
+                            upstream_name=upstream_name,
+                            status=502,
+                            error="upstream_protocol_error",
+                            detail=str(exc),
+                            error_type="upstream_protocol_error",
+                        ),
+                        ensure_ascii=True,
+                        separators=(",", ":"),
+                    ).encode("utf-8")
+
                 try:
                     for frame in self._iter_upstream_sse_events(
                         response,
@@ -16327,29 +16423,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 except (UpstreamSseSemanticError, SseFrameTooLargeError) as exc:
                     status = 502
                     converted_stream_failure = True
-                    body = json.dumps(
-                        _json_error_payload_for_inbound_format(
-                            inbound_format=inbound_format,
-                            upstream_name=upstream_name,
-                            status=status,
-                            error="upstream_protocol_error",
-                            detail=str(exc),
-                            error_type="upstream_protocol_error",
-                        ),
-                        ensure_ascii=True,
-                        separators=(",", ":"),
-                    ).encode("utf-8")
-                    write_proxy_event(
-                        "upstream_stream_protocol_error",
-                        request_id=request_id,
-                        model=model,
-                        upstream=upstream_name,
-                        status=status,
-                        upstream_format=upstream_format,
-                        inbound_format=inbound_format,
-                        error=type(exc).__name__,
-                        detail=str(exc),
-                    )
+                    body = buffered_protocol_error_body(exc)
                 except UpstreamStreamIncompleteError:
                     incomplete_frame = True
                 except (IncompleteRead, TimeoutError, OSError, URLError) as exc:
@@ -16394,6 +16468,16 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                             status=status,
                             upstream_format=upstream_format,
                             inbound_format=inbound_format,
+                        )
+                    except UpstreamProtocolTranslationError:
+                        if verified_source_format is None:
+                            raise
+                        status = 502
+                        converted_stream_failure = True
+                        body = buffered_protocol_error_body(
+                            _verified_converted_sse_semantic_error(
+                                verified_source_format
+                            )
                         )
                 is_event_stream = False
                 buffered_json_response = True
@@ -16713,6 +16797,10 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                                 )
                 except (UpstreamSseSemanticError, SseFrameTooLargeError) as exc:
                     return finish_converted_sse_semantic_error(exc)
+                except UpstreamProtocolTranslationError:
+                    return finish_converted_sse_semantic_error(
+                        _verified_converted_sse_semantic_error("responses")
+                    )
                 except UpstreamStreamIncompleteError:
                     incomplete_frame = True
                 except UpstreamStreamIdleTimeoutError as exc:
@@ -16876,6 +16964,12 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                                 return finish_downstream_stream_closed(exc)
                 except (UpstreamSseSemanticError, SseFrameTooLargeError) as exc:
                     return finish_converted_sse_semantic_error(exc)
+                except UpstreamProtocolTranslationError:
+                    return finish_converted_sse_semantic_error(
+                        _verified_converted_sse_semantic_error(
+                            "chat_completions"
+                        )
+                    )
                 except UpstreamStreamIncompleteError:
                     incomplete_frame = True
                 except UpstreamStreamIdleTimeoutError as exc:

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -2726,7 +2726,40 @@ class UpstreamSseSemanticError(ValueError):
     """A complete converted SSE frame is not valid source-protocol JSON."""
 
 
-def _converted_sse_payload(event: SseEvent) -> Mapping[str, Any] | str | None:
+def _validate_verified_converted_sse_payload(
+    payload: Mapping[str, Any],
+    source_format: str,
+) -> None:
+    if source_format == "responses":
+        if (
+            payload.get("type") == "response.output_text.delta"
+            and not isinstance(payload.get("delta"), str)
+        ):
+            raise UpstreamSseSemanticError(
+                "Upstream returned a structurally invalid complete Responses SSE event."
+            )
+        return
+    if source_format != "chat_completions":
+        return
+    choices = payload.get("choices")
+    if not isinstance(choices, list):
+        return
+    for choice in choices:
+        if (
+            isinstance(choice, Mapping)
+            and "delta" in choice
+            and not isinstance(choice.get("delta"), Mapping)
+        ):
+            raise UpstreamSseSemanticError(
+                "Upstream returned a structurally invalid complete Chat Completions SSE event."
+            )
+
+
+def _converted_sse_payload(
+    event: SseEvent,
+    *,
+    verified_source_format: str | None = None,
+) -> Mapping[str, Any] | str | None:
     if not any(line.name == b"data" for line in event.lines) or not event.data:
         return None
     if event.data == b"[DONE]":
@@ -2741,6 +2774,8 @@ def _converted_sse_payload(event: SseEvent) -> Mapping[str, Any] | str | None:
         raise UpstreamSseSemanticError(
             "Upstream returned a structurally invalid complete SSE event."
         )
+    if verified_source_format is not None:
+        _validate_verified_converted_sse_payload(payload, verified_source_format)
     return payload
 
 
@@ -15149,9 +15184,15 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
         assembler = SseEventAssembler()
         pending_events: list[SseEvent] = []
         assembler_finished = False
+        deferred_size_error: SseFrameTooLargeError | None = None
 
         def assemble_chunk(chunk: bytes) -> bool:
-            events = assembler.feed(chunk)
+            nonlocal deferred_size_error
+            events: list[SseEvent] = []
+            try:
+                assembler.feed(chunk, on_event=events.append)
+            except SseFrameTooLargeError as exc:
+                deferred_size_error = exc
             pending_events.extend(events)
             return any(event_resets_idle_timeout(event) for event in events)
 
@@ -15166,6 +15207,8 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 ready_events = tuple(pending_events)
                 pending_events.clear()
                 yield from ready_events
+                if deferred_size_error is not None:
+                    raise deferred_size_error
 
             termination = assembler.finish()
             assembler_finished = True
@@ -16010,6 +16053,15 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
         # SSE into a single JSON response body.
         buffer_sse_to_json = is_event_stream and not caller_stream
         buffered_json_response = False
+        buffered_chat_sse_to_responses = False
+        verified_source_format = (
+            upstream_format
+            if (
+                behavior_profile == BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED
+                and upstream_format != inbound_format
+            )
+            else None
+        )
         usage_context = _usage_observed_context(
             event_context,
             request_id=request_id,
@@ -16141,17 +16193,28 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
             if buffer_sse_to_json:
                 # Buffer the full SSE stream into a list of events.
                 events: list[Mapping[str, Any]] = []
+                chat_chunks: list[Mapping[str, Any] | str] = []
                 incomplete_frame = False
                 try:
                     for frame in self._iter_upstream_sse_events(
                         response,
-                        event_resets_idle_timeout=_responses_sse_event_resets_idle_timeout,
+                        event_resets_idle_timeout=(
+                            _chat_sse_event_resets_idle_timeout
+                            if upstream_format == "chat_completions"
+                            else _responses_sse_event_resets_idle_timeout
+                        ),
                         on_chunk=observe_diagnostic_sse_line,
                     ):
-                        payload = _converted_sse_payload(frame)
-                        if payload is None or payload == "[DONE]":
+                        payload = _converted_sse_payload(
+                            frame,
+                            verified_source_format=verified_source_format,
+                        )
+                        if payload is None:
                             continue
-                        events.append(payload)
+                        if upstream_format == "chat_completions":
+                            chat_chunks.append(payload)
+                        elif payload != "[DONE]":
+                            events.append(payload)
                 except (UpstreamSseSemanticError, SseFrameTooLargeError) as exc:
                     status = 502
                     converted_stream_failure = True
@@ -16191,7 +16254,23 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                             raise UpstreamStreamIncompleteError(
                                 "Upstream SSE stream ended with an incomplete pending frame"
                             )
-                        body = _events_to_responses_body(events, require_completed=True)
+                        if (
+                            upstream_format == "chat_completions"
+                            and not want_chat_output
+                        ):
+                            response_events = _chat_stream_chunks_to_response_events(
+                                chat_chunks
+                            )
+                            body = _events_to_responses_body(
+                                response_events,
+                                require_completed=True,
+                            )
+                            buffered_chat_sse_to_responses = True
+                        else:
+                            body = _events_to_responses_body(
+                                events,
+                                require_completed=True,
+                            )
                     except UpstreamStreamIncompleteError:
                         if defer_stream_errors:
                             raise
@@ -16242,10 +16321,13 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                             compatible_response_body(body, upstream_name, event_context=compatibility_event_context)
                         )
             elif upstream_format == "chat_completions":
-                converted_body = _chat_completion_to_response_body(
-                    body,
-                    repair=behavior_profile != BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
-                )
+                if buffered_chat_sse_to_responses:
+                    converted_body = body
+                else:
+                    converted_body = _chat_completion_to_response_body(
+                        body,
+                        repair=behavior_profile != BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+                    )
                 if behavior_profile == BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED:
                     body = converted_body
                 else:
@@ -16477,7 +16559,10 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         on_chunk=observe_diagnostic_sse_line,
                     ):
                         line_ending = _sse_line_ending(frame.raw)
-                        payload = _converted_sse_payload(frame)
+                        payload = _converted_sse_payload(
+                            frame,
+                            verified_source_format="responses",
+                        )
                         if payload is None or payload == "[DONE]":
                             continue
                         event = payload
@@ -16630,7 +16715,10 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         on_chunk=observe_diagnostic_sse_line,
                     ):
                         line_ending = _sse_line_ending(frame.raw)
-                        payload = _converted_sse_payload(frame)
+                        payload = _converted_sse_payload(
+                            frame,
+                            verified_source_format="chat_completions",
+                        )
                         if payload is None:
                             continue
                         events: list[dict[str, Any]] = []

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -49,6 +49,7 @@ import urllib3
 
 from sse_events import (
     DEFAULT_MAX_FRAME_BYTES,
+    SseAssemblerClosedError,
     SseEvent,
     SseEventAssembler,
     SseFrameTooLargeError,
@@ -2721,6 +2722,47 @@ def _parse_sse_json_payload(line: bytes) -> dict[str, Any] | None:
     return payload if isinstance(payload, dict) else None
 
 
+class UpstreamSseSemanticError(ValueError):
+    """A complete converted SSE frame is not valid source-protocol JSON."""
+
+
+def _converted_sse_payload(event: SseEvent) -> Mapping[str, Any] | str | None:
+    if not any(line.name == b"data" for line in event.lines) or not event.data:
+        return None
+    if event.data == b"[DONE]":
+        return "[DONE]"
+    try:
+        payload = json.loads(event.data.decode("utf-8-sig"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise UpstreamSseSemanticError(
+            "Upstream returned a malformed complete SSE event."
+        ) from exc
+    if not isinstance(payload, Mapping):
+        raise UpstreamSseSemanticError(
+            "Upstream returned a structurally invalid complete SSE event."
+        )
+    return payload
+
+
+def _responses_sse_event_resets_idle_timeout(event: SseEvent) -> bool:
+    try:
+        payload = _converted_sse_payload(event)
+    except UpstreamSseSemanticError:
+        return False
+    if not isinstance(payload, Mapping):
+        return False
+    event_type = payload.get("type")
+    return isinstance(event_type, str) and (event_type.startswith("response.") or event_type == "error")
+
+
+def _chat_sse_event_resets_idle_timeout(event: SseEvent) -> bool:
+    try:
+        payload = _converted_sse_payload(event)
+    except UpstreamSseSemanticError:
+        return False
+    return payload == "[DONE]" or isinstance(payload, Mapping)
+
+
 SSE_EVENT_TYPE_TELEMETRY_LIMIT = 64
 
 
@@ -3136,19 +3178,6 @@ def _chat_stream_chunk_starts_downstream_output(chunk: Mapping[str, Any]) -> boo
             if isinstance(message.get("tool_calls"), list) and message.get("tool_calls"):
                 return True
     return False
-
-
-def _chat_sse_line_resets_idle_timeout(line: bytes) -> bool:
-    payload_bytes = _sse_payload_bytes(line)
-    if payload_bytes is None:
-        return False
-    if payload_bytes == b"[DONE]":
-        return True
-    try:
-        payload = json.loads(payload_bytes.decode("utf-8-sig"))
-    except (UnicodeDecodeError, json.JSONDecodeError):
-        return False
-    return isinstance(payload, Mapping)
 
 
 def _chat_stream_chunks_have_terminal(chunks: list[Mapping[str, Any] | str]) -> bool:
@@ -11147,13 +11176,24 @@ def _extract_model_response_text(payload: Any) -> str:
 def _image_proxy_response_body(response: Any) -> bytes:
     if _is_event_stream(response.headers):
         events: list[Mapping[str, Any]] = []
+        assembler = SseEventAssembler()
         while True:
-            line = response.readline()
-            if not line:
+            chunk = response.readline()
+            if not chunk:
                 break
-            event = _parse_sse_json_payload(line)
-            if isinstance(event, Mapping):
-                events.append(event)
+            for frame in assembler.feed(chunk):
+                payload = _converted_sse_payload(frame)
+                if isinstance(payload, Mapping):
+                    events.append(payload)
+        termination = assembler.finish()
+        if termination.disposition == "incomplete":
+            raise UpstreamStreamIncompleteError(
+                "Image proxy SSE stream ended with an incomplete pending frame"
+            )
+        for frame in termination.events:
+            payload = _converted_sse_payload(frame)
+            if isinstance(payload, Mapping):
+                events.append(payload)
         return _events_to_responses_body(events)
 
     body = b""
@@ -15084,7 +15124,12 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 if isinstance(value, bytes) and value:
                     now = time.monotonic()
                     last_transport_at = now
-                    if model_event_idle_guard_enabled and line_resets_idle_timeout is not None and line_resets_idle_timeout(value):
+                    resets_model_event_timeout = (
+                        line_resets_idle_timeout(value)
+                        if line_resets_idle_timeout is not None
+                        else False
+                    )
+                    if model_event_idle_guard_enabled and resets_model_event_timeout:
                         last_model_event_at = now
                     observe_line(value)
                 yield value
@@ -15093,6 +15138,48 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
         finally:
             lifecycle.close()
             lifecycle.join(timeout=_UpstreamSseReaderLifecycle.JOIN_TIMEOUT_SECONDS)
+
+    def _iter_upstream_sse_events(
+        self,
+        response: Any,
+        *,
+        event_resets_idle_timeout: Callable[[SseEvent], bool],
+        on_chunk: Callable[[bytes], None] | None = None,
+    ) -> Any:
+        assembler = SseEventAssembler()
+        pending_events: list[SseEvent] = []
+        assembler_finished = False
+
+        def assemble_chunk(chunk: bytes) -> bool:
+            events = assembler.feed(chunk)
+            pending_events.extend(events)
+            return any(event_resets_idle_timeout(event) for event in events)
+
+        try:
+            for chunk in self._iter_upstream_sse_lines(
+                response,
+                line_resets_idle_timeout=assemble_chunk,
+                on_line=on_chunk,
+            ):
+                if not chunk:
+                    break
+                ready_events = tuple(pending_events)
+                pending_events.clear()
+                yield from ready_events
+
+            termination = assembler.finish()
+            assembler_finished = True
+            yield from termination.events
+            if termination.disposition == "incomplete":
+                raise UpstreamStreamIncompleteError(
+                    "Upstream SSE stream ended with an incomplete pending frame"
+                )
+        finally:
+            if not assembler_finished:
+                try:
+                    assembler.cancel()
+                except SseAssemblerClosedError:
+                    pass
 
     def _write_sse_error_event(self, upstream_name: str, exc: BaseException) -> None:
         self._write_sse_event(
@@ -16015,46 +16102,111 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
             )
             return 499
 
+        def finish_converted_sse_semantic_error(
+            exc: UpstreamSseSemanticError | SseFrameTooLargeError,
+        ) -> int:
+            error_code = getattr(exc, "classification", "upstream_protocol_error")
+            self.close_connection = True
+            write_proxy_event(
+                "upstream_stream_protocol_error",
+                request_id=request_id,
+                model=model,
+                upstream=upstream_name,
+                status=502,
+                upstream_format=upstream_format,
+                inbound_format=inbound_format,
+                error=type(exc).__name__,
+                detail=str(exc),
+            )
+            if not send_downstream_response_headers_once():
+                return finish_downstream_stream_closed(
+                    seam.last_write_error() or OSError("downstream closed")
+                )
+            if not self._write_downstream_sse_error(
+                inbound_format=inbound_format,
+                upstream_name=upstream_name,
+                status=502,
+                error=error_code,
+                detail=str(exc),
+            ):
+                return finish_downstream_stream_closed(
+                    seam.last_write_error() or OSError("downstream closed")
+                )
+            _capture_usage(usage_capture, None, missing_reason="stream_protocol_error")
+            return 502
+
         headers_sent = headers_already_sent
         if not is_event_stream or buffer_sse_to_json:
+            converted_stream_failure = False
             if buffer_sse_to_json:
                 # Buffer the full SSE stream into a list of events.
                 events: list[Mapping[str, Any]] = []
+                incomplete_frame = False
                 try:
-                    while True:
-                        line = response.readline()
-                        if not line:
-                            break
-                        payload_bytes = _sse_payload_bytes(line)
-                        if payload_bytes is None:
+                    for frame in self._iter_upstream_sse_events(
+                        response,
+                        event_resets_idle_timeout=_responses_sse_event_resets_idle_timeout,
+                        on_chunk=observe_diagnostic_sse_line,
+                    ):
+                        payload = _converted_sse_payload(frame)
+                        if payload is None or payload == "[DONE]":
                             continue
-                        try:
-                            event = json.loads(payload_bytes.decode("utf-8-sig"))
-                        except (UnicodeDecodeError, json.JSONDecodeError):
-                            continue
-                        if isinstance(event, dict):
-                            events.append(event)
-                except (IncompleteRead, TimeoutError, OSError, URLError) as exc:
-                    if defer_stream_errors:
-                        raise UpstreamStreamInterruptedError(exc) from exc
-                    raise
-                # Reconstruct a Responses-format body from the events.
-                try:
-                    body = _events_to_responses_body(events, require_completed=True)
-                except UpstreamStreamIncompleteError:
-                    if defer_stream_errors:
-                        raise
+                        events.append(payload)
+                except (UpstreamSseSemanticError, SseFrameTooLargeError) as exc:
                     status = 502
-                    body = _incomplete_stream_json_error_body(upstream_name)
+                    converted_stream_failure = True
+                    body = json.dumps(
+                        _json_error_payload_for_inbound_format(
+                            inbound_format=inbound_format,
+                            upstream_name=upstream_name,
+                            status=status,
+                            error="upstream_protocol_error",
+                            detail=str(exc),
+                            error_type="upstream_protocol_error",
+                        ),
+                        ensure_ascii=True,
+                        separators=(",", ":"),
+                    ).encode("utf-8")
                     write_proxy_event(
-                        "upstream_stream_incomplete",
+                        "upstream_stream_protocol_error",
                         request_id=request_id,
                         model=model,
                         upstream=upstream_name,
                         status=status,
                         upstream_format=upstream_format,
                         inbound_format=inbound_format,
+                        error=type(exc).__name__,
+                        detail=str(exc),
                     )
+                except UpstreamStreamIncompleteError:
+                    incomplete_frame = True
+                except (IncompleteRead, TimeoutError, OSError, URLError) as exc:
+                    if defer_stream_errors:
+                        raise UpstreamStreamInterruptedError(exc) from exc
+                    raise
+                # Reconstruct a Responses-format body from the events.
+                if not converted_stream_failure:
+                    try:
+                        if incomplete_frame:
+                            raise UpstreamStreamIncompleteError(
+                                "Upstream SSE stream ended with an incomplete pending frame"
+                            )
+                        body = _events_to_responses_body(events, require_completed=True)
+                    except UpstreamStreamIncompleteError:
+                        if defer_stream_errors:
+                            raise
+                        status = 502
+                        converted_stream_failure = True
+                        body = _incomplete_stream_json_error_body(upstream_name)
+                        write_proxy_event(
+                            "upstream_stream_incomplete",
+                            request_id=request_id,
+                            model=model,
+                            upstream=upstream_name,
+                            status=status,
+                            upstream_format=upstream_format,
+                            inbound_format=inbound_format,
+                        )
                 is_event_stream = False
                 buffered_json_response = True
             else:
@@ -16070,7 +16222,9 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         raise UpstreamStreamInterruptedError(exc) from exc
                     raise
             upstream_body_for_usage = body
-            if want_chat_output:
+            if converted_stream_failure:
+                pass
+            elif want_chat_output:
                 if upstream_format == "chat_completions":
                     body = _response_body_to_chat_completion_body(
                         compatible_response_body(
@@ -16315,29 +16469,21 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
             ):
                 line_ending = b"\n"
                 converter = _ResponsesToChatStreamConverter()
+                incomplete_frame = False
                 try:
-                    for line in self._iter_upstream_sse_lines(
+                    for frame in self._iter_upstream_sse_events(
                         response,
-                        line_resets_idle_timeout=_responses_sse_line_resets_idle_timeout,
-                        on_line=observe_diagnostic_sse_line,
+                        event_resets_idle_timeout=_responses_sse_event_resets_idle_timeout,
+                        on_chunk=observe_diagnostic_sse_line,
                     ):
-                        if not line:
-                            break
-                        line_ending = _sse_line_ending(line)
-                        payload_bytes = _sse_payload_bytes(line)
-                        if payload_bytes is None:
+                        line_ending = _sse_line_ending(frame.raw)
+                        payload = _converted_sse_payload(frame)
+                        if payload is None or payload == "[DONE]":
                             continue
-                        if payload_bytes == b"[DONE]":
-                            continue
-                        try:
-                            event = json.loads(payload_bytes.decode("utf-8-sig"))
-                        except (UnicodeDecodeError, json.JSONDecodeError):
-                            continue
-                        if not isinstance(event, Mapping):
-                            continue
+                        event = payload
                         _offer_usage_observed_sse_line(
                             usage_context,
-                            line,
+                            frame.raw,
                             upstream_format=upstream_format,
                         )
                         error_type = _responses_stream_error_type(event)
@@ -16371,6 +16517,10 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                                 return finish_downstream_stream_closed(
                                     seam.last_write_error() or OSError("downstream closed")
                                 )
+                except (UpstreamSseSemanticError, SseFrameTooLargeError) as exc:
+                    return finish_converted_sse_semantic_error(exc)
+                except UpstreamStreamIncompleteError:
+                    incomplete_frame = True
                 except UpstreamStreamIdleTimeoutError as exc:
                     self.close_connection = True
                     write_proxy_event(
@@ -16430,7 +16580,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         )
                     _capture_usage(usage_capture, None, missing_reason="stream_interrupted")
                     return 502
-                if not converter.completed:
+                if incomplete_frame or not converter.completed:
                     self.close_connection = True
                     write_proxy_event(
                         "upstream_stream_incomplete",
@@ -16472,28 +16622,21 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
             ):
                 line_ending = b"\n"
                 converter = _ChatToResponsesStreamConverter()
+                incomplete_frame = False
                 try:
-                    for line in self._iter_upstream_sse_lines(
+                    for frame in self._iter_upstream_sse_events(
                         response,
-                        line_resets_idle_timeout=_chat_sse_line_resets_idle_timeout,
-                        on_line=observe_diagnostic_sse_line,
+                        event_resets_idle_timeout=_chat_sse_event_resets_idle_timeout,
+                        on_chunk=observe_diagnostic_sse_line,
                     ):
-                        if not line:
-                            break
-                        line_ending = _sse_line_ending(line)
-                        payload_bytes = _sse_payload_bytes(line)
-                        if payload_bytes is None:
+                        line_ending = _sse_line_ending(frame.raw)
+                        payload = _converted_sse_payload(frame)
+                        if payload is None:
                             continue
                         events: list[dict[str, Any]] = []
-                        if payload_bytes == b"[DONE]":
+                        if payload == "[DONE]":
                             events = converter.events_for_done()
                         else:
-                            try:
-                                payload = json.loads(payload_bytes.decode("utf-8-sig"))
-                            except (UnicodeDecodeError, json.JSONDecodeError):
-                                continue
-                            if not isinstance(payload, Mapping):
-                                continue
                             chat_error_detail = _chat_stream_error_detail(payload)
                             if chat_error_detail is not None:
                                 write_proxy_event(
@@ -16521,7 +16664,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                                 return 502
                             _offer_usage_observed_sse_line(
                                 usage_context,
-                                line,
+                                frame.raw,
                                 upstream_format=upstream_format,
                             )
                             events = converter.events_for_chunk(payload)
@@ -16535,6 +16678,10 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                                     )
                             except OSError as exc:
                                 return finish_downstream_stream_closed(exc)
+                except (UpstreamSseSemanticError, SseFrameTooLargeError) as exc:
+                    return finish_converted_sse_semantic_error(exc)
+                except UpstreamStreamIncompleteError:
+                    incomplete_frame = True
                 except UpstreamStreamIdleTimeoutError as exc:
                     self.close_connection = True
                     write_proxy_event(
@@ -16586,7 +16733,22 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         )
                     _capture_usage(usage_capture, None, missing_reason="stream_interrupted")
                     return 502
-                if not converter.completed:
+                if (
+                    not incomplete_frame
+                    and not converter.completed
+                    and converter.pending_incomplete is not None
+                ):
+                    for event in converter.events_for_done():
+                        try:
+                            if not self._write_sse_bytes(
+                                _sse_json_line(event, line_ending) + line_ending
+                            ):
+                                return finish_downstream_stream_closed(
+                                    seam.last_write_error() or OSError("downstream closed")
+                                )
+                        except OSError as exc:
+                            return finish_downstream_stream_closed(exc)
+                if incomplete_frame or not converter.completed:
                     self.close_connection = True
                     write_proxy_event(
                         "upstream_stream_incomplete",
@@ -16609,13 +16771,6 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         )
                     _capture_usage(usage_capture, None, missing_reason="stream_incomplete")
                     return 502
-                try:
-                    if not self._write_sse_done():
-                        return finish_downstream_stream_closed(
-                            seam.last_write_error() or OSError("downstream closed")
-                        )
-                except OSError as exc:
-                    return finish_downstream_stream_closed(exc)
                 self.close_connection = True
                 _capture_usage(usage_capture, None, missing_reason="async_usage_pending")
                 return status
@@ -16624,32 +16779,30 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 # Upstream returns Responses SSE; convert to Chat Completions SSE.
                 line_ending = b"\n"
                 events: list[Mapping[str, Any]] = []
+                incomplete_frame = False
                 try:
-                    for line in self._iter_upstream_sse_lines(
+                    for frame in self._iter_upstream_sse_events(
                         response,
-                        line_resets_idle_timeout=_responses_sse_line_resets_idle_timeout,
-                        on_line=observe_diagnostic_sse_line,
+                        event_resets_idle_timeout=_responses_sse_event_resets_idle_timeout,
+                        on_chunk=observe_diagnostic_sse_line,
                     ):
-                        if not line:
-                            break
-                        line_ending = _sse_line_ending(line)
-                        payload_bytes = _sse_payload_bytes(line)
-                        if payload_bytes is None:
+                        line_ending = _sse_line_ending(frame.raw)
+                        event = _converted_sse_payload(frame)
+                        if event is None or event == "[DONE]":
                             continue
-                        try:
-                            event = json.loads(payload_bytes.decode("utf-8-sig"))
-                        except (UnicodeDecodeError, json.JSONDecodeError):
-                            continue
-                        if isinstance(event, dict):
-                            events.append(event)
-                            if behavior_profile == BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED:
-                                _offer_usage_observed_sse_line(
-                                    usage_context,
-                                    line,
-                                    upstream_format=upstream_format,
-                                )
-                            else:
-                                _capture_usage(usage_capture, _usage_from_response_event(event))
+                        events.append(event)
+                        if behavior_profile == BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED:
+                            _offer_usage_observed_sse_line(
+                                usage_context,
+                                frame.raw,
+                                upstream_format=upstream_format,
+                            )
+                        else:
+                            _capture_usage(usage_capture, _usage_from_response_event(event))
+                except (UpstreamSseSemanticError, SseFrameTooLargeError) as exc:
+                    return finish_converted_sse_semantic_error(exc)
+                except UpstreamStreamIncompleteError:
+                    incomplete_frame = True
                 except UpstreamStreamIdleTimeoutError as exc:
                     if defer_stream_errors:
                         raise
@@ -16706,6 +16859,10 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                     _capture_usage(usage_capture, None, missing_reason="stream_interrupted")
                     return 502
                 try:
+                    if incomplete_frame:
+                        raise UpstreamStreamIncompleteError(
+                            "Upstream SSE stream ended with an incomplete pending frame"
+                        )
                     response_body = compatible_response_body(
                         _events_to_responses_body(events, require_completed=True),
                         upstream_name,
@@ -16765,35 +16922,33 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
             if upstream_format == "chat_completions":
                 line_ending = b"\n"
                 chunks: list[Mapping[str, Any] | str] = []
+                incomplete_frame = False
                 try:
-                    for line in self._iter_upstream_sse_lines(
+                    for frame in self._iter_upstream_sse_events(
                         response,
-                        line_resets_idle_timeout=_chat_sse_line_resets_idle_timeout,
-                        on_line=observe_diagnostic_sse_line,
+                        event_resets_idle_timeout=_chat_sse_event_resets_idle_timeout,
+                        on_chunk=observe_diagnostic_sse_line,
                     ):
-                        if not line:
-                            break
-                        line_ending = _sse_line_ending(line)
-                        payload_bytes = _sse_payload_bytes(line)
-                        if payload_bytes is None:
+                        line_ending = _sse_line_ending(frame.raw)
+                        payload = _converted_sse_payload(frame)
+                        if payload is None:
                             continue
-                        if payload_bytes == b"[DONE]":
+                        if payload == "[DONE]":
                             chunks.append("[DONE]")
                             continue
-                        try:
-                            payload = json.loads(payload_bytes.decode("utf-8-sig"))
-                        except (UnicodeDecodeError, json.JSONDecodeError):
-                            continue
-                        if isinstance(payload, dict):
-                            chunks.append(payload)
-                            if behavior_profile == BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED:
-                                _offer_usage_observed_sse_line(
-                                    usage_context,
-                                    line,
-                                    upstream_format=upstream_format,
-                                )
-                            else:
-                                _capture_usage(usage_capture, _usage_from_payload(payload))
+                        chunks.append(payload)
+                        if behavior_profile == BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED:
+                            _offer_usage_observed_sse_line(
+                                usage_context,
+                                frame.raw,
+                                upstream_format=upstream_format,
+                            )
+                        else:
+                            _capture_usage(usage_capture, _usage_from_payload(payload))
+                except (UpstreamSseSemanticError, SseFrameTooLargeError) as exc:
+                    return finish_converted_sse_semantic_error(exc)
+                except UpstreamStreamIncompleteError:
+                    incomplete_frame = True
                 except UpstreamStreamIdleTimeoutError as exc:
                     if defer_stream_errors:
                         raise
@@ -16849,7 +17004,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         )
                     _capture_usage(usage_capture, None, missing_reason="stream_interrupted")
                     return 502
-                if not _chat_stream_chunks_have_terminal(chunks):
+                if incomplete_frame or not _chat_stream_chunks_have_terminal(chunks):
                     if defer_stream_errors:
                         raise UpstreamStreamIncompleteError(
                             "Chat Completions stream ended without finish_reason or [DONE]"

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -13003,6 +13003,7 @@ class _GatewayDownstreamStreamCommit:
         self._last_upstream_byte_at: float | None = None
         self._last_write_error: OSError | None = None
         self._last_successful_completion_bytes = b""
+        self._ensure_headers_committed_callback: Callable[[], bool] | None = None
 
     @property
     def terminal_committed(self) -> bool:
@@ -13053,6 +13054,21 @@ class _GatewayDownstreamStreamCommit:
         | None,
     ) -> None:
         self._synthetic_terminal_failure_callback = synthetic_terminal_failure_callback
+
+    def set_ensure_headers_committed_callback(
+        self,
+        callback: Callable[[], bool] | None,
+    ) -> None:
+        self._ensure_headers_committed_callback = callback
+
+    def _ensure_headers_committed_before_write(self) -> bool:
+        callback = self._ensure_headers_committed_callback
+        if callback is None:
+            return True
+        if not callback():
+            return False
+        self._ensure_headers_committed_callback = None
+        return True
 
     def _close_upstream_response(self, response: Any) -> None:
         close = getattr(response, "close", None)
@@ -13112,6 +13128,8 @@ class _GatewayDownstreamStreamCommit:
         if not line:
             return True
         if self._terminal_committed:
+            return False
+        if not self._ensure_headers_committed_before_write():
             return False
         terminal_observed_now = self._observe_line(line)
         if terminal_observed_now:
@@ -13178,6 +13196,8 @@ class _GatewayDownstreamStreamCommit:
             return True
         if self._terminal_committed:
             return False
+        if not self._ensure_headers_committed_before_write():
+            return False
         terminal_observed_now = False
         if observe:
             terminal_observed_now = self._observe_line(data)
@@ -13224,6 +13244,8 @@ class _GatewayDownstreamStreamCommit:
         if self._downstream_closed or self._terminal_committed:
             return False, None, None
         if self._synthetic_terminal_failure_callback is None:
+            return False, None, None
+        if not self._ensure_headers_committed_before_write():
             return False, None, None
         try:
             size_limit_exceeded = isinstance(exc, SseFrameTooLargeError)
@@ -16794,6 +16816,9 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 mark_downstream_sse_started()
             return True
 
+        seam.set_ensure_headers_committed_callback(
+            send_downstream_response_headers_once if defer_stream_headers else None
+        )
         if not defer_stream_headers:
             if not send_downstream_response_headers_once():
                 return finish_downstream_stream_closed(

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -16336,20 +16336,10 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 event_context=event_context,
                 defer_stream_errors=defer_stream_errors,
             )
-        defer_verified_final_conversion_headers = (
-            is_event_stream
-            and caller_stream
-            and verified_source_format == "responses"
-            and want_chat_output
-            and behavior_profile != BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED
-        )
         defer_stream_headers = (
             is_event_stream
             and caller_stream
-            and (
-                lifecycle_empty_final_resample_enabled(event_context, request_kind)
-                or defer_verified_final_conversion_headers
-            )
+            and lifecycle_empty_final_resample_enabled(event_context, request_kind)
         )
 
         def finish_downstream_stream_closed(exc: OSError) -> int:

--- a/src-python/protocol_translation.py
+++ b/src-python/protocol_translation.py
@@ -2815,8 +2815,17 @@ def events_to_responses_body(
     usage_from_response: UsageFromResponse = _default_usage_from_response,
 ) -> bytes:
     """Reconstruct a non-streaming Responses body from Responses SSE events."""
-    if require_completed and not responses_events_have_completed(events):
-        raise UpstreamStreamIncompleteError("Responses stream ended before response.completed")
+    terminal_types = {
+        event.get("type")
+        for event in events
+        if isinstance(event, Mapping)
+    }
+    if require_completed and not terminal_types.intersection(
+        {"response.completed", "response.incomplete"}
+    ):
+        raise UpstreamStreamIncompleteError(
+            "Responses stream ended before response.completed or response.incomplete"
+        )
 
     output: list[dict[str, Any]] = []
     response_id = f"resp_{uuid.uuid4().hex[:12]}"
@@ -2857,7 +2866,7 @@ def events_to_responses_body(
             tool_input = event.get("input")
             if current_item and isinstance(tool_input, str):
                 current_item["input"] = tool_input
-        elif event_type == "response.completed":
+        elif event_type in {"response.completed", "response.incomplete"}:
             response = event.get("response")
             if isinstance(response, Mapping):
                 response_payload.update(dict(response))

--- a/src-python/protocol_translation.py
+++ b/src-python/protocol_translation.py
@@ -73,6 +73,36 @@ def _default_usage_from_response(response: Mapping[str, Any]) -> Mapping[str, An
     return usage if isinstance(usage, Mapping) else None
 
 
+def _chat_completion_usage_to_responses_usage(usage: Mapping[str, Any]) -> dict[str, Any]:
+    mapped: dict[str, Any] = {}
+    for source_name, target_name in (
+        ("prompt_tokens", "input_tokens"),
+        ("completion_tokens", "output_tokens"),
+        ("total_tokens", "total_tokens"),
+        ("prompt_tokens_details", "input_tokens_details"),
+        ("completion_tokens_details", "output_tokens_details"),
+    ):
+        if source_name in usage:
+            value = usage[source_name]
+            mapped[target_name] = dict(value) if isinstance(value, Mapping) else value
+    return mapped
+
+
+def _responses_usage_to_chat_usage(usage: Mapping[str, Any]) -> dict[str, Any]:
+    mapped: dict[str, Any] = {}
+    for source_name, target_name in (
+        ("input_tokens", "prompt_tokens"),
+        ("output_tokens", "completion_tokens"),
+        ("total_tokens", "total_tokens"),
+        ("input_tokens_details", "prompt_tokens_details"),
+        ("output_tokens_details", "completion_tokens_details"),
+    ):
+        if source_name in usage:
+            value = usage[source_name]
+            mapped[target_name] = dict(value) if isinstance(value, Mapping) else value
+    return mapped
+
+
 def _raise_for_unsupported_chat_message_semantics(message: Mapping[str, Any]) -> None:
     for field in ("refusal", "audio", "annotations", "reasoning", "reasoning_content"):
         value = message.get(field)
@@ -1072,8 +1102,9 @@ def chat_completion_to_response_body(
     }
     if incomplete_details is not None:
         response_payload["incomplete_details"] = incomplete_details
-    if "usage" in payload:
-        response_payload["usage"] = payload["usage"]
+    usage = payload.get("usage")
+    if isinstance(usage, Mapping):
+        response_payload["usage"] = _chat_completion_usage_to_responses_usage(usage)
 
     if repair and repair_response is not None:
         response_payload = repair_response(response_payload)
@@ -1220,7 +1251,7 @@ def response_body_to_chat_completion_body(
     }
     usage = payload.get("usage")
     if isinstance(usage, dict):
-        chat_payload["usage"] = usage
+        chat_payload["usage"] = _responses_usage_to_chat_usage(usage)
     return json.dumps(chat_payload, ensure_ascii=True, separators=(",", ":")).encode("utf-8")
 
 
@@ -1452,6 +1483,7 @@ def chat_stream_chunks_to_response_events(
     incomplete_details: dict[str, str] | None = None
     response_id = f"resp_{uuid.uuid4().hex[:12]}"
     model: str | None = None
+    usage: dict[str, Any] | None = None
     next_output_index = 0
     message_output_index: int | None = None
 
@@ -1522,6 +1554,9 @@ def chat_stream_chunks_to_response_events(
         choices = chunk.get("choices")
         if not isinstance(choices, list):
             continue
+        chunk_usage = chunk.get("usage")
+        if isinstance(chunk_usage, Mapping):
+            usage = _chat_completion_usage_to_responses_usage(chunk_usage)
         for choice in choices:
             if not isinstance(choice, dict):
                 continue
@@ -1759,6 +1794,8 @@ def chat_stream_chunks_to_response_events(
         completed_response["incomplete_details"] = incomplete_details
     if model:
         completed_response["model"] = model
+    if usage is not None:
+        completed_response["usage"] = usage
     events.append(
         {
             "type": "response.incomplete" if incomplete_details is not None else "response.completed",
@@ -2377,6 +2414,12 @@ class ResponsesToChatStreamConverter:
             chunks: list[dict[str, Any]] = []
             response_obj = event.get("response")
             if isinstance(response_obj, Mapping):
+                response_id = response_obj.get("id")
+                if isinstance(response_id, str) and response_id:
+                    self.response_id = response_id
+                response_model = response_obj.get("model")
+                if isinstance(response_model, str) and response_model:
+                    self.model = response_model
                 output = response_obj.get("output")
                 if "output" in response_obj and not isinstance(output, list):
                     raise UnsupportedProtocolTranslationError(
@@ -2410,6 +2453,18 @@ class ResponsesToChatStreamConverter:
                         finish_reason = "tool_calls"
             self.completed = True
             chunks.append(self._chunk({}, finish_reason=finish_reason))
+            usage = response_obj.get("usage") if isinstance(response_obj, Mapping) else None
+            if isinstance(usage, Mapping):
+                chunks.append(
+                    {
+                        "id": self.response_id or f"chatcmpl_{uuid.uuid4().hex[:12]}",
+                        "object": "chat.completion.chunk",
+                        "created": int(time.time()),
+                        "model": self.model,
+                        "choices": [],
+                        "usage": _responses_usage_to_chat_usage(usage),
+                    }
+                )
             return chunks
         return []
 
@@ -2428,6 +2483,8 @@ class ChatToResponsesStreamConverter:
         self.created = False
         self.message_started = False
         self.completed = False
+        self.pending_incomplete: bool | None = None
+        self.usage: dict[str, Any] | None = None
 
     def _allocate_output_index(self) -> int:
         output_index = self.next_output_index
@@ -2591,11 +2648,13 @@ class ChatToResponsesStreamConverter:
         }
         if incomplete:
             response["incomplete_details"] = {"reason": "max_output_tokens"}
+        if self.usage is not None:
+            response["usage"] = dict(self.usage)
         events.append({"type": "response.incomplete" if incomplete else "response.completed", "response": response})
         return events
 
     def events_for_done(self) -> list[dict[str, Any]]:
-        return self._complete_events()
+        return self._complete_events(incomplete=self.pending_incomplete is True)
 
     def events_for_chunk(self, chunk: Mapping[str, Any]) -> list[dict[str, Any]]:
         _validate_chat_stream_choices(chunk)
@@ -2603,6 +2662,20 @@ class ChatToResponsesStreamConverter:
         if self.completed:
             if _is_chat_stream_usage_only_chunk(chunk):
                 return []
+            raise UnsupportedProtocolTranslationError(
+                "unsupported_protocol_semantics",
+                "Cannot translate Chat Completions stream semantics after a terminal chunk.",
+            )
+        if _is_chat_stream_usage_only_chunk(chunk):
+            usage = chunk.get("usage")
+            if not isinstance(usage, Mapping):
+                raise UnsupportedProtocolTranslationError(
+                    "unsupported_protocol_semantics",
+                    "Cannot translate a Chat Completions usage chunk without an object usage payload.",
+                )
+            self.usage = _chat_completion_usage_to_responses_usage(usage)
+            return []
+        if self.pending_incomplete is not None:
             raise UnsupportedProtocolTranslationError(
                 "unsupported_protocol_semantics",
                 "Cannot translate Chat Completions stream semantics after a terminal chunk.",
@@ -2724,14 +2797,14 @@ class ChatToResponsesStreamConverter:
                             )
             finish_reason = choice.get("finish_reason")
             if finish_reason == "length":
-                events.extend(self._complete_events(incomplete=True))
+                self.pending_incomplete = True
             elif finish_reason is not None:
                 if finish_reason not in {"stop", "tool_calls"}:
                     raise UnsupportedProtocolTranslationError(
                         "unsupported_protocol_semantics",
                         f"Cannot translate Chat Completions finish_reason {finish_reason!r} to Responses stream events.",
                     )
-                events.extend(self._complete_events())
+                self.pending_incomplete = False
         return events
 
 

--- a/src-python/protocol_translation.py
+++ b/src-python/protocol_translation.py
@@ -2834,6 +2834,7 @@ def events_to_responses_body(
     current_item: dict[str, Any] | None = None
     usage: Mapping[str, Any] | None = None
     response_payload: dict[str, Any] = {}
+    terminal_status: str | None = None
 
     for event in events:
         if not isinstance(event, Mapping):
@@ -2876,6 +2877,11 @@ def events_to_responses_body(
                 response_output = response.get("output")
                 if isinstance(response_output, list) and not output:
                     output = [dict(item) for item in response_output if isinstance(item, dict)]
+            terminal_status = (
+                "incomplete"
+                if event_type == "response.incomplete"
+                else "completed"
+            )
 
     if text_parts and not any(item.get("type") == "message" for item in output):
         output.append(
@@ -2889,7 +2895,10 @@ def events_to_responses_body(
     payload: dict[str, Any] = dict(response_payload)
     payload["id"] = response_id
     payload.setdefault("object", "response")
-    payload.setdefault("status", "completed")
+    if terminal_status is not None:
+        payload["status"] = terminal_status
+    else:
+        payload.setdefault("status", "completed")
     if model is not None or "model" not in payload:
         payload["model"] = model
     if output or not isinstance(payload.get("output"), list):

--- a/tests/test_chat_completions_gateway.py
+++ b/tests/test_chat_completions_gateway.py
@@ -525,7 +525,10 @@ class ResponseBodyToChatTests(unittest.TestCase):
         self.assertEqual(choice["message"]["role"], "assistant")
         self.assertEqual(choice["message"]["content"], "Hello!")
         self.assertEqual(choice["finish_reason"], "stop")
-        self.assertEqual(result["usage"]["input_tokens"], 10)
+        self.assertEqual(
+            result["usage"],
+            {"prompt_tokens": 10, "completion_tokens": 2},
+        )
 
     def test_function_call_response(self):
         body = json.dumps({

--- a/tests/test_protocol_translation.py
+++ b/tests/test_protocol_translation.py
@@ -1172,8 +1172,9 @@ class ProtocolTranslationTests(unittest.TestCase):
         self.assertEqual(raised.exception.code, "unpaired_tool_call")
 
         converter = protocol_translation.ChatToResponsesStreamConverter()
+        converter.events_for_chunk(chunk)
         with self.assertRaises(protocol_translation.UnsupportedProtocolTranslationError) as raised:
-            converter.events_for_chunk(chunk)
+            converter.events_for_done()
         self.assertEqual(raised.exception.code, "unpaired_tool_call")
 
     def test_chat_length_stream_maps_to_responses_incomplete_event(self):
@@ -1186,8 +1187,10 @@ class ProtocolTranslationTests(unittest.TestCase):
 
         converter = protocol_translation.ChatToResponsesStreamConverter()
         stateful_events = converter.events_for_chunk(chunk)
-        self.assertEqual(stateful_events[-1]["type"], "response.incomplete")
-        self.assertEqual(stateful_events[-1]["response"]["status"], "incomplete")
+        self.assertFalse(any(event["type"] == "response.incomplete" for event in stateful_events))
+        stateful_terminal = converter.events_for_done()
+        self.assertEqual(stateful_terminal[-1]["type"], "response.incomplete")
+        self.assertEqual(stateful_terminal[-1]["response"]["status"], "incomplete")
 
     def test_chat_stream_custom_tool_delta_fails_closed(self):
         chunk = {
@@ -1279,7 +1282,7 @@ class ProtocolTranslationTests(unittest.TestCase):
 
         converter = protocol_translation.ChatToResponsesStreamConverter()
         terminal_events = converter.events_for_chunk(terminal_chunk)
-        self.assertEqual(terminal_events[-1]["type"], "response.completed")
+        self.assertFalse(any(event["type"] == "response.completed" for event in terminal_events))
         with self.assertRaises(protocol_translation.UnsupportedProtocolTranslationError) as raised:
             converter.events_for_chunk(late_chunk)
         self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
@@ -1298,11 +1301,115 @@ class ProtocolTranslationTests(unittest.TestCase):
         )
         self.assertEqual(events[-1]["type"], "response.completed")
         self.assertEqual(events[-1]["response"]["output"][0]["content"][0]["text"], "A")
+        self.assertEqual(
+            events[-1]["response"]["usage"],
+            {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+        )
 
         converter = protocol_translation.ChatToResponsesStreamConverter()
-        converter.events_for_chunk(terminal_chunk)
+        pending_terminal = converter.events_for_chunk(terminal_chunk)
+        self.assertFalse(any(event["type"] == "response.completed" for event in pending_terminal))
         self.assertEqual(converter.events_for_chunk(usage_chunk), [])
-        self.assertEqual(converter.events_for_done(), [])
+        terminal_events = converter.events_for_done()
+        self.assertEqual(terminal_events[-1]["type"], "response.completed")
+        self.assertEqual(
+            terminal_events[-1]["response"]["usage"],
+            {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+        )
+
+    def test_responses_stream_usage_maps_to_chat_usage_chunk_before_done(self):
+        converter = protocol_translation.ResponsesToChatStreamConverter()
+        converter.chunks_for_event(
+            {
+                "type": "response.created",
+                "response": {"id": "resp_usage", "model": "canonical-model"},
+            }
+        )
+
+        chunks = converter.chunks_for_event(
+            {
+                "type": "response.completed",
+                "response": {
+                    "id": "resp_usage",
+                    "model": "canonical-model",
+                    "output": [],
+                    "usage": {
+                        "input_tokens": 8,
+                        "input_tokens_details": {"cached_tokens": 3},
+                        "output_tokens": 5,
+                        "output_tokens_details": {"reasoning_tokens": 2},
+                        "total_tokens": 13,
+                    },
+                },
+            }
+        )
+
+        self.assertEqual(chunks[0]["choices"][0]["finish_reason"], "stop")
+        self.assertEqual(chunks[1]["choices"], [])
+        self.assertEqual(
+            chunks[1]["usage"],
+            {
+                "prompt_tokens": 8,
+                "prompt_tokens_details": {"cached_tokens": 3},
+                "completion_tokens": 5,
+                "completion_tokens_details": {"reasoning_tokens": 2},
+                "total_tokens": 13,
+            },
+        )
+
+    def test_body_usage_fields_map_between_protocol_names(self):
+        chat_body = json.dumps(
+            {
+                "id": "chatcmpl_usage",
+                "object": "chat.completion",
+                "model": "chat-model",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "done"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 8,
+                    "completion_tokens": 5,
+                    "total_tokens": 13,
+                },
+            }
+        ).encode("utf-8")
+        responses_body = json.dumps(
+            {
+                "id": "resp_usage",
+                "object": "response",
+                "status": "completed",
+                "model": "responses-model",
+                "output": [
+                    {
+                        "id": "msg_usage",
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": "done", "annotations": []}],
+                    }
+                ],
+                "usage": {
+                    "input_tokens": 7,
+                    "output_tokens": 4,
+                    "total_tokens": 11,
+                },
+            }
+        ).encode("utf-8")
+
+        as_responses = json.loads(protocol_translation.chat_completion_to_response_body(chat_body))
+        as_chat = json.loads(protocol_translation.response_body_to_chat_completion_body(responses_body))
+
+        self.assertEqual(
+            as_responses["usage"],
+            {"input_tokens": 8, "output_tokens": 5, "total_tokens": 13},
+        )
+        self.assertEqual(
+            as_chat["usage"],
+            {"prompt_tokens": 7, "completion_tokens": 4, "total_tokens": 11},
+        )
 
     def test_chat_stream_rejects_unknown_tool_fields_and_non_string_arguments(self):
         tool_calls = (
@@ -1763,6 +1870,7 @@ class ProtocolTranslationTests(unittest.TestCase):
                 "choices": [{"delta": {"content": "Hello"}, "finish_reason": "stop"}],
             }
         )
+        events.extend(chat_to_responses.events_for_done())
         self.assertEqual(events[-1]["type"], "response.completed")
 
         responses_to_chat = protocol_translation.ResponsesToChatStreamConverter()

--- a/tests/test_protocol_translation.py
+++ b/tests/test_protocol_translation.py
@@ -1862,6 +1862,46 @@ class ProtocolTranslationTests(unittest.TestCase):
         self.assertEqual(input_done["input"], item["input"])
         self.assertEqual(reconstructed["output"], [item])
 
+    def test_events_to_responses_body_terminal_type_is_authoritative(self):
+        cases = (
+            ("incomplete_missing_status", "response.incomplete", None, "incomplete"),
+            ("incomplete_contradictory_status", "response.incomplete", "completed", "incomplete"),
+            ("completed_missing_status", "response.completed", None, "completed"),
+            ("completed_contradictory_status", "response.completed", "incomplete", "completed"),
+        )
+
+        for name, event_type, embedded_status, expected_status in cases:
+            with self.subTest(name=name):
+                response = {
+                    "id": f"resp_{name}",
+                    "object": "response",
+                    "output": [],
+                }
+                if embedded_status is not None:
+                    response["status"] = embedded_status
+                if event_type == "response.incomplete":
+                    response["incomplete_details"] = {"reason": "max_output_tokens"}
+
+                reconstructed = json.loads(
+                    protocol_translation.events_to_responses_body(
+                        [{"type": event_type, "response": response}],
+                        require_completed=True,
+                    )
+                )
+
+                self.assertEqual(reconstructed["status"], expected_status)
+                if event_type == "response.incomplete":
+                    self.assertEqual(
+                        reconstructed["incomplete_details"],
+                        {"reason": "max_output_tokens"},
+                    )
+
+        with self.assertRaises(protocol_translation.UpstreamStreamIncompleteError):
+            protocol_translation.events_to_responses_body(
+                [{"type": "response.output_text.delta", "delta": "partial"}],
+                require_completed=True,
+            )
+
     def test_stateful_stream_converters_emit_terminal_protocol_events(self):
         chat_to_responses = protocol_translation.ChatToResponsesStreamConverter()
         events = chat_to_responses.events_for_chunk(

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -3289,6 +3289,127 @@ class RoutingTests(unittest.TestCase):
             {"input_tokens": 7, "output_tokens": 5, "total_tokens": 12},
         )
 
+    def test_buffered_chat_length_terminal_reconstructs_incomplete_responses_body(self):
+        chunks = [
+            {
+                "id": "chatcmpl_buffered_length",
+                "object": "chat.completion.chunk",
+                "model": "canonical-chat-length",
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {
+                            "content": "partial text",
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "id": "call_partial",
+                                    "type": "function",
+                                    "function": {
+                                        "name": "lookup",
+                                        "arguments": '{"q":"partial"}',
+                                    },
+                                }
+                            ],
+                        },
+                        "finish_reason": "length",
+                    }
+                ],
+            },
+            {
+                "id": "chatcmpl_buffered_length",
+                "object": "chat.completion.chunk",
+                "model": "canonical-chat-length",
+                "choices": [],
+                "usage": {
+                    "prompt_tokens": 9,
+                    "completion_tokens": 6,
+                    "total_tokens": 15,
+                },
+            },
+        ]
+        response = FakeSseResponse(
+            [f"data: {json.dumps(chunk)}\n\n".encode("utf-8") for chunk in chunks]
+            + [b"data: [DONE]\n\n", b""]
+        )
+        fake = FakeHandler()
+
+        status = CodexProxyHandler._relay_upstream_response(
+            fake,
+            response,
+            "chat_only_provider",
+            request_id="req-buffered-chat-length",
+            model="caller-model",
+            upstream_format="chat_completions",
+            inbound_format="responses",
+            caller_stream=False,
+            behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+            usage_capture={},
+        )
+
+        payload = json.loads(b"".join(fake.wfile.writes))
+        output_by_type = {item["type"]: item for item in payload["output"]}
+        self.assertEqual(status, 200)
+        self.assertEqual(payload["status"], "incomplete")
+        self.assertEqual(
+            payload["incomplete_details"],
+            {"reason": "max_output_tokens"},
+        )
+        self.assertEqual(payload["model"], "canonical-chat-length")
+        self.assertEqual(
+            output_by_type["message"]["content"][0]["text"],
+            "partial text",
+        )
+        self.assertEqual(output_by_type["function_call"]["call_id"], "call_partial")
+        self.assertEqual(output_by_type["function_call"]["name"], "lookup")
+        self.assertEqual(
+            output_by_type["function_call"]["arguments"],
+            '{"q":"partial"}',
+        )
+        self.assertEqual(
+            payload["usage"],
+            {"input_tokens": 9, "output_tokens": 6, "total_tokens": 15},
+        )
+
+    def test_buffered_chat_sse_without_source_terminal_remains_incomplete_error(self):
+        partial_chunk = {
+            "id": "chatcmpl_buffered_unterminated",
+            "object": "chat.completion.chunk",
+            "model": "canonical-chat-unterminated",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"content": "partial without terminal"},
+                    "finish_reason": None,
+                }
+            ],
+        }
+        fake = FakeHandler()
+
+        status = CodexProxyHandler._relay_upstream_response(
+            fake,
+            FakeSseResponse(
+                [
+                    f"data: {json.dumps(partial_chunk)}\n\n".encode("utf-8"),
+                    b"",
+                ]
+            ),
+            "chat_only_provider",
+            request_id="req-buffered-chat-unterminated",
+            model="caller-model",
+            upstream_format="chat_completions",
+            inbound_format="responses",
+            caller_stream=False,
+            behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+            usage_capture={},
+        )
+
+        payload = json.loads(b"".join(fake.wfile.writes))
+        self.assertEqual(status, 502)
+        self.assertEqual(payload["error"]["type"], "upstream_stream_incomplete")
+        self.assertEqual(payload["error"]["code"], "upstream_stream_incomplete")
+        self.assertNotIn("output", payload)
+
     def test_image_proxy_sse_to_body_uses_complete_frames(self):
         response = FakeSseResponse(
             [
@@ -3406,6 +3527,42 @@ class RoutingTests(unittest.TestCase):
                 observations.append((event.raw, event.data, raised.exception.classification))
 
         self.assertEqual(observations[0], observations[1])
+
+    def test_converted_size_failure_after_committed_terminal_is_suppressed(self):
+        finish_chunk = (
+            b'data: {"id":"chatcmpl_terminal","object":"chat.completion.chunk",'
+            b'"model":"canonical-terminal-model","choices":[{"index":0,"delta":{},'
+            b'"finish_reason":"stop"}]}\r\r'
+        )
+        oversized_frame = b"data: " + (b"x" * DEFAULT_MAX_FRAME_BYTES)
+        response = FakeSseResponse(
+            [
+                finish_chunk,
+                b"data: [DONE]\r\r" + oversized_frame,
+                b"",
+            ]
+        )
+        fake = FakeHandler()
+
+        status = CodexProxyHandler._relay_upstream_response(
+            fake,
+            response,
+            "chat_only_provider",
+            request_id="req-terminal-before-size-failure",
+            model="caller-model",
+            upstream_format="chat_completions",
+            inbound_format="responses",
+            caller_stream=True,
+            behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+            usage_capture={},
+        )
+
+        written = b"".join(fake.wfile.writes)
+        self.assertEqual(status, 200)
+        self.assertEqual(written.count(b"response.completed"), 1)
+        self.assertNotIn(b"event: error", written)
+        self.assertNotIn(b"sse_frame_too_large", written)
+        self.assertNotIn(oversized_frame[-64:], written)
 
     def test_malformed_converted_request_completes_once_with_502_without_retry(self):
         self.external_model["upstream_format"] = "chat_completions"
@@ -3535,6 +3692,128 @@ class RoutingTests(unittest.TestCase):
                 self.assertNotIn(b"SECRET_", written)
                 self.assertNotIn(b"later_success", written)
                 self.assertNotIn(case["forbidden_terminal"], written)
+
+    def test_verified_cross_protocol_source_shape_table_fails_once_without_retry(self):
+        cases = (
+            (
+                "responses_terminal_envelope",
+                "responses",
+                b'data: {"type":"response.completed","response":"SECRET_RESPONSES_TERMINAL"}\n\n',
+            ),
+            (
+                "responses_created_envelope",
+                "responses",
+                b'data: {"type":"response.created","response":["SECRET_RESPONSES_CREATED"]}\n\n',
+            ),
+            (
+                "responses_output_item_envelope",
+                "responses",
+                b'data: {"type":"response.output_item.added","item":"SECRET_RESPONSES_ITEM"}\n\n',
+            ),
+            (
+                "responses_terminal_output_item_envelope",
+                "responses",
+                b'data: {"type":"response.completed","response":{"status":"completed","output":["SECRET_RESPONSES_TERMINAL_ITEM"]}}\n\n',
+            ),
+            (
+                "chat_choice_envelope",
+                "chat_completions",
+                b'data: {"choices":["SECRET_CHAT_CHOICE"]}\n\n',
+            ),
+            (
+                "chat_finish_reason_envelope",
+                "chat_completions",
+                b'data: {"choices":[{"index":0,"delta":{},"finish_reason":{"secret":"SECRET_CHAT_FINISH"}}]}\n\n',
+            ),
+            (
+                "chat_usage_envelope",
+                "chat_completions",
+                b'data: {"choices":[],"usage":"SECRET_CHAT_USAGE"}\n\n',
+            ),
+            (
+                "chat_tool_calls_envelope",
+                "chat_completions",
+                b'data: {"choices":[{"index":0,"delta":{"tool_calls":"SECRET_CHAT_TOOL_CALLS"},"finish_reason":null}]}\n\n',
+            ),
+        )
+
+        for name, source_format, invalid_frame in cases:
+            with self.subTest(name=name):
+                self.write_proxy_event.reset_mock()
+                self.external_model["upstream_format"] = source_format
+                responses_source = source_format == "responses"
+                path = (
+                    "/v1/providers/volc/chat/completions"
+                    if responses_source
+                    else "/v1/providers/volc/responses"
+                )
+                request = (
+                    {
+                        "model": "volc/glm-5.2",
+                        "messages": [{"role": "user", "content": "hi"}],
+                        "stream": True,
+                    }
+                    if responses_source
+                    else {
+                        "model": "volc/glm-5.2",
+                        "input": [{"type": "message", "role": "user", "content": "hi"}],
+                        "stream": True,
+                    }
+                )
+                later_frames = (
+                    [
+                        b'data: {"type":"response.completed","response":{"id":"later_success","status":"completed","output":[]}}\n\n',
+                        b"",
+                    ]
+                    if responses_source
+                    else [
+                        b'data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\n',
+                        b"data: [DONE]\n\n",
+                        b"",
+                    ]
+                )
+                frames = [invalid_frame, *later_frames]
+                handler, fake = post_handler(
+                    path,
+                    json.dumps(request).encode("utf-8"),
+                    headers={"X-Codex-Client-Id": "opencode"},
+                )
+
+                with (
+                    patch.dict(
+                        os.environ,
+                        {
+                            "CODEX_PROXY_AUTO_RETRY_ENABLED": "1",
+                            "CODEX_PROXY_AUTO_RETRY_MAX_ATTEMPTS": "3",
+                        },
+                        clear=False,
+                    ),
+                    patch(
+                        "codex_proxy.urlopen",
+                        side_effect=lambda *_args, **_kwargs: FakeSseResponse(frames),
+                    ) as mock_urlopen,
+                ):
+                    CodexProxyHandler.do_POST(handler)
+
+                written = b"".join(fake.wfile.writes)
+                request_complete = [
+                    call.kwargs
+                    for call in self.write_proxy_event.call_args_list
+                    if call.args and call.args[0] == "request_complete"
+                ]
+                self.assertEqual(mock_urlopen.call_count, 1)
+                self.assertEqual(len(request_complete), 1)
+                self.assertEqual(request_complete[0]["status"], 502)
+                self.assertEqual(
+                    written.count(b"data: " if responses_source else b"event: error"),
+                    1,
+                )
+                self.assertNotIn(b"SECRET_", written)
+                self.assertNotIn(b"later_success", written)
+                self.assertNotIn(
+                    b"data: [DONE]" if responses_source else b"response.completed",
+                    written,
+                )
 
     def test_upstream_http_error_emits_request_complete_with_status(self):
         body = json.dumps({"model": "volc/glm-5.2", "messages": [{"role": "user", "content": "hi"}], "stream": False}).encode("utf-8")

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -3866,6 +3866,114 @@ class RoutingTests(unittest.TestCase):
         for write_index in write_indices:
             self.assertLess(end_headers_index, write_index)
 
+    def test_lifecycle_resample_stream_headers_precede_keepalives(self):
+        handler = FakeHandler()
+        call_order = []
+
+        class RecordingWFile(FakeWFile):
+            def write(self, data):
+                call_order.append(("write", data))
+                super().write(data)
+
+        handler.wfile = RecordingWFile()
+
+        def record_send_response(status, message=None):
+            call_order.append(("send_response", status))
+            handler.status = status
+
+        def record_send_header(key, value):
+            call_order.append(("send_header", key))
+            handler.headers.append((key, value))
+
+        def record_end_headers():
+            call_order.append(("end_headers", None))
+            handler.headers_ended = True
+
+        handler.send_response = record_send_response
+        handler.send_header = record_send_header
+        handler.end_headers = record_end_headers
+        terminal = {
+            "type": "response.completed",
+            "response": {
+                "id": "resp_lifecycle_complete",
+                "status": "completed",
+                "model": "gpt-5.5",
+                "output": [
+                    {
+                        "id": "msg_lifecycle_complete",
+                        "type": "message",
+                        "status": "completed",
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "output_text",
+                                "text": "Lifecycle complete.",
+                                "annotations": [],
+                            }
+                        ],
+                    }
+                ],
+            },
+        }
+        response = FakeDelayedSseResponse(
+            [
+                b"data: "
+                + json.dumps(terminal, separators=(",", ":")).encode("utf-8")
+                + b"\n\n",
+                b"",
+            ],
+            first_delay_seconds=0.05,
+        )
+
+        with patch.dict(
+            os.environ,
+            {"CODEX_PROXY_SSE_KEEPALIVE_SECONDS": "0.01"},
+            clear=False,
+        ):
+            result = CodexProxyHandler._relay_upstream_response(
+                handler,
+                response,
+                "official",
+                request_id="req-lifecycle-header-order",
+                model="gpt-5.5",
+                upstream_format="responses",
+                inbound_format="chat_completions",
+                caller_stream=True,
+                event_context={
+                    "request_id": "req-lifecycle-header-order",
+                    "repair_policy": codex_proxy.REPAIR_CODEX_SUBAGENT,
+                    "subagent_lifecycle_complete": True,
+                },
+                behavior_profile=codex_proxy.BEHAVIOR_OFFICIAL_GATEWAY_COMPAT,
+            )
+
+        written = b"".join(handler.wfile.writes)
+        self.assertEqual(result, 200)
+        self.assertGreaterEqual(written.count(b": codexhub.keepalive\n\n"), 1)
+        self.assertIn(b"Lifecycle complete.", written)
+        self.assertEqual(written.count(b"data: [DONE]\n\n"), 1)
+        self.assertEqual(
+            sum(name == "send_response" for name, _value in call_order),
+            1,
+        )
+        self.assertEqual(
+            sum(name == "end_headers" for name, _value in call_order),
+            1,
+        )
+        end_headers_index = next(
+            index
+            for index, (name, _value) in enumerate(call_order)
+            if name == "end_headers"
+        )
+        write_indices = [
+            index
+            for index, (name, _value) in enumerate(call_order)
+            if name == "write"
+        ]
+        self.assertTrue(write_indices)
+        for write_index in write_indices:
+            self.assertLess(end_headers_index, write_index)
+
     def test_verified_cross_protocol_source_shape_table_fails_once_without_retry(self):
         cases = (
             (

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -9808,8 +9808,8 @@ class RoutingTests(unittest.TestCase):
         fixture = _load_glm_apply_patch_retry_fixture()
         handler = FakeHandler()
         response = FakeSseResponse(
-            [f"data: {json.dumps(chunk)}\n".encode("utf-8") for chunk in fixture["stream_chunks"]]
-            + [b"data: [DONE]\n", b""]
+            [f"data: {json.dumps(chunk)}\n\n".encode("utf-8") for chunk in fixture["stream_chunks"]]
+            + [b"data: [DONE]\n\n", b""]
         )
 
         status = CodexProxyHandler._relay_upstream_response(
@@ -16343,8 +16343,8 @@ Execution constraints:
             {"usage": {"prompt_tokens": 2, "completion_tokens": 1, "total_tokens": 3}, "choices": []},
         ]
         close_response = FakeSseResponse(
-            [f"data: {json.dumps(chunk)}\n".encode("utf-8") for chunk in close_chunks]
-            + [b"data: [DONE]\n", b""]
+            [f"data: {json.dumps(chunk)}\n\n".encode("utf-8") for chunk in close_chunks]
+            + [b"data: [DONE]\n\n", b""]
         )
         CodexProxyHandler._relay_upstream_response(
             close_handler,
@@ -18589,8 +18589,8 @@ Execution constraints:
             },
         ]
         return FakeSseResponse(
-            [f"data: {json.dumps(chunk)}\n".encode("utf-8") for chunk in chunks]
-            + [b"data: [DONE]\n", b""]
+            [f"data: {json.dumps(chunk)}\n\n".encode("utf-8") for chunk in chunks]
+            + [b"data: [DONE]\n\n", b""]
         )
 
     def _native_wait_sse_events(self, *, call_id):

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -117,6 +117,9 @@ class FakeHandler:
     def _iter_upstream_sse_lines(self, *args, **kwargs):
         return CodexProxyHandler._iter_upstream_sse_lines(self, *args, **kwargs)
 
+    def _iter_upstream_sse_events(self, *args, **kwargs):
+        return CodexProxyHandler._iter_upstream_sse_events(self, *args, **kwargs)
+
     def _write_sse_protocol_error_event(self, upstream_name, status, detail, *, error="UpstreamProtocolError"):
         return CodexProxyHandler._write_sse_protocol_error_event(
             self,
@@ -2928,6 +2931,382 @@ class RoutingTests(unittest.TestCase):
             self.assertEqual(body.count(case["terminal"]), 1, case["name"])
             self.assertIn(b"sentinel", body, case["name"])
             self.assertEqual(close_call_count, 1, case["name"])
+
+    def test_converted_responses_stream_uses_complete_frames_across_transport_fragmentation(self):
+        fake = FakeHandler()
+        response = FakeSseResponse(
+            [
+                b": keepalive\r",
+                b"\nretry: 1500\r\n\r",
+                b"\n",
+                b"event: response.created\r\ndata: {\"type\":\"response.created\",",
+                b"\r\ndata: \"response\":{\"id\":\"resp_fragmented\",\"model\":\"canonical-model\"}}\r\n\r\n",
+                b"data: {\"type\":\"response.output_text.delta\",\"delta\":\"frag",
+                b"mented\"}\r",
+                b"\n\r\n",
+                b"data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_fragmented\",",
+                b"\"model\":\"canonical-model\",\"status\":\"completed\",\"output\":[],\"usage\":{\"input_tokens\":8,\"output_tokens\":5,\"total_tokens\":13}}}\r\n\r\n",
+                b"",
+            ]
+        )
+
+        status = CodexProxyHandler._relay_upstream_response(
+            fake,
+            response,
+            "responses_only_provider",
+            request_id="req-converted-fragmented",
+            model="caller-model",
+            upstream_format="responses",
+            inbound_format="chat_completions",
+            caller_stream=True,
+            behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+            usage_capture={},
+        )
+
+        written = b"".join(fake.wfile.writes)
+        self.assertEqual(status, 200)
+        self.assertIn(b'"model":"canonical-model"', written)
+        self.assertIn(b'"content":"fragmented"', written)
+        self.assertIn(b'"prompt_tokens":8', written)
+        self.assertIn(b'"completion_tokens":5', written)
+        self.assertEqual(written.count(b"data: [DONE]"), 1)
+        self.assertNotIn(b'"error"', written)
+
+    def test_converted_chat_stream_uses_complete_frames_across_transport_fragmentation(self):
+        fake = FakeHandler()
+        response = FakeSseResponse(
+            [
+                b": keepalive\n\n",
+                b"event: chat.chunk\ndata: {\"id\":\"chatcmpl_fragmented\",\"object\":\"chat.completion.chunk\",",
+                b"\ndata: \"model\":\"canonical-chat-model\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"frag",
+                b"mented\"},\"finish_reason\":null}]}\n\n",
+                b"data: {\"id\":\"chatcmpl_fragmented\",\"object\":\"chat.completion.chunk\",",
+                b"\"model\":\"canonical-chat-model\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\r\r",
+                b'data: {"choices":[],"usage":{"prompt_tokens":7,"completion_tokens":4,"total_tokens":11}}\r\r',
+                b"data: [DO",
+                b"NE]\r\r",
+                b"",
+            ]
+        )
+
+        status = CodexProxyHandler._relay_upstream_response(
+            fake,
+            response,
+            "chat_only_provider",
+            request_id="req-converted-chat-fragmented",
+            model="caller-model",
+            upstream_format="chat_completions",
+            inbound_format="responses",
+            caller_stream=True,
+            behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+            usage_capture={},
+        )
+
+        written = b"".join(fake.wfile.writes)
+        self.assertEqual(status, 200)
+        self.assertIn(b'"model":"canonical-chat-model"', written)
+        self.assertIn(b'"delta":"fragmented"', written)
+        self.assertIn(b'"input_tokens":7', written)
+        self.assertIn(b'"output_tokens":4', written)
+        self.assertEqual(written.count(b"response.completed"), 1)
+        self.assertNotIn(b"data: [DONE]", written)
+        self.assertNotIn(b'"error"', written)
+
+    def test_converted_stream_incomplete_frame_is_not_emitted_as_partial_success(self):
+        fake = FakeHandler()
+        response = FakeSseResponse(
+            [
+                b'data: {"type":"response.output_text.delta","delta":"complete"}\n\n',
+                b'data: {"type":"response.completed","response":{"id":"resp_SECRET',
+                b"",
+            ]
+        )
+
+        status = CodexProxyHandler._relay_upstream_response(
+            fake,
+            response,
+            "responses_only_provider",
+            request_id="req-converted-incomplete-frame",
+            model="caller-model",
+            upstream_format="responses",
+            inbound_format="chat_completions",
+            caller_stream=True,
+            behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+            usage_capture={},
+        )
+
+        written = b"".join(fake.wfile.writes)
+        self.assertEqual(status, 502)
+        self.assertIn(b'"content":"complete"', written)
+        self.assertNotIn(b"resp_SECRET", written)
+        self.assertEqual(written.count(b'"code":"upstream_stream_incomplete"'), 1)
+        self.assertNotIn(b"data: [DONE]", written)
+
+    def test_malformed_complete_converted_frames_fail_once_without_payload_echo_or_later_success(self):
+        cases = (
+            (
+                "responses_to_chat",
+                "responses",
+                "chat_completions",
+                b"data: \xffSECRET_RESPONSES\n\n",
+                b'data: {"type":"response.completed","response":{"id":"later_success"}}\n\n',
+                b'"code":"upstream_protocol_error"',
+                b"data: [DONE]",
+            ),
+            (
+                "chat_to_responses",
+                "chat_completions",
+                "responses",
+                b"data: {SECRET_CHAT]\r\n\r\n",
+                b'data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\r\n\r\n',
+                b"event: error",
+                b"response.completed",
+            ),
+        )
+
+        for (
+            name,
+            upstream_format,
+            inbound_format,
+            malformed,
+            later_success,
+            error_marker,
+            forbidden_terminal,
+        ) in cases:
+            with self.subTest(name=name):
+                fake = FakeHandler()
+                response = FakeSseResponse([malformed, later_success, b""])
+
+                status = CodexProxyHandler._relay_upstream_response(
+                    fake,
+                    response,
+                    f"{name}_provider",
+                    request_id=f"req-{name}-malformed",
+                    model="caller-model",
+                    upstream_format=upstream_format,
+                    inbound_format=inbound_format,
+                    caller_stream=True,
+                    behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+                    usage_capture={},
+                )
+
+                written = b"".join(fake.wfile.writes)
+                self.assertEqual(status, 502)
+                self.assertEqual(written.count(error_marker), 1)
+                self.assertNotIn(b"SECRET", written)
+                self.assertNotIn(b"later_success", written)
+                self.assertNotIn(forbidden_terminal, written)
+
+    def test_buffered_converted_streams_also_parse_only_complete_frames(self):
+        cases = (
+            (
+                "responses_to_chat",
+                "responses",
+                "chat_completions",
+                [
+                    b'data: {"type":"response.created","response":{"id":"resp_buffered","model":"canonical-responses"}}\n\n',
+                    b'data: {"type":"response.output_text.delta",\n',
+                    b'data: "delta":"buffered responses"}\n\n',
+                    b'data: {"type":"response.completed","response":{"id":"resp_buffered","model":"canonical-responses","status":"completed","output":[]}}\n\n',
+                    b"",
+                ],
+                b'"content":"buffered responses"',
+                b"data: [DONE]",
+            ),
+            (
+                "chat_to_responses",
+                "chat_completions",
+                "responses",
+                [
+                    b'data: {"id":"chatcmpl_buffered","object":"chat.completion.chunk","model":"canonical-chat",',
+                    b'\r\ndata: "choices":[{"index":0,"delta":{"content":"buffered chat"},"finish_reason":null}]}\r\n\r\n',
+                    b'data: {"id":"chatcmpl_buffered","object":"chat.completion.chunk","model":"canonical-chat","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\r\n\r\n',
+                    b"data: [DONE]\r\n\r\n",
+                    b"",
+                ],
+                b'"delta":"buffered chat"',
+                b"response.completed",
+            ),
+        )
+
+        for name, upstream_format, inbound_format, stream, content, terminal in cases:
+            with self.subTest(name=name):
+                fake = FakeHandler()
+
+                status = CodexProxyHandler._relay_upstream_response(
+                    fake,
+                    FakeSseResponse(stream),
+                    f"{name}_generic_provider",
+                    request_id=f"req-{name}-buffered",
+                    model="caller-model",
+                    upstream_format=upstream_format,
+                    inbound_format=inbound_format,
+                    caller_stream=True,
+                    behavior_profile=None,
+                    usage_capture={},
+                )
+
+                written = b"".join(fake.wfile.writes)
+                self.assertEqual(status, 200)
+                self.assertIn(content, written)
+                self.assertEqual(written.count(terminal), 1)
+                self.assertNotIn(b'"error"', written)
+
+    def test_sse_to_non_streaming_json_uses_complete_frames(self):
+        fake = FakeHandler()
+        response = FakeSseResponse(
+            [
+                b'data: {"type":"response.created","response":{"id":"resp_json","model":"canonical-json"}}\r\n\r\n',
+                b'data: {"type":"response.output_text.delta",\r\n',
+                b'data: "delta":"buffered json"}\r\n\r\n',
+                b'data: {"type":"response.completed","response":{"id":"resp_json","model":"canonical-json","status":"completed","output":[]}}\r\n\r\n',
+                b"",
+            ]
+        )
+
+        status = CodexProxyHandler._relay_upstream_response(
+            fake,
+            response,
+            "responses_provider",
+            request_id="req-sse-to-json-frames",
+            model="caller-model",
+            upstream_format="responses",
+            inbound_format="responses",
+            caller_stream=False,
+            behavior_profile=None,
+            usage_capture={},
+        )
+
+        payload = json.loads(b"".join(fake.wfile.writes))
+        self.assertEqual(status, 200)
+        self.assertEqual(payload["id"], "resp_json")
+        self.assertEqual(payload["model"], "canonical-json")
+        self.assertEqual(payload["output"][0]["content"][0]["text"], "buffered json")
+
+    def test_image_proxy_sse_to_body_uses_complete_frames(self):
+        response = FakeSseResponse(
+            [
+                b'data: {"type":"response.created","response":{"id":"resp_image","model":"vision-model"}}\n\n',
+                b'data: {"type":"response.output_text.delta",\n',
+                b'data: "delta":"described image"}\n\n',
+                b'data: {"type":"response.completed","response":{"id":"resp_image","model":"vision-model","status":"completed","output":[]}}\n\n',
+                b"",
+            ]
+        )
+
+        payload = json.loads(codex_proxy._image_proxy_response_body(response))
+
+        self.assertEqual(payload["id"], "resp_image")
+        self.assertEqual(payload["model"], "vision-model")
+        self.assertEqual(payload["output"][0]["content"][0]["text"], "described image")
+
+    def test_converted_target_events_are_invariant_to_transport_partitioning(self):
+        sources = (
+            (
+                "responses_to_chat",
+                "responses",
+                "chat_completions",
+                (
+                    b": comment\r\n\r\n"
+                    b'data: {"type":"response.created","response":{"id":"resp_partition","model":"responses-model"}}\r\n\r\n'
+                    b'data: {"type":"response.output_text.delta","delta":"partitioned"}\r\n\r\n'
+                    b'data: {"type":"response.completed","response":{"id":"resp_partition","model":"responses-model","status":"completed","output":[]}}\r\n\r\n'
+                ),
+            ),
+            (
+                "chat_to_responses",
+                "chat_completions",
+                "responses",
+                (
+                    b": comment\n\n"
+                    b'data: {"id":"chatcmpl_partition","object":"chat.completion.chunk","model":"chat-model","choices":[{"index":0,"delta":{"content":"partitioned"},"finish_reason":null}]}\n\n'
+                    b'data: {"id":"chatcmpl_partition","object":"chat.completion.chunk","model":"chat-model","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\n'
+                    b"data: [DONE]\n\n"
+                ),
+            ),
+        )
+        fixed_uuid = Mock(hex="0123456789abcdef0123456789abcdef")
+
+        for name, upstream_format, inbound_format, raw in sources:
+            partitions = (
+                [raw, b""],
+                [bytes((byte,)) for byte in raw] + [b""],
+                [raw[:7], raw[7:31], raw[31:-5], raw[-5:], b""],
+            )
+            outputs = []
+            with (
+                patch("protocol_translation.time.time", return_value=1234567890),
+                patch("protocol_translation.uuid.uuid4", return_value=fixed_uuid),
+            ):
+                for chunks in partitions:
+                    fake = FakeHandler()
+                    status = CodexProxyHandler._relay_upstream_response(
+                        fake,
+                        FakeSseResponse(chunks),
+                        f"{name}_provider",
+                        request_id=f"req-{name}-partition",
+                        model="caller-model",
+                        upstream_format=upstream_format,
+                        inbound_format=inbound_format,
+                        caller_stream=True,
+                        behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+                        usage_capture={},
+                    )
+                    self.assertEqual(status, 200)
+                    outputs.append(b"".join(fake.wfile.writes))
+
+            with self.subTest(name=name):
+                self.assertEqual(outputs[1:], outputs[:-1])
+
+    def test_malformed_converted_request_completes_once_with_502_without_retry(self):
+        self.external_model["upstream_format"] = "chat_completions"
+        body = json.dumps(
+            {
+                "model": "volc/glm-5.2",
+                "input": [{"type": "message", "role": "user", "content": "hi"}],
+                "stream": True,
+            }
+        ).encode("utf-8")
+        handler, fake = post_handler(
+            "/v1/providers/volc/responses",
+            body,
+            headers={"X-Codex-Client-Id": "opencode"},
+        )
+        malformed = FakeSseResponse(
+            [
+                b"data: \xffSECRET_CONVERTED\n\n",
+                b'data: {"choices":[{"index":0,"delta":{"content":"later_success"},"finish_reason":"stop"}]}\n\n',
+                b"data: [DONE]\n\n",
+                b"",
+            ]
+        )
+
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "CODEX_PROXY_AUTO_RETRY_ENABLED": "1",
+                    "CODEX_PROXY_AUTO_RETRY_MAX_ATTEMPTS": "3",
+                },
+                clear=False,
+            ),
+            patch("codex_proxy.urlopen", return_value=malformed) as mock_urlopen,
+        ):
+            CodexProxyHandler.do_POST(handler)
+
+        written = b"".join(fake.wfile.writes)
+        request_complete = [
+            call.kwargs
+            for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] == "request_complete"
+        ]
+        self.assertEqual(mock_urlopen.call_count, 1)
+        self.assertEqual(len(request_complete), 1)
+        self.assertEqual(request_complete[0]["status"], 502)
+        self.assertEqual(written.count(b"event: error"), 1)
+        self.assertNotIn(b"SECRET_CONVERTED", written)
+        self.assertNotIn(b"later_success", written)
+        self.assertNotIn(b"response.completed", written)
 
     def test_upstream_http_error_emits_request_complete_with_status(self):
         body = json.dumps({"model": "volc/glm-5.2", "messages": [{"role": "user", "content": "hi"}], "stream": False}).encode("utf-8")
@@ -8800,7 +9179,7 @@ class RoutingTests(unittest.TestCase):
             },
         ]
         response = FakeSseResponse(
-            [f"data: {json.dumps(chunk)}\n".encode("utf-8") for chunk in chunks] + [b"data: [DONE]\n", b""]
+            [f"data: {json.dumps(chunk)}\n\n".encode("utf-8") for chunk in chunks] + [b"data: [DONE]\n\n", b""]
         )
 
         CodexProxyHandler._relay_upstream_response(
@@ -8848,7 +9227,7 @@ class RoutingTests(unittest.TestCase):
             },
         ]
         response = FakeSseResponse(
-            [f"data: {json.dumps(chunk)}\n".encode("utf-8") for chunk in chunks] + [b"data: [DONE]\n", b""]
+            [f"data: {json.dumps(chunk)}\n\n".encode("utf-8") for chunk in chunks] + [b"data: [DONE]\n\n", b""]
         )
 
         CodexProxyHandler._relay_upstream_response(
@@ -8937,7 +9316,7 @@ class RoutingTests(unittest.TestCase):
             },
         ]
         response = FakeSseResponse(
-            [f"data: {json.dumps(chunk)}\n".encode("utf-8") for chunk in chunks] + [b"data: [DONE]\n", b""]
+            [f"data: {json.dumps(chunk)}\n\n".encode("utf-8") for chunk in chunks] + [b"data: [DONE]\n\n", b""]
         )
 
         CodexProxyHandler._relay_upstream_response(
@@ -9009,7 +9388,7 @@ class RoutingTests(unittest.TestCase):
             },
         ]
         response = FakeSseResponse(
-            [f"data: {json.dumps(chunk)}\n".encode("utf-8") for chunk in chunks] + [b"data: [DONE]\n", b""]
+            [f"data: {json.dumps(chunk)}\n\n".encode("utf-8") for chunk in chunks] + [b"data: [DONE]\n\n", b""]
         )
 
         CodexProxyHandler._relay_upstream_response(
@@ -9054,7 +9433,7 @@ class RoutingTests(unittest.TestCase):
             {"choices": [{"delta": {"content": "lo"}, "finish_reason": "stop"}]},
         ]
         response = FakeSseResponse(
-            [f"data: {json.dumps(chunk)}\n".encode("utf-8") for chunk in chunks] + [b"data: [DONE]\n", b""]
+            [f"data: {json.dumps(chunk)}\n\n".encode("utf-8") for chunk in chunks] + [b"data: [DONE]\n\n", b""]
         )
 
         CodexProxyHandler._relay_upstream_response(
@@ -9083,7 +9462,7 @@ class RoutingTests(unittest.TestCase):
             {"choices": [{"delta": {"content": "ok"}, "finish_reason": "stop"}]},
             {"usage": {"prompt_tokens": 2, "completion_tokens": 1, "total_tokens": 3}, "choices": []},        ]
         response = FakeSseResponse(
-            [f"data: {json.dumps(chunk)}\n".encode("utf-8") for chunk in chunks] + [b"data: [DONE]\n", b""]
+            [f"data: {json.dumps(chunk)}\n\n".encode("utf-8") for chunk in chunks] + [b"data: [DONE]\n\n", b""]
         )
 
         status = CodexProxyHandler._relay_upstream_response(
@@ -9199,7 +9578,7 @@ class RoutingTests(unittest.TestCase):
             {"choices": [{"delta": {"content": "ok"}, "finish_reason": "stop"}]},
             {"usage": {"prompt_tokens": 2, "completion_tokens": 1, "total_tokens": 3}, "choices": []},        ]
         response = FakeSseResponse(
-            [f"data: {json.dumps(chunk)}\n".encode("utf-8") for chunk in chunks] + [b"data: [DONE]\n", b""]
+            [f"data: {json.dumps(chunk)}\n\n".encode("utf-8") for chunk in chunks] + [b"data: [DONE]\n\n", b""]
         )
 
         status = CodexProxyHandler._relay_transparent_upstream_response(
@@ -19822,7 +20201,7 @@ Use an implementer subagent, then a spec reviewer, then a code quality reviewer.
             {"usage": {"prompt_tokens": 2, "completion_tokens": 1, "total_tokens": 3}, "choices": []},
         ]
         response = FakeSseResponse(
-            [f"data: {json.dumps(chunk)}\n".encode("utf-8") for chunk in chunks] + [b"data: [DONE]\n", b""]
+            [f"data: {json.dumps(chunk)}\n\n".encode("utf-8") for chunk in chunks] + [b"data: [DONE]\n\n", b""]
         )
 
         status = CodexProxyHandler._relay_transparent_upstream_response(

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -3740,7 +3740,7 @@ class RoutingTests(unittest.TestCase):
         self.assertNotIn(b"later_success", written)
         self.assertNotIn(b"data: [DONE]", written)
 
-    def test_official_streaming_final_conversion_error_is_sanitized_before_headers(self):
+    def test_official_streaming_headers_precede_keepalives_and_conversion_error_is_sanitized(self):
         body = json.dumps(
             {
                 "model": "openai/gpt-5.5",
@@ -3749,6 +3749,31 @@ class RoutingTests(unittest.TestCase):
             }
         ).encode("utf-8")
         handler, fake = post_handler("/v1/chat/completions", body)
+        call_order = []
+
+        class RecordingWFile(FakeWFile):
+            def write(self, data):
+                call_order.append(("write", data))
+                super().write(data)
+
+        fake.wfile = RecordingWFile()
+        handler.wfile = fake.wfile
+
+        def record_send_response(status, message=None):
+            call_order.append(("send_response", status))
+            fake.send_response(status, message)
+
+        def record_send_header(key, value):
+            call_order.append(("send_header", key))
+            fake.send_header(key, value)
+
+        def record_end_headers():
+            call_order.append(("end_headers", None))
+            fake.end_headers()
+
+        handler.send_response = record_send_response
+        handler.send_header = record_send_header
+        handler.end_headers = record_end_headers
         terminal = {
             "type": "response.completed",
             "response": {
@@ -3791,6 +3816,7 @@ class RoutingTests(unittest.TestCase):
                 {
                     "CODEX_PROXY_AUTO_RETRY_ENABLED": "1",
                     "CODEX_PROXY_AUTO_RETRY_MAX_ATTEMPTS": "3",
+                    "CODEX_PROXY_SSE_KEEPALIVE_SECONDS": "0.01",
                 },
                 clear=False,
             ),
@@ -3798,7 +3824,10 @@ class RoutingTests(unittest.TestCase):
             patch("codex_proxy.codex_account_id", return_value="acct-1"),
             patch(
                 "codex_proxy._official_urlopen",
-                side_effect=lambda *_args, **_kwargs: FakeSseResponse(frames),
+                side_effect=lambda *_args, **_kwargs: FakeDelayedSseResponse(
+                    frames,
+                    first_delay_seconds=0.05,
+                ),
             ) as mock_urlopen,
         ):
             CodexProxyHandler.do_POST(handler)
@@ -3813,9 +3842,29 @@ class RoutingTests(unittest.TestCase):
         self.assertEqual(len(request_complete), 1)
         self.assertEqual(request_complete[0]["status"], 502)
         self.assertEqual(written.count(b'"code":"upstream_protocol_error"'), 1)
+        self.assertGreaterEqual(written.count(b": codexhub.keepalive\n\n"), 1)
         self.assertNotIn(b"SECRET_", written)
         self.assertNotIn(b"unsupported_protocol_semantics", written)
         self.assertNotIn(b"data: [DONE]", written)
+        send_response_index = next(
+            index
+            for index, (name, _value) in enumerate(call_order)
+            if name == "send_response"
+        )
+        end_headers_index = next(
+            index
+            for index, (name, _value) in enumerate(call_order)
+            if name == "end_headers"
+        )
+        write_indices = [
+            index
+            for index, (name, _value) in enumerate(call_order)
+            if name == "write"
+        ]
+        self.assertLess(send_response_index, end_headers_index)
+        self.assertTrue(write_indices)
+        for write_index in write_indices:
+            self.assertLess(end_headers_index, write_index)
 
     def test_verified_cross_protocol_source_shape_table_fails_once_without_retry(self):
         cases = (

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -3974,6 +3974,84 @@ class RoutingTests(unittest.TestCase):
         for write_index in write_indices:
             self.assertLess(end_headers_index, write_index)
 
+    def test_retry_notice_disarms_deferred_lifecycle_headers(self):
+        handler = FakeHandler()
+        call_order = []
+
+        class RecordingWFile(FakeWFile):
+            def write(self, data):
+                call_order.append(("write", data))
+                super().write(data)
+
+        handler.wfile = RecordingWFile()
+
+        def record_send_response(status, message=None):
+            call_order.append(("send_response", status))
+            handler.status = status
+
+        def record_send_header(key, value):
+            call_order.append(("send_header", key))
+            handler.headers.append((key, value))
+
+        def record_end_headers():
+            call_order.append(("end_headers", None))
+            handler.headers_ended = True
+
+        handler.send_response = record_send_response
+        handler.send_header = record_send_header
+        handler.end_headers = record_end_headers
+        seam = codex_proxy._GatewayDownstreamStreamCommit(
+            handler,
+            None,
+            "ollama_cloud",
+            request_id="req-lifecycle-retry-headers",
+            inbound_format="responses",
+            upstream_format="responses",
+        )
+        handler._downstream_stream_commit = seam
+        seam.set_ensure_headers_committed_callback(
+            lambda: handler._send_sse_headers(200, "ollama_cloud")
+        )
+
+        retry_headers_sent = handler._send_sse_headers(200, "ollama_cloud")
+        retry_notice_sent = handler._write_sse_event(
+            "codexhub.retry",
+            {
+                "type": "codexhub.retry",
+                "attempt": 1,
+                "max_attempts": 2,
+                "retry_in_seconds": 0,
+            },
+        )
+
+        self.assertTrue(retry_headers_sent)
+        self.assertTrue(retry_notice_sent)
+        self.assertEqual(
+            sum(name == "send_response" for name, _value in call_order),
+            1,
+        )
+        self.assertEqual(
+            sum(name == "end_headers" for name, _value in call_order),
+            1,
+        )
+        end_headers_index = next(
+            index
+            for index, (name, _value) in enumerate(call_order)
+            if name == "end_headers"
+        )
+        write_indices = [
+            index
+            for index, (name, _value) in enumerate(call_order)
+            if name == "write"
+        ]
+        self.assertTrue(write_indices)
+        for write_index in write_indices:
+            self.assertLess(end_headers_index, write_index)
+        self.assertEqual(
+            b"".join(handler.wfile.writes).count(b"event: codexhub.retry\n"),
+            1,
+        )
+
     def test_verified_cross_protocol_source_shape_table_fails_once_without_retry(self):
         cases = (
             (

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -3815,6 +3815,328 @@ class RoutingTests(unittest.TestCase):
                     written,
                 )
 
+    def test_verified_cross_protocol_consumed_leaf_table_fails_once_without_echo(self):
+        def responses_usage_payload(field):
+            usage = {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2}
+            usage[field] = f"SECRET_RESPONSES_{field.upper()}"
+            return {
+                "type": "response.completed",
+                "response": {
+                    "id": f"resp_bad_{field}",
+                    "status": "completed",
+                    "output": [],
+                    "usage": usage,
+                },
+            }
+
+        def responses_function_payload(field):
+            item = {
+                "id": "fc_valid",
+                "type": "function_call",
+                "call_id": "call_valid",
+                "name": "tool_valid",
+                "arguments": "",
+            }
+            item[field] = {"secret": f"SECRET_RESPONSES_{field.upper()}"}
+            return {"type": "response.output_item.added", "item": item}
+
+        def chat_usage_payload(field):
+            usage = {
+                "prompt_tokens": 1,
+                "completion_tokens": 1,
+                "total_tokens": 2,
+            }
+            usage[field] = f"SECRET_CHAT_{field.upper()}"
+            return {"choices": [], "usage": usage}
+
+        def chat_tool_payload(field):
+            tool_call = {
+                "index": 0,
+                "id": "call_valid",
+                "type": "function",
+                "function": {"name": "tool_valid", "arguments": ""},
+            }
+            target = tool_call["function"] if field in {"name", "arguments"} else tool_call
+            target[field] = {"secret": f"SECRET_CHAT_{field.upper()}"}
+            return {
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {"tool_calls": [tool_call]},
+                        "finish_reason": None,
+                    }
+                ]
+            }
+
+        cases = (
+            (
+                "responses_usage_input_tokens",
+                "responses",
+                responses_usage_payload("input_tokens"),
+            ),
+            (
+                "responses_usage_output_tokens",
+                "responses",
+                responses_usage_payload("output_tokens"),
+            ),
+            (
+                "responses_usage_total_tokens",
+                "responses",
+                responses_usage_payload("total_tokens"),
+            ),
+            (
+                "responses_content_part_text",
+                "responses",
+                {
+                    "type": "response.content_part.added",
+                    "part": {
+                        "type": "output_text",
+                        "text": 225,
+                        "annotations": [{"secret": "SECRET_RESPONSES_PART_TEXT"}],
+                    },
+                },
+            ),
+            (
+                "responses_message_content_text",
+                "responses",
+                {
+                    "type": "response.output_item.added",
+                    "item": {
+                        "id": "msg_bad_text",
+                        "type": "message",
+                        "status": "in_progress",
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "output_text",
+                                "text": {"secret": "SECRET_RESPONSES_MESSAGE_TEXT"},
+                                "annotations": [],
+                            }
+                        ],
+                    },
+                },
+            ),
+            (
+                "responses_function_item_id",
+                "responses",
+                responses_function_payload("id"),
+            ),
+            (
+                "responses_function_call_id",
+                "responses",
+                responses_function_payload("call_id"),
+            ),
+            (
+                "responses_function_name",
+                "responses",
+                responses_function_payload("name"),
+            ),
+            (
+                "responses_function_arguments",
+                "responses",
+                responses_function_payload("arguments"),
+            ),
+            (
+                "chat_usage_prompt_tokens",
+                "chat_completions",
+                chat_usage_payload("prompt_tokens"),
+            ),
+            (
+                "chat_usage_completion_tokens",
+                "chat_completions",
+                chat_usage_payload("completion_tokens"),
+            ),
+            (
+                "chat_usage_total_tokens",
+                "chat_completions",
+                chat_usage_payload("total_tokens"),
+            ),
+            (
+                "chat_content",
+                "chat_completions",
+                {
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {"content": {"secret": "SECRET_CHAT_CONTENT"}},
+                            "finish_reason": None,
+                        }
+                    ]
+                },
+            ),
+            (
+                "chat_tool_id",
+                "chat_completions",
+                chat_tool_payload("id"),
+            ),
+            (
+                "chat_tool_name",
+                "chat_completions",
+                chat_tool_payload("name"),
+            ),
+            (
+                "chat_tool_arguments",
+                "chat_completions",
+                chat_tool_payload("arguments"),
+            ),
+            (
+                "chat_unsupported_consumed_delta",
+                "chat_completions",
+                {
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {
+                                "reasoning_content": "SECRET_CHAT_UNSUPPORTED_DELTA"
+                            },
+                            "finish_reason": None,
+                        }
+                    ]
+                },
+            ),
+        )
+
+        for name, source_format, invalid_payload in cases:
+            with self.subTest(name=name):
+                self.write_proxy_event.reset_mock()
+                self.external_model["upstream_format"] = source_format
+                responses_source = source_format == "responses"
+                path = (
+                    "/v1/providers/volc/chat/completions"
+                    if responses_source
+                    else "/v1/providers/volc/responses"
+                )
+                request = (
+                    {
+                        "model": "volc/glm-5.2",
+                        "messages": [{"role": "user", "content": "hi"}],
+                        "stream": True,
+                    }
+                    if responses_source
+                    else {
+                        "model": "volc/glm-5.2",
+                        "input": [{"type": "message", "role": "user", "content": "hi"}],
+                        "stream": True,
+                    }
+                )
+                invalid_frame = (
+                    b"data: "
+                    + json.dumps(invalid_payload, separators=(",", ":")).encode("utf-8")
+                    + b"\n\n"
+                )
+                later_frames = (
+                    [
+                        b'data: {"type":"response.completed","response":{"id":"later_success","status":"completed","output":[]}}\n\n',
+                        b"",
+                    ]
+                    if responses_source
+                    else [
+                        b'data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\n',
+                        b"data: [DONE]\n\n",
+                        b"",
+                    ]
+                )
+                handler, fake = post_handler(
+                    path,
+                    json.dumps(request).encode("utf-8"),
+                    headers={"X-Codex-Client-Id": "opencode"},
+                )
+
+                with (
+                    patch.dict(
+                        os.environ,
+                        {
+                            "CODEX_PROXY_AUTO_RETRY_ENABLED": "1",
+                            "CODEX_PROXY_AUTO_RETRY_MAX_ATTEMPTS": "3",
+                        },
+                        clear=False,
+                    ),
+                    patch(
+                        "codex_proxy.urlopen",
+                        side_effect=lambda *_args, **_kwargs: FakeSseResponse(
+                            [invalid_frame, *later_frames]
+                        ),
+                    ) as mock_urlopen,
+                ):
+                    CodexProxyHandler.do_POST(handler)
+
+                written = b"".join(fake.wfile.writes)
+                request_complete = [
+                    call.kwargs
+                    for call in self.write_proxy_event.call_args_list
+                    if call.args and call.args[0] == "request_complete"
+                ]
+                self.assertEqual(mock_urlopen.call_count, 1)
+                self.assertEqual(len(request_complete), 1)
+                self.assertEqual(request_complete[0]["status"], 502)
+                self.assertEqual(
+                    written.count(b"data: " if responses_source else b"event: error"),
+                    1,
+                )
+                self.assertNotIn(b"SECRET_", written)
+                self.assertNotIn(b"later_success", written)
+                self.assertNotIn(
+                    b"data: [DONE]" if responses_source else b"response.completed",
+                    written,
+                )
+
+    def test_buffered_verified_conversion_error_is_sanitized_502_without_echo(self):
+        self.external_model["upstream_format"] = "chat_completions"
+        handler, fake = post_handler(
+            "/v1/providers/volc/responses",
+            json.dumps(
+                {
+                    "model": "volc/glm-5.2",
+                    "input": [{"type": "message", "role": "user", "content": "hi"}],
+                    "stream": False,
+                }
+            ).encode("utf-8"),
+            headers={"X-Codex-Client-Id": "opencode"},
+        )
+        frames = [
+            b'data: {"choices":[{"index":0,"delta":{"reasoning_content":"SECRET_BUFFERED_CONVERSION"},"finish_reason":null}]}\n\n',
+            b'data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\n',
+            b"data: [DONE]\n\n",
+            b"",
+        ]
+
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "CODEX_PROXY_AUTO_RETRY_ENABLED": "1",
+                    "CODEX_PROXY_AUTO_RETRY_MAX_ATTEMPTS": "3",
+                },
+                clear=False,
+            ),
+            patch(
+                "codex_proxy.urlopen",
+                side_effect=lambda *_args, **_kwargs: FakeSseResponse(frames),
+            ) as mock_urlopen,
+        ):
+            CodexProxyHandler.do_POST(handler)
+
+        written = b"".join(fake.wfile.writes)
+        payload = json.loads(written)
+        request_complete = [
+            call.kwargs
+            for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] == "request_complete"
+        ]
+        self.assertEqual(mock_urlopen.call_count, 1)
+        self.assertEqual(len(request_complete), 1)
+        self.assertEqual(request_complete[0]["status"], 502)
+        self.assertEqual(
+            payload["codexhub_error"]["details"]["type"],
+            "upstream_protocol_error",
+        )
+        self.assertEqual(
+            payload["codexhub_error"]["details"]["error"],
+            "upstream_protocol_error",
+        )
+        self.assertNotIn(b"SECRET_", written)
+        self.assertNotIn(b"response.completed", written)
+
     def test_upstream_http_error_emits_request_complete_with_status(self):
         body = json.dumps({"model": "volc/glm-5.2", "messages": [{"role": "user", "content": "hi"}], "stream": False}).encode("utf-8")
         handler, fake = post_handler("/v1/providers/volc/chat/completions", body, headers={"X-Codex-Client-Id": "opencode"})

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -3693,6 +3693,53 @@ class RoutingTests(unittest.TestCase):
                 self.assertNotIn(b"later_success", written)
                 self.assertNotIn(case["forbidden_terminal"], written)
 
+    def test_official_cross_protocol_stream_validates_complete_source_frames(self):
+        body = json.dumps(
+            {
+                "model": "openai/gpt-5.5",
+                "messages": [{"role": "user", "content": "hi"}],
+                "stream": True,
+            }
+        ).encode("utf-8")
+        handler, fake = post_handler("/v1/chat/completions", body)
+        frames = [
+            b'data: {"type":"response.output_text.delta","delta":225,"secret":"SECRET_OFFICIAL_DELTA"}\n\n',
+            b'data: {"type":"response.completed","response":{"id":"later_success","status":"completed","output":[]}}\n\n',
+            b"",
+        ]
+
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "CODEX_PROXY_AUTO_RETRY_ENABLED": "1",
+                    "CODEX_PROXY_AUTO_RETRY_MAX_ATTEMPTS": "3",
+                },
+                clear=False,
+            ),
+            patch("codex_proxy.codex_access_token", return_value="sub-token"),
+            patch("codex_proxy.codex_account_id", return_value="acct-1"),
+            patch(
+                "codex_proxy._official_urlopen",
+                side_effect=lambda *_args, **_kwargs: FakeSseResponse(frames),
+            ) as mock_urlopen,
+        ):
+            CodexProxyHandler.do_POST(handler)
+
+        written = b"".join(fake.wfile.writes)
+        request_complete = [
+            call.kwargs
+            for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] == "request_complete"
+        ]
+        self.assertEqual(mock_urlopen.call_count, 1)
+        self.assertEqual(len(request_complete), 1)
+        self.assertEqual(request_complete[0]["status"], 502)
+        self.assertEqual(written.count(b"data: "), 1)
+        self.assertNotIn(b"SECRET_", written)
+        self.assertNotIn(b"later_success", written)
+        self.assertNotIn(b"data: [DONE]", written)
+
     def test_verified_cross_protocol_source_shape_table_fails_once_without_retry(self):
         cases = (
             (
@@ -4080,6 +4127,225 @@ class RoutingTests(unittest.TestCase):
                     written,
                 )
 
+    def test_verified_cross_protocol_consumed_ids_and_error_envelopes_are_sanitized(self):
+        def frame(payload):
+            return (
+                b"data: "
+                + json.dumps(payload, separators=(",", ":")).encode("utf-8")
+                + b"\n\n"
+            )
+
+        tool_item = {
+            "id": "225",
+            "type": "function_call",
+            "status": "in_progress",
+            "call_id": "call_valid",
+            "name": "tool_valid",
+            "arguments": "",
+        }
+        paired_tool_frame = frame(
+            {"type": "response.output_item.added", "item": tool_item}
+        )
+        cases = (
+            (
+                "responses_function_arguments_delta_item_id",
+                "responses",
+                [
+                    paired_tool_frame,
+                    frame(
+                        {
+                            "type": "response.function_call_arguments.delta",
+                            "item_id": 225,
+                            "delta": "SECRET_RESPONSES_ARGUMENT_DELTA",
+                        }
+                    ),
+                ],
+            ),
+            (
+                "responses_function_arguments_done_item_id",
+                "responses",
+                [
+                    paired_tool_frame,
+                    frame(
+                        {
+                            "type": "response.function_call_arguments.done",
+                            "item_id": 225,
+                            "arguments": "SECRET_RESPONSES_ARGUMENT_DONE",
+                        }
+                    ),
+                ],
+            ),
+            (
+                "responses_top_level_error_message",
+                "responses",
+                [
+                    frame(
+                        {
+                            "type": "error",
+                            "error": {
+                                "code": "provider_error",
+                                "message": {
+                                    "secret": "SECRET_RESPONSES_ERROR_MESSAGE"
+                                },
+                            },
+                        }
+                    )
+                ],
+            ),
+            (
+                "responses_failed_error_code",
+                "responses",
+                [
+                    frame(
+                        {
+                            "type": "response.failed",
+                            "response": {
+                                "id": "resp_failed_secret",
+                                "status": "failed",
+                                "error": {
+                                    "code": {
+                                        "secret": "SECRET_RESPONSES_ERROR_CODE"
+                                    },
+                                    "message": "provider failed",
+                                },
+                            },
+                        }
+                    )
+                ],
+            ),
+            (
+                "chat_error_message",
+                "chat_completions",
+                [
+                    frame(
+                        {
+                            "error": {
+                                "code": "provider_error",
+                                "message": {
+                                    "secret": "SECRET_CHAT_ERROR_MESSAGE"
+                                },
+                            }
+                        }
+                    )
+                ],
+            ),
+            (
+                "chat_error_code",
+                "chat_completions",
+                [
+                    frame(
+                        {
+                            "choices": [],
+                            "error": {
+                                "code": {"secret": "SECRET_CHAT_ERROR_CODE"},
+                                "message": "provider failed",
+                            }
+                        }
+                    )
+                ],
+            ),
+        )
+
+        for name, source_format, invalid_frames in cases:
+            with self.subTest(name=name):
+                self.write_proxy_event.reset_mock()
+                self.external_model["upstream_format"] = source_format
+                responses_source = source_format == "responses"
+                path = (
+                    "/v1/providers/volc/chat/completions"
+                    if responses_source
+                    else "/v1/providers/volc/responses"
+                )
+                request = (
+                    {
+                        "model": "volc/glm-5.2",
+                        "messages": [{"role": "user", "content": "hi"}],
+                        "stream": True,
+                    }
+                    if responses_source
+                    else {
+                        "model": "volc/glm-5.2",
+                        "input": [{"type": "message", "role": "user", "content": "hi"}],
+                        "stream": True,
+                    }
+                )
+                later_frames = (
+                    [
+                        frame(
+                            {
+                                "type": "response.completed",
+                                "response": {
+                                    "id": "later_success",
+                                    "status": "completed",
+                                    "output": [],
+                                },
+                            }
+                        ),
+                        b"",
+                    ]
+                    if responses_source
+                    else [
+                        frame(
+                            {
+                                "choices": [
+                                    {
+                                        "index": 0,
+                                        "delta": {},
+                                        "finish_reason": "stop",
+                                    }
+                                ]
+                            }
+                        ),
+                        b"data: [DONE]\n\n",
+                        b"",
+                    ]
+                )
+                handler, fake = post_handler(
+                    path,
+                    json.dumps(request).encode("utf-8"),
+                    headers={"X-Codex-Client-Id": "opencode"},
+                )
+
+                with (
+                    patch.dict(
+                        os.environ,
+                        {
+                            "CODEX_PROXY_AUTO_RETRY_ENABLED": "1",
+                            "CODEX_PROXY_AUTO_RETRY_MAX_ATTEMPTS": "3",
+                        },
+                        clear=False,
+                    ),
+                    patch(
+                        "codex_proxy.urlopen",
+                        side_effect=lambda *_args, **_kwargs: FakeSseResponse(
+                            [*invalid_frames, *later_frames]
+                        ),
+                    ) as mock_urlopen,
+                ):
+                    CodexProxyHandler.do_POST(handler)
+
+                written = b"".join(fake.wfile.writes)
+                request_complete = [
+                    call.kwargs
+                    for call in self.write_proxy_event.call_args_list
+                    if call.args and call.args[0] == "request_complete"
+                ]
+                error_marker = (
+                    b'"code":"upstream_protocol_error"'
+                    if responses_source
+                    else b"event: error"
+                )
+                self.assertEqual(mock_urlopen.call_count, 1)
+                self.assertEqual(len(request_complete), 1)
+                self.assertEqual(request_complete[0]["status"], 502)
+                self.assertEqual(written.count(error_marker), 1)
+                self.assertNotIn(b"SECRET_", written)
+                self.assertNotIn(b"later_success", written)
+                self.assertNotIn(
+                    b"data: [DONE]" if responses_source else b"response.completed",
+                    written,
+                )
+
     def test_buffered_verified_conversion_error_is_sanitized_502_without_echo(self):
         self.external_model["upstream_format"] = "chat_completions"
         handler, fake = post_handler(
@@ -4136,6 +4402,91 @@ class RoutingTests(unittest.TestCase):
         )
         self.assertNotIn(b"SECRET_", written)
         self.assertNotIn(b"response.completed", written)
+
+    def test_buffered_verified_responses_to_chat_conversion_error_is_sanitized_502(self):
+        self.external_model["upstream_format"] = "responses"
+        handler, fake = post_handler(
+            "/v1/providers/volc/chat/completions",
+            json.dumps(
+                {
+                    "model": "volc/glm-5.2",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "stream": False,
+                }
+            ).encode("utf-8"),
+            headers={"X-Codex-Client-Id": "opencode"},
+        )
+        item = {
+            "id": "msg_buffered_annotations",
+            "type": "message",
+            "status": "completed",
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "output_text",
+                    "text": "SECRET_BUFFERED_RESPONSE_TEXT",
+                    "annotations": [
+                        {"type": "url_citation", "url": "SECRET_BUFFERED_ANNOTATION"}
+                    ],
+                }
+            ],
+        }
+        frames = [
+            (
+                b"data: "
+                + json.dumps(
+                    {"type": "response.output_item.done", "item": item},
+                    separators=(",", ":"),
+                ).encode("utf-8")
+                + b"\n\n"
+            ),
+            (
+                b"data: "
+                + json.dumps(
+                    {
+                        "type": "response.completed",
+                        "response": {
+                            "id": "resp_buffered_annotations",
+                            "status": "completed",
+                            "output": [item],
+                        },
+                    },
+                    separators=(",", ":"),
+                ).encode("utf-8")
+                + b"\n\n"
+            ),
+            b"",
+        ]
+
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "CODEX_PROXY_AUTO_RETRY_ENABLED": "1",
+                    "CODEX_PROXY_AUTO_RETRY_MAX_ATTEMPTS": "3",
+                },
+                clear=False,
+            ),
+            patch(
+                "codex_proxy.urlopen",
+                side_effect=lambda *_args, **_kwargs: FakeSseResponse(frames),
+            ) as mock_urlopen,
+        ):
+            CodexProxyHandler.do_POST(handler)
+
+        written = b"".join(fake.wfile.writes)
+        payload = json.loads(written)
+        request_complete = [
+            call.kwargs
+            for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] == "request_complete"
+        ]
+        self.assertEqual(mock_urlopen.call_count, 1)
+        self.assertEqual(len(request_complete), 1)
+        self.assertEqual(request_complete[0]["status"], 502)
+        self.assertEqual(payload["error"]["type"], "upstream_protocol_error")
+        self.assertNotIn(b"SECRET_", written)
+        self.assertNotIn(b"resp_buffered_annotations", written)
 
     def test_upstream_http_error_emits_request_complete_with_status(self):
         body = json.dumps({"model": "volc/glm-5.2", "messages": [{"role": "user", "content": "hi"}], "stream": False}).encode("utf-8")

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -3740,6 +3740,83 @@ class RoutingTests(unittest.TestCase):
         self.assertNotIn(b"later_success", written)
         self.assertNotIn(b"data: [DONE]", written)
 
+    def test_official_streaming_final_conversion_error_is_sanitized_before_headers(self):
+        body = json.dumps(
+            {
+                "model": "openai/gpt-5.5",
+                "messages": [{"role": "user", "content": "hi"}],
+                "stream": True,
+            }
+        ).encode("utf-8")
+        handler, fake = post_handler("/v1/chat/completions", body)
+        terminal = {
+            "type": "response.completed",
+            "response": {
+                "id": "resp_official_annotations",
+                "status": "completed",
+                "output": [
+                    {
+                        "id": "msg_official_annotations",
+                        "type": "message",
+                        "status": "completed",
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "output_text",
+                                "text": "SECRET_OFFICIAL_RESPONSE_TEXT",
+                                "annotations": [
+                                    {
+                                        "type": "url_citation",
+                                        "url": "SECRET_OFFICIAL_ANNOTATION",
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            },
+        }
+        frames = [
+            (
+                b"data: "
+                + json.dumps(terminal, separators=(",", ":")).encode("utf-8")
+                + b"\n\n"
+            ),
+            b"",
+        ]
+
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "CODEX_PROXY_AUTO_RETRY_ENABLED": "1",
+                    "CODEX_PROXY_AUTO_RETRY_MAX_ATTEMPTS": "3",
+                },
+                clear=False,
+            ),
+            patch("codex_proxy.codex_access_token", return_value="sub-token"),
+            patch("codex_proxy.codex_account_id", return_value="acct-1"),
+            patch(
+                "codex_proxy._official_urlopen",
+                side_effect=lambda *_args, **_kwargs: FakeSseResponse(frames),
+            ) as mock_urlopen,
+        ):
+            CodexProxyHandler.do_POST(handler)
+
+        written = b"".join(fake.wfile.writes)
+        request_complete = [
+            call.kwargs
+            for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] == "request_complete"
+        ]
+        self.assertEqual(mock_urlopen.call_count, 1)
+        self.assertEqual(len(request_complete), 1)
+        self.assertEqual(request_complete[0]["status"], 502)
+        self.assertEqual(written.count(b'"code":"upstream_protocol_error"'), 1)
+        self.assertNotIn(b"SECRET_", written)
+        self.assertNotIn(b"unsupported_protocol_semantics", written)
+        self.assertNotIn(b"data: [DONE]", written)
+
     def test_verified_cross_protocol_source_shape_table_fails_once_without_retry(self):
         cases = (
             (

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -3183,6 +3183,112 @@ class RoutingTests(unittest.TestCase):
         self.assertEqual(payload["model"], "canonical-json")
         self.assertEqual(payload["output"][0]["content"][0]["text"], "buffered json")
 
+    def test_buffered_chat_sse_to_responses_reconstructs_chat_source_semantics(self):
+        chunks = [
+            {
+                "id": "chatcmpl_buffered",
+                "object": "chat.completion.chunk",
+                "model": "canonical-chat-buffered",
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {"content": "buffered chat"},
+                        "finish_reason": None,
+                    }
+                ],
+            },
+            {
+                "id": "chatcmpl_buffered",
+                "object": "chat.completion.chunk",
+                "model": "canonical-chat-buffered",
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "id": "call_buffered",
+                                    "type": "function",
+                                    "function": {
+                                        "name": "lookup",
+                                        "arguments": '{"q":',
+                                    },
+                                }
+                            ]
+                        },
+                        "finish_reason": None,
+                    }
+                ],
+            },
+            {
+                "id": "chatcmpl_buffered",
+                "object": "chat.completion.chunk",
+                "model": "canonical-chat-buffered",
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "function": {"arguments": '"value"}'},
+                                }
+                            ]
+                        },
+                        "finish_reason": "tool_calls",
+                    }
+                ],
+            },
+            {
+                "id": "chatcmpl_buffered",
+                "object": "chat.completion.chunk",
+                "model": "canonical-chat-buffered",
+                "choices": [],
+                "usage": {
+                    "prompt_tokens": 7,
+                    "completion_tokens": 5,
+                    "total_tokens": 12,
+                },
+            },
+        ]
+        response = FakeSseResponse(
+            [f"data: {json.dumps(chunk)}\r\r".encode("utf-8") for chunk in chunks]
+            + [b"data: [DONE]\r\r", b""]
+        )
+        fake = FakeHandler()
+
+        status = CodexProxyHandler._relay_upstream_response(
+            fake,
+            response,
+            "chat_only_provider",
+            request_id="req-buffered-chat-to-responses",
+            model="caller-model",
+            upstream_format="chat_completions",
+            inbound_format="responses",
+            caller_stream=False,
+            behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+            usage_capture={},
+        )
+
+        payload = json.loads(b"".join(fake.wfile.writes))
+        output_by_type = {item["type"]: item for item in payload["output"]}
+        self.assertEqual(status, 200)
+        self.assertEqual(payload["object"], "response")
+        self.assertEqual(payload["status"], "completed")
+        self.assertEqual(payload["model"], "canonical-chat-buffered")
+        self.assertEqual(
+            output_by_type["message"]["content"][0]["text"],
+            "buffered chat",
+        )
+        self.assertEqual(output_by_type["function_call"]["call_id"], "call_buffered")
+        self.assertEqual(output_by_type["function_call"]["name"], "lookup")
+        self.assertEqual(output_by_type["function_call"]["arguments"], '{"q":"value"}')
+        self.assertEqual(
+            payload["usage"],
+            {"input_tokens": 7, "output_tokens": 5, "total_tokens": 12},
+        )
+
     def test_image_proxy_sse_to_body_uses_complete_frames(self):
         response = FakeSseResponse(
             [
@@ -3258,6 +3364,49 @@ class RoutingTests(unittest.TestCase):
             with self.subTest(name=name):
                 self.assertEqual(outputs[1:], outputs[:-1])
 
+    def test_converted_event_iterator_emits_completed_cr_frame_before_same_read_size_failure(self):
+        completed_frame = (
+            b'data: {"type":"response.output_text.delta","delta":"before limit"}\r\r'
+        )
+        oversized_frame = b"data: " + (b"x" * DEFAULT_MAX_FRAME_BYTES)
+        partitions = (
+            ("same_read", [completed_frame + oversized_frame, b""]),
+            (
+                "split_reads",
+                [completed_frame + oversized_frame[:1], oversized_frame[1:], b""],
+            ),
+        )
+        observations = []
+
+        for name, chunks in partitions:
+            with self.subTest(name=name):
+                iterator = CodexProxyHandler._iter_upstream_sse_events(
+                    FakeHandler(),
+                    FakeSseResponse(chunks),
+                    event_resets_idle_timeout=lambda event: bool(event.data),
+                )
+
+                event = next(iterator)
+                with self.assertRaises(SseFrameTooLargeError) as raised:
+                    next(iterator)
+
+                self.assertEqual(event.raw, completed_frame)
+                self.assertEqual(
+                    json.loads(event.data),
+                    {
+                        "type": "response.output_text.delta",
+                        "delta": "before limit",
+                    },
+                )
+                self.assertEqual(raised.exception.classification, "sse_frame_too_large")
+                self.assertGreater(
+                    raised.exception.pending_bytes,
+                    raised.exception.max_frame_bytes,
+                )
+                observations.append((event.raw, event.data, raised.exception.classification))
+
+        self.assertEqual(observations[0], observations[1])
+
     def test_malformed_converted_request_completes_once_with_502_without_retry(self):
         self.external_model["upstream_format"] = "chat_completions"
         body = json.dumps(
@@ -3307,6 +3456,85 @@ class RoutingTests(unittest.TestCase):
         self.assertNotIn(b"SECRET_CONVERTED", written)
         self.assertNotIn(b"later_success", written)
         self.assertNotIn(b"response.completed", written)
+
+    def test_verified_converted_structural_errors_complete_once_with_502_without_retry(self):
+        cases = (
+            {
+                "name": "responses_to_chat",
+                "upstream_format": "responses",
+                "path": "/v1/providers/volc/chat/completions",
+                "request": {
+                    "model": "volc/glm-5.2",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "stream": True,
+                },
+                "frames": [
+                    b'data: {"type":"response.output_text.delta","delta":225,"secret":"SECRET_RESPONSES_STRUCTURAL"}\n\n',
+                    b'data: {"type":"response.completed","response":{"id":"later_success","model":"later-model","status":"completed","output":[]}}\n\n',
+                    b"",
+                ],
+                "error_marker": b"data: ",
+                "forbidden_terminal": b"data: [DONE]",
+            },
+            {
+                "name": "chat_to_responses",
+                "upstream_format": "chat_completions",
+                "path": "/v1/providers/volc/responses",
+                "request": {
+                    "model": "volc/glm-5.2",
+                    "input": [{"type": "message", "role": "user", "content": "hi"}],
+                    "stream": True,
+                },
+                "frames": [
+                    b'data: {"id":"chatcmpl_secret","object":"chat.completion.chunk","choices":[{"index":0,"delta":"SECRET_CHAT_STRUCTURAL","finish_reason":null}]}\n\n',
+                    b'data: {"id":"chatcmpl_later","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\n',
+                    b"data: [DONE]\n\n",
+                    b"",
+                ],
+                "error_marker": b"event: error",
+                "forbidden_terminal": b"response.completed",
+            },
+        )
+
+        for case in cases:
+            with self.subTest(name=case["name"]):
+                self.write_proxy_event.reset_mock()
+                self.external_model["upstream_format"] = case["upstream_format"]
+                handler, fake = post_handler(
+                    case["path"],
+                    json.dumps(case["request"]).encode("utf-8"),
+                    headers={"X-Codex-Client-Id": "opencode"},
+                )
+
+                with (
+                    patch.dict(
+                        os.environ,
+                        {
+                            "CODEX_PROXY_AUTO_RETRY_ENABLED": "1",
+                            "CODEX_PROXY_AUTO_RETRY_MAX_ATTEMPTS": "3",
+                        },
+                        clear=False,
+                    ),
+                    patch(
+                        "codex_proxy.urlopen",
+                        return_value=FakeSseResponse(case["frames"]),
+                    ) as mock_urlopen,
+                ):
+                    CodexProxyHandler.do_POST(handler)
+
+                written = b"".join(fake.wfile.writes)
+                request_complete = [
+                    call.kwargs
+                    for call in self.write_proxy_event.call_args_list
+                    if call.args and call.args[0] == "request_complete"
+                ]
+                self.assertEqual(mock_urlopen.call_count, 1)
+                self.assertEqual(len(request_complete), 1)
+                self.assertEqual(request_complete[0]["status"], 502)
+                self.assertEqual(written.count(case["error_marker"]), 1)
+                self.assertNotIn(b"SECRET_", written)
+                self.assertNotIn(b"later_success", written)
+                self.assertNotIn(case["forbidden_terminal"], written)
 
     def test_upstream_http_error_emits_request_complete_with_status(self):
         body = json.dumps({"model": "volc/glm-5.2", "messages": [{"role": "user", "content": "hi"}], "stream": False}).encode("utf-8")


### PR DESCRIPTION
## Summary

- Parse converted SSE streams only at complete event boundaries while preserving transparent byte passthrough.
- Normalize verified cross-protocol structural and conversion failures to one sanitized target-protocol terminal outcome.
- Preserve terminal-once semantics and enforce one header block before all streamed body writes across keepalive, lifecycle-resample, retry-notice, and error paths.

Issue: #225

## Local evidence

- Exact-local Standards review: PASS.
- Exact-local strict Spec review: PASS.
- Focused regressions and bounded affected SSE/protocol/routing nodes passed; final correction set: 9 passed.
- Changed-file compilation and `git diff --check` passed.
- Report-only quality gates completed with zero parse errors.

## Deviations

None.

<!-- orchestrator:delivery:v1 -->
```json
{"contract_sha256":"e3edc856bfd3ff0d4a89211c029a3c342c15549e93699a4f18e0d946c0eae790","candidate_sha":"83c3ecb7f31e5f1c5ebea504b3ecf733303ea2e1","changed_paths":["src-python/codex_proxy.py","src-python/protocol_translation.py","tests/test_chat_completions_gateway.py","tests/test_protocol_translation.py","tests/test_routing.py"],"tdd":{"red":"Focused regressions reproduced transport-partition event loss, verified conversion shape failures, incomplete reconstruction, terminal conflicts, header-order faults, and the exact-SHA CI test-contract failures.","green":"Exact regressions and bounded affected SSE, protocol, routing, and usage nodes passed; the nine exact-SHA CI failure nodes passed locally after fixture and expectation correction.","refactor":"Kept conversion on the existing lossless assembler and protocol bridge, centralized terminal and header ownership in the existing request-scoped stream seam, and aligned legacy tests with target-protocol usage names and complete SSE framing."},"verification":["Exact nine CI failure pytest nodes: 9 passed","Bounded usage and event-boundary pytest neighbors: 5 passed, 2 subtests passed","python -m py_compile changed Python files: passed","git diff --check: passed","python scripts/report_quality_gates.py: report-only; parse_errors=0"],"deviations":[],"risks":[]}
```