### PR TITLE
release: freeze and qualify CodexHub 0.1.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ For a packaged same-version replacement smoke, first inspect the contract, then 
 ```powershell
 .\scripts\Test-BuildFlavorReplacement.ps1 -DryRun
 .\scripts\Test-BuildFlavorReplacement.ps1 `
-  -Version 0.1.5 `
-  -NormalInstaller .\CodexHub_0.1.5_x64-setup.exe `
-  -DebugInstaller .\CodexHub_0.1.5_debug_x64-setup.exe `
+  -Version 0.1.7 `
+  -NormalInstaller .\CodexHub_0.1.7_x64-setup.exe `
+  -DebugInstaller .\CodexHub_0.1.7_debug_x64-setup.exe `
   -SettingsPath "$env:USERPROFILE\.codex\proxy\settings.json" `
   -InstalledExe 'C:\path\to\CodexHub.exe' `
   -RunInstall -LaunchAfterInstall

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -88,9 +88,9 @@ CodexHub Desktop App
 ```powershell
 .\scripts\Test-BuildFlavorReplacement.ps1 -DryRun
 .\scripts\Test-BuildFlavorReplacement.ps1 `
-  -Version 0.1.5 `
-  -NormalInstaller .\CodexHub_0.1.5_x64-setup.exe `
-  -DebugInstaller .\CodexHub_0.1.5_debug_x64-setup.exe `
+  -Version 0.1.7 `
+  -NormalInstaller .\CodexHub_0.1.7_x64-setup.exe `
+  -DebugInstaller .\CodexHub_0.1.7_debug_x64-setup.exe `
   -SettingsPath "$env:USERPROFILE\.codex\proxy\settings.json" `
   -InstalledExe 'C:\path\to\CodexHub.exe' `
   -RunInstall -LaunchAfterInstall

--- a/docs/agents/real-client-e2e.md
+++ b/docs/agents/real-client-e2e.md
@@ -342,7 +342,11 @@ model, missing/duplicate Gateway request completion, duplicate client terminal,
 error, or malformed output fails the case. Actual contradictory models and
 private request IDs are not copied into uploadable artifacts.
 
-Raw client output and diagnostics remain in bounded memory. Per-case files
+Raw client output and diagnostics are not persisted. Before parsing and
+hashing, ordinary process probes retain at most 64 KiB per stream. Automated
+client JSONL retains at most 1 MiB per stream so long native reasoning updates
+cannot hide the later assistant terminal evidence; reaching that client limit
+fails the case closed instead of accepting a truncated prefix. Per-case files
 contain only capture hashes and approved fields.
 
 ## Wall-clock supervision

--- a/docs/agents/real-client-e2e.md
+++ b/docs/agents/real-client-e2e.md
@@ -372,7 +372,10 @@ Completed GUI evidence must not exist when the runner starts. After all
 preflight checks, the runner emits `manual-evidence.template.json`, starts the
 isolated candidate, launches Codex Desktop and ZCode, and waits up to
 `-ManualEvidenceTimeoutSeconds` for a new `manual-evidence.json`. A native GUI
-that exits before finalization fails immediately.
+that exits before finalization fails immediately. The runner also probes the
+candidate Gateway throughout the wait and fails as
+`candidate_gateway_unavailable_during_manual_evidence` after two consecutive
+misses instead of leaving native clients to retry a dead local listener.
 
 The `-ManualEvidenceTimeoutSeconds` manual window is finite (default `900`,
 maximum `3600`) and remains distinct from automated per-process timeouts. It is
@@ -475,6 +478,10 @@ powershell -NoProfile -File scripts/Run-RealClientE2E.ps1 `
    `recentProjects` and `lastWorkspaceSession` to the fresh case root. This
    prevents a copied task from silently resolving relative tools against an
    older run while retaining the operator's completed setup.
+   Keep the candidate CodexHub window open (minimizing it is safe) until the
+   runner exits. Closing that window intentionally stops the current-session
+   Gateway before hiding CodexHub to the tray, so the manual matrix can no
+   longer produce valid evidence.
    Complete and finalize the four GUI cases as described above while the
    runner is waiting.
 7. Confirm exit `0`, summary outcome `passed`, all twelve cases passed, and the

--- a/docs/agents/real-client-e2e.md
+++ b/docs/agents/real-client-e2e.md
@@ -372,7 +372,9 @@ Completed GUI evidence must not exist when the runner starts. After all
 preflight checks, the runner emits `manual-evidence.template.json`, starts the
 isolated candidate, launches Codex Desktop and ZCode, and waits up to
 `-ManualEvidenceTimeoutSeconds` for a new `manual-evidence.json`. A native GUI
-that exits before finalization fails immediately. The runner also probes the
+launch explicitly enables visible windows even though automated clients and
+probes remain headless. A native GUI that exits before finalization fails
+immediately. The runner also probes the
 candidate Gateway throughout the wait and fails as
 `candidate_gateway_unavailable_during_manual_evidence` after two consecutive
 misses instead of leaving native clients to retry a dead local listener.

--- a/docs/agents/real-client-e2e.md
+++ b/docs/agents/real-client-e2e.md
@@ -293,8 +293,10 @@ contracts; accepting a newer version never relaxes these shapes:
   `-C`;
 - OpenCode binds the case root with `--dir`, uses a fixed title, and runs
   `--pure`;
-- Pi enables only the built-in `read` tool and disables context files,
-  extensions, skills, and prompt templates;
+- Pi receives the complete prompt as one quoted positional message, enables
+  only the built-in `read` tool, and disables context files, extensions,
+  skills, and prompt templates. Windows batch launch must preserve that single
+  argument instead of splitting it into queued follow-up messages;
 - OMP binds the case root with `--cwd`, enables only `read`, disables title
   generation, extensions, skills, and rules, and does not persist a session.
 
@@ -320,6 +322,11 @@ not relabeled as stream deltas. Streaming is proven separately from correlated
 production Gateway `request_complete.is_stream = true` evidence for both the
 tool request and final continuation; the sanitized case records
 `streaming_request_count = 2`.
+
+Official Codex diagnostics may canonicalize `gpt-5.6-luna` as
+`openai/gpt-5.6-luna`. The runner treats those two spellings as the same
+qualified route in both contradiction detection and the final pass decision;
+no other model alias is accepted.
 
 Client output does not prove routing. For each attempt, the runner reads only
 new lines from the isolated Debug Gateway's

--- a/docs/releases/0.1.7.md
+++ b/docs/releases/0.1.7.md
@@ -1,0 +1,36 @@
+# CodexHub 0.1.7
+
+CodexHub 0.1.7 is a model-access console that is stable, visible, and reversible（稳定、可见、可逆的模型访问控制台）. This release concentrates on dependable Responses streaming, explicit route identity, bounded failure handling, and recoverable client configuration before expanding the product surface.
+
+## Highlights
+
+- Responses streams are forwarded and converted on complete SSE event boundaries, with one terminal outcome and one request completion.
+- Main-generation retries are bounded by a shared 180-second pre-response budget. Official requests use at most two open attempts, while non-Official replay remains limited to safe pre-write or explicitly idempotent requests.
+- Managed-client configuration exposes canonical provider, model, and protocol identity. OpenCode and Pi keep a version-independent rollback baseline so a later CodexHub version can still restore the pre-managed state.
+- Real-client qualification uses isolated, reusable client roots and bounded process cleanup instead of shared Desktop state.
+- Normal and Debug builds retain separate update manifests and artifact names while sharing the same installed application and supported user state.
+
+## Qualified Clients And Routes
+
+The release qualification covers Codex Desktop, Codex CLI, OpenCode, ZCode, Pi, and OMP. Each client is checked once with:
+
+- Official OpenAI Responses using the canonical Official route and model identity.
+- Ollama Cloud Native Responses using `ollama-cloud/glm-5.2` or the client-qualified `codexhub-ollama-cloud/glm-5.2` selector.
+
+The qualification verifies route/model/protocol readback, text and SSE completion, a real read-only tool call and result, cancellation and terminal accounting, exactly one successful request completion, and bounded process cleanup. Volc Chat conversion, local `localhost:11434` fallback, and generic Chat fallback are not part of the 0.1.7 release matrix.
+
+## Known Limits
+
+- Ollama Cloud Native Responses is the qualified third-party release route. Other OpenAI-compatible or Chat-only Providers remain configurable, but are not covered by the final 12-case release claim.
+- A bounded Desktop comparison cannot prove that every historical upstream or Windows network failure is eliminated. Residual faults are contained by the shared request budget and explicit terminal behavior rather than replaying exposed model output.
+- Codex Desktop may cancel a background resume request before output and produce a Gateway `499` while the GUI remains alive. The qualified foreground Official and Ollama Cloud turns completed without retry or opaque reconnect.
+- Normal and Debug installers are two flavors of the same application. They replace one another at the same version and must not be run side by side.
+
+## Rollback
+
+1. In CodexHub, disconnect Codex from the Gateway to restore the supported Direct Official configuration.
+2. On the Gateway page, use **Restore** for managed OpenCode, ZCode, Pi, or OMP configuration. OpenCode and Pi restoration uses the persistent pre-managed baseline when available.
+3. Stop the Gateway before installing another build flavor or an earlier signed CodexHub release.
+4. To roll back the application, install the prior signed installer and verify its published SHA-256. User settings and supported rollback provenance are preserved; do not delete the Codex runtime directory as part of a normal rollback.
+
+If a restore operation reports that its baseline is missing, unreadable, or owned by another installation, stop and inspect the preview instead of overwriting the client configuration.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codexhub-frontend",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codexhub-frontend",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codexhub-frontend",
   "private": true,
-  "version": "0.1.6",
+  "version": "0.1.7",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/scripts/Run-Issue160VirtualBoxSmoke.ps1
+++ b/scripts/Run-Issue160VirtualBoxSmoke.ps1
@@ -12,9 +12,9 @@ if ($KeepAppRunning) { throw "Issue #160 smoke cannot leave the app running." }
 $debugFlag = Join-Path $root "artifacts\issue160-debug.flag"
 $flavor = if (Test-Path -LiteralPath $debugFlag) { "debug" } else { "normal" }
 $installerName = if ($flavor -eq "debug") {
-    "CodexHub_0.1.6_debug_x64-setup.exe"
+    "CodexHub_0.1.7_debug_x64-setup.exe"
 } else {
-    "CodexHub_0.1.6_x64-setup.exe"
+    "CodexHub_0.1.7_x64-setup.exe"
 }
 $installer = Join-Path $root "artifacts\$installerName"
 $deadline = [DateTime]::UtcNow.AddSeconds($LaunchTimeoutSeconds)

--- a/scripts/Run-RealClientE2E.ps1
+++ b/scripts/Run-RealClientE2E.ps1
@@ -852,6 +852,54 @@ function Start-IsolatedProcess {
     return $process
 }
 
+function Wait-DesktopInitialInstanceSettled {
+    param(
+        [System.Diagnostics.Process]$Process,
+        [string]$LaunchMarker,
+        [int]$TimeoutMilliseconds = 5000
+    )
+    $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+    $minimumSettleMilliseconds = 2500
+    while ($stopwatch.ElapsedMilliseconds -lt $TimeoutMilliseconds) {
+        if ($Process.HasExited) {
+            $stopwatch.Stop()
+            throw 'manual_gui_exited_before_project_open'
+        }
+        if ((Test-Path -LiteralPath $LaunchMarker -PathType Leaf) -or
+            $stopwatch.ElapsedMilliseconds -ge $minimumSettleMilliseconds) {
+            $stopwatch.Stop()
+            return
+        }
+        Start-Sleep -Milliseconds 100
+    }
+    $stopwatch.Stop()
+    throw 'manual_desktop_initial_instance_timeout'
+}
+
+function Invoke-DesktopProjectOpen {
+    param(
+        [string]$Executable,
+        [string]$CaseRoot,
+        [string]$UserDataRoot,
+        [hashtable]$Environment
+    )
+    $result = Invoke-IsolatedProcess `
+        -Executable $Executable `
+        -Arguments @(
+            "--user-data-dir=$UserDataRoot",
+            '--no-first-run',
+            '--open-project',
+            $CaseRoot
+        ) `
+        -CaseRoot $CaseRoot `
+        -Environment $Environment `
+        -StandardInput '' `
+        -ProcessTimeoutSeconds 10
+    if ($result.timed_out -or $result.exit_code -ne 0) {
+        throw 'manual_desktop_project_open_failed'
+    }
+}
+
 function Test-DebugPortableBuildResources {
     param([string]$Executable)
     $root = Split-Path -Parent $Executable
@@ -3082,38 +3130,63 @@ try {
         $guiSentinelPath = Join-Path $guiCaseRoot 'sentinel.txt'
         [System.IO.File]::WriteAllText($guiSentinelPath, "SENTINEL:codexhub-real-client-e2e:$($guiCase.case_id)", $script:Utf8NoBom)
         [void]$manualSentinelPaths.Add($guiSentinelPath)
+        $guiLaunchMarker = Join-Path $workRoot "gui-$($guiCase.case_id).launched"
         $guiArguments = if ($guiClient -ceq 'desktop') {
             $desktopUserDataRoot = Join-Path $guiCaseRoot 'browser-profile'
             [void](New-Item -ItemType Directory -Force -Path $desktopUserDataRoot)
             @(
                 "--user-data-dir=$desktopUserDataRoot",
-                '--no-first-run',
-                '--open-project',
-                $guiCaseRoot
+                '--no-first-run'
             )
         }
         else {
             @($guiCaseRoot)
         }
         $guiExecutable = if ($guiClient -ceq 'desktop') { $desktopLaunchExecutable } else { $executables[$guiClient] }
-        $guiProcess = Start-IsolatedProcess -Executable $guiExecutable -Arguments $guiArguments -CaseRoot $guiCaseRoot -Environment @{
+        $guiEnvironment = @{
             CODEXHUB_E2E_GUI_CLIENT = $guiClient
             CODEXHUB_E2E_CASES = $guiCase.case_id
             CODEXHUB_E2E_MODELS = $guiCase.canonical_model
             CODEXHUB_E2E_MANUAL_TEMPLATE = $manualTemplatePath
             CODEXHUB_E2E_MANUAL_EVIDENCE = $manualEvidencePath
-            CODEXHUB_E2E_GUI_LAUNCH_MARKER = (Join-Path $workRoot "gui-$($guiCase.case_id).launched")
+            CODEXHUB_E2E_GUI_LAUNCH_MARKER = $guiLaunchMarker
         }
+        $guiProcess = Start-IsolatedProcess -Executable $guiExecutable -Arguments $guiArguments -CaseRoot $guiCaseRoot -Environment $guiEnvironment
         [void]$trackedProcesses.Add($guiProcess)
         [void]$nativeGuiProcesses.Add($guiProcess)
+        if ($guiClient -ceq 'desktop') {
+            Wait-DesktopInitialInstanceSettled -Process $guiProcess -LaunchMarker $guiLaunchMarker
+            Invoke-DesktopProjectOpen `
+                -Executable $guiExecutable `
+                -CaseRoot $guiCaseRoot `
+                -UserDataRoot $desktopUserDataRoot `
+                -Environment $guiEnvironment
+        }
     }
 
     $manualDeadline = [DateTime]::UtcNow.AddSeconds($ManualEvidenceTimeoutSeconds)
+    $gatewayHealthFailureCount = 0
+    $nextGatewayHealthCheck = [DateTime]::UtcNow
     while (-not (Test-Path -LiteralPath $manualEvidencePath -PathType Leaf)) {
         foreach ($guiProcess in $nativeGuiProcesses) {
             if ($guiProcess.HasExited) {
                 throw 'manual_gui_exited_before_finalization'
             }
+        }
+        if ($candidateProcess.HasExited) {
+            throw 'candidate_debug_build_exited_during_manual_evidence'
+        }
+        if ([DateTime]::UtcNow -ge $nextGatewayHealthCheck) {
+            if (Test-GatewayHealth -Port ([int]$script:GatewayConfig.listen_port)) {
+                $gatewayHealthFailureCount = 0
+            }
+            else {
+                $gatewayHealthFailureCount += 1
+                if ($gatewayHealthFailureCount -ge 2) {
+                    throw 'candidate_gateway_unavailable_during_manual_evidence'
+                }
+            }
+            $nextGatewayHealthCheck = [DateTime]::UtcNow.AddMilliseconds(1000)
         }
         if ([DateTime]::UtcNow -ge $manualDeadline) {
             throw 'manual_evidence_timeout'

--- a/scripts/Run-RealClientE2E.ps1
+++ b/scripts/Run-RealClientE2E.ps1
@@ -3085,7 +3085,12 @@ try {
         $guiArguments = if ($guiClient -ceq 'desktop') {
             $desktopUserDataRoot = Join-Path $guiCaseRoot 'browser-profile'
             [void](New-Item -ItemType Directory -Force -Path $desktopUserDataRoot)
-            @("--user-data-dir=$desktopUserDataRoot", '--no-first-run', $guiCaseRoot)
+            @(
+                "--user-data-dir=$desktopUserDataRoot",
+                '--no-first-run',
+                '--open-project',
+                $guiCaseRoot
+            )
         }
         else {
             @($guiCaseRoot)

--- a/scripts/Run-RealClientE2E.ps1
+++ b/scripts/Run-RealClientE2E.ps1
@@ -839,6 +839,7 @@ function Start-IsolatedProcess {
     $startInfo.RedirectStandardInput = $false
     $startInfo.RedirectStandardOutput = $false
     $startInfo.RedirectStandardError = $false
+    $startInfo.CreateNoWindow = $false
     $process = [System.Diagnostics.Process]::new()
     $process.StartInfo = $startInfo
     [void]$process.Start()

--- a/scripts/Run-RealClientE2E.ps1
+++ b/scripts/Run-RealClientE2E.ps1
@@ -704,11 +704,10 @@ function New-IsolatedStartInfo {
     if ($extension -iin @('.cmd', '.bat')) {
         $startInfo.FileName = if ($env:ComSpec) { $env:ComSpec } else { 'cmd.exe' }
         $commandLine = @(
-            'call'
             (ConvertTo-ProcessArgument $Executable)
             ($Arguments | ForEach-Object { ConvertTo-ProcessArgument $_ })
         ) -join ' '
-        $startInfo.Arguments = "/d /s /c $(ConvertTo-ProcessArgument $commandLine)"
+        $startInfo.Arguments = '/d /s /c "' + $commandLine + '"'
     }
     elseif ($extension -ieq '.ps1') {
         $startInfo.FileName = (Get-Command powershell.exe -ErrorAction Stop).Source
@@ -1567,7 +1566,7 @@ function Measure-AutomatedAttempt {
         $Attempt.process.exit_code -eq 0 -and
         $Attempt.malformed_count -eq 0 -and
         $modelEvents.Count -eq 1 -and
-        (Get-JsonProperty $modelEvents[0] 'model') -ceq $Case.gateway_model -and
+        (Test-CanonicalModelMatch -Actual ([string](Get-JsonProperty $modelEvents[0] 'model')) -Expected $Case.gateway_model) -and
         $allToolEvents.Count -eq 1 -and $toolEvents.Count -eq 1 -and
         $gatewayRequestEvents.Count -eq ($allToolEvents.Count + 1) -and
         $gatewayCompleteEvents.Count -eq ($allToolEvents.Count + 1) -and

--- a/scripts/Run-RealClientE2E.ps1
+++ b/scripts/Run-RealClientE2E.ps1
@@ -199,6 +199,7 @@ $script:MinimumVersions = [ordered]@{
 }
 $script:ObservedVersions = [ordered]@{}
 $script:MaximumCapturedCharacters = 65536
+$script:MaximumClientEventCharacters = 1048576
 $script:Utf8NoBom = [System.Text.UTF8Encoding]::new($false)
 $script:ProcessJobHandle = [IntPtr]::Zero
 $script:ProcessJobAvailable = $null -ne ('CodexHubE2EJob' -as [type])
@@ -761,7 +762,8 @@ function Invoke-IsolatedProcess {
         [string]$CaseRoot,
         [hashtable]$Environment,
         [string]$StandardInput,
-        [int]$ProcessTimeoutSeconds
+        [int]$ProcessTimeoutSeconds,
+        [int]$MaximumCapturedCharacters = $script:MaximumCapturedCharacters
     )
     foreach ($relative in @('.codex', '.config', 'appdata\roaming', 'appdata\local', 'temp')) {
         [void](New-Item -ItemType Directory -Force -Path (Join-Path $CaseRoot $relative))
@@ -809,11 +811,13 @@ function Invoke-IsolatedProcess {
     $stderr = if ($stderrTask.Status -eq [System.Threading.Tasks.TaskStatus]::RanToCompletion) { $stderrTask.GetAwaiter().GetResult() } else { '' }
     $startedAt.Stop()
     $exitCode = if ($completed) { $process.ExitCode } else { -1 }
-    if ($stdout.Length -gt $script:MaximumCapturedCharacters) {
-        $stdout = $stdout.Substring(0, $script:MaximumCapturedCharacters)
+    $stdoutTruncated = $stdout.Length -gt $MaximumCapturedCharacters
+    $stderrTruncated = $stderr.Length -gt $MaximumCapturedCharacters
+    if ($stdoutTruncated) {
+        $stdout = $stdout.Substring(0, $MaximumCapturedCharacters)
     }
-    if ($stderr.Length -gt $script:MaximumCapturedCharacters) {
-        $stderr = $stderr.Substring(0, $script:MaximumCapturedCharacters)
+    if ($stderrTruncated) {
+        $stderr = $stderr.Substring(0, $MaximumCapturedCharacters)
     }
     return [pscustomobject]@{
         timed_out = -not $completed
@@ -821,6 +825,8 @@ function Invoke-IsolatedProcess {
         duration_ms = [Math]::Min([int]$startedAt.ElapsedMilliseconds, $ProcessTimeoutSeconds * 1000)
         stdout = $stdout
         stderr = $stderr
+        stdout_truncated = $stdoutTruncated
+        stderr_truncated = $stderrTruncated
     }
 }
 
@@ -1491,7 +1497,7 @@ function Invoke-ClientAttempt {
         CODEXHUB_E2E_DIAGNOSTICS_PATH = $script:DiagnosticsPath
     }
     $diagnosticStartLine = Get-DiagnosticLineCount
-    $processResult = Invoke-IsolatedProcess -Executable $Executable -Arguments $arguments -CaseRoot $CaseRoot -Environment $environment -StandardInput $prompt -ProcessTimeoutSeconds $TimeoutSeconds
+    $processResult = Invoke-IsolatedProcess -Executable $Executable -Arguments $arguments -CaseRoot $CaseRoot -Environment $environment -StandardInput $prompt -ProcessTimeoutSeconds $TimeoutSeconds -MaximumCapturedCharacters $script:MaximumClientEventCharacters
     Remove-Item -LiteralPath $sentinelPath -Force -ErrorAction SilentlyContinue
     $parsed = ConvertFrom-ClientEvents -Client $Case.client -Text $processResult.stdout
     $expectedRequestCount = @($parsed.events | Where-Object { (Get-JsonProperty $_ 'event') -eq 'tool_call' }).Count + 1
@@ -1499,7 +1505,7 @@ function Invoke-ClientAttempt {
     return [pscustomobject]@{
         process = $processResult
         events = @($parsed.events) + $gatewayEvents
-        malformed_count = $parsed.malformed_count
+        malformed_count = $parsed.malformed_count + [int][bool]$processResult.stdout_truncated
     }
 }
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "codexhub"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "dirs 5.0.1",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codexhub"
-version = "0.1.6"
+version = "0.1.7"
 description = "CodexHub desktop backend and CLI"
 authors = ["CodexHub"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "CodexHub",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "identifier": "com.codexhub.app",
   "build": {
     "frontendDist": "../frontend/dist",

--- a/tests/fixtures/real_client_e2e/fake-client-codex-official-alias.cmd
+++ b/tests/fixtures/real_client_e2e/fake-client-codex-official-alias.cmd
@@ -1,0 +1,12 @@
+@echo off
+setlocal
+if defined CODEXHUB_E2E_VERSION_PROBE goto delegate
+if defined CODEXHUB_E2E_GUI_CLIENT goto delegate
+if /I "%CODEXHUB_E2E_CLIENT%"=="codex-cli" if /I "%CODEXHUB_E2E_CASE%"=="codex-cli-luna" (
+  set "CODEXHUB_E2E_MODEL=openai/gpt-5.6-luna"
+  set "CODEXHUB_E2E_GATEWAY_MODEL=openai/gpt-5.6-luna"
+)
+
+:delegate
+call "%~dp0fake-client-real-contract.cmd" %*
+exit /b %errorlevel%

--- a/tests/fixtures/real_client_e2e/fake-client-desktop-argv.cmd
+++ b/tests/fixtures/real_client_e2e/fake-client-desktop-argv.cmd
@@ -1,5 +1,12 @@
 @echo off
+set "OPEN_PROJECT="
+for %%A in (%*) do if /I "%%~A"=="--open-project" set "OPEN_PROJECT=1"
 if not "%CODEXHUB_E2E_GUI_CLIENT%"=="" (
+  if /I "%CODEXHUB_E2E_GUI_CLIENT%"=="desktop" if defined OPEN_PROJECT (
+    <nul set /p "=%*">"%CODEXHUB_E2E_GUI_LAUNCH_MARKER%.project.argv"
+    <nul set /p "=%~f0">"%CODEXHUB_E2E_GUI_LAUNCH_MARKER%.project.executable"
+    exit /b 0
+  )
   <nul set /p "=%*">"%CODEXHUB_E2E_GUI_LAUNCH_MARKER%.argv"
   <nul set /p "=%~f0">"%CODEXHUB_E2E_GUI_LAUNCH_MARKER%.executable"
   <nul set /p "=%USERNAME%|%USERDOMAIN%">"%CODEXHUB_E2E_GUI_LAUNCH_MARKER%.identity"

--- a/tests/fixtures/real_client_e2e/fake-client-pi-large-jsonl.cmd
+++ b/tests/fixtures/real_client_e2e/fake-client-pi-large-jsonl.cmd
@@ -1,0 +1,10 @@
+@echo off
+if defined CODEXHUB_E2E_VERSION_PROBE (
+  call "%~dp0fake-client-real-contract.cmd" %*
+  exit /b %ERRORLEVEL%
+)
+if /I "%CODEXHUB_E2E_CLIENT%"=="pi" (
+  for /L %%I in (1,1,600) do echo {"type":"message_update","assistantMessageEvent":{"type":"thinking_delta","delta":"bounded-padding-bounded-padding-bounded-padding-bounded-padding-bounded-padding"}}
+)
+call "%~dp0fake-client-real-contract.cmd" %*
+exit /b %ERRORLEVEL%

--- a/tests/fixtures/real_client_e2e/fake-client-pi-oversize-jsonl.cmd
+++ b/tests/fixtures/real_client_e2e/fake-client-pi-oversize-jsonl.cmd
@@ -1,0 +1,10 @@
+@echo off
+if defined CODEXHUB_E2E_VERSION_PROBE (
+  call "%~dp0fake-client-real-contract.cmd" %*
+  exit /b %ERRORLEVEL%
+)
+if /I "%CODEXHUB_E2E_CLIENT%"=="pi" if /I "%CODEXHUB_E2E_GATEWAY_MODEL%"=="openai/gpt-5.6-luna" (
+  for /L %%I in (1,1,8000) do echo {"type":"message_update","assistantMessageEvent":{"type":"thinking_delta","delta":"bounded-padding-bounded-padding-bounded-padding-bounded-padding-bounded-padding"}}
+)
+call "%~dp0fake-client-real-contract.cmd" %*
+exit /b %ERRORLEVEL%

--- a/tests/fixtures/real_client_e2e/fake-client-pi-single-prompt.cmd
+++ b/tests/fixtures/real_client_e2e/fake-client-pi-single-prompt.cmd
@@ -1,0 +1,17 @@
+@echo off
+setlocal
+if defined CODEXHUB_E2E_VERSION_PROBE goto delegate
+if defined CODEXHUB_E2E_GUI_CLIENT goto delegate
+if /I not "%CODEXHUB_E2E_CLIENT%"=="pi" exit /b 51
+call :check_prompt %*
+if errorlevel 1 exit /b %errorlevel%
+
+:delegate
+call "%~dp0fake-client-real-contract.cmd" %*
+exit /b %errorlevel%
+
+:check_prompt
+for /L %%N in (1,1,12) do shift /1
+if not "%~2"=="" exit /b 52
+if not "%~1"=="Read ./sentinel.txt once with exactly one read-only tool call, then stream exactly %CODEXHUB_E2E_SENTINEL% and stop." exit /b 53
+exit /b 0

--- a/tests/fixtures/real_client_e2e/fake-client-real-contract.cmd
+++ b/tests/fixtures/real_client_e2e/fake-client-real-contract.cmd
@@ -4,6 +4,9 @@ if defined CODEXHUB_E2E_VERSION_PROBE (
   exit /b 0
 )
 if defined CODEXHUB_E2E_GUI_CLIENT (
+  set "OPEN_PROJECT="
+  for %%A in (%*) do if /I "%%~A"=="--open-project" set "OPEN_PROJECT=1"
+  if /I "%CODEXHUB_E2E_GUI_CLIENT%"=="desktop" if defined OPEN_PROJECT exit /b 0
   echo launched>"%CODEXHUB_E2E_GUI_LAUNCH_MARKER%"
   ping.exe 127.0.0.1 -t >nul
 )

--- a/tests/fixtures/real_client_e2e/fake-client-workspace-argv.cmd
+++ b/tests/fixtures/real_client_e2e/fake-client-workspace-argv.cmd
@@ -35,5 +35,5 @@ if "%CODEXHUB_E2E_CLIENT%"=="codex-cli" (
 )
 
 :delegate
-call "%~dp0fake-client-real-contract.cmd"
+call "%~dp0fake-client-real-contract.cmd" %*
 exit /b %errorlevel%

--- a/tests/fixtures/real_client_e2e/fake-debug-build-gateway-exits.cmd
+++ b/tests/fixtures/real_client_e2e/fake-debug-build-gateway-exits.cmd
@@ -1,0 +1,30 @@
+@echo off
+setlocal EnableDelayedExpansion
+if /I "%~1"=="refresh-models" (
+  set "catalog=%CODEXHUB_RUNTIME_HOME%\model-catalogs"
+  if not exist "!catalog!" mkdir "!catalog!"
+  python.exe "%~dp0write-catalog.py" "!catalog!\codexhub-model-catalog.json"
+  if errorlevel 1 exit /b 37
+  exit /b 0
+)
+if not "%~1"=="" exit /b 39
+if not defined CODEXHUB_E2E_CANDIDATE_SHA exit /b 21
+if not defined CODEXHUB_RUNTIME_HOME exit /b 22
+if not defined CODEXHUB_CODEX_TARGET_HOME exit /b 23
+if not defined CODEX_PROXY_GATEWAY_CLIENT_KEY exit /b 24
+if not defined OLLAMA_API_KEY exit /b 25
+if /I not "%HOME%"=="%CD%" exit /b 29
+if /I not "%USERPROFILE%"=="%CD%" exit /b 30
+if /I not "%APPDATA%"=="%CD%\appdata\roaming" exit /b 31
+if /I not "%LOCALAPPDATA%"=="%CD%\appdata\local" exit /b 32
+if /I not "%XDG_CONFIG_HOME%"=="%CD%\.config" exit /b 33
+if /I not "%TEMP%"=="%CD%\temp" exit /b 34
+if /I not "%TMP%"=="%CD%\temp" exit /b 35
+if /I not "%CODEX_HOME%"=="%CODEXHUB_CODEX_TARGET_HOME%" exit /b 36
+if defined CODEXHUB_HOST_SESSION exit /b 37
+if defined OPENAI_API_KEY exit /b 38
+if not exist "%CODEXHUB_RUNTIME_HOME%\proxy\settings.json" exit /b 26
+if not exist "%CODEXHUB_RUNTIME_HOME%\proxy\config\providers.toml" exit /b 27
+if not exist "%CODEXHUB_CODEX_TARGET_HOME%\auth.json" exit /b 28
+start "" /b python.exe "%~dp0fake-debug-gateway.py" --port %CODEXHUB_E2E_GATEWAY_PORT% --exit-after-seconds 2
+ping.exe 127.0.0.1 -t >nul

--- a/tests/fixtures/real_client_e2e/fake-debug-gateway.py
+++ b/tests/fixtures/real_client_e2e/fake-debug-gateway.py
@@ -3,11 +3,13 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import json
 import os
 from pathlib import Path
+import threading
 
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--port", type=int, required=True)
 parser.add_argument("--bad-health", action="store_true")
+parser.add_argument("--exit-after-seconds", type=float)
 args = parser.parse_args()
 settings = json.loads(
     (Path(os.environ["CODEXHUB_RUNTIME_HOME"]) / "proxy" / "settings.json").read_text()
@@ -37,4 +39,9 @@ class Server(ThreadingHTTPServer):
 
 if args.port != int(settings["proxy_port"]):
     raise SystemExit(2)
-Server(("127.0.0.1", args.port), Handler).serve_forever()
+server = Server(("127.0.0.1", args.port), Handler)
+if args.exit_after_seconds is not None:
+    timer = threading.Timer(args.exit_after_seconds, server.shutdown)
+    timer.daemon = True
+    timer.start()
+server.serve_forever()

--- a/tests/fixtures/real_client_e2e/fake-gui-expanding-tree.cmd
+++ b/tests/fixtures/real_client_e2e/fake-gui-expanding-tree.cmd
@@ -1,9 +1,14 @@
 @echo off
+set "OPEN_PROJECT="
+for %%A in (%*) do (
+  if /I "%%~A"=="--open-project" set "OPEN_PROJECT=1"
+)
 if defined CODEXHUB_E2E_VERSION_PROBE (
   echo %CODEXHUB_E2E_MINIMUM_VERSION%
   exit /b 0
 )
 if defined CODEXHUB_E2E_GUI_CLIENT (
+  if /I "%CODEXHUB_E2E_GUI_CLIENT%"=="desktop" if defined OPEN_PROJECT exit /b 0
   echo launched>"%CODEXHUB_E2E_GUI_LAUNCH_MARKER%"
   python.exe "%~dp0fake-gui-expanding-tree.py" "%CODEXHUB_E2E_GUI_LAUNCH_MARKER%.orphan"
 )

--- a/tests/test_real_client_e2e.py
+++ b/tests/test_real_client_e2e.py
@@ -1924,6 +1924,7 @@ def test_desktop_gui_cases_use_distinct_case_local_user_data_directories(tmp_pat
         assert arguments.count("--user-data-dir=") == 1
         assert str(expected_profile).casefold() in arguments.casefold()
         assert "--no-first-run" in arguments
+        assert arguments.count("--open-project") == 1
         expected_workspace = work / "gui-desktop" / case_id
         assert arguments.rstrip('"').casefold().endswith(
             str(expected_workspace).casefold()

--- a/tests/test_real_client_e2e.py
+++ b/tests/test_real_client_e2e.py
@@ -1908,7 +1908,7 @@ def test_desktop_executable_must_match_appx_manifest_entry(tmp_path):
     assert not (tmp_path / "output" / "manual-evidence.template.json").exists()
 
 
-def test_desktop_gui_cases_use_distinct_case_local_user_data_directories(tmp_path):
+def test_desktop_gui_cases_open_projects_via_ready_second_instance(tmp_path):
     result = _run(
         tmp_path,
         client_fakes={"CodexDesktopPath": "fake-client-desktop-argv.cmd"},
@@ -1918,19 +1918,45 @@ def test_desktop_gui_cases_use_distinct_case_local_user_data_directories(tmp_pat
     work = tmp_path / "output" / "isolated" / "work"
     observed = {}
     for case_id in ("desktop-luna", "desktop-ollama-cloud"):
-        argument_log = work / f"gui-{case_id}.launched.argv"
-        arguments = argument_log.read_text(encoding="ascii").strip()
+        initial_log = work / f"gui-{case_id}.launched.argv"
+        initial_arguments = initial_log.read_text(encoding="ascii").strip()
+        project_log = work / f"gui-{case_id}.launched.project.argv"
+        project_arguments = project_log.read_text(encoding="ascii").strip()
         expected_profile = work / "gui-desktop" / case_id / "browser-profile"
-        assert arguments.count("--user-data-dir=") == 1
-        assert str(expected_profile).casefold() in arguments.casefold()
-        assert "--no-first-run" in arguments
-        assert arguments.count("--open-project") == 1
+        assert initial_arguments.count("--user-data-dir=") == 1
+        assert str(expected_profile).casefold() in initial_arguments.casefold()
+        assert "--no-first-run" in initial_arguments
+        assert "--open-project" not in initial_arguments
+        assert project_arguments.count("--user-data-dir=") == 1
+        assert str(expected_profile).casefold() in project_arguments.casefold()
+        assert "--no-first-run" in project_arguments
+        assert project_arguments.count("--open-project") == 1
         expected_workspace = work / "gui-desktop" / case_id
-        assert arguments.rstrip('"').casefold().endswith(
+        assert project_arguments.rstrip('"').casefold().endswith(
             str(expected_workspace).casefold()
         )
-        observed[case_id] = arguments
+        observed[case_id] = (initial_arguments, project_arguments)
     assert observed["desktop-luna"] != observed["desktop-ollama-cloud"]
+
+
+def test_gateway_exit_during_manual_evidence_fails_fast(tmp_path):
+    started = time.monotonic()
+    result = _run(
+        tmp_path,
+        debug_fake="fake-debug-build-gateway-exits.cmd",
+        finalize_manual=False,
+        manual_timeout_seconds=30,
+        overall_timeout_seconds=60,
+    )
+    elapsed = time.monotonic() - started
+
+    assert result.returncode != 0
+    summary = json.loads((tmp_path / "output" / "summary.json").read_text())
+    assert (
+        summary["failure_classification"]
+        == "candidate_gateway_unavailable_during_manual_evidence"
+    )
+    assert elapsed < 25
 
 
 def test_zcode_gui_cases_open_their_case_local_workspaces(tmp_path):
@@ -2698,7 +2724,7 @@ def test_missing_manual_evidence_and_early_gui_exit_are_classified(tmp_path):
         (tmp_path / "exited" / "output" / "summary.json").read_text(encoding="utf-8-sig")
     )
     assert missing_summary["failure_classification"] == "manual_evidence_timeout"
-    assert exited_summary["failure_classification"] == "manual_gui_exited_before_finalization"
+    assert exited_summary["failure_classification"] == "manual_gui_exited_before_project_open"
 
 
 def test_candidate_startup_failure_emits_one_summary_without_partial_artifacts(tmp_path):

--- a/tests/test_real_client_e2e.py
+++ b/tests/test_real_client_e2e.py
@@ -1155,6 +1155,32 @@ def test_automated_clients_bind_fresh_workspace_and_minimal_read_only_context(tm
     assert [case["outcome"] for case in automated] == ["passed"] * 8
 
 
+def test_pi_batch_launch_preserves_the_prompt_as_one_positional_message(tmp_path):
+    result = _run(
+        tmp_path,
+        client_fakes={"PiPath": "fake-client-pi-single-prompt.cmd"},
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_codex_cli_accepts_the_official_canonical_diagnostic_alias(tmp_path):
+    result = _run(
+        tmp_path,
+        client_fakes={"CodexCliPath": "fake-client-codex-official-alias.cmd"},
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    summary = json.loads(
+        (tmp_path / "output" / "summary.json").read_text(encoding="utf-8-sig")
+    )
+    codex_luna = next(
+        case for case in summary["cases"] if case["case_id"] == "codex-cli-luna"
+    )
+    assert codex_luna["outcome"] == "passed"
+    assert codex_luna["gateway_model"] == "gpt-5.6-luna"
+
+
 def test_windows_client_state_paths_are_isolated_per_case(tmp_path):
     result = _run(tmp_path, fake="fake-client-isolation.cmd")
 

--- a/tests/test_real_client_e2e.py
+++ b/tests/test_real_client_e2e.py
@@ -1164,6 +1164,43 @@ def test_pi_batch_launch_preserves_the_prompt_as_one_positional_message(tmp_path
     assert result.returncode == 0, result.stdout + result.stderr
 
 
+def test_pi_large_structured_event_stream_preserves_terminal_evidence(tmp_path):
+    result = _run(
+        tmp_path,
+        client_fakes={"PiPath": "fake-client-pi-large-jsonl.cmd"},
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    summary = json.loads(
+        (tmp_path / "output" / "summary.json").read_text(encoding="utf-8-sig")
+    )
+    pi_cases = [
+        case for case in summary["cases"] if case["case_id"].startswith("pi-")
+    ]
+    assert [case["outcome"] for case in pi_cases] == ["passed", "passed"]
+    assert [case["terminal_classification"] for case in pi_cases] == [
+        "completed",
+        "completed",
+    ]
+
+
+def test_oversize_structured_event_stream_fails_closed(tmp_path):
+    result = _run(
+        tmp_path,
+        client_fakes={"PiPath": "fake-client-pi-oversize-jsonl.cmd"},
+    )
+
+    assert result.returncode != 0
+    summary = json.loads(
+        (tmp_path / "output" / "summary.json").read_text(encoding="utf-8-sig")
+    )
+    pi_cases = [
+        case for case in summary["cases"] if case["case_id"].startswith("pi-")
+    ]
+    assert [case["outcome"] for case in pi_cases] == ["failed", "passed"]
+    assert pi_cases[0]["retry_classification"] == "not_eligible"
+
+
 def test_codex_cli_accepts_the_official_canonical_diagnostic_alias(tmp_path):
     result = _run(
         tmp_path,

--- a/tests/test_real_client_e2e.py
+++ b/tests/test_real_client_e2e.py
@@ -1908,6 +1908,21 @@ def test_desktop_executable_must_match_appx_manifest_entry(tmp_path):
     assert not (tmp_path / "output" / "manual-evidence.template.json").exists()
 
 
+def test_native_gui_launch_explicitly_enables_visible_windows():
+    source = SCRIPT.read_text(encoding="utf-8")
+    shared_start_info = source[
+        source.index("function New-IsolatedStartInfo"):
+        source.index("function Invoke-IsolatedProcess")
+    ]
+    gui_launch = source[
+        source.index("function Start-IsolatedProcess"):
+        source.index("function Wait-DesktopInitialInstanceSettled")
+    ]
+
+    assert "$startInfo.CreateNoWindow = $true" in shared_start_info
+    assert "$startInfo.CreateNoWindow = $false" in gui_launch
+
+
 def test_desktop_gui_cases_open_projects_via_ready_second_instance(tmp_path):
     result = _run(
         tmp_path,

--- a/tests/test_release_channel_scripts.py
+++ b/tests/test_release_channel_scripts.py
@@ -20,7 +20,7 @@ def test_official_transport_wheel_is_pinned_and_packaged():
 
 
 def test_release_version_is_consistent_across_manifests():
-    expected = "0.1.6"
+    expected = "0.1.7"
     tauri = json.loads((ROOT / "src-tauri" / "tauri.conf.json").read_text(encoding="utf-8"))
     cargo = tomllib.loads((ROOT / "src-tauri" / "Cargo.toml").read_text(encoding="utf-8"))
     cargo_lock = tomllib.loads((ROOT / "src-tauri" / "Cargo.lock").read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary

- align all release metadata, artifact naming, README examples, and release notes on 0.1.7
- freeze one immutable candidate for Official Responses and Ollama Cloud Native Responses
- harden the real-client qualification runner for visible GUI launches, isolated workspace binding, current Codex model aliases, Pi single-prompt launch identity, and bounded structured event capture
- retain provider-independent Desktop/ZCode seed slots and fail closed on fallback, reconnect, duplicate terminal, malformed output, or over-bound client JSONL

## Why

The final qualification exposed two harness defects rather than product-route failures: Windows batch quoting could split Pi's one-shot prompt into queued follow-up messages, and the shared 64 KiB process-output prefix could cut Pi Luna JSONL before its final `message_end` / `agent_end`. The runner now gives automated client JSONL a dedicated 1 MiB retained limit and treats reaching that limit as a failure, while ordinary probes remain capped at 64 KiB.

## Frozen candidate

- commit: `5f73ab1707c7b75c9e0c0760f367aa8b21e121f2`
- tree: `c103fd5faa20da9318c9a545c6c02ab78b359d14`
- debug EXE SHA-256: `39c1a3c77296d3ca5c6ef471d72717eb9a820a046c853cc21d834b9fb65a7d4a`
- debug portable ZIP SHA-256: `cf3db82ab26a0d4323fcedcff69663ce191e20a8f077d0603826f550027410c7`
- authoritative summary SHA-256: `18361ef9943a3339d7613af714927121a3bbcf978c11bd8a44aa37a58c4a9c18`

## Qualification

- Python core: 1,876 tests, 0 failures, 1 existing skip
- synthetic real-client contract: 142/142 passed under the checked-in Windows watchdog
- Python partition completeness, PowerShell parse, `git diff --check`, and report-only quality command: passed
- exact-candidate frontend production build and Rust release-optimized debug portable build: passed
- release-equivalent Rust normal/debug tests, clippy, release flavor, and WSL `safe_file` gates were green before the final E2E-runner-only delta
- authoritative real-client run: 12/12 passed, exactly 6 Official + 6 Ollama Cloud, all Responses
- every case: one successful request completion, one read-only tool call, one exact sentinel, two streaming Gateway completions, completed terminal, zero fallback, zero duplicate terminal, zero reconnect
- qualified client versions: Codex Desktop 26.721.4979.0, Codex CLI 0.145.0, ZCode 3.5.3, OpenCode 1.18.6, Pi 0.80.6, OMP 17.0.3

## Manual observation

The current Codex Desktop build displayed one transient `codex-windows-sandbox-setup.exe` “module not found” dialog while opening the Desktop Ollama Cloud case. The same isolated case subsequently created the Task and completed the required tool/sentinel flow. Correlated evidence still showed one completion, no fallback, no reconnect, and no duplicate terminal. This is retained as a client-side observation, not hidden or treated as a Gateway failure.

Tracks #227. The issue should remain open until the merged `dev` artifact is explicitly accepted by the user.