### PR TITLE
Stabilize retries and qualify Ollama Cloud Responses for 0.1.7

### DIFF
--- a/docs/agents/real-client-e2e.md
+++ b/docs/agents/real-client-e2e.md
@@ -8,7 +8,7 @@ canonical routes. HTTP/configuration preflight alone is never an E2E pass.
 
 Run on the authoritative machine-bound local dedicated Windows host
 environment `codexhub-real-client-e2e` with a new output root, dedicated Codex
-login input, dedicated Volc credential, and no reused host user session or
+login input, dedicated Ollama Cloud credential, and no reused host user session or
 client configuration. A VM or named snapshot is not required. The runner
 verifies each native installed version against these compatibility floors
 before launching the candidate or a client:
@@ -77,15 +77,15 @@ Use a new output directory for every invocation. Before launch it contains:
       profile.json
       auth.json
     credentials/
-      volc.json
+      ollama.json
     config/
       gateway.json
       host-environment.json
     gui-seed/
       desktop-luna/
-      desktop-volc/
+      desktop-third-party/
       zcode-luna/
-      zcode-volc/
+      zcode-third-party/
 ```
 
 `isolated/work` must not exist before invocation. The runner verifies the
@@ -95,12 +95,16 @@ is empty before any executable probe or launch.
 
 `isolated/gui-seed` is the invocation-local staging location for an
 operator-controlled durable seed stored outside all run output directories.
-Before launch, copy each of the four named case directories from that durable
-seed into this location. Never copy a prior run's `isolated/work`. The runner
-accepts only canonical, non-reparse, independently copied seed files and
-normalizes or discards client runtime state before it creates the fresh case
-roots. Keep the durable seed private; it contains dedicated-account browser
-login state and is never uploaded.
+Before launch, copy each of the four named seed-slot directories from that
+durable seed into this location. The third-party slot names remain stable when
+the qualified Provider changes. For one compatibility migration, the runner
+also accepts `desktop-volc` or `zcode-volc` only when the corresponding
+`*-third-party` slot is absent; it independently copies from the legacy source
+without modifying or deleting it. Never copy a prior run's `isolated/work`.
+The runner accepts only canonical, non-reparse, independently copied seed files
+and normalizes or discards client runtime state before it creates the fresh
+case roots. Keep the durable seed private; it contains dedicated-account
+browser login state and is never uploaded.
 
 `profile.json` contains only readiness assertions and no account identifier:
 
@@ -117,8 +121,8 @@ login state and is never uploaded.
 `auth.json` is freshly materialized directly in this invocation's isolated
 root; it is never discovered or copied from the current user's Codex home. It
 must use `chatgpt` mode and contain non-empty access and refresh tokens.
-`volc.json` has schema
-`codexhub.real-client-volc.v1` and one non-empty `api_key`. `gateway.json` has
+`ollama.json` has schema
+`codexhub.real-client-ollama.v1` and one non-empty `api_key`. `gateway.json` has
 schema `codexhub.real-client-gateway.v1`, a loopback `listen_port` below the
 Windows dynamic client range (`1024`–`49151`), and a dedicated
 `gateway_client_key`. Preflight must also be able to bind that port
@@ -179,11 +183,11 @@ Operators must not seed this state by hand or hard-code a context limit.
 
 After `refresh-models` succeeds, the runner contract-probes the actual passed
 `-ManagedClientConfigBuild` for Codex, OpenCode, ZCode, Pi, and OMP across both
-Official and Volc selections. Each probe performs `preview`/`apply`/`readback`
+Official and Ollama Cloud selections. Each probe performs `preview`/`apply`/`readback`
 in the final case-local root, passing the explicit candidate runtime catalog
 via `--catalog-path` for every Official `gpt-5.6-luna` preview, apply, and
-readback probe. Volc continues to use the production provider configuration
-and its Chat Completions route without a catalog-path override. The verified roots
+readback probe. Ollama Cloud uses the production provider configuration
+and its Native Responses route without a catalog-path override. The verified roots
 are then reused for the corresponding client launch. Thus the probe detects
 candidate #194 CLI schema drift and verifies that the candidate-managed catalog
 drives Official model resolution without a second materialization or host-state
@@ -240,14 +244,15 @@ PIDs, credentials, or account data.
 Provider protocol selection comes only from #194 preview/apply/readback. The
 runner verifies those three results agree, then verifies the real Gateway
 diagnostics agree with the returned canonical route. Under the current
-production providers this yields Responses for Luna and Chat Completions for
-Volc; the runner contains no endpoint root, SDK, or protocol-format generator.
+production providers this yields Responses for the Official Luna leg and Native
+Responses for the Ollama Cloud leg; the runner contains no endpoint root, SDK, or
+protocol-format generator.
 
 Every child receives a cleared environment with case-local `HOME`,
 `USERPROFILE`, `APPDATA`, `LOCALAPPDATA`, `CODEX_HOME`, `XDG_CONFIG_HOME`,
 `TEMP`, and `TMP`. The candidate receives the production-consumed
 `CODEXHUB_RUNTIME_HOME`, `CODEXHUB_CODEX_TARGET_HOME`, exact verified
-`CODEXHUB_CODEX_PATH`, Gateway key, and Volc environment values. The runner
+`CODEXHUB_CODEX_PATH`, Gateway key, and Ollama environment values. The runner
 never discovers, copies, or modifies host shared sessions. Isolated inputs
 must be regular files under the invocation's `isolated/` root; reparse points
 and hard links fail as host-session reuse.
@@ -256,20 +261,26 @@ and hard links fail as host-session reuse.
 
 The fixed case order and selectors are:
 
-| Case | Client | Client selector | Gateway canonical route | Finalization |
-|---|---|---|---|---|
-| `desktop-luna` | Codex Desktop | `gpt-5.6-luna` | `gpt-5.6-luna` | human GUI |
-| `desktop-volc` | Codex Desktop | `volc/glm-5.2` | `volc/glm-5.2` | human GUI |
-| `codex-cli-luna` | Codex CLI | `gpt-5.6-luna` | `gpt-5.6-luna` | automated |
-| `codex-cli-volc` | Codex CLI | `volc/glm-5.2` | `volc/glm-5.2` | automated |
-| `opencode-luna` | OpenCode | `codexhub-openai/gpt-5.6-luna` | `openai/gpt-5.6-luna` | automated |
-| `opencode-volc` | OpenCode | `codexhub-volc/glm-5.2` | `volc/glm-5.2` | automated |
-| `zcode-luna` | ZCode | `codexhub-openai/gpt-5.6-luna` | `openai/gpt-5.6-luna` | human GUI |
-| `zcode-volc` | ZCode | `codexhub-volc/glm-5.2` | `volc/glm-5.2` | human GUI |
-| `pi-luna` | Pi | `codexhub-openai/gpt-5.6-luna` | `openai/gpt-5.6-luna` | automated |
-| `pi-volc` | Pi | `codexhub-volc/glm-5.2` | `volc/glm-5.2` | automated |
-| `omp-luna` | OMP | `codexhub-openai/gpt-5.6-luna` | `openai/gpt-5.6-luna` | automated |
-| `omp-volc` | OMP | `codexhub-volc/glm-5.2` | `volc/glm-5.2` | automated |
+| Case | Client | Provider | Client selector | Gateway canonical route | Protocol | Finalization |
+|---|---|---|---|---|---|---|
+| `desktop-luna` | Codex Desktop | Official | `gpt-5.6-luna` | `gpt-5.6-luna` | `responses` | human GUI |
+| `desktop-ollama-cloud` | Codex Desktop | Ollama Cloud | `ollama-cloud/glm-5.2` | `ollama-cloud/glm-5.2` | `responses` | human GUI |
+| `codex-cli-luna` | Codex CLI | Official | `gpt-5.6-luna` | `gpt-5.6-luna` | `responses` | automated |
+| `codex-cli-ollama-cloud` | Codex CLI | Ollama Cloud | `ollama-cloud/glm-5.2` | `ollama-cloud/glm-5.2` | `responses` | automated |
+| `opencode-luna` | OpenCode | Official | `codexhub-openai/gpt-5.6-luna` | `openai/gpt-5.6-luna` | `responses` | automated |
+| `opencode-ollama-cloud` | OpenCode | Ollama Cloud | `codexhub-ollama-cloud/glm-5.2` | `ollama-cloud/glm-5.2` | `responses` | automated |
+| `zcode-luna` | ZCode | Official | `codexhub-openai/gpt-5.6-luna` | `openai/gpt-5.6-luna` | `responses` | human GUI |
+| `zcode-ollama-cloud` | ZCode | Ollama Cloud | `codexhub-ollama-cloud/glm-5.2` | `ollama-cloud/glm-5.2` | `responses` | human GUI |
+| `pi-luna` | Pi | Official | `codexhub-openai/gpt-5.6-luna` | `openai/gpt-5.6-luna` | `responses` | automated |
+| `pi-ollama-cloud` | Pi | Ollama Cloud | `codexhub-ollama-cloud/glm-5.2` | `ollama-cloud/glm-5.2` | `responses` | automated |
+| `omp-luna` | OMP | Official | `codexhub-openai/gpt-5.6-luna` | `openai/gpt-5.6-luna` | `responses` | automated |
+| `omp-ollama-cloud` | OMP | Ollama Cloud | `codexhub-ollama-cloud/glm-5.2` | `ollama-cloud/glm-5.2` | `responses` | automated |
+
+The one full 12-case run is the Phase 0 / 0.1.7 release qualification and occurs
+only on the final frozen 0.1.7 candidate. Its third-party leg is the Ollama
+Cloud Native Responses path; the previous Volc Chat Completions
+path remains available as ordinary, non-release regression coverage and is not represented as
+Native Responses evidence in this matrix.
 
 Each case creates one disposable `sentinel.txt`. The client must use exactly
 one successful read-only read tool, emit the named sentinel once, and finish
@@ -368,7 +379,7 @@ maximum `3600`) and remains distinct from automated per-process timeouts. It is
 still contained by the overall runner deadline; it never disables or extends
 that outer deadline.
 
-The template uses schema `codexhub.real-client-manual-evidence.v2` and contains
+The template uses schema `codexhub.real-client-manual-evidence.v3` and contains
 the candidate SHA, managed-client-config candidate SHA, and a random
 `run_binding_sha256`. At the host console, the
 human confirms the dedicated login and GUI, performs both model cases in each
@@ -377,7 +388,7 @@ the template to `manual-evidence.json` and changes only the observed fields:
 
 ```json
 {
-  "schema": "codexhub.real-client-manual-evidence.v2",
+  "schema": "codexhub.real-client-manual-evidence.v3",
   "candidate_sha": "<candidate SHA>",
   "managed_client_config_sha": "<materializer candidate SHA>",
   "run_binding_sha256": "<unchanged template hash>",
@@ -387,7 +398,12 @@ the template to `manual-evidence.json` and changes only the observed fields:
     {
       "case_id": "desktop-luna",
       "client": "desktop",
+      "provider_id": "official",
+      "client_selector": "gpt-5.6-luna",
       "canonical_model": "gpt-5.6-luna",
+      "gateway_model": "gpt-5.6-luna",
+      "endpoint_binding": "/v1/responses",
+      "protocol": "responses",
       "sentinel_relative_path": "isolated/work/gui-desktop/desktop-luna/sentinel.txt",
       "human_finalized": true,
       "outcome": "passed",
@@ -418,7 +434,7 @@ absolute path, or request/session/task identifier.
    modify any current user's Codex, ZCode, OpenCode, Pi, OMP, or provider
    session/configuration.
 2. Create a fresh output root and directly materialize its machine-bound host
-   manifest and dedicated Codex/Volc inputs. Do not use links or copy an
+   manifest and dedicated Codex/Ollama Cloud inputs. Do not use links or copy an
    existing host session, and do not create `isolated/work`.
 3. Check out the candidate. Run the exact `build-windows-portable.ps1 -Flavor
    debug -RepoRoot <absolute-repo-root>` command above, select the resulting
@@ -438,15 +454,16 @@ powershell -NoProfile -File scripts/Run-RealClientE2E.ps1 `
   -ManagedClientConfigBuild <candidate-portable-path> `
   -ManagedClientConfigSha <candidate-materializer-sha> `
   -LunaModel codexhub-openai/gpt-5.6-luna `
-  -VolcModel codexhub-volc/glm-5.2 `
+  -ThirdPartyModel codexhub-ollama-cloud/glm-5.2 `
   -OutputDirectory <path> `
   -HostEnvironmentManifest <path-to-host-environment.json> `
   -OverallTimeoutSeconds 5400 `
   -ManualEvidenceTimeoutSeconds 900
 ```
 
-6. Wait for the template and four case-local GUI launches (Desktop Luna/Volc
-   and ZCode Luna/Volc). Each launch consumes its own #194-applied root.
+6. Wait for the template and four case-local GUI launches (Desktop and ZCode,
+   each with Luna and Ollama Cloud). Each launch consumes its own #194-applied
+   root.
    Reusable Desktop GUI seeds preserve the browser profile and a normalized
    allowlist of completed-onboarding state. The normalized `.codex` state
    never copies project history, remote installation or host identity, session
@@ -487,17 +504,19 @@ completion. An outer timeout references only the fixed sanitized
 `runner-timeout.json` diagnostic. A complete matrix keeps one sanitized
 artifact per case and uses `failure_classification` `none` or `case_failure`.
 
-The success-summary top-level schema is exactly `schema`, `candidate_sha`,
+The success summary uses schema `codexhub.real-client-e2e-summary.v2`. Its
+top-level keys are exactly `schema`, `candidate_sha`,
 `managed_client_config_sha`, `run_binding_sha256`, `outcome`, `failure_classification`, `hashes`,
 `pinned_versions`, `canonical_models`, `counts`, `cases`, and `artifacts`.
 The legacy-named `pinned_versions` object contains the actual normalized versions
 verified for this run, not the compatibility floors.
 Its `hashes` object contains exactly `debug_build` and
 `managed_client_config_build`; fingerprints of the host
-manifest, account profile/auth, Volc credential, Gateway configuration, and
+manifest, account profile/auth, Ollama credential, Gateway configuration, and
 manual evidence are forbidden. Failure summaries omit `run_binding_sha256`
-and `hashes`. Summary/per-case content is otherwise limited to verified versions,
-canonical model IDs, bounded timings and counts, classifications, outcomes,
-and relative artifact names. It never contains credentials,
+and `hashes`. Every successful per-case entry binds the client, Provider,
+client selector, canonical model, Gateway model, endpoint binding, and
+`responses` wire protocol alongside bounded timings and counts,
+classifications, outcomes, and relative artifact names. It never contains credentials,
 authorization headers, prompts, non-sentinel model output, usernames, account
 identifiers, absolute paths, or private request/session/task IDs.

--- a/scripts/Run-RealClientE2E.ps1
+++ b/scripts/Run-RealClientE2E.ps1
@@ -16,7 +16,7 @@ param(
     [string]$LunaModel,
 
     [Parameter(Mandatory = $true)]
-    [string]$VolcModel,
+    [string]$ThirdPartyModel,
 
     [Parameter(Mandatory = $true)]
     [string]$OutputDirectory,
@@ -328,13 +328,13 @@ function Get-ReportedClientVersions {
 function Get-FailureSummaryValue {
     param([string]$FailureClassification, [string[]]$Artifacts = @())
     return [ordered]@{
-        schema = 'codexhub.real-client-e2e-summary.v1'
+        schema = 'codexhub.real-client-e2e-summary.v2'
         candidate_sha = if ($CandidateSha -match '^[0-9a-fA-F]{40}$') { $CandidateSha.ToLowerInvariant() } else { $null }
         managed_client_config_sha = if ($ManagedClientConfigSha -match '^[0-9a-fA-F]{40}$') { $ManagedClientConfigSha.ToLowerInvariant() } else { $null }
         outcome = 'failed'
         failure_classification = $FailureClassification
         pinned_versions = Get-ReportedClientVersions
-        canonical_models = @('gpt-5.6-luna', 'volc/glm-5.2', 'codexhub-openai/gpt-5.6-luna', 'codexhub-volc/glm-5.2')
+        canonical_models = @('gpt-5.6-luna', 'ollama-cloud/glm-5.2', 'codexhub-openai/gpt-5.6-luna', 'codexhub-ollama-cloud/glm-5.2')
         counts = [ordered]@{
             case_count = 0
             passed_count = 0
@@ -382,7 +382,7 @@ function Invoke-RunnerSupervisor {
         ManagedClientConfigBuild = $ManagedClientConfigBuild
         ManagedClientConfigSha = $ManagedClientConfigSha
         LunaModel = $LunaModel
-        VolcModel = $VolcModel
+        ThirdPartyModel = $ThirdPartyModel
         OutputDirectory = $OutputDirectory
         HostEnvironmentManifest = $HostEnvironmentManifest
         TestWindowsInstallMetadataFixture = $TestWindowsInstallMetadataFixture
@@ -407,7 +407,7 @@ function Invoke-RunnerSupervisor {
   -ManagedClientConfigBuild '.' `
   -ManagedClientConfigSha '0000000000000000000000000000000000000000' `
   -LunaModel 'internal' `
-  -VolcModel 'internal' `
+  -ThirdPartyModel 'internal' `
   -OutputDirectory '.' `
   -HostEnvironmentManifest '.' `
   -TimeoutSeconds 1 `
@@ -1359,6 +1359,17 @@ function Read-CorrelatedGatewayEvents {
     if ($modelContradictionCount -gt 0) {
         [void]$events.Add([pscustomobject]@{ event = 'error' })
     }
+    $routeContradictionCount = @($nativeEvents | Where-Object {
+        if ([string](Get-JsonProperty $_ 'event' '') -cne 'request_complete') {
+            return $false
+        }
+        return [string](Get-JsonProperty $_ 'provider_id' '') -cne [string]$Case.diagnostic_provider_id -or
+            [string](Get-JsonProperty $_ 'upstream_format' '') -cne [string]$Case.protocol -or
+            [string](Get-JsonProperty $_ 'inbound_format' '') -cne [string]$Case.protocol
+    }).Count
+    if ($routeContradictionCount -gt 0) {
+        [void]$events.Add([pscustomobject]@{ event = 'error' })
+    }
     $starts = @($nativeEvents | Where-Object { [string](Get-JsonProperty $_ 'event' '') -eq 'request_start' })
     foreach ($start in $starts) {
         [void]$events.Add([pscustomobject]@{ event = 'gateway_request' })
@@ -1570,7 +1581,13 @@ function Invoke-AutomatedCase {
     $artifact = [ordered]@{
         case_id = $Case.case_id
         candidate_sha = $CandidateSha
+        client = $Case.client
+        provider_id = $Case.provider_id
+        client_selector = $Case.client_selector
         canonical_model = $Case.canonical_model
+        gateway_model = $Case.gateway_model
+        endpoint_binding = $Case.endpoint_binding
+        protocol = $Case.protocol
         outcome = if ($measurement.passed) { 'passed' } else { 'failed' }
         stdout_sha256 = Get-TextSha256 -Text $attempt.process.stdout
         stderr_sha256 = Get-TextSha256 -Text $attempt.process.stderr
@@ -1578,7 +1595,13 @@ function Invoke-AutomatedCase {
     Write-JsonFile -Path $artifactPath -Value $artifact
     return [ordered]@{
         case_id = $Case.case_id
+        client = $Case.client
+        provider_id = $Case.provider_id
+        client_selector = $Case.client_selector
         canonical_model = $Case.canonical_model
+        gateway_model = $Case.gateway_model
+        endpoint_binding = $Case.endpoint_binding
+        protocol = $Case.protocol
         outcome = $artifact.outcome
         duration_ms = $duration
         request_complete_count = $measurement.request_complete_count
@@ -1610,7 +1633,7 @@ function Get-ManualResults {
     if (($topLevelNames -join ',') -cne 'candidate_sha,cases,gui_confirmed,login_confirmed,managed_client_config_sha,run_binding_sha256,schema') {
         throw 'manual_evidence_schema_invalid'
     }
-    if ((Get-JsonProperty $evidence 'schema') -cne 'codexhub.real-client-manual-evidence.v2') {
+    if ((Get-JsonProperty $evidence 'schema') -cne 'codexhub.real-client-manual-evidence.v3') {
         throw 'manual_evidence_schema_invalid'
     }
     if ((Get-JsonProperty $evidence 'candidate_sha') -cne $CandidateSha) {
@@ -1640,9 +1663,10 @@ function Get-ManualResults {
         }
         $item = $matches[0]
         $expectedNames = @(
-            'canonical_model', 'case_id', 'client', 'duplicate_terminal_count',
-            'fallback_count', 'http_status', 'human_finalized', 'outcome',
-            'read_only_tool_call_count', 'reconnect_classification',
+            'canonical_model', 'case_id', 'client', 'client_selector',
+            'duplicate_terminal_count', 'endpoint_binding', 'fallback_count',
+            'gateway_model', 'http_status', 'human_finalized', 'outcome',
+            'protocol', 'provider_id', 'read_only_tool_call_count', 'reconnect_classification',
             'request_complete_count', 'sentinel_chunk_count', 'sentinel_relative_path',
             'streaming_request_count',
             'terminal_classification'
@@ -1652,7 +1676,12 @@ function Get-ManualResults {
             throw 'manual_evidence_schema_invalid'
         }
         $valid = (Get-JsonProperty $item 'client') -ceq $expected.client -and
+            (Get-JsonProperty $item 'provider_id') -ceq $expected.provider_id -and
+            (Get-JsonProperty $item 'client_selector') -ceq $expected.client_selector -and
             (Get-JsonProperty $item 'canonical_model') -ceq $expected.canonical_model -and
+            (Get-JsonProperty $item 'gateway_model') -ceq $expected.gateway_model -and
+            (Get-JsonProperty $item 'endpoint_binding') -ceq $expected.endpoint_binding -and
+            (Get-JsonProperty $item 'protocol') -ceq $expected.protocol -and
             (Get-JsonProperty $item 'sentinel_relative_path') -ceq "isolated/work/gui-$($expected.client)/$($expected.case_id)/sentinel.txt" -and
             (Get-JsonProperty $item 'human_finalized' $false) -eq $true -and
             (Get-JsonProperty $item 'outcome') -ceq 'passed' -and
@@ -1673,13 +1702,25 @@ function Get-ManualResults {
         Write-JsonFile -Path $artifactPath -Value ([ordered]@{
             case_id = $expected.case_id
             candidate_sha = $CandidateSha
+            client = $expected.client
+            provider_id = $expected.provider_id
+            client_selector = $expected.client_selector
             canonical_model = $expected.canonical_model
+            gateway_model = $expected.gateway_model
+            endpoint_binding = $expected.endpoint_binding
+            protocol = $expected.protocol
             outcome = 'passed'
             evidence_sha256 = Get-Sha256 -Path $EvidencePath
         })
         [void]$results.Add([ordered]@{
             case_id = $expected.case_id
+            client = $expected.client
+            provider_id = $expected.provider_id
+            client_selector = $expected.client_selector
             canonical_model = $expected.canonical_model
+            gateway_model = $expected.gateway_model
+            endpoint_binding = $expected.endpoint_binding
+            protocol = $expected.protocol
             outcome = 'passed'
             duration_ms = 0
             request_complete_count = 1
@@ -1712,7 +1753,12 @@ function Write-ManualEvidenceTemplate {
         [ordered]@{
             case_id = $_.case_id
             client = $_.client
+            provider_id = $_.provider_id
+            client_selector = $_.client_selector
             canonical_model = $_.canonical_model
+            gateway_model = $_.gateway_model
+            endpoint_binding = $_.endpoint_binding
+            protocol = $_.protocol
             sentinel_relative_path = "isolated/work/gui-$($_.client)/$($_.case_id)/sentinel.txt"
             human_finalized = $false
             outcome = 'pending'
@@ -1728,7 +1774,7 @@ function Write-ManualEvidenceTemplate {
         }
     })
     Write-JsonFile -Path $Path -Value ([ordered]@{
-        schema = 'codexhub.real-client-manual-evidence.v2'
+        schema = 'codexhub.real-client-manual-evidence.v3'
         candidate_sha = $CandidateSha
         managed_client_config_sha = $ManagedClientConfigSha
         run_binding_sha256 = $RunBinding
@@ -2589,6 +2635,9 @@ function Initialize-ClientConfiguration {
         (@(Get-JsonProperty $apply 'target_names' @()) -join ',') -cne (@(Get-JsonProperty $preview 'target_names' @()) -join ','))) {
         throw 'client_configuration_materializer_contradiction'
     }
+    if ($Model -like 'ollama-cloud/*' -and [string](Get-JsonProperty $readback 'route_protocol' '') -cne 'responses') {
+        throw 'client_configuration_materializer_contradiction'
+    }
     $targetNames = @((Get-JsonProperty $preview 'target_names' @()) | ForEach-Object { [string]$_ })
     Publish-ManagedClientTargets -Client $managedClient -ApplyRoot $applyRoot -TargetNames $targetNames -CaseRoot $CaseRoot
     return [pscustomobject]@{
@@ -2612,24 +2661,24 @@ function Initialize-CandidateRuntime {
         gateway_client_key = [string]$script:GatewayConfig.gateway_client_key
         gateway_enable_models = $true
         gateway_enable_responses = $true
-        gateway_enable_chat_completions = $true
+        gateway_enable_chat_completions = $false
         proxy_port = [int]$script:GatewayConfig.listen_port
     })
     $providerText = @"
 [[providers]]
-id = "volc"
-name = "Volcengine"
-base_url = "https://ark.cn-beijing.volces.com/api/coding/v3"
-api_key = "{env:VOLCENGINE_API_KEY}"
+id = "ollama-cloud"
+name = "Ollama Cloud"
+base_url = "https://ollama.com/v1"
+api_key = "{env:OLLAMA_API_KEY}"
 upstream_format = "responses"
 available_upstream_formats = ["responses"]
 enabled = true
 
   [[providers.models]]
   id = "glm-5.2"
-  display_name = "Volc GLM-5.2"
-  context_window = 1024000
-  max_output_tokens = 8192
+  display_name = "Ollama Cloud GLM-5.2"
+  context_window = 1000000
+  max_output_tokens = 131072
   enabled = true
 "@
     [System.IO.File]::WriteAllText((Join-Path $proxyRoot 'config\providers.toml'), $providerText, $script:Utf8NoBom)
@@ -2668,7 +2717,7 @@ try {
     $forwardedArguments = $forwardedJson | ConvertFrom-Json -ErrorAction Stop
     Assert-ExactJsonProperties -Value $forwardedArguments -Names @(
         'CandidateSha', 'DebugBuild', 'ManagedClientConfigBuild',
-        'ManagedClientConfigSha', 'LunaModel', 'VolcModel', 'OutputDirectory',
+        'ManagedClientConfigSha', 'LunaModel', 'ThirdPartyModel', 'OutputDirectory',
         'HostEnvironmentManifest', 'TestWindowsInstallMetadataFixture',
         'CodexDesktopPath', 'CodexCliPath', 'ZCodePath', 'OpenCodePath',
         'PiPath', 'OmpPath', 'TimeoutSeconds', 'ManualEvidenceTimeoutSeconds',
@@ -2679,7 +2728,7 @@ try {
     $ManagedClientConfigBuild = [string]$forwardedArguments.ManagedClientConfigBuild
     $ManagedClientConfigSha = [string]$forwardedArguments.ManagedClientConfigSha
     $LunaModel = [string]$forwardedArguments.LunaModel
-    $VolcModel = [string]$forwardedArguments.VolcModel
+    $ThirdPartyModel = [string]$forwardedArguments.ThirdPartyModel
     $OutputDirectory = [string]$forwardedArguments.OutputDirectory
     $HostEnvironmentManifest = [string]$forwardedArguments.HostEnvironmentManifest
     $TestWindowsInstallMetadataFixture = [string]$forwardedArguments.TestWindowsInstallMetadataFixture
@@ -2716,8 +2765,8 @@ if ($ManagedClientConfigSha -notmatch '^[0-9a-f]{40}$') {
 if ($LunaModel -cne 'codexhub-openai/gpt-5.6-luna') {
     throw 'preflight_luna_model_invalid'
 }
-if ($VolcModel -cne 'codexhub-volc/glm-5.2') {
-    throw 'preflight_volc_model_invalid'
+if ($ThirdPartyModel -cne 'codexhub-ollama-cloud/glm-5.2') {
+    throw 'preflight_third_party_model_invalid'
 }
 if ($TimeoutSeconds -lt 1 -or $TimeoutSeconds -gt 900 -or
     $ManualEvidenceTimeoutSeconds -lt 1 -or $ManualEvidenceTimeoutSeconds -gt 3600 -or
@@ -2731,7 +2780,7 @@ $OutputDirectory = (Resolve-Path -LiteralPath $OutputDirectory).Path
 $isolationRoot = Join-Path $OutputDirectory 'isolated'
 $accountPath = Join-Path $isolationRoot 'account\profile.json'
 $accountAuthPath = Join-Path $isolationRoot 'account\auth.json'
-$credentialPath = Join-Path $isolationRoot 'credentials\volc.json'
+$credentialPath = Join-Path $isolationRoot 'credentials\ollama.json'
 $configRoot = Join-Path $isolationRoot 'config'
 $guiSeedRoot = Join-Path $isolationRoot 'gui-seed'
 $workRoot = Join-Path $isolationRoot 'work'
@@ -2835,10 +2884,10 @@ if ([string](Get-JsonProperty $accountAuth 'auth_mode' '') -cne 'chatgpt' -or
     [string](Get-JsonProperty $authTokens 'refresh_token' '') -eq '') {
     throw 'preflight_codex_login_missing'
 }
-$credential = Read-JsonObject -Path $credentialPath -Failure 'preflight_volc_credential_invalid'
-Assert-ExactJsonProperties -Value $credential -Names @('schema', 'api_key') -Failure 'preflight_volc_credential_invalid'
-if ([string]$credential.schema -cne 'codexhub.real-client-volc.v1' -or [string]$credential.api_key -notmatch '^\S{16,}$') {
-    throw 'preflight_volc_credential_invalid'
+$credential = Read-JsonObject -Path $credentialPath -Failure 'preflight_ollama_credential_invalid'
+Assert-ExactJsonProperties -Value $credential -Names @('schema', 'api_key') -Failure 'preflight_ollama_credential_invalid'
+if ([string]$credential.schema -cne 'codexhub.real-client-ollama.v1' -or [string]$credential.api_key -notmatch '^\S{16,}$') {
+    throw 'preflight_ollama_credential_invalid'
 }
 $script:GatewayConfig = Read-JsonObject -Path $gatewayConfigPath -Failure 'preflight_gateway_config_invalid'
 Assert-ExactJsonProperties -Value $script:GatewayConfig -Names @('schema', 'listen_port', 'gateway_client_key') -Failure 'preflight_gateway_config_invalid'
@@ -2897,20 +2946,20 @@ $desktopLaunchExecutable = Copy-DesktopApplicationPayload `
 [void](New-Item -ItemType Directory -Path (Join-Path $artifactRoot 'cases'))
 
 $manualCases = @(
-    [pscustomobject]@{ case_id = 'desktop-luna'; client = 'desktop'; canonical_model = 'gpt-5.6-luna'; gateway_model = 'gpt-5.6-luna' },
-    [pscustomobject]@{ case_id = 'desktop-volc'; client = 'desktop'; canonical_model = 'volc/glm-5.2'; gateway_model = 'volc/glm-5.2' },
-    [pscustomobject]@{ case_id = 'zcode-luna'; client = 'zcode'; canonical_model = $LunaModel; gateway_model = 'openai/gpt-5.6-luna' },
-    [pscustomobject]@{ case_id = 'zcode-volc'; client = 'zcode'; canonical_model = $VolcModel; gateway_model = 'volc/glm-5.2' }
+    [pscustomobject]@{ case_id = 'desktop-luna'; client = 'desktop'; provider_id = 'official'; diagnostic_provider_id = 'official'; client_selector = 'gpt-5.6-luna'; canonical_model = 'gpt-5.6-luna'; gateway_model = 'gpt-5.6-luna'; endpoint_binding = '/v1/responses'; protocol = 'responses'; seed_slot = 'desktop-luna'; legacy_seed_slot = '' },
+    [pscustomobject]@{ case_id = 'desktop-ollama-cloud'; client = 'desktop'; provider_id = 'ollama-cloud'; diagnostic_provider_id = 'ollama_cloud'; client_selector = 'ollama-cloud/glm-5.2'; canonical_model = 'ollama-cloud/glm-5.2'; gateway_model = 'ollama-cloud/glm-5.2'; endpoint_binding = '/v1/providers/ollama-cloud/responses'; protocol = 'responses'; seed_slot = 'desktop-third-party'; legacy_seed_slot = 'desktop-volc' },
+    [pscustomobject]@{ case_id = 'zcode-luna'; client = 'zcode'; provider_id = 'official'; diagnostic_provider_id = 'official'; client_selector = $LunaModel; canonical_model = $LunaModel; gateway_model = 'openai/gpt-5.6-luna'; endpoint_binding = '/v1/providers/openai/responses'; protocol = 'responses'; seed_slot = 'zcode-luna'; legacy_seed_slot = '' },
+    [pscustomobject]@{ case_id = 'zcode-ollama-cloud'; client = 'zcode'; provider_id = 'ollama-cloud'; diagnostic_provider_id = 'ollama_cloud'; client_selector = $ThirdPartyModel; canonical_model = $ThirdPartyModel; gateway_model = 'ollama-cloud/glm-5.2'; endpoint_binding = '/v1/providers/ollama-cloud/responses'; protocol = 'responses'; seed_slot = 'zcode-third-party'; legacy_seed_slot = 'zcode-volc' }
 )
 $automatedCases = @(
-    [pscustomobject]@{ case_id = 'codex-cli-luna'; client = 'codex-cli'; canonical_model = 'gpt-5.6-luna'; gateway_model = 'gpt-5.6-luna' },
-    [pscustomobject]@{ case_id = 'codex-cli-volc'; client = 'codex-cli'; canonical_model = 'volc/glm-5.2'; gateway_model = 'volc/glm-5.2' },
-    [pscustomobject]@{ case_id = 'opencode-luna'; client = 'opencode'; canonical_model = $LunaModel; gateway_model = 'openai/gpt-5.6-luna' },
-    [pscustomobject]@{ case_id = 'opencode-volc'; client = 'opencode'; canonical_model = $VolcModel; gateway_model = 'volc/glm-5.2' },
-    [pscustomobject]@{ case_id = 'pi-luna'; client = 'pi'; canonical_model = $LunaModel; gateway_model = 'openai/gpt-5.6-luna' },
-    [pscustomobject]@{ case_id = 'pi-volc'; client = 'pi'; canonical_model = $VolcModel; gateway_model = 'volc/glm-5.2' },
-    [pscustomobject]@{ case_id = 'omp-luna'; client = 'omp'; canonical_model = $LunaModel; gateway_model = 'openai/gpt-5.6-luna' },
-    [pscustomobject]@{ case_id = 'omp-volc'; client = 'omp'; canonical_model = $VolcModel; gateway_model = 'volc/glm-5.2' }
+    [pscustomobject]@{ case_id = 'codex-cli-luna'; client = 'codex-cli'; provider_id = 'official'; diagnostic_provider_id = 'official'; client_selector = 'gpt-5.6-luna'; canonical_model = 'gpt-5.6-luna'; gateway_model = 'gpt-5.6-luna'; endpoint_binding = '/v1/responses'; protocol = 'responses' },
+    [pscustomobject]@{ case_id = 'codex-cli-ollama-cloud'; client = 'codex-cli'; provider_id = 'ollama-cloud'; diagnostic_provider_id = 'ollama_cloud'; client_selector = 'ollama-cloud/glm-5.2'; canonical_model = 'ollama-cloud/glm-5.2'; gateway_model = 'ollama-cloud/glm-5.2'; endpoint_binding = '/v1/providers/ollama-cloud/responses'; protocol = 'responses' },
+    [pscustomobject]@{ case_id = 'opencode-luna'; client = 'opencode'; provider_id = 'official'; diagnostic_provider_id = 'official'; client_selector = $LunaModel; canonical_model = $LunaModel; gateway_model = 'openai/gpt-5.6-luna'; endpoint_binding = '/v1/providers/openai/responses'; protocol = 'responses' },
+    [pscustomobject]@{ case_id = 'opencode-ollama-cloud'; client = 'opencode'; provider_id = 'ollama-cloud'; diagnostic_provider_id = 'ollama_cloud'; client_selector = $ThirdPartyModel; canonical_model = $ThirdPartyModel; gateway_model = 'ollama-cloud/glm-5.2'; endpoint_binding = '/v1/providers/ollama-cloud/responses'; protocol = 'responses' },
+    [pscustomobject]@{ case_id = 'pi-luna'; client = 'pi'; provider_id = 'official'; diagnostic_provider_id = 'official'; client_selector = $LunaModel; canonical_model = $LunaModel; gateway_model = 'openai/gpt-5.6-luna'; endpoint_binding = '/v1/providers/openai/responses'; protocol = 'responses' },
+    [pscustomobject]@{ case_id = 'pi-ollama-cloud'; client = 'pi'; provider_id = 'ollama-cloud'; diagnostic_provider_id = 'ollama_cloud'; client_selector = $ThirdPartyModel; canonical_model = $ThirdPartyModel; gateway_model = 'ollama-cloud/glm-5.2'; endpoint_binding = '/v1/providers/ollama-cloud/responses'; protocol = 'responses' },
+    [pscustomobject]@{ case_id = 'omp-luna'; client = 'omp'; provider_id = 'official'; diagnostic_provider_id = 'official'; client_selector = $LunaModel; canonical_model = $LunaModel; gateway_model = 'openai/gpt-5.6-luna'; endpoint_binding = '/v1/providers/openai/responses'; protocol = 'responses' },
+    [pscustomobject]@{ case_id = 'omp-ollama-cloud'; client = 'omp'; provider_id = 'ollama-cloud'; diagnostic_provider_id = 'ollama_cloud'; client_selector = $ThirdPartyModel; canonical_model = $ThirdPartyModel; gateway_model = 'ollama-cloud/glm-5.2'; endpoint_binding = '/v1/providers/ollama-cloud/responses'; protocol = 'responses' }
 )
 
 $runBinding = New-RunBinding
@@ -2948,7 +2997,7 @@ try {
         CODEX_HOME = $script:CandidateCodexRoot
         CODEXHUB_CODEX_PATH = [string]$executables['codex-cli']
         CODEX_PROXY_GATEWAY_CLIENT_KEY = [string]$script:GatewayConfig.gateway_client_key
-        VOLCENGINE_API_KEY = [string]$credential.api_key
+        OLLAMA_API_KEY = [string]$credential.api_key
         CODEXHUB_E2E_CONTRACT_PROBE_LOG = $script:ManagedClientConfigLogPath
     }
     Set-RunnerPhase -Phase 'candidate_startup'
@@ -2979,12 +3028,27 @@ try {
         }
         [void](New-Item -ItemType Directory -Path $caseRoot -Force)
         if ($case.client -in @('desktop', 'zcode')) {
-            $seedCaseRoot = Join-Path $guiSeedRoot $case.case_id
+            $seedCaseRoot = Join-Path $guiSeedRoot $case.seed_slot
+            if (-not (Test-Path -LiteralPath $seedCaseRoot -PathType Container) -and
+                $case.legacy_seed_slot) {
+                $legacySeedCaseRoot = Join-Path $guiSeedRoot $case.legacy_seed_slot
+                if (Test-Path -LiteralPath $legacySeedCaseRoot -PathType Container) {
+                    $seedCaseRoot = $legacySeedCaseRoot
+                }
+            }
             if (Test-Path -LiteralPath $seedCaseRoot -PathType Container) {
                 Copy-GuiStateSeed -SeedCaseRoot $seedCaseRoot -CaseRoot $caseRoot -Client $case.client -IsolationRoot $isolationRoot
             }
         }
-        $caseConfigurations[$case.case_id] = Initialize-ClientConfiguration -Client $case.client -CaseRoot $caseRoot -Model $case.gateway_model -CatalogPath $candidateCatalogPath
+        $configuration = Initialize-ClientConfiguration -Client $case.client -CaseRoot $caseRoot -Model $case.gateway_model -CatalogPath $candidateCatalogPath
+        if (
+            [string]$configuration.launch_model -cne [string]$case.client_selector -or
+            [string]$configuration.canonical_model -cne [string]$case.gateway_model -or
+            [string]$configuration.route_protocol -cne [string]$case.protocol
+        ) {
+            throw 'client_configuration_materializer_contradiction'
+        }
+        $caseConfigurations[$case.case_id] = $configuration
     }
     [void](Initialize-ClientConfiguration -Client 'desktop' -CaseRoot $candidateRoot -Model 'gpt-5.6-luna' -CatalogPath $candidateCatalogPath)
     $candidateStartupStopwatch.Stop()
@@ -3063,19 +3127,19 @@ try {
         $manualById[$result.case_id] = $result
     }
     $caseOrder = @(
-        'desktop-luna', 'desktop-volc',
-        'codex-cli-luna', 'codex-cli-volc',
-        'opencode-luna', 'opencode-volc',
-        'zcode-luna', 'zcode-volc',
-        'pi-luna', 'pi-volc',
-        'omp-luna', 'omp-volc'
+        'desktop-luna', 'desktop-ollama-cloud',
+        'codex-cli-luna', 'codex-cli-ollama-cloud',
+        'opencode-luna', 'opencode-ollama-cloud',
+        'zcode-luna', 'zcode-ollama-cloud',
+        'pi-luna', 'pi-ollama-cloud',
+        'omp-luna', 'omp-ollama-cloud'
     )
     $caseResults = @($caseOrder | ForEach-Object {
         if ($manualById.ContainsKey($_)) { $manualById[$_] } else { $automatedById[$_] }
     })
     $passedCount = @($caseResults | Where-Object { $_.outcome -ceq 'passed' }).Count
     $summary = [ordered]@{
-        schema = 'codexhub.real-client-e2e-summary.v1'
+        schema = 'codexhub.real-client-e2e-summary.v2'
         candidate_sha = $CandidateSha
         managed_client_config_sha = $ManagedClientConfigSha
         run_binding_sha256 = $runBinding
@@ -3086,7 +3150,7 @@ try {
             managed_client_config_build = Get-Sha256 -Path $ManagedClientConfigBuild
         }
         pinned_versions = $actualVersions
-        canonical_models = @('gpt-5.6-luna', 'volc/glm-5.2', $LunaModel, $VolcModel)
+        canonical_models = @('gpt-5.6-luna', 'ollama-cloud/glm-5.2', $LunaModel, $ThirdPartyModel)
         counts = [ordered]@{
             case_count = 12
             passed_count = $passedCount
@@ -3125,13 +3189,13 @@ catch {
         }
     }
     $failureSummary = [ordered]@{
-        schema = 'codexhub.real-client-e2e-summary.v1'
+        schema = 'codexhub.real-client-e2e-summary.v2'
         candidate_sha = if ($CandidateSha -match '^[0-9a-f]{40}$') { $CandidateSha } else { $null }
         managed_client_config_sha = if ($ManagedClientConfigSha -match '^[0-9a-f]{40}$') { $ManagedClientConfigSha } else { $null }
         outcome = 'failed'
         failure_classification = $failureClassification
         pinned_versions = Get-ReportedClientVersions
-        canonical_models = @('gpt-5.6-luna', 'volc/glm-5.2', 'codexhub-openai/gpt-5.6-luna', 'codexhub-volc/glm-5.2')
+        canonical_models = @('gpt-5.6-luna', 'ollama-cloud/glm-5.2', 'codexhub-openai/gpt-5.6-luna', 'codexhub-ollama-cloud/glm-5.2')
         counts = [ordered]@{
             case_count = 0
             passed_count = 0

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -1021,6 +1021,12 @@ CAPACITY_RETRY_FAILURE_CLASSES = {
 CAPACITY_RETRY_CADENCE_SECONDS = (10, 20, 30, 60)
 TRANSIENT_HTTP_RETRY_STATUSES = {408, 409, 421, 425, 429, 500, 502, 503, 504}
 AUTO_UPSTREAM_PROTOCOL_FALLBACK_STATUSES = {404, 405, 415, 422}
+
+RETRY_SAFETY_SAFE_PREWRITE = "safe_prewrite"
+RETRY_SAFETY_GUARANTEED_IDEMPOTENT = "guaranteed_idempotent"
+RETRY_SAFETY_SUPPRESSED_POST_WRITE = "suppressed_post_write"
+RETRY_SAFETY_SUPPRESSED_POST_EXPOSURE = "suppressed_post_exposure"
+RETRY_SAFETY_UNKNOWN = "unknown"
 PERMANENT_HTTP_ERROR_STATUSES = {
     400,
     401,
@@ -10403,13 +10409,29 @@ def compatible_sse_line(
     return _sse_json_line(payload, line_ending)
 
 
-def safe_upstream_error_detail(exc: BaseException) -> str:
+def _retry_identity_from_context(event_context: Mapping[str, Any] | None) -> str | None:
+    """Return the private stable retry identity if one exists in the context."""
+    if event_context is None:
+        return None
+    identity = event_context.get("_retry_attempt_identity")
+    return identity if isinstance(identity, str) and identity else None
+
+
+def _redact_identity_in_text(text: str, identity: str | None) -> str:
+    if identity and identity in text:
+        return text.replace(identity, "[retry_identity_redacted]")
+    return text
+
+
+def safe_upstream_error_detail(exc: BaseException, *, redact_identity: str | None = None) -> str:
     reason = getattr(exc, "reason", None)
     source = reason if reason is not None else exc
     detail = f"{type(source).__name__}: {source}"
     detail = detail.replace("\r", " ").replace("\n", " ")
     if "Bearer " in detail:
         detail = detail.split("Bearer ", 1)[0] + "Bearer [redacted]"
+    if redact_identity:
+        detail = detail.replace(redact_identity, "[retry_identity_redacted]")
     return detail[:300]
 
 
@@ -10442,6 +10464,196 @@ def transport_failure_phase(exc: BaseException | None) -> str | None:
     if isinstance(exc, (OSError, URLError)):
         return "tcp_connect"
     return None
+
+
+def _retry_safety_failure_phase(exc: BaseException | None) -> str | None:
+    """Phase label used for the request-scoped retry-safety decision.
+
+    This function is conservative: it returns a pre-write phase only when the
+    exception itself is a structurally unambiguous instance of that phase.
+    Generic TimeoutError, SSLError, OSError, and URLError are ambiguous (they
+    can occur during connect, request write, or body read) and therefore return
+    ``None`` so the caller-supplied ``failure_phase`` or the ``unknown`` safety
+    class is used.  Only specifically inspected exception types carry
+    authoritative phase evidence: socket.gaierror (DNS), ConnectionRefusedError
+    (TCP connect), and ssl.SSLCertVerificationError (TLS handshake).  Text
+    needles in OS-level error messages are never treated as proof because the
+    same message can occur after the request has been written.
+    """
+    if exc is None:
+        return None
+    if isinstance(exc, (UpstreamStreamIncompleteError, UpstreamStreamErrorEvent)):
+        return "stream_body"
+    if isinstance(exc, HTTPError):
+        return "response_headers"
+    if isinstance(exc, IncompleteRead):
+        return "response_headers"
+    if isinstance(exc, socket.gaierror):
+        return "dns"
+    if isinstance(exc, ConnectionRefusedError):
+        return "tcp_connect"
+    if isinstance(exc, ssl.SSLCertVerificationError):
+        return "tls_handshake"
+    if isinstance(exc, URLError):
+        nested = _retry_safety_failure_phase(exc.reason)
+        if nested is not None:
+            return nested
+    return None
+
+
+def _model_access_path_idempotency_guaranteed(model_access_path: tuple[str, ...]) -> bool:
+    """Return True when the exact Model Access Path carries an explicit guarantee.
+
+    The default allowlist is empty: no non-Official main-generation POST is
+    assumed idempotent unless it is explicitly enrolled here.  This keeps the
+    conservative default while providing a single seam for future guarantees.
+    """
+    return False
+
+
+def _model_access_path_from_event_context(
+    event_context: Mapping[str, Any] | None,
+    upstream_name: str,
+    upstream_format: str,
+) -> tuple[str, ...]:
+    model = ""
+    behavior_profile = ""
+    inbound_format = ""
+    if event_context is not None:
+        try:
+            model = str(event_context.get("model") or "")
+        except Exception:
+            model = ""
+        try:
+            behavior_profile = str(event_context.get("behavior_profile") or "")
+        except Exception:
+            behavior_profile = ""
+        try:
+            inbound_format = str(event_context.get("_caller_wire_format") or "")
+        except Exception:
+            inbound_format = ""
+    return (upstream_name, model, behavior_profile, upstream_format, inbound_format)
+
+
+def _ensure_retry_attempt_identity(
+    event_context: dict[str, Any] | None,
+    request: Request,
+    model_access_path: tuple[str, ...],
+) -> str | None:
+    """Return the stable attempt identity for this logical request.
+
+    The identity is stored in the mutable event context under a private key so
+    it is not emitted by _public_event_context.  When the Model Access Path is
+    explicitly idempotent, the identity is attached to the upstream request as
+    an idempotency key; it is never logged, returned to the client, or placed
+    in telemetry payloads.
+    """
+    if event_context is None:
+        return None
+    identity = event_context.get("_retry_attempt_identity")
+    if not isinstance(identity, str):
+        identity = uuid.uuid4().hex
+        event_context["_retry_attempt_identity"] = identity
+    if _model_access_path_idempotency_guaranteed(model_access_path):
+        request.headers["X-CodexHub-Retry-Attempt-Identity"] = identity
+    return identity
+
+
+_SUPPRESSED_RETRY_SAFETY_CLASSES = frozenset({
+    RETRY_SAFETY_SUPPRESSED_POST_WRITE,
+    RETRY_SAFETY_SUPPRESSED_POST_EXPOSURE,
+    RETRY_SAFETY_UNKNOWN,
+})
+
+
+def _retry_safety_class(
+    exc: BaseException,
+    *,
+    request: Request,
+    upstream_name: str,
+    request_kind: str,
+    downstream_exposed: bool,
+    model_access_path: tuple[str, ...],
+    failure_phase: str | None = None,
+) -> str:
+    """Classify whether this failure is safe to retry for a non-Official main-generation POST.
+
+    Official main-generation POSTs and all other request kinds preserve their
+    existing retry behavior and receive no classification here.
+
+    Callers that already know the failure occurred during the response stream
+    may pass ``failure_phase`` to override the exception-based heuristic; this
+    is required to distinguish a connect-time ``TimeoutError`` from a body-read
+    ``TimeoutError``.
+    """
+    if upstream_name == "official" or request_kind != RETRY_REQUEST_MAIN_GENERATION:
+        return RETRY_SAFETY_SAFE_PREWRITE
+    if request.get_method() != "POST":
+        return RETRY_SAFETY_SAFE_PREWRITE
+    if downstream_exposed:
+        return RETRY_SAFETY_SUPPRESSED_POST_EXPOSURE
+    if _model_access_path_idempotency_guaranteed(model_access_path):
+        return RETRY_SAFETY_GUARANTEED_IDEMPOTENT
+    phase = failure_phase if failure_phase is not None else _retry_safety_failure_phase(exc)
+    if phase in {"dns", "tcp_connect", "tls_handshake"}:
+        return RETRY_SAFETY_SAFE_PREWRITE
+    if phase in {"request_write", "response_headers", "stream_body"}:
+        return RETRY_SAFETY_SUPPRESSED_POST_WRITE
+    return RETRY_SAFETY_UNKNOWN
+
+
+def _emit_upstream_retry_suppressed_event(
+    event_context: Mapping[str, Any] | None,
+    *,
+    upstream_name: str,
+    upstream_format: str,
+    request_kind: str,
+    attempt: int,
+    max_attempts: int,
+    exc: BaseException,
+    failure_class: str,
+    failure_phase: str | None,
+    retry_safety_class: str,
+) -> None:
+    identity = _retry_identity_from_context(event_context)
+    detail = safe_upstream_error_detail(exc, redact_identity=identity)
+    if isinstance(exc, UpstreamStreamErrorEvent):
+        detail = "Upstream SSE error event"
+    _write_adapter_event(
+        event_context,
+        "upstream_retry_suppressed",
+        upstream=upstream_name,
+        provider_id=upstream_name,
+        upstream_format=upstream_format,
+        request_kind=request_kind,
+        retryable=False,
+        failure_class=failure_class,
+        status=_upstream_retry_status(exc),
+        attempt=attempt,
+        max_attempts=max_attempts,
+        delay_ms=0,
+        error=type(exc).__name__,
+        detail=detail,
+        failure_phase=failure_phase or transport_failure_phase(exc),
+        retry_safety_class=retry_safety_class,
+    )
+
+
+def _downstream_has_been_exposed(handler: Any) -> bool:
+    """Return True if upstream response content has been exposed downstream.
+
+    Exposure includes both bytes already written to the downstream socket and
+    upstream content (visible/tool output) that the relay layer has accepted and
+    would relay, even if it is still buffered.  Headers alone and metadata-only
+    events such as ``response.created`` do not count as exposure.
+    """
+    seam = _handler_downstream_stream_commit(handler)
+    if seam is None:
+        return False
+    return bool(
+        getattr(seam, "_downstream_output_started", False)
+        or getattr(seam, "_downstream_content_exposed", False)
+    )
 
 
 def _header_items(headers: Mapping[str, str] | Any) -> list[tuple[str, str]]:
@@ -10795,11 +11007,15 @@ def _is_event_stream(headers: Mapping[str, str] | Any) -> bool:
     return bool(transfer_encoding and "chunked" in transfer_encoding.lower())
 
 
+_UNSET_CONTENT_ENCODING = object()
+
+
 def _filtered_response_headers(
     headers: Mapping[str, str] | Any,
     is_event_stream: bool,
     content_length: int | None = None,
     content_type: str | None = None,
+    content_encoding: str | None | object = _UNSET_CONTENT_ENCODING,
 ) -> list[tuple[str, str]]:
     outgoing: list[tuple[str, str]] = []
     for key, value in _header_items(headers):
@@ -10810,11 +11026,15 @@ def _filtered_response_headers(
             continue
         if lowered == "content-type" and content_type is not None:
             continue
+        if lowered == "content-encoding" and content_encoding is not _UNSET_CONTENT_ENCODING:
+            continue
         outgoing.append((key, value))
     if content_type is not None:
         outgoing.append(("Content-Type", content_type))
     if content_length is not None:
         outgoing.append(("Content-Length", str(content_length)))
+    if content_encoding is not _UNSET_CONTENT_ENCODING and isinstance(content_encoding, str) and content_encoding:
+        outgoing.append(("Content-Encoding", content_encoding))
     return outgoing
 
 
@@ -12238,24 +12458,35 @@ def _emit_upstream_retry_event(
     delay_seconds: int,
     failure_class: str | None = None,
     failure_phase: str | None = None,
+    retry_safety_class: str | None = None,
 ) -> None:
+    identity = _retry_identity_from_context(event_context)
     resolved_failure_class = failure_class or _upstream_failure_class(exc)
+    if isinstance(exc, UpstreamStreamErrorEvent):
+        detail = "Upstream SSE error event"
+    else:
+        detail = safe_upstream_error_detail(exc, redact_identity=identity)
+    fields: dict[str, Any] = {
+        "upstream": upstream_name,
+        "provider_id": upstream_name,
+        "upstream_format": upstream_format,
+        "request_kind": request_kind,
+        "retryable": True,
+        "failure_class": resolved_failure_class,
+        "status": _upstream_retry_status(exc),
+        "attempt": attempt,
+        "max_attempts": max_attempts,
+        "delay_ms": delay_seconds * 1000,
+        "error": type(exc).__name__,
+        "detail": detail,
+        "failure_phase": failure_phase or transport_failure_phase(exc),
+    }
+    if retry_safety_class is not None:
+        fields["retry_safety_class"] = retry_safety_class
     _write_adapter_event(
         event_context,
         "upstream_retry",
-        upstream=upstream_name,
-        provider_id=upstream_name,
-        upstream_format=upstream_format,
-        request_kind=request_kind,
-        retryable=True,
-        failure_class=resolved_failure_class,
-        status=_upstream_retry_status(exc),
-        attempt=attempt,
-        max_attempts=max_attempts,
-        delay_ms=delay_seconds * 1000,
-        error=type(exc).__name__,
-        detail=safe_upstream_error_detail(exc),
-        failure_phase=failure_phase or transport_failure_phase(exc),
+        **fields,
     )
 
 
@@ -12270,6 +12501,7 @@ def _downstream_retry_payload(
     delay_seconds: int,
     failure_class: str | None = None,
     failure_phase: str | None = None,
+    redact_identity: str | None = None,
 ) -> dict[str, Any]:
     return {
         "type": "codexhub.retry",
@@ -12282,7 +12514,7 @@ def _downstream_retry_payload(
         "max_attempts": max_attempts,
         "delay_ms": delay_seconds * 1000,
         "error": type(exc).__name__,
-        "detail": safe_upstream_error_detail(exc),
+        "detail": safe_upstream_error_detail(exc, redact_identity=redact_identity),
         "failure_phase": failure_phase or transport_failure_phase(exc),
     }
 
@@ -12297,6 +12529,7 @@ class DownstreamErrorSpec:
     detail: str | None = None
     error_type: str = "upstream_error"
     preserve_explicit_error: bool = False
+    redact_identity: str | None = None
 
 
 def _typed_error_code(
@@ -12395,9 +12628,15 @@ def _downstream_stream_error_payload(
     error: str | None = None,
     detail: str | None = None,
     error_type: str = "upstream_stream_error",
+    redact_identity: str | None = None,
 ) -> dict[str, Any]:
     error_code = error or (type(exc).__name__ if exc is not None else "UpstreamStreamError")
-    error_detail = detail or (safe_upstream_error_detail(exc) if exc is not None else "")
+    if detail is not None:
+        error_detail = _redact_identity_in_text(detail, redact_identity)
+    elif exc is not None:
+        error_detail = safe_upstream_error_detail(exc, redact_identity=redact_identity)
+    else:
+        error_detail = ""
     failure_class = _upstream_failure_class(exc) if exc is not None else None
     if failure_class is None and error_code in {
         "upstream_stream_idle_timeout",
@@ -12441,10 +12680,15 @@ def _downstream_sse_error_payload_for_inbound_format(error: DownstreamErrorSpec)
             error=error.error,
             detail=error.detail,
             error_type=error_type,
+            redact_identity=error.redact_identity,
         )
     if error.exc is not None:
         if not error.preserve_explicit_error:
-            return _downstream_stream_error_payload(upstream_name=error.upstream_name, exc=error.exc)
+            return _downstream_stream_error_payload(
+                upstream_name=error.upstream_name,
+                exc=error.exc,
+                redact_identity=error.redact_identity,
+            )
         return _downstream_stream_error_payload(
             upstream_name=error.upstream_name,
             status=error.status,
@@ -12452,6 +12696,7 @@ def _downstream_sse_error_payload_for_inbound_format(error: DownstreamErrorSpec)
             error=error.error,
             detail=error.detail,
             error_type=error_type,
+            redact_identity=error.redact_identity,
         )
     return _downstream_stream_error_payload(
         upstream_name=error.upstream_name,
@@ -12459,6 +12704,7 @@ def _downstream_sse_error_payload_for_inbound_format(error: DownstreamErrorSpec)
         error=error.error or "UpstreamProtocolError",
         detail=error.detail or error.error or "upstream stream failed",
         error_type=error_type,
+        redact_identity=error.redact_identity,
     )
 
 
@@ -12471,6 +12717,7 @@ def _responses_failed_event_for_stream_error(
     error: str | None = None,
     detail: str | None = None,
     response_id: str | None = None,
+    redact_identity: str | None = None,
 ) -> dict[str, Any]:
     stream_error = _downstream_stream_error_payload(
         upstream_name=upstream_name,
@@ -12478,6 +12725,7 @@ def _responses_failed_event_for_stream_error(
         exc=exc,
         error=error,
         detail=detail,
+        redact_identity=redact_identity,
     )
     error_payload: dict[str, Any] = {
         "code": stream_error.get("error") or "UpstreamStreamError",
@@ -12511,9 +12759,15 @@ def _chat_completion_error_payload(
     error: str | None = None,
     detail: str | None = None,
     error_type: str = "upstream_error",
+    redact_identity: str | None = None,
 ) -> dict[str, Any]:
     error_code = error or (type(exc).__name__ if exc is not None else "UpstreamError")
-    error_detail = detail or (safe_upstream_error_detail(exc) if exc is not None else "")
+    if detail is not None:
+        error_detail = _redact_identity_in_text(detail, redact_identity)
+    elif exc is not None:
+        error_detail = safe_upstream_error_detail(exc, redact_identity=redact_identity)
+    else:
+        error_detail = ""
     message = error_detail or error_code
     return {
         "error": {
@@ -12574,6 +12828,7 @@ def _downstream_json_error_payload(error: DownstreamErrorSpec) -> dict[str, Any]
         error=error.error,
         detail=error.detail,
         error_type=error.error_type,
+        redact_identity=error.redact_identity,
     )
 
 
@@ -12586,6 +12841,7 @@ def _json_error_payload_for_inbound_format(
     error: str | None = None,
     detail: str | None = None,
     error_type: str = "upstream_error",
+    redact_identity: str | None = None,
 ) -> dict[str, Any]:
     if inbound_format == "chat_completions":
         return _chat_completion_error_payload(
@@ -12595,9 +12851,15 @@ def _json_error_payload_for_inbound_format(
             error=error,
             detail=detail,
             error_type=error_type,
+            redact_identity=redact_identity,
         )
     error_code = error or (type(exc).__name__ if exc is not None else "UpstreamError")
-    error_detail = detail or (safe_upstream_error_detail(exc) if exc is not None else "")
+    if detail is not None:
+        error_detail = _redact_identity_in_text(detail, redact_identity)
+    elif exc is not None:
+        error_detail = safe_upstream_error_detail(exc, redact_identity=redact_identity)
+    else:
+        error_detail = ""
     payload: dict[str, Any] = {"error": error_detail or error_code}
     if error_detail:
         payload["detail"] = error_detail
@@ -12723,17 +12985,29 @@ def _open_upstream_response(
     max_attempts: int | None = None,
     retry_policy: str = RETRY_GATEWAY_FULL,
     retry_http_errors: bool = True,
+    downstream_exposed: Callable[[], bool] | None = None,
 ) -> Any:
     explicit_max_attempts = max_attempts is not None
     base_retry_attempts = _upstream_retry_attempts(request_kind) if max_attempts is None else max(1, max_attempts)
     retry_started_at = time.monotonic()
     diagnostic_request_key = _diagnostic_context_value(event_context, "request_id")
     diagnostic_model = _diagnostic_context_value(event_context, "model")
+    model_access_path = _model_access_path_from_event_context(
+        event_context,
+        upstream_name,
+        upstream_format,
+    )
     attempt = 1
     while True:
         admission = _active_gateway_request()
         if admission is not None:
             admission.raise_if_cancelled()
+        if _model_access_path_idempotency_guaranteed(model_access_path):
+            _ensure_retry_attempt_identity(
+                event_context if isinstance(event_context, dict) else None,
+                request,
+                model_access_path,
+            )
         attempt_started_at = time.monotonic()
         try:
             response = _open_upstream_once(
@@ -12787,10 +13061,22 @@ def _open_upstream_response(
             elapsed_ms = int(max(0.0, time.monotonic() - attempt_started_at) * 1000)
             connection_disposition = _diagnostic_error_connection_disposition(exc)
             try:
-                failure_phase = transport_failure_phase(exc)
+                transport_phase = transport_failure_phase(exc)
             except Exception:
-                failure_phase = "unknown"
-            diagnostic_phase = _diagnostic_transport_phase(failure_phase)
+                transport_phase = "unknown"
+            # The conservative retry-safety phase is authoritative for the
+            # request-scoped retry decision and for any retry telemetry that
+            # downstream consumers may treat as classification evidence.  The
+            # best-effort transport phase is retained only for low-level
+            # diagnostics that are explicitly marked as heuristic.
+            retry_safety_failure_phase = _retry_safety_failure_phase(exc) or "unknown"
+            apply_retry_safety = (
+                upstream_name != "official"
+                and request_kind == RETRY_REQUEST_MAIN_GENERATION
+                and request.get_method() == "POST"
+            )
+            telemetry_failure_phase = retry_safety_failure_phase if apply_retry_safety else transport_phase
+            diagnostic_phase = _diagnostic_transport_phase(transport_phase)
             if diagnostic_phase is not None:
                 _observe_gateway_diagnostic(
                     "observe_upstream_phase",
@@ -12800,7 +13086,7 @@ def _open_upstream_response(
                     retry_budget=base_retry_attempts,
                     elapsed_ms=elapsed_ms,
                     outcome="error",
-                    failure_phase=failure_phase,
+                    failure_phase=transport_phase,
                     provider=upstream_name,
                     model=diagnostic_model,
                 )
@@ -12812,19 +13098,55 @@ def _open_upstream_response(
                     retry_budget=attempt,
                     elapsed_ms=elapsed_ms,
                     outcome="error",
-                    failure_phase=failure_phase,
+                    failure_phase=telemetry_failure_phase,
                     connection_disposition=connection_disposition,
                     provider=upstream_name,
                     model=diagnostic_model,
                 )
                 raise
             failure_class = _upstream_failure_class(exc)
+            downstream_exposed_now = bool(downstream_exposed is not None and downstream_exposed())
+            retry_safety_class = _retry_safety_class(
+                exc,
+                request=request,
+                upstream_name=upstream_name,
+                request_kind=request_kind,
+                downstream_exposed=downstream_exposed_now,
+                model_access_path=model_access_path,
+                failure_phase=retry_safety_failure_phase,
+            )
             retry_attempts = _retry_attempts_for_failure_class(
                 request_kind=request_kind,
                 base_attempts=base_retry_attempts,
                 failure_class=failure_class,
                 explicit_max_attempts=explicit_max_attempts,
             )
+            if retry_safety_class in _SUPPRESSED_RETRY_SAFETY_CLASSES:
+                _observe_gateway_diagnostic(
+                    "observe_upstream_attempt",
+                    diagnostic_request_key,
+                    attempt=attempt,
+                    retry_budget=retry_attempts,
+                    elapsed_ms=elapsed_ms,
+                    outcome="error",
+                    failure_phase=telemetry_failure_phase,
+                    connection_disposition=connection_disposition,
+                    provider=upstream_name,
+                    model=diagnostic_model,
+                )
+                _emit_upstream_retry_suppressed_event(
+                    event_context,
+                    upstream_name=upstream_name,
+                    upstream_format=upstream_format,
+                    request_kind=request_kind,
+                    attempt=attempt,
+                    max_attempts=retry_attempts,
+                    exc=exc,
+                    failure_class=failure_class,
+                    failure_phase=telemetry_failure_phase,
+                    retry_safety_class=retry_safety_class,
+                )
+                raise
             _observe_gateway_diagnostic(
                 "observe_upstream_attempt",
                 diagnostic_request_key,
@@ -12832,7 +13154,7 @@ def _open_upstream_response(
                 retry_budget=retry_attempts,
                 elapsed_ms=elapsed_ms,
                 outcome="error",
-                failure_phase=failure_phase,
+                failure_phase=telemetry_failure_phase,
                 connection_disposition=connection_disposition,
                 provider=upstream_name,
                 model=diagnostic_model,
@@ -12855,6 +13177,8 @@ def _open_upstream_response(
                 exc=exc,
                 delay_seconds=delay_seconds,
                 failure_class=failure_class,
+                failure_phase=telemetry_failure_phase,
+                retry_safety_class=retry_safety_class,
             )
             if downstream_retry_callback is not None and retry_policy != RETRY_CONSERVATIVE_PRE_OUTPUT:
                 if not downstream_retry_callback(
@@ -12865,8 +13189,10 @@ def _open_upstream_response(
                         attempt=attempt,
                         max_attempts=retry_attempts,
                         exc=exc,
+                        failure_phase=telemetry_failure_phase,
                         delay_seconds=delay_seconds,
                         failure_class=failure_class,
+                        redact_identity=_retry_identity_from_context(event_context),
                     )
                 ):
                     raise DownstreamClosedBeforeRetryError("downstream closed before upstream retry")
@@ -12882,6 +13208,7 @@ def _responses_synthetic_terminal_failure(
     response_id: str | None,
     upstream_name: str,
     model: str | None,
+    redact_identity: str | None = None,
 ) -> tuple[bool, str | None, str | None]:
     """Write a Responses-format synthetic terminal failure event."""
     if not handler._write_sse_event(
@@ -12892,13 +13219,14 @@ def _responses_synthetic_terminal_failure(
             status=status,
             exc=exc,
             response_id=response_id,
+            redact_identity=redact_identity,
         ),
     ):
         seam = _handler_downstream_stream_commit(handler)
         write_exc = seam.last_write_error() if seam is not None else None
         if write_exc is None:
             write_exc = OSError("downstream closed")
-        return False, type(write_exc).__name__, safe_upstream_error_detail(write_exc)
+        return False, type(write_exc).__name__, safe_upstream_error_detail(write_exc, redact_identity=redact_identity)
     return True, None, None
 
 
@@ -12997,6 +13325,7 @@ class _GatewayDownstreamStreamCommit:
         self._terminal_committed = False
         self._downstream_closed = False
         self._downstream_output_started = False
+        self._downstream_content_exposed = False
         self._terminal_drain_timeout_shortened = False
         self._lines_streamed = 0
         self._bytes_streamed = 0
@@ -13032,6 +13361,15 @@ class _GatewayDownstreamStreamCommit:
             self._close_upstream_response(response)
             return
         self._upstream_response = response
+
+    def mark_downstream_content_exposed(self) -> None:
+        """Record that upstream response content has been produced for the client.
+
+        This is semantic exposure: it is set when the upstream emits visible or
+        tool output that would be relayed downstream, even if the bytes are still
+        buffered in the relay layer and have not yet been written to the socket.
+        """
+        self._downstream_content_exposed = True
 
     def set_terminal_observer(self, terminal_observer: Callable[[str | None, bytes, Any], bool] | None) -> None:
         self._sse_stats = PassthroughSseSemanticStats(
@@ -13719,6 +14057,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
             send_user_requested_shutdown()
             return
         previous_admission = _activate_gateway_request(admission)
+        adapter_event_context: dict[str, Any] | None = None
 
         try:
             admission.raise_if_cancelled()
@@ -14298,6 +14637,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                                 if enable_transparent_metered
                                 else RETRY_GATEWAY_FULL,
                                 retry_http_errors=not is_official_http_passthrough,
+                                downstream_exposed=lambda: _downstream_has_been_exposed(self),
                             ) as response:
                                 seam = _handler_downstream_stream_commit(self)
                                 if seam is not None:
@@ -14340,10 +14680,39 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                                 exc,
                                 (LifecycleEmptyFinalResponseError, LifecycleFinalFormatResponseError),
                             )
+                            retry_safety_class: str | None = None
                             if lifecycle_retry:
                                 retry_exc: BaseException = exc
                                 failure_class = RETRY_FAILURE_QUICK_TRANSIENT
                                 lifecycle_final_retry_reason = "empty" if isinstance(exc, LifecycleEmptyFinalResponseError) else "format"
+                                stream_model_access_path = _model_access_path_from_event_context(
+                                    adapter_event_context,
+                                    upstream_name,
+                                    selected_upstream_format,
+                                )
+                                retry_safety_class = _retry_safety_class(
+                                    retry_exc,
+                                    request=request,
+                                    upstream_name=upstream_name,
+                                    request_kind=request_kind,
+                                    downstream_exposed=_downstream_has_been_exposed(self),
+                                    model_access_path=stream_model_access_path,
+                                    failure_phase="stream_body",
+                                )
+                                if retry_safety_class in _SUPPRESSED_RETRY_SAFETY_CLASSES:
+                                    _emit_upstream_retry_suppressed_event(
+                                        adapter_event_context,
+                                        upstream_name=upstream_name,
+                                        upstream_format=selected_upstream_format,
+                                        request_kind=request_kind,
+                                        attempt=relay_attempt,
+                                        max_attempts=max_relay_attempts,
+                                        exc=retry_exc,
+                                        failure_class=failure_class,
+                                        failure_phase="stream_body",
+                                        retry_safety_class=retry_safety_class,
+                                    )
+                                    raise retry_exc
                                 retry_limit = max_relay_attempts
                                 if relay_attempt >= retry_limit:
                                     raise
@@ -14357,6 +14726,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                                         UpstreamStreamIncompleteError,
                                     ),
                                 )
+                                is_stream_error_event = isinstance(exc, UpstreamStreamErrorEvent)
                                 retry_exc = exc.cause if isinstance(exc, UpstreamStreamInterruptedError) else exc
                                 failure_class = _upstream_failure_class(retry_exc)
                                 relay_attempts = _retry_attempts_for_failure_class(
@@ -14370,6 +14740,65 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                                     relay_attempts = min(relay_attempts, 2)
                                 max_relay_attempts = relay_attempts + lifecycle_final_extra_attempts
                                 retry_limit = relay_attempts
+                                stream_failure_phase = "stream_body" if (stream_failure or is_stream_error_event) else None
+                                stream_model_access_path = _model_access_path_from_event_context(
+                                    adapter_event_context,
+                                    upstream_name,
+                                    selected_upstream_format,
+                                )
+                                retry_safety_class = _retry_safety_class(
+                                    retry_exc,
+                                    request=request,
+                                    upstream_name=upstream_name,
+                                    request_kind=request_kind,
+                                    downstream_exposed=_downstream_has_been_exposed(self),
+                                    model_access_path=stream_model_access_path,
+                                    failure_phase=stream_failure_phase,
+                                )
+                                if retry_safety_class in _SUPPRESSED_RETRY_SAFETY_CLASSES:
+                                    _emit_upstream_retry_suppressed_event(
+                                        adapter_event_context,
+                                        upstream_name=upstream_name,
+                                        upstream_format=selected_upstream_format,
+                                        request_kind=request_kind,
+                                        attempt=relay_attempt,
+                                        max_attempts=retry_limit,
+                                        exc=retry_exc,
+                                        failure_class=failure_class,
+                                        failure_phase=stream_failure_phase,
+                                        retry_safety_class=retry_safety_class,
+                                    )
+                                    if isinstance(retry_exc, UpstreamEmptyCompletedResponseError):
+                                        detail = "Upstream Responses stream completed without visible output or tool calls."
+                                        write_proxy_event(
+                                            "upstream_empty_completed_response",
+                                            request_id=request_id,
+                                            model=model,
+                                            upstream=upstream_name,
+                                            status=502,
+                                            upstream_format=selected_upstream_format,
+                                            inbound_format=inbound_format,
+                                            terminal_seen=False,
+                                            completed_seen=True,
+                                            visible_or_tool_output_seen=False,
+                                            completed_tool_calls=0,
+                                            pending_downstream_lines=0,
+                                            pending_downstream_bytes=0,
+                                            last_event_type="response.completed",
+                                        )
+                                        if not self._write_downstream_sse_error(
+                                            inbound_format=inbound_format,
+                                            upstream_name=upstream_name,
+                                            status=502,
+                                            error="upstream_empty_completed_response",
+                                            detail=detail,
+                                            redact_identity=_retry_identity_from_context(adapter_event_context),
+                                        ):
+                                            finish_downstream_write_failure()
+                                            return
+                                        _capture_usage(usage_capture, None, missing_reason="empty_completed_response")
+                                        return
+                                    raise retry_exc
                                 if relay_attempt >= retry_limit or failure_class == RETRY_FAILURE_PERMANENT:
                                     raise retry_exc
                                 delay_seconds = gateway_retry_delay_seconds(
@@ -14399,6 +14828,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                                 delay_seconds=delay_seconds,
                                 failure_class=failure_class,
                                 failure_phase="stream_body" if stream_failure else None,
+                                retry_safety_class=retry_safety_class,
                             )
                             if not emit_downstream_retry(
                                 _downstream_retry_payload(
@@ -14411,6 +14841,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                                     delay_seconds=delay_seconds,
                                     failure_class=failure_class,
                                     failure_phase="stream_body" if stream_failure else None,
+                                    redact_identity=_retry_identity_from_context(adapter_event_context),
                                 )
                             ):
                                 finish_downstream_write_failure()
@@ -14425,32 +14856,63 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                     break
                 except HTTPError as exc:
                     next_format_available = format_index + 1 < len(upstream_format_options)
-                    if (
+                    fallback_allowed = (
                         configured_upstream_format == "auto"
                         and selected_upstream_format == "responses"
                         and next_format_available
                         and not downstream_sse_started
                         and _auto_protocol_fallback_allowed(exc)
-                    ):
-                        write_proxy_event(
-                            "upstream_protocol_fallback",
-                            request_id=request_id,
-                            model=model_canonical,
-                            model_requested=model_requested,
-                            model_canonical=model_canonical,
-                            upstream=upstream_name,
-                            provider_id=upstream_name,
-                            provider_hint=provider_hint,
-                            upstream_format=configured_upstream_format,
-                            behavior_profile=behavior_profile,
-                            failed_upstream_format=selected_upstream_format,
-                            next_upstream_format=upstream_format_options[format_index + 1],
-                            status=getattr(exc, "code", 502),
-                            error="HTTPError",
-                            detail=safe_upstream_error_detail(exc),
-                            **proxy_request_context,
+                    )
+                    if fallback_allowed:
+                        fallback_model_access_path = _model_access_path_from_event_context(
+                            adapter_event_context,
+                            upstream_name,
+                            selected_upstream_format,
                         )
-                        continue
+                        fallback_retry_safety_class = _retry_safety_class(
+                            exc,
+                            request=request,
+                            upstream_name=upstream_name,
+                            request_kind=request_kind,
+                            downstream_exposed=bool(downstream_sse_started),
+                            model_access_path=fallback_model_access_path,
+                            failure_phase="response_headers",
+                        )
+                        if fallback_retry_safety_class not in _SUPPRESSED_RETRY_SAFETY_CLASSES:
+                            write_proxy_event(
+                                "upstream_protocol_fallback",
+                                request_id=request_id,
+                                model=model_canonical,
+                                model_requested=model_requested,
+                                model_canonical=model_canonical,
+                                upstream=upstream_name,
+                                provider_id=upstream_name,
+                                provider_hint=provider_hint,
+                                upstream_format=configured_upstream_format,
+                                behavior_profile=behavior_profile,
+                                failed_upstream_format=selected_upstream_format,
+                                next_upstream_format=upstream_format_options[format_index + 1],
+                                status=getattr(exc, "code", 502),
+                                error="HTTPError",
+                                detail=safe_upstream_error_detail(
+                                    exc,
+                                    redact_identity=_retry_identity_from_context(adapter_event_context),
+                                ),
+                                **proxy_request_context,
+                            )
+                            continue
+                        _emit_upstream_retry_suppressed_event(
+                            adapter_event_context,
+                            upstream_name=upstream_name,
+                            upstream_format=selected_upstream_format,
+                            request_kind=request_kind,
+                            attempt=relay_attempt,
+                            max_attempts=relay_attempts,
+                            exc=exc,
+                            failure_class=_upstream_failure_class(exc),
+                            failure_phase="response_headers",
+                            retry_safety_class=fallback_retry_safety_class,
+                        )
                     raise
             else:
                 raise RuntimeError("unreachable upstream protocol selection state")
@@ -14483,7 +14945,8 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
             if admission.cancelled:
                 send_user_requested_shutdown()
                 return
-            detail = safe_upstream_error_detail(exc)
+            identity = _retry_identity_from_context(adapter_event_context)
+            detail = safe_upstream_error_detail(exc, redact_identity=identity)
             write_proxy_event(
                 "request_error",
                 request_id=request_id,
@@ -14508,6 +14971,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                     exc=exc,
                     error="compact_empty_response",
                     detail=detail,
+                    redact_identity=identity,
                 ):
                     finish_downstream_write_failure()
                 return
@@ -14519,13 +14983,15 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 exc=exc,
                 error="compact_empty_response",
                 detail=detail,
+                redact_identity=identity,
                 error_type="compact_empty_response",
             )
         except (LifecycleEmptyFinalResponseError, LifecycleFinalFormatResponseError) as exc:
             if admission.cancelled:
                 send_user_requested_shutdown()
                 return
-            detail = safe_upstream_error_detail(exc)
+            identity = _retry_identity_from_context(adapter_event_context)
+            detail = safe_upstream_error_detail(exc, redact_identity=identity)
             error_code = (
                 "lifecycle_empty_final_response"
                 if isinstance(exc, LifecycleEmptyFinalResponseError)
@@ -14554,6 +15020,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                     exc=exc,
                     error=error_code,
                     detail=detail,
+                    redact_identity=identity,
                 ):
                     finish_downstream_write_failure()
                 return
@@ -14565,12 +15032,15 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 exc=exc,
                 error=error_code,
                 detail=detail,
+                redact_identity=identity,
                 error_type=error_code,
             )
         except ImageProxyError as exc:
             if admission.cancelled:
                 send_user_requested_shutdown()
                 return
+            identity = _retry_identity_from_context(adapter_event_context)
+            detail = _redact_identity_in_text(str(exc)[:300], identity)
             if not request_start_written and callable(write_request_start_once):
                 fallback_request_observability = {
                     **caller_request_observability,
@@ -14589,7 +15059,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 inbound_format=inbound_format,
                 status=502,
                 error=type(exc).__name__,
-                detail=str(exc)[:300],
+                detail=detail,
                 duration_ms=int((time.monotonic() - started_at) * 1000),
                 **proxy_request_context,
             )
@@ -14600,7 +15070,8 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                     status=502,
                     exc=exc,
                     error="image_proxy_error",
-                    detail=str(exc),
+                    detail=detail,
+                    redact_identity=identity,
                 ):
                     finish_downstream_write_failure()
                 return
@@ -14611,14 +15082,16 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 request_id=request_id,
                 exc=exc,
                 error="image_proxy_error",
-                detail=str(exc),
+                detail=detail,
+                redact_identity=identity,
                 error_type="image_proxy_error",
             )
         except UpstreamProtocolTranslationError as exc:
             if admission.cancelled:
                 send_user_requested_shutdown()
                 return
-            detail = str(exc)
+            identity = _retry_identity_from_context(adapter_event_context)
+            detail = _redact_identity_in_text(str(exc), identity)
             error_code = exc.cause.code
             is_apply_patch_adapter_error = error_code == APPLY_PATCH_ADAPTER_ERROR_CODE
             error_status = 400
@@ -14661,6 +15134,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                             error=error_code,
                             detail=detail,
                             response_id=response_lifecycle_state.get("response_id"),
+                            redact_identity=identity,
                         ),
                     ):
                         finish_downstream_write_failure()
@@ -14686,6 +15160,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         detail=detail,
                         error_type=sse_error_type,
                         preserve_explicit_error=True,
+                        redact_identity=identity,
                     ):
                         finish_downstream_write_failure()
                         return
@@ -14698,12 +15173,15 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 exc=exc,
                 error=error_code,
                 detail=detail,
+                redact_identity=identity,
                 error_type=json_error_type,
             )
         except ValueError as exc:
             if admission.cancelled:
                 send_user_requested_shutdown()
                 return
+            identity = _retry_identity_from_context(adapter_event_context)
+            detail = _redact_identity_in_text(str(exc)[:300], identity)
             write_proxy_event(
                 "request_error",
                 request_id=request_id,
@@ -14716,7 +15194,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 inbound_format=inbound_format,
                 status=400,
                 error=type(exc).__name__,
-                detail=str(exc)[:300],
+                detail=detail,
                 duration_ms=int((time.monotonic() - started_at) * 1000),
                 **proxy_request_context,
             )
@@ -14727,19 +15205,22 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 request_id=request_id,
                 exc=exc,
                 error=type(exc).__name__,
-                detail=str(exc),
+                detail=detail,
+                redact_identity=identity,
                 error_type="invalid_request_error",
             )
         except HTTPError as exc:
             if admission.cancelled:
                 send_user_requested_shutdown()
                 return
+            identity = _retry_identity_from_context(adapter_event_context)
             if downstream_sse_started:
                 if not self._write_downstream_sse_error(
                     inbound_format=inbound_format,
                     upstream_name=upstream_name or "upstream_error",
                     status=getattr(exc, "code", 502),
                     exc=exc,
+                    redact_identity=identity,
                 ):
                     finish_downstream_write_failure()
                     return
@@ -14768,12 +15249,19 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 )
                 return
             try:
+                previous_retry_identity = (
+                    adapter_event_context.get("_retry_attempt_identity")
+                    if isinstance(adapter_event_context, Mapping)
+                    else None
+                )
                 adapter_event_context = {
                     "request_id": request_id,
                     "model": canonical_model_id(model) if model else None,
                     "behavior_profile": behavior_profile,
                     **proxy_request_context,
                 }
+                if isinstance(previous_retry_identity, str) and previous_retry_identity:
+                    adapter_event_context["_retry_attempt_identity"] = previous_retry_identity
                 status = self._relay_upstream_response(
                     exc,
                     upstream_name or "upstream_error",
@@ -14829,7 +15317,8 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
             if admission.cancelled:
                 send_user_requested_shutdown()
                 return
-            detail = safe_upstream_error_detail(exc)
+            identity = _retry_identity_from_context(adapter_event_context)
+            detail = safe_upstream_error_detail(exc, redact_identity=identity)
             write_proxy_event(
                 "request_error",
                 request_id=request_id,
@@ -14849,6 +15338,8 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                     inbound_format=inbound_format,
                     upstream_name=upstream_name or "upstream_error",
                     exc=exc,
+                    detail=detail,
+                    redact_identity=identity,
                 ):
                     finish_downstream_write_failure()
                 return
@@ -14859,12 +15350,14 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 request_id=request_id,
                 exc=exc,
                 detail=detail,
+                redact_identity=identity,
             )
         except (OSError, URLError) as exc:
             if admission.cancelled:
                 send_user_requested_shutdown()
                 return
-            detail = safe_upstream_error_detail(exc)
+            identity = _retry_identity_from_context(adapter_event_context)
+            detail = safe_upstream_error_detail(exc, redact_identity=identity)
             write_proxy_event(
                 "request_error",
                 request_id=request_id,
@@ -14884,6 +15377,8 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                     inbound_format=inbound_format,
                     upstream_name=upstream_name or "upstream_error",
                     exc=exc,
+                    detail=detail,
+                    redact_identity=identity,
                 ):
                     finish_downstream_write_failure()
                 return
@@ -14894,13 +15389,15 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 request_id=request_id,
                 exc=exc,
                 detail=detail,
+                redact_identity=identity,
             )
         except Exception as exc:
             if admission.cancelled:
                 send_user_requested_shutdown()
                 return
-            detail = safe_upstream_error_detail(exc)
-            logger.exception("unexpected proxy error request_id=%s", request_id)
+            identity = _retry_identity_from_context(adapter_event_context)
+            detail = safe_upstream_error_detail(exc, redact_identity=identity)
+            logger.error("unexpected proxy error request_id=%s detail=%s", request_id, detail)
             write_proxy_event(
                 "request_error",
                 request_id=request_id,
@@ -14920,6 +15417,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                     upstream_name=upstream_name or "upstream_error",
                     status=500,
                     exc=exc,
+                    redact_identity=identity,
                 ):
                     finish_downstream_write_failure()
                 return
@@ -14930,6 +15428,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 request_id=request_id,
                 exc=exc,
                 detail=detail,
+                redact_identity=identity,
             )
         finally:
             _restore_gateway_request(previous_admission)
@@ -15476,7 +15975,13 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 except SseAssemblerClosedError:
                     pass
 
-    def _write_sse_error_event(self, upstream_name: str, exc: BaseException) -> None:
+    def _write_sse_error_event(
+        self,
+        upstream_name: str,
+        exc: BaseException,
+        *,
+        redact_identity: str | None = None,
+    ) -> None:
         self._write_sse_event(
             "error",
             _downstream_sse_error_payload_for_inbound_format(
@@ -15484,6 +15989,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                     inbound_format="responses",
                     upstream_name=upstream_name,
                     exc=exc,
+                    redact_identity=redact_identity,
                 )
             ),
         )
@@ -15499,6 +16005,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
         detail: str | None = None,
         error_type: str = "upstream_error",
         preserve_explicit_error: bool = False,
+        redact_identity: str | None = None,
     ) -> bool:
         error_spec = DownstreamErrorSpec(
             inbound_format=inbound_format,
@@ -15509,6 +16016,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
             detail=detail,
             error_type=error_type,
             preserve_explicit_error=preserve_explicit_error,
+            redact_identity=redact_identity,
         )
         if inbound_format == "chat_completions":
             data = (
@@ -15536,6 +16044,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
         detail: str,
         *,
         error: str = "UpstreamProtocolError",
+        redact_identity: str | None = None,
     ) -> None:
         self._write_sse_event(
             "error",
@@ -15546,6 +16055,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                     status=status,
                     error=error,
                     detail=detail,
+                    redact_identity=redact_identity,
                 )
             ),
         )
@@ -15561,6 +16071,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
         error: str | None = None,
         detail: str | None = None,
         error_type: str = "upstream_error",
+        redact_identity: str | None = None,
     ) -> None:
         error_spec = DownstreamErrorSpec(
             inbound_format=inbound_format,
@@ -15570,6 +16081,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
             error=error,
             detail=detail,
             error_type=error_type,
+            redact_identity=redact_identity,
         )
         self._safe_send_json(
             status,
@@ -15877,9 +16389,29 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
             upstream_format=upstream_format,
             inbound_format=inbound_format,
         )
+        relay_redact_identity = _retry_identity_from_context(event_context)
         admission = _active_gateway_request()
         headers_sent = bool(headers_already_sent)
         chat_mode = inbound_format == "chat_completions"
+
+        def _synthetic_terminal_failure_callback(
+            handler: CodexProxyHandler,
+            exc: BaseException,
+            status: int,
+            response_id: str | None,
+            upstream_name: str,
+            model: str | None,
+        ) -> tuple[bool, str | None, str | None]:
+            return _responses_synthetic_terminal_failure(
+                handler,
+                exc,
+                status=status,
+                response_id=response_id,
+                upstream_name=upstream_name,
+                model=model,
+                redact_identity=relay_redact_identity,
+            )
+
         request_scoped_seam = _handler_downstream_stream_commit(self)
         if request_scoped_seam is not None:
             request_scoped_seam.set_terminal_observer(
@@ -15891,7 +16423,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 )
             )
             request_scoped_seam.set_synthetic_terminal_failure_callback(
-                _responses_synthetic_terminal_failure if not chat_mode else None
+                _synthetic_terminal_failure_callback if not chat_mode else None
             )
             seam = request_scoped_seam
         else:
@@ -15910,7 +16442,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                     context, line, upstream_format=upstream_format
                 ),
                 synthetic_terminal_failure_callback=(
-                    _responses_synthetic_terminal_failure if not chat_mode else None
+                    _synthetic_terminal_failure_callback if not chat_mode else None
                 ),
             )
         _capture_usage(usage_capture, None, missing_reason="async_usage_pending")
@@ -15954,14 +16486,22 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
             )
             return 499
 
-        def send_downstream_headers_once() -> bool:
+        def send_downstream_headers_once(
+            content_length: int | None = None,
+            content_encoding: str | None | object = _UNSET_CONTENT_ENCODING,
+        ) -> bool:
             nonlocal headers_sent
             if headers_sent:
                 return True
 
             def _send() -> None:
                 self.send_response(status)
-                for key, value in _filtered_response_headers(response.headers, is_event_stream):
+                for key, value in _filtered_response_headers(
+                    response.headers,
+                    is_event_stream,
+                    content_length=content_length,
+                    content_encoding=content_encoding,
+                ):
                     self.send_header(key, value)
                 self.send_header("X-Codex-Proxy-Upstream", upstream_name)
                 self.send_header("Connection", "close")
@@ -15974,7 +16514,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 mark_downstream_sse_started()
             return True
 
-        if not (defer_stream_errors and is_event_stream and not headers_already_sent):
+        if is_event_stream and not (defer_stream_errors and not headers_already_sent):
             if not send_downstream_headers_once():
                 return _handle_write_failure()
 
@@ -16007,7 +16547,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 upstream_format=upstream_format,
                 inbound_format=inbound_format,
                 error=error,
-                detail=detail,
+                detail=_redact_identity_in_text(detail, relay_redact_identity),
                 failure_phase=failure_phase,
                 failure_side=failure_side,
                 failure_class=failure_class,
@@ -16055,6 +16595,47 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 return status
             return _handle_cancellation()
 
+        def _send_terminal_json_error(
+            status_code: int,
+            detail: str,
+            error_type: str = "upstream_error",
+            *,
+            telemetry_event: str | None = None,
+            telemetry_error: str | None = None,
+        ) -> int:
+            sanitized_detail = _redact_identity_in_text(detail, relay_redact_identity)
+            if telemetry_event is not None:
+                write_proxy_event(
+                    telemetry_event,
+                    request_id=request_id,
+                    model=model,
+                    upstream=upstream_name,
+                    status=status_code,
+                    upstream_format=upstream_format,
+                    inbound_format=inbound_format,
+                    error=telemetry_error or error_type,
+                    detail=sanitized_detail,
+                )
+            if inbound_format == "chat_completions":
+                terminal_payload = _chat_completion_error_payload(
+                    upstream_name=upstream_name,
+                    status=status_code,
+                    detail=sanitized_detail,
+                    error_type=error_type,
+                    redact_identity=relay_redact_identity,
+                )
+            else:
+                terminal_payload = _downstream_stream_error_payload(
+                    upstream_name=upstream_name,
+                    status=status_code,
+                    detail=sanitized_detail,
+                    error_type=error_type,
+                    redact_identity=relay_redact_identity,
+                )
+            self._send_json(status_code, terminal_payload)
+            self.close_connection = True
+            return status_code
+
         if not is_event_stream:
             body = b""
             try:
@@ -16074,20 +16655,47 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                     return status
                 if admission is not None and admission.cancelled:
                     return _handle_cancellation()
-                self.close_connection = True
-                write_proxy_event(
-                    "transparent_body_read_failed",
-                    request_id=request_id,
-                    model=model,
-                    upstream=upstream_name,
-                    status=502,
-                    upstream_format=upstream_format,
-                    inbound_format=inbound_format,
-                    error=type(exc).__name__,
-                    detail=safe_upstream_error_detail(exc),
+                return _send_terminal_json_error(
+                    502,
+                    safe_upstream_error_detail(exc, redact_identity=relay_redact_identity),
+                    telemetry_event="transparent_body_read_failed",
+                    telemetry_error=type(exc).__name__,
                 )
-                return 502
 
+            drop_content_encoding = False
+            if relay_redact_identity is not None and status >= 400:
+                content_encoding_value = _get_header(response.headers, "Content-Encoding")
+                if content_encoding_value:
+                    decoded_body, did_decode, decode_error = decoded_request_body(
+                        body, content_encoding_value
+                    )
+                    if did_decode:
+                        body = decoded_body
+                        drop_content_encoding = True
+                    else:
+                        detail = (
+                            f"upstream {status} response body uses unsupported or malformed "
+                            f"Content-Encoding ({content_encoding_value}); cannot safely relay"
+                        )
+                        if decode_error:
+                            detail = f"{detail}: {decode_error}"
+                        return _send_terminal_json_error(
+                            502,
+                            detail,
+                            error_type="upstream_protocol_error",
+                            telemetry_event="transparent_body_decode_failed",
+                            telemetry_error="ContentEncodingDecodeError",
+                        )
+                body = body.replace(
+                    relay_redact_identity.encode("utf-8"),
+                    b"[retry_identity_redacted]",
+                )
+            content_encoding = None if drop_content_encoding else _UNSET_CONTENT_ENCODING
+            if not send_downstream_headers_once(
+                content_length=len(body),
+                content_encoding=content_encoding,
+            ):
+                return _handle_write_failure()
             if not self._write_non_streaming_body_relay(body):
                 return _handle_write_failure()
             _offer_usage_observed_body(usage_context, body)
@@ -16122,11 +16730,12 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 return status
             if defer_stream_errors and not headers_sent:
                 raise UpstreamStreamInterruptedError(exc) from exc
+            stream_failure_detail = safe_upstream_error_detail(exc, redact_identity=relay_redact_identity)
             if seam.downstream_closed:
                 _emit_stream_closed(
                     status_code=499,
                     error=type(exc).__name__,
-                    detail=safe_upstream_error_detail(exc),
+                    detail=stream_failure_detail,
                     failure_phase="stream_body",
                     failure_side="upstream_read",
                     failure_class="downstream_client_closed",
@@ -16163,7 +16772,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
             _emit_stream_closed(
                 status_code=502,
                 error=type(exc).__name__,
-                detail=safe_upstream_error_detail(exc),
+                detail=stream_failure_detail,
                 failure_phase="stream_body",
                 failure_side="upstream_read",
                 failure_class=getattr(exc, "classification", "upstream_stream_interrupted"),
@@ -16319,6 +16928,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
             upstream_format=upstream_format,
             inbound_format=inbound_format,
         )
+        relay_redact_identity = _retry_identity_from_context(event_context)
 
         def observe_diagnostic_sse_line(line: bytes) -> None:
             _observe_gateway_diagnostic("observe_sse_line", request_id, len(line))
@@ -16437,6 +17047,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 status=502,
                 error=error_code,
                 detail=str(exc),
+                redact_identity=relay_redact_identity,
             ):
                 return finish_downstream_stream_closed(
                     seam.last_write_error() or OSError("downstream closed")
@@ -16466,6 +17077,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                     error="upstream_protocol_error",
                     detail=str(exc),
                     error_type="upstream_protocol_error",
+                    redact_identity=relay_redact_identity,
                 ),
                 ensure_ascii=True,
                 separators=(",", ":"),
@@ -16673,6 +17285,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                                     else "Upstream returned a final response with extra text outside the requested report format."
                                 ),
                                 error_type=_lifecycle_final_issue_missing_reason(lifecycle_issue),
+                                redact_identity=relay_redact_identity,
                             ),
                             ensure_ascii=True,
                             separators=(",", ":"),
@@ -16694,6 +17307,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         error="compact_empty_response",
                         detail="Upstream returned an empty compact summary.",
                         error_type="compact_empty_response",
+                        redact_identity=relay_redact_identity,
                     ),
                     ensure_ascii=True,
                     separators=(",", ":"),
@@ -16794,6 +17408,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                     status=status,
                     error="UpstreamProtocolError",
                     detail=f"upstream returned non-SSE response after downstream SSE retry status: HTTP {status}",
+                    redact_identity=relay_redact_identity,
                 ):
                     return finish_downstream_stream_closed(
                         seam.last_write_error() or OSError("downstream closed")
@@ -16868,7 +17483,10 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         )
                         error_type = _responses_stream_error_type(event)
                         if error_type is not None:
-                            detail = _responses_stream_error_detail(event)
+                            detail = _redact_identity_in_text(
+                                _responses_stream_error_detail(event),
+                                relay_redact_identity,
+                            )
                             write_proxy_event(
                                 "upstream_stream_error_event",
                                 request_id=request_id,
@@ -16886,6 +17504,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                                 status=502,
                                 error=error_type,
                                 detail=detail,
+                                redact_identity=relay_redact_identity,
                             ):
                                 return finish_downstream_stream_closed(
                                     seam.last_write_error() or OSError("downstream closed")
@@ -16907,6 +17526,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                     incomplete_frame = True
                 except UpstreamStreamIdleTimeoutError as exc:
                     self.close_connection = True
+                    idle_detail = safe_upstream_error_detail(exc, redact_identity=relay_redact_identity)
                     write_proxy_event(
                         "upstream_stream_idle_timeout",
                         request_id=request_id,
@@ -16917,7 +17537,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         inbound_format=inbound_format,
                         stream_idle_timeout_seconds=exc.timeout_seconds,
                         stream_idle_phase=exc.phase,
-                        detail=safe_upstream_error_detail(exc),
+                        detail=idle_detail,
                     )
                     if not send_downstream_response_headers_once():
                         return finish_downstream_stream_closed(
@@ -16928,7 +17548,8 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         upstream_name=upstream_name,
                         status=502,
                         error="upstream_stream_idle_timeout",
-                        detail=safe_upstream_error_detail(exc),
+                        detail=idle_detail,
+                        redact_identity=relay_redact_identity,
                     ):
                         return finish_downstream_stream_closed(
                             seam.last_write_error() or OSError("downstream closed")
@@ -16941,6 +17562,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                     )
                 except (IncompleteRead, TimeoutError, OSError, URLError) as exc:
                     self.close_connection = True
+                    stream_detail = safe_upstream_error_detail(exc, redact_identity=relay_redact_identity)
                     write_proxy_event(
                         "upstream_stream_interrupted",
                         request_id=request_id,
@@ -16948,7 +17570,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         upstream=upstream_name,
                         status=502,
                         error=type(exc).__name__,
-                        detail=safe_upstream_error_detail(exc),
+                        detail=stream_detail,
                     )
                     if not send_downstream_response_headers_once():
                         return finish_downstream_stream_closed(
@@ -16958,6 +17580,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         inbound_format=inbound_format,
                         upstream_name=upstream_name,
                         exc=exc,
+                        redact_identity=relay_redact_identity,
                     ):
                         return finish_downstream_stream_closed(
                             seam.last_write_error() or OSError("downstream closed")
@@ -16985,6 +17608,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         status=502,
                         error="upstream_stream_incomplete",
                         detail="Upstream stream ended before response.completed.",
+                        redact_identity=relay_redact_identity,
                     ):
                         return finish_downstream_stream_closed(
                             seam.last_write_error() or OSError("downstream closed")
@@ -17023,8 +17647,11 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         if payload == "[DONE]":
                             events = converter.events_for_done()
                         else:
-                            chat_error_detail = _chat_stream_error_detail(payload)
-                            if chat_error_detail is not None:
+                            chat_error_detail = _redact_identity_in_text(
+                                _chat_stream_error_detail(payload) or "",
+                                relay_redact_identity,
+                            )
+                            if chat_error_detail:
                                 write_proxy_event(
                                     "upstream_stream_error_event",
                                     request_id=request_id,
@@ -17042,6 +17669,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                                     status=502,
                                     error="chat_completions_error",
                                     detail=chat_error_detail,
+                                    redact_identity=relay_redact_identity,
                                 ):
                                     return finish_downstream_stream_closed(
                                         seam.last_write_error() or OSError("downstream closed")
@@ -17076,6 +17704,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                     incomplete_frame = True
                 except UpstreamStreamIdleTimeoutError as exc:
                     self.close_connection = True
+                    idle_detail = safe_upstream_error_detail(exc, redact_identity=relay_redact_identity)
                     write_proxy_event(
                         "upstream_stream_idle_timeout",
                         request_id=request_id,
@@ -17086,14 +17715,15 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         inbound_format=inbound_format,
                         stream_idle_timeout_seconds=exc.timeout_seconds,
                         stream_idle_phase=exc.phase,
-                        detail=safe_upstream_error_detail(exc),
+                        detail=idle_detail,
                     )
                     if not self._write_downstream_sse_error(
                         inbound_format=inbound_format,
                         upstream_name=upstream_name,
                         status=502,
                         error="upstream_stream_idle_timeout",
-                        detail=safe_upstream_error_detail(exc),
+                        detail=idle_detail,
+                        redact_identity=relay_redact_identity,
                     ):
                         return finish_downstream_stream_closed(
                             seam.last_write_error() or OSError("downstream closed")
@@ -17105,7 +17735,10 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         seam.last_write_error() or OSError("downstream closed")
                     )
                 except (IncompleteRead, TimeoutError, OSError, URLError) as exc:
+                    if defer_stream_errors:
+                        raise UpstreamStreamInterruptedError(exc) from exc
                     self.close_connection = True
+                    stream_detail = safe_upstream_error_detail(exc, redact_identity=relay_redact_identity)
                     write_proxy_event(
                         "upstream_stream_interrupted",
                         request_id=request_id,
@@ -17113,12 +17746,13 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         upstream=upstream_name,
                         status=502,
                         error=type(exc).__name__,
-                        detail=safe_upstream_error_detail(exc),
+                        detail=stream_detail,
                     )
                     if not self._write_downstream_sse_error(
                         inbound_format=inbound_format,
                         upstream_name=upstream_name,
                         exc=exc,
+                        redact_identity=relay_redact_identity,
                     ):
                         return finish_downstream_stream_closed(
                             seam.last_write_error() or OSError("downstream closed")
@@ -17157,6 +17791,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         status=502,
                         error="upstream_stream_incomplete",
                         detail="Upstream Chat Completions stream ended without finish_reason or [DONE].",
+                        redact_identity=relay_redact_identity,
                     ):
                         return finish_downstream_stream_closed(
                             seam.last_write_error() or OSError("downstream closed")
@@ -17202,6 +17837,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                     if defer_stream_errors:
                         raise
                     self.close_connection = True
+                    idle_detail = safe_upstream_error_detail(exc, redact_identity=relay_redact_identity)
                     write_proxy_event(
                         "upstream_stream_idle_timeout",
                         request_id=request_id,
@@ -17212,7 +17848,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         inbound_format=inbound_format,
                         stream_idle_timeout_seconds=exc.timeout_seconds,
                         stream_idle_phase=exc.phase,
-                        detail=safe_upstream_error_detail(exc),
+                        detail=idle_detail,
                     )
                     if not send_downstream_response_headers_once():
                         return finish_downstream_stream_closed(
@@ -17223,7 +17859,8 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         upstream_name=upstream_name,
                         status=502,
                         error="upstream_stream_idle_timeout",
-                        detail=safe_upstream_error_detail(exc),
+                        detail=idle_detail,
+                        redact_identity=relay_redact_identity,
                     ):
                         return finish_downstream_stream_closed(
                             seam.last_write_error() or OSError("downstream closed")
@@ -17238,6 +17875,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                     if defer_stream_errors:
                         raise UpstreamStreamInterruptedError(exc) from exc
                     self.close_connection = True
+                    stream_detail = safe_upstream_error_detail(exc, redact_identity=relay_redact_identity)
                     write_proxy_event(
                         "upstream_stream_interrupted",
                         request_id=request_id,
@@ -17245,7 +17883,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         upstream=upstream_name,
                         status=502,
                         error=type(exc).__name__,
-                        detail=safe_upstream_error_detail(exc),
+                        detail=stream_detail,
                     )
                     if not send_downstream_response_headers_once():
                         return finish_downstream_stream_closed(
@@ -17255,6 +17893,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         inbound_format=inbound_format,
                         upstream_name=upstream_name,
                         exc=exc,
+                        redact_identity=relay_redact_identity,
                     ):
                         return finish_downstream_stream_closed(
                             seam.last_write_error() or OSError("downstream closed")
@@ -17294,6 +17933,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         status=502,
                         error="upstream_stream_incomplete",
                         detail="Upstream stream ended before response.completed.",
+                        redact_identity=relay_redact_identity,
                     ):
                         return finish_downstream_stream_closed(
                             seam.last_write_error() or OSError("downstream closed")
@@ -17374,6 +18014,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                     if defer_stream_errors:
                         raise
                     self.close_connection = True
+                    idle_detail = safe_upstream_error_detail(exc, redact_identity=relay_redact_identity)
                     write_proxy_event(
                         "upstream_stream_idle_timeout",
                         request_id=request_id,
@@ -17384,14 +18025,15 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         inbound_format=inbound_format,
                         stream_idle_timeout_seconds=exc.timeout_seconds,
                         stream_idle_phase=exc.phase,
-                        detail=safe_upstream_error_detail(exc),
+                        detail=idle_detail,
                     )
                     if not self._write_downstream_sse_error(
                         inbound_format=inbound_format,
                         upstream_name=upstream_name,
                         status=502,
                         error="upstream_stream_idle_timeout",
-                        detail=safe_upstream_error_detail(exc),
+                        detail=idle_detail,
+                        redact_identity=relay_redact_identity,
                     ):
                         return finish_downstream_stream_closed(
                             seam.last_write_error() or OSError("downstream closed")
@@ -17406,6 +18048,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                     if defer_stream_errors:
                         raise UpstreamStreamInterruptedError(exc) from exc
                     self.close_connection = True
+                    stream_detail = safe_upstream_error_detail(exc, redact_identity=relay_redact_identity)
                     write_proxy_event(
                         "upstream_stream_interrupted",
                         request_id=request_id,
@@ -17413,12 +18056,13 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         upstream=upstream_name,
                         status=502,
                         error=type(exc).__name__,
-                        detail=safe_upstream_error_detail(exc),
+                        detail=stream_detail,
                     )
                     if not self._write_downstream_sse_error(
                         inbound_format=inbound_format,
                         upstream_name=upstream_name,
                         exc=exc,
+                        redact_identity=relay_redact_identity,
                     ):
                         return finish_downstream_stream_closed(
                             seam.last_write_error() or OSError("downstream closed")
@@ -17446,6 +18090,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         status=502,
                         error="upstream_stream_incomplete",
                         detail="Upstream Chat Completions stream ended without finish_reason or [DONE].",
+                        redact_identity=relay_redact_identity,
                     ):
                         return finish_downstream_stream_closed(
                             seam.last_write_error() or OSError("downstream closed")
@@ -17636,6 +18281,8 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                                 saw_terminal_event = True
                             if _responses_event_starts_downstream_output(usage_payload):
                                 downstream_output_started = True
+                                if seam is not None:
+                                    seam.mark_downstream_content_exposed()
                             _capture_usage(usage_capture, _usage_from_response_event(usage_payload))
                         rewritten_line = line
                         if apply_patch_stream_adapter is not None and isinstance(usage_payload, Mapping):
@@ -17678,18 +18325,20 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         stream_idle_phase=exc.phase,
                         terminal_seen=saw_terminal_event,
                         downstream_output_started=downstream_output_started,
-                        detail=safe_upstream_error_detail(exc),
+                        detail=safe_upstream_error_detail(exc, redact_identity=relay_redact_identity),
                     )
                     if not send_downstream_response_headers_once():
                         return finish_downstream_stream_closed(
                             seam.last_write_error() or OSError("downstream closed")
                         )
+                    idle_detail = safe_upstream_error_detail(exc, redact_identity=relay_redact_identity)
                     if not self._write_downstream_sse_error(
                         inbound_format=inbound_format,
                         upstream_name=upstream_name,
                         status=502,
                         error="upstream_stream_idle_timeout",
-                        detail=safe_upstream_error_detail(exc),
+                        detail=idle_detail,
+                        redact_identity=relay_redact_identity,
                     ):
                         return finish_downstream_stream_closed(
                             seam.last_write_error() or OSError("downstream closed")
@@ -17702,6 +18351,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                     )
                 except (IncompleteRead, TimeoutError, OSError, URLError) as exc:
                     self.close_connection = True
+                    stream_detail = safe_upstream_error_detail(exc, redact_identity=relay_redact_identity)
                     write_proxy_event(
                         "upstream_stream_interrupted",
                         request_id=request_id,
@@ -17709,7 +18359,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         upstream=upstream_name,
                         status=502,
                         error=type(exc).__name__,
-                        detail=safe_upstream_error_detail(exc),
+                        detail=stream_detail,
                     )
                     if not send_downstream_response_headers_once():
                         return finish_downstream_stream_closed(
@@ -17719,6 +18369,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         inbound_format=inbound_format,
                         upstream_name=upstream_name,
                         exc=exc,
+                        redact_identity=relay_redact_identity,
                     ):
                         return finish_downstream_stream_closed(
                             seam.last_write_error() or OSError("downstream closed")
@@ -17748,6 +18399,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         status=502,
                         error="upstream_stream_incomplete",
                         detail="Upstream Responses stream ended without a terminal event.",
+                        redact_identity=relay_redact_identity,
                     ):
                         return finish_downstream_stream_closed(
                             seam.last_write_error() or OSError("downstream closed")
@@ -17862,13 +18514,25 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
             def write_response_failed_event(error_payload: Mapping[str, Any]) -> None:
                 pending_downstream_lines.clear()
                 error_value = error_payload.get("error")
+                if isinstance(error_value, Mapping):
+                    sanitized_error: dict[str, Any] = {
+                        key: _redact_identity_in_text(str(value), relay_redact_identity)
+                        for key, value in error_value.items()
+                    }
+                else:
+                    sanitized_error = {
+                        "message": _redact_identity_in_text(
+                            str(error_value or "Upstream stream error"),
+                            relay_redact_identity,
+                        )
+                    }
                 response_payload = {
                     "id": f"resp_{uuid.uuid4().hex[:12]}",
                     "object": "response",
                     "status": "failed",
                     "model": model,
                     "output": [],
-                    "error": error_value if isinstance(error_value, Mapping) else {"message": str(error_value or "Upstream stream error")},
+                    "error": sanitized_error,
                 }
                 if not self._write_sse_event(
                     "response.failed",
@@ -17959,6 +18623,9 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                                 pending_sse_event_metadata = []
                                 raise exc
                             self.close_connection = True
+                            stream_error_detail = safe_upstream_error_detail(
+                                exc, redact_identity=relay_redact_identity
+                            )
                             write_proxy_event(
                                 "upstream_stream_error_event",
                                 request_id=request_id,
@@ -17968,7 +18635,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                                 upstream_format=upstream_format,
                                 inbound_format=inbound_format,
                                 failure_class=_upstream_failure_class(exc),
-                                detail=safe_upstream_error_detail(exc),
+                                detail=stream_error_detail,
                             )
                             write_response_failed_event(usage_payload)
                             _capture_usage(usage_capture, None, missing_reason="stream_error_event")
@@ -17985,6 +18652,8 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                             saw_completed_event = True
                         if _responses_event_has_visible_or_tool_output(usage_payload, upstream_name):
                             visible_or_tool_output_seen = True
+                            if seam is not None:
+                                seam.mark_downstream_content_exposed()
                         empty_completed_candidate = (
                             upstream_name != "official"
                             and event_type == "response.completed"
@@ -18069,6 +18738,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 if defer_stream_errors and not downstream_output_started:
                     raise
                 self.close_connection = True
+                idle_detail = safe_upstream_error_detail(exc, redact_identity=relay_redact_identity)
                 write_proxy_event(
                     "upstream_stream_idle_timeout",
                     request_id=request_id,
@@ -18081,14 +18751,15 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                     stream_idle_phase=exc.phase,
                     terminal_seen=saw_terminal_event,
                     downstream_output_started=downstream_output_started,
-                    detail=safe_upstream_error_detail(exc),
+                    detail=idle_detail,
                 )
                 if not self._write_downstream_sse_error(
                     inbound_format=inbound_format,
                     upstream_name=upstream_name,
                     status=502,
                     error="upstream_stream_idle_timeout",
-                    detail=safe_upstream_error_detail(exc),
+                    detail=idle_detail,
+                    redact_identity=relay_redact_identity,
                 ):
                     return finish_downstream_stream_closed(
                         seam.last_write_error() or OSError("downstream closed")
@@ -18103,6 +18774,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 if defer_stream_errors and not downstream_output_started:
                     raise UpstreamStreamInterruptedError(exc) from exc
                 self.close_connection = True
+                stream_detail = safe_upstream_error_detail(exc, redact_identity=relay_redact_identity)
                 write_proxy_event(
                     "upstream_stream_interrupted",
                     request_id=request_id,
@@ -18110,12 +18782,13 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                     upstream=upstream_name,
                     status=502,
                     error=type(exc).__name__,
-                    detail=safe_upstream_error_detail(exc),
+                    detail=stream_detail,
                 )
                 if not self._write_downstream_sse_error(
                     inbound_format=inbound_format,
                     upstream_name=upstream_name,
                     exc=exc,
+                    redact_identity=relay_redact_identity,
                 ):
                     return finish_downstream_stream_closed(
                         seam.last_write_error() or OSError("downstream closed")
@@ -18163,6 +18836,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                     status=502,
                     error="upstream_stream_incomplete",
                     detail="Upstream Responses stream ended without a terminal event.",
+                    redact_identity=relay_redact_identity,
                 ):
                     return finish_downstream_stream_closed(
                         seam.last_write_error() or OSError("downstream closed")
@@ -18208,6 +18882,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                     status=502,
                     error="upstream_empty_completed_response",
                     detail=detail,
+                    redact_identity=relay_redact_identity,
                 ):
                     return finish_downstream_stream_closed(
                         seam.last_write_error() or OSError("downstream closed")

--- a/tests/fixtures/real_client_e2e/fake-client-codex-tool-invalid.cmd
+++ b/tests/fixtures/real_client_e2e/fake-client-codex-tool-invalid.cmd
@@ -1,7 +1,7 @@
 @echo off
 if defined CODEXHUB_E2E_CASE (
   if "%CODEXHUB_E2E_CASE%"=="codex-cli-luna" set "CODEXHUB_E2E_CODEX_TOOL_RESULT=missing"
-  if "%CODEXHUB_E2E_CASE%"=="codex-cli-volc" set "CODEXHUB_E2E_CODEX_TOOL_RESULT=failed"
+  if "%CODEXHUB_E2E_CASE%"=="codex-cli-ollama-cloud" set "CODEXHUB_E2E_CODEX_TOOL_RESULT=failed"
 )
 call "%~dp0fake-client-real-contract.cmd" %*
 exit /b %errorlevel%

--- a/tests/fixtures/real_client_e2e/fake-client-real-contract.cmd
+++ b/tests/fixtures/real_client_e2e/fake-client-real-contract.cmd
@@ -12,14 +12,17 @@ if not defined CODEXHUB_E2E_CLIENT exit /b 12
 if not defined CODEXHUB_E2E_DIAGNOSTICS_PATH exit /b 13
 set "GATEWAY_MODEL=%CODEXHUB_E2E_MODEL%"
 if /I "%CODEXHUB_E2E_MODEL%"=="codexhub-openai/gpt-5.6-luna" set "GATEWAY_MODEL=openai/gpt-5.6-luna"
-if /I "%CODEXHUB_E2E_MODEL%"=="codexhub-volc/glm-5.2" set "GATEWAY_MODEL=volc/glm-5.2"
+if /I "%CODEXHUB_E2E_MODEL%"=="codexhub-ollama-cloud/glm-5.2" set "GATEWAY_MODEL=ollama-cloud/glm-5.2"
 if /I not "%GATEWAY_MODEL%"=="%CODEXHUB_E2E_GATEWAY_MODEL%" exit /b 17
-set "PROVIDER_ID=openai"
+set "PROVIDER_ID=official"
 set "UPSTREAM_FORMAT=responses"
 set "INBOUND_FORMAT=responses"
-if /I "%GATEWAY_MODEL%"=="volc/glm-5.2" set "PROVIDER_ID=volc"
-if /I "%GATEWAY_MODEL%"=="volc/glm-5.2" set "UPSTREAM_FORMAT=chat_completions"
-if /I "%GATEWAY_MODEL%"=="volc/glm-5.2" set "INBOUND_FORMAT=chat_completions"
+if /I "%GATEWAY_MODEL%"=="ollama-cloud/glm-5.2" set "PROVIDER_ID=ollama_cloud"
+if defined CODEXHUB_E2E_FORCE_ROUTE_CONTRADICTION (
+  set "PROVIDER_ID=wrong-provider"
+  set "UPSTREAM_FORMAT=chat_completions"
+  set "INBOUND_FORMAT=chat_completions"
+)
 set "IS_STREAM=true"
 if defined CODEXHUB_E2E_FORCE_NONSTREAM set "IS_STREAM=false"
 if "%CODEXHUB_E2E_CLIENT%"=="codex-cli" set "CLIENT_CONFIG=%CD%\.codex\config.toml"

--- a/tests/fixtures/real_client_e2e/fake-client-route-contradiction.cmd
+++ b/tests/fixtures/real_client_e2e/fake-client-route-contradiction.cmd
@@ -1,0 +1,4 @@
+@echo off
+set "CODEXHUB_E2E_FORCE_ROUTE_CONTRADICTION=1"
+call "%~dp0fake-client-real-contract.cmd" %*
+exit /b %errorlevel%

--- a/tests/fixtures/real_client_e2e/fake-client-terminal-states.cmd
+++ b/tests/fixtures/real_client_e2e/fake-client-terminal-states.cmd
@@ -7,9 +7,9 @@ if not defined CODEXHUB_E2E_CASE exit /b 0
 if not "%CODEXHUB_E2E_CLIENT%"=="pi" if not "%CODEXHUB_E2E_CLIENT%"=="omp" exit /b 20
 echo {"type":"tool_execution_end","toolName":"read","isError":false}
 if "%CODEXHUB_E2E_CASE%"=="pi-luna" echo {"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"%CODEXHUB_E2E_SENTINEL%"}],"stopReason":"error","errorMessage":"fixture-terminal-error"}}
-if "%CODEXHUB_E2E_CASE%"=="pi-volc" echo {"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"%CODEXHUB_E2E_SENTINEL%"}],"stopReason":"aborted"}}
+if "%CODEXHUB_E2E_CASE%"=="pi-ollama-cloud" echo {"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"%CODEXHUB_E2E_SENTINEL%"}],"stopReason":"aborted"}}
 if "%CODEXHUB_E2E_CASE%"=="omp-luna" echo {"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"%CODEXHUB_E2E_SENTINEL%"}],"stopReason":"length"}}
-if "%CODEXHUB_E2E_CASE%"=="omp-volc" echo {"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"%CODEXHUB_E2E_SENTINEL%"}]}}
+if "%CODEXHUB_E2E_CASE%"=="omp-ollama-cloud" echo {"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"%CODEXHUB_E2E_SENTINEL%"}]}}
 echo {"type":"agent_end"}
 echo {"event":"request_start","request_id":"%CODEXHUB_E2E_CASE%-attempt-1-request-1","client_id":"%CODEXHUB_E2E_CLIENT%","model_canonical":"%CODEXHUB_E2E_GATEWAY_MODEL%"}>>"%CODEXHUB_E2E_DIAGNOSTICS_PATH%"
 echo {"event":"request_complete","request_id":"%CODEXHUB_E2E_CASE%-attempt-1-request-1","method":"POST","model":"%CODEXHUB_E2E_GATEWAY_MODEL%","model_canonical":"%CODEXHUB_E2E_GATEWAY_MODEL%","status":200,"duration_ms":1,"client_id":"%CODEXHUB_E2E_CLIENT%"}>>"%CODEXHUB_E2E_DIAGNOSTICS_PATH%"

--- a/tests/fixtures/real_client_e2e/fake-client-timeout.cmd
+++ b/tests/fixtures/real_client_e2e/fake-client-timeout.cmd
@@ -4,7 +4,7 @@ if defined CODEXHUB_E2E_VERSION_PROBE (
   exit /b 0
 )
 if not defined CODEXHUB_E2E_CASE exit /b 0
-if "%CODEXHUB_E2E_CASE%"=="codex-cli-volc" (
+if "%CODEXHUB_E2E_CASE%"=="codex-cli-ollama-cloud" (
   echo Authorization: Bearer fixture-private-token C:\Users\private-account 1>&2
   exit /b 7
 )

--- a/tests/fixtures/real_client_e2e/fake-debug-build-contract-probe.cmd
+++ b/tests/fixtures/real_client_e2e/fake-debug-build-contract-probe.cmd
@@ -13,7 +13,7 @@ if not defined CODEXHUB_E2E_CANDIDATE_SHA exit /b 21
 if not defined CODEXHUB_RUNTIME_HOME exit /b 22
 if not defined CODEXHUB_CODEX_TARGET_HOME exit /b 23
 if not defined CODEX_PROXY_GATEWAY_CLIENT_KEY exit /b 24
-if not defined VOLCENGINE_API_KEY exit /b 25
+if not defined OLLAMA_API_KEY exit /b 25
 python.exe "%~dp0validate-managed-client-contract-probe.py" "%CODEXHUB_E2E_CONTRACT_PROBE_LOG%"
 if errorlevel 1 exit /b 51
 python.exe "%~dp0fake-debug-gateway.py" --port %CODEXHUB_E2E_GATEWAY_PORT%

--- a/tests/fixtures/real_client_e2e/fake-debug-build.cmd
+++ b/tests/fixtures/real_client_e2e/fake-debug-build.cmd
@@ -12,7 +12,7 @@ if not defined CODEXHUB_E2E_CANDIDATE_SHA exit /b 21
 if not defined CODEXHUB_RUNTIME_HOME exit /b 22
 if not defined CODEXHUB_CODEX_TARGET_HOME exit /b 23
 if not defined CODEX_PROXY_GATEWAY_CLIENT_KEY exit /b 24
-if not defined VOLCENGINE_API_KEY exit /b 25
+if not defined OLLAMA_API_KEY exit /b 25
 if /I not "%HOME%"=="%CD%" exit /b 29
 if /I not "%USERPROFILE%"=="%CD%" exit /b 30
 if /I not "%APPDATA%"=="%CD%\appdata\roaming" exit /b 31

--- a/tests/fixtures/real_client_e2e/fake-managed-client-config.py
+++ b/tests/fixtures/real_client_e2e/fake-managed-client-config.py
@@ -48,7 +48,7 @@ def selection(client: str, model: str, catalog_path: str | None) -> tuple[str, s
         return f"custom/{model}", "responses"
     provider, model_id = model.split("/", 1)
     selector = f"codexhub-{provider}/{model_id}"
-    protocol = "responses" if provider == "openai" else "chat_completions"
+    protocol = "responses"
     if model_id == "gpt-5.6-luna" and catalog_path is None:
         fail("openai/gpt-5.6-luna requires candidate catalog", 11)
     return selector, protocol
@@ -80,7 +80,7 @@ def write_zcode(root: Path) -> None:
     gateway = "http://127.0.0.1:19190"
     specs = {
         "codexhub-openai": ("openai", "gpt-5.6-luna", "openai", "openai-responses", "responses"),
-        "codexhub-volc": ("volc", "glm-5.2", "openai-compatible", "openai-chat-completions", "chat/completions"),
+        "codexhub-ollama-cloud": ("ollama-cloud", "glm-5.2", "openai", "openai-responses", "responses"),
     }
     catalog_providers = []
     cache_providers = []
@@ -229,7 +229,7 @@ def main() -> None:
         if state != {"client": client, "model": model}:
             fail("readback state mismatch", 8)
     if mode == "contradiction-zcode" and client == "zcode" and verb == "readback":
-        selector = "codexhub-volc/contradiction"
+        selector = "codexhub-ollama-cloud/contradiction"
     log_path = os.environ.get("CODEXHUB_E2E_MATERIALIZER_LOG")
     if log_path:
         with Path(log_path).open("a", encoding="utf-8") as stream:
@@ -239,6 +239,7 @@ def main() -> None:
                         "verb": verb,
                         "client": client,
                         "model": model,
+                        "route_protocol": protocol,
                         "root_role": root.name,
                         "flags": sorted(args),
                         "catalog_path": catalog_path,

--- a/tests/fixtures/real_client_e2e/validate-managed-client-contract-probe.py
+++ b/tests/fixtures/real_client_e2e/validate-managed-client-contract-probe.py
@@ -7,9 +7,9 @@ EXPECTED = {
     (client, model)
     for client in ("codex", "opencode", "zcode", "pi", "omp")
     for model in (
-        ("gpt-5.6-luna", "volc/glm-5.2")
+        ("gpt-5.6-luna", "ollama-cloud/glm-5.2")
         if client == "codex"
-        else ("openai/gpt-5.6-luna", "volc/glm-5.2")
+        else ("openai/gpt-5.6-luna", "ollama-cloud/glm-5.2")
     )
 }
 
@@ -27,7 +27,7 @@ def main(path: Path) -> None:
     for row in rows:
         if row["model"] in ("gpt-5.6-luna", "openai/gpt-5.6-luna"):
             assert "--catalog-path" in row["flags"], row
-        elif row["model"] == "volc/glm-5.2":
+        elif row["model"] == "ollama-cloud/glm-5.2":
             assert "--catalog-path" not in row["flags"], row
 
 

--- a/tests/test_chat_completions_gateway.py
+++ b/tests/test_chat_completions_gateway.py
@@ -2893,6 +2893,14 @@ class ChatCompletionsEndpointTests(unittest.TestCase):
         event_names = [call.args[0] for call in self.write_proxy_event.call_args_list if call.args]
         self.assertNotIn("upstream_retry", event_names)
         self.assertNotIn("sse_retry_notice", event_names)
+        self.assertIn("upstream_retry_suppressed", event_names)
+        suppressed_events = [
+            call.kwargs
+            for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] == "upstream_retry_suppressed"
+        ]
+        self.assertEqual(len(suppressed_events), 1)
+        self.assertEqual(suppressed_events[0]["retry_safety_class"], "suppressed_post_exposure")
 
     def test_provider_scoped_chat_to_responses_streaming_fallback_emits_chat_delta_incrementally(self):
         policy = codex_proxy.load_policy(codex_proxy.POLICY_PATH)
@@ -4273,7 +4281,7 @@ class ChatCompletionsEndpointTests(unittest.TestCase):
         result = json.loads(b"".join(handler.wfile.writes))
         self.assertEqual(result["choices"][0]["message"]["content"], "Responses OK")
 
-    def test_auto_upstream_format_falls_back_to_chat_for_protocol_http_error(self):
+    def test_auto_upstream_format_suppresses_chat_fallback_for_protocol_http_error(self):
         policy = codex_proxy.load_policy(codex_proxy.POLICY_PATH)
         external_model = {
             "alias": "auto/glm-5.2",
@@ -4297,16 +4305,6 @@ class ChatCompletionsEndpointTests(unittest.TestCase):
             "stream": False,
         }).encode("utf-8")
         handler = self._make_handler(body, path="/v1/providers/auto/chat/completions")
-        chat_body = json.dumps({
-            "id": "chatcmpl_auto",
-            "object": "chat.completion",
-            "model": "glm-5.2",
-            "choices": [{
-                "index": 0,
-                "message": {"role": "assistant", "content": "Chat fallback OK"},
-                "finish_reason": "stop",
-            }],
-        }).encode("utf-8")
 
         with (
             patch.dict("os.environ", {"CODEX_PROXY_AUTO_RETRY_ENABLED": "0"}, clear=False),
@@ -4315,19 +4313,31 @@ class ChatCompletionsEndpointTests(unittest.TestCase):
                 return_value=replace(policy, allowed_provider_models=policy.allowed_provider_models + ("auto/glm-5.2",)),
             ),
             patch("codex_proxy.resolve_external_model_alias", return_value=external_model),
-            patch("codex_proxy.urlopen", side_effect=[_http_error(404), _FakeJsonResponse(chat_body)]) as mock_urlopen,
+            patch("codex_proxy.urlopen", side_effect=[_http_error(404)]) as mock_urlopen,
         ):
             CodexProxyHandler.do_POST(handler)
 
-        self.assertEqual(mock_urlopen.call_count, 2)
-        self.assertTrue(mock_urlopen.call_args_list[0].args[0].full_url.endswith("/responses"))
-        self.assertTrue(mock_urlopen.call_args_list[1].args[0].full_url.endswith("/chat/completions"))
-        chat_payload = json.loads(mock_urlopen.call_args_list[1].args[0].data)
-        self.assertIn("messages", chat_payload)
+        self.assertEqual(mock_urlopen.call_count, 1)
+        self.assertTrue(mock_urlopen.call_args.args[0].full_url.endswith("/responses"))
+        suppressed_events = [
+            call.kwargs
+            for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] == "upstream_retry_suppressed"
+        ]
+        self.assertGreaterEqual(len(suppressed_events), 1)
+        self.assertTrue(
+            any(
+                e["error"] == "HTTPError"
+                and e["retry_safety_class"] == "suppressed_post_write"
+                and e["failure_phase"] == "response_headers"
+                and e["upstream_format"] == "responses"
+                for e in suppressed_events
+            )
+        )
         result = json.loads(b"".join(handler.wfile.writes))
-        self.assertEqual(result["choices"][0]["message"]["content"], "Chat fallback OK")
+        self.assertEqual(result["error"]["type"], "upstream_error")
 
-    def test_auto_handler_preserves_completed_tool_lifecycle_through_chat_fallback(self):
+    def test_auto_handler_suppresses_chat_fallback_for_tool_protocol_http_error(self):
         policy = codex_proxy.load_policy(codex_proxy.POLICY_PATH)
         external_model = {
             "alias": "auto/glm-5.2",
@@ -4375,16 +4385,6 @@ class ChatCompletionsEndpointTests(unittest.TestCase):
             "stream": False,
         }).encode("utf-8")
         handler = self._make_handler(body, path="/v1/providers/auto/chat/completions")
-        chat_body = json.dumps({
-            "id": "chatcmpl_auto_tools",
-            "object": "chat.completion",
-            "model": "glm-5.2",
-            "choices": [{
-                "index": 0,
-                "message": {"role": "assistant", "content": "Done after one tool result."},
-                "finish_reason": "stop",
-            }],
-        }).encode("utf-8")
 
         with (
             patch.dict("os.environ", {"CODEX_PROXY_AUTO_RETRY_ENABLED": "0"}, clear=False),
@@ -4393,20 +4393,29 @@ class ChatCompletionsEndpointTests(unittest.TestCase):
                 return_value=replace(policy, allowed_provider_models=policy.allowed_provider_models + ("auto/glm-5.2",)),
             ),
             patch("codex_proxy.resolve_external_model_alias", return_value=external_model),
-            patch("codex_proxy.urlopen", side_effect=[_http_error(404), _FakeJsonResponse(chat_body)]) as mock_urlopen,
+            patch("codex_proxy.urlopen", side_effect=[_http_error(404)]) as mock_urlopen,
         ):
             CodexProxyHandler.do_POST(handler)
 
-        self.assertEqual(mock_urlopen.call_count, 2)
-        responses_payload = json.loads(mock_urlopen.call_args_list[0].args[0].data)
+        self.assertEqual(mock_urlopen.call_count, 1)
+        responses_payload = json.loads(mock_urlopen.call_args.args[0].data)
         self.assertEqual(responses_payload["input"][1]["type"], "function_call")
         self.assertEqual(responses_payload["input"][2]["type"], "function_call_output")
-        chat_payload = json.loads(mock_urlopen.call_args_list[1].args[0].data)
-        self.assertEqual(chat_payload["messages"][1]["tool_calls"][0]["id"], "call_list_skills")
-        self.assertEqual(chat_payload["messages"][2]["role"], "tool")
-        self.assertEqual(chat_payload["messages"][2]["tool_call_id"], "call_list_skills")
+        suppressed_events = [
+            call.kwargs
+            for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] == "upstream_retry_suppressed"
+        ]
+        self.assertGreaterEqual(len(suppressed_events), 1)
+        self.assertTrue(
+            any(
+                e["error"] == "HTTPError"
+                and e["retry_safety_class"] == "suppressed_post_write"
+                for e in suppressed_events
+            )
+        )
         result = json.loads(b"".join(handler.wfile.writes))
-        self.assertEqual(result["choices"][0]["message"]["content"], "Done after one tool result.")
+        self.assertEqual(result["error"]["type"], "upstream_error")
 
     def test_auto_upstream_format_does_not_fallback_after_responses_stream_starts(self):
         policy = codex_proxy.load_policy(codex_proxy.POLICY_PATH)

--- a/tests/test_proxy_event_logging.py
+++ b/tests/test_proxy_event_logging.py
@@ -10,7 +10,8 @@ import threading
 from pathlib import Path
 from unittest import TestCase
 from unittest.mock import patch
-from urllib.error import URLError
+import io
+from urllib.error import HTTPError, URLError
 
 import codex_proxy
 from lock_fixtures import write_dead_legacy_lock
@@ -81,6 +82,71 @@ class ProxyEventLoggingTests(TestCase):
                     self.assertEqual(retry["request_id"], "req-open-seam")
                     self.assertEqual(retry["upstream"], "official")
                     self.assertEqual(retry["failure_phase"], "tcp_connect")
+            finally:
+                importlib.reload(codex_proxy)
+
+    def test_non_official_http_error_emits_upstream_retry_suppressed(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            codex_home = Path(tmpdir) / "codex-home"
+            try:
+                with patch.dict("os.environ", {"CODEX_HOME": str(codex_home)}, clear=False):
+                    importlib.reload(codex_proxy)
+                    request = codex_proxy.Request(
+                        "https://example.test/v1/responses", data=b"{}", method="POST"
+                    )
+
+                    with (
+                        patch.dict(
+                            "os.environ",
+                            {
+                                "CODEX_PROXY_AUTO_RETRY_ENABLED": "1",
+                                "CODEX_PROXY_AUTO_RETRY_MAX_ATTEMPTS": "2",
+                            },
+                            clear=False,
+                        ),
+                        patch(
+                            "codex_proxy._open_upstream_once",
+                            side_effect=HTTPError(
+                                "https://example.test/v1/responses",
+                                503,
+                                "Service Unavailable",
+                                {},
+                                io.BytesIO(b"upstream error"),
+                            ),
+                        ) as open_once,
+                        patch("codex_proxy.time.sleep"),
+                    ):
+                        with self.assertRaises(HTTPError):
+                            codex_proxy._open_upstream_response(
+                                request,
+                                upstream_name="volcengine",
+                                upstream_format="responses",
+                                timeout=1,
+                                event_context={
+                                    "request_id": "req-suppressed",
+                                    "model": "volc/glm-5.2",
+                                },
+                            )
+
+                    self.assertEqual(open_once.call_count, 1)
+                    self.assertTrue(codex_proxy.flush_proxy_event_writer())
+                    payloads = [
+                        json.loads(line)
+                        for line in codex_proxy.PROXY_EVENT_LOG_PATH.read_text(
+                            encoding="utf-8"
+                        ).splitlines()
+                        if line.strip()
+                    ]
+                    suppressed = next(
+                        payload
+                        for payload in payloads
+                        if payload["event"] == "upstream_retry_suppressed"
+                    )
+                    self.assertEqual(suppressed["request_id"], "req-suppressed")
+                    self.assertEqual(suppressed["upstream"], "volcengine")
+                    self.assertEqual(suppressed["failure_phase"], "response_headers")
+                    self.assertEqual(suppressed["retry_safety_class"], "suppressed_post_write")
+                    self.assertNotIn("upstream_retry", [p["event"] for p in payloads])
             finally:
                 importlib.reload(codex_proxy)
 

--- a/tests/test_real_client_e2e.py
+++ b/tests/test_real_client_e2e.py
@@ -18,7 +18,7 @@ SCRIPT = ROOT / "scripts" / "Run-RealClientE2E.ps1"
 FIXTURES = ROOT / "tests" / "fixtures" / "real_client_e2e"
 CANDIDATE_SHA = "a" * 40
 LUNA_MODEL = "codexhub-openai/gpt-5.6-luna"
-VOLC_MODEL = "codexhub-volc/glm-5.2"
+THIRD_PARTY_MODEL = "codexhub-ollama-cloud/glm-5.2"
 MINIMUM_VERSIONS = {
     "desktop": "26.715.8383.0",
     "codex_cli": "0.144.5",
@@ -63,7 +63,13 @@ COUNT_KEYS = {
 }
 CASE_KEYS = {
     "case_id",
+    "client",
+    "provider_id",
+    "client_selector",
     "canonical_model",
+    "gateway_model",
+    "endpoint_binding",
+    "protocol",
     "outcome",
     "duration_ms",
     "request_complete_count",
@@ -83,6 +89,116 @@ AUTOMATED_CASE_KEYS = CASE_KEYS | {
     "gateway_request_count",
     "gateway_complete_count",
 }
+EXPECTED_CASE_BINDINGS = {
+    "desktop-luna": {
+        "client": "desktop",
+        "provider_id": "official",
+        "client_selector": "gpt-5.6-luna",
+        "canonical_model": "gpt-5.6-luna",
+        "gateway_model": "gpt-5.6-luna",
+        "endpoint_binding": "/v1/responses",
+        "protocol": "responses",
+    },
+    "desktop-ollama-cloud": {
+        "client": "desktop",
+        "provider_id": "ollama-cloud",
+        "client_selector": "ollama-cloud/glm-5.2",
+        "canonical_model": "ollama-cloud/glm-5.2",
+        "gateway_model": "ollama-cloud/glm-5.2",
+        "endpoint_binding": "/v1/providers/ollama-cloud/responses",
+        "protocol": "responses",
+    },
+    "codex-cli-luna": {
+        "client": "codex-cli",
+        "provider_id": "official",
+        "client_selector": "gpt-5.6-luna",
+        "canonical_model": "gpt-5.6-luna",
+        "gateway_model": "gpt-5.6-luna",
+        "endpoint_binding": "/v1/responses",
+        "protocol": "responses",
+    },
+    "codex-cli-ollama-cloud": {
+        "client": "codex-cli",
+        "provider_id": "ollama-cloud",
+        "client_selector": "ollama-cloud/glm-5.2",
+        "canonical_model": "ollama-cloud/glm-5.2",
+        "gateway_model": "ollama-cloud/glm-5.2",
+        "endpoint_binding": "/v1/providers/ollama-cloud/responses",
+        "protocol": "responses",
+    },
+    "opencode-luna": {
+        "client": "opencode",
+        "provider_id": "official",
+        "client_selector": LUNA_MODEL,
+        "canonical_model": LUNA_MODEL,
+        "gateway_model": "openai/gpt-5.6-luna",
+        "endpoint_binding": "/v1/providers/openai/responses",
+        "protocol": "responses",
+    },
+    "opencode-ollama-cloud": {
+        "client": "opencode",
+        "provider_id": "ollama-cloud",
+        "client_selector": THIRD_PARTY_MODEL,
+        "canonical_model": THIRD_PARTY_MODEL,
+        "gateway_model": "ollama-cloud/glm-5.2",
+        "endpoint_binding": "/v1/providers/ollama-cloud/responses",
+        "protocol": "responses",
+    },
+    "zcode-luna": {
+        "client": "zcode",
+        "provider_id": "official",
+        "client_selector": LUNA_MODEL,
+        "canonical_model": LUNA_MODEL,
+        "gateway_model": "openai/gpt-5.6-luna",
+        "endpoint_binding": "/v1/providers/openai/responses",
+        "protocol": "responses",
+    },
+    "zcode-ollama-cloud": {
+        "client": "zcode",
+        "provider_id": "ollama-cloud",
+        "client_selector": THIRD_PARTY_MODEL,
+        "canonical_model": THIRD_PARTY_MODEL,
+        "gateway_model": "ollama-cloud/glm-5.2",
+        "endpoint_binding": "/v1/providers/ollama-cloud/responses",
+        "protocol": "responses",
+    },
+    "pi-luna": {
+        "client": "pi",
+        "provider_id": "official",
+        "client_selector": LUNA_MODEL,
+        "canonical_model": LUNA_MODEL,
+        "gateway_model": "openai/gpt-5.6-luna",
+        "endpoint_binding": "/v1/providers/openai/responses",
+        "protocol": "responses",
+    },
+    "pi-ollama-cloud": {
+        "client": "pi",
+        "provider_id": "ollama-cloud",
+        "client_selector": THIRD_PARTY_MODEL,
+        "canonical_model": THIRD_PARTY_MODEL,
+        "gateway_model": "ollama-cloud/glm-5.2",
+        "endpoint_binding": "/v1/providers/ollama-cloud/responses",
+        "protocol": "responses",
+    },
+    "omp-luna": {
+        "client": "omp",
+        "provider_id": "official",
+        "client_selector": LUNA_MODEL,
+        "canonical_model": LUNA_MODEL,
+        "gateway_model": "openai/gpt-5.6-luna",
+        "endpoint_binding": "/v1/providers/openai/responses",
+        "protocol": "responses",
+    },
+    "omp-ollama-cloud": {
+        "client": "omp",
+        "provider_id": "ollama-cloud",
+        "client_selector": THIRD_PARTY_MODEL,
+        "canonical_model": THIRD_PARTY_MODEL,
+        "gateway_model": "ollama-cloud/glm-5.2",
+        "endpoint_binding": "/v1/providers/ollama-cloud/responses",
+        "protocol": "responses",
+    },
+}
 
 
 def _powershell() -> str:
@@ -92,11 +208,16 @@ def _powershell() -> str:
     return executable
 
 
-def _manual_case(case_id: str, client: str, model: str) -> dict:
+def _manual_case(case: dict) -> dict:
     return {
-        "case_id": case_id,
-        "client": client,
-        "canonical_model": model,
+        "case_id": case["case_id"],
+        "client": case["client"],
+        "provider_id": case["provider_id"],
+        "client_selector": case["client_selector"],
+        "canonical_model": case["canonical_model"],
+        "gateway_model": case["gateway_model"],
+        "endpoint_binding": case["endpoint_binding"],
+        "protocol": case["protocol"],
         "human_finalized": True,
         "outcome": "passed",
         "terminal_classification": "completed",
@@ -144,11 +265,11 @@ def _prepare_run(
         ),
         encoding="utf-8",
     )
-    (isolation / "credentials" / "volc.json").write_text(
+    (isolation / "credentials" / "ollama.json").write_text(
         json.dumps(
             {
-                "schema": "codexhub.real-client-volc.v1",
-                "api_key": "fixture-volc-private-token",
+                "schema": "codexhub.real-client-ollama.v1",
+                "api_key": "fixture-ollama-private-token",
             }
         ),
         encoding="utf-8",
@@ -238,9 +359,9 @@ def _finalize_manual_evidence(
                 (work / f"gui-{case_id}.launched").is_file()
                 for case_id in (
                     "desktop-luna",
-                    "desktop-volc",
+                    "desktop-ollama-cloud",
                     "zcode-luna",
-                    "zcode-volc",
+                    "zcode-ollama-cloud",
                 )
             )
         ):
@@ -248,7 +369,7 @@ def _finalize_manual_evidence(
             evidence["login_confirmed"] = True
             evidence["gui_confirmed"] = True
             for case in evidence["cases"]:
-                case.update(_manual_case(case["case_id"], case["client"], case["canonical_model"]))
+                case.update(_manual_case(case))
             if mutation is not None:
                 mutation(evidence)
             target = output / "manual-evidence.json"
@@ -377,8 +498,8 @@ def _run(
         materializer_sha,
         "-LunaModel",
         LUNA_MODEL,
-        "-VolcModel",
-        VOLC_MODEL,
+        "-ThirdPartyModel",
+        THIRD_PARTY_MODEL,
         "-OutputDirectory",
         str(output),
         "-HostEnvironmentManifest",
@@ -536,12 +657,16 @@ def test_runner_invokes_candidate_materializer_for_every_managed_client(tmp_path
         for client in {"codex", "opencode", "zcode", "pi", "omp"}
     }
     assert applied_models == {
-        "codex": {"gpt-5.6-luna", "volc/glm-5.2"},
-        "opencode": {"openai/gpt-5.6-luna", "volc/glm-5.2"},
-        "zcode": {"openai/gpt-5.6-luna", "volc/glm-5.2"},
-        "pi": {"openai/gpt-5.6-luna", "volc/glm-5.2"},
-        "omp": {"openai/gpt-5.6-luna", "volc/glm-5.2"},
+        "codex": {"gpt-5.6-luna", "ollama-cloud/glm-5.2"},
+        "opencode": {"openai/gpt-5.6-luna", "ollama-cloud/glm-5.2"},
+        "zcode": {"openai/gpt-5.6-luna", "ollama-cloud/glm-5.2"},
+        "pi": {"openai/gpt-5.6-luna", "ollama-cloud/glm-5.2"},
+        "omp": {"openai/gpt-5.6-luna", "ollama-cloud/glm-5.2"},
     }
+    assert all(
+        item["route_protocol"] == "responses"
+        for item in invocations
+    )
     assert "managed-client-config" in SCRIPT.read_text(encoding="utf-8")
     assert "Get-ClientProviderMap" not in SCRIPT.read_text(encoding="utf-8")
 
@@ -746,7 +871,7 @@ def test_opencodex_appdata_shim_fails_under_case_local_isolation(tmp_path):
         case["case_id"]
         for case in summary["cases"]
         if case["outcome"] == "failed"
-    } == {"codex-cli-luna", "codex-cli-volc"}
+    } == {"codex-cli-luna", "codex-cli-ollama-cloud"}
     markers = list(
         (tmp_path / "output" / "isolated" / "work").glob(
             "codex-cli-*/opencodex-appdata-isolated.marker"
@@ -925,7 +1050,7 @@ def test_exact_compatibility_floors_pass_and_emit_one_sanitized_sha_bound_summar
     assert len(summaries) == 1
     summary = json.loads(summaries[0].read_text(encoding="utf-8-sig"))
     _assert_exact_summary_schema(summary)
-    assert summary["schema"] == "codexhub.real-client-e2e-summary.v1"
+    assert summary["schema"] == "codexhub.real-client-e2e-summary.v2"
     assert summary["candidate_sha"] == CANDIDATE_SHA
     assert summary["pinned_versions"] == MINIMUM_VERSIONS
     assert summary["counts"] == {
@@ -937,18 +1062,37 @@ def test_exact_compatibility_floors_pass_and_emit_one_sanitized_sha_bound_summar
     }
     assert [case["case_id"] for case in summary["cases"]] == [
         "desktop-luna",
-        "desktop-volc",
+        "desktop-ollama-cloud",
         "codex-cli-luna",
-        "codex-cli-volc",
+        "codex-cli-ollama-cloud",
         "opencode-luna",
-        "opencode-volc",
+        "opencode-ollama-cloud",
         "zcode-luna",
-        "zcode-volc",
+        "zcode-ollama-cloud",
         "pi-luna",
-        "pi-volc",
+        "pi-ollama-cloud",
         "omp-luna",
-        "omp-volc",
+        "omp-ollama-cloud",
     ]
+    assert {
+        case["case_id"]: {
+            key: case[key]
+            for key in (
+                "client",
+                "provider_id",
+                "client_selector",
+                "canonical_model",
+                "gateway_model",
+                "endpoint_binding",
+                "protocol",
+            )
+        }
+        for case in summary["cases"]
+    } == EXPECTED_CASE_BINDINGS
+    assert [case["provider_id"] for case in summary["cases"]].count("official") == 6
+    assert [case["provider_id"] for case in summary["cases"]].count("ollama-cloud") == 6
+    assert all(case["protocol"] == "responses" for case in summary["cases"])
+    assert all("volc" not in case["case_id"] for case in summary["cases"])
     assert all(case["outcome"] == "passed" for case in summary["cases"])
     assert len(summary["artifacts"]) == 12
     assert all((tmp_path / "output" / artifact).is_file() for artifact in summary["artifacts"])
@@ -958,17 +1102,20 @@ def test_exact_compatibility_floors_pass_and_emit_one_sanitized_sha_bound_summar
     assert template["run_binding_sha256"] == summary["run_binding_sha256"]
     assert not list((tmp_path / "output" / "isolated" / "work").rglob("sentinel.txt"))
     serialized = json.dumps(summary, sort_keys=True)
+    assert "volc" not in serialized.lower()
+    assert "chat_completions" not in serialized
+    assert "localhost:11434" not in serialized
     for secret in (
         "fixture-codex-access-token",
         "fixture-codex-refresh-token",
-        "fixture-volc-private-token",
+        "fixture-ollama-private-token",
         "fixture-gateway-private-key",
     ):
         assert secret not in serialized
     for relative in (
         "isolated/account/profile.json",
         "isolated/account/auth.json",
-        "isolated/credentials/volc.json",
+        "isolated/credentials/ollama.json",
         "isolated/config/gateway.json",
         "isolated/config/host-environment.json",
         "manual-evidence.json",
@@ -1033,7 +1180,7 @@ def test_real_versioned_client_events_are_correlated_with_gateway_diagnostics(tm
         case["canonical_model"]
         for case in automated
         if case["case_id"].startswith(("opencode", "pi", "omp"))
-    } == {LUNA_MODEL, VOLC_MODEL}
+    } == {LUNA_MODEL, THIRD_PARTY_MODEL}
     opencode = [case for case in automated if case["case_id"].startswith("opencode-")]
     assert [case["duplicate_terminal_count"] for case in opencode] == [0, 0]
     diagnostics = list((tmp_path / "output").rglob("codex-proxy-events.jsonl"))
@@ -1043,7 +1190,7 @@ def test_real_versioned_client_events_are_correlated_with_gateway_diagnostics(tm
     assert len(completes) == 16
     assert {event["model_canonical"] for event in completes} == {
         "gpt-5.6-luna",
-        "volc/glm-5.2",
+        "ollama-cloud/glm-5.2",
         "openai/gpt-5.6-luna",
     }
     production_fields = {
@@ -1071,7 +1218,7 @@ def test_real_versioned_client_events_are_correlated_with_gateway_diagnostics(tm
     assert all("sse_terminal_event_seen" not in event for event in completes)
 
 
-def test_volc_managed_client_probes_do_not_receive_catalog_path(tmp_path):
+def test_third_party_managed_client_probes_do_not_receive_catalog_path(tmp_path):
     result = _run(tmp_path)
 
     assert result.returncode == 0, result.stdout + result.stderr
@@ -1088,7 +1235,7 @@ def test_volc_managed_client_probes_do_not_receive_catalog_path(tmp_path):
     assert all(
         "--catalog-path" not in item["flags"]
         for item in invocations
-        if item["model"] == "volc/glm-5.2"
+        if item["model"] == "ollama-cloud/glm-5.2"
     )
 
 
@@ -1124,12 +1271,31 @@ def test_final_client_message_with_nonstream_gateway_completions_fails(tmp_path)
 
 
 def test_zcode_gui_consumes_catalog_from_isolated_roaming_appdata(tmp_path):
-    result = _run(
-        tmp_path,
-        client_fakes={"ZCodePath": "fake-client-zcode-appdata.cmd"},
-    )
+    result = _run(tmp_path)
 
     assert result.returncode == 0, result.stdout + result.stderr
+    case_root = (
+        tmp_path
+        / "output"
+        / "isolated"
+        / "work"
+        / "gui-zcode"
+        / "zcode-ollama-cloud"
+    )
+    catalog = (
+        case_root
+        / "appdata"
+        / "roaming"
+        / "ZCode"
+        / "model-providers"
+        / "codexhub.json"
+    )
+    assert catalog.is_file()
+    assert not (case_root / "appdata" / "ZCode" / "model-providers" / "codexhub.json").exists()
+    payload = json.loads(catalog.read_text(encoding="utf-8-sig"))
+    provider_ids = {provider["id"] for provider in payload.get("providers", [])}
+    assert provider_ids == {"codexhub-openai", "codexhub-ollama-cloud"}
+    assert "codexhub-volc" not in provider_ids
 
 
 def test_wrong_model_fallback_cannot_be_filtered_into_a_false_pass(tmp_path):
@@ -1216,7 +1382,7 @@ def test_pi_rejects_stop_with_contradictory_error_message(tmp_path):
 def test_empty_account_and_arbitrary_credential_cannot_pass_preflight(tmp_path):
     def invalidate_identity(_output, isolation, _debug):
         (isolation / "account" / "profile.json").write_text("{}", encoding="utf-8")
-        (isolation / "credentials" / "volc.json").write_text(
+        (isolation / "credentials" / "ollama.json").write_text(
             '{"api_key":"arbitrary"}', encoding="utf-8"
         )
 
@@ -1231,7 +1397,7 @@ def test_preflight_return_does_not_leave_a_manual_finalizer_thread(tmp_path):
     result = _run(
         tmp_path,
         mutate=lambda _output, isolation, _debug: (
-            isolation / "credentials" / "volc.json"
+            isolation / "credentials" / "ollama.json"
         ).unlink(),
     )
 
@@ -1751,7 +1917,7 @@ def test_desktop_gui_cases_use_distinct_case_local_user_data_directories(tmp_pat
     assert result.returncode == 0, result.stdout + result.stderr
     work = tmp_path / "output" / "isolated" / "work"
     observed = {}
-    for case_id in ("desktop-luna", "desktop-volc"):
+    for case_id in ("desktop-luna", "desktop-ollama-cloud"):
         argument_log = work / f"gui-{case_id}.launched.argv"
         arguments = argument_log.read_text(encoding="ascii").strip()
         expected_profile = work / "gui-desktop" / case_id / "browser-profile"
@@ -1763,7 +1929,7 @@ def test_desktop_gui_cases_use_distinct_case_local_user_data_directories(tmp_pat
             str(expected_workspace).casefold()
         )
         observed[case_id] = arguments
-    assert observed["desktop-luna"] != observed["desktop-volc"]
+    assert observed["desktop-luna"] != observed["desktop-ollama-cloud"]
 
 
 def test_zcode_gui_cases_open_their_case_local_workspaces(tmp_path):
@@ -1774,7 +1940,7 @@ def test_zcode_gui_cases_open_their_case_local_workspaces(tmp_path):
 
     assert result.returncode == 0, result.stdout + result.stderr
     work = tmp_path / "output" / "isolated" / "work"
-    for case_id in ("zcode-luna", "zcode-volc"):
+    for case_id in ("zcode-luna", "zcode-ollama-cloud"):
         arguments = (
             work / f"gui-{case_id}.launched.argv"
         ).read_text(encoding="ascii").strip()
@@ -1784,7 +1950,32 @@ def test_zcode_gui_cases_open_their_case_local_workspaces(tmp_path):
         )
 
 
-def test_candidate_runtime_declares_volc_native_responses_route(tmp_path):
+def test_candidate_runtime_declares_ollama_cloud_native_responses_route(tmp_path):
+    result = _run(tmp_path)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    runtime_config = (
+        tmp_path
+        / "output"
+        / "isolated"
+        / "work"
+        / "candidate"
+        / "runtime"
+        / "proxy"
+        / "config"
+    )
+    providers = (runtime_config / "providers.toml").read_text(encoding="utf-8")
+    settings = json.loads((runtime_config.parent / "settings.json").read_text(encoding="utf-8-sig"))
+    assert 'id = "ollama-cloud"' in providers
+    assert 'base_url = "https://ollama.com/v1"' in providers
+    assert 'upstream_format = "responses"' in providers
+    assert 'available_upstream_formats = ["responses"]' in providers
+    assert "volc" not in providers.lower()
+    assert settings["gateway_enable_responses"] is True
+    assert settings["gateway_enable_chat_completions"] is False
+
+
+def test_release_matrix_uses_ollama_cloud_native_responses(tmp_path):
     result = _run(tmp_path)
 
     assert result.returncode == 0, result.stdout + result.stderr
@@ -1799,22 +1990,72 @@ def test_candidate_runtime_declares_volc_native_responses_route(tmp_path):
         / "config"
         / "providers.toml"
     ).read_text(encoding="utf-8")
+    assert 'id = "ollama-cloud"' in providers
+    assert 'base_url = "https://ollama.com/v1"' in providers
     assert 'upstream_format = "responses"' in providers
-    assert 'available_upstream_formats = ["responses"]' in providers
+    assert "volc" not in providers.lower()
+    assert "localhost:11434" not in providers
+
+    summary = json.loads(
+        (tmp_path / "output" / "summary.json").read_text(encoding="utf-8-sig")
+    )
+    canonical_models = summary["canonical_models"]
+    assert "ollama-cloud/glm-5.2" in canonical_models
+    assert "codexhub-ollama-cloud/glm-5.2" in canonical_models
+    assert "volc/glm-5.2" not in canonical_models
+    assert "codexhub-volc/glm-5.2" not in canonical_models
+
+    diagnostics = list((tmp_path / "output").rglob("codex-proxy-events.jsonl"))[0]
+    for line in diagnostics.read_text(encoding="utf-8").splitlines():
+        event = json.loads(line)
+        if event.get("event") == "request_complete":
+            assert event["upstream_format"] == "responses"
+            assert event["inbound_format"] == "responses"
+            expected_provider = (
+                "ollama_cloud"
+                if event["model_canonical"] == "ollama-cloud/glm-5.2"
+                else "official"
+            )
+            assert event["provider_id"] == expected_provider
+
+
+def test_provider_or_wire_protocol_contradiction_cannot_pass_release_case(tmp_path):
+    result = _run(
+        tmp_path,
+        client_fakes={"PiPath": "fake-client-route-contradiction.cmd"},
+    )
+
+    assert result.returncode != 0
+    summary = json.loads(
+        (tmp_path / "output" / "summary.json").read_text(encoding="utf-8-sig")
+    )
+    pi_cases = [case for case in summary["cases"] if case["client"] == "pi"]
+    assert [case["outcome"] for case in pi_cases] == ["failed", "failed"]
+    assert all(case["error_event_count"] >= 1 for case in pi_cases)
 
 
 def test_gui_cases_copy_reusable_state_into_fresh_isolated_roots(tmp_path):
-    seeded_files = {
-        "desktop-luna/browser-profile/Preferences": "desktop-luna-state",
-        "desktop-volc/browser-profile/Preferences": "desktop-volc-state",
-        "zcode-luna/.zcode/v2/telemetry-state.json": "zcode-luna-state",
-        "zcode-volc/.zcode/v2/telemetry-state.json": "zcode-volc-state",
-    }
+    seeded_files = [
+        ("desktop-luna", "desktop-luna", "browser-profile/Preferences", "desktop-luna-state"),
+        (
+            "desktop-third-party",
+            "desktop-ollama-cloud",
+            "browser-profile/Preferences",
+            "desktop-third-party-state",
+        ),
+        ("zcode-luna", "zcode-luna", ".zcode/v2/telemetry-state.json", "zcode-luna-state"),
+        (
+            "zcode-third-party",
+            "zcode-ollama-cloud",
+            ".zcode/v2/telemetry-state.json",
+            "zcode-third-party-state",
+        ),
+    ]
 
     def seed_gui_state(_output, isolation, _debug):
         seed_root = isolation / "gui-seed"
-        for relative, value in seeded_files.items():
-            path = seed_root / relative
+        for seed_slot, _case_id, relative, value in seeded_files:
+            path = seed_root / seed_slot / relative
             path.parent.mkdir(parents=True, exist_ok=True)
             path.write_text(value, encoding="utf-8")
 
@@ -1822,13 +2063,51 @@ def test_gui_cases_copy_reusable_state_into_fresh_isolated_roots(tmp_path):
 
     assert result.returncode == 0, result.stdout + result.stderr
     work = tmp_path / "output" / "isolated" / "work"
-    for relative, value in seeded_files.items():
-        case_id, case_relative = relative.split("/", 1)
+    for seed_slot, case_id, relative, value in seeded_files:
         client = "desktop" if case_id.startswith("desktop-") else "zcode"
-        source = tmp_path / "output" / "isolated" / "gui-seed" / relative
-        copied = work / f"gui-{client}" / case_id / case_relative
+        source = tmp_path / "output" / "isolated" / "gui-seed" / seed_slot / relative
+        copied = work / f"gui-{client}" / case_id / relative
         assert copied.read_text(encoding="utf-8") == value
         assert copied.stat().st_ino != source.stat().st_ino
+
+
+def test_legacy_volc_gui_seed_falls_back_without_mutating_source(tmp_path):
+    seeded_files = [
+        (
+            "desktop-volc",
+            "desktop-ollama-cloud",
+            "browser-profile/Preferences",
+            "legacy-desktop-state",
+        ),
+        (
+            "zcode-volc",
+            "zcode-ollama-cloud",
+            ".zcode/v2/telemetry-state.json",
+            "legacy-zcode-state",
+        ),
+    ]
+
+    def seed_legacy_gui_state(_output, isolation, _debug):
+        seed_root = isolation / "gui-seed"
+        for seed_slot, _case_id, relative, value in seeded_files:
+            path = seed_root / seed_slot / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(value, encoding="utf-8")
+
+    result = _run(tmp_path, mutate=seed_legacy_gui_state)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    isolation = tmp_path / "output" / "isolated"
+    work = isolation / "work"
+    for seed_slot, case_id, relative, value in seeded_files:
+        client = "desktop" if case_id.startswith("desktop-") else "zcode"
+        source = isolation / "gui-seed" / seed_slot / relative
+        copied = work / f"gui-{client}" / case_id / relative
+        assert source.read_text(encoding="utf-8") == value
+        assert copied.read_text(encoding="utf-8") == value
+        assert copied.stat().st_ino != source.stat().st_ino
+    assert not (isolation / "gui-seed" / "desktop-third-party").exists()
+    assert not (isolation / "gui-seed" / "zcode-third-party").exists()
 
 
 def test_desktop_gui_seed_preserves_onboarding_without_stale_identity_or_history(
@@ -1843,9 +2122,14 @@ def test_desktop_gui_seed_preserves_onboarding_without_stale_identity_or_history
         "2026-07-13-local-projects",
     ]
 
+    seed_cases = (
+        ("desktop-luna", "desktop-luna"),
+        ("desktop-third-party", "desktop-ollama-cloud"),
+    )
+
     def seed_gui_state(_output, isolation, _debug):
-        for case_id in ("desktop-luna", "desktop-volc"):
-            codex_root = isolation / "gui-seed" / case_id / ".codex"
+        for seed_slot, _case_id in seed_cases:
+            codex_root = isolation / "gui-seed" / seed_slot / ".codex"
             codex_root.mkdir(parents=True)
             (codex_root / ".codex-global-state.json").write_text(
                 json.dumps(
@@ -1885,13 +2169,13 @@ def test_desktop_gui_seed_preserves_onboarding_without_stale_identity_or_history
 
     assert result.returncode == 0, result.stdout + result.stderr
     work = tmp_path / "output" / "isolated" / "work" / "gui-desktop"
-    for case_id in ("desktop-luna", "desktop-volc"):
+    for seed_slot, case_id in seed_cases:
         source = (
             tmp_path
             / "output"
             / "isolated"
             / "gui-seed"
-            / case_id
+            / seed_slot
             / ".codex"
             / ".codex-global-state.json"
         )
@@ -2050,7 +2334,7 @@ def test_desktop_gui_preserves_windows_identity_for_sandbox_acl_setup(
 
     assert result.returncode == 0, result.stdout + result.stderr
     work = tmp_path / "output" / "isolated" / "work"
-    for case_id in ("desktop-luna", "desktop-volc"):
+    for case_id in ("desktop-luna", "desktop-ollama-cloud"):
         identity = (work / f"gui-{case_id}.launched.identity").read_text(
             encoding="ascii"
         )
@@ -2071,7 +2355,7 @@ def test_desktop_gui_launches_from_invocation_local_manifest_payload(tmp_path):
     staged_executable = staged_root / source_executable.name
     assert staged_executable.read_bytes() == source_executable.read_bytes()
     assert staged_executable.stat().st_ino != source_executable.stat().st_ino
-    for case_id in ("desktop-luna", "desktop-volc"):
+    for case_id in ("desktop-luna", "desktop-ollama-cloud"):
         launch_path = (
             work / f"gui-{case_id}.launched.executable"
         ).read_text(encoding="ascii")
@@ -2256,7 +2540,7 @@ def test_manual_evidence_cannot_predate_template_and_gui_launch(tmp_path):
 
 def test_preflight_failure_emits_one_bounded_sanitized_summary(tmp_path):
     def remove_credentials(_output, isolation, _debug):
-        (isolation / "credentials" / "volc.json").unlink()
+        (isolation / "credentials" / "ollama.json").unlink()
 
     result = _run(tmp_path, mutate=remove_credentials, finalize_manual=False)
 
@@ -2270,13 +2554,13 @@ def test_preflight_failure_emits_one_bounded_sanitized_summary(tmp_path):
     assert summary["cases"] == []
     assert summary["artifacts"] == []
     serialized = json.dumps(summary, sort_keys=True)
-    assert "fixture-volc-private-token" not in serialized
+    assert "fixture-ollama-private-token" not in serialized
     assert str(tmp_path) not in serialized
 
 
 def test_supervisor_preserves_space_containing_authoritative_path_arguments(tmp_path):
     def remove_credentials(_output, isolation, _debug):
-        (isolation / "credentials" / "volc.json").unlink()
+        (isolation / "credentials" / "ollama.json").unlink()
 
     run_root = tmp_path / "Authoritative Host Run"
     result = _run(
@@ -2385,7 +2669,12 @@ def test_manual_evidence_merge_is_deterministic_for_reordered_input(tmp_path):
         for case in summary["cases"]
         if case["case_id"].startswith(("desktop", "zcode"))
     ]
-    assert manual_ids == ["desktop-luna", "desktop-volc", "zcode-luna", "zcode-volc"]
+    assert manual_ids == [
+        "desktop-luna",
+        "desktop-ollama-cloud",
+        "zcode-luna",
+        "zcode-ollama-cloud",
+    ]
 
 
 def test_missing_manual_evidence_and_early_gui_exit_are_classified(tmp_path):
@@ -2591,7 +2880,7 @@ def test_candidate_context_budget_bootstrap_failure_is_bounded_and_sanitized(tmp
     serialized = startup_path.read_text() + summaries[0].read_text()
     assert str(tmp_path) not in serialized
     assert "fixture-codex-access-token" not in serialized
-    assert "fixture-volc-private-token" not in serialized
+    assert "fixture-ollama-private-token" not in serialized
     assert not list((tmp_path / "output" / "isolated" / "work").glob("gui-*.launched"))
 
 
@@ -2799,9 +3088,18 @@ def test_operator_commands_have_explicit_outer_and_manual_deadlines():
     assert "manual window is finite" in documentation
 
 
+def test_matrix_documentation_declares_native_responses_release_gate():
+    documentation = (ROOT / "docs" / "agents" / "real-client-e2e.md").read_text()
+
+    assert "Responses for the Official Luna leg and Native\nResponses for the Ollama Cloud leg" in documentation
+    assert "one full 12-case run is the Phase 0 / 0.1.7 release qualification" in documentation
+    assert "final frozen 0.1.7 candidate" in documentation
+    assert "previous Volc Chat Completions\npath remains available as ordinary, non-release regression coverage" in documentation
+
+
 def test_missing_credentials_fail_with_sanitized_summary_before_launch(tmp_path):
     def remove_credentials(_output, isolation, _debug):
-        (isolation / "credentials" / "volc.json").unlink()
+        (isolation / "credentials" / "ollama.json").unlink()
 
     result = _run(tmp_path, mutate=remove_credentials)
 

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -3,6 +3,7 @@ import os
 import gzip
 import io
 import json
+import socket
 import ssl
 import tempfile
 import threading
@@ -10,6 +11,7 @@ import time
 import unittest
 import weakref
 from dataclasses import replace
+from http.client import IncompleteRead
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from unittest.mock import Mock, call, patch
@@ -5107,7 +5109,1080 @@ class RoutingTests(unittest.TestCase):
             self.assertEqual(codex_proxy._upstream_retry_attempts(codex_proxy.RETRY_REQUEST_COMPACT), 3)
             self.assertEqual(codex_proxy._upstream_retry_attempts(codex_proxy.RETRY_REQUEST_IMAGE_PROXY_VISION), 3)
 
-    def test_open_upstream_response_retries_http_errors_for_any_provider(self):
+    def test_open_upstream_response_retries_pre_write_dns_tcp_refused_tls_cert_for_non_official_main_gen(self):
+        request = codex_proxy.Request("https://ark.example.test/v1/responses", data=b"{}", method="POST")
+        cases = [
+            (URLError(socket.gaierror("[Errno 11001] getaddrinfo failed")), "dns"),
+            (URLError(ConnectionRefusedError("Connection refused")), "tcp_connect"),
+            (ConnectionRefusedError("Connection refused"), "tcp_connect"),
+            (URLError(ssl.SSLCertVerificationError("certificate verify failed")), "tls_handshake"),
+            (ssl.SSLCertVerificationError("certificate verify failed"), "tls_handshake"),
+        ]
+
+        for exc, expected_phase in cases:
+            with self.subTest(error=type(exc).__name__, phase=expected_phase):
+                self.write_proxy_event.reset_mock()
+                success = FakeResponse(b'{"id":"resp_retry"}')
+                with (
+                    patch.dict(
+                        os.environ,
+                        {
+                            "CODEX_PROXY_AUTO_RETRY_ENABLED": "1",
+                            "CODEX_PROXY_AUTO_RETRY_MAX_ATTEMPTS": "2",
+                        },
+                        clear=False,
+                    ),
+                    patch("codex_proxy.urlopen", side_effect=[exc, success]) as mock_urlopen,
+                    patch("codex_proxy.time.sleep") as mock_sleep,
+                ):
+                    response = codex_proxy._open_upstream_response(
+                        request,
+                        upstream_name="volcengine",
+                        upstream_format="responses",
+                        timeout=1,
+                        event_context={"request_id": "req-pre-write", "model": "volc/glm-5.2"},
+                    )
+
+                self.assertIs(response, success)
+                self.assertEqual(mock_urlopen.call_count, 2)
+                mock_sleep.assert_called_once()
+                retry_events = [
+                    call for call in self.write_proxy_event.call_args_list
+                    if call.args and call.args[0] == "upstream_retry"
+                ]
+                self.assertEqual(len(retry_events), 1)
+                self.assertEqual(retry_events[0].kwargs["retry_safety_class"], "safe_prewrite")
+                self.assertEqual(retry_events[0].kwargs["failure_phase"], expected_phase)
+
+    def test_open_upstream_response_suppresses_ambiguous_open_failures_for_non_official_main_gen(self):
+        request = codex_proxy.Request("https://ark.example.test/v1/responses", data=b"{}", method="POST")
+        cases = [
+            URLError(TimeoutError("connect timed out")),
+            URLError(TimeoutError("operation timed out")),
+            ssl.SSLEOFError("EOF occurred in violation of protocol"),
+            URLError(ssl.SSLError("some tls alert")),
+            OSError("connection reset by peer"),
+            URLError(OSError("connection reset by peer")),
+            BrokenPipeError("broken pipe"),
+        ]
+
+        for exc in cases:
+            with self.subTest(error=repr(exc)):
+                self.write_proxy_event.reset_mock()
+                with (
+                    patch.dict(
+                        os.environ,
+                        {
+                            "CODEX_PROXY_AUTO_RETRY_ENABLED": "1",
+                            "CODEX_PROXY_AUTO_RETRY_MAX_ATTEMPTS": "2",
+                        },
+                        clear=False,
+                    ),
+                    patch("codex_proxy.urlopen", side_effect=[exc, FakeResponse(b'{"id":"resp_retry"}')]) as mock_urlopen,
+                    patch("codex_proxy.time.sleep") as mock_sleep,
+                ):
+                    with self.assertRaises(type(exc)):
+                        codex_proxy._open_upstream_response(
+                            request,
+                            upstream_name="volcengine",
+                            upstream_format="responses",
+                            timeout=1,
+                            event_context={"request_id": "req-ambiguous", "model": "volc/glm-5.2"},
+                        )
+
+                self.assertEqual(mock_urlopen.call_count, 1)
+                mock_sleep.assert_not_called()
+                retry_events = [
+                    call for call in self.write_proxy_event.call_args_list
+                    if call.args and call.args[0] == "upstream_retry"
+                ]
+                self.assertEqual(retry_events, [])
+                suppressed_events = [
+                    call for call in self.write_proxy_event.call_args_list
+                    if call.args and call.args[0] == "upstream_retry_suppressed"
+                ]
+                self.assertEqual(len(suppressed_events), 1)
+                self.assertEqual(suppressed_events[0].kwargs["retry_safety_class"], "unknown")
+                self.assertEqual(suppressed_events[0].kwargs["failure_phase"], "unknown")
+                self.assertEqual(suppressed_events[0].kwargs["attempt"], 1)
+                self.assertGreater(suppressed_events[0].kwargs["max_attempts"], 0)
+
+    def test_dns_text_needles_are_not_structural_proof_and_stay_suppressed(self):
+        """OS-level DNS message strings must not bypass the structural DNS check.
+
+        Only a nested ``socket.gaierror`` instance is authoritative DNS proof.
+        Text needles that happen to mention name resolution can occur after the
+        request has been written, so they must remain unknown/suppressed.
+        """
+        request = codex_proxy.Request("https://ark.example.test/v1/responses", data=b"{}", method="POST")
+        text_needle_cases = [
+            URLError(OSError("temporary failure in name resolution")),
+            URLError(OSError("getaddrinfo failed")),
+            URLError(OSError("nodename nor servname provided, or not known")),
+            URLError(OSError("No address associated with hostname")),
+            OSError("temporary failure in name resolution"),
+        ]
+
+        for exc in text_needle_cases:
+            with self.subTest(error=repr(exc)):
+                self.write_proxy_event.reset_mock()
+                with (
+                    patch.dict(
+                        os.environ,
+                        {
+                            "CODEX_PROXY_AUTO_RETRY_ENABLED": "1",
+                            "CODEX_PROXY_AUTO_RETRY_MAX_ATTEMPTS": "2",
+                        },
+                        clear=False,
+                    ),
+                    patch(
+                        "codex_proxy.urlopen",
+                        side_effect=[exc, FakeResponse(b'{"id":"resp_retry"}')],
+                    ) as mock_urlopen,
+                    patch("codex_proxy.time.sleep") as mock_sleep,
+                ):
+                    with self.assertRaises(type(exc)):
+                        codex_proxy._open_upstream_response(
+                            request,
+                            upstream_name="volcengine",
+                            upstream_format="responses",
+                            timeout=1,
+                            event_context={"request_id": "req-dns-needle", "model": "volc/glm-5.2"},
+                        )
+
+                self.assertEqual(mock_urlopen.call_count, 1)
+                mock_sleep.assert_not_called()
+                suppressed_events = [
+                    call for call in self.write_proxy_event.call_args_list
+                    if call.args and call.args[0] == "upstream_retry_suppressed"
+                ]
+                self.assertEqual(len(suppressed_events), 1)
+                self.assertEqual(suppressed_events[0].kwargs["retry_safety_class"], "unknown")
+                self.assertEqual(suppressed_events[0].kwargs["failure_phase"], "unknown")
+
+    def test_non_official_main_generation_retry_safety_regression(self):
+        """Deterministic coverage of every non-Official main-generation retry/fallback seam.
+
+        The contract requires: pre-write retries only for DNS (authoritative proof);
+        generic connect/TLS/write timeouts and HTTP errors are suppressed; stream
+        failures are suppressed post-write unless downstream content was exposed;
+        SSE error details are sanitized.
+        """
+        request = codex_proxy.Request("https://ark.example.test/v1/responses", data=b"{}", method="POST")
+        event_context = {"request_id": "req-regression", "model": "volc/glm-5.2"}
+
+        # 1. DNS open failure → safe_prewrite retry.
+        with (
+            patch.dict(
+                os.environ,
+                {"CODEX_PROXY_AUTO_RETRY_ENABLED": "1", "CODEX_PROXY_AUTO_RETRY_MAX_ATTEMPTS": "2"},
+                clear=False,
+            ),
+            patch(
+                "codex_proxy.urlopen",
+                side_effect=[
+                    URLError(socket.gaierror("[Errno 11001] getaddrinfo failed")),
+                    FakeResponse(b'{"id":"ok"}'),
+                ],
+            ) as mock_urlopen,
+            patch("codex_proxy.time.sleep"),
+        ):
+            response = codex_proxy._open_upstream_response(
+                request,
+                upstream_name="volcengine",
+                upstream_format="responses",
+                timeout=1,
+                event_context=event_context,
+            )
+        self.assertIsNotNone(response)
+        self.assertEqual(mock_urlopen.call_count, 2)
+
+        # 2. Generic TimeoutError open failure → unknown/suppressed.
+        with (
+            patch.dict(
+                os.environ,
+                {"CODEX_PROXY_AUTO_RETRY_ENABLED": "1", "CODEX_PROXY_AUTO_RETRY_MAX_ATTEMPTS": "2"},
+                clear=False,
+            ),
+            patch("codex_proxy.urlopen", side_effect=[URLError(TimeoutError("timed out"))]) as mock_urlopen,
+            patch("codex_proxy.time.sleep"),
+        ):
+            with self.assertRaises(URLError):
+                codex_proxy._open_upstream_response(
+                    request,
+                    upstream_name="volcengine",
+                    upstream_format="responses",
+                    timeout=1,
+                    event_context=event_context,
+                )
+        self.assertEqual(mock_urlopen.call_count, 1)
+        suppressed = [
+            call.kwargs
+            for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] == "upstream_retry_suppressed"
+        ]
+        self.assertTrue(
+            any(
+                e["retry_safety_class"] == "unknown" and e["failure_phase"] == "unknown"
+                for e in suppressed
+            )
+        )
+
+        # 3. HTTPError open failure → suppressed_post_write.
+        self.write_proxy_event.reset_mock()
+        error = HTTPError(
+            "https://ark.example.test/v1/responses",
+            503,
+            "Service Unavailable",
+            {},
+            io.BytesIO(b'{"error":"overloaded"}'),
+        )
+        with (
+            patch.dict(
+                os.environ,
+                {"CODEX_PROXY_AUTO_RETRY_ENABLED": "1", "CODEX_PROXY_AUTO_RETRY_MAX_ATTEMPTS": "2"},
+                clear=False,
+            ),
+            patch("codex_proxy.urlopen", side_effect=[error]) as mock_urlopen,
+            patch("codex_proxy.time.sleep"),
+        ):
+            with self.assertRaises(HTTPError):
+                codex_proxy._open_upstream_response(
+                    request,
+                    upstream_name="volcengine",
+                    upstream_format="responses",
+                    timeout=1,
+                    event_context=event_context,
+                )
+        self.assertEqual(mock_urlopen.call_count, 1)
+        suppressed = [
+            call.kwargs
+            for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] == "upstream_retry_suppressed"
+        ]
+        self.assertEqual(len(suppressed), 1)
+        self.assertEqual(suppressed[0]["retry_safety_class"], "suppressed_post_write")
+        self.assertEqual(suppressed[0]["failure_phase"], "response_headers")
+
+        # 4. Streaming empty completed response → suppressed_post_write.
+        self.write_proxy_event.reset_mock()
+        body = json.dumps(
+            {
+                "model": "volc/glm-5.2",
+                "input": [{"type": "message", "role": "user", "content": "hi"}],
+                "stream": True,
+            }
+        ).encode("utf-8")
+        handler = CodexProxyHandler.__new__(CodexProxyHandler)
+        handler.path = "/v1/responses"
+        handler.headers = {"Content-Length": str(len(body)), "Content-Type": "application/json"}
+        handler.rfile = io.BytesIO(body)
+        handler.close_connection = False
+        fake = FakeHandler()
+        handler.send_response = fake.send_response
+        handler.send_header = fake.send_header
+        handler.end_headers = fake.end_headers
+        handler.wfile = fake.wfile
+        empty_stream = FakeSseResponse(
+            [
+                b'data: {"type":"response.created","response":{"id":"reg_empty","status":"in_progress"}}\n\n',
+                b'data: {"type":"response.completed","response":{"id":"reg_empty","status":"completed","output":[],"usage":{"input_tokens":7,"output_tokens":0,"total_tokens":7}}}\n\n',
+                b"",
+            ]
+        )
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "CODEX_PROXY_AUTO_RETRY_ENABLED": "1",
+                    "CODEX_PROXY_AUTO_RETRY_MAX_ATTEMPTS": "5",
+                    "CODEX_PROXY_SSE_KEEPALIVE_SECONDS": "0",
+                },
+                clear=False,
+            ),
+            patch("codex_proxy.urlopen", return_value=empty_stream),
+            patch("codex_proxy._sleep_for_retry_with_gateway_cancellation") as mock_retry_wait,
+        ):
+            CodexProxyHandler.do_POST(handler)
+        mock_retry_wait.assert_not_called()
+        suppressed = [
+            call.kwargs
+            for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] == "upstream_retry_suppressed"
+        ]
+        self.assertTrue(
+            any(
+                e["error"] == "UpstreamEmptyCompletedResponseError"
+                and e["retry_safety_class"] == "suppressed_post_write"
+                for e in suppressed
+            )
+        )
+
+        # 5. Streaming incomplete after content exposed → suppressed_post_exposure.
+        self.write_proxy_event.reset_mock()
+        handler = CodexProxyHandler.__new__(CodexProxyHandler)
+        handler.path = "/v1/responses"
+        handler.headers = {"Content-Length": str(len(body)), "Content-Type": "application/json"}
+        handler.rfile = io.BytesIO(body)
+        handler.close_connection = False
+        fake = FakeHandler()
+        handler.send_response = fake.send_response
+        handler.send_header = fake.send_header
+        handler.end_headers = fake.end_headers
+        handler.wfile = fake.wfile
+        exposed_stream = FakeSseResponse(
+            [
+                b'data: {"type":"response.created","response":{"id":"reg_exposed","status":"in_progress"}}\n\n',
+                b'data: {"type":"response.output_text.delta","delta":"partial"}\n\n',
+                b"",
+            ]
+        )
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "CODEX_PROXY_AUTO_RETRY_ENABLED": "1",
+                    "CODEX_PROXY_AUTO_RETRY_MAX_ATTEMPTS": "5",
+                    "CODEX_PROXY_STREAM_RETRY_ELAPSED_LIMIT_SECONDS": "0",
+                    "CODEX_PROXY_SSE_KEEPALIVE_SECONDS": "0",
+                },
+                clear=False,
+            ),
+            patch("codex_proxy.urlopen", return_value=exposed_stream),
+            patch("codex_proxy._sleep_for_retry_with_gateway_cancellation") as mock_retry_wait,
+        ):
+            CodexProxyHandler.do_POST(handler)
+        mock_retry_wait.assert_not_called()
+        suppressed = [
+            call.kwargs
+            for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] == "upstream_retry_suppressed"
+        ]
+        self.assertTrue(
+            any(
+                e["error"] == "UpstreamStreamIncompleteError"
+                and e["retry_safety_class"] == "suppressed_post_exposure"
+                for e in suppressed
+            )
+        )
+
+    def test_stable_retry_identity_redacted_when_exception_echoes_header(self):
+        """A stable attempt identity must never leak outside the upstream header.
+
+        When the upstream transport exception embeds the idempotency header value,
+        retry telemetry and error detail must contain the redacted placeholder, not
+        the raw identity. The identity header itself must be stable across the
+        permitted attempts.
+        """
+        request = codex_proxy.Request("https://ark.example.test/v1/responses", data=b"{}", method="POST")
+        event_context: dict[str, Any] = {"request_id": "req-identity", "model": "volc/glm-5.2"}
+
+        def guaranteed(_model_access_path: tuple[str, ...]) -> bool:
+            return True
+
+        def urlopen_with_identity_echo(req, timeout=None):
+            identity = req.headers.get("X-CodexHub-Retry-Attempt-Identity")
+            if not identity:
+                raise AssertionError("idempotency header missing")
+            raise URLError(ConnectionRefusedError(f"Connection refused {identity}"))
+
+        with (
+            patch.dict(
+                os.environ,
+                {"CODEX_PROXY_AUTO_RETRY_ENABLED": "1", "CODEX_PROXY_AUTO_RETRY_MAX_ATTEMPTS": "2"},
+                clear=False,
+            ),
+            patch(
+                "codex_proxy._model_access_path_idempotency_guaranteed",
+                side_effect=guaranteed,
+            ) as guarantee_mock,
+            patch("codex_proxy.urlopen", side_effect=urlopen_with_identity_echo) as mock_urlopen,
+            patch("codex_proxy.time.sleep"),
+            patch("codex_proxy._write_adapter_event") as write_adapter,
+        ):
+            with self.assertRaises(URLError):
+                codex_proxy._open_upstream_response(
+                    request,
+                    upstream_name="volcengine",
+                    upstream_format="responses",
+                    timeout=1,
+                    event_context=event_context,
+                )
+
+        self.assertEqual(mock_urlopen.call_count, 2)
+        guarantee_mock.assert_called()
+        first_identity = mock_urlopen.call_args_list[0].args[0].headers.get("X-CodexHub-Retry-Attempt-Identity")
+        second_identity = mock_urlopen.call_args_list[1].args[0].headers.get("X-CodexHub-Retry-Attempt-Identity")
+        self.assertTrue(first_identity)
+        self.assertEqual(first_identity, second_identity)
+        self.assertEqual(len(first_identity), 32)
+
+        # The raw identity must not appear in any telemetry payload; the redacted
+        # placeholder must be present in the retry detail.
+        retry_details = []
+        for call in write_adapter.call_args_list:
+            args, kwargs = call
+            payload = dict(kwargs)
+            payload_str = json.dumps(payload, default=str)
+            self.assertNotIn(first_identity, payload_str)
+            if kwargs.get("detail"):
+                retry_details.append(kwargs["detail"])
+        self.assertTrue(
+            any("[retry_identity_redacted]" in d for d in retry_details),
+            retry_details,
+        )
+
+        # The public event context must not expose the private identity key or value.
+        public = codex_proxy._public_event_context(event_context)
+        self.assertNotIn("_retry_attempt_identity", public)
+        self.assertNotIn(first_identity, json.dumps(public, default=str))
+
+    def test_guaranteed_path_redacts_retry_identity_from_downstream_error(self):
+        """Full handler path: raw identity must not reach downstream error surfaces."""
+        body = json.dumps(
+            {
+                "model": "volc/glm-5.2",
+                "input": [{"type": "message", "role": "user", "content": "hi"}],
+                "stream": False,
+            }
+        ).encode("utf-8")
+        handler = CodexProxyHandler.__new__(CodexProxyHandler)
+        handler.path = "/v1/responses"
+        handler.headers = {"Content-Length": str(len(body)), "Content-Type": "application/json"}
+        handler.rfile = io.BytesIO(body)
+        handler.close_connection = False
+        fake = FakeHandler()
+        handler.send_response = fake.send_response
+        handler.send_header = fake.send_header
+        handler.end_headers = fake.end_headers
+        handler.wfile = fake.wfile
+
+        def guaranteed(_model_access_path: tuple[str, ...]) -> bool:
+            return True
+
+        captured_identities: list[str | None] = []
+
+        def urlopen_with_identity_echo(req, timeout=None):
+            identity = req.headers.get("X-CodexHub-Retry-Attempt-Identity")
+            captured_identities.append(identity)
+            if identity is None:
+                raise AssertionError("idempotency header missing")
+            raise URLError(ConnectionRefusedError(f"Connection refused {identity}"))
+
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "CODEX_PROXY_AUTO_RETRY_ENABLED": "1",
+                    "CODEX_PROXY_AUTO_RETRY_MAX_ATTEMPTS": "2",
+                },
+                clear=False,
+            ),
+            patch("codex_proxy._model_access_path_idempotency_guaranteed", side_effect=guaranteed),
+            patch("codex_proxy.urlopen", side_effect=urlopen_with_identity_echo),
+            patch("codex_proxy.time.sleep"),
+        ):
+            CodexProxyHandler.do_POST(handler)
+
+        # Header stable across permitted attempts.
+        self.assertEqual(len(captured_identities), 2)
+        self.assertEqual(captured_identities[0], captured_identities[1])
+        identity = captured_identities[0]
+        self.assertTrue(identity)
+
+        # Downstream response must not contain raw identity; detail should be redacted.
+        raw_response = b"".join(fake.wfile.writes)
+        self.assertNotIn(identity.encode(), raw_response)
+        self.assertIn(b"[retry_identity_redacted]", raw_response)
+
+        # Telemetry must not contain raw identity.
+        for call in self.write_proxy_event.call_args_list:
+            args, kwargs = call
+            payload_str = json.dumps(dict(kwargs), default=str)
+            self.assertNotIn(identity, payload_str)
+
+    def test_streaming_identity_echo_redacted_in_retry_notice_downstream_telemetry_and_logs(self):
+        """Upstream SSE error that echoes the stable identity must never leak it.
+
+        A guaranteed Model Access Path produces a stable ``X-CodexHub-Retry-Attempt-Identity``
+        header.  When the upstream first fails with a safe-prewrite error that embeds the
+        header value, a downstream retry notice is emitted.  The second attempt returns an
+        upstream SSE error event that also embeds the same identity.  The raw identity must
+        be absent from the retry notice, downstream SSE frames, telemetry, and logs.
+        """
+        body = json.dumps(
+            {
+                "model": "volc/glm-5.2",
+                "input": [{"type": "message", "role": "user", "content": "hi"}],
+                "stream": True,
+            }
+        ).encode("utf-8")
+        handler = CodexProxyHandler.__new__(CodexProxyHandler)
+        handler.path = "/v1/responses"
+        handler.headers = {"Content-Length": str(len(body)), "Content-Type": "application/json"}
+        handler.rfile = io.BytesIO(body)
+        handler.close_connection = False
+        fake = FakeHandler()
+        handler.send_response = fake.send_response
+        handler.send_header = fake.send_header
+        handler.end_headers = fake.end_headers
+        handler.wfile = fake.wfile
+
+        captured_identities: list[str | None] = []
+
+        def urlopen_with_retry_then_sse_error(req, timeout=None):
+            identity = req.headers.get("X-CodexHub-Retry-Attempt-Identity")
+            captured_identities.append(identity)
+            if len(captured_identities) == 1:
+                raise URLError(ConnectionRefusedError(f"Connection refused {identity}"))
+            error_event = json.dumps(
+                {
+                    "type": "error",
+                    "error": {
+                        "message": f"upstream internal error {identity}",
+                        "type": "internal_error",
+                        "code": "internal_error",
+                    },
+                },
+                ensure_ascii=True,
+                separators=(",", ":"),
+            )
+            return FakeSseResponse(
+                [
+                    b'data: {"type":"response.created","response":{"id":"stream_err","status":"in_progress"}}\n\n',
+                    f"data: {error_event}\n\n".encode("utf-8"),
+                    b"",
+                ]
+            )
+
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "CODEX_PROXY_AUTO_RETRY_ENABLED": "1",
+                    "CODEX_PROXY_AUTO_RETRY_MAX_ATTEMPTS": "2",
+                    "CODEX_PROXY_DOWNSTREAM_RETRY_NOTICE_ENABLED": "1",
+                    "CODEX_PROXY_SSE_KEEPALIVE_SECONDS": "0",
+                },
+                clear=False,
+            ),
+            patch("codex_proxy._model_access_path_idempotency_guaranteed", return_value=True),
+            patch("codex_proxy.urlopen", side_effect=urlopen_with_retry_then_sse_error),
+            patch("codex_proxy.time.sleep"),
+            self.assertLogs("codex_proxy", level="ERROR") as log_ctx,
+        ):
+            CodexProxyHandler.do_POST(handler)
+
+        self.assertEqual(len(captured_identities), 2)
+        identity = captured_identities[0]
+        self.assertTrue(identity)
+        self.assertEqual(captured_identities[0], captured_identities[1])
+
+        raw_response = b"".join(fake.wfile.writes)
+        self.assertNotIn(identity.encode(), raw_response)
+        self.assertIn(b"[retry_identity_redacted]", raw_response)
+
+        # Retry notice detail and SSE error detail are redacted, not raw.
+        self.assertIn(b"codexhub.retry", raw_response)
+
+        telemetry = [
+            json.dumps(dict(kwargs), default=str)
+            for call in self.write_proxy_event.call_args_list
+            for args, kwargs in [call]
+        ]
+        for payload_str in telemetry:
+            self.assertNotIn(identity, payload_str)
+
+        log_text = "\n".join(log_ctx.output)
+        self.assertNotIn(identity, log_text)
+
+    def test_transparent_responses_stream_interruption_redacts_identity_in_synthetic_terminal(self):
+        """Transparent Responses stream failure must not leak the stable retry identity.
+
+        The synthetic ``response.failed`` event, ``transparent_stream_closed`` telemetry,
+        and any downstream SSE frame must contain the redacted placeholder, not the raw
+        identity echoed by the upstream transport exception.
+        """
+        body = json.dumps(
+            {
+                "model": "openai/gpt-5.5",
+                "input": [{"type": "message", "role": "user", "content": "hi"}],
+                "stream": True,
+            }
+        ).encode("utf-8")
+        handler = CodexProxyHandler.__new__(CodexProxyHandler)
+        handler.path = "/v1/responses"
+        handler.headers = {
+            "Content-Length": str(len(body)),
+            "Content-Type": "application/json",
+            "X-Codex-Client-Id": "opencode",
+        }
+        handler.rfile = io.BytesIO(body)
+        handler.close_connection = False
+        fake = FakeHandler()
+        handler.send_response = fake.send_response
+        handler.send_header = fake.send_header
+        handler.end_headers = fake.end_headers
+        handler.wfile = fake.wfile
+
+        captured_identities: list[str | None] = []
+
+        def official_urlopen_with_identity_echo(req, timeout=None):
+            identity = req.headers.get("X-CodexHub-Retry-Attempt-Identity")
+            captured_identities.append(identity)
+            if identity is None:
+                raise AssertionError("idempotency header missing")
+            return FakeSseResponse(
+                [
+                    b'data: {"type":"response.created","response":{"id":"transparent_interrupt","status":"in_progress"}}\n\n',
+                    URLError(OSError(f"stream interrupted {identity}")),
+                ]
+            )
+
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "CODEX_PROXY_AUTO_RETRY_ENABLED": "1",
+                    "CODEX_PROXY_AUTO_RETRY_MAX_ATTEMPTS": "2",
+                    "CODEX_PROXY_SSE_KEEPALIVE_SECONDS": "0",
+                },
+                clear=False,
+            ),
+            patch("codex_proxy._model_access_path_idempotency_guaranteed", return_value=True),
+            patch("codex_proxy.codex_access_token", return_value="sub-token"),
+            patch("codex_proxy.codex_account_id", return_value="acct-1"),
+            patch("codex_proxy._official_urlopen", side_effect=official_urlopen_with_identity_echo),
+            patch("codex_proxy.time.sleep"),
+        ):
+            CodexProxyHandler.do_POST(handler)
+
+        identity = captured_identities[0]
+        self.assertTrue(identity)
+        self.assertEqual(captured_identities[0], captured_identities[1])
+
+        raw_response = b"".join(fake.wfile.writes)
+        self.assertNotIn(identity.encode(), raw_response)
+        self.assertIn(b"[retry_identity_redacted]", raw_response)
+        self.assertIn(b"response.failed", raw_response)
+
+        telemetry = [
+            json.dumps(dict(kwargs), default=str)
+            for call in self.write_proxy_event.call_args_list
+            for args, kwargs in [call]
+        ]
+        for payload_str in telemetry:
+            self.assertNotIn(identity, payload_str)
+
+    def test_guaranteed_non_stream_transparent_http_error_redacts_identity_in_body(self):
+        """A guaranteed transparent HTTP error body must not echo the stable retry identity.
+
+        The provider response body contains the idempotency header value; the Gateway
+        must redact it from the downstream body and telemetry while preserving
+        transparent byte identity for ordinary (non-guaranteed, non-error) routes.
+        """
+        body = json.dumps(
+            {
+                "model": "openai/gpt-5.5",
+                "input": [{"type": "message", "role": "user", "content": "hi"}],
+                "stream": False,
+            }
+        ).encode("utf-8")
+        handler = CodexProxyHandler.__new__(CodexProxyHandler)
+        handler.path = "/v1/responses"
+        handler.headers = {
+            "Content-Length": str(len(body)),
+            "Content-Type": "application/json",
+            "X-Codex-Client-Id": "opencode",
+        }
+        handler.rfile = io.BytesIO(body)
+        handler.close_connection = False
+        fake = FakeHandler()
+        handler.send_response = fake.send_response
+        handler.send_header = fake.send_header
+        handler.end_headers = fake.end_headers
+        handler.wfile = fake.wfile
+
+        captured_identities: list[str | None] = []
+
+        def official_urlopen_with_identity_echo(req, timeout=None):
+            identity = req.headers.get("X-CodexHub-Retry-Attempt-Identity")
+            captured_identities.append(identity)
+            if identity is None:
+                raise AssertionError("idempotency header missing")
+            error_body = json.dumps(
+                {"error": f"provider error {identity}"},
+                ensure_ascii=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+            raise HTTPError(
+                "https://api.openai.com/v1/responses",
+                503,
+                "Service Unavailable",
+                {},
+                io.BytesIO(error_body),
+            )
+
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "CODEX_PROXY_AUTO_RETRY_ENABLED": "1",
+                    "CODEX_PROXY_AUTO_RETRY_MAX_ATTEMPTS": "2",
+                },
+                clear=False,
+            ),
+            patch("codex_proxy._model_access_path_idempotency_guaranteed", return_value=True),
+            patch("codex_proxy.codex_access_token", return_value="sub-token"),
+            patch("codex_proxy.codex_account_id", return_value="acct-1"),
+            patch("codex_proxy._official_urlopen", side_effect=official_urlopen_with_identity_echo),
+            patch("codex_proxy.time.sleep"),
+        ):
+            CodexProxyHandler.do_POST(handler)
+
+        identity = captured_identities[0]
+        self.assertTrue(identity)
+        self.assertEqual(len(captured_identities), 2)
+        self.assertEqual(captured_identities[0], captured_identities[1])
+
+        raw_response = b"".join(fake.wfile.writes)
+        self.assertNotIn(identity.encode(), raw_response)
+        self.assertIn(b"[retry_identity_redacted]", raw_response)
+
+        # Response must be a single parseable JSON body (no duplicate terminal/fallback).
+        response_payload = json.loads(raw_response)
+        self.assertEqual(response_payload["error"], "provider error [retry_identity_redacted]")
+        self.assertEqual(fake.status, 503)
+        self.assertTrue(fake.headers_ended)
+
+        # Content-Length must reflect the redacted downstream body, not the upstream body.
+        content_length_values = [
+            value for key, value in fake.headers if key.lower() == "content-length"
+        ]
+        self.assertEqual(content_length_values, [str(len(raw_response))])
+
+        telemetry = [
+            json.dumps(dict(kwargs), default=str)
+            for call in self.write_proxy_event.call_args_list
+            for args, kwargs in [call]
+        ]
+        for payload_str in telemetry:
+            self.assertNotIn(identity, payload_str)
+
+    def test_guaranteed_non_stream_transparent_gzip_error_redacts_identity_and_drops_encoding(self):
+        """A gzip-encoded guaranteed transparent HTTP error body must be decoded,
+        redacted, and returned without Content-Encoding so the client does not
+        decompress a body that already contains the raw retry identity.
+        """
+        body = json.dumps(
+            {
+                "model": "openai/gpt-5.5",
+                "input": [{"type": "message", "role": "user", "content": "hi"}],
+                "stream": False,
+            }
+        ).encode("utf-8")
+        handler = CodexProxyHandler.__new__(CodexProxyHandler)
+        handler.path = "/v1/responses"
+        handler.headers = {
+            "Content-Length": str(len(body)),
+            "Content-Type": "application/json",
+            "X-Codex-Client-Id": "opencode",
+        }
+        handler.rfile = io.BytesIO(body)
+        handler.close_connection = False
+        fake = FakeHandler()
+        handler.send_response = fake.send_response
+        handler.send_header = fake.send_header
+        handler.end_headers = fake.end_headers
+        handler.wfile = fake.wfile
+
+        captured_identities: list[str | None] = []
+
+        def official_urlopen_with_gzip_identity_echo(req, timeout=None):
+            identity = req.headers.get("X-CodexHub-Retry-Attempt-Identity")
+            captured_identities.append(identity)
+            if identity is None:
+                raise AssertionError("idempotency header missing")
+            error_body = json.dumps(
+                {"error": f"provider error {identity}"},
+                ensure_ascii=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+            gzipped = gzip.compress(error_body)
+            raise HTTPError(
+                "https://api.openai.com/v1/responses",
+                503,
+                "Service Unavailable",
+                {"Content-Encoding": "gzip"},
+                io.BytesIO(gzipped),
+            )
+
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "CODEX_PROXY_AUTO_RETRY_ENABLED": "1",
+                    "CODEX_PROXY_AUTO_RETRY_MAX_ATTEMPTS": "2",
+                },
+                clear=False,
+            ),
+            patch("codex_proxy._model_access_path_idempotency_guaranteed", return_value=True),
+            patch("codex_proxy.codex_access_token", return_value="sub-token"),
+            patch("codex_proxy.codex_account_id", return_value="acct-1"),
+            patch("codex_proxy._official_urlopen", side_effect=official_urlopen_with_gzip_identity_echo),
+            patch("codex_proxy.time.sleep"),
+        ):
+            CodexProxyHandler.do_POST(handler)
+
+        identity = captured_identities[0]
+        self.assertTrue(identity)
+        self.assertEqual(len(captured_identities), 2)
+        self.assertEqual(captured_identities[0], captured_identities[1])
+
+        raw_response = b"".join(fake.wfile.writes)
+        self.assertNotIn(identity.encode(), raw_response)
+        self.assertIn(b"[retry_identity_redacted]", raw_response)
+
+        response_payload = json.loads(raw_response)
+        self.assertEqual(response_payload["error"], "provider error [retry_identity_redacted]")
+        self.assertEqual(fake.status, 503)
+        self.assertTrue(fake.headers_ended)
+
+        header_names = {key.lower() for key, _ in fake.headers}
+        self.assertNotIn("content-encoding", header_names)
+        content_length_values = [
+            value for key, value in fake.headers if key.lower() == "content-length"
+        ]
+        self.assertEqual(content_length_values, [str(len(raw_response))])
+
+        telemetry = [
+            json.dumps(dict(kwargs), default=str)
+            for call in self.write_proxy_event.call_args_list
+            for args, kwargs in [call]
+        ]
+        for payload_str in telemetry:
+            self.assertNotIn(identity, payload_str)
+
+    def test_transparent_non_stream_body_read_interruption_emits_terminal_response(self):
+        """A non-stream transparent body read failure must emit exactly one
+        sanitized target-protocol terminal response, not just telemetry.
+        """
+        body = json.dumps(
+            {
+                "model": "openai/gpt-5.5",
+                "input": [{"type": "message", "role": "user", "content": "hi"}],
+                "stream": False,
+            }
+        ).encode("utf-8")
+        handler = CodexProxyHandler.__new__(CodexProxyHandler)
+        handler.path = "/v1/responses"
+        handler.headers = {
+            "Content-Length": str(len(body)),
+            "Content-Type": "application/json",
+            "X-Codex-Client-Id": "opencode",
+        }
+        handler.rfile = io.BytesIO(body)
+        handler.close_connection = False
+        fake = FakeHandler()
+        handler.send_response = fake.send_response
+        handler.send_header = fake.send_header
+        handler.end_headers = fake.end_headers
+        handler.wfile = fake.wfile
+
+        class InterruptingResponse:
+            status = 200
+            headers = {
+                "Content-Type": "application/json",
+                "Content-Length": "100",
+            }
+
+            def read(self, size=-1):
+                raise IncompleteRead(b"")
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, traceback):
+                return None
+
+        with (
+            patch.dict(
+                os.environ,
+                {"CODEX_PROXY_AUTO_RETRY_ENABLED": "1", "CODEX_PROXY_AUTO_RETRY_MAX_ATTEMPTS": "2"},
+                clear=False,
+            ),
+            patch("codex_proxy._model_access_path_idempotency_guaranteed", return_value=False),
+            patch("codex_proxy.codex_access_token", return_value="sub-token"),
+            patch("codex_proxy.codex_account_id", return_value="acct-1"),
+            patch("codex_proxy._official_urlopen", return_value=InterruptingResponse()),
+            patch("codex_proxy.time.sleep"),
+        ):
+            CodexProxyHandler.do_POST(handler)
+
+        raw_response = b"".join(fake.wfile.writes)
+        response_payload = json.loads(raw_response)
+        self.assertEqual(fake.status, 502)
+        self.assertTrue(fake.headers_ended)
+        self.assertIn("error", response_payload)
+
+        telemetry_event_types = [
+            call.args[0] for call in self.write_proxy_event.call_args_list if call.args
+        ]
+        self.assertIn("transparent_body_read_failed", telemetry_event_types)
+
+    def _guaranteed_transparent_non_stream_handler_setup(self):
+        body = json.dumps(
+            {
+                "model": "openai/gpt-5.5",
+                "input": [{"type": "message", "role": "user", "content": "hi"}],
+                "stream": False,
+            }
+        ).encode("utf-8")
+        handler = CodexProxyHandler.__new__(CodexProxyHandler)
+        handler.path = "/v1/responses"
+        handler.headers = {
+            "Content-Length": str(len(body)),
+            "Content-Type": "application/json",
+            "X-Codex-Client-Id": "opencode",
+        }
+        handler.rfile = io.BytesIO(body)
+        handler.close_connection = False
+        fake = FakeHandler()
+        handler.send_response = fake.send_response
+        handler.send_header = fake.send_header
+        handler.end_headers = fake.end_headers
+        handler.wfile = fake.wfile
+        return handler, fake
+
+    def test_guaranteed_non_stream_transparent_unsupported_encoding_fails_closed(self):
+        """An unsupported Content-Encoding on a guaranteed error body must fail
+        closed with a sanitized terminal response, not forward encoded bytes that
+        could leak the stable retry identity after downstream decoding.
+        """
+        handler, fake = self._guaranteed_transparent_non_stream_handler_setup()
+        captured_identities: list[str | None] = []
+
+        def official_urlopen_with_br_identity_echo(req, timeout=None):
+            identity = req.headers.get("X-CodexHub-Retry-Attempt-Identity")
+            captured_identities.append(identity)
+            if identity is None:
+                raise AssertionError("idempotency header missing")
+            error_body = json.dumps(
+                {"error": f"provider error {identity}"},
+                ensure_ascii=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+            raise HTTPError(
+                "https://api.openai.com/v1/responses",
+                503,
+                "Service Unavailable",
+                {"Content-Encoding": "br"},
+                io.BytesIO(error_body),
+            )
+
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "CODEX_PROXY_AUTO_RETRY_ENABLED": "1",
+                    "CODEX_PROXY_AUTO_RETRY_MAX_ATTEMPTS": "2",
+                },
+                clear=False,
+            ),
+            patch("codex_proxy._model_access_path_idempotency_guaranteed", return_value=True),
+            patch("codex_proxy.codex_access_token", return_value="sub-token"),
+            patch("codex_proxy.codex_account_id", return_value="acct-1"),
+            patch("codex_proxy._official_urlopen", side_effect=official_urlopen_with_br_identity_echo),
+            patch("codex_proxy.time.sleep"),
+        ):
+            CodexProxyHandler.do_POST(handler)
+
+        identity = captured_identities[0]
+        self.assertTrue(identity)
+        self.assertEqual(len(captured_identities), 2)
+        self.assertEqual(captured_identities[0], captured_identities[1])
+
+        raw_response = b"".join(fake.wfile.writes)
+        self.assertNotIn(identity.encode(), raw_response)
+        response_payload = json.loads(raw_response)
+        self.assertIn("error", response_payload)
+        self.assertEqual(fake.status, 502)
+        self.assertTrue(fake.headers_ended)
+
+        header_names = {key.lower() for key, _ in fake.headers}
+        self.assertNotIn("content-encoding", header_names)
+        content_length_values = [
+            value for key, value in fake.headers if key.lower() == "content-length"
+        ]
+        self.assertEqual(content_length_values, [str(len(raw_response))])
+
+        telemetry_event_types = [
+            call.args[0] for call in self.write_proxy_event.call_args_list if call.args
+        ]
+        self.assertIn("transparent_body_decode_failed", telemetry_event_types)
+
+    def test_guaranteed_non_stream_transparent_malformed_gzip_fails_closed(self):
+        """A malformed gzip body on a guaranteed error must fail closed rather
+        than forward bytes that downstream would decompress and expose.
+        """
+        handler, fake = self._guaranteed_transparent_non_stream_handler_setup()
+        captured_identities: list[str | None] = []
+
+        def official_urlopen_with_bad_gzip_identity_echo(req, timeout=None):
+            identity = req.headers.get("X-CodexHub-Retry-Attempt-Identity")
+            captured_identities.append(identity)
+            if identity is None:
+                raise AssertionError("idempotency header missing")
+            raise HTTPError(
+                "https://api.openai.com/v1/responses",
+                503,
+                "Service Unavailable",
+                {"Content-Encoding": "gzip"},
+                io.BytesIO(b"this is not gzip"),
+            )
+
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "CODEX_PROXY_AUTO_RETRY_ENABLED": "1",
+                    "CODEX_PROXY_AUTO_RETRY_MAX_ATTEMPTS": "2",
+                },
+                clear=False,
+            ),
+            patch("codex_proxy._model_access_path_idempotency_guaranteed", return_value=True),
+            patch("codex_proxy.codex_access_token", return_value="sub-token"),
+            patch("codex_proxy.codex_account_id", return_value="acct-1"),
+            patch("codex_proxy._official_urlopen", side_effect=official_urlopen_with_bad_gzip_identity_echo),
+            patch("codex_proxy.time.sleep"),
+        ):
+            CodexProxyHandler.do_POST(handler)
+
+        identity = captured_identities[0]
+        self.assertTrue(identity)
+        self.assertEqual(len(captured_identities), 2)
+        self.assertEqual(captured_identities[0], captured_identities[1])
+
+        raw_response = b"".join(fake.wfile.writes)
+        self.assertNotIn(identity.encode(), raw_response)
+        response_payload = json.loads(raw_response)
+        self.assertIn("error", response_payload)
+        self.assertEqual(fake.status, 502)
+        self.assertTrue(fake.headers_ended)
+
+        header_names = {key.lower() for key, _ in fake.headers}
+        self.assertNotIn("content-encoding", header_names)
+        content_length_values = [
+            value for key, value in fake.headers if key.lower() == "content-length"
+        ]
+        self.assertEqual(content_length_values, [str(len(raw_response))])
+
+        telemetry_event_types = [
+            call.args[0] for call in self.write_proxy_event.call_args_list if call.args
+        ]
+        self.assertIn("transparent_body_decode_failed", telemetry_event_types)
+
+    def test_open_upstream_response_suppresses_http_errors_for_non_official_main_gen(self):
         request = codex_proxy.Request("https://ark.example.test/v1/responses", data=b"{}", method="POST")
         error = HTTPError(
             "https://ark.example.test/v1/responses",
@@ -5130,33 +6205,122 @@ class RoutingTests(unittest.TestCase):
             patch("codex_proxy.urlopen", side_effect=[error, success]) as mock_urlopen,
             patch("codex_proxy.time.sleep") as mock_sleep,
         ):
+            with self.assertRaises(HTTPError):
+                codex_proxy._open_upstream_response(
+                    request,
+                    upstream_name="volcengine",
+                    upstream_format="responses",
+                    timeout=1,
+                    event_context={"request_id": "req_retry", "model": "volc/glm-5.2"},
+                )
+
+        self.assertEqual(mock_urlopen.call_count, 1)
+        mock_sleep.assert_not_called()
+        suppressed_events = [
+            call for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] == "upstream_retry_suppressed"
+        ]
+        self.assertEqual(len(suppressed_events), 1)
+        fields = suppressed_events[0].kwargs
+        self.assertEqual(fields["request_id"], "req_retry")
+        self.assertEqual(fields["model"], "volc/glm-5.2")
+        self.assertEqual(fields["upstream"], "volcengine")
+        self.assertEqual(fields["status"], 429)
+        self.assertEqual(fields["error"], "HTTPError")
+        self.assertEqual(fields["failure_class"], codex_proxy.RETRY_FAILURE_PROVIDER_THROTTLE)
+        self.assertEqual(fields["retry_safety_class"], "suppressed_post_write")
+        self.assertFalse(fields["retryable"])
+
+    def test_open_upstream_response_uses_stable_identity_for_guaranteed_path(self):
+        request = codex_proxy.Request("https://ark.example.test/v1/responses", data=b"{}", method="POST")
+        error = HTTPError(
+            "https://ark.example.test/v1/responses",
+            503,
+            "Service Unavailable",
+            {},
+            io.BytesIO(b'{"error":"overloaded"}'),
+        )
+        success = FakeResponse(b'{"id":"resp_retry"}')
+        event_context: dict[str, Any] = {"request_id": "req-guaranteed", "model": "volc/glm-5.2"}
+
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "CODEX_PROXY_AUTO_RETRY_ENABLED": "1",
+                    "CODEX_PROXY_AUTO_RETRY_MAX_ATTEMPTS": "2",
+                },
+                clear=False,
+            ),
+            patch(
+                "codex_proxy._model_access_path_idempotency_guaranteed",
+                return_value=True,
+            ) as guarantee_check,
+            patch("codex_proxy.urlopen", side_effect=[error, success]) as mock_urlopen,
+            patch("codex_proxy.time.sleep"),
+        ):
             response = codex_proxy._open_upstream_response(
                 request,
                 upstream_name="volcengine",
                 upstream_format="responses",
                 timeout=1,
-                event_context={"request_id": "req_retry", "model": "volc/glm-5.2"},
+                event_context=event_context,
             )
 
         self.assertIs(response, success)
         self.assertEqual(mock_urlopen.call_count, 2)
-        mock_sleep.assert_called_once_with(10)
+        guarantee_check.assert_called()
+        identity = event_context.get("_retry_attempt_identity")
+        self.assertIsInstance(identity, str)
+        self.assertEqual(len(identity), 32)
+        for call in mock_urlopen.call_args_list:
+            sent_request = call.args[0]
+            self.assertEqual(
+                sent_request.headers.get("X-CodexHub-Retry-Attempt-Identity"),
+                identity,
+            )
         retry_events = [
             call for call in self.write_proxy_event.call_args_list
             if call.args and call.args[0] == "upstream_retry"
         ]
         self.assertEqual(len(retry_events), 1)
-        fields = retry_events[0].kwargs
-        self.assertEqual(fields["request_id"], "req_retry")
-        self.assertEqual(fields["model"], "volc/glm-5.2")
-        self.assertEqual(fields["upstream"], "volcengine")
-        self.assertEqual(fields["provider_id"], "volcengine")
-        self.assertEqual(fields["status"], 429)
-        self.assertEqual(fields["error"], "HTTPError")
-        self.assertEqual(fields["failure_class"], codex_proxy.RETRY_FAILURE_PROVIDER_THROTTLE)
-        self.assertEqual(fields["attempt"], 1)
-        self.assertEqual(fields["max_attempts"], 3)
-        self.assertEqual(fields["delay_ms"], 10000)
+        self.assertEqual(retry_events[0].kwargs["retry_safety_class"], "guaranteed_idempotent")
+
+    def test_open_upstream_response_suppresses_after_downstream_exposure(self):
+        request = codex_proxy.Request("https://ark.example.test/v1/responses", data=b"{}", method="POST")
+        error = URLError(TimeoutError("connect timed out"))
+        exposed = True
+
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "CODEX_PROXY_AUTO_RETRY_ENABLED": "1",
+                    "CODEX_PROXY_AUTO_RETRY_MAX_ATTEMPTS": "2",
+                },
+                clear=False,
+            ),
+            patch("codex_proxy.urlopen", side_effect=error) as mock_urlopen,
+            patch("codex_proxy.time.sleep") as mock_sleep,
+        ):
+            with self.assertRaises(URLError):
+                codex_proxy._open_upstream_response(
+                    request,
+                    upstream_name="volcengine",
+                    upstream_format="responses",
+                    timeout=1,
+                    event_context={"request_id": "req-exposed", "model": "volc/glm-5.2"},
+                    downstream_exposed=lambda: exposed,
+                )
+
+        self.assertEqual(mock_urlopen.call_count, 1)
+        mock_sleep.assert_not_called()
+        suppressed_events = [
+            call for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] == "upstream_retry_suppressed"
+        ]
+        self.assertEqual(len(suppressed_events), 1)
+        self.assertEqual(suppressed_events[0].kwargs["retry_safety_class"], "suppressed_post_exposure")
 
     def test_official_open_uses_gateway_owned_pooled_transport(self):
         request = codex_proxy.Request("https://chatgpt.com/backend-api/codex/responses", data=b"{}", method="POST")
@@ -5502,9 +6666,12 @@ class RoutingTests(unittest.TestCase):
         raw_response.release_conn.assert_called_once()
         raw_response.close.assert_not_called()
 
-    def test_transparent_retry_retries_open_failure_without_downstream_notice(self):
+    def test_transparent_retry_retries_dns_open_failure_without_downstream_notice(self):
+        # Only a specifically verified DNS failure carries authoritative
+        # pre-write proof; generic connect/TLS timeouts are ambiguous because
+        # urlopen spans write and response-header wait.
         request = codex_proxy.Request("https://example.test/v1/chat/completions", data=b"{}", method="POST")
-        error = URLError(TimeoutError("connect timed out"))
+        error = URLError(socket.gaierror("[Errno 11001] getaddrinfo failed"))
         success = FakeResponse(b'{"id":"ok","choices":[{"message":{"content":"done"}}]}')
         downstream_retry = Mock()
 
@@ -5578,7 +6745,7 @@ class RoutingTests(unittest.TestCase):
                 ]
                 self.assertEqual(retry_events, [])
 
-    def test_open_upstream_response_retries_transient_http_errors(self):
+    def test_open_upstream_response_suppresses_transient_http_errors_for_non_official_main_gen(self):
         request = codex_proxy.Request("https://ark.example.test/v1/responses", data=b"{}", method="POST")
         for status in (408, 409, 421, 425, 429, 500, 502, 503, 504, 520):
             with self.subTest(status=status):
@@ -5604,21 +6771,27 @@ class RoutingTests(unittest.TestCase):
                     patch("codex_proxy.urlopen", side_effect=[error, success]) as mock_urlopen,
                     patch("codex_proxy.time.sleep") as mock_sleep,
                 ):
-                    response = codex_proxy._open_upstream_response(
-                        request,
-                        upstream_name="volcengine",
-                        upstream_format="responses",
-                        timeout=1,
-                        event_context={"request_id": "req_transient", "model": "volc/glm-5.2"},
-                        request_kind="main_generation",
-                    )
+                    with self.assertRaises(HTTPError):
+                        codex_proxy._open_upstream_response(
+                            request,
+                            upstream_name="volcengine",
+                            upstream_format="responses",
+                            timeout=1,
+                            event_context={"request_id": "req_transient", "model": "volc/glm-5.2"},
+                            request_kind="main_generation",
+                        )
 
-                self.assertIs(response, success)
-                self.assertEqual(mock_urlopen.call_count, 2)
-                expected_delay = 10 if status == 429 else 2
-                mock_sleep.assert_called_once_with(expected_delay)
+                self.assertEqual(mock_urlopen.call_count, 1)
+                mock_sleep.assert_not_called()
+                suppressed_events = [
+                    call for call in self.write_proxy_event.call_args_list
+                    if call.args and call.args[0] == "upstream_retry_suppressed"
+                ]
+                self.assertEqual(len(suppressed_events), 1)
+                self.assertEqual(suppressed_events[0].kwargs["retry_safety_class"], "suppressed_post_write")
+                self.assertEqual(suppressed_events[0].kwargs["status"], status)
 
-    def test_open_upstream_response_classifies_provider_capacity_codes(self):
+    def test_open_upstream_response_suppresses_provider_capacity_codes_for_non_official_main_gen(self):
         request = codex_proxy.Request("https://ark.example.test/v1/responses", data=b"{}", method="POST")
         cases = [
             (
@@ -5653,28 +6826,29 @@ class RoutingTests(unittest.TestCase):
                         },
                         clear=False,
                     ),
-                    patch("codex_proxy.urlopen", side_effect=[error, success]),
+                    patch("codex_proxy.urlopen", side_effect=[error, success]) as mock_urlopen,
                     patch("codex_proxy.time.sleep") as mock_sleep,
                 ):
-                    response = codex_proxy._open_upstream_response(
-                        request,
-                        upstream_name="volcengine",
-                        upstream_format="responses",
-                        timeout=1,
-                        event_context={"request_id": "req_capacity", "model": "volc/glm-5.2"},
-                        request_kind="main_generation",
-                    )
+                    with self.assertRaises(HTTPError):
+                        codex_proxy._open_upstream_response(
+                            request,
+                            upstream_name="volcengine",
+                            upstream_format="responses",
+                            timeout=1,
+                            event_context={"request_id": "req_capacity", "model": "volc/glm-5.2"},
+                            request_kind="main_generation",
+                        )
 
-                self.assertIs(response, success)
-                expected_delay = 10 if expected_class == codex_proxy.RETRY_FAILURE_PROVIDER_THROTTLE else 2
-                mock_sleep.assert_called_once_with(expected_delay)
-                retry_events = [
+                self.assertEqual(mock_urlopen.call_count, 1)
+                mock_sleep.assert_not_called()
+                suppressed_events = [
                     call.kwargs for call in self.write_proxy_event.call_args_list
-                    if call.args and call.args[0] == "upstream_retry"
+                    if call.args and call.args[0] == "upstream_retry_suppressed"
                 ]
-                self.assertEqual(len(retry_events), 1)
-                self.assertEqual(retry_events[0]["failure_class"], expected_class)
-                self.assertEqual(retry_events[0]["delay_ms"], expected_delay * 1000)
+                self.assertEqual(len(suppressed_events), 1)
+                self.assertEqual(suppressed_events[0]["failure_class"], expected_class)
+                self.assertEqual(suppressed_events[0]["retry_safety_class"], "suppressed_post_write")
+                self.assertFalse(suppressed_events[0]["retryable"])
 
     def test_stream_error_event_classifies_common_provider_error_values(self):
         cases = [
@@ -5856,19 +7030,15 @@ class RoutingTests(unittest.TestCase):
         ]
         self.assertEqual(retry_events, [])
 
-    def test_open_upstream_response_capacity_retry_uses_global_attempts_without_request_kind_override(self):
+    def test_open_upstream_response_suppresses_capacity_retry_for_non_official_main_gen(self):
         request = codex_proxy.Request("https://ark.example.test/v1/responses", data=b"{}", method="POST")
-        errors = [
-            HTTPError(
-                "https://ark.example.test/v1/responses",
-                429,
-                "Too Many Requests",
-                {},
-                io.BytesIO(b'{"error":{"code":"11210","message":"tpm exceeded"}}'),
-            )
-            for _ in range(4)
-        ]
-        success = FakeResponse(b'{"id":"resp_retry"}')
+        error = HTTPError(
+            "https://ark.example.test/v1/responses",
+            429,
+            "Too Many Requests",
+            {},
+            io.BytesIO(b'{"error":{"code":"11210","message":"tpm exceeded"}}'),
+        )
 
         with (
             patch.dict(
@@ -5879,26 +7049,28 @@ class RoutingTests(unittest.TestCase):
                 },
                 clear=False,
             ),
-            patch("codex_proxy.urlopen", side_effect=[*errors, success]) as mock_urlopen,
+            patch("codex_proxy.urlopen", side_effect=error) as mock_urlopen,
             patch("codex_proxy.time.sleep") as mock_sleep,
         ):
-            response = codex_proxy._open_upstream_response(
-                request,
-                upstream_name="volcengine",
-                upstream_format="responses",
-                timeout=1,
-                event_context={"request_id": "req_capacity_global", "model": "volc/glm-5.2"},
-                request_kind="main_generation",
-            )
+            with self.assertRaises(HTTPError):
+                codex_proxy._open_upstream_response(
+                    request,
+                    upstream_name="volcengine",
+                    upstream_format="responses",
+                    timeout=1,
+                    event_context={"request_id": "req_capacity_global", "model": "volc/glm-5.2"},
+                    request_kind="main_generation",
+                )
 
-        self.assertIs(response, success)
-        self.assertEqual(mock_urlopen.call_count, 5)
-        self.assertEqual([call.args[0] for call in mock_sleep.call_args_list], [10, 20, 30, 60])
-        retry_events = [
+        self.assertEqual(mock_urlopen.call_count, 1)
+        mock_sleep.assert_not_called()
+        suppressed_events = [
             call.kwargs for call in self.write_proxy_event.call_args_list
-            if call.args and call.args[0] == "upstream_retry"
+            if call.args and call.args[0] == "upstream_retry_suppressed"
         ]
-        self.assertEqual([event["max_attempts"] for event in retry_events], [5, 5, 5, 5])
+        self.assertEqual(len(suppressed_events), 1)
+        self.assertEqual(suppressed_events[0]["failure_class"], codex_proxy.RETRY_FAILURE_PROVIDER_THROTTLE)
+        self.assertEqual(suppressed_events[0]["retry_safety_class"], "suppressed_post_write")
 
     def test_stream_quick_transient_retry_uses_global_attempts_without_request_kind_override(self):
         with patch.dict(
@@ -5932,7 +7104,7 @@ class RoutingTests(unittest.TestCase):
                 5,
             )
 
-    def test_open_upstream_response_respects_x_should_retry_headers(self):
+    def test_open_upstream_response_x_should_retry_headers_cannot_override_unsafe_phase_for_non_official(self):
         request = codex_proxy.Request("https://ark.example.test/v1/responses", data=b"{}", method="POST")
         forced_retry = HTTPError(
             "https://ark.example.test/v1/responses",
@@ -5960,19 +7132,18 @@ class RoutingTests(unittest.TestCase):
                 clear=False,
             ),
             patch("codex_proxy.urlopen", side_effect=[forced_retry, success]) as mock_urlopen,
-            patch("codex_proxy.time.sleep"),
+            patch("codex_proxy.time.sleep") as mock_sleep,
         ):
-            self.assertIs(
+            with self.assertRaises(HTTPError):
                 codex_proxy._open_upstream_response(
                     request,
                     upstream_name="volcengine",
                     upstream_format="responses",
                     timeout=1,
                     request_kind="main_generation",
-                ),
-                success,
-            )
-        self.assertEqual(mock_urlopen.call_count, 2)
+                )
+        self.assertEqual(mock_urlopen.call_count, 1)
+        mock_sleep.assert_not_called()
 
         with (
             patch.dict(
@@ -6098,14 +7269,6 @@ class RoutingTests(unittest.TestCase):
             {},
             io.BytesIO(b'{"error":{"type":"server_error","message":"try later"}}'),
         )
-        success = FakeSseResponse(
-            [
-                b'data: {"type":"response.created","response":{"id":"resp_retry","status":"in_progress"}}\n\n',
-                b'data: {"type":"response.output_text.delta","delta":"ok"}\n\n',
-                b'data: {"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":1,"output_tokens":1}}}\n\n',
-                b"",
-            ]
-        )
 
         with (
             patch.dict(
@@ -6116,25 +7279,29 @@ class RoutingTests(unittest.TestCase):
                 },
                 clear=False,
             ),
-            patch("codex_proxy.urlopen", side_effect=[error, success]) as mock_urlopen,
+            patch("codex_proxy.urlopen", side_effect=error) as mock_urlopen,
             patch("codex_proxy._sleep_for_retry_with_gateway_cancellation") as mock_retry_wait,
         ):
             CodexProxyHandler.do_POST(handler)
 
-        self.assertEqual(mock_urlopen.call_count, 2)
-        mock_retry_wait.assert_called_once_with(2)
-        self.assertEqual(fake.status, 200)
+        self.assertEqual(mock_urlopen.call_count, 1)
+        mock_retry_wait.assert_not_called()
         written = b"".join(fake.wfile.writes)
         self.assertNotIn(b"event: codexhub.retry\n", written)
         self.assertNotIn(b'"type":"codexhub.retry"', written)
-        self.assertIn(b"response.output_text.delta", written)
         notice_events = [
             call.kwargs for call in self.write_proxy_event.call_args_list
             if call.args and call.args[0] == "sse_retry_notice"
         ]
         self.assertEqual(notice_events, [])
+        suppressed_events = [
+            call.kwargs for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] == "upstream_retry_suppressed"
+        ]
+        self.assertEqual(len(suppressed_events), 1)
+        self.assertEqual(suppressed_events[0]["retry_safety_class"], "suppressed_post_write")
 
-    def test_post_responses_streaming_retries_read_error_before_first_upstream_event(self):
+    def test_post_responses_streaming_suppresses_read_error_for_non_official_main_gen(self):
         body = json.dumps(
             {
                 "model": "volc/glm-5.2",
@@ -6156,14 +7323,6 @@ class RoutingTests(unittest.TestCase):
         handler.end_headers = fake.end_headers
         handler.wfile = fake.wfile
         failed_stream = FakeSseResponse([TimeoutError("read timed out")])
-        success = FakeSseResponse(
-            [
-                b'data: {"type":"response.created","response":{"id":"resp_retry","status":"in_progress"}}\n\n',
-                b'data: {"type":"response.output_text.delta","delta":"ok"}\n\n',
-                b'data: {"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":1,"output_tokens":1}}}\n\n',
-                b"",
-            ]
-        )
 
         with (
             patch.dict(
@@ -6175,27 +7334,32 @@ class RoutingTests(unittest.TestCase):
                 },
                 clear=False,
             ),
-            patch("codex_proxy.urlopen", side_effect=[failed_stream, success]) as mock_urlopen,
+            patch("codex_proxy.urlopen", return_value=failed_stream) as mock_urlopen,
             patch("codex_proxy._sleep_for_retry_with_gateway_cancellation") as mock_retry_wait,
         ):
             CodexProxyHandler.do_POST(handler)
 
-        self.assertEqual(mock_urlopen.call_count, 2)
-        mock_retry_wait.assert_called_once_with(2)
+        self.assertEqual(mock_urlopen.call_count, 1)
+        mock_retry_wait.assert_not_called()
         self.assertEqual(fake.status, 200)
         written = b"".join(fake.wfile.writes)
         self.assertNotIn(b"event: codexhub.retry\n", written)
         self.assertNotIn(b'"type":"codexhub.retry"', written)
-        self.assertIn(b"response.output_text.delta", written)
-        self.assertNotIn(b"upstream_stream_error", written)
+        self.assertIn(b"upstream_stream_error", written)
         retry_events = [
             call.kwargs for call in self.write_proxy_event.call_args_list
             if call.args and call.args[0] == "upstream_retry"
         ]
-        self.assertEqual(len(retry_events), 1)
-        self.assertEqual(retry_events[0]["error"], "TimeoutError")
+        self.assertEqual(retry_events, [])
+        suppressed_events = [
+            call.kwargs for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] == "upstream_retry_suppressed"
+        ]
+        self.assertEqual(len(suppressed_events), 1)
+        self.assertEqual(suppressed_events[0]["error"], "TimeoutError")
+        self.assertEqual(suppressed_events[0]["retry_safety_class"], "suppressed_post_write")
 
-    def test_transparent_provider_responses_retries_sse_error_event_before_downstream_headers(self):
+    def test_transparent_provider_responses_suppresses_sse_error_event_for_non_official_main_gen(self):
         body = json.dumps(
             {
                 "model": "glm-5.2",
@@ -6227,14 +7391,6 @@ class RoutingTests(unittest.TestCase):
                 b"",
             ]
         )
-        success = FakeSseResponse(
-            [
-                b'data: {"type":"response.created","response":{"id":"resp_transparent_retry","status":"in_progress"}}\n\n',
-                b'data: {"type":"response.output_text.delta","delta":"ok"}\n\n',
-                b'data: {"type":"response.completed","response":{"id":"resp_transparent_retry","status":"completed","usage":{"input_tokens":1,"output_tokens":1}}}\n\n',
-                b"",
-            ]
-        )
 
         with (
             patch.dict(
@@ -6246,28 +7402,31 @@ class RoutingTests(unittest.TestCase):
                 },
                 clear=False,
             ),
-            patch("codex_proxy.urlopen", side_effect=[failed_stream, success]) as mock_urlopen,
+            patch("codex_proxy.urlopen", return_value=failed_stream) as mock_urlopen,
             patch("codex_proxy._sleep_for_retry_with_gateway_cancellation") as mock_retry_wait,
         ):
             CodexProxyHandler.do_POST(handler)
 
-        self.assertEqual(mock_urlopen.call_count, 2)
-        mock_retry_wait.assert_called_once_with(2)
-        self.assertEqual(fake.status, 200)
+        self.assertEqual(mock_urlopen.call_count, 1)
+        mock_retry_wait.assert_not_called()
         written = b"".join(fake.wfile.writes)
-        self.assertIn(b"resp_transparent_retry", written)
-        self.assertIn(b"response.output_text.delta", written)
-        self.assertNotIn(b"The system is busy", written)
         self.assertNotIn(b"event: codexhub.retry\n", written)
+        self.assertNotIn(b'"type":"codexhub.retry"', written)
         retry_events = [
             call.kwargs for call in self.write_proxy_event.call_args_list
             if call.args and call.args[0] == "upstream_retry"
         ]
-        self.assertEqual(len(retry_events), 1)
-        self.assertEqual(retry_events[0]["failure_class"], codex_proxy.RETRY_FAILURE_PROVIDER_OVERLOADED)
-        self.assertEqual(retry_events[0]["upstream"], "volcengine")
+        self.assertEqual(retry_events, [])
+        suppressed_events = [
+            call.kwargs for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] == "upstream_retry_suppressed"
+        ]
+        self.assertEqual(len(suppressed_events), 1)
+        self.assertEqual(suppressed_events[0]["failure_class"], codex_proxy.RETRY_FAILURE_PROVIDER_OVERLOADED)
+        self.assertEqual(suppressed_events[0]["upstream"], "volcengine")
+        self.assertEqual(suppressed_events[0]["retry_safety_class"], "suppressed_post_write")
 
-    def test_post_responses_streaming_retries_reset_after_buffered_reasoning_start(self):
+    def test_post_responses_streaming_suppresses_reset_after_buffered_reasoning_start_for_non_official(self):
         body = json.dumps(
             {
                 "model": "volc/glm-5.2",
@@ -6298,14 +7457,6 @@ class RoutingTests(unittest.TestCase):
                 ConnectionResetError("socket reset"),
             ]
         )
-        success = FakeSseResponse(
-            [
-                b'data: {"type":"response.created","response":{"id":"resp_retry","status":"in_progress"}}\n\n',
-                b'data: {"type":"response.output_text.delta","delta":"ok"}\n\n',
-                b'data: {"type":"response.completed","response":{"id":"resp_retry","status":"completed","usage":{"input_tokens":1,"output_tokens":1}}}\n\n',
-                b"",
-            ]
-        )
 
         with (
             patch.dict(
@@ -6317,28 +7468,35 @@ class RoutingTests(unittest.TestCase):
                 },
                 clear=False,
             ),
-            patch("codex_proxy.urlopen", side_effect=[failed_stream, success]) as mock_urlopen,
+            patch("codex_proxy.urlopen", return_value=failed_stream) as mock_urlopen,
             patch("codex_proxy._sleep_for_retry_with_gateway_cancellation") as mock_retry_wait,
         ):
             CodexProxyHandler.do_POST(handler)
 
-        self.assertEqual(mock_urlopen.call_count, 2)
-        mock_retry_wait.assert_called_once_with(2)
+        self.assertEqual(mock_urlopen.call_count, 1)
+        mock_retry_wait.assert_not_called()
         self.assertEqual(fake.status, 200)
         written = b"".join(fake.wfile.writes)
-        self.assertIn(b"resp_retry", written)
-        self.assertIn(b"response.output_text.delta", written)
         self.assertNotIn(b"resp_reset", written)
         self.assertNotIn(b"rs_1", written)
-        self.assertNotIn(b"upstream_stream_error", written)
+        self.assertIn(b"upstream_stream_error", written)
         retry_events = [
             call.kwargs for call in self.write_proxy_event.call_args_list
             if call.args and call.args[0] == "upstream_retry"
         ]
-        self.assertEqual(len(retry_events), 1)
-        self.assertEqual(retry_events[0]["error"], "ConnectionResetError")
+        self.assertEqual(retry_events, [])
+        suppressed_events = [
+            call.kwargs for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] == "upstream_retry_suppressed"
+        ]
+        self.assertEqual(len(suppressed_events), 1)
+        self.assertEqual(suppressed_events[0]["error"], "ConnectionResetError")
+        self.assertIn(
+            suppressed_events[0]["retry_safety_class"],
+            {"suppressed_post_write", "suppressed_post_exposure"},
+        )
 
-    def test_post_responses_streaming_retries_incomplete_after_buffered_text_delta(self):
+    def test_post_responses_streaming_suppresses_incomplete_after_downstream_exposure_for_non_official(self):
         body = json.dumps(
             {
                 "model": "volc/glm-5.2",
@@ -6366,14 +7524,6 @@ class RoutingTests(unittest.TestCase):
                 b"",
             ]
         )
-        success = FakeSseResponse(
-            [
-                b'data: {"type":"response.created","response":{"id":"resp_text_retry","status":"in_progress"}}\n\n',
-                b'data: {"type":"response.output_text.delta","delta":"ok"}\n\n',
-                b'data: {"type":"response.completed","response":{"id":"resp_text_retry","status":"completed","usage":{"input_tokens":1,"output_tokens":1}}}\n\n',
-                b"",
-            ]
-        )
 
         with (
             patch.dict(
@@ -6385,28 +7535,31 @@ class RoutingTests(unittest.TestCase):
                 },
                 clear=False,
             ),
-            patch("codex_proxy.urlopen", side_effect=[failed_stream, success]) as mock_urlopen,
+            patch("codex_proxy.urlopen", return_value=failed_stream) as mock_urlopen,
             patch("codex_proxy._sleep_for_retry_with_gateway_cancellation") as mock_retry_wait,
         ):
             CodexProxyHandler.do_POST(handler)
 
-        self.assertEqual(mock_urlopen.call_count, 2)
-        mock_retry_wait.assert_called_once_with(2)
+        self.assertEqual(mock_urlopen.call_count, 1)
+        mock_retry_wait.assert_not_called()
         self.assertEqual(fake.status, 200)
         written = b"".join(fake.wfile.writes)
-        self.assertIn(b"resp_text_retry", written)
-        self.assertIn(b"response.output_text.delta", written)
-        self.assertIn(b'"delta":"ok"', written)
         self.assertNotIn(b"resp_text_reset", written)
-        self.assertNotIn(b"partial", written)
+        self.assertIn(b"upstream_stream_error", written)
         retry_events = [
             call.kwargs for call in self.write_proxy_event.call_args_list
             if call.args and call.args[0] == "upstream_retry"
         ]
-        self.assertEqual(len(retry_events), 1)
-        self.assertEqual(retry_events[0]["error"], "UpstreamStreamIncompleteError")
+        self.assertEqual(retry_events, [])
+        suppressed_events = [
+            call.kwargs for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] == "upstream_retry_suppressed"
+        ]
+        self.assertEqual(len(suppressed_events), 1)
+        self.assertEqual(suppressed_events[0]["error"], "UpstreamStreamIncompleteError")
+        self.assertEqual(suppressed_events[0]["retry_safety_class"], "suppressed_post_exposure")
 
-    def test_post_responses_streaming_uses_global_attempts_for_buffered_stream_incomplete(self):
+    def test_post_responses_streaming_suppresses_buffered_stream_incomplete_for_non_official(self):
         body = json.dumps(
             {
                 "model": "volc/glm-5.2",
@@ -6427,21 +7580,10 @@ class RoutingTests(unittest.TestCase):
         handler.send_header = fake.send_header
         handler.end_headers = fake.end_headers
         handler.wfile = fake.wfile
-        failed_streams = [
-            FakeSseResponse(
-                [
-                    f'data: {{"type":"response.created","response":{{"id":"resp_text_reset_{index}","status":"in_progress"}}}}\n\n'.encode("utf-8"),
-                    f'data: {{"type":"response.output_text.delta","delta":"partial {index}"}}\n\n'.encode("utf-8"),
-                    b"",
-                ]
-            )
-            for index in range(4)
-        ]
-        success = FakeSseResponse(
+        failed_stream = FakeSseResponse(
             [
-                b'data: {"type":"response.created","response":{"id":"resp_text_retry","status":"in_progress"}}\n\n',
-                b'data: {"type":"response.output_text.delta","delta":"ok"}\n\n',
-                b'data: {"type":"response.completed","response":{"id":"resp_text_retry","status":"completed","usage":{"input_tokens":1,"output_tokens":1}}}\n\n',
+                b'data: {"type":"response.created","response":{"id":"resp_text_reset_0","status":"in_progress"}}\n\n',
+                b'data: {"type":"response.output_text.delta","delta":"partial 0"}\n\n',
                 b"",
             ]
         )
@@ -6457,26 +7599,31 @@ class RoutingTests(unittest.TestCase):
                 },
                 clear=False,
             ),
-            patch("codex_proxy.urlopen", side_effect=[*failed_streams, success]) as mock_urlopen,
+            patch("codex_proxy.urlopen", return_value=failed_stream) as mock_urlopen,
             patch("codex_proxy._sleep_for_retry_with_gateway_cancellation") as mock_retry_wait,
         ):
             CodexProxyHandler.do_POST(handler)
 
-        self.assertEqual(mock_urlopen.call_count, 5)
-        self.assertEqual([call.args[0] for call in mock_retry_wait.call_args_list], [2, 2, 4, 6])
+        self.assertEqual(mock_urlopen.call_count, 1)
+        mock_retry_wait.assert_not_called()
         self.assertEqual(fake.status, 200)
         written = b"".join(fake.wfile.writes)
-        self.assertIn(b"resp_text_retry", written)
-        self.assertIn(b'"delta":"ok"', written)
         self.assertNotIn(b"partial", written)
+        self.assertIn(b"upstream_stream_error", written)
         retry_events = [
             call.kwargs for call in self.write_proxy_event.call_args_list
             if call.args and call.args[0] == "upstream_retry"
         ]
-        self.assertEqual(len(retry_events), 4)
-        self.assertEqual([event["max_attempts"] for event in retry_events], [5, 5, 5, 5])
+        self.assertEqual(retry_events, [])
+        suppressed_events = [
+            call.kwargs for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] == "upstream_retry_suppressed"
+        ]
+        self.assertEqual(len(suppressed_events), 1)
+        self.assertEqual(suppressed_events[0]["error"], "UpstreamStreamIncompleteError")
+        self.assertEqual(suppressed_events[0]["retry_safety_class"], "suppressed_post_exposure")
 
-    def test_post_responses_streaming_retries_empty_completed_once_then_relays_visible_success(self):
+    def test_post_responses_streaming_suppresses_empty_completed_for_non_official_main_gen(self):
         body = json.dumps(
             {
                 "model": "volc/glm-5.2",
@@ -6504,14 +7651,6 @@ class RoutingTests(unittest.TestCase):
                 b"",
             ]
         )
-        success = FakeSseResponse(
-            [
-                b'data: {"type":"response.created","response":{"id":"resp_visible","status":"in_progress"}}\n\n',
-                b'data: {"type":"response.output_text.delta","delta":"ok"}\n\n',
-                b'data: {"type":"response.completed","response":{"id":"resp_visible","status":"completed","output":[{"type":"message","content":[{"type":"output_text","text":"ok"}]}],"usage":{"input_tokens":7,"output_tokens":1,"total_tokens":8}}}\n\n',
-                b"",
-            ]
-        )
 
         with (
             patch.dict(
@@ -6523,28 +7662,31 @@ class RoutingTests(unittest.TestCase):
                 },
                 clear=False,
             ),
-            patch("codex_proxy.urlopen", side_effect=[empty_stream, success]) as mock_urlopen,
+            patch("codex_proxy.urlopen", return_value=empty_stream) as mock_urlopen,
             patch("codex_proxy._sleep_for_retry_with_gateway_cancellation") as mock_retry_wait,
         ):
             CodexProxyHandler.do_POST(handler)
 
-        self.assertEqual(mock_urlopen.call_count, 2)
-        mock_retry_wait.assert_called_once_with(2)
+        self.assertEqual(mock_urlopen.call_count, 1)
+        mock_retry_wait.assert_not_called()
         self.assertEqual(fake.status, 200)
         written = b"".join(fake.wfile.writes)
-        self.assertIn(b"resp_visible", written)
-        self.assertIn(b'"delta":"ok"', written)
         self.assertNotIn(b"resp_empty", written)
-        self.assertNotIn(b"upstream_empty_completed_response", written)
+        self.assertIn(b"upstream_empty_completed_response", written)
         retry_events = [
             call.kwargs for call in self.write_proxy_event.call_args_list
             if call.args and call.args[0] == "upstream_retry"
         ]
-        self.assertEqual(len(retry_events), 1)
-        self.assertEqual(retry_events[0]["error"], "UpstreamEmptyCompletedResponseError")
-        self.assertEqual(retry_events[0]["max_attempts"], 2)
+        self.assertEqual(retry_events, [])
+        suppressed_events = [
+            call.kwargs for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] == "upstream_retry_suppressed"
+        ]
+        self.assertEqual(len(suppressed_events), 1)
+        self.assertEqual(suppressed_events[0]["error"], "UpstreamEmptyCompletedResponseError")
+        self.assertEqual(suppressed_events[0]["retry_safety_class"], "suppressed_post_write")
 
-    def test_post_responses_streaming_empty_completed_retry_is_bounded_to_one_extra_attempt(self):
+    def test_post_responses_streaming_empty_completed_is_suppressed_without_retry_for_non_official(self):
         body = json.dumps(
             {
                 "model": "volc/glm-5.2",
@@ -6565,21 +7707,10 @@ class RoutingTests(unittest.TestCase):
         handler.send_header = fake.send_header
         handler.end_headers = fake.end_headers
         handler.wfile = fake.wfile
-        empty_streams = [
-            FakeSseResponse(
-                [
-                    f'data: {{"type":"response.created","response":{{"id":"resp_empty_{index}","status":"in_progress"}}}}\n\n'.encode("utf-8"),
-                    f'data: {{"type":"response.completed","response":{{"id":"resp_empty_{index}","status":"completed","output":[],"usage":{{"input_tokens":7,"output_tokens":0,"total_tokens":7}}}}}}\n\n'.encode("utf-8"),
-                    b"",
-                ]
-            )
-            for index in range(2)
-        ]
-        should_not_be_used = FakeSseResponse(
+        empty_stream = FakeSseResponse(
             [
-                b'data: {"type":"response.created","response":{"id":"resp_unwanted_success","status":"in_progress"}}\n\n',
-                b'data: {"type":"response.output_text.delta","delta":"late ok"}\n\n',
-                b'data: {"type":"response.completed","response":{"id":"resp_unwanted_success","status":"completed","output":[{"type":"message","content":[{"type":"output_text","text":"late ok"}]}],"usage":{"input_tokens":7,"output_tokens":2,"total_tokens":9}}}\n\n',
+                b'data: {"type":"response.created","response":{"id":"resp_empty_0","status":"in_progress"}}\n\n',
+                b'data: {"type":"response.completed","response":{"id":"resp_empty_0","status":"completed","output":[],"usage":{"input_tokens":7,"output_tokens":0,"total_tokens":7}}}\n\n',
                 b"",
             ]
         )
@@ -6594,27 +7725,30 @@ class RoutingTests(unittest.TestCase):
                 },
                 clear=False,
             ),
-            patch("codex_proxy.urlopen", side_effect=[*empty_streams, should_not_be_used]) as mock_urlopen,
+            patch("codex_proxy.urlopen", return_value=empty_stream) as mock_urlopen,
             patch("codex_proxy._sleep_for_retry_with_gateway_cancellation") as mock_retry_wait,
         ):
             CodexProxyHandler.do_POST(handler)
 
-        self.assertEqual(mock_urlopen.call_count, 2)
-        mock_retry_wait.assert_called_once_with(2)
+        self.assertEqual(mock_urlopen.call_count, 1)
+        mock_retry_wait.assert_not_called()
         self.assertEqual(fake.status, 200)
         written = b"".join(fake.wfile.writes)
         self.assertIn(b"upstream_empty_completed_response", written)
         self.assertNotIn(b'"type":"response.completed"', written)
         self.assertNotIn(b"resp_empty_0", written)
-        self.assertNotIn(b"resp_empty_1", written)
-        self.assertNotIn(b"resp_unwanted_success", written)
         retry_events = [
             call.kwargs for call in self.write_proxy_event.call_args_list
             if call.args and call.args[0] == "upstream_retry"
         ]
-        self.assertEqual(len(retry_events), 1)
-        self.assertEqual(retry_events[0]["error"], "UpstreamEmptyCompletedResponseError")
-        self.assertEqual(retry_events[0]["max_attempts"], 2)
+        self.assertEqual(retry_events, [])
+        suppressed_events = [
+            call.kwargs for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] == "upstream_retry_suppressed"
+        ]
+        self.assertEqual(len(suppressed_events), 1)
+        self.assertEqual(suppressed_events[0]["error"], "UpstreamEmptyCompletedResponseError")
+        self.assertEqual(suppressed_events[0]["retry_safety_class"], "suppressed_post_write")
 
     def test_post_responses_streaming_synthesizes_terminal_after_buffered_tool_call_done(self):
         body = json.dumps(
@@ -21719,7 +22853,7 @@ Use an implementer subagent, then a spec reviewer, then a code quality reviewer.
         self.assertEqual(downstream_event["client_id"], "omp")
         self.assertEqual(downstream_event["status"], 499)
 
-    def test_retry_notice_commit_failure_aborts_new_upstream_attempt(self):
+    def test_retry_notice_is_not_emitted_when_non_official_stream_retry_is_suppressed(self):
         body = json.dumps({
             "model": "volc/glm-5.2",
             "input": [{"type": "message", "role": "user", "content": "hi"}],
@@ -21737,12 +22871,6 @@ Use an implementer subagent, then a spec reviewer, then a code quality reviewer.
             {"Content-Type": "application/json"},
             io.BytesIO(b'{"error":{"type":"server_error","message":"try later"}}'),
         )
-        # fail when the retry notice event is written
-        failing_wfile = FakeWFile(
-            fail_on_write=lambda data, _index: b"codexhub.retry" in data
-        )
-        fake.wfile = failing_wfile
-        handler.wfile = failing_wfile
 
         with (
             patch.dict(
@@ -21754,7 +22882,7 @@ Use an implementer subagent, then a spec reviewer, then a code quality reviewer.
                 },
                 clear=False,
             ),
-            patch("codex_proxy.urlopen", side_effect=[error, error]) as mock_urlopen,
+            patch("codex_proxy.urlopen", side_effect=error) as mock_urlopen,
             patch("codex_proxy._sleep_for_retry_with_gateway_cancellation") as mock_sleep,
         ):
             CodexProxyHandler.do_POST(handler)
@@ -21764,13 +22892,19 @@ Use an implementer subagent, then a spec reviewer, then a code quality reviewer.
         mock_sleep.assert_not_called()
         event_names = [call.args[0] for call in self.write_proxy_event.call_args_list if call.args]
         self.assertNotIn("sse_retry_notice", event_names)
-        self.assertIn("downstream_stream_closed", event_names)
+        self.assertNotIn("downstream_stream_closed", event_names)
         complete_events = [
             call.kwargs for call in self.write_proxy_event.call_args_list
             if call.args and call.args[0] == "request_complete"
         ]
         self.assertEqual(len(complete_events), 1)
-        self.assertEqual(complete_events[0]["status"], 499)
+        self.assertEqual(complete_events[0]["status"], 503)
+        suppressed_events = [
+            call.kwargs for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] == "upstream_retry_suppressed"
+        ]
+        self.assertEqual(len(suppressed_events), 1)
+        self.assertEqual(suppressed_events[0]["retry_safety_class"], "suppressed_post_write")
 
     def test_error_event_write_failure_overrides_upstream_status_to_499(self):
         body = json.dumps({


### PR DESCRIPTION
## Summary

- centralize retry-safety decisions for non-Official main-generation POSTs and suppress unsafe post-write, post-exposure, HTTP, stream, and unknown-phase retries unless the exact Model Access Path has an explicit idempotency guarantee
- reuse one private retry identity for guaranteed attempts and redact it from telemetry, downstream errors, compressed error bodies, and public context
- replace the 0.1.7 Volc Chat release leg with exactly six Official Responses plus six Ollama Cloud Native Responses cases across Desktop, Codex CLI, OpenCode, ZCode, Pi, and OMP
- bind each release case to client, Provider, selector, canonical/Gateway model, endpoint, and Responses protocol; reject Provider/protocol contradictions and keep legacy Volc GUI seeds as independent-copy fallback only
- publish sanitized evidence schemas `codexhub.real-client-e2e-summary.v2` and `codexhub.real-client-manual-evidence.v3`; the live 12-case qualification remains reserved for frozen #227

Closes #17
Closes #226

## Verification

- `python -m pytest -q tests/test_routing.py tests/test_chat_completions_gateway.py tests/test_proxy_event_logging.py` — 674 passed, 192 subtests passed
- `python -m pytest -q --ignore=tests/test_real_client_e2e.py --junitxml=.pytest-results/junit-core.xml --durations=0` — 1451 passed, 1 skipped, 417 subtests passed
- watchdog-bounded `python -m pytest -q tests/test_real_client_e2e.py --junitxml=.pytest-results/junit-synthetic.xml --durations=0` — 136 passed
- `python scripts/ci/check_python_test_partitions.py` — 1452 core + 136 synthetic = 1588, disjoint and complete
- PowerShell parser and `git diff --check` — passed
- `python scripts/report_quality_gates.py` — report-only, parse_errors 0
- exact-SHA direct Standards review — PASS
- exact-SHA direct Spec review against #17 and #226 — PASS

No live-provider 12-case run was performed on this intermediate SHA.