### PR TITLE
Bound main-generation pre-response work for 0.1.7

### DIFF
--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -972,7 +972,8 @@ DEFAULT_TRANSPORT_SSE_IDLE_TIMEOUT_SECONDS = 600.0
 DEFAULT_MODEL_EVENT_SSE_IDLE_TIMEOUT_SECONDS = 300.0
 DEFAULT_PRE_OUTPUT_SSE_IDLE_TIMEOUT_SECONDS = DEFAULT_MODEL_EVENT_SSE_IDLE_TIMEOUT_SECONDS
 DEFAULT_POST_CONTENT_SSE_IDLE_TIMEOUT_SECONDS = DEFAULT_MODEL_EVENT_SSE_IDLE_TIMEOUT_SECONDS
-DEFAULT_OFFICIAL_UPSTREAM_OPEN_ATTEMPTS = 3
+DEFAULT_MAIN_GENERATION_PRE_RESPONSE_BUDGET_SECONDS = 180.0
+DEFAULT_OFFICIAL_UPSTREAM_OPEN_ATTEMPTS = 2
 DEFAULT_GATEWAY_AUTO_RETRY_MAX_ATTEMPTS = 30
 DEFAULT_CAPACITY_RETRY_ELAPSED_LIMIT_SECONDS = 300.0
 DEFAULT_STREAM_RETRY_ELAPSED_LIMIT_SECONDS = 600.0
@@ -1294,6 +1295,22 @@ class UpstreamStreamIdleTimeoutError(TimeoutError):
         super().__init__(f"Upstream stream stalled for {timeout_seconds:g} seconds {detail}.")
 
 
+class GatewayPreResponseBudgetExhausted(TimeoutError):
+    """Raised when main generation cannot reach a usable response within its shared budget."""
+
+    def __init__(
+        self,
+        *,
+        phase: str = "pre_response",
+        attempt: int | None = None,
+        budget_seconds: float = DEFAULT_MAIN_GENERATION_PRE_RESPONSE_BUDGET_SECONDS,
+    ):
+        self.phase = phase
+        self.attempt = attempt
+        self.budget_seconds = budget_seconds
+        super().__init__("Gateway pre-response budget exhausted before a usable upstream response.")
+
+
 def upstream_timeout_seconds() -> int:
     settings_value = _runtime_settings_value("gateway_request_timeout_seconds")
     if isinstance(settings_value, int):
@@ -1446,7 +1463,9 @@ def official_upstream_open_attempts() -> int:
         value = int(raw_value)
     except ValueError:
         return DEFAULT_OFFICIAL_UPSTREAM_OPEN_ATTEMPTS
-    return value if value > 0 else DEFAULT_OFFICIAL_UPSTREAM_OPEN_ATTEMPTS
+    if value <= 0:
+        return DEFAULT_OFFICIAL_UPSTREAM_OPEN_ATTEMPTS
+    return min(value, DEFAULT_OFFICIAL_UPSTREAM_OPEN_ATTEMPTS)
 
 
 def _env_flag(name: str, default: bool) -> bool:
@@ -12541,6 +12560,8 @@ def _typed_error_code(
 ) -> str:
     if error_type == "gateway_auth_error":
         return "gateway.auth"
+    if error_type == "gateway_pre_response_budget_exhausted":
+        return "gateway.pre_response_budget_exhausted"
     if error_type == USER_REQUESTED_SHUTDOWN_OUTCOME:
         return "gateway.user_requested_shutdown"
     if error_type in {"invalid_request_error", "validation_error"}:
@@ -12572,6 +12593,8 @@ def _codexhub_error_payload(
 ) -> dict[str, Any]:
     error_code = error or (type(exc).__name__ if exc is not None else "UpstreamError")
     resolved_failure_class = failure_class
+    if error_code == "gateway_pre_response_budget_exhausted":
+        resolved_failure_class = RETRY_FAILURE_PERMANENT
     if resolved_failure_class is None and exc is not None:
         resolved_failure_class = _upstream_failure_class(exc)
     if resolved_failure_class is None and (
@@ -12962,11 +12985,53 @@ def _parse_gateway_request_input(
     )
 
 
+def _main_generation_pre_response_deadline(
+    started_at: float,
+    request_kind: str,
+) -> float | None:
+    if request_kind != RETRY_REQUEST_MAIN_GENERATION:
+        return None
+    return started_at + DEFAULT_MAIN_GENERATION_PRE_RESPONSE_BUDGET_SECONDS
+
+
+def _remaining_pre_response_budget_seconds(deadline: float | None) -> float | None:
+    if deadline is None:
+        return None
+    return deadline - time.monotonic()
+
+
+def _clamp_timeout_to_pre_response_budget(
+    timeout: int | float,
+    deadline: float | None,
+    *,
+    phase: str,
+    attempt: int | None = None,
+) -> int | float:
+    remaining = _remaining_pre_response_budget_seconds(deadline)
+    if remaining is None:
+        return timeout
+    if remaining <= 0:
+        raise GatewayPreResponseBudgetExhausted(phase=phase, attempt=attempt)
+    return min(float(timeout), remaining)
+
+
+def _require_retry_delay_within_pre_response_budget(
+    deadline: float | None,
+    delay_seconds: int | float,
+    *,
+    phase: str,
+    attempt: int | None = None,
+) -> None:
+    remaining = _remaining_pre_response_budget_seconds(deadline)
+    if remaining is not None and delay_seconds >= remaining:
+        raise GatewayPreResponseBudgetExhausted(phase=phase, attempt=attempt)
+
+
 def _open_upstream_once(
     request: Request,
     *,
     upstream_name: str,
-    timeout: int,
+    timeout: int | float,
 ) -> Any:
     if upstream_name == "official":
         return _official_urlopen(request, timeout=timeout)
@@ -12978,7 +13043,7 @@ def _open_upstream_response(
     *,
     upstream_name: str,
     upstream_format: str,
-    timeout: int,
+    timeout: int | float,
     event_context: Mapping[str, Any] | None = None,
     downstream_retry_callback: Any = None,
     request_kind: str = RETRY_REQUEST_MAIN_GENERATION,
@@ -12986,9 +13051,22 @@ def _open_upstream_response(
     retry_policy: str = RETRY_GATEWAY_FULL,
     retry_http_errors: bool = True,
     downstream_exposed: Callable[[], bool] | None = None,
+    pre_response_deadline: float | None = None,
+    open_attempt_budget: dict[str, int] | None = None,
 ) -> Any:
     explicit_max_attempts = max_attempts is not None
     base_retry_attempts = _upstream_retry_attempts(request_kind) if max_attempts is None else max(1, max_attempts)
+    if open_attempt_budget is not None:
+        remaining_open_attempts = max(
+            0,
+            open_attempt_budget["max_attempts"] - open_attempt_budget["attempts_started"],
+        )
+        if remaining_open_attempts <= 0:
+            raise GatewayPreResponseBudgetExhausted(
+                phase="upstream_open_attempts",
+                attempt=open_attempt_budget["attempts_started"],
+            )
+        base_retry_attempts = min(base_retry_attempts, remaining_open_attempts)
     retry_started_at = time.monotonic()
     diagnostic_request_key = _diagnostic_context_value(event_context, "request_id")
     diagnostic_model = _diagnostic_context_value(event_context, "model")
@@ -12999,6 +13077,12 @@ def _open_upstream_response(
     )
     attempt = 1
     while True:
+        if open_attempt_budget is not None:
+            request_attempt = open_attempt_budget["attempts_started"] + 1
+            request_retry_budget = open_attempt_budget["max_attempts"]
+        else:
+            request_attempt = attempt
+            request_retry_budget = base_retry_attempts
         admission = _active_gateway_request()
         if admission is not None:
             admission.raise_if_cancelled()
@@ -13008,13 +13092,33 @@ def _open_upstream_response(
                 request,
                 model_access_path,
             )
+        attempt_timeout = _clamp_timeout_to_pre_response_budget(
+            timeout,
+            pre_response_deadline,
+            phase="upstream_open",
+            attempt=request_attempt,
+        )
+        if open_attempt_budget is not None:
+            open_attempt_budget["attempts_started"] = request_attempt
         attempt_started_at = time.monotonic()
         try:
             response = _open_upstream_once(
                 request,
                 upstream_name=upstream_name,
-                timeout=timeout,
+                timeout=attempt_timeout,
             )
+            remaining_budget = _remaining_pre_response_budget_seconds(pre_response_deadline)
+            if remaining_budget is not None and remaining_budget <= 0:
+                close_response = getattr(response, "close", None)
+                if callable(close_response):
+                    try:
+                        close_response()
+                    except Exception:
+                        pass
+                raise GatewayPreResponseBudgetExhausted(
+                    phase="response_headers",
+                    attempt=request_attempt,
+                )
             if admission is not None:
                 admission.attach_upstream_transport(response)
                 admission.raise_if_cancelled()
@@ -13029,8 +13133,8 @@ def _open_upstream_response(
                 "observe_upstream_phase",
                 diagnostic_request_key,
                 phase="upstream_request_write",
-                attempt=attempt,
-                retry_budget=base_retry_attempts,
+                attempt=request_attempt,
+                retry_budget=request_retry_budget,
                 elapsed_ms=elapsed_ms,
                 outcome="ok",
                 provider=upstream_name,
@@ -13039,8 +13143,8 @@ def _open_upstream_response(
             _observe_gateway_diagnostic(
                 "observe_upstream_attempt",
                 diagnostic_request_key,
-                attempt=attempt,
-                retry_budget=base_retry_attempts,
+                attempt=request_attempt,
+                retry_budget=request_retry_budget,
                 elapsed_ms=elapsed_ms,
                 outcome="ok",
                 connection_disposition=connection_disposition,
@@ -13055,6 +13159,8 @@ def _open_upstream_response(
                 headers=diagnostic_headers,
             )
             return response
+        except GatewayPreResponseBudgetExhausted:
+            raise
         except (HTTPError, IncompleteRead, OSError, URLError) as exc:
             if admission is not None:
                 admission.raise_if_cancelled()
@@ -13082,8 +13188,8 @@ def _open_upstream_response(
                     "observe_upstream_phase",
                     diagnostic_request_key,
                     phase=diagnostic_phase,
-                    attempt=attempt,
-                    retry_budget=base_retry_attempts,
+                    attempt=request_attempt,
+                    retry_budget=request_retry_budget,
                     elapsed_ms=elapsed_ms,
                     outcome="error",
                     failure_phase=transport_phase,
@@ -13094,8 +13200,8 @@ def _open_upstream_response(
                 _observe_gateway_diagnostic(
                     "observe_upstream_attempt",
                     diagnostic_request_key,
-                    attempt=attempt,
-                    retry_budget=attempt,
+                    attempt=request_attempt,
+                    retry_budget=request_attempt,
                     elapsed_ms=elapsed_ms,
                     outcome="error",
                     failure_phase=telemetry_failure_phase,
@@ -13121,12 +13227,17 @@ def _open_upstream_response(
                 failure_class=failure_class,
                 explicit_max_attempts=explicit_max_attempts,
             )
+            error_retry_budget = (
+                open_attempt_budget["max_attempts"]
+                if open_attempt_budget is not None
+                else retry_attempts
+            )
             if retry_safety_class in _SUPPRESSED_RETRY_SAFETY_CLASSES:
                 _observe_gateway_diagnostic(
                     "observe_upstream_attempt",
                     diagnostic_request_key,
-                    attempt=attempt,
-                    retry_budget=retry_attempts,
+                    attempt=request_attempt,
+                    retry_budget=error_retry_budget,
                     elapsed_ms=elapsed_ms,
                     outcome="error",
                     failure_phase=telemetry_failure_phase,
@@ -13134,13 +13245,19 @@ def _open_upstream_response(
                     provider=upstream_name,
                     model=diagnostic_model,
                 )
+                remaining_budget = _remaining_pre_response_budget_seconds(pre_response_deadline)
+                if remaining_budget is not None and remaining_budget <= 0:
+                    raise GatewayPreResponseBudgetExhausted(
+                        phase=telemetry_failure_phase,
+                        attempt=request_attempt,
+                    ) from exc
                 _emit_upstream_retry_suppressed_event(
                     event_context,
                     upstream_name=upstream_name,
                     upstream_format=upstream_format,
                     request_kind=request_kind,
-                    attempt=attempt,
-                    max_attempts=retry_attempts,
+                    attempt=request_attempt,
+                    max_attempts=error_retry_budget,
                     exc=exc,
                     failure_class=failure_class,
                     failure_phase=telemetry_failure_phase,
@@ -13150,8 +13267,8 @@ def _open_upstream_response(
             _observe_gateway_diagnostic(
                 "observe_upstream_attempt",
                 diagnostic_request_key,
-                attempt=attempt,
-                retry_budget=retry_attempts,
+                attempt=request_attempt,
+                retry_budget=error_retry_budget,
                 elapsed_ms=elapsed_ms,
                 outcome="error",
                 failure_phase=telemetry_failure_phase,
@@ -13159,21 +13276,37 @@ def _open_upstream_response(
                 provider=upstream_name,
                 model=diagnostic_model,
             )
+            remaining_budget = _remaining_pre_response_budget_seconds(pre_response_deadline)
+            if remaining_budget is not None and remaining_budget <= 0:
+                raise GatewayPreResponseBudgetExhausted(
+                    phase=telemetry_failure_phase,
+                    attempt=request_attempt,
+                ) from exc
             if attempt >= retry_attempts or failure_class == RETRY_FAILURE_PERMANENT:
                 raise
-            delay_seconds = gateway_retry_delay_seconds(attempt, failure_class=failure_class, exc=exc)
+            delay_seconds = gateway_retry_delay_seconds(
+                request_attempt,
+                failure_class=failure_class,
+                exc=exc,
+            )
             if (
                 failure_class in CAPACITY_RETRY_FAILURE_CLASSES
                 and not _capacity_retry_elapsed_limit_allows(retry_started_at, delay_seconds)
             ):
                 raise
+            _require_retry_delay_within_pre_response_budget(
+                pre_response_deadline,
+                delay_seconds,
+                phase="retry_delay",
+                attempt=request_attempt,
+            )
             _emit_upstream_retry_event(
                 event_context,
                 upstream_name=upstream_name,
                 upstream_format=upstream_format,
                 request_kind=request_kind,
-                attempt=attempt,
-                max_attempts=retry_attempts,
+                attempt=request_attempt,
+                max_attempts=error_retry_budget,
                 exc=exc,
                 delay_seconds=delay_seconds,
                 failure_class=failure_class,
@@ -13186,8 +13319,8 @@ def _open_upstream_response(
                         upstream_name=upstream_name,
                         upstream_format=upstream_format,
                         request_kind=request_kind,
-                        attempt=attempt,
-                        max_attempts=retry_attempts,
+                        attempt=request_attempt,
+                        max_attempts=error_retry_budget,
                         exc=exc,
                         failure_phase=telemetry_failure_phase,
                         delay_seconds=delay_seconds,
@@ -13952,6 +14085,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
         """
         request_id = uuid.uuid4().hex[:12]
         self._diagnostic_request_id = request_id
+        self._pre_response_deadline = None
         started_at = time.monotonic()
         request_context = request_context_from_headers(self.headers)
         if not _local_request_authorized(self.headers, request_context):
@@ -14232,6 +14366,10 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
             if is_transparent_metered:
                 request_kind = RETRY_REQUEST_MAIN_GENERATION
                 proxy_request_context = _event_context_with_request_kind(request_context, request_kind)
+            self._pre_response_deadline = _main_generation_pre_response_deadline(
+                started_at,
+                request_kind,
+            )
             vision_proxy_policy = vision_proxy_policy_for_route(route_decision, behavior_profile)
             reasoning_policy = _reasoning_policy_for_request(inbound_payload, upstream, model)
             route_policy_event_fields = {
@@ -14598,6 +14736,14 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
             configured_upstream_format = upstream_format
             selected_upstream_format = upstream_format
             upstream_format_options = _upstream_format_candidates(configured_upstream_format)
+            official_open_attempt_budget = (
+                {
+                    "max_attempts": official_upstream_open_attempts(),
+                    "attempts_started": 0,
+                }
+                if is_official_http_passthrough
+                else None
+            )
             for format_index, selected_upstream_format in enumerate(upstream_format_options):
                 if isinstance(adapter_event_context, dict):
                     adapter_event_context["tool_protocol"] = _external_tool_protocol(
@@ -14632,12 +14778,20 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                                 event_context=adapter_event_context,
                                 downstream_retry_callback=emit_downstream_retry if emit_retry_to_downstream else None,
                                 request_kind=request_kind,
-                                max_attempts=official_upstream_open_attempts() if is_official_http_passthrough else None,
+                                max_attempts=(
+                                    official_open_attempt_budget["max_attempts"]
+                                    if official_open_attempt_budget is not None
+                                    else None
+                                ),
                                 retry_policy=route_decision.retry_policy
                                 if enable_transparent_metered
                                 else RETRY_GATEWAY_FULL,
                                 retry_http_errors=not is_official_http_passthrough,
                                 downstream_exposed=lambda: _downstream_has_been_exposed(self),
+                                pre_response_deadline=(
+                                    None if downstream_sse_started else self._pre_response_deadline
+                                ),
+                                open_attempt_budget=official_open_attempt_budget,
                             ) as response:
                                 seam = _handler_downstream_stream_commit(self)
                                 if seam is not None:
@@ -15313,6 +15467,68 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 **usage_capture,
                 **proxy_request_context,
             )
+        except GatewayPreResponseBudgetExhausted as exc:
+            if admission.cancelled:
+                send_user_requested_shutdown()
+                return
+            error_code = "gateway_pre_response_budget_exhausted"
+            detail = "Gateway pre-response budget exhausted before a usable upstream response."
+            event_fields = {
+                "failure_phase": exc.phase,
+                "attempt": exc.attempt,
+                "pre_response_budget_ms": int(exc.budget_seconds * 1000),
+                "retryable": False,
+            }
+            write_proxy_event(
+                "request_error",
+                request_id=request_id,
+                model=canonical_model_id(model) if model else None,
+                model_requested=model_requested,
+                upstream=upstream_name,
+                upstream_format=upstream_format,
+                behavior_profile=behavior_profile,
+                inbound_format=inbound_format,
+                status=504,
+                error=error_code,
+                detail=detail,
+                duration_ms=int((time.monotonic() - started_at) * 1000),
+                **event_fields,
+                **proxy_request_context,
+            )
+            self._safe_send_downstream_json_error(
+                504,
+                inbound_format=inbound_format,
+                upstream_name=upstream_name or "gateway",
+                request_id=request_id,
+                error=error_code,
+                detail=detail,
+                error_type=error_code,
+            )
+            self.close_connection = True
+            write_proxy_event(
+                "request_complete",
+                request_id=request_id,
+                method="POST",
+                model=canonical_model_id(model) if model else None,
+                model_requested=model_requested,
+                model_canonical=canonical_model_id(model) if model else None,
+                upstream=upstream_name,
+                provider_id=upstream_name,
+                provider_hint=provider_hint,
+                upstream_format=upstream_format,
+                reports_cached_input_tokens=reports_cached_input_tokens,
+                behavior_profile=behavior_profile,
+                inbound_format=inbound_format,
+                route_reason=route_reason,
+                route_mode="official" if upstream_name == "official" else "codexhub",
+                is_stream=caller_stream,
+                status=504,
+                duration_ms=int((time.monotonic() - started_at) * 1000),
+                **event_fields,
+                **request_observability,
+                **usage_capture,
+                **proxy_request_context,
+            )
         except IncompleteRead as exc:
             if admission.cancelled:
                 send_user_requested_shutdown()
@@ -15431,6 +15647,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 redact_identity=identity,
             )
         finally:
+            self._pre_response_deadline = None
             _restore_gateway_request(previous_admission)
             shutdown_controller.complete(admission)
 

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1446,6 +1446,14 @@ class RoutingTests(unittest.TestCase):
             CodexProxyHandler.do_POST(handler)
 
         self.assertEqual(open_response.call_args.kwargs.get("max_attempts"), codex_proxy.official_upstream_open_attempts())
+        self.assertIsInstance(open_response.call_args.kwargs.get("pre_response_deadline"), float)
+        self.assertEqual(
+            open_response.call_args.kwargs.get("open_attempt_budget"),
+            {
+                "max_attempts": codex_proxy.official_upstream_open_attempts(),
+                "attempts_started": 0,
+            },
+        )
         self.assertFalse(open_response.call_args.kwargs.get("retry_http_errors"))
         self.assertTrue(relayed[0]["defer_stream_errors"])
         self.assert_no_official_passthrough_gateway_events()
@@ -4978,9 +4986,71 @@ class RoutingTests(unittest.TestCase):
         self.assertEqual(retry_events[0]["failure_phase"], "tcp_connect")
         handler._relay_upstream_response.assert_called_once()
 
+    def test_official_passthrough_pre_response_budget_exhaustion_returns_one_504_completion(self):
+        body = json.dumps(
+            {
+                "model": "gpt-5.5-fast",
+                "input": [{"type": "message", "role": "user", "content": "hi"}],
+                "stream": True,
+            }
+        ).encode("utf-8")
+        handler = CodexProxyHandler.__new__(CodexProxyHandler)
+        handler.path = "/v1/responses"
+        handler.headers = {
+            "Content-Length": str(len(body)),
+            "Content-Type": "application/json",
+            "X-Codex-Client-Id": "codex-app",
+        }
+        handler.rfile = io.BytesIO(body)
+        handler.close_connection = False
+        fake = FakeHandler()
+        handler.send_response = fake.send_response
+        handler.send_header = fake.send_header
+        handler.end_headers = fake.end_headers
+        handler.wfile = fake.wfile
+        budget_error_type = getattr(codex_proxy, "GatewayPreResponseBudgetExhausted", TimeoutError)
+
+        with (
+            patch("codex_proxy.codex_access_token", return_value="sub-token"),
+            patch("codex_proxy.codex_account_id", return_value="acct-1"),
+            patch("codex_proxy._open_upstream_response", side_effect=budget_error_type()),
+        ):
+            CodexProxyHandler.do_POST(handler)
+
+        self.assertEqual(fake.status, 504)
+        written = b"".join(fake.wfile.writes)
+        self.assertIn(b"gateway_pre_response_budget_exhausted", written)
+        self.assertNotIn(b"chatgpt.com", written)
+        response_payload = json.loads(written.decode("utf-8"))
+        self.assertEqual(
+            response_payload["codexhub_error"]["code"],
+            "gateway.pre_response_budget_exhausted",
+        )
+        self.assertFalse(response_payload["codexhub_error"]["retryable"])
+        request_errors = [
+            call.kwargs
+            for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] == "request_error"
+        ]
+        request_completions = [
+            call.kwargs
+            for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] == "request_complete"
+        ]
+        self.assertEqual(len(request_errors), 1)
+        self.assertEqual(request_errors[0]["status"], 504)
+        self.assertEqual(request_errors[0]["error"], "gateway_pre_response_budget_exhausted")
+        self.assertEqual(len(request_completions), 1)
+        self.assertEqual(request_completions[0]["status"], 504)
+        self.assertNotIn(
+            "upstream_retry",
+            [call.args[0] for call in self.write_proxy_event.call_args_list if call.args],
+        )
+
     def test_transport_failure_phase_classifies_ssl_eof(self):
         error = ssl.SSLEOFError("EOF occurred in violation of protocol")
         self.assertEqual(codex_proxy.transport_failure_phase(error), "tls_handshake")
+
     def test_gateway_auto_retry_settings_fall_back_to_runtime_settings_when_env_missing(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             settings_path = os.path.join(temp_dir, "settings.json")
@@ -5011,6 +5081,233 @@ class RoutingTests(unittest.TestCase):
                 patch("codex_proxy.RUNTIME_PROXY_DIR", Path(temp_dir)),
             ):
                 self.assertEqual(upstream_timeout_seconds(), 45)
+
+    def test_official_upstream_open_attempts_are_hard_capped_at_two(self):
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(codex_proxy.official_upstream_open_attempts(), 2)
+        with patch.dict(
+            os.environ,
+            {"CODEX_PROXY_OFFICIAL_UPSTREAM_OPEN_ATTEMPTS": "99"},
+            clear=True,
+        ):
+            self.assertEqual(codex_proxy.official_upstream_open_attempts(), 2)
+        with patch.dict(
+            os.environ,
+            {"CODEX_PROXY_OFFICIAL_UPSTREAM_OPEN_ATTEMPTS": "1"},
+            clear=True,
+        ):
+            self.assertEqual(codex_proxy.official_upstream_open_attempts(), 1)
+
+    def test_open_upstream_response_clamps_each_attempt_to_shared_pre_response_deadline(self):
+        request = codex_proxy.Request(
+            "https://chatgpt.com/backend-api/codex/responses",
+            data=b"{}",
+            method="POST",
+        )
+        now = [0.0]
+        observed_timeouts = []
+        observed_sleeps = []
+        success = FakeResponse(b'{"id":"resp_recovered"}')
+
+        def open_upstream(_request, *, timeout):
+            observed_timeouts.append(timeout)
+            if len(observed_timeouts) == 1:
+                now[0] += 170.0
+                raise TimeoutError("connect timed out")
+            return success
+
+        def sleep_for_retry(delay_seconds):
+            observed_sleeps.append(delay_seconds)
+            now[0] += delay_seconds
+
+        with (
+            patch("codex_proxy.time.monotonic", side_effect=lambda: now[0]),
+            patch("codex_proxy._official_urlopen", side_effect=open_upstream),
+            patch(
+                "codex_proxy._sleep_for_retry_with_gateway_cancellation",
+                side_effect=sleep_for_retry,
+            ),
+        ):
+            response = codex_proxy._open_upstream_response(
+                request,
+                upstream_name="official",
+                upstream_format="responses",
+                timeout=300,
+                event_context={"request_id": "req-shared-budget"},
+                request_kind=codex_proxy.RETRY_REQUEST_MAIN_GENERATION,
+                max_attempts=2,
+                pre_response_deadline=180.0,
+            )
+
+        self.assertIs(response, success)
+        self.assertEqual(observed_timeouts, [180.0, 8.0])
+        self.assertEqual(observed_sleeps, [2])
+
+    def test_ollama_cloud_safe_prewrite_retry_shares_pre_response_deadline(self):
+        request = codex_proxy.Request(
+            "https://ollama.com/v1/responses",
+            data=b"{}",
+            method="POST",
+        )
+        now = [175.0]
+        observed_timeouts = []
+        success = FakeResponse(b'{"id":"resp_ollama_recovered"}')
+
+        def open_upstream(_request, *, timeout):
+            observed_timeouts.append(timeout)
+            if len(observed_timeouts) == 1:
+                raise ConnectionRefusedError("connection refused")
+            return success
+
+        def sleep_for_retry(delay_seconds):
+            now[0] += delay_seconds
+
+        with (
+            patch("codex_proxy.time.monotonic", side_effect=lambda: now[0]),
+            patch("codex_proxy.urlopen", side_effect=open_upstream),
+            patch(
+                "codex_proxy._sleep_for_retry_with_gateway_cancellation",
+                side_effect=sleep_for_retry,
+            ),
+        ):
+            response = codex_proxy._open_upstream_response(
+                request,
+                upstream_name="ollama-cloud",
+                upstream_format="responses",
+                timeout=300,
+                event_context={
+                    "request_id": "req-ollama-shared-budget",
+                    "model": "codexhub-ollama-cloud/glm-5.2",
+                },
+                request_kind=codex_proxy.RETRY_REQUEST_MAIN_GENERATION,
+                max_attempts=2,
+                pre_response_deadline=180.0,
+            )
+
+        self.assertIs(response, success)
+        self.assertEqual(observed_timeouts, [5.0, 3.0])
+
+    def test_open_upstream_response_does_not_sleep_or_retry_past_pre_response_deadline(self):
+        request = codex_proxy.Request(
+            "https://chatgpt.com/backend-api/codex/responses",
+            data=b"{}",
+            method="POST",
+        )
+        now = [179.0]
+        observed_timeouts = []
+        observed_sleeps = []
+        budget_error_type = getattr(codex_proxy, "GatewayPreResponseBudgetExhausted", TimeoutError)
+
+        def open_upstream(_request, *, timeout):
+            observed_timeouts.append(timeout)
+            now[0] += 0.5
+            raise TimeoutError("connect timed out")
+
+        def sleep_for_retry(delay_seconds):
+            observed_sleeps.append(delay_seconds)
+            now[0] += delay_seconds
+
+        with (
+            patch("codex_proxy.time.monotonic", side_effect=lambda: now[0]),
+            patch("codex_proxy._official_urlopen", side_effect=open_upstream),
+            patch(
+                "codex_proxy._sleep_for_retry_with_gateway_cancellation",
+                side_effect=sleep_for_retry,
+            ),
+        ):
+            with self.assertRaises(budget_error_type):
+                codex_proxy._open_upstream_response(
+                    request,
+                    upstream_name="official",
+                    upstream_format="responses",
+                    timeout=300,
+                    event_context={"request_id": "req-no-budget-retry"},
+                    request_kind=codex_proxy.RETRY_REQUEST_MAIN_GENERATION,
+                    max_attempts=2,
+                    pre_response_deadline=180.0,
+                )
+
+        self.assertEqual(observed_timeouts, [1.0])
+        self.assertEqual(observed_sleeps, [])
+        retry_events = [
+            call
+            for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] == "upstream_retry"
+        ]
+        self.assertEqual(retry_events, [])
+
+    def test_open_upstream_response_rejects_and_closes_response_returned_after_deadline(self):
+        request = codex_proxy.Request(
+            "https://chatgpt.com/backend-api/codex/responses",
+            data=b"{}",
+            method="POST",
+        )
+        now = [179.0]
+        late_response = FakeResponse(b'{"id":"resp_late"}')
+        late_response.close = Mock()
+
+        def open_upstream(_request, *, timeout):
+            self.assertEqual(timeout, 1.0)
+            now[0] = 180.1
+            return late_response
+
+        with (
+            patch("codex_proxy.time.monotonic", side_effect=lambda: now[0]),
+            patch("codex_proxy._official_urlopen", side_effect=open_upstream),
+        ):
+            with self.assertRaises(codex_proxy.GatewayPreResponseBudgetExhausted):
+                codex_proxy._open_upstream_response(
+                    request,
+                    upstream_name="official",
+                    upstream_format="responses",
+                    timeout=300,
+                    event_context={"request_id": "req-late-headers"},
+                    request_kind=codex_proxy.RETRY_REQUEST_MAIN_GENERATION,
+                    max_attempts=2,
+                    pre_response_deadline=180.0,
+                )
+
+        late_response.close.assert_called_once_with()
+
+    def test_official_open_attempt_budget_is_shared_across_relay_reopens(self):
+        request = codex_proxy.Request(
+            "https://chatgpt.com/backend-api/codex/responses",
+            data=b"{}",
+            method="POST",
+        )
+        first_response = FakeResponse(b'{"id":"resp_first"}')
+        open_attempt_budget = {"max_attempts": 2, "attempts_started": 0}
+
+        with patch(
+            "codex_proxy._official_urlopen",
+            side_effect=[first_response, TimeoutError("second open failed"), AssertionError("third open")],
+        ) as open_upstream:
+            response = codex_proxy._open_upstream_response(
+                request,
+                upstream_name="official",
+                upstream_format="responses",
+                timeout=300,
+                event_context={"request_id": "req-shared-open-attempts"},
+                request_kind=codex_proxy.RETRY_REQUEST_MAIN_GENERATION,
+                max_attempts=2,
+                open_attempt_budget=open_attempt_budget,
+            )
+            self.assertIs(response, first_response)
+
+            with self.assertRaisesRegex(TimeoutError, "second open failed"):
+                codex_proxy._open_upstream_response(
+                    request,
+                    upstream_name="official",
+                    upstream_format="responses",
+                    timeout=300,
+                    event_context={"request_id": "req-shared-open-attempts"},
+                    request_kind=codex_proxy.RETRY_REQUEST_MAIN_GENERATION,
+                    max_attempts=2,
+                    open_attempt_budget=open_attempt_budget,
+                )
+
+        self.assertEqual(open_upstream.call_count, 2)
+        self.assertEqual(open_attempt_budget["attempts_started"], 2)
 
     def test_gateway_auto_retry_runtime_settings_override_stale_env(self):
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary

- enforce one request-scoped 180-second pre-response wall-clock budget across upstream open attempts and retry delays for main generation
- hard-cap Official HTTP passthrough at two open attempts total across pre-first-byte relay reopens
- return one sanitized, non-retryable HTTP 504 and one completion when the pre-exposure budget is exhausted
- preserve the merged #17 non-Official retry-safety decision and the existing post-exposure commit/terminal seam

## Verification

- RED: the initial budget/cap fixtures failed 4/4 before the production change
- `python -m pytest -q tests/test_routing.py tests/test_proxy_event_logging.py tests/test_proxy_shutdown.py` — 600 passed, 182 subtests
- exact `b6ab722a3fda6c52973409fd6272e8aadf26d1ea` short-path core — 1458 passed, 1 skipped, 417 subtests
- the only long-worktree core failure was the unchanged portable invalid-flavor assertion; the same exact SHA passes it from `D:\Workstation\ch114`, confirming PowerShell long-path stderr truncation
- `git diff HEAD^ --check` — pass
- `python scripts/report_quality_gates.py` — report-only baseline, parse errors 0
- direct Standards and Spec reviews — PASS

## Disposition

Refs #114.

This is the explicitly partial deterministic containment slice. It does not claim the initiating disconnect root cause and does not close #114. The required live same-candidate Desktop/CLI A/B is blocked because the dedicated isolated Codex profile has zero existing Tasks; no Task was created and no shared Desktop state was used. #141 therefore also remains open and blocking.