### PR TITLE
Preserve Codex agents config across overlay lifecycle

### DIFF
--- a/docs/evidence/issue-199/README.md
+++ b/docs/evidence/issue-199/README.md
@@ -3,6 +3,8 @@
 Candidate base: `ae927c687390017903435cd9bf4314610b6da229` (`origin/dev`)
 Independent-review repair fixed point:
 `ed3e4afa642dd8ba2b806cdd990cf111444f961a`
+Second-review repair fixed point:
+`c9a7a09cd7e88c640cf3d71fd69c862f23e3dd5f`
 
 ## Proven lifecycle
 
@@ -32,20 +34,36 @@ a missing or same-owner-but-diverged live file could lose its only backup, and
 a concurrent takeover retry could invalidate restore's snapshot before
 cleanup.
 
-Apply and restore now hold one shared per-config lifecycle lock from the first
-read through final publication and cleanup. Under that lock, interrupted
-cleanup requires an existing live config byte-identical to the recovery
-backup. Missing or diverged state fails closed without deleting either
-recovery artifact. A deterministic thread test proves a retry cannot publish
-while restore holds this transaction.
+Apply, restore, and context-guard writes now hold one shared, canonical
+per-config lifecycle lock from the first read through final publication and
+cleanup. Managed paths are canonicalized before use, and path aliases or
+hardlinks between the config, backup, sidecar, and context-guard state are
+rejected before mutation. Under the lock, every writer preflights takeover
+metadata: terminal cleanup completes before a new write, invalid or
+unrecognized state fails closed, and only an exact takeover retry may proceed
+from interrupted state. Missing or diverged state retains every recovery
+artifact. A deterministic thread test proves a retry cannot publish while
+restore holds this transaction. Real writer-versus-writer subprocess tests
+prove apply and context guard serialize, and that a second restore resumes a
+published cleanup journal after the contending restore process is killed.
 
 Cleanup is a resumable two-phase operation. Before deleting recovery bytes,
-CodexHub atomically records the exact final-config SHA-256 and terminal status
-in the takeover sidecar. A retry removes remaining artifacts only after the
-live config, original owner, digest, and any remaining backup all revalidate.
-Journal publication, backup deletion, and sidecar deletion failures are
-covered, including completed owner restoration as well as interrupted
-takeover cleanup.
+CodexHub atomically records separate source-config, recovery-backup, and
+intended-final SHA-256 digests plus the terminal status in the takeover
+sidecar. This journal is durable before final config publication. A retry
+publishes or cleans up only after the live config, both owners, intended
+terminal transformation, and every remaining artifact revalidate. Journal
+publication, final publication, backup deletion, and sidecar deletion failures
+are covered before and after each operation's externally visible commit point,
+including transformed unified history from an unowned original, completed
+owner restoration, and interrupted takeover cleanup.
+
+Takeover metadata reads explicitly classify the sidecar as absent, valid, or
+invalid. Only absence permits the legacy no-sidecar restore path. Truncated or
+unreadable JSON, future or non-integral versions, unknown fields or owners,
+duplicate keys, partial/null journals, malformed digests, unsupported statuses,
+and inconsistent owner/digest/status/artifact combinations all fail closed
+while retaining the live config, recovery backup, and sidecar.
 
 CodexHub continues to own only its existing provider/catalog/context overlay
 and websocket feature flags. It does not parse, normalize, enable, or supply
@@ -54,15 +72,24 @@ defaults for agent or collaboration V2 configuration.
 ## Local verification
 
 - `python -m pytest -q tests/test_config_overlay.py`
-  - `58 passed, 8 subtests passed in 3.36s`
+  - `79 passed, 37 subtests passed in 10.24s`
 - `python -m pytest -q --ignore=tests/test_real_client_e2e.py`
-  - `1471 passed, 1 skipped, 420 subtests passed in 106.86s`
+  - corrected-toolchain rerun: `1491 passed, 1 failed, 1 skipped, 449
+    subtests passed in 109.43s`
+  - the sole failure was the unrelated localized-PowerShell stderr assertion
+    `test_portable_rejects_invalid_flavor_before_building`; it passed in the
+    immediate focused diagnostic run together with the two child-Python tests
+    affected by the restarted host's initial `PATH`
 - `git diff --check`
   - passed
 - `python scripts/report_quality_gates.py`
   - report-only exit `0`, `parse_errors: 0`
   - repository baseline: 2 unused imports, 83 dead-function reports, and 146
     duplicate-name reports; no changed-file finding was identified
+- local Standards/Spec self-review
+  - writer-preflight, duplicate-key, path-alias, and ambiguous-commit edge
+    cases found during review were repaired; the final delta has no remaining
+    actionable finding
 
 The issue's literal unpartitioned `python -m pytest -q` command was also
 attempted once. It exceeded a 1,200-second local outer bound while including

--- a/docs/evidence/issue-199/README.md
+++ b/docs/evidence/issue-199/README.md
@@ -107,6 +107,43 @@ tested independently from the implementation. A forged owned journal with
 otherwise coherent source/recovery/final digests is rejected during sidecar
 read, before live publication or receipt creation.
 
+### Active-takeover context-guard re-anchor repair
+
+Final Spec review of `415a45f077dc03f0cc051b09b6121aad4bc14770`
+found that a successful context-guard update changed the active takeover's
+recovery backup but left `recovery_sha256` anchored to the previous bytes.
+The update reported success, while the next restore failed closed with
+`recovery backup is missing or diverged`.
+
+Context-guard backup updates now use the existing takeover metadata and
+lifecycle phase model under the same canonical per-config lock. The active
+anchor remains the base authority while a bounded
+`RECOVERY_REANCHOR_JOURNAL` records only the candidate recovery SHA-256.
+Journal readback is durable before the candidate backup is published; exact
+backup readback is durable before ordinary active metadata promotes the
+candidate digest. Resume accepts only the exact base or candidate bytes with
+the recorded original owner. Base bytes roll the journal back to the base
+anchor, candidate bytes promote the candidate anchor, and any third bytes or
+owner mismatch fail closed without changing or deleting recovery evidence.
+
+The context-guard state is durable before an enabled active-takeover update so
+a fresh retry retains the distinct prior live and backup values. The recovery
+backup and anchor commit before the live config, so every injected failure
+between journal, backup, and anchor publication leaves the live takeover bytes
+unchanged. A fresh CLI process resolves the typed journal, retries the requested
+enable or disable, and restores the original owner with the intended context
+settings while preserving provider, model, agents, comments, and unknown TOML.
+
+Tests cover before- and after-commit errors at journal publication, recovery
+backup publication, and candidate-anchor publication for both enable and
+disable (`12` crash-prefix subtests). Duplicate, future, unknown, malformed,
+mixed-phase, and same-owner re-anchor records fail before mutation. A valid
+journal with unknown third recovery bytes retains the live config, backup,
+metadata, and context state. Re-anchor metadata contains exactly version,
+owners, and the two fixed SHA-256 fields; bounded-size assertions prove it
+contains no agent config, collaboration setting, provider credential, or
+Gateway key.
+
 Completion receipts use the same strict absent/valid/invalid classification.
 Legacy or missing fields, truncated or unreadable JSON, duplicate keys,
 future/non-integral versions, unknown fields/owners/statuses, malformed
@@ -155,6 +192,23 @@ defaults for agent or collaboration V2 configuration.
 
 ## Local verification
 
+- Post-review active-takeover context-guard repair:
+  - ordinary enable and enable-then-disable lifecycle tests were red on
+    `415a45f077dc03f0cc051b09b6121aad4bc14770` because restore rejected the
+    stale recovery anchor; both are green after the typed re-anchor repair;
+  - committed-backup-error fresh-process retry was red before the journal and
+    green afterward;
+  - `py -3.13 -m pytest -q tests/test_config_overlay.py`
+    - `110 passed, 202 subtests passed in 94.01s`;
+  - subsequent parser-only delta:
+    `1 passed, 31 subtests passed in 6.64s`;
+  - `py -3.13 -m py_compile src-python/config_overlay.py
+    tests/test_config_overlay.py` and `py -3.13 -m compileall -q src-python
+    tests/test_config_overlay.py` passed;
+  - `git diff --check` passed;
+  - report-only quality gates exited `0` with `parse_errors: 0`; repository
+    baseline remained 2 unused imports, 83 dead-function reports, and 146
+    duplicate-name reports, with no changed-file finding.
 - `Python313\python.exe -m pytest -q tests/test_config_overlay.py`
   - `106 passed, 186 subtests passed in 43.83s`
 - `Python313\python.exe -m pytest -q --ignore=tests/test_real_client_e2e.py`

--- a/docs/evidence/issue-199/README.md
+++ b/docs/evidence/issue-199/README.md
@@ -1,0 +1,50 @@
+# Issue #199 agents configuration preservation
+
+Candidate base: `ae927c687390017903435cd9bf4314610b6da229` (`origin/dev`)
+
+## Proven lifecycle
+
+The regression fixture follows Codex `rust-v0.145.0` agent configuration:
+
+- `[agents]` enablement, canonical
+  `max_concurrent_threads_per_session`, and the retained `max_threads` alias;
+- default subagent model and reasoning effort;
+- nested role descriptions, `config_file` paths, and nickname candidates;
+- structured `features.multi_agent_v2` settings with explicit enabled and
+  disabled choices;
+- an absent backend/defaults case proving that CodexHub does not invent a V2
+  choice, agent tree, role, model, or reasoning default;
+- an unknown future agent value proving open-set preservation.
+
+Tests exercise Stable connect, same-owner restart/reapply and readback,
+Developer takeover, interrupted takeover cleanup, each owner restore, and exact
+final restoration of the pre-owned bytes. The interrupted-takeover fixture
+exposed a defect: after the takeover backup and sidecar were durable but before
+the live config write completed, restore rewrote the still-active Stable
+configuration as unified Official history. Cleanup now recognizes that pending
+state, removes only the incomplete Developer takeover artifacts, and leaves the
+prior owner's live configuration byte-for-byte unchanged.
+
+CodexHub continues to own only its existing provider/catalog/context overlay
+and websocket feature flags. It does not parse, normalize, enable, or supply
+defaults for agent or collaboration V2 configuration.
+
+## Local verification
+
+- `python -m pytest -q tests/test_config_overlay.py`
+  - `49 passed, 8 subtests passed in 2.60s`
+- `python -m pytest -q --ignore=tests/test_real_client_e2e.py`
+  - `1462 passed, 1 skipped, 420 subtests passed in 114.73s`
+- `git diff --check`
+  - passed
+- `python scripts/report_quality_gates.py`
+  - report-only exit `0`, `parse_errors: 0`
+  - repository baseline: 2 unused imports, 83 dead-function reports, and 146
+    duplicate-name reports; no changed-file finding was identified
+
+The issue's literal unpartitioned `python -m pytest -q` command was also
+attempted once. It exceeded a 1,200-second local outer bound while including
+the separately governed real-client module and emitted no captured failure.
+The repository verification policy classifies this diff under the Python core
+suite above; none of the changed paths are in the synthetic real-client
+contract relevance list.

--- a/docs/evidence/issue-199/README.md
+++ b/docs/evidence/issue-199/README.md
@@ -7,6 +7,8 @@ Second-review repair fixed point:
 `c9a7a09cd7e88c640cf3d71fd69c862f23e3dd5f`
 Completion-receipt review fixed point:
 `5e9e7e9416f4cecbeef421fc71e20542e2c1a5bf`
+Digest-anchor and status-legality review fixed point:
+`b7b8e46595f924203a5bd9eb17d1acce81d66282`
 
 ## Proven lifecycle
 
@@ -86,10 +88,59 @@ duplicate keys, partial/null journals, malformed digests, unsupported statuses,
 and inconsistent owner/digest/status/artifact combinations all fail closed
 while retaining the live config, recovery backup, and sidecar.
 
+Active takeover metadata now binds the exact recovery backup bytes with a
+lowercase SHA-256 in addition to both owner identities. Takeover apply reads
+back the durable backup and sidecar before publishing the new live config.
+Apply, context guard, restart, and restore share one typed lifecycle snapshot;
+active, interrupted, cleanup-journal, and completion-receipt paths validate the
+same owner/digest anchor before any restore or cleanup mutation. Same-marker
+drift in unknown agent keys, model/provider fields, comments, or raw newline
+bytes therefore fails closed across owned and unowned takeovers, both channel
+directions, interrupted takeover, and a fresh-process retry.
+
+Cleanup journal and completion receipt status legality also uses one typed
+phase validator. Unified-history transformation statuses are legal only when
+the original config was unowned. `interrupted_takeover_discarded` and
+`restored_takeover_backup` are the only identity statuses legal with an owned
+original. The full original-owner × status × active/journal/receipt matrix is
+tested independently from the implementation. A forged owned journal with
+otherwise coherent source/recovery/final digests is rejected during sidecar
+read, before live publication or receipt creation.
+
 Completion receipts use the same strict absent/valid/invalid classification.
 Legacy or missing fields, truncated or unreadable JSON, duplicate keys,
 future/non-integral versions, unknown fields/owners/statuses, malformed
 digests, and owner/status inconsistencies all fail closed without mutation.
+
+### 0.1.7 active-sidecar recovery boundary
+
+An active 0.1.7 takeover sidecar has `version`, `takeover_owner`, and
+`original_owner`, but no durable recovery digest. The current reader reports
+the typed `MISSING_RECOVERY_ANCHOR` reason and refuses Stable/Developer
+reapply or restore before changing the live config, backup, sidecar, or
+completion receipt. It never silently strips the legacy sidecar or computes a
+new digest from the untrusted backup, because either action would bless bytes
+whose identity was never recorded.
+
+Safe recovery is therefore an explicit offline operation:
+
+1. Stop Stable, Developer, and the Gateway so no config writer remains.
+2. Copy the live config, takeover backup, takeover sidecar, and any completion
+   receipt to a separate quarantine location. Do not delete either recovery
+   artifact.
+3. Compare the backup with an independent known-good pre-takeover copy or have
+   the user verify the intended owner/config bytes. The legacy sidecar alone
+   cannot establish that identity. If no independent evidence exists, retain
+   all artifacts and escalate instead of auto-restoring.
+4. With all writers still stopped, restore only the independently verified
+   backup bytes to the live config. Move the legacy backup and sidecar together
+   to quarantine rather than deleting them, then restart the verified original
+   owner channel. Retain the quarantine until normal connect/restore behavior
+   is confirmed.
+
+This path deliberately avoids logging or embedding config, provider
+credentials, Gateway keys, or agent config contents. New sidecars contain only
+fixed owner/version fields and the bounded recovery digest.
 
 Managed-path validation now covers the config, backup, metadata, completion
 receipt, context state, lifecycle target, and every corresponding
@@ -104,13 +155,26 @@ defaults for agent or collaboration V2 configuration.
 
 ## Local verification
 
-- `py -3.13 -m pytest -q tests/test_config_overlay.py`
-  - `97 passed, 85 subtests passed in 41.05s`
-- `py -3.13 -m pytest -q --ignore=tests/test_real_client_e2e.py`
-  - corrected-toolchain run: `1509 passed, 1 skipped, 495 subtests passed in
-    130.11s`
-- final completion/rotation delta after the Python core run
-  - `12 passed, 85 deselected, 31 subtests passed in 13.13s`
+- `Python313\python.exe -m pytest -q tests/test_config_overlay.py`
+  - `106 passed, 186 subtests passed in 43.83s`
+- `Python313\python.exe -m pytest -q --ignore=tests/test_real_client_e2e.py`
+  with the Python 3.13 directory first on `PATH`
+  - authoritative corrected-toolchain run: `1519 passed, 1 skipped, 598
+    subtests passed in 133.56s`
+  - the first run inherited the Hermes Python 3.11 executable in child-process
+    `PATH`: `1517 passed, 1 skipped, 598 subtests passed`, with only the two
+    issue #108 PowerShell evidence replays failing
+  - sanitized failure artifacts identified Python 3.11 parsing the repository's
+    PEP 695 syntax and `evidence_validator_execution_failed`; placing Python
+    3.13 first on `PATH` made those isolated two tests pass before the
+    authoritative full run
+- repair-specific TDD evidence
+  - same-owner-marker agent-key backup drift: red because restore accepted the
+    bytes; green after durable recovery anchoring
+  - owner × status × phase matrix: 12 owned/unowned-only journal combinations
+    red; all `81` matrix subtests green after the shared legality validator
+  - durable backup/sidecar readback replacement: 2 red subtests; both green
+    after pre-live-publication validation
 - `py -3.13 -m compileall -q src-python tests/test_config_overlay.py`
   - passed
 - `git diff --check`
@@ -119,11 +183,8 @@ defaults for agent or collaboration V2 configuration.
   - report-only exit `0`, `parse_errors: 0`
   - repository baseline: 2 unused imports, 83 dead-function reports, and 146
     duplicate-name reports; no changed-file finding was identified
-- local Standards/Spec self-review
-  - receipt retirement, same-owner staged-backup, second no-op restore,
-    duplicate-key, path/lock-alias, and ambiguous-commit edge cases found
-    during review were repaired; the final delta has no remaining actionable
-    finding
+- Worker delta inspection does not claim review acceptance; the pushed exact
+  SHA remains subject to a fresh Orchestrator-owned Standards/Spec review.
 
 The issue's literal unpartitioned `python -m pytest -q` command was also
 attempted once. It exceeded a 1,200-second local outer bound while including

--- a/docs/evidence/issue-199/README.md
+++ b/docs/evidence/issue-199/README.md
@@ -118,13 +118,18 @@ The update reported success, while the next restore failed closed with
 Context-guard backup updates now use the existing takeover metadata and
 lifecycle phase model under the same canonical per-config lock. The active
 anchor remains the base authority while a bounded
-`RECOVERY_REANCHOR_JOURNAL` records only the candidate recovery SHA-256.
+`RECOVERY_REANCHOR_JOURNAL` records only the candidate recovery SHA-256 and
+the exact pre-operation live-config SHA-256.
 Journal readback is durable before the candidate backup is published; exact
 backup readback is durable before ordinary active metadata promotes the
-candidate digest. Resume accepts only the exact base or candidate bytes with
-the recorded original owner. Base bytes roll the journal back to the base
-anchor, candidate bytes promote the candidate anchor, and any third bytes or
-owner mismatch fail closed without changing or deleting recovery evidence.
+candidate digest. One typed preflight shared by restore and every managed
+writer requires the exact journaled live bytes and takeover owner, the exact
+base or candidate backup bytes and original owner, valid metadata, and no
+coexisting completion receipt before any journal promotion or rollback.
+Base bytes roll the journal back to the base anchor, candidate bytes promote
+the candidate anchor, and live drift, owner mismatch, third recovery bytes,
+or completion-state mismatch fail closed without changing or deleting any
+config, backup, metadata, completion, or context-state evidence.
 
 The context-guard state is durable before an enabled active-takeover update so
 a fresh retry retains the distinct prior live and backup values. The recovery
@@ -136,13 +141,16 @@ settings while preserving provider, model, agents, comments, and unknown TOML.
 
 Tests cover before- and after-commit errors at journal publication, recovery
 backup publication, and candidate-anchor publication for both enable and
-disable (`12` crash-prefix subtests). Duplicate, future, unknown, malformed,
-mixed-phase, and same-owner re-anchor records fail before mutation. A valid
-journal with unknown third recovery bytes retains the live config, backup,
-metadata, and context state. Re-anchor metadata contains exactly version,
-owners, and the two fixed SHA-256 fields; bounded-size assertions prove it
-contains no agent config, collaboration setting, provider credential, or
-Gateway key.
+disable (`12` crash-prefix subtests). Another `12` fresh-process subtests cover
+restore and managed-write preparation with base/candidate recovery bytes,
+same-owner raw live drift, owner mismatch, and an inconsistent completion
+receipt; every managed artifact remains byte-for-byte unchanged. Duplicate,
+future, unknown, malformed, missing-field, mixed-phase, and same-owner
+re-anchor records fail before mutation. A valid journal with unknown third
+recovery bytes retains the live config, backup, metadata, and context state.
+Re-anchor metadata contains exactly version, owners, and three fixed SHA-256
+fields; bounded-size assertions prove it contains no agent config,
+collaboration setting, provider credential, or Gateway key.
 
 Completion receipts use the same strict absent/valid/invalid classification.
 Legacy or missing fields, truncated or unreadable JSON, duplicate keys,
@@ -198,6 +206,12 @@ defaults for agent or collaboration V2 configuration.
     stale recovery anchor; both are green after the typed re-anchor repair;
   - committed-backup-error fresh-process retry was red before the journal and
     green afterward;
+  - same-owner raw live drift after a durable re-anchor journal was red on
+    `7154a7dffe10b7c528ba217e0c8b64b48311b6aa`: fresh restore exited
+    successfully and consumed recovery evidence; it is green after the exact
+    live-byte anchor and complete preflight;
+  - final affected overlay/parser matrix:
+    `9 passed, 145 subtests passed in 31.50s`;
   - `py -3.13 -m pytest -q tests/test_config_overlay.py`
     - `110 passed, 202 subtests passed in 94.01s`;
   - subsequent parser-only delta:

--- a/docs/evidence/issue-199/README.md
+++ b/docs/evidence/issue-199/README.md
@@ -1,6 +1,8 @@
 # Issue #199 agents configuration preservation
 
 Candidate base: `ae927c687390017903435cd9bf4314610b6da229` (`origin/dev`)
+Independent-review repair fixed point:
+`ed3e4afa642dd8ba2b806cdd990cf111444f961a`
 
 ## Proven lifecycle
 
@@ -17,13 +19,33 @@ The regression fixture follows Codex `rust-v0.145.0` agent configuration:
 - an unknown future agent value proving open-set preservation.
 
 Tests exercise Stable connect, same-owner restart/reapply and readback,
-Developer takeover, interrupted takeover cleanup, each owner restore, and exact
-final restoration of the pre-owned bytes. The interrupted-takeover fixture
-exposed a defect: after the takeover backup and sidecar were durable but before
-the live config write completed, restore rewrote the still-active Stable
-configuration as unified Official history. Cleanup now recognizes that pending
-state, removes only the incomplete Developer takeover artifacts, and leaves the
-prior owner's live configuration byte-for-byte unchanged.
+takeover in both Stable/Developer directions, interrupted takeover cleanup,
+each owner restore, and exact final restoration of the pre-owned bytes. Both
+inline structured `features.multi_agent_v2` and explicit
+`[features.multi_agent_v2]` table syntax are covered.
+
+The interrupted-takeover fixture exposed a defect: after the takeover backup
+and sidecar were durable but before the live config write completed, restore
+rewrote the still-active Stable configuration as unified Official history.
+Independent review then identified that owner markers alone were insufficient:
+a missing or same-owner-but-diverged live file could lose its only backup, and
+a concurrent takeover retry could invalidate restore's snapshot before
+cleanup.
+
+Apply and restore now hold one shared per-config lifecycle lock from the first
+read through final publication and cleanup. Under that lock, interrupted
+cleanup requires an existing live config byte-identical to the recovery
+backup. Missing or diverged state fails closed without deleting either
+recovery artifact. A deterministic thread test proves a retry cannot publish
+while restore holds this transaction.
+
+Cleanup is a resumable two-phase operation. Before deleting recovery bytes,
+CodexHub atomically records the exact final-config SHA-256 and terminal status
+in the takeover sidecar. A retry removes remaining artifacts only after the
+live config, original owner, digest, and any remaining backup all revalidate.
+Journal publication, backup deletion, and sidecar deletion failures are
+covered, including completed owner restoration as well as interrupted
+takeover cleanup.
 
 CodexHub continues to own only its existing provider/catalog/context overlay
 and websocket feature flags. It does not parse, normalize, enable, or supply
@@ -32,9 +54,9 @@ defaults for agent or collaboration V2 configuration.
 ## Local verification
 
 - `python -m pytest -q tests/test_config_overlay.py`
-  - `49 passed, 8 subtests passed in 2.60s`
+  - `58 passed, 8 subtests passed in 3.36s`
 - `python -m pytest -q --ignore=tests/test_real_client_e2e.py`
-  - `1462 passed, 1 skipped, 420 subtests passed in 114.73s`
+  - `1471 passed, 1 skipped, 420 subtests passed in 106.86s`
 - `git diff --check`
   - passed
 - `python scripts/report_quality_gates.py`

--- a/docs/evidence/issue-199/README.md
+++ b/docs/evidence/issue-199/README.md
@@ -5,6 +5,8 @@ Independent-review repair fixed point:
 `ed3e4afa642dd8ba2b806cdd990cf111444f961a`
 Second-review repair fixed point:
 `c9a7a09cd7e88c640cf3d71fd69c862f23e3dd5f`
+Completion-receipt review fixed point:
+`5e9e7e9416f4cecbeef421fc71e20542e2c1a5bf`
 
 ## Proven lifecycle
 
@@ -58,6 +60,25 @@ are covered before and after each operation's externally visible commit point,
 including transformed unified history from an unowned original, completed
 owner restoration, and interrupted takeover cleanup.
 
+Cleanup completion is also durable after both recovery artifacts disappear.
+Before deleting either artifact, CodexHub publishes and reads back one bounded
+completion receipt containing only versioned owner identifiers, a fixed
+terminal status, the completed SHA-256, and the exact SHA-256 of a backup that
+a later same-owner apply may stage. It contains no config text or credential.
+An owned, unowned/unified, or interrupted cleanup retry therefore recognizes
+the exact completed generation even when sidecar deletion committed before an
+error or process death was reported.
+
+The receipt has a bounded one-file lifecycle rather than an accumulating
+history. Context-guard writes rebase its two digests under the lifecycle lock.
+A later apply retires it only after the new live config and recovery backup are
+durable, and after takeover metadata is durable when ownership changes.
+Pre-publication crashes roll back to the completed receipt; ambiguous
+receipt-retirement failures recover from the new backup/metadata. Same-owner,
+different-owner, Direct Official, explicit-provider no-op, and second-restore
+paths are covered. Unrelated artifacts cannot use a stale receipt as recovery
+authority.
+
 Takeover metadata reads explicitly classify the sidecar as absent, valid, or
 invalid. Only absence permits the legacy no-sidecar restore path. Truncated or
 unreadable JSON, future or non-integral versions, unknown fields or owners,
@@ -65,31 +86,44 @@ duplicate keys, partial/null journals, malformed digests, unsupported statuses,
 and inconsistent owner/digest/status/artifact combinations all fail closed
 while retaining the live config, recovery backup, and sidecar.
 
+Completion receipts use the same strict absent/valid/invalid classification.
+Legacy or missing fields, truncated or unreadable JSON, duplicate keys,
+future/non-integral versions, unknown fields/owners/statuses, malformed
+digests, and owner/status inconsistencies all fail closed without mutation.
+
+Managed-path validation now covers the config, backup, metadata, completion
+receipt, context state, lifecycle target, and every corresponding
+`file_lock_for` `.lock` and `.lock.guard` namespace. Direct aliases and
+hardlinks fail before lifecycle-lock acquisition or file mutation, including
+the formerly reentrant `state = lifecycle target` and lock-poisoning
+`state = config.lock` cases.
+
 CodexHub continues to own only its existing provider/catalog/context overlay
 and websocket feature flags. It does not parse, normalize, enable, or supply
 defaults for agent or collaboration V2 configuration.
 
 ## Local verification
 
-- `python -m pytest -q tests/test_config_overlay.py`
-  - `79 passed, 37 subtests passed in 10.24s`
-- `python -m pytest -q --ignore=tests/test_real_client_e2e.py`
-  - corrected-toolchain rerun: `1491 passed, 1 failed, 1 skipped, 449
-    subtests passed in 109.43s`
-  - the sole failure was the unrelated localized-PowerShell stderr assertion
-    `test_portable_rejects_invalid_flavor_before_building`; it passed in the
-    immediate focused diagnostic run together with the two child-Python tests
-    affected by the restarted host's initial `PATH`
+- `py -3.13 -m pytest -q tests/test_config_overlay.py`
+  - `97 passed, 85 subtests passed in 41.05s`
+- `py -3.13 -m pytest -q --ignore=tests/test_real_client_e2e.py`
+  - corrected-toolchain run: `1509 passed, 1 skipped, 495 subtests passed in
+    130.11s`
+- final completion/rotation delta after the Python core run
+  - `12 passed, 85 deselected, 31 subtests passed in 13.13s`
+- `py -3.13 -m compileall -q src-python tests/test_config_overlay.py`
+  - passed
 - `git diff --check`
   - passed
-- `python scripts/report_quality_gates.py`
+- `py -3.13 scripts/report_quality_gates.py --json`
   - report-only exit `0`, `parse_errors: 0`
   - repository baseline: 2 unused imports, 83 dead-function reports, and 146
     duplicate-name reports; no changed-file finding was identified
 - local Standards/Spec self-review
-  - writer-preflight, duplicate-key, path-alias, and ambiguous-commit edge
-    cases found during review were repaired; the final delta has no remaining
-    actionable finding
+  - receipt retirement, same-owner staged-backup, second no-op restore,
+    duplicate-key, path/lock-alias, and ambiguous-commit edge cases found
+    during review were repaired; the final delta has no remaining actionable
+    finding
 
 The issue's literal unpartitioned `python -m pytest -q` command was also
 attempted once. It exceeded a 1,200-second local outer bound while including

--- a/src-python/config_overlay.py
+++ b/src-python/config_overlay.py
@@ -57,6 +57,7 @@ UNOWNED_TAKEOVER_CLEANUP_STATUSES = TAKEOVER_CLEANUP_STATUSES - {
 class TakeoverLifecyclePhase(Enum):
     ABSENT = "absent"
     ACTIVE = "active"
+    RECOVERY_REANCHOR_JOURNAL = "recovery_reanchor_journal"
     CLEANUP_JOURNAL = "cleanup_journal"
     COMPLETION_RECEIPT = "completion_receipt"
 
@@ -316,6 +317,37 @@ def set_context_guard(
         )
 
 
+def _publish_context_guard_updates(
+    target_paths: dict[str, Path],
+    updated_text_by_target: dict[str, str],
+    metadata: TakeoverMetadata | None,
+    takeover_state: TakeoverPreparedState,
+) -> None:
+    backup_reanchored = False
+    if (
+        metadata is not None
+        and takeover_state is TakeoverPreparedState.ACTIVE
+        and "backup" in updated_text_by_target
+    ):
+        _publish_takeover_recovery_reanchor(
+            target_paths["backup"],
+            metadata,
+            updated_text_by_target["backup"],
+        )
+        backup_reanchored = True
+
+    for target, path in target_paths.items():
+        if target not in updated_text_by_target:
+            continue
+        if target == "backup" and backup_reanchored:
+            continue
+        atomic_write_text(
+            path,
+            updated_text_by_target[target],
+            encoding="utf-8",
+        )
+
+
 def _set_context_guard_locked(
     config_path: Path,
     backup_path: Path,
@@ -324,7 +356,7 @@ def _set_context_guard_locked(
     enabled: bool,
     catalog_path: Path | None = None,
 ) -> dict[str, int | bool | None]:
-    _, takeover_state = _prepare_managed_config_write(
+    metadata, takeover_state = _prepare_managed_config_write(
         config_path,
         backup_path,
         operation="context guard update",
@@ -336,6 +368,11 @@ def _set_context_guard_locked(
     target_paths = {"config": config_path}
     if backup_path.exists():
         target_paths["backup"] = backup_path
+    active_takeover_backup = (
+        metadata is not None
+        and takeover_state is TakeoverPreparedState.ACTIVE
+        and "backup" in target_paths
+    )
     if enabled:
         selected_model = top_level_value(
             read_text_preserving_newlines(config_path) if config_path.exists() else "",
@@ -357,6 +394,7 @@ def _set_context_guard_locked(
             "model_auto_compact_token_limit": str(budget[1]),
         }
         state = _read_context_guard_state(state_path) or {}
+        updated_text_by_target: dict[str, str] = {}
         for target, path in target_paths.items():
             entry = state.get(target)
             if entry is None:
@@ -369,14 +407,24 @@ def _set_context_guard_locked(
                 state[target] = entry
             entry["managed"] = dict(managed_values)
             text = read_text_preserving_newlines(path) if path.exists() else ""
-            atomic_write_text(path, set_top_level_values(text, managed_values), encoding="utf-8")
-        atomic_write_text(
-            state_path,
-            json.dumps(state, ensure_ascii=False, indent=2) + "\n",
-            encoding="utf-8",
+            updated_text_by_target[target] = set_top_level_values(
+                text,
+                managed_values,
+            )
+        state_text = json.dumps(state, ensure_ascii=False, indent=2) + "\n"
+        if active_takeover_backup:
+            atomic_write_text(state_path, state_text, encoding="utf-8")
+        _publish_context_guard_updates(
+            target_paths,
+            updated_text_by_target,
+            metadata,
+            takeover_state,
         )
+        if not active_takeover_backup:
+            atomic_write_text(state_path, state_text, encoding="utf-8")
     else:
         state_by_target = _read_context_guard_state(state_path) or {}
+        updated_text_by_target = {}
         for target, path in target_paths.items():
             if not path.exists():
                 continue
@@ -407,7 +455,16 @@ def _set_context_guard_locked(
                     if managed_value is not None and top_level_value(text, key) == managed_value
                 }
             if updates:
-                atomic_write_text(path, set_top_level_values(text, updates), encoding="utf-8")
+                updated_text_by_target[target] = set_top_level_values(
+                    text,
+                    updates,
+                )
+        _publish_context_guard_updates(
+            target_paths,
+            updated_text_by_target,
+            metadata,
+            takeover_state,
+        )
         state_path.unlink(missing_ok=True)
 
     lifecycle = _read_takeover_lifecycle(
@@ -762,6 +819,7 @@ class TakeoverMetadata:
     takeover_owner: str
     original_owner: str | None
     recovery_sha256: str
+    reanchor_recovery_sha256: str | None
     cleanup_source_sha256: str | None
     cleanup_recovery_sha256: str | None
     cleanup_final_sha256: str | None
@@ -826,6 +884,7 @@ def write_takeover_metadata(
     original_owner: str | None,
     *,
     recovery_sha256: str,
+    reanchor_recovery_sha256: str | None = None,
     cleanup_source_sha256: str | None = None,
     cleanup_recovery_sha256: str | None = None,
     cleanup_final_sha256: str | None = None,
@@ -837,16 +896,24 @@ def write_takeover_metadata(
         cleanup_final_sha256,
         cleanup_status,
     )
+    if reanchor_recovery_sha256 is not None and any(
+        value is not None for value in cleanup_values
+    ):
+        raise ValueError("takeover re-anchor and cleanup journals cannot overlap")
     if any(value is None for value in cleanup_values) and any(
         value is not None for value in cleanup_values
     ):
         raise ValueError("takeover cleanup digests and status must be written together")
     phase = (
-        TakeoverLifecyclePhase.ACTIVE
-        if cleanup_status is None
-        else TakeoverLifecyclePhase.CLEANUP_JOURNAL
+        TakeoverLifecyclePhase.CLEANUP_JOURNAL
+        if cleanup_status is not None
+        else TakeoverLifecyclePhase.ACTIVE
     )
-    if not _is_legal_takeover_status(original_owner, cleanup_status, phase):
+    if reanchor_recovery_sha256 is None and not _is_legal_takeover_status(
+        original_owner,
+        cleanup_status,
+        phase,
+    ):
         raise ValueError("unsupported takeover cleanup status for original owner")
     if (
         cleanup_recovery_sha256 is not None
@@ -855,13 +922,20 @@ def write_takeover_metadata(
         raise ValueError("takeover cleanup recovery digest must match its durable anchor")
     if re.fullmatch(r"[0-9a-f]{64}", recovery_sha256) is None:
         raise ValueError("takeover recovery digest must be a lowercase SHA-256")
+    if (
+        reanchor_recovery_sha256 is not None
+        and re.fullmatch(r"[0-9a-f]{64}", reanchor_recovery_sha256) is None
+    ):
+        raise ValueError("takeover re-anchor digest must be a lowercase SHA-256")
     metadata = {
         "version": 1,
         "takeover_owner": takeover_owner,
         "original_owner": original_owner,
         "recovery_sha256": recovery_sha256,
     }
-    if cleanup_source_sha256 is not None:
+    if reanchor_recovery_sha256 is not None:
+        metadata["reanchor_recovery_sha256"] = reanchor_recovery_sha256
+    elif cleanup_source_sha256 is not None:
         metadata["cleanup_source_sha256"] = cleanup_source_sha256
         metadata["cleanup_recovery_sha256"] = cleanup_recovery_sha256
         metadata["cleanup_final_sha256"] = cleanup_final_sha256
@@ -893,6 +967,7 @@ def read_takeover_metadata(backup_path: Path) -> TakeoverMetadataRead:
         "cleanup_final_sha256",
         "cleanup_status",
     }
+    reanchor_keys = {"reanchor_recovery_sha256"}
     metadata_keys = frozenset(metadata)
     legacy_base_keys = base_keys - {"recovery_sha256"}
     if (
@@ -908,7 +983,11 @@ def read_takeover_metadata(backup_path: Path) -> TakeoverMetadataRead:
             TakeoverRecordState.INVALID,
             error=TakeoverRecordError.MISSING_RECOVERY_ANCHOR,
         )
-    if metadata_keys not in {frozenset(base_keys), frozenset(base_keys | cleanup_keys)}:
+    if metadata_keys not in {
+        frozenset(base_keys),
+        frozenset(base_keys | reanchor_keys),
+        frozenset(base_keys | cleanup_keys),
+    }:
         return TakeoverMetadataRead(TakeoverRecordState.INVALID)
     version = metadata.get("version")
     if type(version) is not int or version != 1:
@@ -916,6 +995,7 @@ def read_takeover_metadata(backup_path: Path) -> TakeoverMetadataRead:
     takeover_owner = metadata.get("takeover_owner")
     original_owner = metadata.get("original_owner")
     recovery_sha256 = metadata.get("recovery_sha256")
+    reanchor_recovery_sha256 = metadata.get("reanchor_recovery_sha256")
     if not isinstance(takeover_owner, str) or takeover_owner not in {"release", "beta"}:
         return TakeoverMetadataRead(TakeoverRecordState.INVALID)
     if original_owner is not None and (
@@ -940,10 +1020,18 @@ def read_takeover_metadata(backup_path: Path) -> TakeoverMetadataRead:
         cleanup_final_sha256,
         cleanup_status,
     )
+    has_reanchor_field = metadata_keys == frozenset(base_keys | reanchor_keys)
     has_cleanup_fields = metadata_keys == frozenset(base_keys | cleanup_keys)
     if has_cleanup_fields and any(value is None for value in cleanup_values):
         return TakeoverMetadataRead(TakeoverRecordState.INVALID)
     if not has_cleanup_fields and any(value is not None for value in cleanup_values):
+        return TakeoverMetadataRead(TakeoverRecordState.INVALID)
+    if has_reanchor_field and (
+        not isinstance(reanchor_recovery_sha256, str)
+        or re.fullmatch(r"[0-9a-f]{64}", reanchor_recovery_sha256) is None
+    ):
+        return TakeoverMetadataRead(TakeoverRecordState.INVALID)
+    if not has_reanchor_field and reanchor_recovery_sha256 is not None:
         return TakeoverMetadataRead(TakeoverRecordState.INVALID)
     digests = (
         cleanup_source_sha256,
@@ -969,6 +1057,7 @@ def read_takeover_metadata(backup_path: Path) -> TakeoverMetadataRead:
             takeover_owner=takeover_owner,
             original_owner=original_owner,
             recovery_sha256=recovery_sha256,
+            reanchor_recovery_sha256=reanchor_recovery_sha256,
             cleanup_source_sha256=cleanup_source_sha256,
             cleanup_recovery_sha256=cleanup_recovery_sha256,
             cleanup_final_sha256=cleanup_final_sha256,
@@ -1089,11 +1178,12 @@ def _read_takeover_lifecycle(
     ):
         raise RuntimeError(f"refusing {operation}: completion ownership is inconsistent")
     if metadata is not None:
-        phase = (
-            TakeoverLifecyclePhase.CLEANUP_JOURNAL
-            if metadata.cleanup_source_sha256 is not None
-            else TakeoverLifecyclePhase.ACTIVE
-        )
+        if metadata.cleanup_source_sha256 is not None:
+            phase = TakeoverLifecyclePhase.CLEANUP_JOURNAL
+        elif metadata.reanchor_recovery_sha256 is not None:
+            phase = TakeoverLifecyclePhase.RECOVERY_REANCHOR_JOURNAL
+        else:
+            phase = TakeoverLifecyclePhase.ACTIVE
     elif completion is not None:
         phase = TakeoverLifecyclePhase.COMPLETION_RECEIPT
     else:
@@ -1198,7 +1288,102 @@ def _matches_active_takeover_metadata(
         and metadata.takeover_owner == takeover_owner
         and metadata.original_owner == original_owner
         and metadata.recovery_sha256 == recovery_sha256
+        and metadata.reanchor_recovery_sha256 is None
         and metadata.cleanup_source_sha256 is None
+    )
+
+
+def _resume_takeover_reanchor(
+    backup_path: Path,
+    metadata: TakeoverMetadata,
+    *,
+    operation: str,
+) -> TakeoverMetadata:
+    candidate_sha256 = metadata.reanchor_recovery_sha256
+    if candidate_sha256 is None:
+        raise RuntimeError(f"refusing {operation}: takeover re-anchor journal is incomplete")
+    if not backup_path.exists():
+        raise RuntimeError(f"refusing {operation}: recovery backup is missing or diverged")
+
+    recovery = read_text_preserving_newlines(backup_path)
+    recovery_sha256 = takeover_text_sha256(recovery)
+    if (
+        overlay_owner(recovery) != metadata.original_owner
+        or recovery_sha256
+        not in {metadata.recovery_sha256, candidate_sha256}
+    ):
+        raise RuntimeError(f"refusing {operation}: recovery backup is missing or diverged")
+
+    write_takeover_metadata(
+        backup_path,
+        metadata.takeover_owner,
+        metadata.original_owner,
+        recovery_sha256=recovery_sha256,
+    )
+    readback = read_takeover_metadata(backup_path)
+    if not _matches_active_takeover_metadata(
+        readback.metadata,
+        takeover_owner=metadata.takeover_owner,
+        original_owner=metadata.original_owner,
+        recovery_sha256=recovery_sha256,
+    ):
+        raise RuntimeError(f"refusing {operation}: takeover re-anchor readback failed")
+    active = readback.metadata
+    if active is None:
+        raise RuntimeError(f"refusing {operation}: takeover re-anchor readback failed")
+    return active
+
+
+def _publish_takeover_recovery_reanchor(
+    backup_path: Path,
+    metadata: TakeoverMetadata,
+    candidate: str,
+) -> TakeoverMetadata:
+    current = read_text_preserving_newlines(backup_path)
+    if not _matches_takeover_recovery(current, metadata):
+        raise RuntimeError(
+            "refusing context guard update: recovery backup is missing or diverged"
+        )
+    if candidate == current:
+        return metadata
+
+    candidate_sha256 = takeover_text_sha256(candidate)
+    write_takeover_metadata(
+        backup_path,
+        metadata.takeover_owner,
+        metadata.original_owner,
+        recovery_sha256=metadata.recovery_sha256,
+        reanchor_recovery_sha256=candidate_sha256,
+    )
+    journal_read = read_takeover_metadata(backup_path)
+    journal = journal_read.metadata
+    if (
+        journal_read.state is not TakeoverRecordState.VALID
+        or journal is None
+        or journal.takeover_owner != metadata.takeover_owner
+        or journal.original_owner != metadata.original_owner
+        or journal.recovery_sha256 != metadata.recovery_sha256
+        or journal.reanchor_recovery_sha256 != candidate_sha256
+        or journal.cleanup_source_sha256 is not None
+    ):
+        raise RuntimeError(
+            "refusing context guard update: takeover re-anchor journal readback failed"
+        )
+
+    atomic_write_text(backup_path, candidate, encoding="utf-8")
+    published = read_text_preserving_newlines(backup_path)
+    if (
+        published != candidate
+        or overlay_owner(published) != metadata.original_owner
+        or takeover_text_sha256(published) != candidate_sha256
+    ):
+        raise RuntimeError(
+            "refusing context guard update: recovery backup publication diverged"
+        )
+    return _resume_takeover_reanchor(
+        backup_path,
+        journal,
+        operation="context guard update",
     )
 
 
@@ -1348,6 +1533,12 @@ def _prepare_managed_config_write(
     if lifecycle.phase is TakeoverLifecyclePhase.CLEANUP_JOURNAL:
         _resume_takeover_cleanup(config_path, backup_path, metadata)
         return None, TakeoverPreparedState.CLEANUP_RESUMED
+    if lifecycle.phase is TakeoverLifecyclePhase.RECOVERY_REANCHOR_JOURNAL:
+        metadata = _resume_takeover_reanchor(
+            backup_path,
+            metadata,
+            operation=operation,
+        )
     if not backup_path.exists():
         raise RuntimeError(f"refusing {operation}: recovery backup is missing or diverged")
 
@@ -1654,6 +1845,14 @@ def _restore_overlay_locked(config_path: Path, backup_path: Path, unified_histor
         if metadata is None:
             raise RuntimeError("refusing takeover restore: takeover metadata is invalid")
         return _resume_takeover_cleanup(config_path, backup_path, metadata)
+    if lifecycle.phase is TakeoverLifecyclePhase.RECOVERY_REANCHOR_JOURNAL:
+        if metadata is None:
+            raise RuntimeError("refusing takeover restore: takeover metadata is invalid")
+        metadata = _resume_takeover_reanchor(
+            backup_path,
+            metadata,
+            operation="takeover restore",
+        )
 
     if not backup_path.exists() and metadata is not None:
         raise RuntimeError("refusing takeover restore: recovery backup is missing or diverged")

--- a/src-python/config_overlay.py
+++ b/src-python/config_overlay.py
@@ -48,6 +48,10 @@ TAKEOVER_CLEANUP_STATUSES = {
     "replaced_managed_gateway",
     "restored_takeover_backup",
 }
+UNOWNED_TAKEOVER_CLEANUP_STATUSES = TAKEOVER_CLEANUP_STATUSES - {
+    "interrupted_takeover_discarded",
+    "restored_takeover_backup",
+}
 
 
 def toml_literal(value: str) -> str:
@@ -369,6 +373,21 @@ def _set_context_guard_locked(
             if updates:
                 atomic_write_text(path, set_top_level_values(text, updates), encoding="utf-8")
         state_path.unlink(missing_ok=True)
+
+    completion_read = read_takeover_completion(backup_path)
+    if completion_read.state is TakeoverMetadataState.INVALID:
+        raise RuntimeError("refusing context guard update: takeover completion is invalid")
+    if completion_read.receipt is not None:
+        completion_text_path = backup_path if backup_path.exists() else config_path
+        if not completion_text_path.exists():
+            raise RuntimeError(
+                "refusing context guard update: completed config is missing or diverged"
+            )
+        _rebase_takeover_completion(
+            backup_path,
+            completion_read.receipt,
+            read_text_preserving_newlines(completion_text_path),
+        )
 
     return context_guard_status(config_path, state_path)
 
@@ -697,6 +716,10 @@ def takeover_metadata_path(backup_path: Path) -> Path:
     return backup_path.with_name(f"{backup_path.name}.takeover.json")
 
 
+def takeover_completion_path(backup_path: Path) -> Path:
+    return backup_path.with_name(f"{backup_path.name}.takeover.completed.json")
+
+
 @dataclass(frozen=True)
 class TakeoverMetadata:
     takeover_owner: str
@@ -719,8 +742,32 @@ class TakeoverMetadataRead:
     metadata: TakeoverMetadata | None = None
 
 
+@dataclass(frozen=True)
+class TakeoverCompletionReceipt:
+    takeover_owner: str
+    original_owner: str | None
+    final_sha256: str
+    same_owner_backup_sha256: str
+    status: str
+
+
+@dataclass(frozen=True)
+class TakeoverCompletionRead:
+    state: TakeoverMetadataState
+    receipt: TakeoverCompletionReceipt | None = None
+
+
 def takeover_text_sha256(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _reject_duplicate_json_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate takeover state key: {key}")
+        result[key] = value
+    return result
 
 
 def write_takeover_metadata(
@@ -764,19 +811,10 @@ def write_takeover_metadata(
 
 def read_takeover_metadata(backup_path: Path) -> TakeoverMetadataRead:
     metadata_path = takeover_metadata_path(backup_path)
-
-    def reject_duplicate_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
-        result: dict[str, object] = {}
-        for key, value in pairs:
-            if key in result:
-                raise ValueError(f"duplicate takeover metadata key: {key}")
-            result[key] = value
-        return result
-
     try:
         metadata = json.loads(
             metadata_path.read_text(encoding="utf-8"),
-            object_pairs_hook=reject_duplicate_keys,
+            object_pairs_hook=_reject_duplicate_json_keys,
         )
     except FileNotFoundError:
         return TakeoverMetadataRead(TakeoverMetadataState.ABSENT)
@@ -850,6 +888,147 @@ def read_takeover_metadata(backup_path: Path) -> TakeoverMetadataRead:
     )
 
 
+def write_takeover_completion_receipt(
+    backup_path: Path,
+    receipt: TakeoverCompletionReceipt,
+) -> None:
+    payload = {
+        "version": 1,
+        "takeover_owner": receipt.takeover_owner,
+        "original_owner": receipt.original_owner,
+        "final_sha256": receipt.final_sha256,
+        "same_owner_backup_sha256": receipt.same_owner_backup_sha256,
+        "status": receipt.status,
+    }
+    atomic_write_text(
+        takeover_completion_path(backup_path),
+        json.dumps(payload, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def read_takeover_completion(backup_path: Path) -> TakeoverCompletionRead:
+    try:
+        receipt = json.loads(
+            takeover_completion_path(backup_path).read_text(encoding="utf-8"),
+            object_pairs_hook=_reject_duplicate_json_keys,
+        )
+    except FileNotFoundError:
+        return TakeoverCompletionRead(TakeoverMetadataState.ABSENT)
+    except (OSError, ValueError, TypeError, RecursionError):
+        return TakeoverCompletionRead(TakeoverMetadataState.INVALID)
+    expected_keys = {
+        "version",
+        "takeover_owner",
+        "original_owner",
+        "final_sha256",
+        "same_owner_backup_sha256",
+        "status",
+    }
+    if not isinstance(receipt, dict) or set(receipt) != expected_keys:
+        return TakeoverCompletionRead(TakeoverMetadataState.INVALID)
+    if type(receipt.get("version")) is not int or receipt["version"] != 1:
+        return TakeoverCompletionRead(TakeoverMetadataState.INVALID)
+    takeover_owner = receipt.get("takeover_owner")
+    original_owner = receipt.get("original_owner")
+    final_sha256 = receipt.get("final_sha256")
+    same_owner_backup_sha256 = receipt.get("same_owner_backup_sha256")
+    status = receipt.get("status")
+    if not isinstance(takeover_owner, str) or takeover_owner not in {"release", "beta"}:
+        return TakeoverCompletionRead(TakeoverMetadataState.INVALID)
+    if original_owner is not None and (
+        not isinstance(original_owner, str)
+        or original_owner not in {"release", "beta"}
+    ):
+        return TakeoverCompletionRead(TakeoverMetadataState.INVALID)
+    if original_owner == takeover_owner:
+        return TakeoverCompletionRead(TakeoverMetadataState.INVALID)
+    if (
+        not isinstance(final_sha256, str)
+        or re.fullmatch(r"[0-9a-f]{64}", final_sha256) is None
+        or not isinstance(same_owner_backup_sha256, str)
+        or re.fullmatch(r"[0-9a-f]{64}", same_owner_backup_sha256) is None
+        or not isinstance(status, str)
+        or status not in TAKEOVER_CLEANUP_STATUSES
+        or (
+            status in UNOWNED_TAKEOVER_CLEANUP_STATUSES
+            and original_owner is not None
+        )
+    ):
+        return TakeoverCompletionRead(TakeoverMetadataState.INVALID)
+    return TakeoverCompletionRead(
+        TakeoverMetadataState.VALID,
+        TakeoverCompletionReceipt(
+            takeover_owner=takeover_owner,
+            original_owner=original_owner,
+            final_sha256=final_sha256,
+            same_owner_backup_sha256=same_owner_backup_sha256,
+            status=status,
+        ),
+    )
+
+
+def _rebase_takeover_completion(
+    backup_path: Path,
+    receipt: TakeoverCompletionReceipt,
+    text: str,
+) -> TakeoverCompletionReceipt:
+    if overlay_owner(text) != receipt.original_owner:
+        raise RuntimeError(
+            "refusing managed config write: completed owner is inconsistent"
+        )
+    rebased = TakeoverCompletionReceipt(
+        takeover_owner=receipt.takeover_owner,
+        original_owner=receipt.original_owner,
+        final_sha256=takeover_text_sha256(text),
+        same_owner_backup_sha256=takeover_text_sha256(
+            strip_marked_overlay(text)
+        ),
+        status=receipt.status,
+    )
+    if rebased == receipt:
+        return receipt
+    write_takeover_completion_receipt(backup_path, rebased)
+    readback = read_takeover_completion(backup_path)
+    if (
+        readback.state is not TakeoverMetadataState.VALID
+        or readback.receipt != rebased
+    ):
+        raise RuntimeError(
+            "refusing managed config write: completion receipt readback failed"
+        )
+    return rebased
+
+
+def _matches_takeover_completion(
+    text: str,
+    receipt: TakeoverCompletionReceipt,
+) -> bool:
+    return (
+        overlay_owner(text) == receipt.original_owner
+        and takeover_text_sha256(text) == receipt.final_sha256
+        and takeover_text_sha256(strip_marked_overlay(text))
+        == receipt.same_owner_backup_sha256
+    )
+
+
+def _matches_takeover_completion_backup(
+    text: str,
+    receipt: TakeoverCompletionReceipt,
+) -> bool:
+    # A later apply can stage either the completed bytes or the exact bytes
+    # produced by removing only the completed owner's marked overlay.
+    digest = takeover_text_sha256(text)
+    return _matches_takeover_completion(text, receipt) or (
+        digest == receipt.same_owner_backup_sha256
+        and overlay_owner(text) is None
+    )
+
+
+def _retire_takeover_completion(backup_path: Path) -> None:
+    takeover_completion_path(backup_path).unlink()
+
+
 def is_active_takeover_backup(
     config_text: str,
     backup_text: str,
@@ -921,18 +1100,37 @@ def _validate_managed_write_paths(
     state_path: Path | None = None,
 ) -> None:
     metadata_path = takeover_metadata_path(backup_path)
-    named_paths = [
+    completion_path = takeover_completion_path(backup_path)
+    managed_paths = [
         ("config", config_path),
         ("backup", backup_path),
         ("metadata", metadata_path),
+        ("completion receipt", completion_path),
     ]
     if state_path is not None:
-        named_paths.append(("context guard state", state_path))
+        managed_paths.append(("context guard state", state_path))
+    lock_targets = [
+        *managed_paths,
+        ("lifecycle target", overlay_lifecycle_lock_target(config_path)),
+    ]
+    named_paths: list[tuple[str, Path]] = list(lock_targets)
+    for name, path in lock_targets:
+        lock_path = path.with_name(f"{path.name}.lock")
+        named_paths.extend(
+            [
+                (f"{name} lock namespace", lock_path),
+                (
+                    f"{name} lock guard namespace",
+                    lock_path.with_name(f"{lock_path.name}.guard"),
+                ),
+            ]
+        )
     for index, (left_name, left_path) in enumerate(named_paths):
         for right_name, right_path in named_paths[index + 1 :]:
             if _paths_refer_to_same_file(left_path, right_path):
                 raise ValueError(
-                    f"managed write paths must be distinct: {left_name} aliases {right_name}"
+                    "managed paths and lock namespaces must be distinct: "
+                    f"{left_name} aliases {right_name}"
                 )
 
 
@@ -953,8 +1151,30 @@ def _prepare_managed_config_write(
     metadata_read = read_takeover_metadata(backup_path)
     if metadata_read.state is TakeoverMetadataState.INVALID:
         raise RuntimeError(f"refusing {operation}: takeover metadata is invalid")
+    completion_read = read_takeover_completion(backup_path)
+    if completion_read.state is TakeoverMetadataState.INVALID:
+        raise RuntimeError(f"refusing {operation}: takeover completion is invalid")
     metadata = metadata_read.metadata
     if metadata is None:
+        if completion_read.receipt is not None:
+            completion = completion_read.receipt
+            if backup_path.exists():
+                recovery = read_text_preserving_newlines(backup_path)
+                if not _matches_takeover_completion_backup(recovery, completion):
+                    raise RuntimeError(
+                        f"refusing {operation}: completion recovery is inconsistent"
+                    )
+                _retire_takeover_completion(backup_path)
+            elif not config_path.exists():
+                raise RuntimeError(
+                    f"refusing {operation}: completed config is missing or diverged"
+                )
+            else:
+                _rebase_takeover_completion(
+                    backup_path,
+                    completion,
+                    read_text_preserving_newlines(config_path),
+                )
         return None, "absent"
     if metadata.cleanup_source_sha256 is not None:
         _resume_takeover_cleanup(config_path, backup_path, metadata)
@@ -969,10 +1189,22 @@ def _prepare_managed_config_write(
             raise RuntimeError(
                 f"refusing {operation}: live config is missing or diverged"
             )
-        return metadata, "interrupted"
-    if is_active_takeover_backup(current, recovery, metadata):
-        return metadata, "active"
-    raise RuntimeError(f"refusing {operation}: takeover state is not recognized")
+        takeover_state = "interrupted"
+    elif is_active_takeover_backup(current, recovery, metadata):
+        takeover_state = "active"
+    else:
+        raise RuntimeError(f"refusing {operation}: takeover state is not recognized")
+    if completion_read.receipt is not None:
+        completion = completion_read.receipt
+        if (
+            completion.original_owner != metadata.original_owner
+            or not _matches_takeover_completion_backup(recovery, completion)
+        ):
+            raise RuntimeError(
+                f"refusing {operation}: completion recovery is inconsistent"
+            )
+        _retire_takeover_completion(backup_path)
+    return metadata, takeover_state
 
 
 def apply_overlay(
@@ -1066,6 +1298,34 @@ def _apply_overlay_locked(
     updated = insert_provider_section(updated, build_provider_section(base_url, gateway_key))
     atomic_write_text(config_path, updated, encoding="utf-8")
 
+    # Retire an older completed generation only after this apply has durable
+    # live bytes, a recovery backup, and takeover metadata when ownership moved.
+    completion_read = read_takeover_completion(backup_path)
+    if completion_read.state is TakeoverMetadataState.INVALID:
+        raise RuntimeError("refusing overlay apply: takeover completion is invalid")
+    if completion_read.receipt is not None:
+        if not backup_path.exists() or not _matches_takeover_completion_backup(
+            read_text_preserving_newlines(backup_path),
+            completion_read.receipt,
+        ):
+            raise RuntimeError(
+                "refusing overlay apply: completion recovery is inconsistent"
+            )
+        if cross_owner_takeover:
+            new_metadata_read = read_takeover_metadata(backup_path)
+            new_metadata = new_metadata_read.metadata
+            if (
+                new_metadata_read.state is not TakeoverMetadataState.VALID
+                or new_metadata is None
+                or new_metadata.takeover_owner != owner
+                or new_metadata.original_owner != active_owner
+                or new_metadata.cleanup_source_sha256 is not None
+            ):
+                raise RuntimeError(
+                    "refusing overlay apply: takeover ownership evidence is inconsistent"
+                )
+        _retire_takeover_completion(backup_path)
+
 
 def restore_overlay(config_path: Path, backup_path: Path, unified_history: bool = False) -> str:
     config_path = config_path.resolve(strict=False)
@@ -1121,6 +1381,7 @@ def _resume_takeover_cleanup(
     if current_sha256 == final_sha256:
         if overlay_owner(current) != metadata.original_owner:
             raise RuntimeError("refusing takeover cleanup: final config owner is inconsistent")
+        completed_text = current
     elif current_sha256 == source_sha256:
         if overlay_owner(current) != metadata.takeover_owner or final_text is None:
             raise RuntimeError("refusing takeover cleanup: live config is missing or diverged")
@@ -1131,8 +1392,26 @@ def _resume_takeover_cleanup(
             or takeover_text_sha256(published) != final_sha256
         ):
             raise RuntimeError("refusing takeover cleanup: final config publication diverged")
+        completed_text = published
     else:
         raise RuntimeError("refusing takeover cleanup: live config is missing or diverged")
+
+    expected_completion = TakeoverCompletionReceipt(
+        takeover_owner=metadata.takeover_owner,
+        original_owner=metadata.original_owner,
+        final_sha256=final_sha256,
+        same_owner_backup_sha256=takeover_text_sha256(
+            strip_marked_overlay(completed_text)
+        ),
+        status=status,
+    )
+    write_takeover_completion_receipt(backup_path, expected_completion)
+    completion_read = read_takeover_completion(backup_path)
+    if (
+        completion_read.state is not TakeoverMetadataState.VALID
+        or completion_read.receipt != expected_completion
+    ):
+        raise RuntimeError("refusing takeover cleanup: completion receipt readback failed")
 
     if backup_path.exists():
         backup_path.unlink()
@@ -1171,12 +1450,63 @@ def _restore_overlay_locked(config_path: Path, backup_path: Path, unified_histor
     metadata_read = read_takeover_metadata(backup_path)
     if metadata_read.state is TakeoverMetadataState.INVALID:
         raise RuntimeError("refusing takeover restore: takeover metadata is invalid")
+    completion_read = read_takeover_completion(backup_path)
+    if completion_read.state is TakeoverMetadataState.INVALID:
+        raise RuntimeError("refusing takeover restore: takeover completion is invalid")
     metadata = metadata_read.metadata
+    if (
+        metadata is not None
+        and completion_read.receipt is not None
+        and completion_read.receipt.original_owner != metadata.original_owner
+    ):
+        raise RuntimeError(
+            "refusing takeover restore: completion ownership is inconsistent"
+        )
     if metadata is not None and metadata.cleanup_source_sha256 is not None:
         return _resume_takeover_cleanup(config_path, backup_path, metadata)
 
     if not backup_path.exists() and metadata is not None:
         raise RuntimeError("refusing takeover restore: recovery backup is missing or diverged")
+    if (
+        backup_path.exists()
+        and metadata is not None
+        and completion_read.receipt is not None
+        and not _matches_takeover_completion_backup(
+            read_text_preserving_newlines(backup_path),
+            completion_read.receipt,
+        )
+    ):
+        raise RuntimeError(
+            "refusing takeover restore: completion recovery is inconsistent"
+        )
+    if not backup_path.exists() and metadata is None and completion_read.receipt is not None:
+        completion = completion_read.receipt
+        if not config_path.exists():
+            raise RuntimeError(
+                "refusing takeover restore: completed live config is missing or diverged"
+            )
+        current = read_text_preserving_newlines(config_path)
+        if not _matches_takeover_completion(current, completion):
+            raise RuntimeError(
+                "refusing takeover restore: completed live config is missing or diverged"
+            )
+        return completion.status
+    if backup_path.exists() and metadata is None and completion_read.receipt is not None:
+        completion = completion_read.receipt
+        staged_backup = read_text_preserving_newlines(backup_path)
+        if config_path.exists():
+            current = read_text_preserving_newlines(config_path)
+            if (
+                _matches_takeover_completion(current, completion)
+                and _matches_takeover_completion_backup(staged_backup, completion)
+            ):
+                backup_path.unlink()
+                return completion.status
+        if not _matches_takeover_completion_backup(staged_backup, completion):
+            raise RuntimeError(
+                "refusing takeover restore: completion recovery is inconsistent"
+            )
+        _retire_takeover_completion(backup_path)
 
     if backup_path.exists():
         restored = read_text_preserving_newlines(backup_path)
@@ -1227,7 +1557,7 @@ def _restore_overlay_locked(config_path: Path, backup_path: Path, unified_histor
         if metadata is not None:
             raise RuntimeError("refusing takeover restore: state is not recognized")
     elif config_path.exists():
-        restored = strip_marked_overlay(config_path.read_text(encoding="utf-8"))
+        restored = strip_marked_overlay(read_text_preserving_newlines(config_path))
         restore_from_backup = False
     else:
         restored = ""

--- a/src-python/config_overlay.py
+++ b/src-python/config_overlay.py
@@ -54,6 +54,42 @@ UNOWNED_TAKEOVER_CLEANUP_STATUSES = TAKEOVER_CLEANUP_STATUSES - {
 }
 
 
+class TakeoverLifecyclePhase(Enum):
+    ABSENT = "absent"
+    ACTIVE = "active"
+    CLEANUP_JOURNAL = "cleanup_journal"
+    COMPLETION_RECEIPT = "completion_receipt"
+
+
+class TakeoverPreparedState(Enum):
+    ABSENT = "absent"
+    ACTIVE = "active"
+    INTERRUPTED = "interrupted"
+    CLEANUP_RESUMED = "cleanup_resumed"
+
+
+def _is_legal_takeover_status(
+    original_owner: str | None,
+    status: object,
+    phase: TakeoverLifecyclePhase,
+) -> bool:
+    if phase is TakeoverLifecyclePhase.ACTIVE:
+        return status is None
+    if phase not in {
+        TakeoverLifecyclePhase.CLEANUP_JOURNAL,
+        TakeoverLifecyclePhase.COMPLETION_RECEIPT,
+    }:
+        return False
+    return (
+        isinstance(status, str)
+        and status in TAKEOVER_CLEANUP_STATUSES
+        and (
+            original_owner is None
+            or status not in UNOWNED_TAKEOVER_CLEANUP_STATUSES
+        )
+    )
+
+
 def toml_literal(value: str) -> str:
     return "'" + value.replace("'", "''") + "'"
 
@@ -293,7 +329,7 @@ def _set_context_guard_locked(
         backup_path,
         operation="context guard update",
     )
-    if takeover_state == "interrupted":
+    if takeover_state is TakeoverPreparedState.INTERRUPTED:
         raise RuntimeError(
             "refusing context guard update: interrupted takeover recovery is pending"
         )
@@ -374,10 +410,11 @@ def _set_context_guard_locked(
                 atomic_write_text(path, set_top_level_values(text, updates), encoding="utf-8")
         state_path.unlink(missing_ok=True)
 
-    completion_read = read_takeover_completion(backup_path)
-    if completion_read.state is TakeoverMetadataState.INVALID:
-        raise RuntimeError("refusing context guard update: takeover completion is invalid")
-    if completion_read.receipt is not None:
+    lifecycle = _read_takeover_lifecycle(
+        backup_path,
+        operation="context guard update",
+    )
+    if lifecycle.completion is not None:
         completion_text_path = backup_path if backup_path.exists() else config_path
         if not completion_text_path.exists():
             raise RuntimeError(
@@ -385,7 +422,7 @@ def _set_context_guard_locked(
             )
         _rebase_takeover_completion(
             backup_path,
-            completion_read.receipt,
+            lifecycle.completion,
             read_text_preserving_newlines(completion_text_path),
         )
 
@@ -724,22 +761,28 @@ def takeover_completion_path(backup_path: Path) -> Path:
 class TakeoverMetadata:
     takeover_owner: str
     original_owner: str | None
+    recovery_sha256: str
     cleanup_source_sha256: str | None
     cleanup_recovery_sha256: str | None
     cleanup_final_sha256: str | None
     cleanup_status: str | None
 
 
-class TakeoverMetadataState(Enum):
+class TakeoverRecordState(Enum):
     ABSENT = "absent"
     VALID = "valid"
     INVALID = "invalid"
 
 
+class TakeoverRecordError(Enum):
+    MISSING_RECOVERY_ANCHOR = "missing_recovery_anchor"
+
+
 @dataclass(frozen=True)
 class TakeoverMetadataRead:
-    state: TakeoverMetadataState
+    state: TakeoverRecordState
     metadata: TakeoverMetadata | None = None
+    error: TakeoverRecordError | None = None
 
 
 @dataclass(frozen=True)
@@ -753,8 +796,15 @@ class TakeoverCompletionReceipt:
 
 @dataclass(frozen=True)
 class TakeoverCompletionRead:
-    state: TakeoverMetadataState
+    state: TakeoverRecordState
     receipt: TakeoverCompletionReceipt | None = None
+
+
+@dataclass(frozen=True)
+class TakeoverLifecycleSnapshot:
+    phase: TakeoverLifecyclePhase
+    metadata: TakeoverMetadata | None
+    completion: TakeoverCompletionReceipt | None
 
 
 def takeover_text_sha256(text: str) -> str:
@@ -775,6 +825,7 @@ def write_takeover_metadata(
     takeover_owner: str,
     original_owner: str | None,
     *,
+    recovery_sha256: str,
     cleanup_source_sha256: str | None = None,
     cleanup_recovery_sha256: str | None = None,
     cleanup_final_sha256: str | None = None,
@@ -790,12 +841,25 @@ def write_takeover_metadata(
         value is not None for value in cleanup_values
     ):
         raise ValueError("takeover cleanup digests and status must be written together")
-    if cleanup_status is not None and cleanup_status not in TAKEOVER_CLEANUP_STATUSES:
-        raise ValueError("unsupported takeover cleanup status")
+    phase = (
+        TakeoverLifecyclePhase.ACTIVE
+        if cleanup_status is None
+        else TakeoverLifecyclePhase.CLEANUP_JOURNAL
+    )
+    if not _is_legal_takeover_status(original_owner, cleanup_status, phase):
+        raise ValueError("unsupported takeover cleanup status for original owner")
+    if (
+        cleanup_recovery_sha256 is not None
+        and cleanup_recovery_sha256 != recovery_sha256
+    ):
+        raise ValueError("takeover cleanup recovery digest must match its durable anchor")
+    if re.fullmatch(r"[0-9a-f]{64}", recovery_sha256) is None:
+        raise ValueError("takeover recovery digest must be a lowercase SHA-256")
     metadata = {
         "version": 1,
         "takeover_owner": takeover_owner,
         "original_owner": original_owner,
+        "recovery_sha256": recovery_sha256,
     }
     if cleanup_source_sha256 is not None:
         metadata["cleanup_source_sha256"] = cleanup_source_sha256
@@ -817,12 +881,12 @@ def read_takeover_metadata(backup_path: Path) -> TakeoverMetadataRead:
             object_pairs_hook=_reject_duplicate_json_keys,
         )
     except FileNotFoundError:
-        return TakeoverMetadataRead(TakeoverMetadataState.ABSENT)
+        return TakeoverMetadataRead(TakeoverRecordState.ABSENT)
     except (OSError, ValueError, TypeError, RecursionError):
-        return TakeoverMetadataRead(TakeoverMetadataState.INVALID)
+        return TakeoverMetadataRead(TakeoverRecordState.INVALID)
     if not isinstance(metadata, dict):
-        return TakeoverMetadataRead(TakeoverMetadataState.INVALID)
-    base_keys = {"version", "takeover_owner", "original_owner"}
+        return TakeoverMetadataRead(TakeoverRecordState.INVALID)
+    base_keys = {"version", "takeover_owner", "original_owner", "recovery_sha256"}
     cleanup_keys = {
         "cleanup_source_sha256",
         "cleanup_recovery_sha256",
@@ -830,22 +894,42 @@ def read_takeover_metadata(backup_path: Path) -> TakeoverMetadataRead:
         "cleanup_status",
     }
     metadata_keys = frozenset(metadata)
+    legacy_base_keys = base_keys - {"recovery_sha256"}
+    if (
+        type(metadata.get("version")) is int
+        and metadata["version"] == 1
+        and metadata_keys
+        in {
+            frozenset(legacy_base_keys),
+            frozenset(legacy_base_keys | cleanup_keys),
+        }
+    ):
+        return TakeoverMetadataRead(
+            TakeoverRecordState.INVALID,
+            error=TakeoverRecordError.MISSING_RECOVERY_ANCHOR,
+        )
     if metadata_keys not in {frozenset(base_keys), frozenset(base_keys | cleanup_keys)}:
-        return TakeoverMetadataRead(TakeoverMetadataState.INVALID)
+        return TakeoverMetadataRead(TakeoverRecordState.INVALID)
     version = metadata.get("version")
     if type(version) is not int or version != 1:
-        return TakeoverMetadataRead(TakeoverMetadataState.INVALID)
+        return TakeoverMetadataRead(TakeoverRecordState.INVALID)
     takeover_owner = metadata.get("takeover_owner")
     original_owner = metadata.get("original_owner")
+    recovery_sha256 = metadata.get("recovery_sha256")
     if not isinstance(takeover_owner, str) or takeover_owner not in {"release", "beta"}:
-        return TakeoverMetadataRead(TakeoverMetadataState.INVALID)
+        return TakeoverMetadataRead(TakeoverRecordState.INVALID)
     if original_owner is not None and (
         not isinstance(original_owner, str)
         or original_owner not in {"release", "beta"}
     ):
-        return TakeoverMetadataRead(TakeoverMetadataState.INVALID)
+        return TakeoverMetadataRead(TakeoverRecordState.INVALID)
     if original_owner == takeover_owner:
-        return TakeoverMetadataRead(TakeoverMetadataState.INVALID)
+        return TakeoverMetadataRead(TakeoverRecordState.INVALID)
+    if (
+        not isinstance(recovery_sha256, str)
+        or re.fullmatch(r"[0-9a-f]{64}", recovery_sha256) is None
+    ):
+        return TakeoverMetadataRead(TakeoverRecordState.INVALID)
     cleanup_source_sha256 = metadata.get("cleanup_source_sha256")
     cleanup_recovery_sha256 = metadata.get("cleanup_recovery_sha256")
     cleanup_final_sha256 = metadata.get("cleanup_final_sha256")
@@ -858,9 +942,9 @@ def read_takeover_metadata(backup_path: Path) -> TakeoverMetadataRead:
     )
     has_cleanup_fields = metadata_keys == frozenset(base_keys | cleanup_keys)
     if has_cleanup_fields and any(value is None for value in cleanup_values):
-        return TakeoverMetadataRead(TakeoverMetadataState.INVALID)
+        return TakeoverMetadataRead(TakeoverRecordState.INVALID)
     if not has_cleanup_fields and any(value is not None for value in cleanup_values):
-        return TakeoverMetadataRead(TakeoverMetadataState.INVALID)
+        return TakeoverMetadataRead(TakeoverRecordState.INVALID)
     digests = (
         cleanup_source_sha256,
         cleanup_recovery_sha256,
@@ -871,15 +955,20 @@ def read_takeover_metadata(backup_path: Path) -> TakeoverMetadataRead:
             not isinstance(digest, str) or re.fullmatch(r"[0-9a-f]{64}", digest) is None
             for digest in digests
         )
-        or not isinstance(cleanup_status, str)
-        or cleanup_status not in TAKEOVER_CLEANUP_STATUSES
+        or cleanup_recovery_sha256 != recovery_sha256
+        or not _is_legal_takeover_status(
+            original_owner,
+            cleanup_status,
+            TakeoverLifecyclePhase.CLEANUP_JOURNAL,
+        )
     ):
-        return TakeoverMetadataRead(TakeoverMetadataState.INVALID)
+        return TakeoverMetadataRead(TakeoverRecordState.INVALID)
     return TakeoverMetadataRead(
-        TakeoverMetadataState.VALID,
+        TakeoverRecordState.VALID,
         TakeoverMetadata(
             takeover_owner=takeover_owner,
             original_owner=original_owner,
+            recovery_sha256=recovery_sha256,
             cleanup_source_sha256=cleanup_source_sha256,
             cleanup_recovery_sha256=cleanup_recovery_sha256,
             cleanup_final_sha256=cleanup_final_sha256,
@@ -892,6 +981,12 @@ def write_takeover_completion_receipt(
     backup_path: Path,
     receipt: TakeoverCompletionReceipt,
 ) -> None:
+    if not _is_legal_takeover_status(
+        receipt.original_owner,
+        receipt.status,
+        TakeoverLifecyclePhase.COMPLETION_RECEIPT,
+    ):
+        raise ValueError("unsupported takeover completion status for original owner")
     payload = {
         "version": 1,
         "takeover_owner": receipt.takeover_owner,
@@ -914,9 +1009,9 @@ def read_takeover_completion(backup_path: Path) -> TakeoverCompletionRead:
             object_pairs_hook=_reject_duplicate_json_keys,
         )
     except FileNotFoundError:
-        return TakeoverCompletionRead(TakeoverMetadataState.ABSENT)
+        return TakeoverCompletionRead(TakeoverRecordState.ABSENT)
     except (OSError, ValueError, TypeError, RecursionError):
-        return TakeoverCompletionRead(TakeoverMetadataState.INVALID)
+        return TakeoverCompletionRead(TakeoverRecordState.INVALID)
     expected_keys = {
         "version",
         "takeover_owner",
@@ -926,38 +1021,37 @@ def read_takeover_completion(backup_path: Path) -> TakeoverCompletionRead:
         "status",
     }
     if not isinstance(receipt, dict) or set(receipt) != expected_keys:
-        return TakeoverCompletionRead(TakeoverMetadataState.INVALID)
+        return TakeoverCompletionRead(TakeoverRecordState.INVALID)
     if type(receipt.get("version")) is not int or receipt["version"] != 1:
-        return TakeoverCompletionRead(TakeoverMetadataState.INVALID)
+        return TakeoverCompletionRead(TakeoverRecordState.INVALID)
     takeover_owner = receipt.get("takeover_owner")
     original_owner = receipt.get("original_owner")
     final_sha256 = receipt.get("final_sha256")
     same_owner_backup_sha256 = receipt.get("same_owner_backup_sha256")
     status = receipt.get("status")
     if not isinstance(takeover_owner, str) or takeover_owner not in {"release", "beta"}:
-        return TakeoverCompletionRead(TakeoverMetadataState.INVALID)
+        return TakeoverCompletionRead(TakeoverRecordState.INVALID)
     if original_owner is not None and (
         not isinstance(original_owner, str)
         or original_owner not in {"release", "beta"}
     ):
-        return TakeoverCompletionRead(TakeoverMetadataState.INVALID)
+        return TakeoverCompletionRead(TakeoverRecordState.INVALID)
     if original_owner == takeover_owner:
-        return TakeoverCompletionRead(TakeoverMetadataState.INVALID)
+        return TakeoverCompletionRead(TakeoverRecordState.INVALID)
     if (
         not isinstance(final_sha256, str)
         or re.fullmatch(r"[0-9a-f]{64}", final_sha256) is None
         or not isinstance(same_owner_backup_sha256, str)
         or re.fullmatch(r"[0-9a-f]{64}", same_owner_backup_sha256) is None
-        or not isinstance(status, str)
-        or status not in TAKEOVER_CLEANUP_STATUSES
-        or (
-            status in UNOWNED_TAKEOVER_CLEANUP_STATUSES
-            and original_owner is not None
+        or not _is_legal_takeover_status(
+            original_owner,
+            status,
+            TakeoverLifecyclePhase.COMPLETION_RECEIPT,
         )
     ):
-        return TakeoverCompletionRead(TakeoverMetadataState.INVALID)
+        return TakeoverCompletionRead(TakeoverRecordState.INVALID)
     return TakeoverCompletionRead(
-        TakeoverMetadataState.VALID,
+        TakeoverRecordState.VALID,
         TakeoverCompletionReceipt(
             takeover_owner=takeover_owner,
             original_owner=original_owner,
@@ -965,6 +1059,49 @@ def read_takeover_completion(backup_path: Path) -> TakeoverCompletionRead:
             same_owner_backup_sha256=same_owner_backup_sha256,
             status=status,
         ),
+    )
+
+
+def _read_takeover_lifecycle(
+    backup_path: Path,
+    *,
+    operation: str,
+) -> TakeoverLifecycleSnapshot:
+    metadata_read = read_takeover_metadata(backup_path)
+    if metadata_read.state is TakeoverRecordState.INVALID:
+        if metadata_read.error is TakeoverRecordError.MISSING_RECOVERY_ANCHOR:
+            raise RuntimeError(
+                f"refusing {operation}: takeover metadata is invalid "
+                "(missing durable recovery anchor; preserve config, backup, "
+                "and sidecar for safe recovery)"
+            )
+        raise RuntimeError(f"refusing {operation}: takeover metadata is invalid")
+    completion_read = read_takeover_completion(backup_path)
+    if completion_read.state is TakeoverRecordState.INVALID:
+        raise RuntimeError(f"refusing {operation}: takeover completion is invalid")
+
+    metadata = metadata_read.metadata
+    completion = completion_read.receipt
+    if (
+        metadata is not None
+        and completion is not None
+        and completion.original_owner != metadata.original_owner
+    ):
+        raise RuntimeError(f"refusing {operation}: completion ownership is inconsistent")
+    if metadata is not None:
+        phase = (
+            TakeoverLifecyclePhase.CLEANUP_JOURNAL
+            if metadata.cleanup_source_sha256 is not None
+            else TakeoverLifecyclePhase.ACTIVE
+        )
+    elif completion is not None:
+        phase = TakeoverLifecyclePhase.COMPLETION_RECEIPT
+    else:
+        phase = TakeoverLifecyclePhase.ABSENT
+    return TakeoverLifecycleSnapshot(
+        phase=phase,
+        metadata=metadata,
+        completion=completion,
     )
 
 
@@ -991,7 +1128,7 @@ def _rebase_takeover_completion(
     write_takeover_completion_receipt(backup_path, rebased)
     readback = read_takeover_completion(backup_path)
     if (
-        readback.state is not TakeoverMetadataState.VALID
+        readback.state is not TakeoverRecordState.VALID
         or readback.receipt != rebased
     ):
         raise RuntimeError(
@@ -1025,8 +1162,44 @@ def _matches_takeover_completion_backup(
     )
 
 
+def _require_takeover_completion_recovery(
+    text: str,
+    receipt: TakeoverCompletionReceipt,
+    *,
+    operation: str,
+) -> None:
+    if not _matches_takeover_completion_backup(text, receipt):
+        raise RuntimeError(f"refusing {operation}: completion recovery is inconsistent")
+
+
 def _retire_takeover_completion(backup_path: Path) -> None:
     takeover_completion_path(backup_path).unlink()
+
+
+def _matches_takeover_recovery(
+    backup_text: str,
+    metadata: TakeoverMetadata,
+) -> bool:
+    return (
+        overlay_owner(backup_text) == metadata.original_owner
+        and takeover_text_sha256(backup_text) == metadata.recovery_sha256
+    )
+
+
+def _matches_active_takeover_metadata(
+    metadata: TakeoverMetadata | None,
+    *,
+    takeover_owner: str,
+    original_owner: str | None,
+    recovery_sha256: str,
+) -> bool:
+    return (
+        metadata is not None
+        and metadata.takeover_owner == takeover_owner
+        and metadata.original_owner == original_owner
+        and metadata.recovery_sha256 == recovery_sha256
+        and metadata.cleanup_source_sha256 is None
+    )
 
 
 def is_active_takeover_backup(
@@ -1037,7 +1210,7 @@ def is_active_takeover_backup(
     return (
         metadata is not None
         and overlay_owner(config_text) == metadata.takeover_owner
-        and overlay_owner(backup_text) == metadata.original_owner
+        and _matches_takeover_recovery(backup_text, metadata)
     )
 
 
@@ -1049,7 +1222,7 @@ def is_interrupted_takeover(
     return (
         metadata is not None
         and overlay_owner(config_text) == metadata.original_owner
-        and overlay_owner(backup_text) == metadata.original_owner
+        and _matches_takeover_recovery(backup_text, metadata)
     )
 
 
@@ -1139,7 +1312,7 @@ def _prepare_managed_config_write(
     backup_path: Path,
     *,
     operation: str,
-) -> tuple[TakeoverMetadata | None, str]:
+) -> tuple[TakeoverMetadata | None, TakeoverPreparedState]:
     """Validate or finish takeover recovery before another managed write.
 
     Callers already hold the lifecycle lock. A terminal cleanup journal is
@@ -1148,22 +1321,18 @@ def _prepare_managed_config_write(
     byte-bound journal yet. Interrupted takeover state is returned to the
     caller, which may allow only the exact takeover retry.
     """
-    metadata_read = read_takeover_metadata(backup_path)
-    if metadata_read.state is TakeoverMetadataState.INVALID:
-        raise RuntimeError(f"refusing {operation}: takeover metadata is invalid")
-    completion_read = read_takeover_completion(backup_path)
-    if completion_read.state is TakeoverMetadataState.INVALID:
-        raise RuntimeError(f"refusing {operation}: takeover completion is invalid")
-    metadata = metadata_read.metadata
+    lifecycle = _read_takeover_lifecycle(backup_path, operation=operation)
+    metadata = lifecycle.metadata
+    completion = lifecycle.completion
     if metadata is None:
-        if completion_read.receipt is not None:
-            completion = completion_read.receipt
+        if completion is not None:
             if backup_path.exists():
                 recovery = read_text_preserving_newlines(backup_path)
-                if not _matches_takeover_completion_backup(recovery, completion):
-                    raise RuntimeError(
-                        f"refusing {operation}: completion recovery is inconsistent"
-                    )
+                _require_takeover_completion_recovery(
+                    recovery,
+                    completion,
+                    operation=operation,
+                )
                 _retire_takeover_completion(backup_path)
             elif not config_path.exists():
                 raise RuntimeError(
@@ -1175,34 +1344,34 @@ def _prepare_managed_config_write(
                     completion,
                     read_text_preserving_newlines(config_path),
                 )
-        return None, "absent"
-    if metadata.cleanup_source_sha256 is not None:
+        return None, TakeoverPreparedState.ABSENT
+    if lifecycle.phase is TakeoverLifecyclePhase.CLEANUP_JOURNAL:
         _resume_takeover_cleanup(config_path, backup_path, metadata)
-        return None, "cleanup_resumed"
+        return None, TakeoverPreparedState.CLEANUP_RESUMED
     if not backup_path.exists():
         raise RuntimeError(f"refusing {operation}: recovery backup is missing or diverged")
 
     recovery = read_text_preserving_newlines(backup_path)
+    if completion is not None:
+        _require_takeover_completion_recovery(
+            recovery,
+            completion,
+            operation=operation,
+        )
+    if not _matches_takeover_recovery(recovery, metadata):
+        raise RuntimeError(f"refusing {operation}: recovery backup is missing or diverged")
     current = read_text_preserving_newlines(config_path) if config_path.exists() else ""
     if is_interrupted_takeover(current, recovery, metadata):
         if not config_path.exists() or current != recovery:
             raise RuntimeError(
                 f"refusing {operation}: live config is missing or diverged"
             )
-        takeover_state = "interrupted"
+        takeover_state = TakeoverPreparedState.INTERRUPTED
     elif is_active_takeover_backup(current, recovery, metadata):
-        takeover_state = "active"
+        takeover_state = TakeoverPreparedState.ACTIVE
     else:
         raise RuntimeError(f"refusing {operation}: takeover state is not recognized")
-    if completion_read.receipt is not None:
-        completion = completion_read.receipt
-        if (
-            completion.original_owner != metadata.original_owner
-            or not _matches_takeover_completion_backup(recovery, completion)
-        ):
-            raise RuntimeError(
-                f"refusing {operation}: completion recovery is inconsistent"
-            )
+    if completion is not None:
         _retire_takeover_completion(backup_path)
     return metadata, takeover_state
 
@@ -1250,11 +1419,11 @@ def _apply_overlay_locked(
         backup_path,
         operation="overlay apply",
     )
-    if takeover_state == "active" and (
+    if takeover_state is TakeoverPreparedState.ACTIVE and (
         metadata is None or owner != metadata.takeover_owner
     ):
         raise RuntimeError("refusing overlay apply: active takeover belongs to another owner")
-    if takeover_state == "interrupted" and (
+    if takeover_state is TakeoverPreparedState.INTERRUPTED and (
         metadata is None
         or owner != metadata.takeover_owner
         or not takeover
@@ -1280,7 +1449,28 @@ def _apply_overlay_locked(
         atomic_write_text(backup_path, backup, encoding="utf-8")
         metadata_path = takeover_metadata_path(backup_path)
         if cross_owner_takeover:
-            write_takeover_metadata(backup_path, owner, active_owner)
+            published_backup = read_text_preserving_newlines(backup_path)
+            if published_backup != backup:
+                raise RuntimeError(
+                    "refusing overlay apply: recovery backup publication diverged"
+                )
+            recovery_sha256 = takeover_text_sha256(published_backup)
+            write_takeover_metadata(
+                backup_path,
+                owner,
+                active_owner,
+                recovery_sha256=recovery_sha256,
+            )
+            metadata_read = read_takeover_metadata(backup_path)
+            if not _matches_active_takeover_metadata(
+                metadata_read.metadata,
+                takeover_owner=owner,
+                original_owner=active_owner,
+                recovery_sha256=recovery_sha256,
+            ):
+                raise RuntimeError(
+                    "refusing overlay apply: takeover ownership evidence is inconsistent"
+                )
         elif metadata_path.exists():
             metadata_path.unlink()
 
@@ -1300,26 +1490,32 @@ def _apply_overlay_locked(
 
     # Retire an older completed generation only after this apply has durable
     # live bytes, a recovery backup, and takeover metadata when ownership moved.
-    completion_read = read_takeover_completion(backup_path)
-    if completion_read.state is TakeoverMetadataState.INVALID:
-        raise RuntimeError("refusing overlay apply: takeover completion is invalid")
-    if completion_read.receipt is not None:
-        if not backup_path.exists() or not _matches_takeover_completion_backup(
-            read_text_preserving_newlines(backup_path),
-            completion_read.receipt,
-        ):
+    lifecycle = _read_takeover_lifecycle(
+        backup_path,
+        operation="overlay apply",
+    )
+    if lifecycle.completion is not None:
+        if not backup_path.exists():
             raise RuntimeError(
                 "refusing overlay apply: completion recovery is inconsistent"
             )
+        _require_takeover_completion_recovery(
+            read_text_preserving_newlines(backup_path),
+            lifecycle.completion,
+            operation="overlay apply",
+        )
         if cross_owner_takeover:
-            new_metadata_read = read_takeover_metadata(backup_path)
-            new_metadata = new_metadata_read.metadata
-            if (
-                new_metadata_read.state is not TakeoverMetadataState.VALID
-                or new_metadata is None
-                or new_metadata.takeover_owner != owner
-                or new_metadata.original_owner != active_owner
-                or new_metadata.cleanup_source_sha256 is not None
+            new_metadata = lifecycle.metadata
+            recovery_sha256 = takeover_text_sha256(
+                read_text_preserving_newlines(backup_path)
+            )
+            if lifecycle.phase is not TakeoverLifecyclePhase.ACTIVE or not (
+                _matches_active_takeover_metadata(
+                    new_metadata,
+                    takeover_owner=owner,
+                    original_owner=active_owner,
+                    recovery_sha256=recovery_sha256,
+                )
             ):
                 raise RuntimeError(
                     "refusing overlay apply: takeover ownership evidence is inconsistent"
@@ -1408,7 +1604,7 @@ def _resume_takeover_cleanup(
     write_takeover_completion_receipt(backup_path, expected_completion)
     completion_read = read_takeover_completion(backup_path)
     if (
-        completion_read.state is not TakeoverMetadataState.VALID
+        completion_read.state is not TakeoverRecordState.VALID
         or completion_read.receipt != expected_completion
     ):
         raise RuntimeError("refusing takeover cleanup: completion receipt readback failed")
@@ -1432,13 +1628,14 @@ def _start_takeover_cleanup(
         backup_path,
         metadata.takeover_owner,
         metadata.original_owner,
+        recovery_sha256=metadata.recovery_sha256,
         cleanup_source_sha256=takeover_text_sha256(current),
         cleanup_recovery_sha256=takeover_text_sha256(recovery),
         cleanup_final_sha256=takeover_text_sha256(final),
         cleanup_status=status,
     )
     journal_read = read_takeover_metadata(backup_path)
-    if journal_read.state is not TakeoverMetadataState.VALID:
+    if journal_read.state is not TakeoverRecordState.VALID:
         raise RuntimeError("refusing takeover cleanup: journal readback failed")
     journal = journal_read.metadata
     if journal is None:
@@ -1447,22 +1644,15 @@ def _start_takeover_cleanup(
 
 
 def _restore_overlay_locked(config_path: Path, backup_path: Path, unified_history: bool) -> str:
-    metadata_read = read_takeover_metadata(backup_path)
-    if metadata_read.state is TakeoverMetadataState.INVALID:
-        raise RuntimeError("refusing takeover restore: takeover metadata is invalid")
-    completion_read = read_takeover_completion(backup_path)
-    if completion_read.state is TakeoverMetadataState.INVALID:
-        raise RuntimeError("refusing takeover restore: takeover completion is invalid")
-    metadata = metadata_read.metadata
-    if (
-        metadata is not None
-        and completion_read.receipt is not None
-        and completion_read.receipt.original_owner != metadata.original_owner
-    ):
-        raise RuntimeError(
-            "refusing takeover restore: completion ownership is inconsistent"
-        )
-    if metadata is not None and metadata.cleanup_source_sha256 is not None:
+    lifecycle = _read_takeover_lifecycle(
+        backup_path,
+        operation="takeover restore",
+    )
+    metadata = lifecycle.metadata
+    completion = lifecycle.completion
+    if lifecycle.phase is TakeoverLifecyclePhase.CLEANUP_JOURNAL:
+        if metadata is None:
+            raise RuntimeError("refusing takeover restore: takeover metadata is invalid")
         return _resume_takeover_cleanup(config_path, backup_path, metadata)
 
     if not backup_path.exists() and metadata is not None:
@@ -1470,17 +1660,23 @@ def _restore_overlay_locked(config_path: Path, backup_path: Path, unified_histor
     if (
         backup_path.exists()
         and metadata is not None
-        and completion_read.receipt is not None
-        and not _matches_takeover_completion_backup(
+        and completion is not None
+    ):
+        _require_takeover_completion_recovery(
             read_text_preserving_newlines(backup_path),
-            completion_read.receipt,
+            completion,
+            operation="takeover restore",
+        )
+    if (
+        backup_path.exists()
+        and metadata is not None
+        and not _matches_takeover_recovery(
+            read_text_preserving_newlines(backup_path),
+            metadata,
         )
     ):
-        raise RuntimeError(
-            "refusing takeover restore: completion recovery is inconsistent"
-        )
-    if not backup_path.exists() and metadata is None and completion_read.receipt is not None:
-        completion = completion_read.receipt
+        raise RuntimeError("refusing takeover restore: recovery backup is missing or diverged")
+    if not backup_path.exists() and metadata is None and completion is not None:
         if not config_path.exists():
             raise RuntimeError(
                 "refusing takeover restore: completed live config is missing or diverged"
@@ -1491,8 +1687,7 @@ def _restore_overlay_locked(config_path: Path, backup_path: Path, unified_histor
                 "refusing takeover restore: completed live config is missing or diverged"
             )
         return completion.status
-    if backup_path.exists() and metadata is None and completion_read.receipt is not None:
-        completion = completion_read.receipt
+    if backup_path.exists() and metadata is None and completion is not None:
         staged_backup = read_text_preserving_newlines(backup_path)
         if config_path.exists():
             current = read_text_preserving_newlines(config_path)
@@ -1502,10 +1697,11 @@ def _restore_overlay_locked(config_path: Path, backup_path: Path, unified_histor
             ):
                 backup_path.unlink()
                 return completion.status
-        if not _matches_takeover_completion_backup(staged_backup, completion):
-            raise RuntimeError(
-                "refusing takeover restore: completion recovery is inconsistent"
-            )
+        _require_takeover_completion_recovery(
+            staged_backup,
+            completion,
+            operation="takeover restore",
+        )
         _retire_takeover_completion(backup_path)
 
     if backup_path.exists():

--- a/src-python/config_overlay.py
+++ b/src-python/config_overlay.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import argparse
 from dataclasses import dataclass
+import hashlib
 import json
 from pathlib import Path
 
-from atomic_io import atomic_write_text
+from atomic_io import atomic_write_text, file_lock_for
 from model_limits import (
     CURRENT_DIRECT_OFFICIAL_SOURCE,
     DEGRADED_LAST_KNOWN_OFFICIAL_SOURCE,
@@ -35,6 +36,10 @@ NATIVE_AUTO_COMPACT_PERCENT = 90
 CONTEXT_GUARD_KEYS = {
     "model_context_window",
     "model_auto_compact_token_limit",
+}
+TAKEOVER_CLEANUP_STATUSES = {
+    "interrupted_takeover_discarded",
+    "restored_takeover_backup",
 }
 
 
@@ -654,12 +659,38 @@ def takeover_metadata_path(backup_path: Path) -> Path:
     return backup_path.with_name(f"{backup_path.name}.takeover.json")
 
 
-def write_takeover_metadata(backup_path: Path, takeover_owner: str, original_owner: str | None) -> None:
+@dataclass(frozen=True)
+class TakeoverMetadata:
+    takeover_owner: str
+    original_owner: str | None
+    cleanup_sha256: str | None
+    cleanup_status: str | None
+
+
+def takeover_text_sha256(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def write_takeover_metadata(
+    backup_path: Path,
+    takeover_owner: str,
+    original_owner: str | None,
+    *,
+    cleanup_sha256: str | None = None,
+    cleanup_status: str | None = None,
+) -> None:
+    if (cleanup_sha256 is None) != (cleanup_status is None):
+        raise ValueError("takeover cleanup digest and status must be written together")
+    if cleanup_status is not None and cleanup_status not in TAKEOVER_CLEANUP_STATUSES:
+        raise ValueError("unsupported takeover cleanup status")
     metadata = {
         "version": 1,
         "takeover_owner": takeover_owner,
         "original_owner": original_owner,
     }
+    if cleanup_sha256 is not None:
+        metadata["cleanup_sha256"] = cleanup_sha256
+        metadata["cleanup_status"] = cleanup_status
     atomic_write_text(
         takeover_metadata_path(backup_path),
         json.dumps(metadata, sort_keys=True) + "\n",
@@ -667,11 +698,13 @@ def write_takeover_metadata(backup_path: Path, takeover_owner: str, original_own
     )
 
 
-def takeover_owners(backup_path: Path) -> tuple[str, str | None] | None:
+def read_takeover_metadata(backup_path: Path) -> TakeoverMetadata | None:
     metadata_path = takeover_metadata_path(backup_path)
     try:
         metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
     except (OSError, ValueError, TypeError):
+        return None
+    if not isinstance(metadata, dict):
         return None
     if metadata.get("version") != 1:
         return None
@@ -683,23 +716,55 @@ def takeover_owners(backup_path: Path) -> tuple[str, str | None] | None:
         return None
     if original_owner == takeover_owner:
         return None
-    return takeover_owner, original_owner
+    cleanup_sha256 = metadata.get("cleanup_sha256")
+    cleanup_status = metadata.get("cleanup_status")
+    if (cleanup_sha256 is None) != (cleanup_status is None):
+        return None
+    if cleanup_sha256 is not None and (
+        not isinstance(cleanup_sha256, str)
+        or re.fullmatch(r"[0-9a-f]{64}", cleanup_sha256) is None
+        or not isinstance(cleanup_status, str)
+        or cleanup_status not in TAKEOVER_CLEANUP_STATUSES
+    ):
+        return None
+    return TakeoverMetadata(
+        takeover_owner=takeover_owner,
+        original_owner=original_owner,
+        cleanup_sha256=cleanup_sha256,
+        cleanup_status=cleanup_status,
+    )
 
 
-def is_active_takeover_backup(config_text: str, backup_text: str, backup_path: Path) -> bool:
-    owners = takeover_owners(backup_path)
-    if owners is None:
-        return False
-    takeover_owner, original_owner = owners
-    return overlay_owner(config_text) == takeover_owner and overlay_owner(backup_text) == original_owner
+def is_active_takeover_backup(
+    config_text: str,
+    backup_text: str,
+    metadata: TakeoverMetadata | None,
+) -> bool:
+    return (
+        metadata is not None
+        and overlay_owner(config_text) == metadata.takeover_owner
+        and overlay_owner(backup_text) == metadata.original_owner
+    )
 
 
-def is_interrupted_takeover(config_text: str, backup_text: str, backup_path: Path) -> bool:
-    owners = takeover_owners(backup_path)
-    if owners is None:
-        return False
-    _, original_owner = owners
-    return overlay_owner(config_text) == original_owner and overlay_owner(backup_text) == original_owner
+def is_interrupted_takeover(
+    config_text: str,
+    backup_text: str,
+    metadata: TakeoverMetadata | None,
+) -> bool:
+    return (
+        metadata is not None
+        and overlay_owner(config_text) == metadata.original_owner
+        and overlay_owner(backup_text) == metadata.original_owner
+    )
+
+
+def matches_completed_takeover_cleanup(text: str, metadata: TakeoverMetadata) -> bool:
+    return (
+        metadata.cleanup_sha256 is not None
+        and overlay_owner(text) == metadata.original_owner
+        and takeover_text_sha256(text) == metadata.cleanup_sha256
+    )
 
 
 def build_provider_section(base_url: str, gateway_key: str) -> str:
@@ -726,6 +791,11 @@ def insert_provider_section(text: str, provider_section: str) -> str:
     return provider_section
 
 
+def overlay_lifecycle_lock_target(config_path: Path) -> Path:
+    """Return the shared transaction-lock target for one managed Codex config."""
+    return config_path.with_name(f".{config_path.name}.codexhub-overlay-lifecycle")
+
+
 def apply_overlay(
     config_path: Path,
     backup_path: Path,
@@ -734,6 +804,30 @@ def apply_overlay(
     owner: str = "release",
     takeover: bool = False,
     gateway_key: str = "codexhub-proxy",
+) -> None:
+    # Apply and restore must read, classify, and publish while holding the same
+    # lock. Individual atomic-file locks cannot prevent a retry from changing
+    # the live config between restore classification and recovery cleanup.
+    with file_lock_for(overlay_lifecycle_lock_target(config_path)):
+        _apply_overlay_locked(
+            config_path,
+            backup_path,
+            catalog_path,
+            base_url,
+            owner,
+            takeover,
+            gateway_key,
+        )
+
+
+def _apply_overlay_locked(
+    config_path: Path,
+    backup_path: Path,
+    catalog_path: Path | None,
+    base_url: str,
+    owner: str,
+    takeover: bool,
+    gateway_key: str,
 ) -> None:
     if owner not in {"release", "beta"}:
         raise ValueError(f"unsupported CodexHub owner: {owner}")
@@ -775,21 +869,71 @@ def apply_overlay(
 
 
 def restore_overlay(config_path: Path, backup_path: Path, unified_history: bool = False) -> str:
+    with file_lock_for(overlay_lifecycle_lock_target(config_path)):
+        return _restore_overlay_locked(config_path, backup_path, unified_history)
+
+
+def _restore_overlay_locked(config_path: Path, backup_path: Path, unified_history: bool) -> str:
+    metadata = read_takeover_metadata(backup_path)
+    if metadata is not None and metadata.cleanup_sha256 is not None and config_path.exists():
+        current = read_text_preserving_newlines(config_path)
+        if matches_completed_takeover_cleanup(current, metadata):
+            if backup_path.exists():
+                restored = read_text_preserving_newlines(backup_path)
+                if not matches_completed_takeover_cleanup(restored, metadata):
+                    raise RuntimeError(
+                        "refusing takeover cleanup: recovery backup is missing or diverged"
+                    )
+                backup_path.unlink()
+            takeover_metadata_path(backup_path).unlink()
+            if metadata.cleanup_status is None:
+                raise RuntimeError("refusing takeover cleanup: metadata is invalid")
+            return metadata.cleanup_status
+
+    if not backup_path.exists() and metadata is not None:
+        raise RuntimeError("refusing takeover restore: recovery backup is missing or diverged")
+
     if backup_path.exists():
         restored = read_text_preserving_newlines(backup_path)
         current = read_text_preserving_newlines(config_path) if config_path.exists() else ""
         restore_from_backup = True
-        if is_interrupted_takeover(current, restored, backup_path):
+        if is_interrupted_takeover(current, restored, metadata):
+            if not config_path.exists() or current != restored:
+                raise RuntimeError(
+                    "refusing interrupted takeover cleanup: live config is missing or diverged"
+                )
+            if metadata is None:
+                raise RuntimeError("refusing interrupted takeover cleanup: metadata is invalid")
+            write_takeover_metadata(
+                backup_path,
+                metadata.takeover_owner,
+                metadata.original_owner,
+                cleanup_sha256=takeover_text_sha256(current),
+                cleanup_status="interrupted_takeover_discarded",
+            )
             backup_path.unlink()
             takeover_metadata_path(backup_path).unlink()
             return "interrupted_takeover_discarded"
-        if is_active_takeover_backup(current, restored, backup_path):
+        if is_active_takeover_backup(current, restored, metadata):
             restored_owner = overlay_owner(restored)
             if not unified_history or restored_owner is not None:
+                if metadata is None:
+                    raise RuntimeError("refusing takeover restore: metadata is invalid")
+                write_takeover_metadata(
+                    backup_path,
+                    metadata.takeover_owner,
+                    metadata.original_owner,
+                    cleanup_sha256=takeover_text_sha256(restored),
+                    cleanup_status="restored_takeover_backup",
+                )
                 atomic_write_text(config_path, restored, encoding="utf-8")
                 backup_path.unlink()
                 takeover_metadata_path(backup_path).unlink()
                 return "restored_takeover_backup"
+        if metadata is not None and metadata.cleanup_sha256 is not None:
+            raise RuntimeError(
+                "refusing takeover cleanup: live config or recovery backup diverged"
+            )
     elif config_path.exists():
         restored = strip_marked_overlay(config_path.read_text(encoding="utf-8"))
         restore_from_backup = False

--- a/src-python/config_overlay.py
+++ b/src-python/config_overlay.py
@@ -330,6 +330,7 @@ def _publish_context_guard_updates(
         and "backup" in updated_text_by_target
     ):
         _publish_takeover_recovery_reanchor(
+            target_paths["config"],
             target_paths["backup"],
             metadata,
             updated_text_by_target["backup"],
@@ -820,6 +821,7 @@ class TakeoverMetadata:
     original_owner: str | None
     recovery_sha256: str
     reanchor_recovery_sha256: str | None
+    reanchor_live_sha256: str | None
     cleanup_source_sha256: str | None
     cleanup_recovery_sha256: str | None
     cleanup_final_sha256: str | None
@@ -865,6 +867,12 @@ class TakeoverLifecycleSnapshot:
     completion: TakeoverCompletionReceipt | None
 
 
+@dataclass(frozen=True)
+class TakeoverReanchorPreflight:
+    metadata: TakeoverMetadata
+    recovery_sha256: str
+
+
 def takeover_text_sha256(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
@@ -885,6 +893,7 @@ def write_takeover_metadata(
     *,
     recovery_sha256: str,
     reanchor_recovery_sha256: str | None = None,
+    reanchor_live_sha256: str | None = None,
     cleanup_source_sha256: str | None = None,
     cleanup_recovery_sha256: str | None = None,
     cleanup_final_sha256: str | None = None,
@@ -896,6 +905,14 @@ def write_takeover_metadata(
         cleanup_final_sha256,
         cleanup_status,
     )
+    reanchor_values = (
+        reanchor_recovery_sha256,
+        reanchor_live_sha256,
+    )
+    if any(value is None for value in reanchor_values) and any(
+        value is not None for value in reanchor_values
+    ):
+        raise ValueError("takeover re-anchor digests must be written together")
     if reanchor_recovery_sha256 is not None and any(
         value is not None for value in cleanup_values
     ):
@@ -924,9 +941,13 @@ def write_takeover_metadata(
         raise ValueError("takeover recovery digest must be a lowercase SHA-256")
     if (
         reanchor_recovery_sha256 is not None
-        and re.fullmatch(r"[0-9a-f]{64}", reanchor_recovery_sha256) is None
+        and any(
+            re.fullmatch(r"[0-9a-f]{64}", digest) is None
+            for digest in reanchor_values
+            if digest is not None
+        )
     ):
-        raise ValueError("takeover re-anchor digest must be a lowercase SHA-256")
+        raise ValueError("takeover re-anchor digests must be lowercase SHA-256 values")
     metadata = {
         "version": 1,
         "takeover_owner": takeover_owner,
@@ -935,6 +956,7 @@ def write_takeover_metadata(
     }
     if reanchor_recovery_sha256 is not None:
         metadata["reanchor_recovery_sha256"] = reanchor_recovery_sha256
+        metadata["reanchor_live_sha256"] = reanchor_live_sha256
     elif cleanup_source_sha256 is not None:
         metadata["cleanup_source_sha256"] = cleanup_source_sha256
         metadata["cleanup_recovery_sha256"] = cleanup_recovery_sha256
@@ -967,7 +989,10 @@ def read_takeover_metadata(backup_path: Path) -> TakeoverMetadataRead:
         "cleanup_final_sha256",
         "cleanup_status",
     }
-    reanchor_keys = {"reanchor_recovery_sha256"}
+    reanchor_keys = {
+        "reanchor_recovery_sha256",
+        "reanchor_live_sha256",
+    }
     metadata_keys = frozenset(metadata)
     legacy_base_keys = base_keys - {"recovery_sha256"}
     if (
@@ -996,6 +1021,7 @@ def read_takeover_metadata(backup_path: Path) -> TakeoverMetadataRead:
     original_owner = metadata.get("original_owner")
     recovery_sha256 = metadata.get("recovery_sha256")
     reanchor_recovery_sha256 = metadata.get("reanchor_recovery_sha256")
+    reanchor_live_sha256 = metadata.get("reanchor_live_sha256")
     if not isinstance(takeover_owner, str) or takeover_owner not in {"release", "beta"}:
         return TakeoverMetadataRead(TakeoverRecordState.INVALID)
     if original_owner is not None and (
@@ -1027,11 +1053,23 @@ def read_takeover_metadata(backup_path: Path) -> TakeoverMetadataRead:
     if not has_cleanup_fields and any(value is not None for value in cleanup_values):
         return TakeoverMetadataRead(TakeoverRecordState.INVALID)
     if has_reanchor_field and (
-        not isinstance(reanchor_recovery_sha256, str)
-        or re.fullmatch(r"[0-9a-f]{64}", reanchor_recovery_sha256) is None
+        any(
+            not isinstance(digest, str)
+            or re.fullmatch(r"[0-9a-f]{64}", digest) is None
+            for digest in (
+                reanchor_recovery_sha256,
+                reanchor_live_sha256,
+            )
+        )
     ):
         return TakeoverMetadataRead(TakeoverRecordState.INVALID)
-    if not has_reanchor_field and reanchor_recovery_sha256 is not None:
+    if not has_reanchor_field and any(
+        digest is not None
+        for digest in (
+            reanchor_recovery_sha256,
+            reanchor_live_sha256,
+        )
+    ):
         return TakeoverMetadataRead(TakeoverRecordState.INVALID)
     digests = (
         cleanup_source_sha256,
@@ -1058,6 +1096,7 @@ def read_takeover_metadata(backup_path: Path) -> TakeoverMetadataRead:
             original_owner=original_owner,
             recovery_sha256=recovery_sha256,
             reanchor_recovery_sha256=reanchor_recovery_sha256,
+            reanchor_live_sha256=reanchor_live_sha256,
             cleanup_source_sha256=cleanup_source_sha256,
             cleanup_recovery_sha256=cleanup_recovery_sha256,
             cleanup_final_sha256=cleanup_final_sha256,
@@ -1289,19 +1328,37 @@ def _matches_active_takeover_metadata(
         and metadata.original_owner == original_owner
         and metadata.recovery_sha256 == recovery_sha256
         and metadata.reanchor_recovery_sha256 is None
+        and metadata.reanchor_live_sha256 is None
         and metadata.cleanup_source_sha256 is None
     )
 
 
-def _resume_takeover_reanchor(
+def _preflight_takeover_reanchor(
+    config_path: Path,
     backup_path: Path,
-    metadata: TakeoverMetadata,
+    lifecycle: TakeoverLifecycleSnapshot,
     *,
     operation: str,
-) -> TakeoverMetadata:
-    candidate_sha256 = metadata.reanchor_recovery_sha256
-    if candidate_sha256 is None:
+) -> TakeoverReanchorPreflight:
+    metadata = lifecycle.metadata
+    if (
+        lifecycle.phase is not TakeoverLifecyclePhase.RECOVERY_REANCHOR_JOURNAL
+        or metadata is None
+        or metadata.reanchor_recovery_sha256 is None
+        or metadata.reanchor_live_sha256 is None
+    ):
         raise RuntimeError(f"refusing {operation}: takeover re-anchor journal is incomplete")
+    if lifecycle.completion is not None:
+        raise RuntimeError(f"refusing {operation}: takeover re-anchor completion is inconsistent")
+    if not config_path.exists():
+        raise RuntimeError(f"refusing {operation}: live config is missing or diverged")
+
+    current = read_text_preserving_newlines(config_path)
+    if (
+        overlay_owner(current) != metadata.takeover_owner
+        or takeover_text_sha256(current) != metadata.reanchor_live_sha256
+    ):
+        raise RuntimeError(f"refusing {operation}: live config is missing or diverged")
     if not backup_path.exists():
         raise RuntimeError(f"refusing {operation}: recovery backup is missing or diverged")
 
@@ -1310,22 +1367,45 @@ def _resume_takeover_reanchor(
     if (
         overlay_owner(recovery) != metadata.original_owner
         or recovery_sha256
-        not in {metadata.recovery_sha256, candidate_sha256}
+        not in {
+            metadata.recovery_sha256,
+            metadata.reanchor_recovery_sha256,
+        }
     ):
         raise RuntimeError(f"refusing {operation}: recovery backup is missing or diverged")
+    return TakeoverReanchorPreflight(
+        metadata=metadata,
+        recovery_sha256=recovery_sha256,
+    )
+
+
+def _resume_takeover_reanchor(
+    config_path: Path,
+    backup_path: Path,
+    lifecycle: TakeoverLifecycleSnapshot,
+    *,
+    operation: str,
+) -> TakeoverMetadata:
+    preflight = _preflight_takeover_reanchor(
+        config_path,
+        backup_path,
+        lifecycle,
+        operation=operation,
+    )
+    metadata = preflight.metadata
 
     write_takeover_metadata(
         backup_path,
         metadata.takeover_owner,
         metadata.original_owner,
-        recovery_sha256=recovery_sha256,
+        recovery_sha256=preflight.recovery_sha256,
     )
     readback = read_takeover_metadata(backup_path)
     if not _matches_active_takeover_metadata(
         readback.metadata,
         takeover_owner=metadata.takeover_owner,
         original_owner=metadata.original_owner,
-        recovery_sha256=recovery_sha256,
+        recovery_sha256=preflight.recovery_sha256,
     ):
         raise RuntimeError(f"refusing {operation}: takeover re-anchor readback failed")
     active = readback.metadata
@@ -1335,6 +1415,7 @@ def _resume_takeover_reanchor(
 
 
 def _publish_takeover_recovery_reanchor(
+    config_path: Path,
     backup_path: Path,
     metadata: TakeoverMetadata,
     candidate: str,
@@ -1347,6 +1428,11 @@ def _publish_takeover_recovery_reanchor(
     if candidate == current:
         return metadata
 
+    live = read_text_preserving_newlines(config_path)
+    if not is_active_takeover_backup(live, current, metadata):
+        raise RuntimeError(
+            "refusing context guard update: live config is missing or diverged"
+        )
     candidate_sha256 = takeover_text_sha256(candidate)
     write_takeover_metadata(
         backup_path,
@@ -1354,17 +1440,23 @@ def _publish_takeover_recovery_reanchor(
         metadata.original_owner,
         recovery_sha256=metadata.recovery_sha256,
         reanchor_recovery_sha256=candidate_sha256,
+        reanchor_live_sha256=takeover_text_sha256(live),
     )
-    journal_read = read_takeover_metadata(backup_path)
-    journal = journal_read.metadata
+    journal_lifecycle = _read_takeover_lifecycle(
+        backup_path,
+        operation="context guard update",
+    )
+    journal = _preflight_takeover_reanchor(
+        config_path,
+        backup_path,
+        journal_lifecycle,
+        operation="context guard update",
+    ).metadata
     if (
-        journal_read.state is not TakeoverRecordState.VALID
-        or journal is None
-        or journal.takeover_owner != metadata.takeover_owner
+        journal.takeover_owner != metadata.takeover_owner
         or journal.original_owner != metadata.original_owner
         or journal.recovery_sha256 != metadata.recovery_sha256
         or journal.reanchor_recovery_sha256 != candidate_sha256
-        or journal.cleanup_source_sha256 is not None
     ):
         raise RuntimeError(
             "refusing context guard update: takeover re-anchor journal readback failed"
@@ -1381,8 +1473,12 @@ def _publish_takeover_recovery_reanchor(
             "refusing context guard update: recovery backup publication diverged"
         )
     return _resume_takeover_reanchor(
+        config_path,
         backup_path,
-        journal,
+        _read_takeover_lifecycle(
+            backup_path,
+            operation="context guard update",
+        ),
         operation="context guard update",
     )
 
@@ -1535,8 +1631,9 @@ def _prepare_managed_config_write(
         return None, TakeoverPreparedState.CLEANUP_RESUMED
     if lifecycle.phase is TakeoverLifecyclePhase.RECOVERY_REANCHOR_JOURNAL:
         metadata = _resume_takeover_reanchor(
+            config_path,
             backup_path,
-            metadata,
+            lifecycle,
             operation=operation,
         )
     if not backup_path.exists():
@@ -1849,8 +1946,9 @@ def _restore_overlay_locked(config_path: Path, backup_path: Path, unified_histor
         if metadata is None:
             raise RuntimeError("refusing takeover restore: takeover metadata is invalid")
         metadata = _resume_takeover_reanchor(
+            config_path,
             backup_path,
-            metadata,
+            lifecycle,
             operation="takeover restore",
         )
 

--- a/src-python/config_overlay.py
+++ b/src-python/config_overlay.py
@@ -667,23 +667,39 @@ def write_takeover_metadata(backup_path: Path, takeover_owner: str, original_own
     )
 
 
-def is_active_takeover_backup(config_text: str, backup_text: str, backup_path: Path) -> bool:
+def takeover_owners(backup_path: Path) -> tuple[str, str | None] | None:
     metadata_path = takeover_metadata_path(backup_path)
     try:
         metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
     except (OSError, ValueError, TypeError):
-        return False
+        return None
     if metadata.get("version") != 1:
-        return False
+        return None
     takeover_owner = metadata.get("takeover_owner")
     original_owner = metadata.get("original_owner")
     if takeover_owner not in {"release", "beta"}:
-        return False
+        return None
     if original_owner not in {None, "release", "beta"}:
-        return False
+        return None
     if original_owner == takeover_owner:
+        return None
+    return takeover_owner, original_owner
+
+
+def is_active_takeover_backup(config_text: str, backup_text: str, backup_path: Path) -> bool:
+    owners = takeover_owners(backup_path)
+    if owners is None:
         return False
+    takeover_owner, original_owner = owners
     return overlay_owner(config_text) == takeover_owner and overlay_owner(backup_text) == original_owner
+
+
+def is_interrupted_takeover(config_text: str, backup_text: str, backup_path: Path) -> bool:
+    owners = takeover_owners(backup_path)
+    if owners is None:
+        return False
+    _, original_owner = owners
+    return overlay_owner(config_text) == original_owner and overlay_owner(backup_text) == original_owner
 
 
 def build_provider_section(base_url: str, gateway_key: str) -> str:
@@ -763,6 +779,10 @@ def restore_overlay(config_path: Path, backup_path: Path, unified_history: bool 
         restored = read_text_preserving_newlines(backup_path)
         current = read_text_preserving_newlines(config_path) if config_path.exists() else ""
         restore_from_backup = True
+        if is_interrupted_takeover(current, restored, backup_path):
+            backup_path.unlink()
+            takeover_metadata_path(backup_path).unlink()
+            return "interrupted_takeover_discarded"
         if is_active_takeover_backup(current, restored, backup_path):
             restored_owner = overlay_owner(restored)
             if not unified_history or restored_owner is not None:

--- a/src-python/config_overlay.py
+++ b/src-python/config_overlay.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 from dataclasses import dataclass
+from enum import Enum
 import hashlib
 import json
 from pathlib import Path
@@ -38,7 +39,13 @@ CONTEXT_GUARD_KEYS = {
     "model_auto_compact_token_limit",
 }
 TAKEOVER_CLEANUP_STATUSES = {
+    "already_unified",
+    "conflicting_custom_provider",
+    "explicit_model_provider",
+    "injected",
     "interrupted_takeover_discarded",
+    "repaired_unified",
+    "replaced_managed_gateway",
     "restored_takeover_backup",
 }
 
@@ -255,6 +262,37 @@ def set_context_guard(
     enabled: bool,
     catalog_path: Path | None = None,
 ) -> dict[str, int | bool | None]:
+    config_path = config_path.resolve(strict=False)
+    backup_path = backup_path.resolve(strict=False)
+    state_path = state_path.resolve(strict=False)
+    _validate_managed_write_paths(config_path, backup_path, state_path)
+    with file_lock_for(overlay_lifecycle_lock_target(config_path)):
+        return _set_context_guard_locked(
+            config_path,
+            backup_path,
+            state_path,
+            enabled=enabled,
+            catalog_path=catalog_path,
+        )
+
+
+def _set_context_guard_locked(
+    config_path: Path,
+    backup_path: Path,
+    state_path: Path,
+    *,
+    enabled: bool,
+    catalog_path: Path | None = None,
+) -> dict[str, int | bool | None]:
+    _, takeover_state = _prepare_managed_config_write(
+        config_path,
+        backup_path,
+        operation="context guard update",
+    )
+    if takeover_state == "interrupted":
+        raise RuntimeError(
+            "refusing context guard update: interrupted takeover recovery is pending"
+        )
     target_paths = {"config": config_path}
     if backup_path.exists():
         target_paths["backup"] = backup_path
@@ -663,8 +701,22 @@ def takeover_metadata_path(backup_path: Path) -> Path:
 class TakeoverMetadata:
     takeover_owner: str
     original_owner: str | None
-    cleanup_sha256: str | None
+    cleanup_source_sha256: str | None
+    cleanup_recovery_sha256: str | None
+    cleanup_final_sha256: str | None
     cleanup_status: str | None
+
+
+class TakeoverMetadataState(Enum):
+    ABSENT = "absent"
+    VALID = "valid"
+    INVALID = "invalid"
+
+
+@dataclass(frozen=True)
+class TakeoverMetadataRead:
+    state: TakeoverMetadataState
+    metadata: TakeoverMetadata | None = None
 
 
 def takeover_text_sha256(text: str) -> str:
@@ -676,11 +728,21 @@ def write_takeover_metadata(
     takeover_owner: str,
     original_owner: str | None,
     *,
-    cleanup_sha256: str | None = None,
+    cleanup_source_sha256: str | None = None,
+    cleanup_recovery_sha256: str | None = None,
+    cleanup_final_sha256: str | None = None,
     cleanup_status: str | None = None,
 ) -> None:
-    if (cleanup_sha256 is None) != (cleanup_status is None):
-        raise ValueError("takeover cleanup digest and status must be written together")
+    cleanup_values = (
+        cleanup_source_sha256,
+        cleanup_recovery_sha256,
+        cleanup_final_sha256,
+        cleanup_status,
+    )
+    if any(value is None for value in cleanup_values) and any(
+        value is not None for value in cleanup_values
+    ):
+        raise ValueError("takeover cleanup digests and status must be written together")
     if cleanup_status is not None and cleanup_status not in TAKEOVER_CLEANUP_STATUSES:
         raise ValueError("unsupported takeover cleanup status")
     metadata = {
@@ -688,8 +750,10 @@ def write_takeover_metadata(
         "takeover_owner": takeover_owner,
         "original_owner": original_owner,
     }
-    if cleanup_sha256 is not None:
-        metadata["cleanup_sha256"] = cleanup_sha256
+    if cleanup_source_sha256 is not None:
+        metadata["cleanup_source_sha256"] = cleanup_source_sha256
+        metadata["cleanup_recovery_sha256"] = cleanup_recovery_sha256
+        metadata["cleanup_final_sha256"] = cleanup_final_sha256
         metadata["cleanup_status"] = cleanup_status
     atomic_write_text(
         takeover_metadata_path(backup_path),
@@ -698,40 +762,91 @@ def write_takeover_metadata(
     )
 
 
-def read_takeover_metadata(backup_path: Path) -> TakeoverMetadata | None:
+def read_takeover_metadata(backup_path: Path) -> TakeoverMetadataRead:
     metadata_path = takeover_metadata_path(backup_path)
+
+    def reject_duplicate_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+        result: dict[str, object] = {}
+        for key, value in pairs:
+            if key in result:
+                raise ValueError(f"duplicate takeover metadata key: {key}")
+            result[key] = value
+        return result
+
     try:
-        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
-    except (OSError, ValueError, TypeError):
-        return None
+        metadata = json.loads(
+            metadata_path.read_text(encoding="utf-8"),
+            object_pairs_hook=reject_duplicate_keys,
+        )
+    except FileNotFoundError:
+        return TakeoverMetadataRead(TakeoverMetadataState.ABSENT)
+    except (OSError, ValueError, TypeError, RecursionError):
+        return TakeoverMetadataRead(TakeoverMetadataState.INVALID)
     if not isinstance(metadata, dict):
-        return None
-    if metadata.get("version") != 1:
-        return None
+        return TakeoverMetadataRead(TakeoverMetadataState.INVALID)
+    base_keys = {"version", "takeover_owner", "original_owner"}
+    cleanup_keys = {
+        "cleanup_source_sha256",
+        "cleanup_recovery_sha256",
+        "cleanup_final_sha256",
+        "cleanup_status",
+    }
+    metadata_keys = frozenset(metadata)
+    if metadata_keys not in {frozenset(base_keys), frozenset(base_keys | cleanup_keys)}:
+        return TakeoverMetadataRead(TakeoverMetadataState.INVALID)
+    version = metadata.get("version")
+    if type(version) is not int or version != 1:
+        return TakeoverMetadataRead(TakeoverMetadataState.INVALID)
     takeover_owner = metadata.get("takeover_owner")
     original_owner = metadata.get("original_owner")
-    if takeover_owner not in {"release", "beta"}:
-        return None
-    if original_owner not in {None, "release", "beta"}:
-        return None
+    if not isinstance(takeover_owner, str) or takeover_owner not in {"release", "beta"}:
+        return TakeoverMetadataRead(TakeoverMetadataState.INVALID)
+    if original_owner is not None and (
+        not isinstance(original_owner, str)
+        or original_owner not in {"release", "beta"}
+    ):
+        return TakeoverMetadataRead(TakeoverMetadataState.INVALID)
     if original_owner == takeover_owner:
-        return None
-    cleanup_sha256 = metadata.get("cleanup_sha256")
+        return TakeoverMetadataRead(TakeoverMetadataState.INVALID)
+    cleanup_source_sha256 = metadata.get("cleanup_source_sha256")
+    cleanup_recovery_sha256 = metadata.get("cleanup_recovery_sha256")
+    cleanup_final_sha256 = metadata.get("cleanup_final_sha256")
     cleanup_status = metadata.get("cleanup_status")
-    if (cleanup_sha256 is None) != (cleanup_status is None):
-        return None
-    if cleanup_sha256 is not None and (
-        not isinstance(cleanup_sha256, str)
-        or re.fullmatch(r"[0-9a-f]{64}", cleanup_sha256) is None
+    cleanup_values = (
+        cleanup_source_sha256,
+        cleanup_recovery_sha256,
+        cleanup_final_sha256,
+        cleanup_status,
+    )
+    has_cleanup_fields = metadata_keys == frozenset(base_keys | cleanup_keys)
+    if has_cleanup_fields and any(value is None for value in cleanup_values):
+        return TakeoverMetadataRead(TakeoverMetadataState.INVALID)
+    if not has_cleanup_fields and any(value is not None for value in cleanup_values):
+        return TakeoverMetadataRead(TakeoverMetadataState.INVALID)
+    digests = (
+        cleanup_source_sha256,
+        cleanup_recovery_sha256,
+        cleanup_final_sha256,
+    )
+    if cleanup_source_sha256 is not None and (
+        any(
+            not isinstance(digest, str) or re.fullmatch(r"[0-9a-f]{64}", digest) is None
+            for digest in digests
+        )
         or not isinstance(cleanup_status, str)
         or cleanup_status not in TAKEOVER_CLEANUP_STATUSES
     ):
-        return None
-    return TakeoverMetadata(
-        takeover_owner=takeover_owner,
-        original_owner=original_owner,
-        cleanup_sha256=cleanup_sha256,
-        cleanup_status=cleanup_status,
+        return TakeoverMetadataRead(TakeoverMetadataState.INVALID)
+    return TakeoverMetadataRead(
+        TakeoverMetadataState.VALID,
+        TakeoverMetadata(
+            takeover_owner=takeover_owner,
+            original_owner=original_owner,
+            cleanup_source_sha256=cleanup_source_sha256,
+            cleanup_recovery_sha256=cleanup_recovery_sha256,
+            cleanup_final_sha256=cleanup_final_sha256,
+            cleanup_status=cleanup_status,
+        ),
     )
 
 
@@ -756,14 +871,6 @@ def is_interrupted_takeover(
         metadata is not None
         and overlay_owner(config_text) == metadata.original_owner
         and overlay_owner(backup_text) == metadata.original_owner
-    )
-
-
-def matches_completed_takeover_cleanup(text: str, metadata: TakeoverMetadata) -> bool:
-    return (
-        metadata.cleanup_sha256 is not None
-        and overlay_owner(text) == metadata.original_owner
-        and takeover_text_sha256(text) == metadata.cleanup_sha256
     )
 
 
@@ -793,7 +900,79 @@ def insert_provider_section(text: str, provider_section: str) -> str:
 
 def overlay_lifecycle_lock_target(config_path: Path) -> Path:
     """Return the shared transaction-lock target for one managed Codex config."""
-    return config_path.with_name(f".{config_path.name}.codexhub-overlay-lifecycle")
+    canonical_config = config_path.resolve(strict=False)
+    return canonical_config.with_name(
+        f".{canonical_config.name}.codexhub-overlay-lifecycle"
+    )
+
+
+def _paths_refer_to_same_file(left: Path, right: Path) -> bool:
+    if left.resolve(strict=False) == right.resolve(strict=False):
+        return True
+    try:
+        return left.exists() and right.exists() and left.samefile(right)
+    except OSError:
+        return False
+
+
+def _validate_managed_write_paths(
+    config_path: Path,
+    backup_path: Path,
+    state_path: Path | None = None,
+) -> None:
+    metadata_path = takeover_metadata_path(backup_path)
+    named_paths = [
+        ("config", config_path),
+        ("backup", backup_path),
+        ("metadata", metadata_path),
+    ]
+    if state_path is not None:
+        named_paths.append(("context guard state", state_path))
+    for index, (left_name, left_path) in enumerate(named_paths):
+        for right_name, right_path in named_paths[index + 1 :]:
+            if _paths_refer_to_same_file(left_path, right_path):
+                raise ValueError(
+                    f"managed write paths must be distinct: {left_name} aliases {right_name}"
+                )
+
+
+def _prepare_managed_config_write(
+    config_path: Path,
+    backup_path: Path,
+    *,
+    operation: str,
+) -> tuple[TakeoverMetadata | None, str]:
+    """Validate or finish takeover recovery before another managed write.
+
+    Callers already hold the lifecycle lock. A terminal cleanup journal is
+    itself the next write to perform, so finish it before starting a new
+    operation. Active takeover metadata can remain in place because it has no
+    byte-bound journal yet. Interrupted takeover state is returned to the
+    caller, which may allow only the exact takeover retry.
+    """
+    metadata_read = read_takeover_metadata(backup_path)
+    if metadata_read.state is TakeoverMetadataState.INVALID:
+        raise RuntimeError(f"refusing {operation}: takeover metadata is invalid")
+    metadata = metadata_read.metadata
+    if metadata is None:
+        return None, "absent"
+    if metadata.cleanup_source_sha256 is not None:
+        _resume_takeover_cleanup(config_path, backup_path, metadata)
+        return None, "cleanup_resumed"
+    if not backup_path.exists():
+        raise RuntimeError(f"refusing {operation}: recovery backup is missing or diverged")
+
+    recovery = read_text_preserving_newlines(backup_path)
+    current = read_text_preserving_newlines(config_path) if config_path.exists() else ""
+    if is_interrupted_takeover(current, recovery, metadata):
+        if not config_path.exists() or current != recovery:
+            raise RuntimeError(
+                f"refusing {operation}: live config is missing or diverged"
+            )
+        return metadata, "interrupted"
+    if is_active_takeover_backup(current, recovery, metadata):
+        return metadata, "active"
+    raise RuntimeError(f"refusing {operation}: takeover state is not recognized")
 
 
 def apply_overlay(
@@ -808,6 +987,9 @@ def apply_overlay(
     # Apply and restore must read, classify, and publish while holding the same
     # lock. Individual atomic-file locks cannot prevent a retry from changing
     # the live config between restore classification and recovery cleanup.
+    config_path = config_path.resolve(strict=False)
+    backup_path = backup_path.resolve(strict=False)
+    _validate_managed_write_paths(config_path, backup_path)
     with file_lock_for(overlay_lifecycle_lock_target(config_path)):
         _apply_overlay_locked(
             config_path,
@@ -831,6 +1013,23 @@ def _apply_overlay_locked(
 ) -> None:
     if owner not in {"release", "beta"}:
         raise ValueError(f"unsupported CodexHub owner: {owner}")
+    metadata, takeover_state = _prepare_managed_config_write(
+        config_path,
+        backup_path,
+        operation="overlay apply",
+    )
+    if takeover_state == "active" and (
+        metadata is None or owner != metadata.takeover_owner
+    ):
+        raise RuntimeError("refusing overlay apply: active takeover belongs to another owner")
+    if takeover_state == "interrupted" and (
+        metadata is None
+        or owner != metadata.takeover_owner
+        or not takeover
+    ):
+        raise RuntimeError(
+            "refusing overlay apply: interrupted takeover recovery is pending"
+        )
     original = read_text_preserving_newlines(config_path) if config_path.exists() else ""
     custom_section = section_key_values(original, f"model_providers.{PROXY_PROVIDER_ID}")
     if custom_section is not None and not (
@@ -869,26 +1068,112 @@ def _apply_overlay_locked(
 
 
 def restore_overlay(config_path: Path, backup_path: Path, unified_history: bool = False) -> str:
+    config_path = config_path.resolve(strict=False)
+    backup_path = backup_path.resolve(strict=False)
+    _validate_managed_write_paths(config_path, backup_path)
     with file_lock_for(overlay_lifecycle_lock_target(config_path)):
         return _restore_overlay_locked(config_path, backup_path, unified_history)
 
 
+def _takeover_cleanup_final_text(
+    recovery_text: str,
+    metadata: TakeoverMetadata,
+) -> str:
+    if metadata.cleanup_status in {
+        "interrupted_takeover_discarded",
+        "restored_takeover_backup",
+    }:
+        return recovery_text
+    final_text, status = inject_unified_history_config(recovery_text)
+    if status != metadata.cleanup_status:
+        raise RuntimeError("refusing takeover cleanup: terminal status is inconsistent")
+    return final_text
+
+
+def _resume_takeover_cleanup(
+    config_path: Path,
+    backup_path: Path,
+    metadata: TakeoverMetadata,
+) -> str:
+    source_sha256 = metadata.cleanup_source_sha256
+    recovery_sha256 = metadata.cleanup_recovery_sha256
+    final_sha256 = metadata.cleanup_final_sha256
+    status = metadata.cleanup_status
+    if None in {source_sha256, recovery_sha256, final_sha256, status}:
+        raise RuntimeError("refusing takeover cleanup: metadata is incomplete")
+    if not config_path.exists():
+        raise RuntimeError("refusing takeover cleanup: live config is missing or diverged")
+
+    final_text: str | None = None
+    if backup_path.exists():
+        recovery_text = read_text_preserving_newlines(backup_path)
+        if (
+            overlay_owner(recovery_text) != metadata.original_owner
+            or takeover_text_sha256(recovery_text) != recovery_sha256
+        ):
+            raise RuntimeError("refusing takeover cleanup: recovery backup is missing or diverged")
+        final_text = _takeover_cleanup_final_text(recovery_text, metadata)
+        if takeover_text_sha256(final_text) != final_sha256:
+            raise RuntimeError("refusing takeover cleanup: intended final config is inconsistent")
+
+    current = read_text_preserving_newlines(config_path)
+    current_sha256 = takeover_text_sha256(current)
+    if current_sha256 == final_sha256:
+        if overlay_owner(current) != metadata.original_owner:
+            raise RuntimeError("refusing takeover cleanup: final config owner is inconsistent")
+    elif current_sha256 == source_sha256:
+        if overlay_owner(current) != metadata.takeover_owner or final_text is None:
+            raise RuntimeError("refusing takeover cleanup: live config is missing or diverged")
+        atomic_write_text(config_path, final_text, encoding="utf-8")
+        published = read_text_preserving_newlines(config_path)
+        if (
+            overlay_owner(published) != metadata.original_owner
+            or takeover_text_sha256(published) != final_sha256
+        ):
+            raise RuntimeError("refusing takeover cleanup: final config publication diverged")
+    else:
+        raise RuntimeError("refusing takeover cleanup: live config is missing or diverged")
+
+    if backup_path.exists():
+        backup_path.unlink()
+    takeover_metadata_path(backup_path).unlink()
+    return status
+
+
+def _start_takeover_cleanup(
+    config_path: Path,
+    backup_path: Path,
+    metadata: TakeoverMetadata,
+    current: str,
+    recovery: str,
+    final: str,
+    status: str,
+) -> str:
+    write_takeover_metadata(
+        backup_path,
+        metadata.takeover_owner,
+        metadata.original_owner,
+        cleanup_source_sha256=takeover_text_sha256(current),
+        cleanup_recovery_sha256=takeover_text_sha256(recovery),
+        cleanup_final_sha256=takeover_text_sha256(final),
+        cleanup_status=status,
+    )
+    journal_read = read_takeover_metadata(backup_path)
+    if journal_read.state is not TakeoverMetadataState.VALID:
+        raise RuntimeError("refusing takeover cleanup: journal readback failed")
+    journal = journal_read.metadata
+    if journal is None:
+        raise RuntimeError("refusing takeover cleanup: journal readback failed")
+    return _resume_takeover_cleanup(config_path, backup_path, journal)
+
+
 def _restore_overlay_locked(config_path: Path, backup_path: Path, unified_history: bool) -> str:
-    metadata = read_takeover_metadata(backup_path)
-    if metadata is not None and metadata.cleanup_sha256 is not None and config_path.exists():
-        current = read_text_preserving_newlines(config_path)
-        if matches_completed_takeover_cleanup(current, metadata):
-            if backup_path.exists():
-                restored = read_text_preserving_newlines(backup_path)
-                if not matches_completed_takeover_cleanup(restored, metadata):
-                    raise RuntimeError(
-                        "refusing takeover cleanup: recovery backup is missing or diverged"
-                    )
-                backup_path.unlink()
-            takeover_metadata_path(backup_path).unlink()
-            if metadata.cleanup_status is None:
-                raise RuntimeError("refusing takeover cleanup: metadata is invalid")
-            return metadata.cleanup_status
+    metadata_read = read_takeover_metadata(backup_path)
+    if metadata_read.state is TakeoverMetadataState.INVALID:
+        raise RuntimeError("refusing takeover restore: takeover metadata is invalid")
+    metadata = metadata_read.metadata
+    if metadata is not None and metadata.cleanup_source_sha256 is not None:
+        return _resume_takeover_cleanup(config_path, backup_path, metadata)
 
     if not backup_path.exists() and metadata is not None:
         raise RuntimeError("refusing takeover restore: recovery backup is missing or diverged")
@@ -904,36 +1189,43 @@ def _restore_overlay_locked(config_path: Path, backup_path: Path, unified_histor
                 )
             if metadata is None:
                 raise RuntimeError("refusing interrupted takeover cleanup: metadata is invalid")
-            write_takeover_metadata(
+            return _start_takeover_cleanup(
+                config_path,
                 backup_path,
-                metadata.takeover_owner,
-                metadata.original_owner,
-                cleanup_sha256=takeover_text_sha256(current),
-                cleanup_status="interrupted_takeover_discarded",
+                metadata,
+                current,
+                restored,
+                restored,
+                "interrupted_takeover_discarded",
             )
-            backup_path.unlink()
-            takeover_metadata_path(backup_path).unlink()
-            return "interrupted_takeover_discarded"
         if is_active_takeover_backup(current, restored, metadata):
             restored_owner = overlay_owner(restored)
             if not unified_history or restored_owner is not None:
                 if metadata is None:
                     raise RuntimeError("refusing takeover restore: metadata is invalid")
-                write_takeover_metadata(
+                return _start_takeover_cleanup(
+                    config_path,
                     backup_path,
-                    metadata.takeover_owner,
-                    metadata.original_owner,
-                    cleanup_sha256=takeover_text_sha256(restored),
-                    cleanup_status="restored_takeover_backup",
+                    metadata,
+                    current,
+                    restored,
+                    restored,
+                    "restored_takeover_backup",
                 )
-                atomic_write_text(config_path, restored, encoding="utf-8")
-                backup_path.unlink()
-                takeover_metadata_path(backup_path).unlink()
-                return "restored_takeover_backup"
-        if metadata is not None and metadata.cleanup_sha256 is not None:
-            raise RuntimeError(
-                "refusing takeover cleanup: live config or recovery backup diverged"
+            if metadata is None:
+                raise RuntimeError("refusing takeover restore: metadata is invalid")
+            final, status = inject_unified_history_config(restored)
+            return _start_takeover_cleanup(
+                config_path,
+                backup_path,
+                metadata,
+                current,
+                restored,
+                final,
+                status,
             )
+        if metadata is not None:
+            raise RuntimeError("refusing takeover restore: state is not recognized")
     elif config_path.exists():
         restored = strip_marked_overlay(config_path.read_text(encoding="utf-8"))
         restore_from_backup = False

--- a/tests/test_config_overlay.py
+++ b/tests/test_config_overlay.py
@@ -339,6 +339,109 @@ class ConfigOverlayTests(unittest.TestCase):
             config_overlay.takeover_metadata_path(backup_path),
         )
 
+    def _active_takeover_reanchor_journal(
+        self,
+        root: Path,
+        recovery_phase: str,
+    ) -> dict[str, Path]:
+        original = RUST_0_145_AGENTS_CONFIG.replace(
+            'model = "ollama-cloud/glm-5.2"\n',
+            "",
+        )
+        config_path = root / "config.toml"
+        stable_backup_path = root / "stable.backup.toml"
+        beta_backup_path = root / "beta.backup.toml"
+        metadata_path = config_overlay.takeover_metadata_path(beta_backup_path)
+        completion_path = config_overlay.takeover_completion_path(beta_backup_path)
+        state_path = root / "context-guard-state.json"
+        config_path.write_text(original, encoding="utf-8")
+        catalog_path = self._official_budget_catalog(root)
+        apply_overlay(
+            config_path,
+            stable_backup_path,
+            None,
+            "http://127.0.0.1:9099",
+            owner="release",
+        )
+        apply_overlay(
+            config_path,
+            beta_backup_path,
+            None,
+            "http://127.0.0.1:9109",
+            owner="beta",
+            takeover=True,
+        )
+        recovery_base = beta_backup_path.read_bytes()
+        real_atomic_write = config_overlay.atomic_write_text
+
+        def stop_at_reanchor_phase(
+            path: Path,
+            text: str,
+            *,
+            encoding: str = "utf-8",
+        ) -> None:
+            real_atomic_write(path, text, encoding=encoding)
+            journal_published = (
+                path == metadata_path
+                and '"reanchor_recovery_sha256"' in text
+            )
+            candidate_published = (
+                recovery_phase == "candidate"
+                and path == beta_backup_path
+            )
+            if (
+                recovery_phase == "base"
+                and journal_published
+            ) or candidate_published:
+                raise OSError(f"simulated durable {recovery_phase} recovery")
+
+        with patch(
+            "config_overlay.atomic_write_text",
+            stop_at_reanchor_phase,
+        ):
+            with self.assertRaisesRegex(
+                OSError,
+                f"durable {recovery_phase} recovery",
+            ):
+                set_context_guard(
+                    config_path,
+                    beta_backup_path,
+                    state_path,
+                    enabled=True,
+                    catalog_path=catalog_path,
+                )
+
+        if recovery_phase == "base":
+            self.assertEqual(beta_backup_path.read_bytes(), recovery_base)
+        else:
+            self.assertNotEqual(beta_backup_path.read_bytes(), recovery_base)
+        journal_read = config_overlay.read_takeover_metadata(beta_backup_path)
+        self.assertIs(
+            journal_read.state,
+            config_overlay.TakeoverRecordState.VALID,
+        )
+        self.assertIsNotNone(
+            journal_read.metadata.reanchor_recovery_sha256
+            if journal_read.metadata is not None
+            else None
+        )
+        return {
+            "config": config_path,
+            "stable_backup": stable_backup_path,
+            "backup": beta_backup_path,
+            "metadata": metadata_path,
+            "completion": completion_path,
+            "state": state_path,
+            "catalog": catalog_path,
+        }
+
+    @staticmethod
+    def _artifact_bytes(paths: tuple[Path, ...]) -> dict[Path, bytes | None]:
+        return {
+            path: path.read_bytes() if path.exists() else None
+            for path in paths
+        }
+
     def _unowned_with_pending_unified_cleanup(
         self,
         root: Path,
@@ -3105,6 +3208,7 @@ class ConfigOverlayTests(unittest.TestCase):
         valid_reanchor = {
             **valid_active,
             "reanchor_recovery_sha256": "2" * 64,
+            "reanchor_live_sha256": "3" * 64,
         }
 
         def changed(payload: dict[str, object], **updates: object) -> str:
@@ -3178,9 +3282,33 @@ class ConfigOverlayTests(unittest.TestCase):
                 valid_reanchor,
                 reanchor_recovery_sha256="not-a-digest",
             ),
+            "malformed_reanchor_live_digest": changed(
+                valid_reanchor,
+                reanchor_live_sha256="not-a-digest",
+            ),
             "uppercase_reanchor_digest": changed(
                 valid_reanchor,
                 reanchor_recovery_sha256="A" * 64,
+            ),
+            "uppercase_reanchor_live_digest": changed(
+                valid_reanchor,
+                reanchor_live_sha256="A" * 64,
+            ),
+            "missing_reanchor_recovery_digest": json.dumps(
+                {
+                    key: value
+                    for key, value in valid_reanchor.items()
+                    if key != "reanchor_recovery_sha256"
+                },
+                sort_keys=True,
+            ),
+            "missing_reanchor_live_digest": json.dumps(
+                {
+                    key: value
+                    for key, value in valid_reanchor.items()
+                    if key != "reanchor_live_sha256"
+                },
+                sort_keys=True,
             ),
             "future_reanchor_version": changed(
                 valid_reanchor,
@@ -3218,7 +3346,10 @@ class ConfigOverlayTests(unittest.TestCase):
                     ),
                     (
                         valid_reanchor,
-                        ("reanchor_recovery_sha256",),
+                        (
+                            "reanchor_recovery_sha256",
+                            "reanchor_live_sha256",
+                        ),
                     ),
                 )
                 for key in keys
@@ -3432,6 +3563,159 @@ class ConfigOverlayTests(unittest.TestCase):
             self.assertEqual(metadata_path.read_bytes(), metadata_before)
             self.assertEqual(state_path.read_bytes(), state_before)
             self.assertFalse(completion_path.exists())
+
+    def test_fresh_process_reanchor_preflight_rejects_live_drift_without_mutation(self):
+        cases = (
+            ("restore", "base", "raw"),
+            ("restore", "base", "owner"),
+            ("restore", "candidate", "raw"),
+            ("restore", "candidate", "owner"),
+            ("managed_apply", "base", "raw"),
+            ("managed_apply", "base", "owner"),
+            ("managed_apply", "candidate", "raw"),
+            ("managed_apply", "candidate", "owner"),
+        )
+
+        for operation, recovery_phase, live_drift in cases:
+            with (
+                self.subTest(
+                    operation=operation,
+                    recovery_phase=recovery_phase,
+                    live_drift=live_drift,
+                ),
+                tempfile.TemporaryDirectory() as tmpdir,
+            ):
+                paths = self._active_takeover_reanchor_journal(
+                    Path(tmpdir),
+                    recovery_phase,
+                )
+                live = paths["config"].read_bytes()
+                if live_drift == "raw":
+                    paths["config"].write_bytes(live + b"# unknown live drift\n")
+                else:
+                    self.assertIn(b"# owner = beta", live)
+                    paths["config"].write_bytes(
+                        live.replace(
+                            b"# owner = beta",
+                            b"# owner = release",
+                            1,
+                        )
+                    )
+                artifact_paths = (
+                    paths["config"],
+                    paths["stable_backup"],
+                    paths["backup"],
+                    paths["metadata"],
+                    paths["completion"],
+                    paths["state"],
+                )
+                before = self._artifact_bytes(artifact_paths)
+                command = [
+                    sys.executable,
+                    "-m",
+                    "config_overlay",
+                    operation.replace("managed_", ""),
+                    "--config",
+                    str(paths["config"]),
+                    "--backup",
+                    str(paths["backup"]),
+                ]
+                if operation == "restore":
+                    command.append("--unified-history")
+                else:
+                    command.extend(
+                        [
+                            "--base-url",
+                            "http://127.0.0.1:9109",
+                            "--owner",
+                            "beta",
+                        ]
+                    )
+
+                result = subprocess.run(
+                    command,
+                    capture_output=True,
+                    text=True,
+                    env=self._subprocess_env(),
+                    timeout=10,
+                )
+
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(
+                    "live config is missing or diverged",
+                    result.stderr,
+                )
+                self.assertEqual(self._artifact_bytes(artifact_paths), before)
+
+    def test_fresh_process_reanchor_preflight_rejects_completion_without_mutation(self):
+        for operation in ("restore", "managed_apply"):
+            for recovery_phase in ("base", "candidate"):
+                with (
+                    self.subTest(
+                        operation=operation,
+                        recovery_phase=recovery_phase,
+                    ),
+                    tempfile.TemporaryDirectory() as tmpdir,
+                ):
+                    paths = self._active_takeover_reanchor_journal(
+                        Path(tmpdir),
+                        recovery_phase,
+                    )
+                    config_overlay.write_takeover_completion_receipt(
+                        paths["backup"],
+                        config_overlay.TakeoverCompletionReceipt(
+                            takeover_owner="beta",
+                            original_owner="release",
+                            final_sha256="0" * 64,
+                            same_owner_backup_sha256="1" * 64,
+                            status="restored_takeover_backup",
+                        ),
+                    )
+                    artifact_paths = (
+                        paths["config"],
+                        paths["stable_backup"],
+                        paths["backup"],
+                        paths["metadata"],
+                        paths["completion"],
+                        paths["state"],
+                    )
+                    before = self._artifact_bytes(artifact_paths)
+                    command = [
+                        sys.executable,
+                        "-m",
+                        "config_overlay",
+                        operation.replace("managed_", ""),
+                        "--config",
+                        str(paths["config"]),
+                        "--backup",
+                        str(paths["backup"]),
+                    ]
+                    if operation == "restore":
+                        command.append("--unified-history")
+                    else:
+                        command.extend(
+                            [
+                                "--base-url",
+                                "http://127.0.0.1:9109",
+                                "--owner",
+                                "beta",
+                            ]
+                        )
+
+                    result = subprocess.run(
+                        command,
+                        capture_output=True,
+                        text=True,
+                        env=self._subprocess_env(),
+                        timeout=10,
+                    )
+
+                    self.assertNotEqual(result.returncode, 0)
+                    self.assertIn(
+                        "takeover re-anchor completion is inconsistent",
+                        result.stderr,
+                    )
+                    self.assertEqual(self._artifact_bytes(artifact_paths), before)
 
     def test_interrupted_takeover_rejects_raw_newline_backup_drift(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -4983,11 +5267,14 @@ class ConfigOverlayTests(unittest.TestCase):
                                 "original_owner",
                                 "recovery_sha256",
                                 "reanchor_recovery_sha256",
+                                "reanchor_live_sha256",
                             },
                         )
-                        self.assertLess(len(raw_journal.encode("utf-8")), 320)
+                        self.assertLess(len(raw_journal.encode("utf-8")), 420)
                         self.assertNotIn("researcher.toml", raw_journal)
                         self.assertNotIn("team_tools", raw_journal)
+                        self.assertNotIn("codexhub-proxy", raw_journal)
+                        self.assertNotIn("127.0.0.1", raw_journal)
 
                     retry = subprocess.run(
                         [

--- a/tests/test_config_overlay.py
+++ b/tests/test_config_overlay.py
@@ -5,6 +5,7 @@ import io
 import json
 import tempfile
 from pathlib import Path
+import threading
 import tomllib
 import unittest
 from unittest.mock import patch
@@ -121,6 +122,59 @@ class ConfigOverlayTests(unittest.TestCase):
             encoding="utf-8",
         )
         return catalog_path
+
+    def _apply_interrupted_takeover(
+        self,
+        config_path: Path,
+        backup_path: Path,
+        catalog_path: Path,
+        *,
+        owner: str,
+        base_url: str,
+    ) -> None:
+        real_atomic_write = config_overlay.atomic_write_text
+
+        def interrupt_live_config_write(path: Path, text: str, *, encoding: str = "utf-8") -> None:
+            if path == config_path:
+                raise OSError(f"simulated interrupted {owner} config update")
+            real_atomic_write(path, text, encoding=encoding)
+
+        with patch("config_overlay.atomic_write_text", interrupt_live_config_write):
+            with self.assertRaisesRegex(OSError, f"interrupted {owner} config update"):
+                apply_overlay(
+                    config_path,
+                    backup_path,
+                    catalog_path,
+                    base_url,
+                    owner=owner,
+                    takeover=True,
+                )
+
+    def _stable_with_interrupted_beta_takeover(
+        self,
+        root: Path,
+    ) -> tuple[Path, Path, Path, bytes]:
+        config_path = root / "config.toml"
+        stable_backup_path = root / "stable.backup.toml"
+        beta_backup_path = root / "beta.backup.toml"
+        catalog_path = root / "catalog.json"
+        config_path.write_text(RUST_0_145_AGENTS_CONFIG, encoding="utf-8")
+        apply_overlay(
+            config_path,
+            stable_backup_path,
+            catalog_path,
+            "http://127.0.0.1:9099",
+            owner="release",
+        )
+        stable_active = config_path.read_bytes()
+        self._apply_interrupted_takeover(
+            config_path,
+            beta_backup_path,
+            catalog_path,
+            owner="beta",
+            base_url="http://127.0.0.1:9109",
+        )
+        return config_path, beta_backup_path, catalog_path, stable_active
 
     def test_strip_top_level_keys_does_not_touch_provider_sections(self):
         text = "\n".join(
@@ -894,6 +948,261 @@ class ConfigOverlayTests(unittest.TestCase):
             restore_overlay(config_path, stable_backup_path)
             self.assertEqual(config_path.read_bytes(), original)
 
+    def test_interrupted_takeover_with_missing_live_config_retains_recovery_artifacts(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path = tmp / "config.toml"
+            backup_path = tmp / "beta.backup.toml"
+            catalog_path = tmp / "catalog.json"
+            original = RUST_0_145_AGENTS_CONFIG.encode()
+            config_path.write_bytes(original)
+            self._apply_interrupted_takeover(
+                config_path,
+                backup_path,
+                catalog_path,
+                owner="beta",
+                base_url="http://127.0.0.1:9109",
+            )
+
+            metadata_path = config_overlay.takeover_metadata_path(backup_path)
+            config_path.unlink()
+
+            with self.assertRaisesRegex(RuntimeError, "live config is missing or diverged"):
+                restore_overlay(config_path, backup_path, unified_history=True)
+
+            self.assertFalse(config_path.exists())
+            self.assertEqual(backup_path.read_bytes(), original)
+            self.assertTrue(metadata_path.exists())
+
+    def test_interrupted_takeover_with_same_owner_diverged_live_bytes_fails_closed(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path, beta_backup_path, _, stable_active_bytes = (
+                self._stable_with_interrupted_beta_takeover(tmp)
+            )
+            stable_active = stable_active_bytes.decode()
+
+            diverged = stable_active + "# user edit after interrupted takeover\n"
+            config_path.write_text(diverged, encoding="utf-8")
+            metadata_path = config_overlay.takeover_metadata_path(beta_backup_path)
+
+            with self.assertRaisesRegex(RuntimeError, "live config is missing or diverged"):
+                restore_overlay(config_path, beta_backup_path, unified_history=True)
+
+            self.assertEqual(config_path.read_text(encoding="utf-8"), diverged)
+            self.assertEqual(beta_backup_path.read_text(encoding="utf-8"), stable_active)
+            self.assertTrue(metadata_path.exists())
+
+    def test_interrupted_restore_serializes_against_concurrent_takeover_retry(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path, beta_backup_path, catalog_path, _ = (
+                self._stable_with_interrupted_beta_takeover(tmp)
+            )
+
+            restore_classified = threading.Event()
+            release_restore = threading.Event()
+            retry_attempted = threading.Event()
+            retry_entered_transaction = threading.Event()
+            thread_errors: list[BaseException] = []
+            real_read_takeover_metadata = config_overlay.read_takeover_metadata
+            real_apply_overlay_locked = config_overlay._apply_overlay_locked
+
+            def pause_after_metadata_read(backup_path: Path) -> config_overlay.TakeoverMetadata | None:
+                result = real_read_takeover_metadata(backup_path)
+                restore_classified.set()
+                if not release_restore.wait(timeout=5):
+                    raise TimeoutError("test did not release restore classification")
+                return result
+
+            def record_retry_transaction_entry(*args: object, **kwargs: object) -> None:
+                retry_entered_transaction.set()
+                real_apply_overlay_locked(*args, **kwargs)
+
+            def run_restore() -> None:
+                try:
+                    restore_overlay(config_path, beta_backup_path, unified_history=True)
+                except BaseException as exc:
+                    thread_errors.append(exc)
+
+            def retry_takeover() -> None:
+                try:
+                    retry_attempted.set()
+                    apply_overlay(
+                        config_path,
+                        beta_backup_path,
+                        catalog_path,
+                        "http://127.0.0.1:9109",
+                        owner="beta",
+                        takeover=True,
+                    )
+                except BaseException as exc:
+                    thread_errors.append(exc)
+
+            with (
+                patch("config_overlay.read_takeover_metadata", pause_after_metadata_read),
+                patch("config_overlay._apply_overlay_locked", record_retry_transaction_entry),
+            ):
+                restore_thread = threading.Thread(target=run_restore)
+                retry_thread = threading.Thread(target=retry_takeover)
+                restore_thread.start()
+                self.assertTrue(restore_classified.wait(timeout=5))
+                retry_thread.start()
+                try:
+                    self.assertTrue(retry_attempted.wait(timeout=5))
+                    self.assertFalse(
+                        retry_entered_transaction.wait(timeout=0.25),
+                        "takeover retry entered while restore held the lifecycle transaction",
+                    )
+                finally:
+                    release_restore.set()
+                    restore_thread.join(timeout=5)
+                    retry_thread.join(timeout=5)
+
+            self.assertFalse(restore_thread.is_alive())
+            self.assertFalse(retry_thread.is_alive())
+            self.assertEqual(thread_errors, [])
+            self.assertEqual(config_overlay.overlay_owner(config_path.read_text(encoding="utf-8")), "beta")
+            self.assertTrue(beta_backup_path.exists())
+            self.assertTrue(config_overlay.takeover_metadata_path(beta_backup_path).exists())
+
+    def test_interrupted_takeover_sidecar_delete_failure_resumes_without_rewriting_live_config(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path, beta_backup_path, _, stable_active = (
+                self._stable_with_interrupted_beta_takeover(tmp)
+            )
+
+            metadata_path = config_overlay.takeover_metadata_path(beta_backup_path)
+            real_unlink = Path.unlink
+
+            def fail_sidecar_delete(path: Path, *args: object, **kwargs: object) -> None:
+                if path == metadata_path:
+                    raise OSError("simulated sidecar delete failure")
+                real_unlink(path, *args, **kwargs)
+
+            with patch.object(Path, "unlink", fail_sidecar_delete):
+                with self.assertRaisesRegex(OSError, "sidecar delete failure"):
+                    restore_overlay(config_path, beta_backup_path, unified_history=True)
+
+            self.assertEqual(config_path.read_bytes(), stable_active)
+            self.assertFalse(beta_backup_path.exists())
+            self.assertTrue(metadata_path.exists())
+
+            status = restore_overlay(config_path, beta_backup_path, unified_history=True)
+
+            self.assertEqual(status, "interrupted_takeover_discarded")
+            self.assertEqual(config_path.read_bytes(), stable_active)
+            self.assertFalse(metadata_path.exists())
+
+    def test_interrupted_takeover_backup_delete_failure_retains_artifacts_for_retry(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path, beta_backup_path, _, stable_active = (
+                self._stable_with_interrupted_beta_takeover(tmp)
+            )
+
+            metadata_path = config_overlay.takeover_metadata_path(beta_backup_path)
+            real_unlink = Path.unlink
+
+            def fail_backup_delete(path: Path, *args: object, **kwargs: object) -> None:
+                if path == beta_backup_path:
+                    raise OSError("simulated backup delete failure")
+                real_unlink(path, *args, **kwargs)
+
+            with patch.object(Path, "unlink", fail_backup_delete):
+                with self.assertRaisesRegex(OSError, "backup delete failure"):
+                    restore_overlay(config_path, beta_backup_path, unified_history=True)
+
+            self.assertEqual(config_path.read_bytes(), stable_active)
+            self.assertTrue(beta_backup_path.exists())
+            self.assertTrue(metadata_path.exists())
+
+            status = restore_overlay(config_path, beta_backup_path, unified_history=True)
+
+            self.assertEqual(status, "interrupted_takeover_discarded")
+            self.assertEqual(config_path.read_bytes(), stable_active)
+            self.assertFalse(beta_backup_path.exists())
+            self.assertFalse(metadata_path.exists())
+
+    def test_interrupted_takeover_cleanup_journal_write_failure_retains_original_artifacts(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path, beta_backup_path, _, stable_active = (
+                self._stable_with_interrupted_beta_takeover(tmp)
+            )
+            real_atomic_write = config_overlay.atomic_write_text
+
+            metadata_path = config_overlay.takeover_metadata_path(beta_backup_path)
+
+            def fail_cleanup_journal_write(path: Path, text: str, *, encoding: str = "utf-8") -> None:
+                if path == metadata_path:
+                    raise OSError("simulated cleanup journal write failure")
+                real_atomic_write(path, text, encoding=encoding)
+
+            with patch("config_overlay.atomic_write_text", fail_cleanup_journal_write):
+                with self.assertRaisesRegex(OSError, "cleanup journal write failure"):
+                    restore_overlay(config_path, beta_backup_path, unified_history=True)
+
+            self.assertEqual(config_path.read_bytes(), stable_active)
+            self.assertTrue(beta_backup_path.exists())
+            self.assertTrue(metadata_path.exists())
+
+            status = restore_overlay(config_path, beta_backup_path, unified_history=True)
+
+            self.assertEqual(status, "interrupted_takeover_discarded")
+            self.assertEqual(config_path.read_bytes(), stable_active)
+            self.assertFalse(beta_backup_path.exists())
+            self.assertFalse(metadata_path.exists())
+
+    def test_completed_takeover_sidecar_delete_failure_resumes_original_owner_restore(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path = tmp / "config.toml"
+            stable_backup_path = tmp / "stable.backup.toml"
+            beta_backup_path = tmp / "beta.backup.toml"
+            catalog_path = tmp / "catalog.json"
+            config_path.write_text(RUST_0_145_AGENTS_CONFIG, encoding="utf-8")
+
+            apply_overlay(
+                config_path,
+                stable_backup_path,
+                catalog_path,
+                "http://127.0.0.1:9099",
+                owner="release",
+            )
+            stable_active = config_path.read_bytes()
+            apply_overlay(
+                config_path,
+                beta_backup_path,
+                catalog_path,
+                "http://127.0.0.1:9109",
+                owner="beta",
+                takeover=True,
+            )
+
+            metadata_path = config_overlay.takeover_metadata_path(beta_backup_path)
+            real_unlink = Path.unlink
+
+            def fail_sidecar_delete(path: Path, *args: object, **kwargs: object) -> None:
+                if path == metadata_path:
+                    raise OSError("simulated sidecar delete failure")
+                real_unlink(path, *args, **kwargs)
+
+            with patch.object(Path, "unlink", fail_sidecar_delete):
+                with self.assertRaisesRegex(OSError, "sidecar delete failure"):
+                    restore_overlay(config_path, beta_backup_path, unified_history=True)
+
+            self.assertEqual(config_path.read_bytes(), stable_active)
+            self.assertFalse(beta_backup_path.exists())
+            self.assertTrue(metadata_path.exists())
+
+            status = restore_overlay(config_path, beta_backup_path, unified_history=True)
+
+            self.assertEqual(status, "restored_takeover_backup")
+            self.assertEqual(config_path.read_bytes(), stable_active)
+            self.assertFalse(metadata_path.exists())
+
     def test_agents_config_survives_connect_restart_readback_and_restore_for_supported_shapes(self):
         legacy_enabled = RUST_0_145_AGENTS_CONFIG.replace(
             "max_concurrent_threads_per_session = 7",
@@ -964,6 +1273,49 @@ class ConfigOverlayTests(unittest.TestCase):
                 restore_overlay(config_path, backup_path)
                 self.assertEqual(config_path.read_bytes(), original_bytes)
 
+    def test_explicit_multi_agent_v2_table_survives_connect_restart_and_restore(self):
+        original = RUST_0_145_AGENTS_CONFIG.replace(
+            'multi_agent_v2 = { enabled = false, max_concurrent_threads_per_session = 5, tool_namespace = "team_tools" }\n',
+            "",
+        ) + (
+            "\n[features.multi_agent_v2]\n"
+            "enabled = false\n"
+            "max_concurrent_threads_per_session = 5\n"
+            'tool_namespace = "team_tools"\n'
+        )
+        expected = tomllib.loads(original)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path = tmp / "config.toml"
+            backup_path = tmp / "config.backup.toml"
+            catalog_path = tmp / "catalog.json"
+            original_bytes = original.encode()
+            config_path.write_bytes(original_bytes)
+
+            apply_overlay(
+                config_path,
+                backup_path,
+                catalog_path,
+                "http://127.0.0.1:9099",
+            )
+            apply_overlay(
+                config_path,
+                backup_path,
+                catalog_path,
+                "http://127.0.0.1:9099",
+            )
+
+            readback = tomllib.loads(config_path.read_text(encoding="utf-8"))
+            self.assertEqual(readback["agents"], expected["agents"])
+            self.assertEqual(
+                readback["features"]["multi_agent_v2"],
+                expected["features"]["multi_agent_v2"],
+            )
+
+            restore_overlay(config_path, backup_path)
+            self.assertEqual(config_path.read_bytes(), original_bytes)
+
     def test_successful_stable_beta_takeover_preserves_one_agents_tree_and_each_owner_restore(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             tmp = Path(tmpdir)
@@ -1016,6 +1368,56 @@ class ConfigOverlayTests(unittest.TestCase):
             self.assertEqual(config_path.read_bytes(), stable_active)
 
             restore_overlay(config_path, stable_backup_path)
+            self.assertEqual(config_path.read_bytes(), original)
+
+    def test_successful_beta_release_takeover_preserves_agents_and_each_owner_restore(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path = tmp / "config.toml"
+            beta_backup_path = tmp / "beta.backup.toml"
+            release_backup_path = tmp / "release.backup.toml"
+            catalog_path = tmp / "catalog.json"
+            original = RUST_0_145_AGENTS_CONFIG.encode()
+            expected = tomllib.loads(RUST_0_145_AGENTS_CONFIG)
+            config_path.write_bytes(original)
+
+            apply_overlay(
+                config_path,
+                beta_backup_path,
+                catalog_path,
+                "http://127.0.0.1:9109",
+                owner="beta",
+            )
+            beta_active = config_path.read_bytes()
+
+            apply_overlay(
+                config_path,
+                release_backup_path,
+                catalog_path,
+                "http://127.0.0.1:9099",
+                owner="release",
+                takeover=True,
+            )
+            apply_overlay(
+                config_path,
+                release_backup_path,
+                catalog_path,
+                "http://127.0.0.1:9099",
+                owner="release",
+            )
+
+            release_readback = tomllib.loads(config_path.read_text(encoding="utf-8"))
+            self.assertEqual(release_readback["agents"], expected["agents"])
+            self.assertEqual(
+                release_readback["features"]["multi_agent_v2"],
+                expected["features"]["multi_agent_v2"],
+            )
+
+            status = restore_overlay(config_path, release_backup_path, unified_history=True)
+            self.assertEqual(status, "restored_takeover_backup")
+            self.assertEqual(config_path.read_bytes(), beta_active)
+
+            restore_overlay(config_path, beta_backup_path)
             self.assertEqual(config_path.read_bytes(), original)
 
     def test_connect_without_agents_or_multi_agent_v2_does_not_invent_user_choices(self):

--- a/tests/test_config_overlay.py
+++ b/tests/test_config_overlay.py
@@ -3,9 +3,13 @@ from __future__ import annotations
 from contextlib import redirect_stdout
 import io
 import json
+import os
+import subprocess
+import sys
 import tempfile
 from pathlib import Path
 import threading
+import time
 import tomllib
 import unittest
 from unittest.mock import patch
@@ -89,6 +93,140 @@ class DeterministicCompactionReplay:
 
 
 class ConfigOverlayTests(unittest.TestCase):
+    def _subprocess_env(self) -> dict[str, str]:
+        env = os.environ.copy()
+        source_path = str(Path(config_overlay.__file__).parent)
+        inherited_pythonpath = env.get("PYTHONPATH")
+        env["PYTHONPATH"] = (
+            source_path
+            if not inherited_pythonpath
+            else source_path + os.pathsep + inherited_pythonpath
+        )
+        return env
+
+    def _start_lifecycle_lock_holder(self, config_path: Path) -> subprocess.Popen[str]:
+        holder_script = "\n".join(
+            [
+                "import sys",
+                "from pathlib import Path",
+                "from atomic_io import file_lock_for",
+                "from config_overlay import overlay_lifecycle_lock_target",
+                "config_path = Path(sys.argv[1])",
+                "with file_lock_for(overlay_lifecycle_lock_target(config_path)):",
+                '    print("held", flush=True)',
+                "    sys.stdin.readline()",
+            ]
+        )
+        holder = subprocess.Popen(
+            [sys.executable, "-c", holder_script, str(config_path)],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=self._subprocess_env(),
+        )
+        assert holder.stdout is not None
+        if holder.stdout.readline().strip() != "held":
+            assert holder.stderr is not None
+            error = holder.stderr.read()
+            holder.wait(timeout=5)
+            self.fail(f"lifecycle lock holder failed to start: {error}")
+        return holder
+
+    def _release_lifecycle_lock_holder(self, holder: subprocess.Popen[str]) -> None:
+        assert holder.stdin is not None
+        assert holder.stderr is not None
+        holder.stdin.write("release\n")
+        holder.stdin.flush()
+        holder.stdin.close()
+        holder.wait(timeout=5)
+        self.assertEqual(holder.returncode, 0, holder.stderr.read())
+
+    def _start_traced_config_overlay_process(
+        self,
+        config_path: Path,
+        arguments: list[str],
+    ) -> tuple[subprocess.Popen[str], str]:
+        traced_cli_script = "\n".join(
+            [
+                "import contextlib",
+                "import sys",
+                "from pathlib import Path",
+                "import config_overlay",
+                "expected = config_overlay.overlay_lifecycle_lock_target(Path(sys.argv[1]))",
+                "real_file_lock_for = config_overlay.file_lock_for",
+                "@contextlib.contextmanager",
+                "def traced_file_lock_for(path):",
+                "    if Path(path).resolve(strict=False) == expected.resolve(strict=False):",
+                '        print("lifecycle-attempt", flush=True)',
+                "    with real_file_lock_for(path) as verify_namespace:",
+                "        yield verify_namespace",
+                "config_overlay.file_lock_for = traced_file_lock_for",
+                "raise SystemExit(config_overlay.main(sys.argv[2:]))",
+            ]
+        )
+        process = subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                traced_cli_script,
+                str(config_path),
+                *arguments,
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=self._subprocess_env(),
+        )
+        assert process.stdout is not None
+        return process, process.stdout.readline().strip()
+
+    def _start_paused_config_overlay_writer(
+        self,
+        config_path: Path,
+        arguments: list[str],
+    ) -> subprocess.Popen[str]:
+        paused_cli_script = "\n".join(
+            [
+                "import contextlib",
+                "import sys",
+                "from pathlib import Path",
+                "import config_overlay",
+                "expected = config_overlay.overlay_lifecycle_lock_target(Path(sys.argv[1]))",
+                "real_file_lock_for = config_overlay.file_lock_for",
+                "@contextlib.contextmanager",
+                "def paused_file_lock_for(path):",
+                "    with real_file_lock_for(path) as verify_namespace:",
+                "        if Path(path).resolve(strict=False) == expected.resolve(strict=False):",
+                '            print("writer-held", flush=True)',
+                "            sys.stdin.readline()",
+                "        yield verify_namespace",
+                "config_overlay.file_lock_for = paused_file_lock_for",
+                "raise SystemExit(config_overlay.main(sys.argv[2:]))",
+            ]
+        )
+        process = subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                paused_cli_script,
+                str(config_path),
+                *arguments,
+            ],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=self._subprocess_env(),
+        )
+        assert process.stdout is not None
+        if process.stdout.readline().strip() != "writer-held":
+            assert process.stderr is not None
+            error = process.stderr.read()
+            process.wait(timeout=5)
+            self.fail(f"managed config writer failed to acquire lifecycle lock: {error}")
+        return process
+
     def _official_budget_catalog(
         self,
         root: Path,
@@ -175,6 +313,50 @@ class ConfigOverlayTests(unittest.TestCase):
             base_url="http://127.0.0.1:9109",
         )
         return config_path, beta_backup_path, catalog_path, stable_active
+
+    def _unowned_with_active_beta_takeover(
+        self,
+        root: Path,
+    ) -> tuple[Path, Path, bytes, bytes, Path]:
+        config_path = root / "config.toml"
+        backup_path = root / "beta.backup.toml"
+        catalog_path = root / "catalog.json"
+        original = RUST_0_145_AGENTS_CONFIG.encode()
+        config_path.write_bytes(original)
+        apply_overlay(
+            config_path,
+            backup_path,
+            catalog_path,
+            "http://127.0.0.1:9109",
+            owner="beta",
+            takeover=True,
+        )
+        return (
+            config_path,
+            backup_path,
+            original,
+            config_path.read_bytes(),
+            config_overlay.takeover_metadata_path(backup_path),
+        )
+
+    def _unowned_with_pending_unified_cleanup(
+        self,
+        root: Path,
+    ) -> tuple[Path, Path, Path]:
+        config_path, backup_path, _, _, metadata_path = (
+            self._unowned_with_active_beta_takeover(root)
+        )
+        real_atomic_write = config_overlay.atomic_write_text
+
+        def fail_final_publish(path: Path, text: str, *, encoding: str = "utf-8") -> None:
+            if path == config_path:
+                raise OSError("simulated pending unified final publication")
+            real_atomic_write(path, text, encoding=encoding)
+
+        with patch("config_overlay.atomic_write_text", fail_final_publish):
+            with self.assertRaisesRegex(OSError, "pending unified final publication"):
+                restore_overlay(config_path, backup_path, unified_history=True)
+        return config_path, backup_path, metadata_path
 
     def test_strip_top_level_keys_does_not_touch_provider_sections(self):
         text = "\n".join(
@@ -1008,7 +1190,9 @@ class ConfigOverlayTests(unittest.TestCase):
             real_read_takeover_metadata = config_overlay.read_takeover_metadata
             real_apply_overlay_locked = config_overlay._apply_overlay_locked
 
-            def pause_after_metadata_read(backup_path: Path) -> config_overlay.TakeoverMetadata | None:
+            def pause_after_metadata_read(
+                backup_path: Path,
+            ) -> config_overlay.TakeoverMetadataRead:
                 result = real_read_takeover_metadata(backup_path)
                 restore_classified.set()
                 if not release_restore.wait(timeout=5):
@@ -1065,6 +1249,338 @@ class ConfigOverlayTests(unittest.TestCase):
             self.assertEqual(config_overlay.overlay_owner(config_path.read_text(encoding="utf-8")), "beta")
             self.assertTrue(beta_backup_path.exists())
             self.assertTrue(config_overlay.takeover_metadata_path(beta_backup_path).exists())
+
+    def test_lifecycle_lock_target_canonicalizes_path_aliases(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            alias_parent = tmp / "alias"
+            alias_parent.mkdir()
+            config_path = tmp / "config.toml"
+            alias_path = alias_parent / ".." / "config.toml"
+
+            self.assertEqual(
+                config_overlay.overlay_lifecycle_lock_target(config_path),
+                config_overlay.overlay_lifecycle_lock_target(alias_path),
+            )
+
+    def test_managed_writers_reject_hardlink_and_state_path_aliases(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path = tmp / "config.toml"
+            backup_path = tmp / "config.backup.toml"
+            catalog_path = self._official_budget_catalog(tmp)
+            original = RUST_0_145_AGENTS_CONFIG.encode()
+            config_path.write_bytes(original)
+            os.link(config_path, backup_path)
+
+            with self.assertRaisesRegex(ValueError, "config aliases backup"):
+                apply_overlay(
+                    config_path,
+                    backup_path,
+                    catalog_path,
+                    "http://127.0.0.1:9099",
+                )
+            self.assertEqual(config_path.read_bytes(), original)
+            self.assertEqual(backup_path.read_bytes(), original)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path = tmp / "config.toml"
+            backup_path = tmp / "config.backup.toml"
+            catalog_path = self._official_budget_catalog(tmp)
+            original = b'model = "gpt-5.6-terra"\n'
+            config_path.write_bytes(original)
+
+            with self.assertRaisesRegex(ValueError, "config aliases context guard state"):
+                set_context_guard(
+                    config_path,
+                    backup_path,
+                    config_path,
+                    enabled=True,
+                    catalog_path=catalog_path,
+                )
+            self.assertEqual(config_path.read_bytes(), original)
+            self.assertFalse(backup_path.exists())
+
+    def test_config_writers_serialize_across_processes_on_canonical_lifecycle_lock(self):
+        for operation in ("apply", "restore", "context_guard"):
+            with self.subTest(operation=operation), tempfile.TemporaryDirectory() as tmpdir:
+                tmp = Path(tmpdir)
+                alias_parent = tmp / "alias"
+                alias_parent.mkdir()
+                config_path = tmp / "config.toml"
+                config_alias = alias_parent / ".." / "config.toml"
+                backup_path = tmp / "config.backup.toml"
+                state_path = tmp / "context-guard-state.json"
+                catalog_path = tmp / "catalog.json"
+                original = RUST_0_145_AGENTS_CONFIG.encode()
+
+                if operation == "apply":
+                    config_path.write_bytes(original)
+                    arguments = [
+                        "apply",
+                        "--config",
+                        str(config_path),
+                        "--backup",
+                        str(backup_path),
+                        "--base-url",
+                        "http://127.0.0.1:9099",
+                    ]
+                elif operation == "restore":
+                    config_path.write_bytes(original)
+                    apply_overlay(
+                        config_path,
+                        backup_path,
+                        None,
+                        "http://127.0.0.1:9099",
+                    )
+                    arguments = [
+                        "restore",
+                        "--config",
+                        str(config_path),
+                        "--backup",
+                        str(backup_path),
+                    ]
+                else:
+                    config_path.write_text('model = "gpt-5.6-terra"\n', encoding="utf-8")
+                    catalog_path = self._official_budget_catalog(tmp)
+                    arguments = [
+                        "context-guard-set",
+                        "--config",
+                        str(config_path),
+                        "--backup",
+                        str(backup_path),
+                        "--state",
+                        str(state_path),
+                        "--catalog",
+                        str(catalog_path),
+                        "--enabled",
+                        "true",
+                    ]
+
+                holder = self._start_lifecycle_lock_holder(config_alias)
+                contender: subprocess.Popen[str] | None = None
+                try:
+                    contender, first_line = self._start_traced_config_overlay_process(
+                        config_path,
+                        arguments,
+                    )
+                    self.assertEqual(first_line, "lifecycle-attempt")
+                    time.sleep(0.25)
+                    self.assertIsNone(
+                        contender.poll(),
+                        f"{operation} bypassed the lifecycle lock",
+                    )
+                    self._release_lifecycle_lock_holder(holder)
+                    stdout, stderr = contender.communicate(timeout=15)
+                    self.assertEqual(
+                        contender.returncode,
+                        0,
+                        f"{operation} failed after lock release: {stdout}\n{stderr}",
+                    )
+                finally:
+                    if contender is not None and contender.poll() is None:
+                        contender.kill()
+                        contender.communicate(timeout=5)
+                    if holder.poll() is None:
+                        holder.kill()
+                        holder.communicate(timeout=5)
+
+                if operation == "apply":
+                    self.assertEqual(
+                        config_overlay.overlay_owner(
+                            config_path.read_text(encoding="utf-8")
+                        ),
+                        "release",
+                    )
+                    self.assertEqual(backup_path.read_bytes(), original)
+                elif operation == "restore":
+                    self.assertEqual(config_path.read_bytes(), original)
+                    self.assertFalse(backup_path.exists())
+                else:
+                    guarded = config_path.read_text(encoding="utf-8")
+                    self.assertIn("model_context_window = 272000", guarded)
+                    self.assertIn(
+                        "model_auto_compact_token_limit = 240000",
+                        guarded,
+                    )
+                    self.assertTrue(state_path.exists())
+
+    def test_lifecycle_lock_recovers_after_holder_process_is_killed(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            alias_parent = tmp / "alias"
+            alias_parent.mkdir()
+            config_path = tmp / "config.toml"
+            config_alias = alias_parent / ".." / "config.toml"
+            backup_path = tmp / "config.backup.toml"
+            config_path.write_text(RUST_0_145_AGENTS_CONFIG, encoding="utf-8")
+            holder = self._start_lifecycle_lock_holder(config_alias)
+
+            holder.kill()
+            holder.communicate(timeout=5)
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(Path(config_overlay.__file__)),
+                    "apply",
+                    "--config",
+                    str(config_path),
+                    "--backup",
+                    str(backup_path),
+                    "--base-url",
+                    "http://127.0.0.1:9099",
+                ],
+                capture_output=True,
+                text=True,
+                env=self._subprocess_env(),
+                timeout=15,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(
+                config_overlay.overlay_owner(config_path.read_text(encoding="utf-8")),
+                "release",
+            )
+            self.assertTrue(backup_path.exists())
+
+    def test_actual_apply_and_context_guard_subprocesses_serialize_as_writers(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            alias_parent = tmp / "alias"
+            alias_parent.mkdir()
+            config_path = tmp / "config.toml"
+            config_alias = alias_parent / ".." / "config.toml"
+            backup_path = tmp / "config.backup.toml"
+            state_path = tmp / "context-guard-state.json"
+            catalog_path = self._official_budget_catalog(tmp)
+            config_path.write_text(
+                RUST_0_145_AGENTS_CONFIG.replace(
+                    'model = "ollama-cloud/glm-5.2"',
+                    'model = "gpt-5.6-terra"',
+                ),
+                encoding="utf-8",
+            )
+            apply_arguments = [
+                "apply",
+                "--config",
+                str(config_alias),
+                "--backup",
+                str(backup_path),
+                "--catalog",
+                str(catalog_path),
+                "--base-url",
+                "http://127.0.0.1:9099",
+            ]
+            context_arguments = [
+                "context-guard-set",
+                "--config",
+                str(config_path),
+                "--backup",
+                str(backup_path),
+                "--state",
+                str(state_path),
+                "--catalog",
+                str(catalog_path),
+                "--enabled",
+                "true",
+            ]
+
+            first_writer = self._start_paused_config_overlay_writer(
+                config_alias,
+                apply_arguments,
+            )
+            second_writer: subprocess.Popen[str] | None = None
+            try:
+                second_writer, first_line = self._start_traced_config_overlay_process(
+                    config_path,
+                    context_arguments,
+                )
+                self.assertEqual(first_line, "lifecycle-attempt")
+                time.sleep(0.25)
+                self.assertIsNone(
+                    second_writer.poll(),
+                    "context guard writer bypassed the active apply transaction",
+                )
+                self._release_lifecycle_lock_holder(first_writer)
+                stdout, stderr = second_writer.communicate(timeout=15)
+                self.assertEqual(second_writer.returncode, 0, f"{stdout}\n{stderr}")
+            finally:
+                if first_writer.poll() is None:
+                    first_writer.kill()
+                    first_writer.communicate(timeout=5)
+                if second_writer is not None and second_writer.poll() is None:
+                    second_writer.kill()
+                    second_writer.communicate(timeout=5)
+
+            for path in (config_path, backup_path):
+                guarded = path.read_text(encoding="utf-8")
+                self.assertIn("model_context_window = 272000", guarded)
+                self.assertIn("model_auto_compact_token_limit = 240000", guarded)
+            self.assertTrue(state_path.exists())
+
+    def test_actual_restore_subprocess_recovers_journal_after_contending_writer_is_killed(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            alias_parent = tmp / "alias"
+            alias_parent.mkdir()
+            config_path, backup_path, metadata_path = (
+                self._unowned_with_pending_unified_cleanup(tmp)
+            )
+            config_alias = alias_parent / ".." / "config.toml"
+            restore_alias_arguments = [
+                "restore",
+                "--config",
+                str(config_alias),
+                "--backup",
+                str(backup_path),
+                "--unified-history",
+            ]
+            restore_arguments = [
+                "restore",
+                "--config",
+                str(config_path),
+                "--backup",
+                str(backup_path),
+                "--unified-history",
+            ]
+
+            killed_writer = self._start_paused_config_overlay_writer(
+                config_alias,
+                restore_alias_arguments,
+            )
+            recovering_writer: subprocess.Popen[str] | None = None
+            try:
+                recovering_writer, first_line = self._start_traced_config_overlay_process(
+                    config_path,
+                    restore_arguments,
+                )
+                self.assertEqual(first_line, "lifecycle-attempt")
+                time.sleep(0.25)
+                self.assertIsNone(
+                    recovering_writer.poll(),
+                    "second restore bypassed the first restore transaction",
+                )
+                killed_writer.kill()
+                killed_writer.communicate(timeout=5)
+                stdout, stderr = recovering_writer.communicate(timeout=15)
+                self.assertEqual(recovering_writer.returncode, 0, f"{stdout}\n{stderr}")
+                self.assertIn("unified_history=injected", stdout)
+            finally:
+                if killed_writer.poll() is None:
+                    killed_writer.kill()
+                    killed_writer.communicate(timeout=5)
+                if recovering_writer is not None and recovering_writer.poll() is None:
+                    recovering_writer.kill()
+                    recovering_writer.communicate(timeout=5)
+
+            restored = tomllib.loads(config_path.read_text(encoding="utf-8"))
+            self.assertEqual(restored["model_provider"], "custom")
+            self.assertEqual(restored["model_providers"]["custom"]["name"], "OpenAI")
+            self.assertFalse(backup_path.exists())
+            self.assertFalse(metadata_path.exists())
 
     def test_interrupted_takeover_sidecar_delete_failure_resumes_without_rewriting_live_config(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -1202,6 +1718,559 @@ class ConfigOverlayTests(unittest.TestCase):
             self.assertEqual(status, "restored_takeover_backup")
             self.assertEqual(config_path.read_bytes(), stable_active)
             self.assertFalse(metadata_path.exists())
+
+    def test_unowned_unified_takeover_journal_write_failure_preserves_recovery_chain(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path, backup_path, original, active, metadata_path = (
+                self._unowned_with_active_beta_takeover(tmp)
+            )
+            metadata_before = metadata_path.read_bytes()
+            real_atomic_write = config_overlay.atomic_write_text
+
+            def fail_journal_write(path: Path, text: str, *, encoding: str = "utf-8") -> None:
+                if path == metadata_path:
+                    raise OSError("simulated unified restore journal failure")
+                real_atomic_write(path, text, encoding=encoding)
+
+            with patch("config_overlay.atomic_write_text", fail_journal_write):
+                with self.assertRaisesRegex(OSError, "unified restore journal failure"):
+                    restore_overlay(config_path, backup_path, unified_history=True)
+
+            self.assertEqual(config_path.read_bytes(), active)
+            self.assertEqual(backup_path.read_bytes(), original)
+            self.assertEqual(metadata_path.read_bytes(), metadata_before)
+
+    def test_unowned_unified_takeover_resumes_after_ambiguous_journal_publish_error(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path, backup_path, original, active, metadata_path = (
+                self._unowned_with_active_beta_takeover(tmp)
+            )
+            real_atomic_write = config_overlay.atomic_write_text
+
+            def publish_journal_then_fail(
+                path: Path,
+                text: str,
+                *,
+                encoding: str = "utf-8",
+            ) -> None:
+                real_atomic_write(path, text, encoding=encoding)
+                if path == metadata_path and "cleanup_source_sha256" in text:
+                    raise OSError("simulated ambiguous journal publication")
+
+            with patch("config_overlay.atomic_write_text", publish_journal_then_fail):
+                with self.assertRaisesRegex(OSError, "ambiguous journal publication"):
+                    restore_overlay(config_path, backup_path, unified_history=True)
+
+            self.assertEqual(config_path.read_bytes(), active)
+            self.assertEqual(backup_path.read_bytes(), original)
+            self.assertIn(
+                "cleanup_recovery_sha256",
+                metadata_path.read_text(encoding="utf-8"),
+            )
+
+            status = restore_overlay(config_path, backup_path, unified_history=True)
+
+            self.assertEqual(status, "injected")
+            self.assertFalse(backup_path.exists())
+            self.assertFalse(metadata_path.exists())
+
+    def test_unowned_unified_takeover_final_publish_failure_resumes_from_journal(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path, backup_path, original, active, metadata_path = (
+                self._unowned_with_active_beta_takeover(tmp)
+            )
+            real_atomic_write = config_overlay.atomic_write_text
+
+            def fail_final_publish(path: Path, text: str, *, encoding: str = "utf-8") -> None:
+                if path == config_path:
+                    raise OSError("simulated unified final publish failure")
+                real_atomic_write(path, text, encoding=encoding)
+
+            with patch("config_overlay.atomic_write_text", fail_final_publish):
+                with self.assertRaisesRegex(OSError, "unified final publish failure"):
+                    restore_overlay(config_path, backup_path, unified_history=True)
+
+            self.assertEqual(config_path.read_bytes(), active)
+            self.assertEqual(backup_path.read_bytes(), original)
+            self.assertTrue(metadata_path.exists())
+
+            status = restore_overlay(config_path, backup_path, unified_history=True)
+            restored = tomllib.loads(config_path.read_text(encoding="utf-8"))
+
+            self.assertEqual(status, "injected")
+            self.assertEqual(restored["agents"], tomllib.loads(RUST_0_145_AGENTS_CONFIG)["agents"])
+            self.assertEqual(restored["model_provider"], "custom")
+            self.assertEqual(restored["model_providers"]["custom"]["name"], "OpenAI")
+            self.assertFalse(backup_path.exists())
+            self.assertFalse(metadata_path.exists())
+
+    def test_unowned_unified_takeover_resumes_after_ambiguous_final_publish_error(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path, backup_path, original, _, metadata_path = (
+                self._unowned_with_active_beta_takeover(tmp)
+            )
+            real_atomic_write = config_overlay.atomic_write_text
+            published: bytes | None = None
+
+            def publish_final_then_fail(
+                path: Path,
+                text: str,
+                *,
+                encoding: str = "utf-8",
+            ) -> None:
+                nonlocal published
+                real_atomic_write(path, text, encoding=encoding)
+                if path == config_path and "OpenAI" in text:
+                    published = config_path.read_bytes()
+                    raise OSError("simulated ambiguous final publication")
+
+            with patch("config_overlay.atomic_write_text", publish_final_then_fail):
+                with self.assertRaisesRegex(OSError, "ambiguous final publication"):
+                    restore_overlay(config_path, backup_path, unified_history=True)
+
+            self.assertIsNotNone(published)
+            self.assertNotEqual(published, original)
+            self.assertEqual(config_path.read_bytes(), published)
+            self.assertEqual(backup_path.read_bytes(), original)
+            self.assertTrue(metadata_path.exists())
+
+            status = restore_overlay(config_path, backup_path, unified_history=True)
+
+            self.assertEqual(status, "injected")
+            self.assertEqual(config_path.read_bytes(), published)
+            self.assertFalse(backup_path.exists())
+            self.assertFalse(metadata_path.exists())
+
+    def test_unowned_unified_takeover_backup_delete_failure_resumes_published_final(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path, backup_path, original, _, metadata_path = (
+                self._unowned_with_active_beta_takeover(tmp)
+            )
+            real_unlink = Path.unlink
+
+            def fail_backup_delete(path: Path, *args: object, **kwargs: object) -> None:
+                if path == backup_path:
+                    raise OSError("simulated unified backup delete failure")
+                real_unlink(path, *args, **kwargs)
+
+            with patch.object(Path, "unlink", fail_backup_delete):
+                with self.assertRaisesRegex(OSError, "unified backup delete failure"):
+                    restore_overlay(config_path, backup_path, unified_history=True)
+
+            published = config_path.read_bytes()
+            self.assertNotEqual(published, original)
+            self.assertEqual(backup_path.read_bytes(), original)
+            self.assertTrue(metadata_path.exists())
+
+            status = restore_overlay(config_path, backup_path, unified_history=True)
+
+            self.assertEqual(status, "injected")
+            self.assertEqual(config_path.read_bytes(), published)
+            self.assertFalse(backup_path.exists())
+            self.assertFalse(metadata_path.exists())
+
+    def test_unowned_unified_takeover_resumes_after_ambiguous_backup_delete_error(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path, backup_path, _, _, metadata_path = (
+                self._unowned_with_active_beta_takeover(tmp)
+            )
+            real_unlink = Path.unlink
+
+            def delete_backup_then_fail(
+                path: Path,
+                *args: object,
+                **kwargs: object,
+            ) -> None:
+                real_unlink(path, *args, **kwargs)
+                if path == backup_path:
+                    raise OSError("simulated ambiguous backup deletion")
+
+            with patch.object(Path, "unlink", delete_backup_then_fail):
+                with self.assertRaisesRegex(OSError, "ambiguous backup deletion"):
+                    restore_overlay(config_path, backup_path, unified_history=True)
+
+            published = config_path.read_bytes()
+            self.assertFalse(backup_path.exists())
+            self.assertTrue(metadata_path.exists())
+
+            status = restore_overlay(config_path, backup_path, unified_history=True)
+
+            self.assertEqual(status, "injected")
+            self.assertEqual(config_path.read_bytes(), published)
+            self.assertFalse(metadata_path.exists())
+
+    def test_unowned_unified_takeover_sidecar_delete_failure_resumes_published_final(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path, backup_path, _, _, metadata_path = (
+                self._unowned_with_active_beta_takeover(tmp)
+            )
+            real_unlink = Path.unlink
+
+            def fail_sidecar_delete(path: Path, *args: object, **kwargs: object) -> None:
+                if path == metadata_path:
+                    raise OSError("simulated unified sidecar delete failure")
+                real_unlink(path, *args, **kwargs)
+
+            with patch.object(Path, "unlink", fail_sidecar_delete):
+                with self.assertRaisesRegex(OSError, "unified sidecar delete failure"):
+                    restore_overlay(config_path, backup_path, unified_history=True)
+
+            published = config_path.read_bytes()
+            self.assertFalse(backup_path.exists())
+            self.assertTrue(metadata_path.exists())
+
+            status = restore_overlay(config_path, backup_path, unified_history=True)
+
+            self.assertEqual(status, "injected")
+            self.assertEqual(config_path.read_bytes(), published)
+            self.assertFalse(metadata_path.exists())
+
+    def test_unowned_unified_takeover_is_idempotent_after_ambiguous_sidecar_delete_error(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path, backup_path, _, _, metadata_path = (
+                self._unowned_with_active_beta_takeover(tmp)
+            )
+            real_unlink = Path.unlink
+
+            def delete_sidecar_then_fail(
+                path: Path,
+                *args: object,
+                **kwargs: object,
+            ) -> None:
+                real_unlink(path, *args, **kwargs)
+                if path == metadata_path:
+                    raise OSError("simulated ambiguous sidecar deletion")
+
+            with patch.object(Path, "unlink", delete_sidecar_then_fail):
+                with self.assertRaisesRegex(OSError, "ambiguous sidecar deletion"):
+                    restore_overlay(config_path, backup_path, unified_history=True)
+
+            published = config_path.read_bytes()
+            self.assertFalse(backup_path.exists())
+            self.assertFalse(metadata_path.exists())
+
+            status = restore_overlay(config_path, backup_path, unified_history=True)
+
+            self.assertEqual(status, "already_unified")
+            self.assertEqual(config_path.read_bytes(), published)
+
+    def test_apply_and_context_guard_reject_invalid_takeover_metadata_without_mutation(self):
+        for operation in ("apply", "context_guard"):
+            with self.subTest(operation=operation), tempfile.TemporaryDirectory() as tmpdir:
+                tmp = Path(tmpdir)
+                config_path, backup_path, original, active, metadata_path = (
+                    self._unowned_with_active_beta_takeover(tmp)
+                )
+                invalid_metadata = b'{"version":2,"future_state":"unknown"}\n'
+                metadata_path.write_bytes(invalid_metadata)
+                state_path = tmp / "context-guard-state.json"
+                catalog_path = self._official_budget_catalog(tmp)
+
+                with self.assertRaisesRegex(RuntimeError, "takeover metadata is invalid"):
+                    if operation == "apply":
+                        apply_overlay(
+                            config_path,
+                            backup_path,
+                            catalog_path,
+                            "http://127.0.0.1:9109",
+                            owner="beta",
+                            takeover=True,
+                        )
+                    else:
+                        set_context_guard(
+                            config_path,
+                            backup_path,
+                            state_path,
+                            enabled=True,
+                            catalog_path=catalog_path,
+                        )
+
+                self.assertEqual(config_path.read_bytes(), active)
+                self.assertEqual(backup_path.read_bytes(), original)
+                self.assertEqual(metadata_path.read_bytes(), invalid_metadata)
+                self.assertFalse(state_path.exists())
+
+    def test_new_managed_write_resumes_pending_cleanup_before_publication(self):
+        for operation in ("apply", "context_guard"):
+            with self.subTest(operation=operation), tempfile.TemporaryDirectory() as tmpdir:
+                tmp = Path(tmpdir)
+                config_path, backup_path, metadata_path = (
+                    self._unowned_with_pending_unified_cleanup(tmp)
+                )
+                catalog_path = self._official_budget_catalog(tmp)
+                state_path = tmp / "context-guard-state.json"
+
+                if operation == "apply":
+                    apply_overlay(
+                        config_path,
+                        backup_path,
+                        catalog_path,
+                        "http://127.0.0.1:9099",
+                        owner="release",
+                    )
+                    self.assertEqual(
+                        config_overlay.overlay_owner(
+                            config_path.read_text(encoding="utf-8")
+                        ),
+                        "release",
+                    )
+                    self.assertTrue(backup_path.exists())
+                else:
+                    result = set_context_guard(
+                        config_path,
+                        backup_path,
+                        state_path,
+                        enabled=True,
+                        catalog_path=catalog_path,
+                    )
+                    self.assertFalse(result["enabled"])
+                    self.assertFalse(backup_path.exists())
+
+                self.assertFalse(metadata_path.exists())
+
+    def test_context_guard_rejects_interrupted_takeover_without_touching_recovery(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path, backup_path, catalog_path, active = (
+                self._stable_with_interrupted_beta_takeover(tmp)
+            )
+            metadata_path = config_overlay.takeover_metadata_path(backup_path)
+            metadata_before = metadata_path.read_bytes()
+            state_path = tmp / "context-guard-state.json"
+
+            with self.assertRaisesRegex(RuntimeError, "interrupted takeover recovery is pending"):
+                set_context_guard(
+                    config_path,
+                    backup_path,
+                    state_path,
+                    enabled=True,
+                    catalog_path=catalog_path,
+                )
+
+            self.assertEqual(config_path.read_bytes(), active)
+            self.assertEqual(backup_path.read_bytes(), active)
+            self.assertEqual(metadata_path.read_bytes(), metadata_before)
+            self.assertFalse(state_path.exists())
+
+    def test_existing_malformed_or_future_takeover_metadata_fails_closed(self):
+        invalid_payloads = {
+            "truncated": "{",
+            "non_object": "[]",
+            "future_version": json.dumps(
+                {
+                    "version": 2,
+                    "takeover_owner": "beta",
+                    "original_owner": None,
+                }
+            ),
+            "boolean_version": json.dumps(
+                {
+                    "version": True,
+                    "takeover_owner": "beta",
+                    "original_owner": None,
+                }
+            ),
+            "duplicate_version": (
+                '{"version":2,"version":1,"takeover_owner":"beta",'
+                '"original_owner":null}'
+            ),
+            "duplicate_owner": (
+                '{"version":1,"takeover_owner":"release",'
+                '"takeover_owner":"beta","original_owner":null}'
+            ),
+            "same_owner": json.dumps(
+                {
+                    "version": 1,
+                    "takeover_owner": "beta",
+                    "original_owner": "beta",
+                }
+            ),
+            "unknown_owner": json.dumps(
+                {
+                    "version": 1,
+                    "takeover_owner": "future-owner",
+                    "original_owner": None,
+                }
+            ),
+            "non_scalar_owner": json.dumps(
+                {
+                    "version": 1,
+                    "takeover_owner": [],
+                    "original_owner": None,
+                }
+            ),
+            "unknown_field": json.dumps(
+                {
+                    "version": 1,
+                    "takeover_owner": "beta",
+                    "original_owner": None,
+                    "future_field": True,
+                }
+            ),
+            "partial_journal": json.dumps(
+                {
+                    "version": 1,
+                    "takeover_owner": "beta",
+                    "original_owner": None,
+                    "cleanup_source_sha256": "0" * 64,
+                }
+            ),
+            "null_journal": json.dumps(
+                {
+                    "version": 1,
+                    "takeover_owner": "beta",
+                    "original_owner": None,
+                    "cleanup_source_sha256": None,
+                    "cleanup_recovery_sha256": None,
+                    "cleanup_final_sha256": None,
+                    "cleanup_status": None,
+                }
+            ),
+            "unknown_status": json.dumps(
+                {
+                    "version": 1,
+                    "takeover_owner": "beta",
+                    "original_owner": None,
+                    "cleanup_source_sha256": "0" * 64,
+                    "cleanup_recovery_sha256": "1" * 64,
+                    "cleanup_final_sha256": "2" * 64,
+                    "cleanup_status": "future_status",
+                }
+            ),
+            "malformed_digest": json.dumps(
+                {
+                    "version": 1,
+                    "takeover_owner": "beta",
+                    "original_owner": None,
+                    "cleanup_source_sha256": "not-a-digest",
+                    "cleanup_recovery_sha256": "1" * 64,
+                    "cleanup_final_sha256": "2" * 64,
+                    "cleanup_status": "injected",
+                }
+            ),
+        }
+
+        for name, payload in invalid_payloads.items():
+            with self.subTest(name=name), tempfile.TemporaryDirectory() as tmpdir:
+                tmp = Path(tmpdir)
+                config_path, backup_path, original, active, metadata_path = (
+                    self._unowned_with_active_beta_takeover(tmp)
+                )
+                metadata_path.write_text(payload, encoding="utf-8")
+
+                with self.assertRaisesRegex(RuntimeError, "takeover metadata is invalid"):
+                    restore_overlay(config_path, backup_path, unified_history=True)
+
+                self.assertEqual(config_path.read_bytes(), active)
+                self.assertEqual(backup_path.read_bytes(), original)
+                self.assertEqual(metadata_path.read_text(encoding="utf-8"), payload)
+
+    def test_existing_unreadable_takeover_metadata_fails_closed(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path, backup_path, original, active, metadata_path = (
+                self._unowned_with_active_beta_takeover(tmp)
+            )
+            metadata_before = metadata_path.read_bytes()
+            real_read_text = Path.read_text
+
+            def fail_sidecar_read(path: Path, *args: object, **kwargs: object) -> str:
+                if path == metadata_path:
+                    raise OSError("simulated transient sidecar read failure")
+                return real_read_text(path, *args, **kwargs)
+
+            with patch.object(Path, "read_text", fail_sidecar_read):
+                with self.assertRaisesRegex(RuntimeError, "takeover metadata is invalid"):
+                    restore_overlay(config_path, backup_path, unified_history=True)
+
+            self.assertEqual(config_path.read_bytes(), active)
+            self.assertEqual(backup_path.read_bytes(), original)
+            self.assertEqual(metadata_path.read_bytes(), metadata_before)
+
+    def test_valid_takeover_metadata_with_unrecognized_live_state_fails_closed(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path, backup_path, original, active, metadata_path = (
+                self._unowned_with_active_beta_takeover(tmp)
+            )
+            unrecognized = active.replace(b"# owner = beta", b"# owner = release")
+            config_path.write_bytes(unrecognized)
+            metadata_before = metadata_path.read_bytes()
+
+            with self.assertRaisesRegex(RuntimeError, "state is not recognized"):
+                restore_overlay(config_path, backup_path, unified_history=True)
+
+            self.assertEqual(config_path.read_bytes(), unrecognized)
+            self.assertEqual(backup_path.read_bytes(), original)
+            self.assertEqual(metadata_path.read_bytes(), metadata_before)
+
+    def test_pending_unified_cleanup_rejects_inconsistent_artifacts_and_journal(self):
+        cases = (
+            ("live_artifact", "live config is missing or diverged"),
+            ("recovery_artifact", "recovery backup is missing or diverged"),
+            ("source_digest", "live config is missing or diverged"),
+            ("recovery_digest", "recovery backup is missing or diverged"),
+            ("final_digest", "intended final config is inconsistent"),
+            ("terminal_status", "terminal status is inconsistent"),
+            ("takeover_owner", "live config is missing or diverged"),
+            ("original_owner", "recovery backup is missing or diverged"),
+        )
+
+        for case, expected_error in cases:
+            with self.subTest(case=case), tempfile.TemporaryDirectory() as tmpdir:
+                config_path, backup_path, metadata_path = (
+                    self._unowned_with_pending_unified_cleanup(Path(tmpdir))
+                )
+                metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+
+                if case == "live_artifact":
+                    config_path.write_text(
+                        config_path.read_text(encoding="utf-8") + "# divergent live edit\n",
+                        encoding="utf-8",
+                    )
+                elif case == "recovery_artifact":
+                    backup_path.write_text(
+                        backup_path.read_text(encoding="utf-8")
+                        + "# divergent recovery edit\n",
+                        encoding="utf-8",
+                    )
+                elif case == "source_digest":
+                    metadata["cleanup_source_sha256"] = "d" * 64
+                elif case == "recovery_digest":
+                    metadata["cleanup_recovery_sha256"] = "e" * 64
+                elif case == "final_digest":
+                    metadata["cleanup_final_sha256"] = "f" * 64
+                elif case == "terminal_status":
+                    metadata["cleanup_status"] = "already_unified"
+                elif case == "takeover_owner":
+                    metadata["takeover_owner"] = "release"
+                else:
+                    metadata["original_owner"] = "release"
+
+                if case not in {"live_artifact", "recovery_artifact"}:
+                    metadata_path.write_text(
+                        json.dumps(metadata, sort_keys=True) + "\n",
+                        encoding="utf-8",
+                    )
+
+                config_before = config_path.read_bytes()
+                backup_before = backup_path.read_bytes()
+                metadata_before = metadata_path.read_bytes()
+
+                with self.assertRaisesRegex(RuntimeError, expected_error):
+                    restore_overlay(config_path, backup_path, unified_history=True)
+
+                self.assertEqual(config_path.read_bytes(), config_before)
+                self.assertEqual(backup_path.read_bytes(), backup_before)
+                self.assertEqual(metadata_path.read_bytes(), metadata_before)
 
     def test_agents_config_survives_connect_restart_readback_and_restore_for_supported_shapes(self):
         legacy_enabled = RUST_0_145_AGENTS_CONFIG.replace(
@@ -1642,7 +2711,7 @@ class ConfigOverlayTests(unittest.TestCase):
             self.assertNotIn('name = "Codex Proxy"', restored)
             self.assertNotIn("base_url", restored)
 
-    def test_restore_ignores_preexisting_same_owner_takeover_sidecar(self):
+    def test_restore_rejects_preexisting_same_owner_takeover_sidecar(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             tmp = Path(tmpdir)
             config = tmp / "config.toml"
@@ -1666,13 +2735,16 @@ class ConfigOverlayTests(unittest.TestCase):
                 ),
                 encoding="utf-8",
             )
+            config_before = config.read_bytes()
+            backup_before = backup.read_bytes()
+            metadata_before = metadata.read_bytes()
 
-            status = restore_overlay(config, backup, unified_history=True)
-            restored = config.read_text(encoding="utf-8")
+            with self.assertRaisesRegex(RuntimeError, "takeover metadata is invalid"):
+                restore_overlay(config, backup, unified_history=True)
 
-            self.assertNotEqual(status, "restored_takeover_backup")
-            self.assertIn('name = "OpenAI"', restored)
-            self.assertFalse(metadata.exists())
+            self.assertEqual(config.read_bytes(), config_before)
+            self.assertEqual(backup.read_bytes(), backup_before)
+            self.assertEqual(metadata.read_bytes(), metadata_before)
 
     def test_restore_overlay_without_backup_strips_managed_overlay(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_config_overlay.py
+++ b/tests/test_config_overlay.py
@@ -2416,6 +2416,14 @@ class ConfigOverlayTests(unittest.TestCase):
                 payload.update(updates)
                 return json.dumps(payload, sort_keys=True)
 
+            def duplicated(key: str) -> str:
+                fields = [
+                    f"{json.dumps(field)}:{json.dumps(value)}"
+                    for field, value in valid.items()
+                ]
+                fields.append(f"{json.dumps(key)}:{json.dumps(valid[key])}")
+                return "{" + ",".join(fields) + "}"
+
             invalid_payloads = {
                 "truncated": "{",
                 "non_object": "[]",
@@ -2428,16 +2436,6 @@ class ConfigOverlayTests(unittest.TestCase):
                 ),
                 "future_version": changed(version=2),
                 "boolean_version": changed(version=True),
-                "duplicate_version": (
-                    '{"version":2,"version":1,"takeover_owner":"beta",'
-                    f'"original_owner":null,"final_sha256":"{valid["final_sha256"]}",'
-                    '"status":"injected"}'
-                ),
-                "duplicate_owner": (
-                    '{"version":1,"takeover_owner":"release",'
-                    '"takeover_owner":"beta","original_owner":null,'
-                    f'"final_sha256":"{valid["final_sha256"]}","status":"injected"}}'
-                ),
                 "same_owner": changed(original_owner="beta"),
                 "unknown_owner": changed(takeover_owner="future-owner"),
                 "non_scalar_owner": changed(takeover_owner=[]),
@@ -2457,6 +2455,19 @@ class ConfigOverlayTests(unittest.TestCase):
                 "unknown_status": changed(status="future_status"),
                 "non_string_status": changed(status=[]),
             }
+            invalid_payloads.update(
+                {
+                    f"duplicate_{key}": duplicated(key)
+                    for key in (
+                        "version",
+                        "takeover_owner",
+                        "original_owner",
+                        "final_sha256",
+                        "same_owner_backup_sha256",
+                        "status",
+                    )
+                }
+            )
             completed = config_path.read_bytes()
 
             for name, payload in invalid_payloads.items():
@@ -3078,102 +3089,106 @@ class ConfigOverlayTests(unittest.TestCase):
             self.assertFalse(state_path.exists())
 
     def test_existing_malformed_or_future_takeover_metadata_fails_closed(self):
+        valid_active = {
+            "version": 1,
+            "takeover_owner": "beta",
+            "original_owner": None,
+            "recovery_sha256": "1" * 64,
+        }
+        valid_journal = {
+            **valid_active,
+            "cleanup_source_sha256": "0" * 64,
+            "cleanup_recovery_sha256": valid_active["recovery_sha256"],
+            "cleanup_final_sha256": "2" * 64,
+            "cleanup_status": "injected",
+        }
+
+        def changed(payload: dict[str, object], **updates: object) -> str:
+            candidate = dict(payload)
+            candidate.update(updates)
+            return json.dumps(candidate, sort_keys=True)
+
+        def duplicated(payload: dict[str, object], key: str) -> str:
+            fields = [
+                f"{json.dumps(field)}:{json.dumps(value)}"
+                for field, value in payload.items()
+            ]
+            fields.append(f"{json.dumps(key)}:{json.dumps(payload[key])}")
+            return "{" + ",".join(fields) + "}"
+
         invalid_payloads = {
             "truncated": "{",
             "non_object": "[]",
-            "future_version": json.dumps(
-                {
-                    "version": 2,
-                    "takeover_owner": "beta",
-                    "original_owner": None,
-                }
-            ),
-            "boolean_version": json.dumps(
-                {
-                    "version": True,
-                    "takeover_owner": "beta",
-                    "original_owner": None,
-                }
-            ),
-            "duplicate_version": (
-                '{"version":2,"version":1,"takeover_owner":"beta",'
-                '"original_owner":null}'
-            ),
-            "duplicate_owner": (
-                '{"version":1,"takeover_owner":"release",'
-                '"takeover_owner":"beta","original_owner":null}'
-            ),
-            "same_owner": json.dumps(
-                {
-                    "version": 1,
-                    "takeover_owner": "beta",
-                    "original_owner": "beta",
-                }
-            ),
-            "unknown_owner": json.dumps(
-                {
-                    "version": 1,
-                    "takeover_owner": "future-owner",
-                    "original_owner": None,
-                }
-            ),
-            "non_scalar_owner": json.dumps(
-                {
-                    "version": 1,
-                    "takeover_owner": [],
-                    "original_owner": None,
-                }
-            ),
+            "future_version": changed(valid_active, version=2),
+            "boolean_version": changed(valid_active, version=True),
+            "same_owner": changed(valid_active, original_owner="beta"),
+            "unknown_owner": changed(valid_active, takeover_owner="future-owner"),
+            "non_scalar_owner": changed(valid_active, takeover_owner=[]),
             "unknown_field": json.dumps(
+                {**valid_active, "future_field": True},
+                sort_keys=True,
+            ),
+            "legacy_missing_recovery_anchor": json.dumps(
                 {
-                    "version": 1,
-                    "takeover_owner": "beta",
-                    "original_owner": None,
-                    "future_field": True,
-                }
+                    key: value
+                    for key, value in valid_active.items()
+                    if key != "recovery_sha256"
+                },
+                sort_keys=True,
+            ),
+            "malformed_recovery_anchor": changed(
+                valid_active,
+                recovery_sha256="not-a-digest",
+            ),
+            "uppercase_recovery_anchor": changed(
+                valid_active,
+                recovery_sha256="A" * 64,
             ),
             "partial_journal": json.dumps(
-                {
-                    "version": 1,
-                    "takeover_owner": "beta",
-                    "original_owner": None,
-                    "cleanup_source_sha256": "0" * 64,
-                }
+                {**valid_active, "cleanup_source_sha256": "0" * 64},
+                sort_keys=True,
             ),
             "null_journal": json.dumps(
                 {
-                    "version": 1,
-                    "takeover_owner": "beta",
-                    "original_owner": None,
+                    **valid_active,
                     "cleanup_source_sha256": None,
                     "cleanup_recovery_sha256": None,
                     "cleanup_final_sha256": None,
                     "cleanup_status": None,
-                }
+                },
+                sort_keys=True,
             ),
-            "unknown_status": json.dumps(
-                {
-                    "version": 1,
-                    "takeover_owner": "beta",
-                    "original_owner": None,
-                    "cleanup_source_sha256": "0" * 64,
-                    "cleanup_recovery_sha256": "1" * 64,
-                    "cleanup_final_sha256": "2" * 64,
-                    "cleanup_status": "future_status",
-                }
+            "unknown_status": changed(
+                valid_journal,
+                cleanup_status="future_status",
             ),
-            "malformed_digest": json.dumps(
-                {
-                    "version": 1,
-                    "takeover_owner": "beta",
-                    "original_owner": None,
-                    "cleanup_source_sha256": "not-a-digest",
-                    "cleanup_recovery_sha256": "1" * 64,
-                    "cleanup_final_sha256": "2" * 64,
-                    "cleanup_status": "injected",
-                }
+            "malformed_cleanup_digest": changed(
+                valid_journal,
+                cleanup_source_sha256="not-a-digest",
+            ),
+            "cleanup_recovery_anchor_mismatch": changed(
+                valid_journal,
+                cleanup_recovery_sha256="3" * 64,
             ),
         }
+        invalid_payloads.update(
+            {
+                f"duplicate_{key}": duplicated(payload, key)
+                for payload, keys in (
+                    (valid_active, tuple(valid_active)),
+                    (
+                        valid_journal,
+                        (
+                            "cleanup_source_sha256",
+                            "cleanup_recovery_sha256",
+                            "cleanup_final_sha256",
+                            "cleanup_status",
+                        ),
+                    ),
+                )
+                for key in keys
+            }
+        )
 
         for name, payload in invalid_payloads.items():
             with self.subTest(name=name), tempfile.TemporaryDirectory() as tmpdir:
@@ -3229,16 +3244,538 @@ class ConfigOverlayTests(unittest.TestCase):
             self.assertEqual(backup_path.read_bytes(), original)
             self.assertEqual(metadata_path.read_bytes(), metadata_before)
 
+    def test_active_owned_takeover_rejects_same_owner_backup_content_drift(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path = tmp / "config.toml"
+            stable_backup_path = tmp / "stable.backup.toml"
+            beta_backup_path = tmp / "beta.backup.toml"
+            config_path.write_text(RUST_0_145_AGENTS_CONFIG, encoding="utf-8")
+            apply_overlay(
+                config_path,
+                stable_backup_path,
+                None,
+                "http://127.0.0.1:9099",
+                owner="release",
+            )
+            apply_overlay(
+                config_path,
+                beta_backup_path,
+                None,
+                "http://127.0.0.1:9109",
+                owner="beta",
+                takeover=True,
+            )
+
+            metadata_path = config_overlay.takeover_metadata_path(beta_backup_path)
+            tampered_backup = beta_backup_path.read_text(encoding="utf-8").replace(
+                'future_scheduler = { strategy = "breadth", burst_limit = 11 }',
+                'future_scheduler = { strategy = "breadth", burst_limit = 12 }',
+            )
+            self.assertIn("# owner = release", tampered_backup)
+            beta_backup_path.write_text(tampered_backup, encoding="utf-8")
+            live_before = config_path.read_bytes()
+            backup_before = beta_backup_path.read_bytes()
+            metadata_before = metadata_path.read_bytes()
+
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "recovery backup is missing or diverged",
+            ):
+                restore_overlay(config_path, beta_backup_path, unified_history=True)
+
+            self.assertEqual(config_path.read_bytes(), live_before)
+            self.assertEqual(beta_backup_path.read_bytes(), backup_before)
+            self.assertEqual(metadata_path.read_bytes(), metadata_before)
+
+    def test_active_unowned_takeover_rejects_comment_only_backup_drift(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path, backup_path, _, _, metadata_path = (
+                self._unowned_with_active_beta_takeover(Path(tmpdir))
+            )
+            backup_path.write_bytes(
+                backup_path.read_bytes() + b"# comment-only recovery drift\n"
+            )
+            self.assertIsNone(
+                config_overlay.overlay_owner(
+                    backup_path.read_text(encoding="utf-8")
+                )
+            )
+            live_before = config_path.read_bytes()
+            backup_before = backup_path.read_bytes()
+            metadata_before = metadata_path.read_bytes()
+
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "recovery backup is missing or diverged",
+            ):
+                restore_overlay(config_path, backup_path, unified_history=True)
+
+            self.assertEqual(config_path.read_bytes(), live_before)
+            self.assertEqual(backup_path.read_bytes(), backup_before)
+            self.assertEqual(metadata_path.read_bytes(), metadata_before)
+
+    def test_interrupted_takeover_rejects_raw_newline_backup_drift(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path, backup_path, _, _ = (
+                self._stable_with_interrupted_beta_takeover(Path(tmpdir))
+            )
+            metadata_path = config_overlay.takeover_metadata_path(backup_path)
+            recovery = backup_path.read_bytes()
+            self.assertIn(b"# owner = release", recovery)
+            backup_path.write_bytes(recovery.replace(b"\n", b"\r\n", 1))
+            self.assertEqual(
+                config_overlay.overlay_owner(
+                    backup_path.read_text(encoding="utf-8")
+                ),
+                "release",
+            )
+            live_before = config_path.read_bytes()
+            backup_before = backup_path.read_bytes()
+            metadata_before = metadata_path.read_bytes()
+
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "recovery backup is missing or diverged",
+            ):
+                restore_overlay(config_path, backup_path, unified_history=True)
+
+            self.assertEqual(config_path.read_bytes(), live_before)
+            self.assertEqual(backup_path.read_bytes(), backup_before)
+            self.assertEqual(metadata_path.read_bytes(), metadata_before)
+
+    def test_release_takeover_rejects_model_provider_drift_after_fresh_process_restart(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path = tmp / "config.toml"
+            beta_backup_path = tmp / "beta.backup.toml"
+            release_backup_path = tmp / "release.backup.toml"
+            config_path.write_text(RUST_0_145_AGENTS_CONFIG, encoding="utf-8")
+            apply_overlay(
+                config_path,
+                beta_backup_path,
+                None,
+                "http://127.0.0.1:9109",
+                owner="beta",
+            )
+            apply_overlay(
+                config_path,
+                release_backup_path,
+                None,
+                "http://127.0.0.1:9099",
+                owner="release",
+                takeover=True,
+            )
+            metadata_path = config_overlay.takeover_metadata_path(release_backup_path)
+            tampered_backup = release_backup_path.read_text(encoding="utf-8").replace(
+                'model = "ollama-cloud/glm-5.2"',
+                'model = "gpt-5.6-terra"',
+            ).replace(
+                'model_provider = "custom"',
+                'model_provider = "openai"',
+                1,
+            )
+            self.assertIn("# owner = beta", tampered_backup)
+            self.assertIn('model = "gpt-5.6-terra"', tampered_backup)
+            self.assertIn('model_provider = "openai"', tampered_backup)
+            release_backup_path.write_text(tampered_backup, encoding="utf-8")
+            live_before = config_path.read_bytes()
+            backup_before = release_backup_path.read_bytes()
+            metadata_before = metadata_path.read_bytes()
+            restore_script = "\n".join(
+                [
+                    "import sys",
+                    "from pathlib import Path",
+                    "from config_overlay import restore_overlay",
+                    "restore_overlay(",
+                    "    Path(sys.argv[1]),",
+                    "    Path(sys.argv[2]),",
+                    "    unified_history=True,",
+                    ")",
+                ]
+            )
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-c",
+                    restore_script,
+                    str(config_path),
+                    str(release_backup_path),
+                ],
+                capture_output=True,
+                text=True,
+                env=self._subprocess_env(),
+                timeout=10,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("recovery backup is missing or diverged", result.stderr)
+            self.assertEqual(config_path.read_bytes(), live_before)
+            self.assertEqual(release_backup_path.read_bytes(), backup_before)
+            self.assertEqual(metadata_path.read_bytes(), metadata_before)
+
+    def test_takeover_recovery_anchor_is_bounded_and_contains_no_config_content(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path = tmp / "config.toml"
+            backup_path = tmp / "beta.backup.toml"
+            sensitive_marker = "anchor-must-never-copy-this-config-content"
+            config_path.write_text(
+                RUST_0_145_AGENTS_CONFIG
+                + f'# {sensitive_marker}\nsecret_future_agent_key = "private"\n',
+                encoding="utf-8",
+            )
+            apply_overlay(
+                config_path,
+                backup_path,
+                None,
+                "http://127.0.0.1:9109",
+                owner="beta",
+                takeover=True,
+                gateway_key="anchor-must-never-copy-this-gateway-key",
+            )
+
+            metadata_path = config_overlay.takeover_metadata_path(backup_path)
+            raw_metadata = metadata_path.read_text(encoding="utf-8")
+            metadata = json.loads(raw_metadata)
+
+            self.assertEqual(
+                set(metadata),
+                {
+                    "version",
+                    "takeover_owner",
+                    "original_owner",
+                    "recovery_sha256",
+                },
+            )
+            self.assertEqual(
+                metadata["recovery_sha256"],
+                config_overlay.takeover_text_sha256(
+                    config_overlay.read_text_preserving_newlines(backup_path)
+                ),
+            )
+            self.assertLess(len(raw_metadata.encode("utf-8")), 256)
+            self.assertNotIn(sensitive_marker, raw_metadata)
+            self.assertNotIn("anchor-must-never-copy-this-gateway-key", raw_metadata)
+            self.assertNotIn("secret_future_agent_key", raw_metadata)
+
+    def test_takeover_anchor_publication_is_verified_before_live_config_write(self):
+        cases = (
+            (
+                "backup",
+                "recovery backup publication diverged",
+                False,
+            ),
+            (
+                "metadata",
+                "takeover ownership evidence is inconsistent",
+                True,
+            ),
+        )
+        for artifact, expected_error, expect_metadata in cases:
+            with self.subTest(artifact=artifact), tempfile.TemporaryDirectory() as tmpdir:
+                tmp = Path(tmpdir)
+                config_path = tmp / "config.toml"
+                stable_backup_path = tmp / "stable.backup.toml"
+                beta_backup_path = tmp / "beta.backup.toml"
+                config_path.write_text(RUST_0_145_AGENTS_CONFIG, encoding="utf-8")
+                apply_overlay(
+                    config_path,
+                    stable_backup_path,
+                    None,
+                    "http://127.0.0.1:9099",
+                    owner="release",
+                )
+                stable_active = config_path.read_bytes()
+                metadata_path = config_overlay.takeover_metadata_path(beta_backup_path)
+                real_atomic_write = config_overlay.atomic_write_text
+
+                def corrupt_publication(
+                    path: Path,
+                    text: str,
+                    *,
+                    encoding: str = "utf-8",
+                ) -> None:
+                    real_atomic_write(path, text, encoding=encoding)
+                    if artifact == "backup" and path == beta_backup_path:
+                        path.write_bytes(path.read_bytes() + b"# publication drift\n")
+                    elif artifact == "metadata" and path == metadata_path:
+                        payload = json.loads(path.read_text(encoding="utf-8"))
+                        payload["recovery_sha256"] = "0" * 64
+                        path.write_text(
+                            json.dumps(payload, sort_keys=True) + "\n",
+                            encoding="utf-8",
+                        )
+
+                with patch("config_overlay.atomic_write_text", corrupt_publication):
+                    with self.assertRaisesRegex(RuntimeError, expected_error):
+                        apply_overlay(
+                            config_path,
+                            beta_backup_path,
+                            None,
+                            "http://127.0.0.1:9109",
+                            owner="beta",
+                            takeover=True,
+                        )
+
+                self.assertEqual(config_path.read_bytes(), stable_active)
+                self.assertTrue(beta_backup_path.exists())
+                self.assertEqual(metadata_path.exists(), expect_metadata)
+                self.assertFalse(
+                    config_overlay.takeover_completion_path(
+                        beta_backup_path
+                    ).exists()
+                )
+
+    def test_legacy_unanchored_takeover_metadata_fails_closed_for_both_channels(self):
+        directions = (
+            ("stable_to_developer", "release", "beta"),
+            ("developer_to_stable", "beta", "release"),
+        )
+        for name, original_owner, takeover_owner in directions:
+            for operation in ("reapply", "restore"):
+                with (
+                    self.subTest(name=name, operation=operation),
+                    tempfile.TemporaryDirectory() as tmpdir,
+                ):
+                    tmp = Path(tmpdir)
+                    config_path = tmp / "config.toml"
+                    original_backup_path = tmp / f"{original_owner}.backup.toml"
+                    takeover_backup_path = tmp / f"{takeover_owner}.backup.toml"
+                    config_path.write_text(
+                        RUST_0_145_AGENTS_CONFIG,
+                        encoding="utf-8",
+                    )
+                    apply_overlay(
+                        config_path,
+                        original_backup_path,
+                        None,
+                        "http://127.0.0.1:9099",
+                        owner=original_owner,
+                    )
+                    apply_overlay(
+                        config_path,
+                        takeover_backup_path,
+                        None,
+                        "http://127.0.0.1:9109",
+                        owner=takeover_owner,
+                        takeover=True,
+                    )
+
+                    metadata_path = config_overlay.takeover_metadata_path(
+                        takeover_backup_path
+                    )
+                    completion_path = config_overlay.takeover_completion_path(
+                        takeover_backup_path
+                    )
+                    legacy_metadata = json.loads(
+                        metadata_path.read_text(encoding="utf-8")
+                    )
+                    legacy_metadata.pop("recovery_sha256")
+                    metadata_path.write_text(
+                        json.dumps(legacy_metadata, sort_keys=True) + "\n",
+                        encoding="utf-8",
+                    )
+                    metadata_read = config_overlay.read_takeover_metadata(
+                        takeover_backup_path
+                    )
+                    self.assertEqual(metadata_read.state.value, "invalid")
+                    self.assertEqual(
+                        metadata_read.error.value,
+                        "missing_recovery_anchor",
+                    )
+                    live_before = config_path.read_bytes()
+                    backup_before = takeover_backup_path.read_bytes()
+                    metadata_before = metadata_path.read_bytes()
+
+                    with self.assertRaisesRegex(
+                        RuntimeError,
+                        "missing durable recovery anchor.*preserve config, backup, and sidecar",
+                    ):
+                        if operation == "reapply":
+                            apply_overlay(
+                                config_path,
+                                takeover_backup_path,
+                                None,
+                                "http://127.0.0.1:9109",
+                                owner=takeover_owner,
+                            )
+                        else:
+                            restore_overlay(
+                                config_path,
+                                takeover_backup_path,
+                                unified_history=True,
+                            )
+
+                    self.assertEqual(config_path.read_bytes(), live_before)
+                    self.assertEqual(takeover_backup_path.read_bytes(), backup_before)
+                    self.assertEqual(metadata_path.read_bytes(), metadata_before)
+                    self.assertFalse(completion_path.exists())
+
+    def test_takeover_status_owner_phase_legality_matrix(self):
+        statuses = (
+            None,
+            "already_unified",
+            "conflicting_custom_provider",
+            "explicit_model_provider",
+            "injected",
+            "interrupted_takeover_discarded",
+            "repaired_unified",
+            "replaced_managed_gateway",
+            "restored_takeover_backup",
+        )
+        identity_statuses = {
+            "interrupted_takeover_discarded",
+            "restored_takeover_backup",
+        }
+
+        for phase in ("active_metadata", "cleanup_journal", "completion_receipt"):
+            for original_owner in (None, "release", "beta"):
+                for status in statuses:
+                    with (
+                        self.subTest(
+                            phase=phase,
+                            original_owner=original_owner,
+                            status=status,
+                        ),
+                        tempfile.TemporaryDirectory() as tmpdir,
+                    ):
+                        backup_path = Path(tmpdir) / "takeover.backup.toml"
+                        takeover_owner = "release" if original_owner == "beta" else "beta"
+                        recovery_sha256 = "1" * 64
+                        if phase == "completion_receipt":
+                            payload = {
+                                "version": 1,
+                                "takeover_owner": takeover_owner,
+                                "original_owner": original_owner,
+                                "final_sha256": "2" * 64,
+                                "same_owner_backup_sha256": "3" * 64,
+                                "status": status,
+                            }
+                            config_overlay.takeover_completion_path(
+                                backup_path
+                            ).write_text(json.dumps(payload), encoding="utf-8")
+                            state = config_overlay.read_takeover_completion(
+                                backup_path
+                            ).state
+                            expected_valid = (
+                                status is not None
+                                and (
+                                    original_owner is None
+                                    or status in identity_statuses
+                                )
+                            )
+                        else:
+                            payload = {
+                                "version": 1,
+                                "takeover_owner": takeover_owner,
+                                "original_owner": original_owner,
+                                "recovery_sha256": recovery_sha256,
+                            }
+                            if phase == "cleanup_journal":
+                                payload.update(
+                                    {
+                                        "cleanup_source_sha256": "0" * 64,
+                                        "cleanup_recovery_sha256": recovery_sha256,
+                                        "cleanup_final_sha256": "2" * 64,
+                                        "cleanup_status": status,
+                                    }
+                                )
+                                expected_valid = (
+                                    status is not None
+                                    and (
+                                        original_owner is None
+                                        or status in identity_statuses
+                                    )
+                                )
+                            else:
+                                if status is not None:
+                                    payload["cleanup_status"] = status
+                                expected_valid = status is None
+                            config_overlay.takeover_metadata_path(
+                                backup_path
+                            ).write_text(json.dumps(payload), encoding="utf-8")
+                            state = config_overlay.read_takeover_metadata(
+                                backup_path
+                            ).state
+
+                        self.assertEqual(
+                            state.value,
+                            "valid" if expected_valid else "invalid",
+                        )
+
+    def test_owned_takeover_rejects_unowned_cleanup_journal_before_mutation(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path = tmp / "config.toml"
+            stable_backup_path = tmp / "stable.backup.toml"
+            beta_backup_path = tmp / "beta.backup.toml"
+            config_path.write_text(RUST_0_145_AGENTS_CONFIG, encoding="utf-8")
+            apply_overlay(
+                config_path,
+                stable_backup_path,
+                None,
+                "http://127.0.0.1:9099",
+                owner="release",
+            )
+            apply_overlay(
+                config_path,
+                beta_backup_path,
+                None,
+                "http://127.0.0.1:9109",
+                owner="beta",
+                takeover=True,
+            )
+
+            metadata_path = config_overlay.takeover_metadata_path(beta_backup_path)
+            completion_path = config_overlay.takeover_completion_path(beta_backup_path)
+            current = config_path.read_text(encoding="utf-8")
+            recovery = beta_backup_path.read_text(encoding="utf-8")
+            final, status = inject_unified_history_config(recovery)
+            self.assertEqual(status, "replaced_managed_gateway")
+            metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+            metadata.update(
+                {
+                    "cleanup_source_sha256": config_overlay.takeover_text_sha256(
+                        current
+                    ),
+                    "cleanup_recovery_sha256": config_overlay.takeover_text_sha256(
+                        recovery
+                    ),
+                    "cleanup_final_sha256": config_overlay.takeover_text_sha256(final),
+                    "cleanup_status": status,
+                }
+            )
+            metadata_path.write_text(
+                json.dumps(metadata, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+            live_before = config_path.read_bytes()
+            backup_before = beta_backup_path.read_bytes()
+            metadata_before = metadata_path.read_bytes()
+
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "takeover metadata is invalid",
+            ):
+                restore_overlay(config_path, beta_backup_path, unified_history=True)
+
+            self.assertEqual(config_path.read_bytes(), live_before)
+            self.assertEqual(beta_backup_path.read_bytes(), backup_before)
+            self.assertEqual(metadata_path.read_bytes(), metadata_before)
+            self.assertFalse(completion_path.exists())
+
     def test_pending_unified_cleanup_rejects_inconsistent_artifacts_and_journal(self):
         cases = (
             ("live_artifact", "live config is missing or diverged"),
             ("recovery_artifact", "recovery backup is missing or diverged"),
             ("source_digest", "live config is missing or diverged"),
-            ("recovery_digest", "recovery backup is missing or diverged"),
+            ("recovery_digest", "takeover metadata is invalid"),
             ("final_digest", "intended final config is inconsistent"),
             ("terminal_status", "terminal status is inconsistent"),
             ("takeover_owner", "live config is missing or diverged"),
-            ("original_owner", "recovery backup is missing or diverged"),
+            ("original_owner", "takeover metadata is invalid"),
         )
 
         for case, expected_error in cases:

--- a/tests/test_config_overlay.py
+++ b/tests/test_config_overlay.py
@@ -5,9 +5,11 @@ import io
 import json
 import tempfile
 from pathlib import Path
+import tomllib
 import unittest
 from unittest.mock import patch
 
+import config_overlay
 from config_overlay import (
     MARKER_BEGIN,
     _selected_official_context_budget,
@@ -25,6 +27,33 @@ from config_overlay import (
     top_level_value,
 )
 from model_limits import FRESH_DIRECT_OFFICIAL_CACHE_AUTHORITY_SOURCE
+
+
+RUST_0_145_AGENTS_CONFIG = """\
+model = "ollama-cloud/glm-5.2"
+model_provider = "openai"
+model_reasoning_effort = "xhigh"
+
+[agents]
+enabled = true
+max_concurrent_threads_per_session = 7
+default_subagent_model = "gpt-5.6-terra"
+default_subagent_reasoning_effort = "high"
+future_scheduler = { strategy = "breadth", burst_limit = 11 }
+
+[agents.researcher]
+description = "Research-focused role."
+config_file = "./agents/researcher.toml"
+nickname_candidates = ["Herodotus", "Ibn Battuta"]
+
+[agents.reviewer]
+description = "Review-focused role."
+config_file = "./agents/reviewer.toml"
+
+[features]
+multi_agent_v2 = { enabled = false, max_concurrent_threads_per_session = 5, tool_namespace = "team_tools" }
+hooks = true
+"""
 
 
 class DeterministicCompactionReplay:
@@ -803,6 +832,211 @@ class ConfigOverlayTests(unittest.TestCase):
                 apply_overlay(config_path, backup_path, catalog_path, "http://127.0.0.1:9099")
             self.assertEqual(config_path.read_text(encoding="utf-8"), original)
             self.assertEqual(backup_path.read_text(encoding="utf-8"), original)
+
+            restore_overlay(config_path, backup_path)
+            self.assertEqual(config_path.read_text(encoding="utf-8"), original)
+
+    def test_interrupted_beta_takeover_leaves_stable_agents_config_and_restore_chain_exact(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path = tmp / "config.toml"
+            stable_backup_path = tmp / "stable.backup.toml"
+            beta_backup_path = tmp / "beta.backup.toml"
+            catalog_path = tmp / "catalog.json"
+            original = RUST_0_145_AGENTS_CONFIG.replace("\n", "\r\n").encode()
+            expected = tomllib.loads(RUST_0_145_AGENTS_CONFIG)
+            config_path.write_bytes(original)
+
+            apply_overlay(
+                config_path,
+                stable_backup_path,
+                catalog_path,
+                "http://127.0.0.1:9099",
+                owner="release",
+            )
+            stable_active = config_path.read_bytes()
+            stable_semantics = tomllib.loads(stable_active.decode())
+            self.assertEqual(stable_semantics["agents"], expected["agents"])
+            self.assertEqual(
+                stable_semantics["features"]["multi_agent_v2"],
+                expected["features"]["multi_agent_v2"],
+            )
+
+            real_atomic_write = config_overlay.atomic_write_text
+
+            def interrupt_live_config_write(path: Path, text: str, *, encoding: str = "utf-8") -> None:
+                if path == config_path:
+                    raise OSError("simulated interrupted beta config update")
+                real_atomic_write(path, text, encoding=encoding)
+
+            with patch("config_overlay.atomic_write_text", interrupt_live_config_write):
+                with self.assertRaisesRegex(OSError, "interrupted beta config update"):
+                    apply_overlay(
+                        config_path,
+                        beta_backup_path,
+                        catalog_path,
+                        "http://127.0.0.1:9109",
+                        owner="beta",
+                        takeover=True,
+                    )
+
+            self.assertEqual(config_path.read_bytes(), stable_active)
+            self.assertEqual(beta_backup_path.read_bytes(), stable_active)
+            self.assertTrue(config_overlay.takeover_metadata_path(beta_backup_path).exists())
+
+            status = restore_overlay(config_path, beta_backup_path, unified_history=True)
+
+            self.assertEqual(status, "interrupted_takeover_discarded")
+            self.assertEqual(config_path.read_bytes(), stable_active)
+            self.assertFalse(beta_backup_path.exists())
+            self.assertFalse(config_overlay.takeover_metadata_path(beta_backup_path).exists())
+
+            restore_overlay(config_path, stable_backup_path)
+            self.assertEqual(config_path.read_bytes(), original)
+
+    def test_agents_config_survives_connect_restart_readback_and_restore_for_supported_shapes(self):
+        legacy_enabled = RUST_0_145_AGENTS_CONFIG.replace(
+            "max_concurrent_threads_per_session = 7",
+            "max_threads = 7",
+        ).replace(
+            "multi_agent_v2 = { enabled = false, max_concurrent_threads_per_session = 5, tool_namespace = \"team_tools\" }",
+            "multi_agent_v2 = { enabled = true, max_concurrent_threads_per_session = 9, tool_namespace = \"team_tools\" }",
+        )
+        no_backend_or_defaults = RUST_0_145_AGENTS_CONFIG.replace(
+            "max_concurrent_threads_per_session = 7",
+            "max_threads = 3",
+        ).replace(
+            'default_subagent_model = "gpt-5.6-terra"\n',
+            "",
+        ).replace(
+            'default_subagent_reasoning_effort = "high"\n',
+            "",
+        ).replace(
+            'multi_agent_v2 = { enabled = false, max_concurrent_threads_per_session = 5, tool_namespace = "team_tools" }\n',
+            "",
+        )
+        cases = (
+            ("canonical_structured_disabled", RUST_0_145_AGENTS_CONFIG, False),
+            ("legacy_alias_structured_enabled", legacy_enabled, True),
+            ("legacy_alias_without_backend_or_defaults", no_backend_or_defaults, None),
+        )
+
+        for name, original, expected_v2_enabled in cases:
+            with self.subTest(name=name), tempfile.TemporaryDirectory() as tmpdir:
+                tmp = Path(tmpdir)
+                config_path = tmp / "config.toml"
+                backup_path = tmp / "config.backup.toml"
+                catalog_path = tmp / "catalog.json"
+                original_bytes = original.encode()
+                expected = tomllib.loads(original)
+                config_path.write_bytes(original_bytes)
+
+                apply_overlay(
+                    config_path,
+                    backup_path,
+                    catalog_path,
+                    "http://127.0.0.1:9099",
+                )
+                apply_overlay(
+                    config_path,
+                    backup_path,
+                    catalog_path,
+                    "http://127.0.0.1:9099",
+                )
+
+                readback = tomllib.loads(config_path.read_text(encoding="utf-8"))
+                self.assertEqual(readback["agents"], expected["agents"])
+                self.assertEqual(backup_path.read_bytes(), original_bytes)
+                if expected_v2_enabled is None:
+                    self.assertNotIn("multi_agent_v2", readback["features"])
+                    self.assertNotIn("default_subagent_model", readback["agents"])
+                    self.assertNotIn("default_subagent_reasoning_effort", readback["agents"])
+                else:
+                    self.assertEqual(
+                        readback["features"]["multi_agent_v2"],
+                        expected["features"]["multi_agent_v2"],
+                    )
+                    self.assertIs(
+                        readback["features"]["multi_agent_v2"]["enabled"],
+                        expected_v2_enabled,
+                    )
+
+                restore_overlay(config_path, backup_path)
+                self.assertEqual(config_path.read_bytes(), original_bytes)
+
+    def test_successful_stable_beta_takeover_preserves_one_agents_tree_and_each_owner_restore(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path = tmp / "config.toml"
+            stable_backup_path = tmp / "stable.backup.toml"
+            beta_backup_path = tmp / "beta.backup.toml"
+            catalog_path = tmp / "catalog.json"
+            original = RUST_0_145_AGENTS_CONFIG.encode()
+            expected = tomllib.loads(RUST_0_145_AGENTS_CONFIG)
+            config_path.write_bytes(original)
+
+            apply_overlay(
+                config_path,
+                stable_backup_path,
+                catalog_path,
+                "http://127.0.0.1:9099",
+                owner="release",
+            )
+            stable_active = config_path.read_bytes()
+
+            apply_overlay(
+                config_path,
+                beta_backup_path,
+                catalog_path,
+                "http://127.0.0.1:9109",
+                owner="beta",
+                takeover=True,
+            )
+            apply_overlay(
+                config_path,
+                beta_backup_path,
+                catalog_path,
+                "http://127.0.0.1:9109",
+                owner="beta",
+            )
+
+            beta_text = config_path.read_text(encoding="utf-8")
+            beta_readback = tomllib.loads(beta_text)
+            self.assertEqual(beta_readback["agents"], expected["agents"])
+            self.assertEqual(
+                beta_readback["features"]["multi_agent_v2"],
+                expected["features"]["multi_agent_v2"],
+            )
+            self.assertEqual(beta_text.count("[agents]"), 1)
+            self.assertEqual(beta_text.count("[agents.researcher]"), 1)
+            self.assertEqual(beta_text.count("[agents.reviewer]"), 1)
+
+            status = restore_overlay(config_path, beta_backup_path, unified_history=True)
+            self.assertEqual(status, "restored_takeover_backup")
+            self.assertEqual(config_path.read_bytes(), stable_active)
+
+            restore_overlay(config_path, stable_backup_path)
+            self.assertEqual(config_path.read_bytes(), original)
+
+    def test_connect_without_agents_or_multi_agent_v2_does_not_invent_user_choices(self):
+        original = '[features]\nhooks = true\n'
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path = tmp / "config.toml"
+            backup_path = tmp / "config.backup.toml"
+            catalog_path = tmp / "catalog.json"
+            config_path.write_text(original, encoding="utf-8")
+
+            apply_overlay(
+                config_path,
+                backup_path,
+                catalog_path,
+                "http://127.0.0.1:9099",
+            )
+
+            readback = tomllib.loads(config_path.read_text(encoding="utf-8"))
+            self.assertNotIn("agents", readback)
+            self.assertNotIn("multi_agent_v2", readback["features"])
 
             restore_overlay(config_path, backup_path)
             self.assertEqual(config_path.read_text(encoding="utf-8"), original)

--- a/tests/test_config_overlay.py
+++ b/tests/test_config_overlay.py
@@ -1302,6 +1302,133 @@ class ConfigOverlayTests(unittest.TestCase):
             self.assertEqual(config_path.read_bytes(), original)
             self.assertFalse(backup_path.exists())
 
+    def test_context_guard_rejects_config_lock_namespace_collision_before_mutation(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path = tmp / "config.toml"
+            backup_path = tmp / "config.backup.toml"
+            state_path = config_path.with_name(f"{config_path.name}.lock")
+            catalog_path = self._official_budget_catalog(tmp)
+            original = b'model = "gpt-5.6-terra"\n'
+            config_path.write_bytes(original)
+
+            with self.assertRaisesRegex(ValueError, "lock namespace"):
+                set_context_guard(
+                    config_path,
+                    backup_path,
+                    state_path,
+                    enabled=True,
+                    catalog_path=catalog_path,
+                )
+
+            self.assertEqual(config_path.read_bytes(), original)
+            self.assertFalse(backup_path.exists())
+            self.assertFalse(state_path.exists())
+
+    def test_context_guard_rejects_every_managed_lock_namespace_collision(self):
+        collision_names = (
+            "config",
+            "backup",
+            "metadata",
+            "completion",
+            "lifecycle",
+            "config_lock",
+            "config_guard",
+            "backup_lock",
+            "backup_guard",
+            "metadata_lock",
+            "metadata_guard",
+            "completion_lock",
+            "completion_guard",
+            "lifecycle_lock",
+            "lifecycle_guard",
+        )
+        for collision_name in collision_names:
+            with self.subTest(collision=collision_name), tempfile.TemporaryDirectory() as tmpdir:
+                tmp = Path(tmpdir)
+                config_path = tmp / "config.toml"
+                backup_path = tmp / "config.backup.toml"
+                metadata_path = config_overlay.takeover_metadata_path(backup_path)
+                completion_path = config_overlay.takeover_completion_path(backup_path)
+                lifecycle_path = config_overlay.overlay_lifecycle_lock_target(config_path)
+                bases = {
+                    "config": config_path,
+                    "backup": backup_path,
+                    "metadata": metadata_path,
+                    "completion": completion_path,
+                    "lifecycle": lifecycle_path,
+                }
+                collision_paths = dict(bases)
+                for name, path in bases.items():
+                    lock_path = path.with_name(f"{path.name}.lock")
+                    collision_paths[f"{name}_lock"] = lock_path
+                    collision_paths[f"{name}_guard"] = lock_path.with_name(
+                        f"{lock_path.name}.guard"
+                    )
+                state_path = collision_paths[collision_name]
+                catalog_path = self._official_budget_catalog(tmp)
+                config_path.write_text(
+                    'model = "gpt-5.6-terra"\n',
+                    encoding="utf-8",
+                )
+                before = {
+                    path.name: path.read_bytes()
+                    for path in tmp.iterdir()
+                    if path.is_file()
+                }
+
+                with self.assertRaisesRegex(ValueError, "lock namespaces"):
+                    set_context_guard(
+                        config_path,
+                        backup_path,
+                        state_path,
+                        enabled=True,
+                        catalog_path=catalog_path,
+                    )
+
+                after = {
+                    path.name: path.read_bytes()
+                    for path in tmp.iterdir()
+                    if path.is_file()
+                }
+                self.assertEqual(after, before)
+
+    def test_apply_and_restore_reject_lock_namespace_collisions_before_mutation(self):
+        for operation in ("apply", "restore"):
+            with self.subTest(operation=operation), tempfile.TemporaryDirectory() as tmpdir:
+                tmp = Path(tmpdir)
+                config_path = tmp / "config.toml"
+                backup_path = config_path.with_name(f"{config_path.name}.lock")
+                original = RUST_0_145_AGENTS_CONFIG.encode()
+                config_path.write_bytes(original)
+                before = {
+                    path.name: path.read_bytes()
+                    for path in tmp.iterdir()
+                    if path.is_file()
+                }
+
+                with self.assertRaisesRegex(ValueError, "lock namespaces"):
+                    if operation == "apply":
+                        apply_overlay(
+                            config_path,
+                            backup_path,
+                            None,
+                            "http://127.0.0.1:9099",
+                        )
+                    else:
+                        restore_overlay(
+                            config_path,
+                            backup_path,
+                            unified_history=True,
+                        )
+
+                after = {
+                    path.name: path.read_bytes()
+                    for path in tmp.iterdir()
+                    if path.is_file()
+                }
+                self.assertEqual(after, before)
+
     def test_config_writers_serialize_across_processes_on_canonical_lifecycle_lock(self):
         for operation in ("apply", "restore", "context_guard"):
             with self.subTest(operation=operation), tempfile.TemporaryDirectory() as tmpdir:
@@ -1611,6 +1738,42 @@ class ConfigOverlayTests(unittest.TestCase):
             self.assertEqual(config_path.read_bytes(), stable_active)
             self.assertFalse(metadata_path.exists())
 
+    def test_interrupted_takeover_retry_survives_ambiguous_terminal_sidecar_deletion(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path, backup_path, _, stable_active = (
+                self._stable_with_interrupted_beta_takeover(tmp)
+            )
+            metadata_path = config_overlay.takeover_metadata_path(backup_path)
+            completion_path = config_overlay.takeover_completion_path(backup_path)
+            real_unlink = Path.unlink
+
+            def delete_sidecar_then_fail(
+                path: Path,
+                *args: object,
+                **kwargs: object,
+            ) -> None:
+                real_unlink(path, *args, **kwargs)
+                if path == metadata_path:
+                    raise OSError("simulated ambiguous interrupted sidecar deletion")
+
+            with patch.object(Path, "unlink", delete_sidecar_then_fail):
+                with self.assertRaisesRegex(
+                    OSError,
+                    "ambiguous interrupted sidecar deletion",
+                ):
+                    restore_overlay(config_path, backup_path, unified_history=True)
+
+            self.assertEqual(config_path.read_bytes(), stable_active)
+            self.assertFalse(backup_path.exists())
+            self.assertFalse(metadata_path.exists())
+            self.assertTrue(completion_path.exists())
+
+            status = restore_overlay(config_path, backup_path, unified_history=True)
+
+            self.assertEqual(status, "interrupted_takeover_discarded")
+            self.assertEqual(config_path.read_bytes(), stable_active)
+
     def test_interrupted_takeover_backup_delete_failure_retains_artifacts_for_retry(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             tmp = Path(tmpdir)
@@ -1718,6 +1881,150 @@ class ConfigOverlayTests(unittest.TestCase):
             self.assertEqual(status, "restored_takeover_backup")
             self.assertEqual(config_path.read_bytes(), stable_active)
             self.assertFalse(metadata_path.exists())
+
+    def test_owned_takeover_retry_survives_ambiguous_terminal_sidecar_deletion(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path = tmp / "config.toml"
+            stable_backup_path = tmp / "stable.backup.toml"
+            beta_backup_path = tmp / "beta.backup.toml"
+            config_path.write_text(RUST_0_145_AGENTS_CONFIG, encoding="utf-8")
+            apply_overlay(
+                config_path,
+                stable_backup_path,
+                None,
+                "http://127.0.0.1:9099",
+                owner="release",
+            )
+            stable_active = config_path.read_bytes()
+            apply_overlay(
+                config_path,
+                beta_backup_path,
+                None,
+                "http://127.0.0.1:9109",
+                owner="beta",
+                takeover=True,
+            )
+            metadata_path = config_overlay.takeover_metadata_path(beta_backup_path)
+            real_unlink = Path.unlink
+
+            def delete_sidecar_then_fail(
+                path: Path,
+                *args: object,
+                **kwargs: object,
+            ) -> None:
+                real_unlink(path, *args, **kwargs)
+                if path == metadata_path:
+                    raise OSError("simulated ambiguous owned sidecar deletion")
+
+            with patch.object(Path, "unlink", delete_sidecar_then_fail):
+                with self.assertRaisesRegex(OSError, "ambiguous owned sidecar deletion"):
+                    restore_overlay(config_path, beta_backup_path, unified_history=True)
+
+            self.assertEqual(config_path.read_bytes(), stable_active)
+            self.assertFalse(beta_backup_path.exists())
+            self.assertFalse(metadata_path.exists())
+
+            status = restore_overlay(
+                config_path,
+                beta_backup_path,
+                unified_history=True,
+            )
+
+            self.assertEqual(status, "restored_takeover_backup")
+            self.assertEqual(config_path.read_bytes(), stable_active)
+
+    def test_owned_takeover_fresh_process_recovers_after_terminal_sidecar_crash(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path = tmp / "config.toml"
+            stable_backup_path = tmp / "stable.backup.toml"
+            beta_backup_path = tmp / "beta.backup.toml"
+            config_path.write_text(RUST_0_145_AGENTS_CONFIG, encoding="utf-8")
+            apply_overlay(
+                config_path,
+                stable_backup_path,
+                None,
+                "http://127.0.0.1:9099",
+                owner="release",
+            )
+            stable_active = config_path.read_bytes()
+            apply_overlay(
+                config_path,
+                beta_backup_path,
+                None,
+                "http://127.0.0.1:9109",
+                owner="beta",
+                takeover=True,
+            )
+            metadata_path = config_overlay.takeover_metadata_path(beta_backup_path)
+            completion_path = config_overlay.takeover_completion_path(beta_backup_path)
+            crash_script = "\n".join(
+                [
+                    "import os",
+                    "import sys",
+                    "from pathlib import Path",
+                    "import config_overlay",
+                    "config_path = Path(sys.argv[1])",
+                    "backup_path = Path(sys.argv[2])",
+                    "metadata_path = config_overlay.takeover_metadata_path(backup_path)",
+                    "real_unlink = Path.unlink",
+                    "def crash_after_sidecar_delete(path, *args, **kwargs):",
+                    "    real_unlink(path, *args, **kwargs)",
+                    "    if path == metadata_path:",
+                    "        os._exit(73)",
+                    "Path.unlink = crash_after_sidecar_delete",
+                    "config_overlay.restore_overlay(",
+                    "    config_path, backup_path, unified_history=True",
+                    ")",
+                ]
+            )
+
+            crashed = subprocess.run(
+                [
+                    sys.executable,
+                    "-c",
+                    crash_script,
+                    str(config_path),
+                    str(beta_backup_path),
+                ],
+                capture_output=True,
+                text=True,
+                env=self._subprocess_env(),
+                timeout=15,
+                check=False,
+            )
+
+            self.assertEqual(crashed.returncode, 73, crashed.stderr)
+            self.assertEqual(config_path.read_bytes(), stable_active)
+            self.assertFalse(beta_backup_path.exists())
+            self.assertFalse(metadata_path.exists())
+            self.assertTrue(completion_path.exists())
+
+            recovered = subprocess.run(
+                [
+                    sys.executable,
+                    str(Path(config_overlay.__file__)),
+                    "restore",
+                    "--config",
+                    str(config_path),
+                    "--backup",
+                    str(beta_backup_path),
+                    "--unified-history",
+                ],
+                capture_output=True,
+                text=True,
+                env=self._subprocess_env(),
+                timeout=15,
+                check=False,
+            )
+
+            self.assertEqual(recovered.returncode, 0, recovered.stderr)
+            self.assertIn(
+                "unified_history=restored_takeover_backup",
+                recovered.stdout,
+            )
+            self.assertEqual(config_path.read_bytes(), stable_active)
 
     def test_unowned_unified_takeover_journal_write_failure_preserves_recovery_chain(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -1845,6 +2152,48 @@ class ConfigOverlayTests(unittest.TestCase):
             self.assertFalse(backup_path.exists())
             self.assertFalse(metadata_path.exists())
 
+    def test_completion_receipt_publication_failures_resume_before_recovery_deletion(self):
+        for ambiguous in (False, True):
+            with self.subTest(ambiguous=ambiguous), tempfile.TemporaryDirectory() as tmpdir:
+                tmp = Path(tmpdir)
+                config_path, backup_path, original, _, metadata_path = (
+                    self._unowned_with_active_beta_takeover(tmp)
+                )
+                completion_path = config_overlay.takeover_completion_path(backup_path)
+                real_atomic_write = config_overlay.atomic_write_text
+
+                def fail_completion_publication(
+                    path: Path,
+                    text: str,
+                    *,
+                    encoding: str = "utf-8",
+                ) -> None:
+                    if path == completion_path:
+                        if ambiguous:
+                            real_atomic_write(path, text, encoding=encoding)
+                        raise OSError("simulated completion receipt publication failure")
+                    real_atomic_write(path, text, encoding=encoding)
+
+                with patch("config_overlay.atomic_write_text", fail_completion_publication):
+                    with self.assertRaisesRegex(
+                        OSError,
+                        "completion receipt publication failure",
+                    ):
+                        restore_overlay(config_path, backup_path, unified_history=True)
+
+                self.assertEqual(backup_path.read_bytes(), original)
+                self.assertTrue(metadata_path.exists())
+                self.assertEqual(completion_path.exists(), ambiguous)
+
+                published = config_path.read_bytes()
+                status = restore_overlay(config_path, backup_path, unified_history=True)
+
+                self.assertEqual(status, "injected")
+                self.assertEqual(config_path.read_bytes(), published)
+                self.assertFalse(backup_path.exists())
+                self.assertFalse(metadata_path.exists())
+                self.assertTrue(completion_path.exists())
+
     def test_unowned_unified_takeover_backup_delete_failure_resumes_published_final(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             tmp = Path(tmpdir)
@@ -1959,8 +2308,11 @@ class ConfigOverlayTests(unittest.TestCase):
 
             status = restore_overlay(config_path, backup_path, unified_history=True)
 
-            self.assertEqual(status, "already_unified")
+            self.assertEqual(status, "injected")
             self.assertEqual(config_path.read_bytes(), published)
+            self.assertTrue(
+                config_overlay.takeover_completion_path(backup_path).exists()
+            )
 
     def test_apply_and_context_guard_reject_invalid_takeover_metadata_without_mutation(self):
         for operation in ("apply", "context_guard"):
@@ -1997,6 +2349,671 @@ class ConfigOverlayTests(unittest.TestCase):
                 self.assertEqual(backup_path.read_bytes(), original)
                 self.assertEqual(metadata_path.read_bytes(), invalid_metadata)
                 self.assertFalse(state_path.exists())
+
+    def test_all_managed_operations_reject_invalid_completion_receipt_without_mutation(self):
+        for operation in ("apply", "context_guard", "restore"):
+            with self.subTest(operation=operation), tempfile.TemporaryDirectory() as tmpdir:
+                tmp = Path(tmpdir)
+                config_path, backup_path, _, _, _ = (
+                    self._unowned_with_active_beta_takeover(tmp)
+                )
+                self.assertEqual(
+                    restore_overlay(config_path, backup_path, unified_history=True),
+                    "injected",
+                )
+                completion_path = config_overlay.takeover_completion_path(backup_path)
+                invalid_receipt = b'{"version":2,"future_state":"unknown"}\n'
+                completion_path.write_bytes(invalid_receipt)
+                config_before = config_path.read_bytes()
+                state_path = tmp / "context-guard-state.json"
+                catalog_path = self._official_budget_catalog(tmp)
+
+                with self.assertRaisesRegex(RuntimeError, "completion is invalid"):
+                    if operation == "apply":
+                        apply_overlay(
+                            config_path,
+                            backup_path,
+                            catalog_path,
+                            "http://127.0.0.1:9109",
+                            owner="beta",
+                            takeover=True,
+                        )
+                    elif operation == "context_guard":
+                        set_context_guard(
+                            config_path,
+                            backup_path,
+                            state_path,
+                            enabled=True,
+                            catalog_path=catalog_path,
+                        )
+                    else:
+                        restore_overlay(
+                            config_path,
+                            backup_path,
+                            unified_history=True,
+                        )
+
+                self.assertEqual(config_path.read_bytes(), config_before)
+                self.assertFalse(backup_path.exists())
+                self.assertEqual(completion_path.read_bytes(), invalid_receipt)
+                self.assertFalse(state_path.exists())
+
+    def test_legacy_malformed_or_future_completion_receipts_fail_closed(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path, backup_path, _, _, _ = (
+                self._unowned_with_active_beta_takeover(tmp)
+            )
+            self.assertEqual(
+                restore_overlay(config_path, backup_path, unified_history=True),
+                "injected",
+            )
+            completion_path = config_overlay.takeover_completion_path(backup_path)
+            valid = json.loads(completion_path.read_text(encoding="utf-8"))
+
+            def changed(**updates: object) -> str:
+                payload = dict(valid)
+                payload.update(updates)
+                return json.dumps(payload, sort_keys=True)
+
+            invalid_payloads = {
+                "truncated": "{",
+                "non_object": "[]",
+                "legacy_missing_terminal_fields": json.dumps(
+                    {
+                        "version": 1,
+                        "takeover_owner": "beta",
+                        "original_owner": None,
+                    }
+                ),
+                "future_version": changed(version=2),
+                "boolean_version": changed(version=True),
+                "duplicate_version": (
+                    '{"version":2,"version":1,"takeover_owner":"beta",'
+                    f'"original_owner":null,"final_sha256":"{valid["final_sha256"]}",'
+                    '"status":"injected"}'
+                ),
+                "duplicate_owner": (
+                    '{"version":1,"takeover_owner":"release",'
+                    '"takeover_owner":"beta","original_owner":null,'
+                    f'"final_sha256":"{valid["final_sha256"]}","status":"injected"}}'
+                ),
+                "same_owner": changed(original_owner="beta"),
+                "unknown_owner": changed(takeover_owner="future-owner"),
+                "non_scalar_owner": changed(takeover_owner=[]),
+                "unknown_field": json.dumps(
+                    {**valid, "future_field": True},
+                    sort_keys=True,
+                ),
+                "missing_status": json.dumps(
+                    {key: value for key, value in valid.items() if key != "status"},
+                    sort_keys=True,
+                ),
+                "malformed_digest": changed(final_sha256="not-a-digest"),
+                "uppercase_digest": changed(final_sha256="A" * 64),
+                "malformed_same_owner_backup_digest": changed(
+                    same_owner_backup_sha256="not-a-digest"
+                ),
+                "unknown_status": changed(status="future_status"),
+                "non_string_status": changed(status=[]),
+            }
+            completed = config_path.read_bytes()
+
+            for name, payload in invalid_payloads.items():
+                with self.subTest(name=name):
+                    completion_path.write_text(payload, encoding="utf-8")
+                    receipt_before = completion_path.read_bytes()
+
+                    with self.assertRaisesRegex(
+                        RuntimeError,
+                        "takeover completion is invalid",
+                    ):
+                        restore_overlay(
+                            config_path,
+                            backup_path,
+                            unified_history=True,
+                        )
+
+                    self.assertEqual(config_path.read_bytes(), completed)
+                    self.assertFalse(backup_path.exists())
+                    self.assertEqual(completion_path.read_bytes(), receipt_before)
+
+    def test_completion_receipt_is_bounded_and_contains_no_config_content(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path = tmp / "config.toml"
+            backup_path = tmp / "beta.backup.toml"
+            catalog_path = self._official_budget_catalog(tmp)
+            sensitive_marker = "receipt-must-never-copy-this-config-content"
+            gateway_key = "receipt-must-never-copy-this-gateway-key"
+            config_path.write_text(
+                'model = "gpt-5.6-terra"\n'
+                f'custom_user_value = "{sensitive_marker}"\n',
+                encoding="utf-8",
+            )
+            apply_overlay(
+                config_path,
+                backup_path,
+                catalog_path,
+                "http://127.0.0.1:9109",
+                owner="beta",
+                takeover=True,
+                gateway_key=gateway_key,
+            )
+
+            self.assertEqual(
+                restore_overlay(config_path, backup_path, unified_history=True),
+                "injected",
+            )
+
+            completion_path = config_overlay.takeover_completion_path(backup_path)
+            raw_receipt = completion_path.read_text(encoding="utf-8")
+            receipt = json.loads(raw_receipt)
+            self.assertEqual(
+                set(receipt),
+                {
+                    "version",
+                    "takeover_owner",
+                    "original_owner",
+                    "final_sha256",
+                    "same_owner_backup_sha256",
+                    "status",
+                },
+            )
+            self.assertLess(len(raw_receipt.encode("utf-8")), 384)
+            self.assertNotIn(sensitive_marker, raw_receipt)
+            self.assertNotIn(gateway_key, raw_receipt)
+            self.assertNotIn("custom_user_value", raw_receipt)
+
+    def test_context_guard_rebases_completed_receipt_for_later_restore_retry(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path = tmp / "config.toml"
+            backup_path = tmp / "beta.backup.toml"
+            state_path = tmp / "context-guard-state.json"
+            catalog_path = self._official_budget_catalog(tmp)
+            config_path.write_text(
+                RUST_0_145_AGENTS_CONFIG.replace(
+                    'model = "ollama-cloud/glm-5.2"',
+                    'model = "gpt-5.6-terra"',
+                ),
+                encoding="utf-8",
+            )
+            apply_overlay(
+                config_path,
+                backup_path,
+                catalog_path,
+                "http://127.0.0.1:9109",
+                owner="beta",
+                takeover=True,
+            )
+            self.assertEqual(
+                restore_overlay(config_path, backup_path, unified_history=True),
+                "injected",
+            )
+            completion_path = config_overlay.takeover_completion_path(backup_path)
+            completion_before = completion_path.read_bytes()
+
+            status = set_context_guard(
+                config_path,
+                backup_path,
+                state_path,
+                enabled=True,
+                catalog_path=catalog_path,
+            )
+            guarded = config_path.read_bytes()
+
+            self.assertTrue(status["enabled"])
+            self.assertNotEqual(completion_path.read_bytes(), completion_before)
+            self.assertEqual(
+                restore_overlay(config_path, backup_path, unified_history=True),
+                "injected",
+            )
+            self.assertEqual(config_path.read_bytes(), guarded)
+
+    def test_later_apply_staging_failure_rotates_back_to_completed_receipt(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path, backup_path, _, _, _ = (
+                self._unowned_with_active_beta_takeover(tmp)
+            )
+            self.assertEqual(
+                restore_overlay(config_path, backup_path, unified_history=True),
+                "injected",
+            )
+            completed = config_path.read_bytes()
+            metadata_path = config_overlay.takeover_metadata_path(backup_path)
+            real_atomic_write = config_overlay.atomic_write_text
+
+            def fail_new_takeover_metadata(
+                path: Path,
+                text: str,
+                *,
+                encoding: str = "utf-8",
+            ) -> None:
+                if path == metadata_path:
+                    raise OSError("simulated later takeover metadata failure")
+                real_atomic_write(path, text, encoding=encoding)
+
+            with patch("config_overlay.atomic_write_text", fail_new_takeover_metadata):
+                with self.assertRaisesRegex(OSError, "later takeover metadata failure"):
+                    apply_overlay(
+                        config_path,
+                        backup_path,
+                        None,
+                        "http://127.0.0.1:9109",
+                        owner="beta",
+                        takeover=True,
+                    )
+
+            self.assertEqual(config_path.read_bytes(), completed)
+            self.assertEqual(backup_path.read_bytes(), completed)
+            self.assertFalse(metadata_path.exists())
+
+            status = restore_overlay(config_path, backup_path, unified_history=True)
+
+            self.assertEqual(status, "injected")
+            self.assertEqual(config_path.read_bytes(), completed)
+            self.assertFalse(backup_path.exists())
+
+    def test_later_same_owner_apply_crash_keeps_completed_owner_active(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path = tmp / "config.toml"
+            release_backup_path = tmp / "release.backup.toml"
+            channel_backup_path = tmp / "channel.backup.toml"
+            config_path.write_text("", encoding="utf-8")
+            apply_overlay(
+                config_path,
+                release_backup_path,
+                None,
+                "http://127.0.0.1:9099",
+                owner="release",
+            )
+            apply_overlay(
+                config_path,
+                channel_backup_path,
+                None,
+                "http://127.0.0.1:9109",
+                owner="beta",
+                takeover=True,
+            )
+            self.assertEqual(
+                restore_overlay(
+                    config_path,
+                    channel_backup_path,
+                    unified_history=True,
+                ),
+                "restored_takeover_backup",
+            )
+            completed = config_path.read_bytes()
+            completion_path = config_overlay.takeover_completion_path(
+                channel_backup_path
+            )
+            real_atomic_write = config_overlay.atomic_write_text
+
+            def fail_later_live_publication(
+                path: Path,
+                text: str,
+                *,
+                encoding: str = "utf-8",
+            ) -> None:
+                if path == config_path:
+                    raise OSError("simulated later same-owner apply crash")
+                real_atomic_write(path, text, encoding=encoding)
+
+            with patch(
+                "config_overlay.atomic_write_text",
+                fail_later_live_publication,
+            ):
+                with self.assertRaisesRegex(OSError, "same-owner apply crash"):
+                    apply_overlay(
+                        config_path,
+                        channel_backup_path,
+                        None,
+                        "http://127.0.0.1:9099",
+                        owner="release",
+                    )
+
+            self.assertEqual(config_path.read_bytes(), completed)
+            self.assertTrue(channel_backup_path.exists())
+            self.assertNotEqual(channel_backup_path.read_bytes(), completed)
+            self.assertTrue(completion_path.exists())
+
+            self.assertEqual(
+                restore_overlay(
+                    config_path,
+                    channel_backup_path,
+                    unified_history=True,
+                ),
+                "restored_takeover_backup",
+            )
+            self.assertEqual(config_path.read_bytes(), completed)
+            self.assertFalse(channel_backup_path.exists())
+            self.assertTrue(completion_path.exists())
+
+    def test_later_apply_rotates_completion_receipt_across_owner_and_provider_cases(self):
+        cases = (
+            ("same_owner", "", "beta", False, "injected"),
+            ("different_owner", "", "release", False, "injected"),
+            (
+                "official_direct",
+                'model_provider = "openai"\n',
+                "beta",
+                False,
+                "injected",
+            ),
+            (
+                "no_op_explicit_provider",
+                'model_provider = "azure"\n',
+                "beta",
+                False,
+                "explicit_model_provider",
+            ),
+            ("different_owner_takeover", "", "release", True, "injected"),
+        )
+        for name, original, later_owner, takeover, initial_status in cases:
+            with self.subTest(name=name), tempfile.TemporaryDirectory() as tmpdir:
+                tmp = Path(tmpdir)
+                config_path = tmp / "config.toml"
+                backup_path = tmp / "channel.backup.toml"
+                config_path.write_text(original, encoding="utf-8")
+                apply_overlay(
+                    config_path,
+                    backup_path,
+                    None,
+                    "http://127.0.0.1:9109",
+                    owner="beta",
+                    takeover=True,
+                )
+                self.assertEqual(
+                    restore_overlay(
+                        config_path,
+                        backup_path,
+                        unified_history=True,
+                    ),
+                    initial_status,
+                )
+                completion_path = config_overlay.takeover_completion_path(backup_path)
+                completed = config_path.read_bytes()
+                self.assertTrue(completion_path.exists())
+
+                apply_overlay(
+                    config_path,
+                    backup_path,
+                    None,
+                    "http://127.0.0.1:9099",
+                    owner=later_owner,
+                    takeover=takeover,
+                )
+
+                self.assertTrue(backup_path.exists())
+                self.assertFalse(
+                    completion_path.exists(),
+                    "a successful later apply retained a stale completion generation",
+                )
+
+                restore_overlay(config_path, backup_path, unified_history=True)
+                restored = config_path.read_bytes()
+                self.assertEqual(restored, completed)
+
+                restore_overlay(config_path, backup_path, unified_history=True)
+                self.assertEqual(config_path.read_bytes(), restored)
+
+    def test_later_apply_receipt_retirement_is_ordered_after_durable_recovery(self):
+        cases = (
+            ("normal_apply", "beta", False),
+            ("takeover_apply", "release", True),
+        )
+        for name, later_owner, takeover in cases:
+            for commit_point in ("before_unlink", "after_unlink"):
+                with (
+                    self.subTest(name=name, commit_point=commit_point),
+                    tempfile.TemporaryDirectory() as tmpdir,
+                ):
+                    self._assert_later_apply_receipt_retirement_prefix(
+                        Path(tmpdir),
+                        later_owner=later_owner,
+                        takeover=takeover,
+                        commit_point=commit_point,
+                    )
+
+    def _assert_later_apply_receipt_retirement_prefix(
+        self,
+        tmp: Path,
+        *,
+        later_owner: str,
+        takeover: bool,
+        commit_point: str,
+    ) -> None:
+        config_path = tmp / "config.toml"
+        backup_path = tmp / "beta.backup.toml"
+        config_path.write_text("", encoding="utf-8")
+        apply_overlay(
+            config_path,
+            backup_path,
+            None,
+            "http://127.0.0.1:9109",
+            owner="beta",
+            takeover=True,
+        )
+        self.assertEqual(
+            restore_overlay(
+                config_path,
+                backup_path,
+                unified_history=True,
+            ),
+            "injected",
+        )
+        completed = config_path.read_bytes()
+        completion_path = config_overlay.takeover_completion_path(backup_path)
+        real_unlink = Path.unlink
+
+        def fail_receipt_retirement(
+            path: Path,
+            *args: object,
+            **kwargs: object,
+        ) -> None:
+            if path == completion_path:
+                self.assertTrue(backup_path.exists())
+                self.assertEqual(
+                    config_overlay.overlay_owner(
+                        config_path.read_text(encoding="utf-8")
+                    ),
+                    later_owner,
+                )
+                metadata_read = config_overlay.read_takeover_metadata(backup_path)
+                if takeover:
+                    self.assertIsNotNone(metadata_read.metadata)
+                    self.assertEqual(
+                        metadata_read.metadata.takeover_owner,
+                        later_owner,
+                    )
+                else:
+                    self.assertIsNone(metadata_read.metadata)
+                if commit_point == "after_unlink":
+                    real_unlink(path, *args, **kwargs)
+                raise OSError(f"simulated {commit_point} receipt retirement")
+            real_unlink(path, *args, **kwargs)
+
+        with patch.object(Path, "unlink", fail_receipt_retirement):
+            with self.assertRaisesRegex(
+                OSError,
+                f"{commit_point} receipt retirement",
+            ):
+                apply_overlay(
+                    config_path,
+                    backup_path,
+                    None,
+                    "http://127.0.0.1:9109",
+                    owner=later_owner,
+                    takeover=takeover,
+                )
+
+        self.assertTrue(backup_path.exists())
+        self.assertEqual(backup_path.read_bytes(), completed)
+        self.assertEqual(
+            config_overlay.overlay_owner(
+                config_path.read_text(encoding="utf-8")
+            ),
+            later_owner,
+        )
+
+        restore_overlay(config_path, backup_path, unified_history=True)
+        recovered = config_path.read_bytes()
+        self.assertEqual(recovered, completed)
+        self.assertFalse(backup_path.exists())
+        self.assertEqual(completion_path.exists(), takeover)
+
+        restore_overlay(config_path, backup_path, unified_history=True)
+        self.assertEqual(config_path.read_bytes(), recovered)
+
+    def test_completion_receipt_does_not_authorize_unrelated_later_artifacts(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path = tmp / "config.toml"
+            backup_path = tmp / "beta.backup.toml"
+            config_path.write_text("", encoding="utf-8")
+            apply_overlay(
+                config_path,
+                backup_path,
+                None,
+                "http://127.0.0.1:9109",
+                owner="beta",
+                takeover=True,
+            )
+            self.assertEqual(
+                restore_overlay(config_path, backup_path, unified_history=True),
+                "injected",
+            )
+            completion_path = config_overlay.takeover_completion_path(backup_path)
+            unrelated_live = (
+                f"{MARKER_BEGIN}\n# owner = release\n"
+                f"{config_overlay.MARKER_END}\n"
+            ).encode()
+            unrelated_backup = (
+                f"{MARKER_BEGIN}\n# owner = beta\n"
+                f"{config_overlay.MARKER_END}\n"
+            ).encode()
+            config_path.write_bytes(unrelated_live)
+            backup_path.write_bytes(unrelated_backup)
+            receipt_before = completion_path.read_bytes()
+
+            with self.assertRaisesRegex(RuntimeError, "completion.*inconsistent"):
+                restore_overlay(config_path, backup_path, unified_history=True)
+
+            self.assertEqual(config_path.read_bytes(), unrelated_live)
+            self.assertEqual(backup_path.read_bytes(), unrelated_backup)
+            self.assertEqual(completion_path.read_bytes(), receipt_before)
+
+    def test_active_takeover_stale_receipt_rejects_diverged_recovery(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path = tmp / "config.toml"
+            backup_path = tmp / "channel.backup.toml"
+            config_path.write_text("", encoding="utf-8")
+            apply_overlay(
+                config_path,
+                backup_path,
+                None,
+                "http://127.0.0.1:9109",
+                owner="beta",
+                takeover=True,
+            )
+            self.assertEqual(
+                restore_overlay(config_path, backup_path, unified_history=True),
+                "injected",
+            )
+            completion_path = config_overlay.takeover_completion_path(backup_path)
+            real_unlink = Path.unlink
+
+            def fail_receipt_retirement(
+                path: Path,
+                *args: object,
+                **kwargs: object,
+            ) -> None:
+                if path == completion_path:
+                    raise OSError("simulated retained stale receipt")
+                real_unlink(path, *args, **kwargs)
+
+            with patch.object(Path, "unlink", fail_receipt_retirement):
+                with self.assertRaisesRegex(OSError, "retained stale receipt"):
+                    apply_overlay(
+                        config_path,
+                        backup_path,
+                        None,
+                        "http://127.0.0.1:9099",
+                        owner="release",
+                        takeover=True,
+                    )
+
+            backup_path.write_text(
+                backup_path.read_text(encoding="utf-8")
+                + "# unrelated recovery bytes\n",
+                encoding="utf-8",
+            )
+            live_before = config_path.read_bytes()
+            backup_before = backup_path.read_bytes()
+            metadata_path = config_overlay.takeover_metadata_path(backup_path)
+            metadata_before = metadata_path.read_bytes()
+            receipt_before = completion_path.read_bytes()
+
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "completion recovery is inconsistent",
+            ):
+                restore_overlay(config_path, backup_path, unified_history=True)
+
+            self.assertEqual(config_path.read_bytes(), live_before)
+            self.assertEqual(backup_path.read_bytes(), backup_before)
+            self.assertEqual(metadata_path.read_bytes(), metadata_before)
+            self.assertEqual(completion_path.read_bytes(), receipt_before)
+
+    def test_owned_completion_rejects_unowned_transformation_status(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path = tmp / "config.toml"
+            stable_backup_path = tmp / "stable.backup.toml"
+            beta_backup_path = tmp / "beta.backup.toml"
+            config_path.write_text(RUST_0_145_AGENTS_CONFIG, encoding="utf-8")
+            apply_overlay(
+                config_path,
+                stable_backup_path,
+                None,
+                "http://127.0.0.1:9099",
+                owner="release",
+            )
+            apply_overlay(
+                config_path,
+                beta_backup_path,
+                None,
+                "http://127.0.0.1:9109",
+                owner="beta",
+                takeover=True,
+            )
+            self.assertEqual(
+                restore_overlay(config_path, beta_backup_path, unified_history=True),
+                "restored_takeover_backup",
+            )
+            completion_path = config_overlay.takeover_completion_path(beta_backup_path)
+            receipt = json.loads(completion_path.read_text(encoding="utf-8"))
+            receipt["status"] = "injected"
+            completion_path.write_text(
+                json.dumps(receipt, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+            config_before = config_path.read_bytes()
+            receipt_before = completion_path.read_bytes()
+
+            with self.assertRaisesRegex(RuntimeError, "completion is invalid"):
+                restore_overlay(
+                    config_path,
+                    beta_backup_path,
+                    unified_history=True,
+                )
+
+            self.assertEqual(config_path.read_bytes(), config_before)
+            self.assertEqual(completion_path.read_bytes(), receipt_before)
 
     def test_new_managed_write_resumes_pending_cleanup_before_publication(self):
         for operation in ("apply", "context_guard"):

--- a/tests/test_config_overlay.py
+++ b/tests/test_config_overlay.py
@@ -3102,6 +3102,10 @@ class ConfigOverlayTests(unittest.TestCase):
             "cleanup_final_sha256": "2" * 64,
             "cleanup_status": "injected",
         }
+        valid_reanchor = {
+            **valid_active,
+            "reanchor_recovery_sha256": "2" * 64,
+        }
 
         def changed(payload: dict[str, object], **updates: object) -> str:
             candidate = dict(payload)
@@ -3170,6 +3174,33 @@ class ConfigOverlayTests(unittest.TestCase):
                 valid_journal,
                 cleanup_recovery_sha256="3" * 64,
             ),
+            "malformed_reanchor_digest": changed(
+                valid_reanchor,
+                reanchor_recovery_sha256="not-a-digest",
+            ),
+            "uppercase_reanchor_digest": changed(
+                valid_reanchor,
+                reanchor_recovery_sha256="A" * 64,
+            ),
+            "future_reanchor_version": changed(
+                valid_reanchor,
+                version=2,
+            ),
+            "unknown_reanchor_field": json.dumps(
+                {**valid_reanchor, "future_field": True},
+                sort_keys=True,
+            ),
+            "same_owner_reanchor": changed(
+                valid_reanchor,
+                original_owner="beta",
+            ),
+            "mixed_reanchor_and_cleanup_journals": json.dumps(
+                {
+                    **valid_journal,
+                    "reanchor_recovery_sha256": "3" * 64,
+                },
+                sort_keys=True,
+            ),
         }
         invalid_payloads.update(
             {
@@ -3184,6 +3215,10 @@ class ConfigOverlayTests(unittest.TestCase):
                             "cleanup_final_sha256",
                             "cleanup_status",
                         ),
+                    ),
+                    (
+                        valid_reanchor,
+                        ("reanchor_recovery_sha256",),
                     ),
                 )
                 for key in keys
@@ -3314,6 +3349,89 @@ class ConfigOverlayTests(unittest.TestCase):
             self.assertEqual(config_path.read_bytes(), live_before)
             self.assertEqual(backup_path.read_bytes(), backup_before)
             self.assertEqual(metadata_path.read_bytes(), metadata_before)
+
+    def test_context_guard_reanchor_journal_rejects_unknown_backup_drift(self):
+        original = RUST_0_145_AGENTS_CONFIG.replace(
+            'model = "ollama-cloud/glm-5.2"\n',
+            "",
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path = tmp / "config.toml"
+            stable_backup_path = tmp / "stable.backup.toml"
+            beta_backup_path = tmp / "beta.backup.toml"
+            metadata_path = config_overlay.takeover_metadata_path(beta_backup_path)
+            completion_path = config_overlay.takeover_completion_path(beta_backup_path)
+            state_path = tmp / "context-guard-state.json"
+            config_path.write_text(original, encoding="utf-8")
+            catalog_path = self._official_budget_catalog(tmp)
+            apply_overlay(
+                config_path,
+                stable_backup_path,
+                None,
+                "http://127.0.0.1:9099",
+                owner="release",
+            )
+            apply_overlay(
+                config_path,
+                beta_backup_path,
+                None,
+                "http://127.0.0.1:9109",
+                owner="beta",
+                takeover=True,
+            )
+            real_atomic_write = config_overlay.atomic_write_text
+
+            def stop_after_journal(
+                path: Path,
+                text: str,
+                *,
+                encoding: str = "utf-8",
+            ) -> None:
+                real_atomic_write(path, text, encoding=encoding)
+                if (
+                    path == metadata_path
+                    and '"reanchor_recovery_sha256"' in text
+                ):
+                    raise OSError("simulated durable re-anchor journal")
+
+            with patch("config_overlay.atomic_write_text", stop_after_journal):
+                with self.assertRaisesRegex(
+                    OSError,
+                    "durable re-anchor journal",
+                ):
+                    set_context_guard(
+                        config_path,
+                        beta_backup_path,
+                        state_path,
+                        enabled=True,
+                        catalog_path=catalog_path,
+                    )
+
+            beta_backup_path.write_bytes(
+                beta_backup_path.read_bytes() + b"# unknown recovery drift\n"
+            )
+            live_before = config_path.read_bytes()
+            backup_before = beta_backup_path.read_bytes()
+            metadata_before = metadata_path.read_bytes()
+            state_before = state_path.read_bytes()
+
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "recovery backup is missing or diverged",
+            ):
+                restore_overlay(
+                    config_path,
+                    beta_backup_path,
+                    unified_history=True,
+                )
+
+            self.assertEqual(config_path.read_bytes(), live_before)
+            self.assertEqual(beta_backup_path.read_bytes(), backup_before)
+            self.assertEqual(metadata_path.read_bytes(), metadata_before)
+            self.assertEqual(state_path.read_bytes(), state_before)
+            self.assertFalse(completion_path.exists())
 
     def test_interrupted_takeover_rejects_raw_newline_backup_drift(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -4604,6 +4722,331 @@ class ConfigOverlayTests(unittest.TestCase):
             self.assertNotIn("model_catalog_json", updated)
             self.assertNotIn("[model_providers.custom]", updated)
             self.assertIn("[features]", updated)
+
+    def test_context_guard_enable_during_active_takeover_preserves_restore_chain(self):
+        original = RUST_0_145_AGENTS_CONFIG.replace(
+            'model = "ollama-cloud/glm-5.2"\n',
+            "",
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path = tmp / "config.toml"
+            stable_backup_path = tmp / "stable.backup.toml"
+            beta_backup_path = tmp / "beta.backup.toml"
+            state_path = tmp / "context-guard-state.json"
+            config_path.write_text(original, encoding="utf-8")
+            catalog_path = self._official_budget_catalog(tmp)
+            expected_agents = tomllib.loads(original)["agents"]
+
+            apply_overlay(
+                config_path,
+                stable_backup_path,
+                None,
+                "http://127.0.0.1:9099",
+                owner="release",
+            )
+            apply_overlay(
+                config_path,
+                beta_backup_path,
+                None,
+                "http://127.0.0.1:9109",
+                owner="beta",
+                takeover=True,
+            )
+
+            enabled = set_context_guard(
+                config_path,
+                beta_backup_path,
+                state_path,
+                enabled=True,
+                catalog_path=catalog_path,
+            )
+            status = restore_overlay(
+                config_path,
+                beta_backup_path,
+                unified_history=True,
+            )
+            restored = config_path.read_text(encoding="utf-8")
+            readback = tomllib.loads(restored)
+
+            self.assertTrue(enabled["enabled"])
+            self.assertEqual(status, "restored_takeover_backup")
+            self.assertEqual(config_overlay.overlay_owner(restored), "release")
+            self.assertEqual(readback["model_context_window"], 272_000)
+            self.assertEqual(
+                readback["model_auto_compact_token_limit"],
+                240_000,
+            )
+            self.assertEqual(readback["agents"], expected_agents)
+
+    def test_context_guard_disable_during_active_takeover_preserves_restore_chain(self):
+        original = RUST_0_145_AGENTS_CONFIG.replace(
+            'model = "ollama-cloud/glm-5.2"\n',
+            "",
+        ).replace(
+            "future_scheduler =",
+            "# context-guard-must-preserve-this-comment\nfuture_scheduler =",
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path = tmp / "config.toml"
+            stable_backup_path = tmp / "stable.backup.toml"
+            beta_backup_path = tmp / "beta.backup.toml"
+            state_path = tmp / "context-guard-state.json"
+            config_path.write_text(original, encoding="utf-8")
+            catalog_path = self._official_budget_catalog(tmp)
+            expected_agents = tomllib.loads(original)["agents"]
+
+            apply_overlay(
+                config_path,
+                stable_backup_path,
+                None,
+                "http://127.0.0.1:9099",
+                owner="release",
+            )
+            apply_overlay(
+                config_path,
+                beta_backup_path,
+                None,
+                "http://127.0.0.1:9109",
+                owner="beta",
+                takeover=True,
+            )
+            set_context_guard(
+                config_path,
+                beta_backup_path,
+                state_path,
+                enabled=True,
+                catalog_path=catalog_path,
+            )
+
+            disabled = set_context_guard(
+                config_path,
+                beta_backup_path,
+                state_path,
+                enabled=False,
+            )
+            status = restore_overlay(
+                config_path,
+                beta_backup_path,
+                unified_history=True,
+            )
+            restored = config_path.read_text(encoding="utf-8")
+            readback = tomllib.loads(restored)
+
+            self.assertFalse(disabled["enabled"])
+            self.assertEqual(status, "restored_takeover_backup")
+            self.assertEqual(config_overlay.overlay_owner(restored), "release")
+            self.assertNotIn("model_context_window", readback)
+            self.assertNotIn("model_auto_compact_token_limit", readback)
+            self.assertEqual(readback["agents"], expected_agents)
+            self.assertEqual(
+                restored.count("# context-guard-must-preserve-this-comment"),
+                1,
+            )
+
+    def test_context_guard_active_takeover_crash_prefixes_resume_in_fresh_process(self):
+        original = RUST_0_145_AGENTS_CONFIG.replace(
+            'model = "ollama-cloud/glm-5.2"\n',
+            "",
+        )
+        boundaries = (
+            ("journal_before", "journal", False),
+            ("journal_after", "journal", True),
+            ("backup_before", "backup", False),
+            ("backup_after", "backup", True),
+            ("anchor_before", "anchor", False),
+            ("anchor_after", "anchor", True),
+        )
+
+        for enabled in (True, False):
+            for name, artifact, commit in boundaries:
+                with (
+                    self.subTest(enabled=enabled, boundary=name),
+                    tempfile.TemporaryDirectory() as tmpdir,
+                ):
+                    tmp = Path(tmpdir)
+                    config_path = tmp / "config.toml"
+                    stable_backup_path = tmp / "stable.backup.toml"
+                    beta_backup_path = tmp / "beta.backup.toml"
+                    metadata_path = config_overlay.takeover_metadata_path(
+                        beta_backup_path
+                    )
+                    state_path = tmp / "context-guard-state.json"
+                    config_path.write_text(original, encoding="utf-8")
+                    catalog_path = self._official_budget_catalog(tmp)
+                    apply_overlay(
+                        config_path,
+                        stable_backup_path,
+                        None,
+                        "http://127.0.0.1:9099",
+                        owner="release",
+                    )
+                    apply_overlay(
+                        config_path,
+                        beta_backup_path,
+                        None,
+                        "http://127.0.0.1:9109",
+                        owner="beta",
+                        takeover=True,
+                    )
+                    if not enabled:
+                        set_context_guard(
+                            config_path,
+                            beta_backup_path,
+                            state_path,
+                            enabled=True,
+                            catalog_path=catalog_path,
+                        )
+
+                    live_base = config_path.read_bytes()
+                    recovery_base = beta_backup_path.read_bytes()
+                    metadata_base = config_overlay.read_takeover_metadata(
+                        beta_backup_path
+                    ).metadata
+                    self.assertIsNotNone(metadata_base)
+                    real_atomic_write = config_overlay.atomic_write_text
+
+                    def fail_at_boundary(
+                        path: Path,
+                        text: str,
+                        *,
+                        encoding: str = "utf-8",
+                    ) -> None:
+                        is_journal = (
+                            path == metadata_path
+                            and '"reanchor_recovery_sha256"' in text
+                        )
+                        is_anchor = (
+                            path == metadata_path
+                            and '"reanchor_recovery_sha256"' not in text
+                        )
+                        matches = (
+                            (artifact == "journal" and is_journal)
+                            or (artifact == "backup" and path == beta_backup_path)
+                            or (artifact == "anchor" and is_anchor)
+                        )
+                        if matches and not commit:
+                            raise OSError(f"simulated {name}")
+                        real_atomic_write(path, text, encoding=encoding)
+                        if matches:
+                            raise OSError(f"simulated {name}")
+
+                    with patch("config_overlay.atomic_write_text", fail_at_boundary):
+                        with self.assertRaisesRegex(OSError, f"simulated {name}"):
+                            set_context_guard(
+                                config_path,
+                                beta_backup_path,
+                                state_path,
+                                enabled=enabled,
+                                catalog_path=catalog_path if enabled else None,
+                            )
+
+                    self.assertEqual(config_path.read_bytes(), live_base)
+                    durable_recovery = beta_backup_path.read_bytes()
+                    durable_metadata = config_overlay.read_takeover_metadata(
+                        beta_backup_path
+                    ).metadata
+                    self.assertIsNotNone(durable_metadata)
+                    if artifact in {"journal", "backup"} and not (
+                        artifact == "backup" and commit
+                    ):
+                        self.assertEqual(durable_recovery, recovery_base)
+                    else:
+                        self.assertNotEqual(durable_recovery, recovery_base)
+                    if artifact == "journal" and not commit:
+                        self.assertIsNone(
+                            durable_metadata.reanchor_recovery_sha256
+                        )
+                    elif artifact == "anchor" and commit:
+                        self.assertIsNone(
+                            durable_metadata.reanchor_recovery_sha256
+                        )
+                        self.assertEqual(
+                            durable_metadata.recovery_sha256,
+                            config_overlay.takeover_text_sha256(
+                                beta_backup_path.read_text(encoding="utf-8")
+                            ),
+                        )
+                    else:
+                        self.assertIsNotNone(
+                            durable_metadata.reanchor_recovery_sha256
+                        )
+                        raw_journal = metadata_path.read_text(encoding="utf-8")
+                        self.assertEqual(
+                            set(json.loads(raw_journal)),
+                            {
+                                "version",
+                                "takeover_owner",
+                                "original_owner",
+                                "recovery_sha256",
+                                "reanchor_recovery_sha256",
+                            },
+                        )
+                        self.assertLess(len(raw_journal.encode("utf-8")), 320)
+                        self.assertNotIn("researcher.toml", raw_journal)
+                        self.assertNotIn("team_tools", raw_journal)
+
+                    retry = subprocess.run(
+                        [
+                            sys.executable,
+                            "-m",
+                            "config_overlay",
+                            "context-guard-set",
+                            "--config",
+                            str(config_path),
+                            "--backup",
+                            str(beta_backup_path),
+                            "--state",
+                            str(state_path),
+                            "--catalog",
+                            str(catalog_path),
+                            "--enabled",
+                            str(enabled).lower(),
+                        ],
+                        capture_output=True,
+                        text=True,
+                        env=self._subprocess_env(),
+                        timeout=10,
+                    )
+
+                    self.assertEqual(retry.returncode, 0, retry.stderr)
+                    self.assertIs(
+                        json.loads(retry.stdout)["enabled"],
+                        enabled,
+                    )
+                    active = config_overlay.read_takeover_metadata(
+                        beta_backup_path
+                    ).metadata
+                    self.assertIsNotNone(active)
+                    self.assertIsNone(active.reanchor_recovery_sha256)
+                    self.assertEqual(
+                        active.recovery_sha256,
+                        config_overlay.takeover_text_sha256(
+                            beta_backup_path.read_text(encoding="utf-8")
+                        ),
+                    )
+                    self.assertEqual(
+                        restore_overlay(
+                            config_path,
+                            beta_backup_path,
+                            unified_history=True,
+                        ),
+                        "restored_takeover_backup",
+                    )
+                    restored = tomllib.loads(
+                        config_path.read_text(encoding="utf-8")
+                    )
+                    self.assertEqual(
+                        "model_context_window" in restored,
+                        enabled,
+                    )
+                    self.assertEqual(
+                        restored["agents"],
+                        tomllib.loads(original)["agents"],
+                    )
 
     def test_context_guard_updates_live_and_overlay_backup_then_restores_previous_values(self):
         original = "\n".join(


### PR DESCRIPTION
## Summary

- preserve rust-v0.145.0 `[agents]`, nested role/config-file values, concurrency aliases, defaults, unknown future values, and explicit/absent collaboration V2 choices throughout the overlay lifecycle
- serialize every production managed writer (`apply`, `restore`, and `context-guard-set`) under one canonical per-config cross-process lifecycle lock
- fail closed on invalid/unreadable/future/inconsistent takeover metadata or completion receipts and on missing, diverged, aliased, or unrecognized recovery state
- journal source/recovery/final digests before cleanup, then persist one bounded terminal receipt so retries remain idempotent after both recovery artifacts are gone

## Completion-receipt repair

Fixed the findings against `5e9e7e9416f4cecbeef421fc71e20542e2c1a5bf`:

- cleanup now publishes and reads back a versioned completion receipt before deleting the backup or journal; owned, unowned/unified, and interrupted retries survive sidecar deletion that committed before an error or process death was reported
- the receipt contains only owners, a fixed status, the completed SHA-256, and the exact same-owner staged-backup SHA-256; it is fixed-size and contains no config or credential text
- legacy, malformed, duplicate-key, future-version, unknown-field/owner/status, bad-digest, and owner/status-inconsistent receipts fail closed without mutation
- later context writes rebase the receipt under the lifecycle lock; later applies retire it only after durable live/recovery bytes and, for takeovers, durable ownership metadata
- crash-prefix coverage proves same-owner, different-owner, Direct Official, explicit-provider no-op, and second-restore behavior; unrelated or diverged artifacts cannot use a stale receipt as recovery authority
- path validation now includes the lifecycle target and every config/backup/metadata/receipt/state `.lock` and `.lock.guard` namespace before lock acquisition or mutation

## Preservation conclusions

CodexHub preserves user-authored `[agents]`, nested role `config_file` references, canonical `max_concurrent_threads_per_session`, retained `max_threads`, default subagent model/reasoning, inline or explicit-table structured `features.multi_agent_v2`, explicit enabled/disabled choices, and unknown future agent values. If `[agents]` or `multi_agent_v2` is absent, CodexHub does not create it or choose a role/model/reasoning/backend default.

## Verification

- `py -3.13 -m pytest -q tests/test_config_overlay.py` — 97 passed, 85 subtests passed in 41.05s
- `py -3.13 -m pytest -q --ignore=tests/test_real_client_e2e.py` — 1509 passed, 1 skipped, 495 subtests passed in 130.11s
- final completion/rotation delta after Python core — 12 passed, 85 deselected, 31 subtests passed in 13.13s
- `py -3.13 -m compileall -q src-python tests/test_config_overlay.py` — passed
- `git diff --check` — passed
- `py -3.13 scripts/report_quality_gates.py --json` — exit 0, parse_errors 0; repository baseline 2 unused imports, 83 dead-function reports, 146 duplicate-name reports; no changed-file finding
- local Standards/Spec self-review — no remaining actionable finding

The changed paths are outside the synthetic real-client relevance list in `docs/agents/verification-policy.md`.

## Risk

The cleanup journal and completion receipt contain only owner identifiers, fixed statuses, and SHA-256 digests; no configuration contents or credentials. Recovery artifacts are deleted only after exact live/recovery/final revalidation under the shared lifecycle lock. A receipt is retired only after a later durable recovery boundary exists. Missing, diverged, malformed, unknown, aliased, or lock-namespace-colliding state is retained or rejected before mutation.

Base SHA: `ae927c687390017903435cd9bf4314610b6da229`
First-review fixed point: `ed3e4afa642dd8ba2b806cdd990cf111444f961a`
Second-review fixed point: `c9a7a09cd7e88c640cf3d71fd69c862f23e3dd5f`
Completion-receipt review input: `5e9e7e9416f4cecbeef421fc71e20542e2c1a5bf`
Repaired head SHA: `b7b8e46595f924203a5bd9eb17d1acce81d66282`

Closes #199