### PR TITLE
Split and path-gate the synthetic real-client CI suite (#235)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,11 +76,11 @@ jobs:
           if ($isPr) {
             $baseSha = '${{ github.event.pull_request.base.sha }}'
             $headSha = '${{ github.event.pull_request.head.sha }}'
-            git fetch origin $baseSha --depth=1
+            git fetch origin $baseSha
             if ($LASTEXITCODE -ne 0) { $acquisitionFailed = $true }
             $mergeBase = git merge-base $baseSha $headSha
             if ($LASTEXITCODE -ne 0) { $acquisitionFailed = $true }
-            $changed = git diff --name-only $mergeBase $headSha
+            $changed = git diff --no-renames --name-only $mergeBase $headSha
             if ($LASTEXITCODE -ne 0) { $acquisitionFailed = $true }
             if (-not $acquisitionFailed) {
               $changed | Out-File -Encoding utf8 $changedFile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -104,7 +106,7 @@ jobs:
             Write-Host 'Synthetic real-client contract: not applicable'
           } else {
             python tests/fixtures/real_client_e2e/run-with-windows-watchdog.py `
-              --timeout-seconds 1800 `
+              --timeout-seconds 3600 `
               -- python -m pytest @($plan.synthetic_args)
           }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,6 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -72,13 +70,24 @@ jobs:
           $event = '${{ github.event_name }}'
           $isPr = $event -eq 'pull_request'
           $changedFile = '.changed-paths.txt'
+          $acquisitionFailed = $false
           if ($isPr) {
             $baseSha = '${{ github.event.pull_request.base.sha }}'
             $headSha = '${{ github.event.pull_request.head.sha }}'
-            git fetch origin $baseSha --depth=1 | Out-Null
-            git diff --name-only $baseSha $headSha | Out-File -Encoding utf8 $changedFile
-          } else {
-            New-Item -ItemType File -Force $changedFile | Out-Null
+            git fetch origin $baseSha --depth=1
+            if ($LASTEXITCODE -ne 0) { $acquisitionFailed = $true }
+            $mergeBase = git merge-base $baseSha $headSha
+            if ($LASTEXITCODE -ne 0) { $acquisitionFailed = $true }
+            $changed = git diff --name-only $mergeBase $headSha
+            if ($LASTEXITCODE -ne 0) { $acquisitionFailed = $true }
+            if (-not $acquisitionFailed) {
+              $changed | Out-File -Encoding utf8 $changedFile
+            }
+          }
+          if ($acquisitionFailed) {
+            # Remove the file so the planner treats this as missing/unreadable
+            # and fails closed to the full synthetic suite.
+            Remove-Item $changedFile -ErrorAction SilentlyContinue
           }
           $plan = python scripts/ci/python_test_plan.py `
             --event $event `
@@ -94,7 +103,9 @@ jobs:
           if ($plan.synthetic_status -eq 'not_applicable') {
             Write-Host 'Synthetic real-client contract: not applicable'
           } else {
-            python -m pytest @($plan.synthetic_args)
+            python tests/fixtures/real_client_e2e/run-with-windows-watchdog.py `
+              --timeout-seconds 1800 `
+              -- python -m pytest @($plan.synthetic_args)
           }
 
       - name: Upload synthetic JUnit evidence

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - dev
       - main
+  workflow_dispatch:
+  schedule:
+    - cron: '17 3 * * 0'
 
 permissions:
   contents: read
@@ -18,8 +21,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  python-tests:
-    name: Python tests
+  python-core:
+    name: Python core
     runs-on: windows-latest
     steps:
       - name: Check out repository
@@ -33,8 +36,74 @@ jobs:
       - name: Install test dependencies
         run: python -m pip install --upgrade pip pytest
 
-      - name: Run pytest
-        run: python -m pytest -q
+      - name: Run Python core partition
+        run: |
+          python -m pytest -q --ignore=tests/test_real_client_e2e.py --junitxml=.pytest-results/junit-core.xml --durations=0
+
+      - name: Upload Python core JUnit evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-core-junit
+          path: .pytest-results/junit-core.xml
+          if-no-files-found: ignore
+
+  python-synthetic:
+    name: Synthetic real-client contract
+    runs-on: windows-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install test dependencies
+        run: python -m pip install --upgrade pip pytest
+
+      - name: Plan synthetic partition
+        id: plan
+        shell: pwsh
+        run: |
+          $event = '${{ github.event_name }}'
+          $isPr = $event -eq 'pull_request'
+          $changedFile = '.changed-paths.txt'
+          if ($isPr) {
+            $baseSha = '${{ github.event.pull_request.base.sha }}'
+            $headSha = '${{ github.event.pull_request.head.sha }}'
+            git fetch origin $baseSha --depth=1 | Out-Null
+            git diff --name-only $baseSha $headSha | Out-File -Encoding utf8 $changedFile
+          } else {
+            New-Item -ItemType File -Force $changedFile | Out-Null
+          }
+          $plan = python scripts/ci/python_test_plan.py `
+            --event $event `
+            $(if ($isPr) { '--is-pull-request' }) `
+            --changed-paths-file $changedFile `
+            --output-json
+          echo "json=$plan" >> $env:GITHUB_OUTPUT
+
+      - name: Run or skip synthetic partition
+        shell: pwsh
+        run: |
+          $plan = '${{ steps.plan.outputs.json }}' | ConvertFrom-Json
+          if ($plan.synthetic_status -eq 'not_applicable') {
+            Write-Host 'Synthetic real-client contract: not applicable'
+          } else {
+            python -m pytest @($plan.synthetic_args)
+          }
+
+      - name: Upload synthetic JUnit evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-synthetic-junit
+          path: .pytest-results/junit-synthetic.xml
+          if-no-files-found: ignore
 
   frontend:
     name: Frontend build and UI contract

--- a/docs/agents/ci.md
+++ b/docs/agents/ci.md
@@ -4,12 +4,17 @@ GitHub Actions runs the required PR validation for branches targeting `dev` and 
 
 ## CI jobs
 
-- Python tests: `python -m pytest -q`
+- **Python core**: `python -m pytest -q --ignore=tests/test_real_client_e2e.py --junitxml=.pytest-results/junit-core.xml --durations=0`. Runs on every PR.
+- **Synthetic real-client contract**: appears on every PR. For unrelated paths it succeeds explicitly as `not applicable` and does not start `scripts/Run-RealClientE2E.ps1`. For relevant paths, and for all non-PR events, it runs `python -m pytest -q tests/test_real_client_e2e.py --junitxml=.pytest-results/junit-synthetic.xml --durations=0`. The planner at `scripts/ci/python_test_plan.py` decides which paths are relevant; `python scripts/ci/check_python_test_partitions.py` proves the core and synthetic partitions are disjoint and complete.
 - Frontend build and UI contract: `npm ci`, `npm run build`, `npm run test:ui-contract` in `frontend/`
 - Rust tests (normal and debug flavors): `cargo test --locked` in `src-tauri/`, plus a release-optimized flavor build
 - Rust clippy: `cargo clippy --locked --all-targets -- -D warnings` in `src-tauri/`
 - Release flavor contract: portable-build dry-run parity for the normal and debug flavors
 - Rust safe_file Linux compile and tests: standalone `rustc --test` compile of `src-tauri/src/safe_file.rs` on Ubuntu, a `clippy-driver -D warnings` lint of the same file, and the resulting cross-language test binary. This job exists because `safe_file.rs` contains `cfg(unix)` FFI that the Windows-only Rust jobs never compile; it must stay free of crate dependencies so the standalone compile keeps working.
+
+### Triggers
+
+PRs to `dev` and `main` run both Python checks, the frontend job, Rust normal/debug tests, Rust clippy, release flavor contract, and Linux `safe_file`. Pushes to `dev` and `main` preserve the same job set. `workflow_dispatch` and a weekly Sunday 03:17 UTC `schedule` run the full validation, including the synthetic suite.
 
 The Rust jobs create a temporary `src-tauri/resources/python/.ci-placeholder` file during CI because Tauri's resource glob requires at least one runtime Python resource file. The placeholder is not committed.
 
@@ -18,7 +23,9 @@ The Rust jobs create a temporary `src-tauri/resources/python/.ci-placeholder` fi
 Use all of these commands when GitHub Actions is unavailable and the change must be integrated. Before opening a normal PR, run only the local suites selected by the verification policy:
 
 ```powershell
-python -m pytest -q
+python -m pytest -q --ignore=tests/test_real_client_e2e.py --junitxml=.pytest-results/junit-core.xml --durations=0
+python -m pytest -q tests/test_real_client_e2e.py --junitxml=.pytest-results/junit-synthetic.xml --durations=0
+python scripts/ci/check_python_test_partitions.py
 
 Push-Location frontend
 npm ci
@@ -33,5 +40,17 @@ cargo test --locked
 cargo clippy --locked --all-targets -- -D warnings
 Pop-Location
 ```
+
+### One-command Python fallback
+
+For changes that touch only Python, the CI planner and partition checker can be
+verified together with:
+
+```powershell
+python -m pytest -q tests/test_ci_python_plan.py && python scripts/ci/check_python_test_partitions.py
+```
+
+This runs the planner/path tests and proves the core and synthetic collections
+are disjoint and complete, without executing `tests/test_real_client_e2e.py`.
 
 Do not commit generated frontend output, local Tauri resource placeholders, or `dist/` artifacts.

--- a/docs/agents/ci.md
+++ b/docs/agents/ci.md
@@ -5,7 +5,7 @@ GitHub Actions runs the required PR validation for branches targeting `dev` and 
 ## CI jobs
 
 - **Python core**: `python -m pytest -q --ignore=tests/test_real_client_e2e.py --junitxml=.pytest-results/junit-core.xml --durations=0`. Runs on every PR.
-- **Synthetic real-client contract**: appears on every PR. For unrelated paths it succeeds explicitly as `not applicable` and does not start `scripts/Run-RealClientE2E.ps1`. For relevant paths, and for all non-PR events, it runs `python -m pytest -q tests/test_real_client_e2e.py --junitxml=.pytest-results/junit-synthetic.xml --durations=0`. The planner at `scripts/ci/python_test_plan.py` decides which paths are relevant; `python scripts/ci/check_python_test_partitions.py` proves the core and synthetic partitions are disjoint and complete.
+- **Synthetic real-client contract**: appears on every PR. For unrelated paths it succeeds explicitly as `not applicable` and does not start `scripts/Run-RealClientE2E.ps1`. For relevant paths, and for all non-PR events, it runs the synthetic module through `tests/fixtures/real_client_e2e/run-with-windows-watchdog.py` with an explicit 1800-second outer bound while retaining JUnit and per-test duration output. The planner at `scripts/ci/python_test_plan.py` decides which paths are relevant using the PR merge-base; `python scripts/ci/check_python_test_partitions.py` proves the core and synthetic partitions are disjoint and complete.
 - Frontend build and UI contract: `npm ci`, `npm run build`, `npm run test:ui-contract` in `frontend/`
 - Rust tests (normal and debug flavors): `cargo test --locked` in `src-tauri/`, plus a release-optimized flavor build
 - Rust clippy: `cargo clippy --locked --all-targets -- -D warnings` in `src-tauri/`
@@ -15,6 +15,22 @@ GitHub Actions runs the required PR validation for branches targeting `dev` and 
 ### Triggers
 
 PRs to `dev` and `main` run both Python checks, the frontend job, Rust normal/debug tests, Rust clippy, release flavor contract, and Linux `safe_file`. Pushes to `dev` and `main` preserve the same job set. `workflow_dispatch` and a weekly Sunday 03:17 UTC `schedule` run the full validation, including the synthetic suite.
+
+### Synthetic real-client contract relevant surface
+
+A PR is considered relevant for the synthetic check when it touches any of the following:
+
+- `scripts/Run-RealClientE2E.ps1` (the E2E runner)
+- `tests/test_real_client_e2e.py` (the synthetic module)
+- `tests/fixtures/real_client_e2e/**` (E2E fixtures and the Windows watchdog runner)
+- `docs/agents/real-client-e2e.md` (real-client operator documentation)
+- `.github/workflows/ci.yml`
+- `scripts/ci/python_test_plan.py`
+- `scripts/ci/check_python_test_partitions.py`
+- `tests/test_ci_python_plan.py`
+- `pytest.ini`
+
+If changed-path acquisition for a PR is missing, unavailable, or fails, the check fails closed and runs the synthetic suite.
 
 The Rust jobs create a temporary `src-tauri/resources/python/.ci-placeholder` file during CI because Tauri's resource glob requires at least one runtime Python resource file. The placeholder is not committed.
 
@@ -43,14 +59,21 @@ Pop-Location
 
 ### One-command Python fallback
 
-For changes that touch only Python, the CI planner and partition checker can be
-verified together with:
+For changes that touch only Python, run both partitions and the completeness
+checker in one chained command:
+
+```powershell
+python -m pytest -q --ignore=tests/test_real_client_e2e.py --junitxml=.pytest-results/junit-core.xml --durations=0 && python -m pytest -q tests/test_real_client_e2e.py --junitxml=.pytest-results/junit-synthetic.xml --durations=0 && python scripts/ci/check_python_test_partitions.py
+```
+
+This executes the core suite, the synthetic suite, and proves the two partitions
+are disjoint and complete.
+
+To verify only the planner/path logic and collection completeness without
+executing `tests/test_real_client_e2e.py`, use:
 
 ```powershell
 python -m pytest -q tests/test_ci_python_plan.py && python scripts/ci/check_python_test_partitions.py
 ```
-
-This runs the planner/path tests and proves the core and synthetic collections
-are disjoint and complete, without executing `tests/test_real_client_e2e.py`.
 
 Do not commit generated frontend output, local Tauri resource placeholders, or `dist/` artifacts.

--- a/docs/agents/ci.md
+++ b/docs/agents/ci.md
@@ -5,7 +5,7 @@ GitHub Actions runs the required PR validation for branches targeting `dev` and 
 ## CI jobs
 
 - **Python core**: `python -m pytest -q --ignore=tests/test_real_client_e2e.py --junitxml=.pytest-results/junit-core.xml --durations=0`. Runs on every PR.
-- **Synthetic real-client contract**: appears on every PR. For unrelated paths it succeeds explicitly as `not applicable` and does not start `scripts/Run-RealClientE2E.ps1`. For relevant paths, and for all non-PR events, it runs the synthetic module through `tests/fixtures/real_client_e2e/run-with-windows-watchdog.py` with an explicit 1800-second outer bound while retaining JUnit and per-test duration output. The planner at `scripts/ci/python_test_plan.py` decides which paths are relevant using the PR merge-base; `python scripts/ci/check_python_test_partitions.py` proves the core and synthetic partitions are disjoint and complete.
+- **Synthetic real-client contract**: appears on every PR. For unrelated paths it succeeds explicitly as `not applicable` and does not start `scripts/Run-RealClientE2E.ps1`. For relevant paths, and for all non-PR events, it runs the synthetic module through `tests/fixtures/real_client_e2e/run-with-windows-watchdog.py` with an explicit 3600-second outer bound while retaining JUnit and per-test duration output. The planner at `scripts/ci/python_test_plan.py` decides which paths are relevant using the PR merge-base; `python scripts/ci/check_python_test_partitions.py` proves the core and synthetic partitions are disjoint and complete.
 - Frontend build and UI contract: `npm ci`, `npm run build`, `npm run test:ui-contract` in `frontend/`
 - Rust tests (normal and debug flavors): `cargo test --locked` in `src-tauri/`, plus a release-optimized flavor build
 - Rust clippy: `cargo clippy --locked --all-targets -- -D warnings` in `src-tauri/`
@@ -40,7 +40,8 @@ Use all of these commands when GitHub Actions is unavailable and the change must
 
 ```powershell
 python -m pytest -q --ignore=tests/test_real_client_e2e.py --junitxml=.pytest-results/junit-core.xml --durations=0
-python -m pytest -q tests/test_real_client_e2e.py --junitxml=.pytest-results/junit-synthetic.xml --durations=0
+python tests/fixtures/real_client_e2e/run-with-windows-watchdog.py --timeout-seconds 3600 -- `
+  python -m pytest -q tests/test_real_client_e2e.py --junitxml=.pytest-results/junit-synthetic.xml --durations=0
 python scripts/ci/check_python_test_partitions.py
 
 Push-Location frontend
@@ -60,14 +61,18 @@ Pop-Location
 ### One-command Python fallback
 
 For changes that touch only Python, run both partitions and the completeness
-checker in one chained command:
+checker in one chained command. The synthetic partition must use the checked-in
+Windows watchdog:
 
 ```powershell
-python -m pytest -q --ignore=tests/test_real_client_e2e.py --junitxml=.pytest-results/junit-core.xml --durations=0 && python -m pytest -q tests/test_real_client_e2e.py --junitxml=.pytest-results/junit-synthetic.xml --durations=0 && python scripts/ci/check_python_test_partitions.py
+python -m pytest -q --ignore=tests/test_real_client_e2e.py --junitxml=.pytest-results/junit-core.xml --durations=0 && `
+python tests/fixtures/real_client_e2e/run-with-windows-watchdog.py --timeout-seconds 3600 -- `
+  python -m pytest -q tests/test_real_client_e2e.py --junitxml=.pytest-results/junit-synthetic.xml --durations=0 && `
+python scripts/ci/check_python_test_partitions.py
 ```
 
-This executes the core suite, the synthetic suite, and proves the two partitions
-are disjoint and complete.
+This executes the core suite, the watchdog-bounded synthetic suite, and proves
+the two partitions are disjoint and complete.
 
 To verify only the planner/path logic and collection completeness without
 executing `tests/test_real_client_e2e.py`, use:

--- a/docs/agents/verification-policy.md
+++ b/docs/agents/verification-policy.md
@@ -24,7 +24,7 @@ Run targeted tests freely while implementing. At the candidate commit,
 
 | Changed boundary | Relevant local full suite |
 |---|---|
-| Python Gateway, routing, protocol translation, analyzers, Python configuration, or Python test infrastructure | `python -m pytest -q` |
+| Python Gateway, routing, protocol translation, analyzers, Python configuration, or Python test infrastructure | `python -m pytest -q --ignore=tests/test_real_client_e2e.py` plus `python -m pytest -q tests/test_real_client_e2e.py` when the changed paths touch the real-client E2E contract surface |
 | Frontend source, UI contracts, frontend configuration, or frontend dependencies | `npm run build` and `npm run test:ui-contract` in `frontend/` |
 | Tauri/Rust commands, Gateway lifecycle, configuration, packaging code, Rust dependencies, or Rust test infrastructure | `cargo test --locked` and `cargo clippy --locked --all-targets -- -D warnings` in `src-tauri/` |
 | Shared frontend/Tauri command or persisted-settings contract | Frontend and Rust suites |
@@ -54,11 +54,31 @@ not block PR, merge, or release under the current policy.
 ## CI authority
 
 GitHub Actions runs every repository job for every PR to `dev` or `main`
-regardless of local verification class (Python tests, frontend build and UI
-contract, Rust tests for both flavors, Rust clippy, release flavor contract,
-and the safe_file Linux compile/lint/tests). Local risk selection reduces
-duplicate work; it does not weaken CI. When CI is unavailable and a merge must
-proceed, reproduce the full fallback in `docs/agents/ci.md`.
+regardless of local verification class (Python core, synthetic real-client
+contract, frontend build and UI contract, Rust tests for both flavors, Rust
+clippy, release flavor contract, and the safe_file Linux compile/lint/tests).
+Local risk selection reduces duplicate work; it does not weaken CI. When CI is
+unavailable and a merge must proceed, reproduce the full fallback in
+`docs/agents/ci.md`.
+
+### Python checks
+
+The Python validation is split into two stable checks so the real-client E2E
+suite is only invoked when its contract surface actually changed:
+
+- **`Python core`** runs on every PR. It executes every Python test except
+  `tests/test_real_client_e2e.py`.
+- **`Synthetic real-client contract`** appears on every PR. For PRs that do not
+  touch a real-client E2E dependency it succeeds explicitly as
+  `not applicable` and does not start `scripts/Run-RealClientE2E.ps1`. For PRs
+  that touch a relevant path it runs `tests/test_real_client_e2e.py` in full.
+
+Non-PR events (`push`, `workflow_dispatch`, the weekly full-validation
+`schedule`, release/full-validation, and unknown events) fail closed and always
+run the synthetic suite. The planner that implements this decision lives at
+`scripts/ci/python_test_plan.py` and is tested by
+`tests/test_ci_python_plan.py`. Collection completeness is verified by
+`python scripts/ci/check_python_test_partitions.py`.
 
 Existing active work migrates incrementally: retain already completed full
 suites and formal reviews, do not restart a Worker, and verify only later

--- a/docs/agents/verification-policy.md
+++ b/docs/agents/verification-policy.md
@@ -24,7 +24,7 @@ Run targeted tests freely while implementing. At the candidate commit,
 
 | Changed boundary | Relevant local full suite |
 |---|---|
-| Python Gateway, routing, protocol translation, analyzers, Python configuration, or Python test infrastructure | `python -m pytest -q --ignore=tests/test_real_client_e2e.py` plus `python -m pytest -q tests/test_real_client_e2e.py` when the changed paths touch the real-client E2E contract surface |
+| Python Gateway, routing, protocol translation, analyzers, Python configuration, or Python test infrastructure | `python -m pytest -q --ignore=tests/test_real_client_e2e.py` plus `python tests/fixtures/real_client_e2e/run-with-windows-watchdog.py --timeout-seconds 3600 -- python -m pytest -q tests/test_real_client_e2e.py` when the changed paths touch the real-client E2E contract surface |
 | Frontend source, UI contracts, frontend configuration, or frontend dependencies | `npm run build` and `npm run test:ui-contract` in `frontend/` |
 | Tauri/Rust commands, Gateway lifecycle, configuration, packaging code, Rust dependencies, or Rust test infrastructure | `cargo test --locked` and `cargo clippy --locked --all-targets -- -D warnings` in `src-tauri/` |
 | Shared frontend/Tauri command or persisted-settings contract | Frontend and Rust suites |

--- a/scripts/ci/check_python_test_partitions.py
+++ b/scripts/ci/check_python_test_partitions.py
@@ -1,0 +1,121 @@
+"""Verify Python test partition completeness without executing tests.
+
+The CI planner splits Python tests into a "core" partition (everything except
+``tests/test_real_client_e2e.py``) and a "synthetic" partition
+(``tests/test_real_client_e2e.py``). This checker proves, by collection only,
+that the two partitions are disjoint and their union equals the full collection.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import List, Set
+
+
+ROOT = Path(__file__).resolve().parents[2]
+REAL_CLIENT_E2E = "tests/test_real_client_e2e.py"
+
+
+def _collect(nodeids: List[str]) -> Set[str]:
+    """Collect pytest nodeids for the given test selection.
+
+    Always uses ``--collect-only`` so no test code executes.
+    """
+    cmd = [
+        sys.executable,
+        "-m",
+        "pytest",
+        "--collect-only",
+        "-q",
+    ] + nodeids
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(ROOT / "src-python")
+    result = subprocess.run(
+        cmd,
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    collected: Set[str] = set()
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        if line.startswith("no tests"):
+            continue
+        if "test session starts" in line.lower():
+            continue
+        if "collected" in line.lower():
+            continue
+        # The whole line is the nodeid; pytest -q emits one nodeid per line.
+        collected.add(line)
+    return collected
+
+
+def _partition_report(
+    full: Set[str],
+    core: Set[str],
+    synthetic: Set[str],
+) -> dict:
+    overlap = core & synthetic
+    union = core | synthetic
+    missing = full - union
+    extra = union - full
+
+    return {
+        "full_count": len(full),
+        "core_count": len(core),
+        "synthetic_count": len(synthetic),
+        "overlap_count": len(overlap),
+        "overlap": sorted(overlap),
+        "missing_count": len(missing),
+        "missing": sorted(missing),
+        "extra_count": len(extra),
+        "extra": sorted(extra),
+        "disjoint": len(overlap) == 0,
+        "complete": full == union,
+    }
+
+
+def main() -> int:
+    print("Collecting full Python test set...")
+    full = _collect([])
+    print(f"  full: {len(full)} tests")
+
+    print("Collecting core partition (excluding real-client E2E)...")
+    core = _collect(["--ignore", REAL_CLIENT_E2E])
+    print(f"  core: {len(core)} tests")
+
+    print("Collecting synthetic partition (real-client E2E only)...")
+    synthetic = _collect([REAL_CLIENT_E2E])
+    print(f"  synthetic: {len(synthetic)} tests")
+
+    report = _partition_report(full, core, synthetic)
+
+    print()
+    print(f"Disjoint: {report['disjoint']} (overlap={report['overlap_count']})")
+    print(f"Union complete: {report['complete']} (missing={report['missing_count']}, extra={report['extra_count']})")
+
+    if report["overlap"]:
+        print("Overlap nodeids:")
+        for nodeid in report["overlap"]:
+            print(f"  {nodeid}")
+    if report["missing"]:
+        print("Missing from union:")
+        for nodeid in report["missing"]:
+            print(f"  {nodeid}")
+    if report["extra"]:
+        print("Extra in union:")
+        for nodeid in report["extra"]:
+            print(f"  {nodeid}")
+
+    return 0 if report["disjoint"] and report["complete"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/python_test_plan.py
+++ b/scripts/ci/python_test_plan.py
@@ -1,0 +1,264 @@
+"""Deterministic Python CI test planner for CodexHub.
+
+This seam decides which Python tests run for a given GitHub Actions event and
+changed-path set. It is intentionally free of third-party path-filter actions
+and relies only on git and pytest semantics.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import List, Optional
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+REAL_CLIENT_E2E = "tests/test_real_client_e2e.py"
+
+# Paths that may affect the synthetic real-client E2E contract. Directory entries
+# must end with a slash so any nested file under that directory is relevant.
+RELEVANT_SYNTHETIC_PATHS = [
+    "scripts/Run-RealClientE2E.ps1",
+    REAL_CLIENT_E2E,
+    "tests/fixtures/real_client_e2e/",
+    "docs/agents/real-client-e2e.md",
+    ".github/workflows/ci.yml",
+    "scripts/ci/python_test_plan.py",
+    "scripts/ci/check_python_test_partitions.py",
+    "tests/test_ci_python_plan.py",
+]
+
+
+@dataclass(frozen=True)
+class PythonTestPlan:
+    """Immutable plan for one CI partition decision."""
+
+    event_name: str
+    core_args: List[str]
+    synthetic_status: str  # "run" or "not_applicable"
+    synthetic_args: Optional[List[str]]
+    description: str
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self), indent=2)
+
+
+def _normalize_path(path: str) -> str:
+    """Return a forward-slash path relative to the repo root."""
+    return path.replace("\\", "/").lstrip("/")
+
+
+def is_relevant_synthetic_path(path: str) -> bool:
+    """Return True if a changed path should trigger the synthetic suite on a PR."""
+    normalized = _normalize_path(path)
+    for relevant in RELEVANT_SYNTHETIC_PATHS:
+        if relevant.endswith("/"):
+            prefix = relevant
+            exact = relevant.rstrip("/")
+            if normalized.startswith(prefix) or normalized == exact:
+                return True
+        else:
+            if normalized == relevant:
+                return True
+    return False
+
+
+def has_relevant_synthetic_path(changed_paths: List[str]) -> bool:
+    return any(is_relevant_synthetic_path(p) for p in changed_paths)
+
+
+def _core_args() -> List[str]:
+    return [
+        "-q",
+        f"--ignore={REAL_CLIENT_E2E}",
+        "--junitxml=.pytest-results/junit-core.xml",
+        "--durations=0",
+    ]
+
+
+def _synthetic_args() -> List[str]:
+    return [
+        "-q",
+        REAL_CLIENT_E2E,
+        "--junitxml=.pytest-results/junit-synthetic.xml",
+        "--durations=0",
+    ]
+
+
+def build_plan(
+    event_name: str,
+    is_pull_request: bool,
+    changed_paths: List[str],
+) -> PythonTestPlan:
+    """Build a deterministic test plan from event metadata.
+
+    PR events run the synthetic suite only when relevant paths changed.
+    Every other event type fails closed and always runs the synthetic suite.
+    The core partition always runs on PRs.
+    """
+    core_args = _core_args()
+
+    if is_pull_request:
+        if has_relevant_synthetic_path(changed_paths):
+            synthetic_status = "run"
+            synthetic_args = _synthetic_args()
+            description = (
+                "Pull request touched a real-client E2E dependency; "
+                "running the synthetic real-client contract."
+            )
+        else:
+            synthetic_status = "not_applicable"
+            synthetic_args = None
+            description = (
+                "Pull request did not touch a real-client E2E dependency; "
+                "synthetic real-client contract is not applicable."
+            )
+    else:
+        synthetic_status = "run"
+        synthetic_args = _synthetic_args()
+        description = (
+            f"{event_name} is not a pull request; fail closed by running "
+            "the synthetic real-client contract."
+        )
+
+    return PythonTestPlan(
+        event_name=event_name,
+        core_args=core_args,
+        synthetic_status=synthetic_status,
+        synthetic_args=synthetic_args,
+        description=description,
+    )
+
+
+def _read_changed_paths_file(path: Path) -> List[str]:
+    if not path.exists():
+        return []
+    return [line.strip() for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def _changed_paths_from_git(base_ref: str, head_ref: str) -> List[str]:
+    """Return changed paths between two refs using git diff --name-only.
+
+    Fetches the base ref shallowly if needed so the diff is always available.
+    """
+    try:
+        subprocess.run(
+            ["git", "fetch", "origin", f"{base_ref}:refs/remotes/origin/{base_ref}", "--depth=1"],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+        )
+    except subprocess.CalledProcessError:
+        # If the ref already exists locally, fetch failure is non-fatal.
+        pass
+
+    result = subprocess.run(
+        ["git", "diff", "--name-only", f"origin/{base_ref}...{head_ref}"],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def _plan_from_environment() -> PythonTestPlan:
+    """Build a plan using GitHub Actions environment variables.
+
+    Expects GITHUB_EVENT_NAME. For pull_request events, uses GITHUB_BASE_REF and
+    GITHUB_HEAD_REF to compute changed paths.
+    """
+    event_name = os.environ.get("GITHUB_EVENT_NAME", "unknown")
+    is_pull_request = event_name == "pull_request"
+
+    if is_pull_request:
+        base_ref = os.environ.get("GITHUB_BASE_REF", "")
+        head_ref = os.environ.get("GITHUB_HEAD_REF", "HEAD")
+        if base_ref:
+            changed_paths = _changed_paths_from_git(base_ref, head_ref)
+        else:
+            changed_paths = []
+    else:
+        changed_paths = []
+
+    return build_plan(event_name, is_pull_request, changed_paths)
+
+
+def main_plan_from_environment() -> PythonTestPlan:
+    """Public entry point used by tests and CI for environment-based planning."""
+    return _plan_from_environment()
+
+
+def _parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Plan Python test partitions for CodexHub CI.",
+    )
+    parser.add_argument(
+        "--event",
+        default=os.environ.get("GITHUB_EVENT_NAME", "unknown"),
+        help="GitHub Actions event name (default: GITHUB_EVENT_NAME).",
+    )
+    parser.add_argument(
+        "--is-pull-request",
+        action="store_true",
+        help="Treat the event as a pull request.",
+    )
+    parser.add_argument(
+        "--changed-paths",
+        nargs="*",
+        default=None,
+        help="Explicit list of changed paths for a pull request.",
+    )
+    parser.add_argument(
+        "--changed-paths-file",
+        default=None,
+        help="UTF-8 file with one changed path per line for a pull request.",
+    )
+    parser.add_argument(
+        "--output-json",
+        action="store_true",
+        help="Emit the plan as JSON instead of human-readable text.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = _parse_args(argv)
+    event_name = args.event
+    is_pull_request = args.is_pull_request or event_name == "pull_request"
+
+    if args.changed_paths is not None:
+        changed_paths = args.changed_paths
+    elif args.changed_paths_file:
+        changed_paths = _read_changed_paths_file(Path(args.changed_paths_file))
+    elif is_pull_request:
+        changed_paths = _changed_paths_from_git(
+            os.environ.get("GITHUB_BASE_REF", "dev"),
+            os.environ.get("GITHUB_HEAD_REF", "HEAD"),
+        )
+    else:
+        changed_paths = []
+
+    plan = build_plan(event_name, is_pull_request, changed_paths)
+
+    if args.output_json:
+        print(plan.to_json())
+    else:
+        print(plan.description)
+        print(f"Core args: {' '.join(plan.core_args)}")
+        if plan.synthetic_status == "run":
+            print(f"Synthetic args: {' '.join(plan.synthetic_args)}")
+        else:
+            print("Synthetic: not applicable")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/python_test_plan.py
+++ b/scripts/ci/python_test_plan.py
@@ -32,6 +32,7 @@ RELEVANT_SYNTHETIC_PATHS = [
     "scripts/ci/python_test_plan.py",
     "scripts/ci/check_python_test_partitions.py",
     "tests/test_ci_python_plan.py",
+    "pytest.ini",
 ]
 
 
@@ -94,18 +95,28 @@ def _synthetic_args() -> List[str]:
 def build_plan(
     event_name: str,
     is_pull_request: bool,
-    changed_paths: List[str],
+    changed_paths: Optional[List[str]],
 ) -> PythonTestPlan:
     """Build a deterministic test plan from event metadata.
 
     PR events run the synthetic suite only when relevant paths changed.
-    Every other event type fails closed and always runs the synthetic suite.
-    The core partition always runs on PRs.
+    A ``None`` changed-path set means acquisition failed or was unavailable,
+    so PRs fail closed and run the synthetic suite. Every other event type
+    also fails closed and always runs the synthetic suite. The core partition
+    always runs on PRs.
     """
     core_args = _core_args()
 
     if is_pull_request:
-        if has_relevant_synthetic_path(changed_paths):
+        if changed_paths is None:
+            synthetic_status = "run"
+            synthetic_args = _synthetic_args()
+            description = (
+                "Pull request changed-path acquisition failed or was "
+                "unavailable; fail closed by running the synthetic "
+                "real-client contract."
+            )
+        elif has_relevant_synthetic_path(changed_paths):
             synthetic_status = "run"
             synthetic_args = _synthetic_args()
             description = (
@@ -136,36 +147,46 @@ def build_plan(
     )
 
 
-def _read_changed_paths_file(path: Path) -> List[str]:
-    if not path.exists():
-        return []
-    return [line.strip() for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+def _read_changed_paths_file(path: Path) -> Optional[List[str]]:
+    """Read changed paths or return ``None`` when the file is missing/unreadable."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    return [line.strip() for line in text.splitlines() if line.strip()]
 
 
-def _changed_paths_from_git(base_ref: str, head_ref: str) -> List[str]:
-    """Return changed paths between two refs using git diff --name-only.
+def _changed_paths_from_git(base_ref: str, head_ref: str) -> Optional[List[str]]:
+    """Return changed paths between the merge-base and head, or ``None`` on failure.
 
-    Fetches the base ref shallowly if needed so the diff is always available.
+    Uses ``git merge-base`` so the comparison is against the actual PR fork
+    point, not a naive base-tip diff. Any fetch, merge-base, or diff failure
+    returns ``None`` so the caller can fail closed.
     """
     try:
         subprocess.run(
-            ["git", "fetch", "origin", f"{base_ref}:refs/remotes/origin/{base_ref}", "--depth=1"],
+            ["git", "fetch", "origin", base_ref, "--depth=1"],
             cwd=ROOT,
             check=True,
             capture_output=True,
         )
+        merge_base = subprocess.run(
+            ["git", "merge-base", f"origin/{base_ref}", head_ref],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        result = subprocess.run(
+            ["git", "diff", "--name-only", merge_base, head_ref],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return [line.strip() for line in result.stdout.splitlines() if line.strip()]
     except subprocess.CalledProcessError:
-        # If the ref already exists locally, fetch failure is non-fatal.
-        pass
-
-    result = subprocess.run(
-        ["git", "diff", "--name-only", f"origin/{base_ref}...{head_ref}"],
-        cwd=ROOT,
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+        return None
 
 
 def _plan_from_environment() -> PythonTestPlan:
@@ -183,7 +204,8 @@ def _plan_from_environment() -> PythonTestPlan:
         if base_ref:
             changed_paths = _changed_paths_from_git(base_ref, head_ref)
         else:
-            changed_paths = []
+            # Missing base ref means path acquisition is unavailable; fail closed.
+            changed_paths = None
     else:
         changed_paths = []
 

--- a/tests/test_ci_python_plan.py
+++ b/tests/test_ci_python_plan.py
@@ -7,6 +7,14 @@ from pathlib import Path
 
 import pytest
 
+
+try:
+    import yaml
+
+    _HAS_YAML = True
+except Exception:  # pragma: no cover
+    _HAS_YAML = False
+
 ROOT = Path(__file__).resolve().parents[1]
 PLANNER_PATH = ROOT / "scripts" / "ci" / "python_test_plan.py"
 CHECKER_PATH = ROOT / "scripts" / "ci" / "check_python_test_partitions.py"
@@ -237,3 +245,60 @@ def test_checker_runs_without_executing_tests():
     assert "disjoint" in out.stdout.lower()
     assert "union" in out.stdout.lower()
     assert "true" in out.stdout.lower()
+
+
+@pytest.mark.skipif(not _HAS_YAML, reason="PyYAML not installed")
+def test_ci_yaml_has_full_checkout_for_synthetic_merge_base():
+    """Regression: shallow checkout breaks git merge-base on a fresh PR runner."""
+    workflow_path = ROOT / ".github" / "workflows" / "ci.yml"
+    workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+    synthetic_job = workflow["jobs"]["python-synthetic"]
+    checkout_steps = [
+        step
+        for step in synthetic_job["steps"]
+        if isinstance(step, dict) and step.get("name") == "Check out repository"
+    ]
+    assert len(checkout_steps) == 1
+    checkout = checkout_steps[0]
+    assert checkout.get("uses", "").startswith("actions/checkout")
+    assert checkout.get("with", {}).get("fetch-depth") == 0
+
+
+def test_ci_yaml_synthetic_run_uses_watchdog_with_3600s_bound():
+    workflow_text = (ROOT / ".github" / "workflows" / "ci.yml").read_text(
+        encoding="utf-8"
+    )
+    # The synthetic run step must invoke the checked-in watchdog and use 3600s.
+    assert "run-with-windows-watchdog.py" in workflow_text
+    assert "--timeout-seconds 3600" in workflow_text
+    # Direct unattended pytest of the synthetic module is not allowed.
+    synthetic_step = workflow_text.split("Run or skip synthetic partition")[1]
+    assert "python -m pytest" in synthetic_step
+    assert "run-with-windows-watchdog.py" in synthetic_step
+
+
+def test_ci_md_fallback_commands_use_watchdog_with_3600s_bound():
+    ci_md = (ROOT / "docs" / "agents" / "ci.md").read_text(encoding="utf-8")
+    # Both fallback blocks must run the synthetic module through the watchdog.
+    assert "run-with-windows-watchdog.py" in ci_md
+    assert "--timeout-seconds 3600" in ci_md
+    # Direct unattended synthetic pytest must not remain in a fallback block.
+    fallback_start = ci_md.find("## Full manual fallback")
+    assert fallback_start != -1
+    fallback_section = ci_md[fallback_start:]
+    # Every synthetic pytest command in the fallback must be a continuation of
+    # a watchdog invocation, not a direct unattended command.
+    marker = "python -m pytest -q tests/test_real_client_e2e.py"
+    pos = 0
+    while True:
+        idx = fallback_section.find(marker, pos)
+        if idx == -1:
+            break
+        preceding = fallback_section[:idx]
+        watchdog_pos = preceding.rfind("run-with-windows-watchdog.py")
+        continuation_pos = preceding.rfind("-- `")
+        assert watchdog_pos != -1, "synthetic pytest without watchdog in fallback section"
+        assert watchdog_pos < continuation_pos < idx, (
+            "unattended synthetic pytest in fallback section"
+        )
+        pos = idx + len(marker)

--- a/tests/test_ci_python_plan.py
+++ b/tests/test_ci_python_plan.py
@@ -342,3 +342,39 @@ def test_ci_md_fallback_commands_use_watchdog_with_3600s_bound():
             "unattended synthetic pytest in fallback section"
         )
         pos = idx + len(marker)
+
+
+def test_ci_yaml_synthetic_job_has_no_depth_boundary():
+    """Regression: re-shallowing base history can make merge-base fail."""
+    workflow_text = (ROOT / ".github" / "workflows" / "ci.yml").read_text(
+        encoding="utf-8"
+    )
+    synthetic_job = _workflow_job_text(workflow_text, "python-synthetic")
+    assert "--depth=" not in synthetic_job, "synthetic job must not re-shallow history"
+
+
+def test_ci_yaml_changed_paths_uses_no_renames():
+    workflow_text = (ROOT / ".github" / "workflows" / "ci.yml").read_text(
+        encoding="utf-8"
+    )
+    synthetic_job = _workflow_job_text(workflow_text, "python-synthetic")
+    plan_step = _step_run_text(synthetic_job, "Plan synthetic partition")
+    assert "git diff" in plan_step
+    assert "--no-renames" in plan_step
+    assert "--name-only" in plan_step
+
+
+def test_pr_rename_from_relevant_to_unrelated_runs_synthetic(plan):
+    # With --no-renames git diff emits both the old relevant path and the new
+    # unrelated path; the old path must keep the check synthetic.
+    changed = ["tests/test_real_client_e2e.py", "src-python/codex_proxy.py"]
+    p = plan.build_plan("pull_request", True, changed)
+    assert p.synthetic_status == "run"
+
+
+def test_pr_rename_from_unrelated_to_relevant_runs_synthetic(plan):
+    # With --no-renames git diff emits both the old unrelated path and the new
+    # relevant path; the new path must make the check synthetic.
+    changed = ["src-python/codex_proxy.py", "tests/test_real_client_e2e.py"]
+    p = plan.build_plan("pull_request", True, changed)
+    assert p.synthetic_status == "run"

--- a/tests/test_ci_python_plan.py
+++ b/tests/test_ci_python_plan.py
@@ -89,6 +89,11 @@ def test_pr_planner_test_change_runs_synthetic(plan):
     assert p.synthetic_status == "run"
 
 
+def test_pr_pytest_ini_change_runs_synthetic(plan):
+    p = plan.build_plan("pull_request", True, ["pytest.ini"])
+    assert p.synthetic_status == "run"
+
+
 def test_pr_mixed_unrelated_and_relevant_runs_synthetic(plan):
     p = plan.build_plan(
         "pull_request",
@@ -137,6 +142,36 @@ def test_synthetic_args_do_not_start_run_real_client_e2e_ps1(plan):
 def test_not_applicable_plan_description_is_explicit(plan):
     p = plan.build_plan("pull_request", True, ["src-python/codex_proxy.py"])
     assert "not applicable" in p.description.lower()
+
+
+def test_pr_missing_changed_paths_fails_closed_to_synthetic(plan):
+    p = plan.build_plan("pull_request", True, None)
+    assert p.synthetic_status == "run"
+    assert p.synthetic_args is not None
+
+
+def test_unreadable_changed_paths_file_fails_closed_to_synthetic(tmp_path):
+    # A directory at the path makes read_text fail, so the planner treats it as
+    # missing/unreadable and fails closed to full validation.
+    bad_path = tmp_path / "changed-paths.txt"
+    bad_path.mkdir()
+    out = subprocess.run(
+        [
+            sys.executable,
+            str(PLANNER_PATH),
+            "--event",
+            "pull_request",
+            "--is-pull-request",
+            "--changed-paths-file",
+            str(bad_path),
+            "--output-json",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    payload = json.loads(out.stdout)
+    assert payload["synthetic_status"] == "run"
 
 
 def test_cli_json_output_matches_build_plan(plan, tmp_path):

--- a/tests/test_ci_python_plan.py
+++ b/tests/test_ci_python_plan.py
@@ -1,0 +1,204 @@
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+PLANNER_PATH = ROOT / "scripts" / "ci" / "python_test_plan.py"
+CHECKER_PATH = ROOT / "scripts" / "ci" / "check_python_test_partitions.py"
+
+
+def _load_module(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def plan():
+    return _load_module(PLANNER_PATH, "python_test_plan")
+
+
+def test_module_paths_exist():
+    assert PLANNER_PATH.exists()
+    assert CHECKER_PATH.exists()
+
+
+def test_core_args_always_ignore_real_client_e2e(plan):
+    p = plan.build_plan("pull_request", True, ["src-python/codex_proxy.py"])
+    assert "--ignore=tests/test_real_client_e2e.py" in p.core_args
+
+
+def test_pr_unrelated_paths_synthetic_is_not_applicable(plan):
+    p = plan.build_plan("pull_request", True, ["src-python/codex_proxy.py"])
+    assert p.synthetic_status == "not_applicable"
+    assert p.synthetic_args is None
+
+
+def test_pr_ci_yml_change_runs_synthetic(plan):
+    p = plan.build_plan("pull_request", True, [".github/workflows/ci.yml"])
+    assert p.synthetic_status == "run"
+    assert p.synthetic_args is not None
+    assert "tests/test_real_client_e2e.py" in p.synthetic_args
+
+
+def test_pr_real_client_e2e_change_runs_synthetic(plan):
+    p = plan.build_plan("pull_request", True, ["tests/test_real_client_e2e.py"])
+    assert p.synthetic_status == "run"
+
+
+def test_pr_run_real_client_e2e_script_change_runs_synthetic(plan):
+    p = plan.build_plan("pull_request", True, ["scripts/Run-RealClientE2E.ps1"])
+    assert p.synthetic_status == "run"
+
+
+def test_pr_fixture_change_runs_synthetic(plan):
+    p = plan.build_plan(
+        "pull_request",
+        True,
+        ["tests/fixtures/real_client_e2e/fake-client-real-contract.cmd"],
+    )
+    assert p.synthetic_status == "run"
+
+
+def test_pr_real_client_e2e_doc_change_runs_synthetic(plan):
+    p = plan.build_plan("pull_request", True, ["docs/agents/real-client-e2e.md"])
+    assert p.synthetic_status == "run"
+
+
+def test_pr_planner_change_runs_synthetic(plan):
+    p = plan.build_plan("pull_request", True, ["scripts/ci/python_test_plan.py"])
+    assert p.synthetic_status == "run"
+
+
+def test_pr_checker_change_runs_synthetic(plan):
+    p = plan.build_plan(
+        "pull_request", True, ["scripts/ci/check_python_test_partitions.py"]
+    )
+    assert p.synthetic_status == "run"
+
+
+def test_pr_planner_test_change_runs_synthetic(plan):
+    p = plan.build_plan("pull_request", True, ["tests/test_ci_python_plan.py"])
+    assert p.synthetic_status == "run"
+
+
+def test_pr_mixed_unrelated_and_relevant_runs_synthetic(plan):
+    p = plan.build_plan(
+        "pull_request",
+        True,
+        ["src-python/codex_proxy.py", "tests/test_real_client_e2e.py"],
+    )
+    assert p.synthetic_status == "run"
+
+
+def test_push_event_fails_closed_and_runs_synthetic(plan):
+    p = plan.build_plan("push", False, ["src-python/codex_proxy.py"])
+    assert p.synthetic_status == "run"
+    assert p.synthetic_args is not None
+    assert "tests/test_real_client_e2e.py" in p.synthetic_args
+
+
+def test_workflow_dispatch_event_fails_closed(plan):
+    p = plan.build_plan("workflow_dispatch", False, [])
+    assert p.synthetic_status == "run"
+
+
+def test_schedule_event_fails_closed(plan):
+    p = plan.build_plan("schedule", False, [])
+    assert p.synthetic_status == "run"
+
+
+def test_unknown_non_pr_event_fails_closed(plan):
+    p = plan.build_plan("release", False, [])
+    assert p.synthetic_status == "run"
+
+
+def test_core_and_synthetic_emit_junit_and_durations(plan):
+    p = plan.build_plan("pull_request", True, ["tests/test_real_client_e2e.py"])
+    assert "--junitxml=.pytest-results/junit-core.xml" in p.core_args
+    assert "--durations=0" in p.core_args
+    assert "--junitxml=.pytest-results/junit-synthetic.xml" in p.synthetic_args
+    assert "--durations=0" in p.synthetic_args
+
+
+def test_synthetic_args_do_not_start_run_real_client_e2e_ps1(plan):
+    p = plan.build_plan("pull_request", True, ["tests/test_real_client_e2e.py"])
+    joined = " ".join(p.synthetic_args)
+    assert "Run-RealClientE2E.ps1" not in joined
+
+
+def test_not_applicable_plan_description_is_explicit(plan):
+    p = plan.build_plan("pull_request", True, ["src-python/codex_proxy.py"])
+    assert "not applicable" in p.description.lower()
+
+
+def test_cli_json_output_matches_build_plan(plan, tmp_path):
+    out = subprocess.run(
+        [
+            sys.executable,
+            str(PLANNER_PATH),
+            "--event",
+            "pull_request",
+            "--is-pull-request",
+            "--changed-paths",
+            "tests/test_real_client_e2e.py",
+            "--output-json",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    payload = json.loads(out.stdout)
+    assert payload["synthetic_status"] == "run"
+    assert "tests/test_real_client_e2e.py" in payload["synthetic_args"]
+
+
+def test_cli_not_applicable_output_is_valid_json(plan):
+    out = subprocess.run(
+        [
+            sys.executable,
+            str(PLANNER_PATH),
+            "--event",
+            "pull_request",
+            "--is-pull-request",
+            "--changed-paths",
+            "src-python/codex_proxy.py",
+            "--output-json",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    payload = json.loads(out.stdout)
+    assert payload["synthetic_status"] == "not_applicable"
+    assert payload["synthetic_args"] is None
+
+
+def test_environment_event_name_is_respected(monkeypatch):
+    # Reload the module with a patched environment to exercise the CLI default path.
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "schedule")
+    fresh = _load_module(PLANNER_PATH, "python_test_plan_env")
+    plan = fresh.main_plan_from_environment()
+    assert plan.synthetic_status == "run"
+
+
+def test_checker_runs_without_executing_tests():
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(ROOT / "src-python")
+    out = subprocess.run(
+        [sys.executable, str(CHECKER_PATH)],
+        capture_output=True,
+        text=True,
+        check=True,
+        env=env,
+    )
+    assert "disjoint" in out.stdout.lower()
+    assert "union" in out.stdout.lower()
+    assert "true" in out.stdout.lower()

--- a/tests/test_ci_python_plan.py
+++ b/tests/test_ci_python_plan.py
@@ -1,19 +1,12 @@
 import importlib.util
 import json
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
 
 import pytest
-
-
-try:
-    import yaml
-
-    _HAS_YAML = True
-except Exception:  # pragma: no cover
-    _HAS_YAML = False
 
 ROOT = Path(__file__).resolve().parents[1]
 PLANNER_PATH = ROOT / "scripts" / "ci" / "python_test_plan.py"
@@ -31,6 +24,47 @@ def _load_module(path: Path, name: str):
 @pytest.fixture(scope="module")
 def plan():
     return _load_module(PLANNER_PATH, "python_test_plan")
+
+
+def _workflow_job_text(workflow_text: str, job_name: str) -> str:
+    """Return the raw text of a top-level GitHub Actions job."""
+    start = workflow_text.find(f"  {job_name}:")
+    assert start != -1, f"job {job_name!r} not found"
+    after = workflow_text[start + 1 :]
+    next_job = re.search(r"\n  [a-zA-Z0-9_-]+:", after)
+    if next_job:
+        end = start + 1 + next_job.start()
+    else:
+        end = len(workflow_text)
+    return workflow_text[start:end]
+
+
+def _step_run_text(job_text: str, step_name: str) -> str:
+    """Return the run-script text for a named step in a job."""
+    step_start = job_text.find(f"- name: {step_name}")
+    assert step_start != -1, f"step {step_name!r} not found"
+    after = job_text[step_start + 1 :]
+    next_step = re.search(r"\n  - name:", after)
+    if next_step:
+        step_end = step_start + 1 + next_step.start()
+    else:
+        step_end = len(job_text)
+    step_text = job_text[step_start:step_end]
+    run_match = re.search(r"\n        run: (.*)", step_text)
+    if not run_match:
+        return ""
+    run_first = run_match.group(1).strip()
+    if run_first and run_first not in ("|", ">", "|-", ">-"):
+        return run_first
+    run_lines = []
+    for line in step_text[run_match.end() :].splitlines():
+        if line.startswith("          "):
+            run_lines.append(line[10:])
+        elif line == "":
+            run_lines.append("")
+        else:
+            break
+    return "\n".join(run_lines)
 
 
 def test_module_paths_exist():
@@ -247,34 +281,40 @@ def test_checker_runs_without_executing_tests():
     assert "true" in out.stdout.lower()
 
 
-@pytest.mark.skipif(not _HAS_YAML, reason="PyYAML not installed")
 def test_ci_yaml_has_full_checkout_for_synthetic_merge_base():
     """Regression: shallow checkout breaks git merge-base on a fresh PR runner."""
-    workflow_path = ROOT / ".github" / "workflows" / "ci.yml"
-    workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
-    synthetic_job = workflow["jobs"]["python-synthetic"]
-    checkout_steps = [
-        step
-        for step in synthetic_job["steps"]
-        if isinstance(step, dict) and step.get("name") == "Check out repository"
-    ]
-    assert len(checkout_steps) == 1
-    checkout = checkout_steps[0]
-    assert checkout.get("uses", "").startswith("actions/checkout")
-    assert checkout.get("with", {}).get("fetch-depth") == 0
+    workflow_text = (ROOT / ".github" / "workflows" / "ci.yml").read_text(
+        encoding="utf-8"
+    )
+    synthetic_job = _workflow_job_text(workflow_text, "python-synthetic")
+    checkout_start = synthetic_job.find("- name: Check out repository")
+    assert checkout_start != -1
+    checkout_end = synthetic_job.find("- name:", checkout_start + 1)
+    if checkout_end == -1:
+        checkout_end = len(synthetic_job)
+    checkout_step = synthetic_job[checkout_start:checkout_end]
+    assert checkout_step.strip().startswith("- name: Check out repository")
+    assert "actions/checkout" in checkout_step
+    assert "fetch-depth: 0" in checkout_step
 
 
 def test_ci_yaml_synthetic_run_uses_watchdog_with_3600s_bound():
     workflow_text = (ROOT / ".github" / "workflows" / "ci.yml").read_text(
         encoding="utf-8"
     )
-    # The synthetic run step must invoke the checked-in watchdog and use 3600s.
-    assert "run-with-windows-watchdog.py" in workflow_text
-    assert "--timeout-seconds 3600" in workflow_text
-    # Direct unattended pytest of the synthetic module is not allowed.
-    synthetic_step = workflow_text.split("Run or skip synthetic partition")[1]
-    assert "python -m pytest" in synthetic_step
-    assert "run-with-windows-watchdog.py" in synthetic_step
+    synthetic_job = _workflow_job_text(workflow_text, "python-synthetic")
+    run_script = _step_run_text(synthetic_job, "Run or skip synthetic partition")
+    # Normalize PowerShell backtick continuations and whitespace into one line.
+    normalized = run_script.replace("`", "").replace("\n", " ")
+    normalized = " ".join(normalized.split())
+    # Isolate the exact watchdog command and assert ordered components.
+    watchdog_idx = normalized.find(
+        "tests/fixtures/real_client_e2e/run-with-windows-watchdog.py"
+    )
+    timeout_idx = normalized.find("--timeout-seconds 3600")
+    separator_idx = normalized.find("-- ")
+    pytest_idx = normalized.find("python -m pytest")
+    assert -1 < watchdog_idx < timeout_idx < separator_idx < pytest_idx, normalized
 
 
 def test_ci_md_fallback_commands_use_watchdog_with_3600s_bound():


### PR DESCRIPTION
<!-- orchestrator:delivery:v1 -->
```json
{
  "contract_sha256": "a22434aca48e268249b6f95a968cd2870b2909864515a6fb4701b0c9c95bbdb0",
  "candidate_sha": "4f4e854a73701d02b06080bdbb84b6b6fc812d88",
  "changed_paths": [
    ".github/workflows/ci.yml",
    "docs/agents/ci.md",
    "docs/agents/verification-policy.md",
    "scripts/ci/check_python_test_partitions.py",
    "scripts/ci/python_test_plan.py",
    "tests/test_ci_python_plan.py"
  ],
  "tdd": {
    "red": "Added planner, path-selection, workflow-shape, partition, and watchdog tests first and observed the intended failures.",
    "green": "Implemented the minimal Python-core and path-gated synthetic real-client CI split until the focused tests and partition checker passed.",
    "refactor": "Hardened merge-base selection, watchdog bounds, rename handling, and exact workflow-step isolation without changing the test inventory."
  },
  "verification": [
    "python -m pytest -q tests/test_ci_python_plan.py: 33 passed",
    "python scripts/ci/check_python_test_partitions.py: full 1560, core 1428, synthetic 132, disjoint true, union complete true",
    "git diff --check: clean"
  ],
  "deviations": [],
  "risks": []
}
```
