### PR TITLE
Introduce immutable RoutePlan seam for Gateway routing

### DIFF
--- a/docs/evidence/issue-61/README.md
+++ b/docs/evidence/issue-61/README.md
@@ -2,7 +2,9 @@
 
 Risk class: `strict` (Gateway routing/protocol policy).
 
-Base: `origin/dev` at `ae927c687390017903435cd9bf4314610b6da229`.
+Base: `origin/dev` at `42b0c375d97bad025a8deed07c6a72068df2b97c`.
+
+Exact candidate head: `2e578bc10abf26084facc6b8009205ffd85801cb`.
 
 ## Architecture
 
@@ -100,6 +102,27 @@ Base: `origin/dev` at `ae927c687390017903435cd9bf4314610b6da229`.
   regression.
 
 ## Candidate verification
+
+### Exact-head verification (2026-08-01)
+
+- Focused routing/Gateway gate:
+  `py -3.13 -m pytest -q tests/test_routing.py
+  tests/test_chat_completions_gateway.py tests/test_proxy_event_logging.py`
+  — 712 passed, 233 subtests passed in 50.28 seconds.
+- Authoritative Python 3.13 core:
+  `py -3.13 -m pytest -q --ignore=tests/test_real_client_e2e.py`
+  — 1,527 passed, 1 skipped, 460 subtests passed in 124.21 seconds.
+- `py -3.13 -m py_compile src-python/codex_proxy.py tests/test_routing.py`
+  — passed.
+- `git diff --check` — passed (only the repository's CRLF normalization
+  warning was emitted).
+- `py -3.13 scripts/report_quality_gates.py --json` — report-only, exit 0:
+  2 unused imports, 84 dead functions, 152 duplicate names, 0 parse errors.
+  These findings remain non-blocking baseline reports; no new RoutePlan
+  finding was introduced.
+- Hosted CI run `30682449604` for this exact head passed `CI classifier`,
+  `Python core`, and `CI / gate`; the remaining jobs were correctly skipped
+  by the path classifier.
 
 - Third-review affected delta:
   `python -m pytest -q tests/test_routing.py tests/test_chat_completions_gateway.py tests/test_proxy_event_logging.py`

--- a/docs/evidence/issue-61/README.md
+++ b/docs/evidence/issue-61/README.md
@@ -28,6 +28,21 @@ Base: `origin/dev` at `ae927c687390017903435cd9bf4314610b6da229`.
   before upstream I/O.
   Existing request/response adapters, relay paths, retries, usage capture,
   Vision Proxy behavior, and official keepalive transport remain unchanged.
+- Each immutable `RouteAttemptPlan` now owns its endpoint URL, actual ordered
+  request-conversion steps, authentication/streaming/usage/transport/mutation
+  policies, tool protocol choices, cross-protocol verification choice, and a
+  frozen `RetryExecutionPlan`. Runtime settings are captured into
+  `RouteRuntimeFacts` before planning; the handler/open/relay execution path
+  consumes the attempt contract without re-reading routing or retry settings.
+- Planned telemetry is explicitly scoped as a `planned_union`, while selected
+  attempt telemetry reports the actual executed protocol, net wire adapter,
+  conversion chain, and mutations. In particular, a Chat caller on an `auto`
+  route truthfully records Chat-to-Responses for attempt 0 and
+  Chat-to-Responses followed by Responses-to-Chat for the fallback attempt.
+- Caller-tool stripping is a named `caller_tool_stripping` mutation. Optional
+  capability-manifest state now fails closed unless version and cryptographic
+  hash form a complete valid pair; only a valid pair with an explicit
+  `Supported` state is reported as supported.
 
 ## TDD and review
 
@@ -44,17 +59,28 @@ Base: `origin/dev` at `ae927c687390017903435cd9bf4314610b6da229`.
 
 ## Candidate verification
 
-- `python -m pytest -q tests/test_routing.py tests/test_chat_completions_gateway.py tests/test_proxy_event_logging.py`
-  — 693 passed, 213 subtests passed in 43.65 seconds after the repair review.
+- Third-review affected delta:
+  `python -m pytest -q tests/test_routing.py tests/test_chat_completions_gateway.py tests/test_proxy_event_logging.py`
+  — 701 passed, 226 subtests passed in 44.98 seconds with Python 3.13.
+  Coverage includes the attempt execution contract, actual Chat `auto` 404
+  fallback bodies/telemetry, manifest identity pairs, caller-tool stripping,
+  and handler-level Vision Proxy pass/proxy/reject/failure I/O behavior.
 - `python -m pytest -q --ignore=tests/test_real_client_e2e.py`
-  — 1,470 passed, 1 skipped, 438 subtests passed in 95.35 seconds with Python
+  — 1,477 passed, 1 skipped, 451 subtests passed in 100.23 seconds with Python
   3.13 first on `PATH` so nested PowerShell replay subprocesses use the
-  repository-required interpreter.
+  repository-required interpreter. An earlier run from the Python 3.13 parent
+  process but with ambient Python 3.11 first on `PATH` produced only two
+  issue-108 replay-smoke failures because the nested interpreter rejected
+  Python 3.13 syntax (1,475 passed, 1 skipped); that environment result is not
+  the candidate gate. Per the verification policy, the later repair delta
+  reran affected tests rather than duplicating the complete core suite.
 - A literal `python -m pytest` was attempted because the issue text names it,
   then terminated without a test result when the current verification policy
   guardrail identified the separately governed synthetic real-client
   partition. None of that partition's listed contract-surface paths changed,
   so it is not applicable to this PR.
+- `python -m py_compile src-python/codex_proxy.py tests/test_routing.py` —
+  passed.
 - `git diff --check` — passed (Git emitted only the repository's CRLF
   normalization warning).
 - `python scripts/report_quality_gates.py --json` — report-only, exit 0:

--- a/docs/evidence/issue-61/README.md
+++ b/docs/evidence/issue-61/README.md
@@ -34,13 +34,15 @@ Base: `origin/dev` at `ae927c687390017903435cd9bf4314610b6da229`.
   frozen `RetryExecutionPlan`. Runtime settings are captured into
   `RouteRuntimeFacts` before planning; the handler/open/relay execution path
   consumes the attempt contract without re-reading routing or retry settings.
-- Production planning materializes authentication once per request and stores
-  the complete outbound header snapshot in `FrozenRequestHeaders` on every
-  attempt. Header values use redacted, deeply immutable wrappers excluded from
-  representation, equality, telemetry, and event evidence; they are expanded
-  only when the HTTP `Request` is constructed. Provider/config/auth changes
-  after planning cannot affect the active request, while the next request
-  takes a fresh snapshot.
+- Production planning is pure and emits unmaterialized attempt headers. After
+  all typed fail-closed decisions prove the route executable, the handler
+  materializes authentication exactly once and binds one complete outbound
+  `FrozenRequestHeaders` snapshot across the immutable attempt plan. Header
+  values use redacted, deeply immutable wrappers excluded from representation,
+  equality, telemetry, and event evidence; they are expanded only when the
+  HTTP `Request` is constructed. Provider/config/auth changes after binding
+  cannot affect the active request, while the next request takes a fresh
+  snapshot.
 - Success, streaming, and final `HTTPError` responses all consume the same
   required `RelayExecutionPlan`. The relay no longer accepts profile strings
   or optional policy arguments from which it could re-derive streaming, usage,
@@ -184,5 +186,65 @@ Base: `origin/dev` at `ae927c687390017903435cd9bf4314610b6da229`.
 - `git diff --check` — passed apart from the repository's CRLF normalization
   warnings. The synthetic real-client partition was not run because none of
   its policy-listed contract-surface paths changed.
+
+## Sixth-review repair
+
+- Authentication ordering used a focused RED/GREEN slice. Before the repair,
+  the valid route had no post-plan binding seam and both the unsupported
+  official Anthropic route and Vision `REJECT` route materialized Codex
+  credentials before failing. The handler now plans first, rejects
+  non-executable routes before credential, mutation, or network work, then
+  materializes exactly once and binds one redacted immutable header snapshot.
+  A key-rotation assertion proves the active request cannot drift after
+  binding.
+- No-attempt plans now carry exactly one typed `RouteFailureObservation`
+  instead of deriving fallback defaults from an absent attempt. The RED
+  compact/API-key/Anthropic case reported `main_generation`; GREEN preserves
+  the true `compact` request kind and `api_key` authentication in both the plan
+  and safe event evidence.
+- Runtime model metadata now retains #250's nested `capability_binding` as a
+  typed `RouteCapabilityBinding`. A present malformed, stale, or protocol-
+  mismatched binding yields `Unqualified` with zero attempts before
+  authentication, request mutation, or upstream I/O. A valid current Chat
+  binding remains executable. Missing legacy metadata remains observable as
+  unqualified evidence without retroactively blocking pre-#250 catalogs.
+- Exact restart disclosure and the committed transaction/readback lifecycle
+  remain owned by #250 / PR #261. The #61 issue records that boundary and the
+  exact downstream requirement in
+  https://github.com/NOirBRight/CodexHub/issues/61#issuecomment-5127547716:
+  quit and reopen Codex App; stop and restart a running `codex app-server`;
+  newly started CLI processes apply immediately. This repair changes no #250
+  files and does not claim that downstream Toast integration is complete.
+- The relay test helper no longer accepts a legacy `behavior_profile` selector
+  or verification override. The exact 38 mapping-dependent callers were
+  converted to typed literal `RelayPlanFixture` objects, and a focused RED test
+  proves the removed selector is rejected.
+
+## Sixth-review repair verification
+
+- Focused auth ordering and non-executable route gate: 4 passed, 2 subtests
+  passed in 0.52 seconds.
+- Focused no-attempt observation, route-capability binding, and relay-helper
+  contract tests each passed after their corresponding RED failure.
+- Routing plus shutdown gate:
+  `py -3.13 -m pytest -q tests/test_routing.py tests/test_proxy_shutdown.py`
+  — 614 passed, 223 subtests passed in 35.08 seconds.
+- Chat/event gate:
+  `py -3.13 -m pytest -q tests/test_chat_completions_gateway.py
+  tests/test_proxy_event_logging.py` — 117 passed, 10 subtests passed in
+  17.43 seconds.
+- The five new review-matrix tests passed together (5 passed, 2 subtests);
+  the binding test also passed after switching its setup to the real
+  `choose_upstream` metadata-copy path.
+- `py -3.13 -m py_compile src-python/codex_proxy.py tests/test_routing.py
+  tests/test_proxy_shutdown.py tests/test_chat_completions_gateway.py
+  tests/test_proxy_event_logging.py` — passed.
+- `py -3.13 scripts/report_quality_gates.py --json` — report-only, exit 0:
+  2 unused imports, 83 dead functions, 146 duplicate names, 0 parse errors.
+- `git diff --check` — passed apart from the repository's CRLF normalization
+  warnings.
+- Per the strict delta policy, the previously green full Python core was not
+  rerun for this repair. The synthetic real-client partition remains not
+  applicable because no listed contract-surface path changed.
 
 No live-provider or manual Desktop evidence is required by issue #61.

--- a/docs/evidence/issue-61/README.md
+++ b/docs/evidence/issue-61/README.md
@@ -34,15 +34,32 @@ Base: `origin/dev` at `ae927c687390017903435cd9bf4314610b6da229`.
   frozen `RetryExecutionPlan`. Runtime settings are captured into
   `RouteRuntimeFacts` before planning; the handler/open/relay execution path
   consumes the attempt contract without re-reading routing or retry settings.
+- Production planning materializes authentication once per request and stores
+  the complete outbound header snapshot in `FrozenRequestHeaders` on every
+  attempt. Header values use redacted, deeply immutable wrappers excluded from
+  representation, equality, telemetry, and event evidence; they are expanded
+  only when the HTTP `Request` is constructed. Provider/config/auth changes
+  after planning cannot affect the active request, while the next request
+  takes a fresh snapshot.
+- Success, streaming, and final `HTTPError` responses all consume the same
+  required `RelayExecutionPlan`. The relay no longer accepts profile strings
+  or optional policy arguments from which it could re-derive streaming, usage,
+  response/SSE mutation, verification, lifecycle, or request-kind behavior.
 - Planned telemetry is explicitly scoped as a `planned_union`, while selected
   attempt telemetry reports the actual executed protocol, net wire adapter,
   conversion chain, and mutations. In particular, a Chat caller on an `auto`
   route truthfully records Chat-to-Responses for attempt 0 and
   Chat-to-Responses followed by Responses-to-Chat for the fallback attempt.
+  Safe request-body observations are recomputed from each real attempt body;
+  fallback evidence describes the failed body and final evidence describes the
+  last executed body. Planned, selected, fallback, and final aliases derive
+  from one canonical attempt telemetry snapshot.
 - Caller-tool stripping is a named `caller_tool_stripping` mutation. Optional
   capability-manifest state now fails closed unless version and cryptographic
-  hash form a complete valid pair; only a valid pair with an explicit
-  `Supported` state is reported as supported.
+  hash form a complete valid pair using the supported
+  `provider-capabilities.v3` schema; future/unknown versions remain
+  `Unqualified`. Only a supported pair with an explicit `Supported` state is
+  reported as supported.
 
 ## TDD and review
 
@@ -56,6 +73,12 @@ Base: `origin/dev` at `ae927c687390017903435cd9bf4314610b6da229`.
   removed the legacy `RouteDecision` middle-man so there is one planning
   interface. The report-only scan then identified the obsolete
   `vision_proxy_policy_for_route` helper; it was removed before publication.
+- Independent fourth-review repair used four vertical red/green slices:
+  future manifest `v999` was incorrectly `Supported`; a provider key changed
+  after planning altered the active request; Chat auto fallback final HMAC
+  described attempt 0; and final `HTTPError` lacked the future-policy relay
+  sentinel. Each test failed on `76b02adf` before its corresponding repair and
+  passed afterward.
 
 ## Candidate verification
 
@@ -65,6 +88,21 @@ Base: `origin/dev` at `ae927c687390017903435cd9bf4314610b6da229`.
   Coverage includes the attempt execution contract, actual Chat `auto` 404
   fallback bodies/telemetry, manifest identity pairs, caller-tool stripping,
   and handler-level Vision Proxy pass/proxy/reject/failure I/O behavior.
+- Fourth-review repair focused gate:
+  `python -m pytest -q tests/test_routing.py tests/test_chat_completions_gateway.py tests/test_proxy_event_logging.py`
+  — 704 passed, 227 subtests passed in 52.12 seconds with Python 3.13.
+- After moving generated Codex request identities into the immutable
+  materialization input, the affected focused suites plus the shutdown
+  cancellation contract passed again: 705 passed, 227 subtests passed in
+  47.30 seconds.
+- Fourth-review repair Python core candidate:
+  `python -m pytest -q --ignore=tests/test_real_client_e2e.py`
+  — 1,481 passed, 1 skipped, 452 subtests passed in 86.65 seconds with Python
+  3.13.11 first on `PATH`. Before correcting the inherited `PATH`, a
+  non-candidate run had two nested issue-108 PowerShell replay failures, one
+  shared diagnostic-tail ordering failure, and one shutdown test that still
+  mocked the superseded header-building seam (1,477 passed, 1 skipped). The
+  affected tests all passed after interpreter/seam correction.
 - `python -m pytest -q --ignore=tests/test_real_client_e2e.py`
   — 1,477 passed, 1 skipped, 451 subtests passed in 100.23 seconds with Python
   3.13 first on `PATH` so nested PowerShell replay subprocesses use the
@@ -79,8 +117,8 @@ Base: `origin/dev` at `ae927c687390017903435cd9bf4314610b6da229`.
   guardrail identified the separately governed synthetic real-client
   partition. None of that partition's listed contract-surface paths changed,
   so it is not applicable to this PR.
-- `python -m py_compile src-python/codex_proxy.py tests/test_routing.py` —
-  passed.
+- `python -m py_compile src-python/codex_proxy.py tests/test_routing.py tests/test_proxy_shutdown.py`
+  — passed.
 - `git diff --check` — passed (Git emitted only the repository's CRLF
   normalization warning).
 - `python scripts/report_quality_gates.py --json` — report-only, exit 0:

--- a/docs/evidence/issue-61/README.md
+++ b/docs/evidence/issue-61/README.md
@@ -4,7 +4,7 @@ Risk class: `strict` (Gateway routing/protocol policy).
 
 Base: `origin/dev` at `42b0c375d97bad025a8deed07c6a72068df2b97c`.
 
-Exact candidate head: `2e578bc10abf26084facc6b8009205ffd85801cb`.
+Exact candidate head: `50ef0aee6d8c04248a077da84123b6f320fe504b`.
 
 ## Architecture
 

--- a/docs/evidence/issue-61/README.md
+++ b/docs/evidence/issue-61/README.md
@@ -247,4 +247,21 @@ Base: `origin/dev` at `ae927c687390017903435cd9bf4314610b6da229`.
   rerun for this repair. The synthetic real-client partition remains not
   applicable because no listed contract-surface path changed.
 
+## Final relay-helper contract repair
+
+- RED: the new static contract reported the helper's `RELAY_GATEWAY` default
+  plus all 58 implicit call sites. GREEN requires the keyword-only
+  `RelayPlanFixture`, and all 109 helper calls now supply an explicit typed
+  fixture; the sole legacy `behavior_profile` call remains the deliberate
+  rejection regression.
+- Directed static-contract and legacy-rejection tests: 2 passed in 1.17
+  seconds. Full routing: `py -3.13 -m pytest -q tests/test_routing.py` —
+  595 passed, 223 subtests passed in 31.21 seconds.
+- `py -3.13 -m py_compile tests/test_routing.py` and `git diff --check`
+  passed; the latter emitted only the repository's CRLF warning. The
+  report-only quality scan remained at 2 unused imports, 83 dead functions,
+  146 duplicate names, and 0 parse errors.
+- This repair changes test contracts and evidence only; production behavior
+  is unchanged. No full core or synthetic real-client suite was rerun.
+
 No live-provider or manual Desktop evidence is required by issue #61.

--- a/docs/evidence/issue-61/README.md
+++ b/docs/evidence/issue-61/README.md
@@ -79,6 +79,23 @@ Base: `origin/dev` at `ae927c687390017903435cd9bf4314610b6da229`.
   described attempt 0; and final `HTTPError` lacked the future-policy relay
   sentinel. Each test failed on `76b02adf` before its corresponding repair and
   passed afterward.
+- Fifth-review repair added public-seam RED coverage for the remaining four
+  review findings. Both compact `auto` directions reproduced a Responses 404
+  followed by a Chat 400 whose final relay still used attempt 0 format; real
+  JSON and SSE relays with same-format `verify=true` reproduced the deleted
+  `behavior_profile` `NameError`; and the RoutePlan dataclass still accepted
+  duplicate primary-attempt constructor fields. The focused RED reported five
+  failing subtests at `013e1daa`. The repaired focused selection then passed
+  6 tests and 4 subtests.
+- Relay tests now use small typed fixtures with literal policy expectations.
+  Converted fixtures are selected explicitly at the call site; the helper does
+  not branch on production profiles or derive expected policy from the tested
+  upstream/inbound formats. A full routing run found one remaining assertion
+  against the deliberately removed `upstream_format` relay keyword
+  (589 passed, 221 subtests passed). Updating that assertion to the required
+  `RelayExecutionPlan.selected_upstream_format` contract produced 590 passed,
+  221 subtests passed; this was a test-contract update, not a production
+  regression.
 
 ## Candidate verification
 
@@ -125,5 +142,47 @@ Base: `origin/dev` at `ae927c687390017903435cd9bf4314610b6da229`.
   2 unused imports, 83 dead functions, 146 duplicate names, 0 parse errors.
   No new RoutePlan finding remains; baseline findings were not changed or
   allowlisted.
+
+## Fifth-review repair verification
+
+- Full routing: `py -3.13 -m pytest -q tests/test_routing.py` — 590 passed,
+  221 subtests passed in 31.03 seconds.
+- Chat/event/shutdown focused gate:
+  `py -3.13 -m pytest -q tests/test_chat_completions_gateway.py
+  tests/test_proxy_event_logging.py tests/test_proxy_shutdown.py` — 137 passed,
+  10 subtests passed in 23.76 seconds.
+- Final routing plus shutdown gate after removing every duplicated executable
+  primary field, including `request_kind`: 610 passed, 221 subtests passed in
+  34.46 seconds.
+- `/shutdown` has an explicit independent-credential regression: the real
+  endpoint completes while both upstream selection and operational provider
+  authentication materialization are fail-if-called. The directed test passed.
+- The first core attempt used a Python 3.13 parent but inherited Hermes Python
+  3.11 first on `PATH`. It reported 1,481 passed, 1 skipped, 456 subtests and
+  three failures: one shared diagnostic incident-counter ordering failure, plus
+  two nested issue-108 PowerShell replays whose child interpreter rejected the
+  repository's Python 3.13 type-parameter syntax. The diagnostic test passed
+  immediately in isolation; a direct traceback identified the two replay
+  failures as Python 3.11 `SyntaxError`, not route-plan behavior.
+- Authoritative core with
+  `C:\Users\noirb\AppData\Local\Programs\Python\Python313` first on `PATH`:
+  1,484 passed, 1 skipped, 456 subtests passed in 92.29 seconds. A later
+  redundant path-recording run printed the same Python 3.13.11 executable and
+  had only the independently reproduced diagnostic incident-counter flake
+  (1,483 passed); no product or test code was changed to mask it.
+- `py -3.13 -m py_compile src-python/codex_proxy.py tests/test_routing.py
+  tests/test_proxy_shutdown.py` — passed.
+- Static contract scan: `_relay_upstream_response` has no `upstream_format`
+  argument, contains no `behavior_profile` name, and all four production calls
+  pass the required `RelayExecutionPlan`. `RoutePlan` exposes executable
+  primary values only as read-only attempt views; its dataclass fields no
+  longer include the duplicated values.
+- `py -3.13 scripts/report_quality_gates.py --json` — report-only, exit 0:
+  2 unused imports, 83 dead functions, 146 duplicate names, 0 parse errors.
+  The obsolete cross-protocol profile helper was deleted; no new finding was
+  introduced.
+- `git diff --check` — passed apart from the repository's CRLF normalization
+  warnings. The synthetic real-client partition was not run because none of
+  its policy-listed contract-surface paths changed.
 
 No live-provider or manual Desktop evidence is required by issue #61.

--- a/docs/evidence/issue-61/README.md
+++ b/docs/evidence/issue-61/README.md
@@ -9,15 +9,23 @@ Base: `origin/dev` at `ae927c687390017903435cd9bf4314610b6da229`.
 - `route_plan_for_request` is the single pure seam that produces the frozen
   `RoutePlan` before request mutation or upstream I/O.
 - The plan binds provider, requested/canonical/upstream model, authentication,
-  inbound/configured/selected protocol, capability-manifest version, Codex
-  compatibility, tool exposure/evidence, collaboration backend, execution
-  owner, streaming, retry, usage, Vision Proxy, transport, and named mutation
-  policies.
+  inbound/configured protocol, immutable ordered protocol attempts and their
+  body conversion/fallback/telemetry policy, optional route-qualified
+  capability-manifest identity, Codex compatibility, tool exposure/evidence,
+  collaboration backend, execution owner, streaming, retry, usage, Vision
+  Proxy, transport, and named mutation policies.
 - `Supported`, `Unsupported`, and `Unqualified` are typed capability states.
   Candidate native tool modes retain their evidence but resolve to current
   Gateway compatibility for third-party Codex App routes. They cannot enable
   passthrough or remove semantic repair.
-- `_proxy_post_request` consumes the plan's final route flags and policies.
+- The RoutePlan schema identity is independent of optional manifest
+  version/hash evidence; absent #250 metadata remains `Unqualified` rather
+  than receiving a fabricated manifest identity.
+- `_proxy_post_request` consumes plan-owned compact/raw/candidate injection,
+  ordered Responses-to-Chat fallback attempts, and the effective Vision action
+  and network plan. Recognized-but-unimplemented Anthropic routes fail
+  `Unsupported`; unknown configured protocols fail `Unqualified`; both stop
+  before upstream I/O.
   Existing request/response adapters, relay paths, retries, usage capture,
   Vision Proxy behavior, and official keepalive transport remain unchanged.
 
@@ -36,10 +44,12 @@ Base: `origin/dev` at `ae927c687390017903435cd9bf4314610b6da229`.
 
 ## Candidate verification
 
-- `python -m pytest tests/test_routing.py tests/test_chat_completions_gateway.py tests/test_proxy_event_logging.py`
-  — 684 passed in 51.39 seconds after the final review fix.
+- `python -m pytest -q tests/test_routing.py tests/test_chat_completions_gateway.py tests/test_proxy_event_logging.py`
+  — 693 passed, 213 subtests passed in 43.65 seconds after the repair review.
 - `python -m pytest -q --ignore=tests/test_real_client_e2e.py`
-  — 1,461 passed, 1 skipped, 425 subtests passed in 101.52 seconds.
+  — 1,470 passed, 1 skipped, 438 subtests passed in 95.35 seconds with Python
+  3.13 first on `PATH` so nested PowerShell replay subprocesses use the
+  repository-required interpreter.
 - A literal `python -m pytest` was attempted because the issue text names it,
   then terminated without a test result when the current verification policy
   guardrail identified the separately governed synthetic real-client

--- a/docs/evidence/issue-61/README.md
+++ b/docs/evidence/issue-61/README.md
@@ -1,0 +1,55 @@
+# Issue #61 verification record
+
+Risk class: `strict` (Gateway routing/protocol policy).
+
+Base: `origin/dev` at `ae927c687390017903435cd9bf4314610b6da229`.
+
+## Architecture
+
+- `route_plan_for_request` is the single pure seam that produces the frozen
+  `RoutePlan` before request mutation or upstream I/O.
+- The plan binds provider, requested/canonical/upstream model, authentication,
+  inbound/configured/selected protocol, capability-manifest version, Codex
+  compatibility, tool exposure/evidence, collaboration backend, execution
+  owner, streaming, retry, usage, Vision Proxy, transport, and named mutation
+  policies.
+- `Supported`, `Unsupported`, and `Unqualified` are typed capability states.
+  Candidate native tool modes retain their evidence but resolve to current
+  Gateway compatibility for third-party Codex App routes. They cannot enable
+  passthrough or remove semantic repair.
+- `_proxy_post_request` consumes the plan's final route flags and policies.
+  Existing request/response adapters, relay paths, retries, usage capture,
+  Vision Proxy behavior, and official keepalive transport remain unchanged.
+
+## TDD and review
+
+- Initial focused RED:
+  `python -m pytest -q tests/test_routing.py -k "route_plan"` — 3 failed
+  because the `RoutePlan` seam and typed policy enums did not exist.
+- Focused GREEN after implementation:
+  `python -m pytest -q tests/test_routing.py -k "route_plan"` — 8 passed,
+  559 deselected, 8 subtests passed.
+- Local Standards/Spec self-review against issue #61 and the repository rules
+  removed the legacy `RouteDecision` middle-man so there is one planning
+  interface. The report-only scan then identified the obsolete
+  `vision_proxy_policy_for_route` helper; it was removed before publication.
+
+## Candidate verification
+
+- `python -m pytest tests/test_routing.py tests/test_chat_completions_gateway.py tests/test_proxy_event_logging.py`
+  — 684 passed in 51.39 seconds after the final review fix.
+- `python -m pytest -q --ignore=tests/test_real_client_e2e.py`
+  — 1,461 passed, 1 skipped, 425 subtests passed in 101.52 seconds.
+- A literal `python -m pytest` was attempted because the issue text names it,
+  then terminated without a test result when the current verification policy
+  guardrail identified the separately governed synthetic real-client
+  partition. None of that partition's listed contract-surface paths changed,
+  so it is not applicable to this PR.
+- `git diff --check` — passed (Git emitted only the repository's CRLF
+  normalization warning).
+- `python scripts/report_quality_gates.py --json` — report-only, exit 0:
+  2 unused imports, 83 dead functions, 146 duplicate names, 0 parse errors.
+  No new RoutePlan finding remains; baseline findings were not changed or
+  allowlisted.
+
+No live-provider or manual Desktop evidence is required by issue #61.

--- a/docs/evidence/issue-61/README.md
+++ b/docs/evidence/issue-61/README.md
@@ -4,7 +4,9 @@ Risk class: `strict` (Gateway routing/protocol policy).
 
 Base: `origin/dev` at `42b0c375d97bad025a8deed07c6a72068df2b97c`.
 
-Exact candidate head: `50ef0aee6d8c04248a077da84123b6f320fe504b`.
+Implementation candidate (code-only) head: `2e578bc10abf26084facc6b8009205ffd85801cb`.
+The later commits on this PR refresh this evidence record only; they do not
+change the implementation or test files.
 
 ## Architecture
 
@@ -112,6 +114,9 @@ Exact candidate head: `50ef0aee6d8c04248a077da84123b6f320fe504b`.
 - Authoritative Python 3.13 core:
   `py -3.13 -m pytest -q --ignore=tests/test_real_client_e2e.py`
   — 1,527 passed, 1 skipped, 460 subtests passed in 124.21 seconds.
+  A separate repeat in an ambient nested-interpreter environment reproduced
+  two unchanged issue-108 replay-smoke failures; the Hosted Python core run
+  is the acceptance result for this exact head.
 - `py -3.13 -m py_compile src-python/codex_proxy.py tests/test_routing.py`
   — passed.
 - `git diff --check` — passed (only the repository's CRLF normalization

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -3082,23 +3082,6 @@ class UpstreamSseSemanticError(ValueError):
     """A complete converted SSE frame is not valid source-protocol JSON."""
 
 
-def _verified_cross_protocol_source_format(
-    *,
-    behavior_profile: str | None,
-    upstream_format: str,
-    inbound_format: str,
-) -> str | None:
-    if upstream_format == inbound_format:
-        return None
-    if behavior_profile not in {
-        BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
-        BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH,
-        BEHAVIOR_OFFICIAL_GATEWAY_COMPAT,
-    }:
-        return None
-    return upstream_format
-
-
 def _verified_converted_sse_semantic_error(
     source_format: str,
 ) -> UpstreamSseSemanticError:
@@ -11383,6 +11366,7 @@ class RetryExecutionPlan:
 
 @dataclass(frozen=True)
 class RelayExecutionPlan:
+    selected_upstream_format: str
     request_kind: str
     streaming_policy: StreamingPolicy
     usage_policy: UsagePolicy
@@ -11430,6 +11414,7 @@ class RouteAttemptPlan:
         lifecycle_final_retry_enabled: bool,
     ) -> RelayExecutionPlan:
         return RelayExecutionPlan(
+            selected_upstream_format=self.selected_upstream_format,
             request_kind=self.retry.request_kind,
             streaming_policy=self.streaming_policy,
             usage_policy=self.usage_policy,
@@ -11500,11 +11485,9 @@ class RoutePlan:
     model_requested: str | None
     canonical_model: str | None
     upstream_model: str | None
-    authentication_strategy: AuthenticationStrategy
     inbound_protocol: RouteProtocol
     configured_upstream_protocol_name: str
     configured_upstream_protocol: RouteProtocol
-    upstream_protocol: RouteProtocol
     protocol_capability_state: CapabilityState
     protocol_failure_reason: str | None
     attempts: tuple[RouteAttemptPlan, ...]
@@ -11512,28 +11495,17 @@ class RoutePlan:
     capability_manifest_hash: str | None
     capability_manifest_state: CapabilityState
     behavior_profile: str
-    selected_upstream_format: str
-    wire_format_adapter: str
     caller_request_body_mode: CallerRequestBodyMode
     prepared_request_protocol: RouteProtocol
     codex_semantic_adapter: str
-    request_kind: str
     raw_provider_probe: bool
     request_kind_policy: str
-    retry_policy: RetryPolicy
-    retry_eligibility: CapabilityState
-    usage_policy: UsagePolicy
     repair_policy: str
     vision: VisionPlan
     tool_exposure: ToolExposurePolicy
     codex_compatibility_policy: CodexCompatibilityPolicy
     collaboration_backend: CollaborationBackend
     execution_owner: ExecutionOwner
-    streaming_policy: StreamingPolicy
-    transport_policy: TransportPolicy
-    request_mutation_policy: MutationPolicy
-    response_mutation_policy: MutationPolicy
-    sse_mutation_policy: MutationPolicy
     named_mutations: frozenset[RouteMutation]
     official_http_passthrough: bool
     transparent_metered: bool
@@ -11552,6 +11524,123 @@ class RoutePlan:
     @property
     def primary_attempt(self) -> RouteAttemptPlan | None:
         return self.attempts[0] if self.attempts else None
+
+    @property
+    def request_kind(self) -> str:
+        primary_attempt = self.primary_attempt
+        return (
+            primary_attempt.retry.request_kind
+            if primary_attempt is not None
+            else RETRY_REQUEST_MAIN_GENERATION
+        )
+
+    @property
+    def authentication_strategy(self) -> AuthenticationStrategy:
+        primary_attempt = self.primary_attempt
+        return (
+            primary_attempt.authentication_strategy
+            if primary_attempt is not None
+            else AuthenticationStrategy.UNKNOWN
+        )
+
+    @property
+    def upstream_protocol(self) -> RouteProtocol:
+        primary_attempt = self.primary_attempt
+        return (
+            primary_attempt.upstream_protocol
+            if primary_attempt is not None
+            else RouteProtocol.UNKNOWN
+        )
+
+    @property
+    def selected_upstream_format(self) -> str:
+        primary_attempt = self.primary_attempt
+        return (
+            primary_attempt.selected_upstream_format
+            if primary_attempt is not None
+            else self.configured_upstream_protocol_name
+        )
+
+    @property
+    def wire_format_adapter(self) -> str:
+        primary_attempt = self.primary_attempt
+        return (
+            primary_attempt.wire_format_adapter
+            if primary_attempt is not None
+            else WIRE_TRANSPARENT
+        )
+
+    @property
+    def retry_policy(self) -> RetryPolicy:
+        primary_attempt = self.primary_attempt
+        return (
+            primary_attempt.retry.policy
+            if primary_attempt is not None
+            else RetryPolicy.GATEWAY_FULL
+        )
+
+    @property
+    def retry_eligibility(self) -> CapabilityState:
+        primary_attempt = self.primary_attempt
+        return (
+            primary_attempt.retry.eligibility
+            if primary_attempt is not None
+            else self.protocol_capability_state
+        )
+
+    @property
+    def usage_policy(self) -> UsagePolicy:
+        primary_attempt = self.primary_attempt
+        return (
+            primary_attempt.usage_policy
+            if primary_attempt is not None
+            else UsagePolicy.SYNC_CAPTURE
+        )
+
+    @property
+    def streaming_policy(self) -> StreamingPolicy:
+        primary_attempt = self.primary_attempt
+        if primary_attempt is not None:
+            return primary_attempt.streaming_policy
+        if self.official_http_passthrough:
+            return StreamingPolicy.OFFICIAL_PASSTHROUGH
+        return StreamingPolicy.GATEWAY_ADAPTED
+
+    @property
+    def transport_policy(self) -> TransportPolicy:
+        primary_attempt = self.primary_attempt
+        if primary_attempt is not None:
+            return primary_attempt.transport_policy
+        if self.official_http_passthrough:
+            return TransportPolicy.OFFICIAL_KEEPALIVE
+        return TransportPolicy.STANDARD
+
+    @property
+    def request_mutation_policy(self) -> MutationPolicy:
+        primary_attempt = self.primary_attempt
+        if primary_attempt is not None:
+            return primary_attempt.request_mutation_policy
+        if self.official_http_passthrough:
+            return MutationPolicy.OFFICIAL_PASSTHROUGH
+        return MutationPolicy.GATEWAY_COMPATIBILITY
+
+    @property
+    def response_mutation_policy(self) -> MutationPolicy:
+        primary_attempt = self.primary_attempt
+        if primary_attempt is not None:
+            return primary_attempt.response_mutation_policy
+        if self.official_http_passthrough:
+            return MutationPolicy.OFFICIAL_PASSTHROUGH
+        return MutationPolicy.GATEWAY_COMPATIBILITY
+
+    @property
+    def sse_mutation_policy(self) -> MutationPolicy:
+        primary_attempt = self.primary_attempt
+        if primary_attempt is not None:
+            return primary_attempt.sse_mutation_policy
+        if self.official_http_passthrough:
+            return MutationPolicy.OFFICIAL_PASSTHROUGH
+        return MutationPolicy.GATEWAY_COMPATIBILITY
 
 
 def behavior_profile_for_request(
@@ -12302,15 +12391,9 @@ def route_plan_for_request(
         model_requested=model_requested,
         canonical_model=canonical_model,
         upstream_model=upstream_model,
-        authentication_strategy=authentication_strategy,
         inbound_protocol=_route_protocol(inbound_format),
         configured_upstream_protocol_name=configured_upstream_format,
         configured_upstream_protocol=configured_upstream_protocol,
-        upstream_protocol=(
-            attempts[0].upstream_protocol
-            if attempts
-            else RouteProtocol.UNKNOWN
-        ),
         protocol_capability_state=protocol_capability_state,
         protocol_failure_reason=(
             None
@@ -12326,8 +12409,6 @@ def route_plan_for_request(
         capability_manifest_hash=manifest_hash,
         capability_manifest_state=manifest_state,
         behavior_profile=behavior_profile,
-        selected_upstream_format=selected_upstream_format,
-        wire_format_adapter=wire_adapter,
         caller_request_body_mode=caller_request_body_mode,
         prepared_request_protocol=(
             RouteProtocol.RESPONSES
@@ -12338,23 +12419,14 @@ def route_plan_for_request(
             else _route_protocol(inbound_format)
         ),
         codex_semantic_adapter=codex_semantic_adapter,
-        request_kind=effective_request_kind,
         raw_provider_probe=raw_provider_probe,
         request_kind_policy=request_kind_policy,
-        retry_policy=retry_policy,
-        retry_eligibility=protocol_capability_state,
-        usage_policy=usage_policy,
         repair_policy=repair_policy,
         vision=vision,
         tool_exposure=tool_exposure,
         codex_compatibility_policy=codex_compatibility_policy,
         collaboration_backend=collaboration_backend,
         execution_owner=ExecutionOwner.CODEX_CLIENT,
-        streaming_policy=streaming_policy,
-        transport_policy=transport_policy,
-        request_mutation_policy=mutation_policy,
-        response_mutation_policy=mutation_policy,
-        sse_mutation_policy=mutation_policy,
         named_mutations=frozenset(named_mutations),
         official_http_passthrough=official_http_passthrough,
         transparent_metered=transparent_metered,
@@ -16407,13 +16479,12 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 nonlocal downstream_sse_started
                 downstream_sse_started = True
 
-            selected_upstream_format = upstream_format
             open_attempt_budget = (
                 primary_route_attempt.retry.new_open_attempt_budget()
             )
             for route_attempt in route_plan.attempts:
                 active_route_attempt = route_attempt
-                selected_upstream_format = route_attempt.selected_upstream_format
+                upstream_format = route_attempt.selected_upstream_format
                 route_attempt_event_fields = _route_attempt_event_fields(route_attempt)
                 proxy_request_context.update(route_attempt_event_fields)
                 if isinstance(adapter_event_context, dict):
@@ -16440,7 +16511,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                     while relay_attempt <= max_relay_attempts:
                         seam = _handler_downstream_stream_commit(self)
                         if seam is not None:
-                            seam.set_upstream_format(selected_upstream_format)
+                            seam.set_upstream_format(upstream_format)
                         request, request_observability = upstream_request_for_attempt(
                             route_attempt,
                             lifecycle_final_retry_reason,
@@ -16450,7 +16521,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                             with _open_upstream_response(
                                 request,
                                 upstream_name=upstream_name,
-                                upstream_format=selected_upstream_format,
+                                upstream_format=upstream_format,
                                 timeout=(
                                     route_attempt.retry.request_timeout_seconds
                                 ),
@@ -16472,7 +16543,6 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                                     upstream_name,
                                     request_id=request_id,
                                     model=model_canonical,
-                                    upstream_format=selected_upstream_format,
                                     inbound_format=inbound_format,
                                     caller_stream=caller_stream,
                                     event_context=adapter_event_context,
@@ -16513,7 +16583,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                                 stream_model_access_path = _model_access_path_from_event_context(
                                     adapter_event_context,
                                     upstream_name,
-                                    selected_upstream_format,
+                                    upstream_format,
                                 )
                                 retry_safety_class = _retry_safety_class(
                                     retry_exc,
@@ -16528,7 +16598,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                                     _emit_upstream_retry_suppressed_event(
                                         adapter_event_context,
                                         upstream_name=upstream_name,
-                                        upstream_format=selected_upstream_format,
+                                        upstream_format=upstream_format,
                                         request_kind=request_kind,
                                         attempt=relay_attempt,
                                         max_attempts=max_relay_attempts,
@@ -16569,7 +16639,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                                 stream_model_access_path = _model_access_path_from_event_context(
                                     adapter_event_context,
                                     upstream_name,
-                                    selected_upstream_format,
+                                    upstream_format,
                                 )
                                 retry_safety_class = _retry_safety_class(
                                     retry_exc,
@@ -16584,7 +16654,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                                     _emit_upstream_retry_suppressed_event(
                                         adapter_event_context,
                                         upstream_name=upstream_name,
-                                        upstream_format=selected_upstream_format,
+                                        upstream_format=upstream_format,
                                         request_kind=request_kind,
                                         attempt=relay_attempt,
                                         max_attempts=retry_limit,
@@ -16601,7 +16671,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                                             model=model,
                                             upstream=upstream_name,
                                             status=502,
-                                            upstream_format=selected_upstream_format,
+                                            upstream_format=upstream_format,
                                             inbound_format=inbound_format,
                                             terminal_seen=False,
                                             completed_seen=True,
@@ -16656,7 +16726,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                             _emit_upstream_retry_event(
                                 adapter_event_context,
                                 upstream_name=upstream_name,
-                                upstream_format=selected_upstream_format,
+                                upstream_format=upstream_format,
                                 request_kind=request_kind,
                                 attempt=relay_attempt,
                                 max_attempts=retry_limit,
@@ -16669,7 +16739,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                             if not emit_downstream_retry(
                                 _downstream_retry_payload(
                                     upstream_name=upstream_name,
-                                    upstream_format=selected_upstream_format,
+                                    upstream_format=upstream_format,
                                     request_kind=request_kind,
                                     attempt=relay_attempt,
                                     max_attempts=retry_limit,
@@ -16688,7 +16758,6 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         relay_attempt += 1
                     else:
                         raise RuntimeError("unreachable upstream relay retry state")
-                    upstream_format = selected_upstream_format
                     break
                 except HTTPError as exc:
                     next_attempt_index = route_attempt.index + 1
@@ -16708,7 +16777,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         fallback_model_access_path = _model_access_path_from_event_context(
                             adapter_event_context,
                             upstream_name,
-                            selected_upstream_format,
+                            upstream_format,
                         )
                         fallback_retry_safety_class = _retry_safety_class(
                             exc,
@@ -16737,7 +16806,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                                 provider_hint=provider_hint,
                                 upstream_format=route_plan.configured_upstream_protocol_name,
                                 behavior_profile=behavior_profile,
-                                failed_upstream_format=selected_upstream_format,
+                                failed_upstream_format=upstream_format,
                                 next_upstream_format=next_attempt.selected_upstream_format,
                                 failed_route_attempt_index=(
                                     failed_attempt_snapshot["index"]
@@ -16788,7 +16857,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         _emit_upstream_retry_suppressed_event(
                             adapter_event_context,
                             upstream_name=upstream_name,
-                            upstream_format=selected_upstream_format,
+                            upstream_format=upstream_format,
                             request_kind=request_kind,
                             attempt=relay_attempt,
                             max_attempts=relay_attempts,
@@ -17156,7 +17225,6 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                     upstream_name or "upstream_error",
                     request_id=request_id,
                     model=canonical_model_id(model) if model else None,
-                    upstream_format=upstream_format,
                     inbound_format=inbound_format,
                     caller_stream=caller_stream,
                     event_context=adapter_event_context,
@@ -17572,6 +17640,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
         upstream = official_upstream()
         upstream_name = upstream["name"]
         relay_execution_plan = RelayExecutionPlan(
+            selected_upstream_format=RouteProtocol.RESPONSES.value,
             request_kind=RETRY_REQUEST_OFFICIAL_CONTROL,
             streaming_policy=StreamingPolicy.GATEWAY_ADAPTED,
             usage_policy=UsagePolicy.SYNC_CAPTURE,
@@ -18836,7 +18905,6 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
         relay_execution_plan: RelayExecutionPlan,
         request_id: str | None = None,
         model: str | None = None,
-        upstream_format: str = "responses",
         inbound_format: str = "responses",
         caller_stream: bool = True,
         event_context: Mapping[str, Any] | None = None,
@@ -18846,6 +18914,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
         mark_downstream_sse_started: Callable[[], None] | None = None,
         response_lifecycle_state: dict[str, str] | None = None,
     ) -> int:
+        upstream_format = relay_execution_plan.selected_upstream_format
         request_kind = relay_execution_plan.request_kind
         streaming_policy = relay_execution_plan.streaming_policy
         usage_policy = relay_execution_plan.usage_policy
@@ -18903,16 +18972,10 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
         verified_source_format = (
             upstream_format
             if (
-                verify_cross_protocol_source is True
+                verify_cross_protocol_source
                 and upstream_format != inbound_format
             )
             else None
-            if verify_cross_protocol_source is False
-            else _verified_cross_protocol_source_format(
-                behavior_profile=behavior_profile,
-                upstream_format=upstream_format,
-                inbound_format=inbound_format,
-            )
         )
         usage_context = _usage_observed_context(
             event_context,

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -1034,6 +1034,11 @@ class AttemptRequestBodyMode(str, Enum):
     CONVERT_RESPONSES_TO_CHAT = "convert_responses_to_chat"
 
 
+class CallerRequestBodyMode(str, Enum):
+    PRESERVE_CALLER = "preserve_caller"
+    CONVERT_CHAT_TO_RESPONSES = "convert_chat_to_responses"
+
+
 class AuthenticationStrategy(str, Enum):
     CODEX_AUTH = "codex_auth"
     API_KEY = "api_key"
@@ -1085,6 +1090,16 @@ class StreamingPolicy(str, Enum):
     GATEWAY_ADAPTED = "gateway_adapted"
 
 
+class RetryPolicy(str, Enum):
+    GATEWAY_FULL = RETRY_GATEWAY_FULL
+    CONSERVATIVE_PRE_OUTPUT = RETRY_CONSERVATIVE_PRE_OUTPUT
+
+
+class UsagePolicy(str, Enum):
+    SYNC_CAPTURE = USAGE_SYNC_CAPTURE
+    ASYNC_TAP = USAGE_ASYNC_TAP
+
+
 class TransportPolicy(str, Enum):
     OFFICIAL_KEEPALIVE = "official_keepalive"
     STANDARD = "standard"
@@ -1106,6 +1121,7 @@ class RouteMutation(str, Enum):
     SYNTHETIC_TERMINAL_FAILURE = "synthetic_terminal_failure"
     IMAGE_CONTENT_REPLACEMENT = "image_content_replacement"
     IMAGE_UNSUPPORTED_REJECTION = "image_unsupported_rejection"
+    CALLER_TOOL_STRIPPING = "caller_tool_stripping"
     UNSUPPORTED_PROTOCOL_REJECTION = "unsupported_protocol_rejection"
 
 
@@ -5112,8 +5128,10 @@ def _adapt_native_responses_tool_declarations(
     payload: dict[str, Any],
     upstream: Mapping[str, Any],
     event_context: Mapping[str, Any] | None,
+    *,
+    codec: str | None = None,
 ) -> bool:
-    codec = _external_native_responses_tool_codec(upstream)
+    codec = codec or _external_native_responses_tool_codec(upstream)
     if codec == "none":
         return False
     tools = payload.get("tools")
@@ -9086,6 +9104,9 @@ def compatible_request_body(
     event_context: Mapping[str, Any] | None = None,
     inject_codex_tools: bool = True,
     behavior_profile: str = BEHAVIOR_EXTERNAL_PROVIDER_GATEWAY,
+    tool_protocol_override: str | None = None,
+    tool_surface_strategy_override: str | None = None,
+    native_responses_tool_codec_override: str | None = None,
 ) -> bytes:
     upstream_name = upstream.get("name")
     official_passthrough = behavior_profile == BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH
@@ -9097,7 +9118,11 @@ def compatible_request_body(
         # Reject malformed configuration before an unparsable external body can
         # bypass the third-party compatibility boundary. Official passthrough
         # never consults the external capability.
-        validated_tool_surface_strategy = _external_tool_surface_strategy(upstream)
+        validated_tool_surface_strategy = (
+            tool_surface_strategy_override
+            if tool_surface_strategy_override is not None
+            else _external_tool_surface_strategy(upstream)
+        )
     try:
         payload = json.loads(body.decode("utf-8-sig"))
     except (UnicodeDecodeError, json.JSONDecodeError):
@@ -9157,7 +9182,11 @@ def compatible_request_body(
         return json.dumps(payload, ensure_ascii=True, separators=(",", ":")).encode("utf-8")
 
     raw_provider_probe = _is_raw_provider_probe_context(event_context)
-    tool_protocol = _external_tool_protocol(upstream)
+    tool_protocol = (
+        tool_protocol_override
+        if tool_protocol_override is not None
+        else _external_tool_protocol(upstream)
+    )
     tool_surface_strategy = (
         validated_tool_surface_strategy
         if validated_tool_surface_strategy is not None
@@ -9494,7 +9523,12 @@ def compatible_request_body(
         return json.dumps(payload, ensure_ascii=True, separators=(",", ":")).encode("utf-8")
     if (
         tool_protocol == "responses_structured"
-        and _adapt_native_responses_tool_declarations(payload, upstream, event_context)
+        and _adapt_native_responses_tool_declarations(
+            payload,
+            upstream,
+            event_context,
+            codec=native_responses_tool_codec_override,
+        )
     ):
         changed = True
     allow_codex_tools = tool_protocol != "none"
@@ -10979,13 +11013,161 @@ class VisionPlan:
 
 
 @dataclass(frozen=True)
+class RouteRuntimeFacts:
+    """Runtime settings captured once before the pure route decision is built."""
+
+    request_timeout_seconds: int
+    request_kind_base_attempts: int
+    request_kind_attempts_configured: bool
+    failure_expansion_attempts: int
+    official_open_attempts: int
+    capacity_elapsed_limit_seconds: float
+    stream_elapsed_limit_seconds: float
+    downstream_retry_notice_enabled: bool
+    pre_response_budget_seconds: float
+
+
+@dataclass(frozen=True)
+class RetryExecutionPlan:
+    eligibility: CapabilityState
+    policy: RetryPolicy
+    request_kind: str
+    request_timeout_seconds: int
+    base_open_attempts: int
+    base_relay_attempts: int
+    failure_expansion_attempts: int
+    request_kind_attempts_configured: bool
+    retry_http_errors: bool
+    open_attempt_budget: int | None
+    capacity_elapsed_limit_seconds: float
+    stream_elapsed_limit_seconds: float
+    emit_downstream_retry_notice: bool
+    pre_response_budget_seconds: float | None
+    lifecycle_final_retry_eligible: bool
+    empty_completed_max_attempts: int = 2
+
+    def _attempts_for_failure_class(
+        self,
+        base_attempts: int,
+        failure_class: str,
+        *,
+        stream_failure: bool,
+    ) -> int:
+        if (
+            base_attempts <= 1
+            or self.request_kind_attempts_configured
+        ):
+            return base_attempts
+        if failure_class in CAPACITY_RETRY_FAILURE_CLASSES:
+            return max(base_attempts, self.failure_expansion_attempts)
+        if stream_failure and failure_class == RETRY_FAILURE_QUICK_TRANSIENT:
+            return max(base_attempts, self.failure_expansion_attempts)
+        return base_attempts
+
+    def open_attempts_for_failure_class(self, failure_class: str) -> int:
+        if self.open_attempt_budget is not None:
+            return self.base_open_attempts
+        return self._attempts_for_failure_class(
+            self.base_open_attempts,
+            failure_class,
+            stream_failure=False,
+        )
+
+    def relay_attempts_for_failure_class(
+        self,
+        failure_class: str,
+        *,
+        stream_failure: bool,
+    ) -> int:
+        return self._attempts_for_failure_class(
+            self.base_relay_attempts,
+            failure_class,
+            stream_failure=stream_failure,
+        )
+
+    def capacity_elapsed_limit_allows(
+        self,
+        elapsed_seconds: float,
+        delay_seconds: int | float,
+    ) -> bool:
+        return (
+            self.capacity_elapsed_limit_seconds <= 0
+            or elapsed_seconds + delay_seconds
+            <= self.capacity_elapsed_limit_seconds
+        )
+
+    def stream_elapsed_limit_allows(
+        self,
+        elapsed_seconds: float,
+        delay_seconds: int | float,
+    ) -> bool:
+        return (
+            self.stream_elapsed_limit_seconds <= 0
+            or elapsed_seconds + delay_seconds
+            <= self.stream_elapsed_limit_seconds
+        )
+
+    def lifecycle_final_extra_attempts(
+        self,
+        event_context: Mapping[str, Any] | None,
+    ) -> int:
+        return int(
+            self.lifecycle_final_retry_eligible
+            and bool((event_context or {}).get("subagent_lifecycle_complete"))
+        )
+
+    def retry_delay_seconds(
+        self,
+        attempt: int,
+        *,
+        failure_class: str,
+        exc: BaseException | None,
+    ) -> int:
+        retry_after_seconds = _retry_after_delay_seconds(exc)
+        if retry_after_seconds is not None:
+            return retry_after_seconds
+        if failure_class == RETRY_FAILURE_PROVIDER_THROTTLE:
+            index = max(1, attempt) - 1
+            if index < len(CAPACITY_RETRY_CADENCE_SECONDS):
+                return CAPACITY_RETRY_CADENCE_SECONDS[index]
+            return CAPACITY_RETRY_CADENCE_SECONDS[-1]
+        return min(max(1, attempt - 1) * 2, 8)
+
+    def pre_response_deadline(self, started_at: float) -> float | None:
+        if self.pre_response_budget_seconds is None:
+            return None
+        return started_at + self.pre_response_budget_seconds
+
+    def new_open_attempt_budget(self) -> dict[str, int] | None:
+        if self.open_attempt_budget is None:
+            return None
+        return {
+            "max_attempts": self.open_attempt_budget,
+            "attempts_started": 0,
+        }
+
+
+@dataclass(frozen=True)
 class RouteAttemptPlan:
     index: int
     upstream_protocol: RouteProtocol
     selected_upstream_format: str
+    endpoint_url: str
     wire_format_adapter: str
+    request_conversion_steps: tuple[str, ...]
     request_body_mode: AttemptRequestBodyMode
+    authentication_strategy: AuthenticationStrategy
+    streaming_policy: StreamingPolicy
+    usage_policy: UsagePolicy
+    transport_policy: TransportPolicy
     request_mutation_policy: MutationPolicy
+    response_mutation_policy: MutationPolicy
+    sse_mutation_policy: MutationPolicy
+    verify_cross_protocol_source: bool
+    retry: RetryExecutionPlan
+    tool_protocol: str
+    tool_surface_strategy: str
+    native_responses_tool_codec: str
     named_mutations: frozenset[RouteMutation]
     fallback_http_statuses: frozenset[int]
 
@@ -10995,6 +11177,18 @@ class RouteAttemptPlan:
 
     def allows_protocol_fallback_status(self, status: int | None) -> bool:
         return isinstance(status, int) and status in self.fallback_http_statuses
+
+    def request_body(self, prepared_body: bytes) -> bytes:
+        if self.request_body_mode == AttemptRequestBodyMode.PREPARED_DIRECT:
+            return prepared_body
+        if (
+            self.request_body_mode
+            == AttemptRequestBodyMode.CONVERT_RESPONSES_TO_CHAT
+        ):
+            return _responses_request_to_chat_completion_body(prepared_body)
+        raise UnsupportedRouteProtocolError(
+            f"unsupported planned request body mode: {self.request_body_mode}"
+        )
 
 
 @dataclass(frozen=True)
@@ -11018,13 +11212,15 @@ class RoutePlan:
     behavior_profile: str
     selected_upstream_format: str
     wire_format_adapter: str
+    caller_request_body_mode: CallerRequestBodyMode
+    prepared_request_protocol: RouteProtocol
     codex_semantic_adapter: str
     request_kind: str
     raw_provider_probe: bool
     request_kind_policy: str
-    retry_policy: str
+    retry_policy: RetryPolicy
     retry_eligibility: CapabilityState
-    usage_policy: str
+    usage_policy: UsagePolicy
     repair_policy: str
     vision: VisionPlan
     tool_exposure: ToolExposurePolicy
@@ -11041,6 +11237,7 @@ class RoutePlan:
     transparent_metered: bool
     transparent_same_format: bool
     transparent_lightweight_fallback: bool
+    transparent_tool_loop_guard: bool
 
     @property
     def mutation_summary(self) -> tuple[RouteMutation, ...]:
@@ -11095,11 +11292,134 @@ def _authentication_strategy(value: Any) -> AuthenticationStrategy:
         return AuthenticationStrategy.UNKNOWN
 
 
+def _route_endpoint_url(
+    upstream: Mapping[str, Any],
+    protocol: RouteProtocol,
+) -> str:
+    base_url = upstream.get("base_url")
+    if protocol == RouteProtocol.RESPONSES:
+        return (
+            _responses_url(upstream, "/v1/responses")
+            if isinstance(base_url, str) and base_url
+            else "/responses"
+        )
+    if protocol == RouteProtocol.CHAT_COMPLETIONS:
+        return (
+            _chat_completions_url(upstream)
+            if isinstance(base_url, str) and base_url
+            else "/chat/completions"
+        )
+    raise UnsupportedRouteProtocolError(
+        f"planned attempt has no executable upstream protocol: {protocol.value}"
+    )
+
+
 def _capability_state(value: Any, *, default: CapabilityState) -> CapabilityState:
     try:
         return CapabilityState(str(value))
     except ValueError:
         return default
+
+
+CAPABILITY_MANIFEST_VERSION_RE = re.compile(
+    r"[A-Za-z0-9](?:[A-Za-z0-9._-]{0,126}[A-Za-z0-9])?"
+)
+CAPABILITY_MANIFEST_HASH_LENGTHS = {
+    "sha256": 64,
+    "sha384": 96,
+    "sha512": 128,
+}
+
+
+def _valid_capability_manifest_version(value: str) -> bool:
+    return CAPABILITY_MANIFEST_VERSION_RE.fullmatch(value) is not None
+
+
+def _valid_capability_manifest_hash(value: str) -> bool:
+    algorithm, separator, digest = value.partition(":")
+    expected_length = CAPABILITY_MANIFEST_HASH_LENGTHS.get(algorithm.lower())
+    return bool(
+        separator
+        and expected_length is not None
+        and len(digest) == expected_length
+        and re.fullmatch(r"[0-9a-fA-F]+", digest)
+    )
+
+
+def _capability_manifest_identity(
+    upstream: Mapping[str, Any],
+) -> tuple[str | None, str | None, CapabilityState]:
+    version_value = upstream.get("capability_manifest_version")
+    version = (
+        version_value.strip()
+        if isinstance(version_value, str) and version_value.strip()
+        else None
+    )
+    hash_value = upstream.get("capability_manifest_hash")
+    manifest_hash = (
+        hash_value.strip()
+        if isinstance(hash_value, str) and hash_value.strip()
+        else None
+    )
+    if not (
+        version is not None
+        and manifest_hash is not None
+        and _valid_capability_manifest_version(version)
+        and _valid_capability_manifest_hash(manifest_hash)
+    ):
+        return None, None, CapabilityState.UNQUALIFIED
+    return (
+        version,
+        manifest_hash,
+        _capability_state(
+            upstream.get("capability_manifest_state"),
+            default=CapabilityState.UNQUALIFIED,
+        ),
+    )
+
+
+def _default_route_runtime_facts(request_kind: str) -> RouteRuntimeFacts:
+    return RouteRuntimeFacts(
+        request_timeout_seconds=DEFAULT_UPSTREAM_TIMEOUT_SECONDS,
+        request_kind_base_attempts=_default_retry_attempts_for_request_kind(
+            request_kind
+        ),
+        request_kind_attempts_configured=False,
+        failure_expansion_attempts=DEFAULT_GATEWAY_AUTO_RETRY_MAX_ATTEMPTS,
+        official_open_attempts=DEFAULT_OFFICIAL_UPSTREAM_OPEN_ATTEMPTS,
+        capacity_elapsed_limit_seconds=(
+            DEFAULT_CAPACITY_RETRY_ELAPSED_LIMIT_SECONDS
+        ),
+        stream_elapsed_limit_seconds=DEFAULT_STREAM_RETRY_ELAPSED_LIMIT_SECONDS,
+        downstream_retry_notice_enabled=False,
+        pre_response_budget_seconds=(
+            DEFAULT_MAIN_GENERATION_PRE_RESPONSE_BUDGET_SECONDS
+        ),
+    )
+
+
+def _route_runtime_facts(request_kind: str) -> RouteRuntimeFacts:
+    return RouteRuntimeFacts(
+        request_timeout_seconds=upstream_timeout_seconds(),
+        request_kind_base_attempts=_upstream_retry_attempts(request_kind),
+        request_kind_attempts_configured=(
+            _request_kind_retry_attempts_configured(request_kind)
+        ),
+        failure_expansion_attempts=gateway_auto_retry_max_attempts(),
+        official_open_attempts=official_upstream_open_attempts(),
+        capacity_elapsed_limit_seconds=(
+            gateway_capacity_retry_elapsed_limit_seconds()
+        ),
+        stream_elapsed_limit_seconds=(
+            gateway_stream_retry_elapsed_limit_seconds()
+        ),
+        downstream_retry_notice_enabled=(
+            gateway_downstream_retry_notice_enabled()
+        ),
+        pre_response_budget_seconds=(
+            DEFAULT_MAIN_GENERATION_PRE_RESPONSE_BUDGET_SECONDS
+        ),
+    )
 
 
 def _vision_plan_for_route(
@@ -11297,6 +11617,12 @@ def route_plan_for_request(
     target_accepts_images: bool = True,
     image_proxy_enabled: bool = False,
     official_http_passthrough_enabled: bool = True,
+    caller_stream: bool = True,
+    runtime_facts: (
+        RouteRuntimeFacts
+        | Mapping[str, RouteRuntimeFacts]
+        | None
+    ) = None,
 ) -> RoutePlan:
     upstream_name = str(upstream.get("name") or "")
     configured_upstream_format = str(upstream.get("upstream_format") or "responses")
@@ -11368,13 +11694,33 @@ def route_plan_for_request(
         if codex_app_external or compatibility_external
         else CODEX_SEMANTIC_NONE
     )
+    effective_request_kind = (
+        RETRY_REQUEST_MAIN_GENERATION if transparent_metered else request_kind
+    )
+    if isinstance(runtime_facts, RouteRuntimeFacts):
+        selected_runtime_facts = runtime_facts
+    elif isinstance(runtime_facts, Mapping):
+        selected_runtime_facts = runtime_facts.get(
+            effective_request_kind,
+            _default_route_runtime_facts(effective_request_kind),
+        )
+    else:
+        selected_runtime_facts = _default_route_runtime_facts(
+            effective_request_kind
+        )
     request_kind_policy = (
         REQUEST_KIND_TRANSPARENT if transparent_metered else REQUEST_KIND_GATEWAY
     )
     retry_policy = (
-        RETRY_CONSERVATIVE_PRE_OUTPUT if transparent_metered else RETRY_GATEWAY_FULL
+        RetryPolicy.CONSERVATIVE_PRE_OUTPUT
+        if transparent_metered
+        else RetryPolicy.GATEWAY_FULL
     )
-    usage_policy = USAGE_ASYNC_TAP if transparent_metered else USAGE_SYNC_CAPTURE
+    usage_policy = (
+        UsagePolicy.ASYNC_TAP
+        if transparent_metered
+        else UsagePolicy.SYNC_CAPTURE
+    )
     repair_policy = (
         REPAIR_CODEX_SUBAGENT
         if codex_app_external and not raw_provider_probe
@@ -11414,6 +11760,22 @@ def route_plan_for_request(
         streaming_policy = StreamingPolicy.GATEWAY_ADAPTED
         mutation_policy = MutationPolicy.GATEWAY_COMPATIBILITY
 
+    authentication_strategy = _authentication_strategy(
+        upstream.get("auth") or "unknown"
+    )
+    transport_policy = (
+        TransportPolicy.OFFICIAL_KEEPALIVE
+        if upstream_name == "official"
+        else TransportPolicy.STANDARD
+    )
+    caller_request_body_mode = (
+        CallerRequestBodyMode.CONVERT_CHAT_TO_RESPONSES
+        if (
+            inbound_format == RouteProtocol.CHAT_COMPLETIONS.value
+            and not transparent_same_format
+        )
+        else CallerRequestBodyMode.PRESERVE_CALLER
+    )
     base_named_mutations = {RouteMutation.MODEL_ALIAS}
     if tool_exposure.gateway_schema_injection:
         base_named_mutations.add(RouteMutation.HARD_CODED_SCHEMA_INJECTION)
@@ -11429,6 +11791,8 @@ def route_plan_for_request(
         base_named_mutations.add(RouteMutation.IMAGE_CONTENT_REPLACEMENT)
     elif vision.action == VisionAction.REJECT:
         base_named_mutations.add(RouteMutation.IMAGE_UNSUPPORTED_REJECTION)
+    if tool_exposure.strip_caller_tools:
+        base_named_mutations.add(RouteMutation.CALLER_TOOL_STRIPPING)
     if not attempt_protocols:
         base_named_mutations.add(RouteMutation.UNSUPPORTED_PROTOCOL_REJECTION)
 
@@ -11438,27 +11802,130 @@ def route_plan_for_request(
             inbound_format,
             attempt_protocol.value,
         )
+        request_body_mode = (
+            AttemptRequestBodyMode.CONVERT_RESPONSES_TO_CHAT
+            if (
+                attempt_protocol == RouteProtocol.CHAT_COMPLETIONS
+                and not (
+                    transparent_same_format
+                    and inbound_format
+                    == RouteProtocol.CHAT_COMPLETIONS.value
+                )
+            )
+            else AttemptRequestBodyMode.PREPARED_DIRECT
+        )
+        request_conversion_steps: list[str] = []
+        if (
+            caller_request_body_mode
+            == CallerRequestBodyMode.CONVERT_CHAT_TO_RESPONSES
+        ):
+            request_conversion_steps.append(WIRE_CHAT_TO_RESPONSES)
+        if (
+            request_body_mode
+            == AttemptRequestBodyMode.CONVERT_RESPONSES_TO_CHAT
+        ):
+            request_conversion_steps.append(WIRE_RESPONSES_TO_CHAT)
         attempt_mutations = set(base_named_mutations)
-        if attempt_wire_adapter != WIRE_TRANSPARENT:
+        if request_conversion_steps:
             attempt_mutations.add(RouteMutation.WIRE_CONVERSION)
+        if official_http_passthrough:
+            base_open_attempts = selected_runtime_facts.official_open_attempts
+            base_relay_attempts = OFFICIAL_PASSTHROUGH_FIRST_EVENT_ATTEMPTS
+            retry_http_errors = False
+            open_attempt_budget = selected_runtime_facts.official_open_attempts
+        else:
+            base_open_attempts = (
+                selected_runtime_facts.request_kind_base_attempts
+            )
+            base_relay_attempts = (
+                selected_runtime_facts.request_kind_base_attempts
+            )
+            retry_http_errors = True
+            open_attempt_budget = None
+        retry_execution = RetryExecutionPlan(
+            eligibility=protocol_capability_state,
+            policy=retry_policy,
+            request_kind=effective_request_kind,
+            request_timeout_seconds=(
+                selected_runtime_facts.request_timeout_seconds
+            ),
+            base_open_attempts=base_open_attempts,
+            base_relay_attempts=base_relay_attempts,
+            failure_expansion_attempts=(
+                selected_runtime_facts.failure_expansion_attempts
+            ),
+            request_kind_attempts_configured=(
+                selected_runtime_facts.request_kind_attempts_configured
+            ),
+            retry_http_errors=retry_http_errors,
+            open_attempt_budget=open_attempt_budget,
+            capacity_elapsed_limit_seconds=(
+                selected_runtime_facts.capacity_elapsed_limit_seconds
+            ),
+            stream_elapsed_limit_seconds=(
+                selected_runtime_facts.stream_elapsed_limit_seconds
+            ),
+            emit_downstream_retry_notice=(
+                not official_http_passthrough
+                and not transparent_metered
+                and caller_stream
+                and inbound_format == RouteProtocol.RESPONSES.value
+                and selected_runtime_facts.downstream_retry_notice_enabled
+            ),
+            pre_response_budget_seconds=(
+                selected_runtime_facts.pre_response_budget_seconds
+                if effective_request_kind
+                == RETRY_REQUEST_MAIN_GENERATION
+                else None
+            ),
+            lifecycle_final_retry_eligible=(
+                not official_http_passthrough
+                and repair_policy != REPAIR_NONE
+                and effective_request_kind
+                == RETRY_REQUEST_MAIN_GENERATION
+            ),
+        )
+        attempt_upstream = {
+            **upstream,
+            "upstream_format": attempt_protocol.value,
+        }
         attempts.append(
             RouteAttemptPlan(
                 index=index,
                 upstream_protocol=attempt_protocol,
                 selected_upstream_format=attempt_protocol.value,
+                endpoint_url=_route_endpoint_url(upstream, attempt_protocol),
                 wire_format_adapter=attempt_wire_adapter,
-                request_body_mode=(
-                    AttemptRequestBodyMode.CONVERT_RESPONSES_TO_CHAT
-                    if (
-                        attempt_protocol == RouteProtocol.CHAT_COMPLETIONS
-                        and not (
-                            transparent_same_format
-                            and inbound_format == RouteProtocol.CHAT_COMPLETIONS.value
-                        )
-                    )
-                    else AttemptRequestBodyMode.PREPARED_DIRECT
-                ),
+                request_conversion_steps=tuple(request_conversion_steps),
+                request_body_mode=request_body_mode,
+                authentication_strategy=authentication_strategy,
+                streaming_policy=streaming_policy,
+                usage_policy=usage_policy,
+                transport_policy=transport_policy,
                 request_mutation_policy=mutation_policy,
+                response_mutation_policy=mutation_policy,
+                sse_mutation_policy=mutation_policy,
+                verify_cross_protocol_source=(
+                    attempt_protocol.value != inbound_format
+                    and behavior_profile
+                    in {
+                        BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+                        BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH,
+                        BEHAVIOR_OFFICIAL_GATEWAY_COMPAT,
+                    }
+                ),
+                retry=retry_execution,
+                tool_protocol=_external_tool_protocol(attempt_upstream),
+                tool_surface_strategy=(
+                    _external_tool_surface_strategy(attempt_upstream)
+                    if upstream_name != "official"
+                    else "eager"
+                ),
+                native_responses_tool_codec=(
+                    _external_native_responses_tool_codec(attempt_upstream)
+                    if upstream_name != "official"
+                    else "none"
+                ),
                 named_mutations=frozenset(attempt_mutations),
                 fallback_http_statuses=(
                     frozenset(AUTO_UPSTREAM_PROTOCOL_FALLBACK_STATUSES)
@@ -11471,10 +11938,10 @@ def route_plan_for_request(
                 ),
             )
         )
-    named_mutations = (
-        attempts[0].named_mutations
-        if attempts
-        else frozenset(base_named_mutations)
+    named_mutations = frozenset(
+        set(base_named_mutations).union(
+            *(attempt.named_mutations for attempt in attempts)
+        )
     )
 
     canonical_model = (
@@ -11488,27 +11955,12 @@ def route_plan_for_request(
         if upstream_model_value
         else canonical_model
     )
-    manifest_version_value = upstream.get("capability_manifest_version")
-    manifest_version = (
-        manifest_version_value.strip()
-        if isinstance(manifest_version_value, str)
-        and manifest_version_value.strip()
-        else None
-    )
-    manifest_hash_value = upstream.get("capability_manifest_hash")
-    manifest_hash = (
-        manifest_hash_value.strip()
-        if isinstance(manifest_hash_value, str)
-        and manifest_hash_value.strip()
-        else None
-    )
-    manifest_state = (
-        _capability_state(
-            upstream.get("capability_manifest_state"),
-            default=CapabilityState.UNQUALIFIED,
-        )
-        if manifest_version is not None or manifest_hash is not None
-        else CapabilityState.UNQUALIFIED
+    (
+        manifest_version,
+        manifest_hash,
+        manifest_state,
+    ) = _capability_manifest_identity(
+        upstream
     )
     return RoutePlan(
         schema_version=ROUTE_PLAN_SCHEMA_VERSION,
@@ -11516,9 +11968,7 @@ def route_plan_for_request(
         model_requested=model_requested,
         canonical_model=canonical_model,
         upstream_model=upstream_model,
-        authentication_strategy=_authentication_strategy(
-            upstream.get("auth") or "unknown"
-        ),
+        authentication_strategy=authentication_strategy,
         inbound_protocol=_route_protocol(inbound_format),
         configured_upstream_protocol_name=configured_upstream_format,
         configured_upstream_protocol=configured_upstream_protocol,
@@ -11544,10 +11994,17 @@ def route_plan_for_request(
         behavior_profile=behavior_profile,
         selected_upstream_format=selected_upstream_format,
         wire_format_adapter=wire_adapter,
-        codex_semantic_adapter=codex_semantic_adapter,
-        request_kind=(
-            RETRY_REQUEST_MAIN_GENERATION if transparent_metered else request_kind
+        caller_request_body_mode=caller_request_body_mode,
+        prepared_request_protocol=(
+            RouteProtocol.RESPONSES
+            if (
+                caller_request_body_mode
+                == CallerRequestBodyMode.CONVERT_CHAT_TO_RESPONSES
+            )
+            else _route_protocol(inbound_format)
         ),
+        codex_semantic_adapter=codex_semantic_adapter,
+        request_kind=effective_request_kind,
         raw_provider_probe=raw_provider_probe,
         request_kind_policy=request_kind_policy,
         retry_policy=retry_policy,
@@ -11560,11 +12017,7 @@ def route_plan_for_request(
         collaboration_backend=collaboration_backend,
         execution_owner=ExecutionOwner.CODEX_CLIENT,
         streaming_policy=streaming_policy,
-        transport_policy=(
-            TransportPolicy.OFFICIAL_KEEPALIVE
-            if upstream_name == "official"
-            else TransportPolicy.STANDARD
-        ),
+        transport_policy=transport_policy,
         request_mutation_policy=mutation_policy,
         response_mutation_policy=mutation_policy,
         sse_mutation_policy=mutation_policy,
@@ -11573,12 +12026,16 @@ def route_plan_for_request(
         transparent_metered=transparent_metered,
         transparent_same_format=transparent_same_format,
         transparent_lightweight_fallback=transparent_lightweight_fallback,
+        transparent_tool_loop_guard=(
+            transparent_same_format and upstream_name != "official"
+        ),
     )
 
 
 def _route_plan_event_fields(plan: RoutePlan) -> dict[str, Any]:
     return {
         "route_plan_schema_version": plan.schema_version,
+        "route_plan_summary_scope": "planned",
         "configured_upstream_protocol_name": plan.configured_upstream_protocol_name,
         "configured_upstream_protocol": plan.configured_upstream_protocol.value,
         "protocol_capability_state": plan.protocol_capability_state.value,
@@ -11588,8 +12045,65 @@ def _route_plan_event_fields(plan: RoutePlan) -> dict[str, Any]:
                 "index": attempt.index,
                 "upstream_protocol": attempt.upstream_protocol.value,
                 "wire_format_adapter": attempt.wire_format_adapter,
+                "request_conversion_steps": list(
+                    attempt.request_conversion_steps
+                ),
                 "request_body_mode": attempt.request_body_mode.value,
+                "authentication_strategy": (
+                    attempt.authentication_strategy.value
+                ),
+                "streaming_policy": attempt.streaming_policy.value,
+                "usage_policy": attempt.usage_policy.value,
+                "transport_policy": attempt.transport_policy.value,
                 "request_mutation_policy": attempt.request_mutation_policy.value,
+                "response_mutation_policy": (
+                    attempt.response_mutation_policy.value
+                ),
+                "sse_mutation_policy": attempt.sse_mutation_policy.value,
+                "verify_cross_protocol_source": (
+                    attempt.verify_cross_protocol_source
+                ),
+                "tool_protocol": attempt.tool_protocol,
+                "tool_surface_strategy": attempt.tool_surface_strategy,
+                "native_responses_tool_codec": (
+                    attempt.native_responses_tool_codec
+                ),
+                "retry": {
+                    "eligibility": attempt.retry.eligibility.value,
+                    "policy": attempt.retry.policy.value,
+                    "request_kind": attempt.retry.request_kind,
+                    "request_timeout_seconds": (
+                        attempt.retry.request_timeout_seconds
+                    ),
+                    "base_open_attempts": attempt.retry.base_open_attempts,
+                    "base_relay_attempts": (
+                        attempt.retry.base_relay_attempts
+                    ),
+                    "failure_expansion_attempts": (
+                        attempt.retry.failure_expansion_attempts
+                    ),
+                    "retry_http_errors": (
+                        attempt.retry.retry_http_errors
+                    ),
+                    "open_attempt_budget": (
+                        attempt.retry.open_attempt_budget
+                    ),
+                    "capacity_elapsed_limit_seconds": (
+                        attempt.retry.capacity_elapsed_limit_seconds
+                    ),
+                    "stream_elapsed_limit_seconds": (
+                        attempt.retry.stream_elapsed_limit_seconds
+                    ),
+                    "emit_downstream_retry_notice": (
+                        attempt.retry.emit_downstream_retry_notice
+                    ),
+                    "pre_response_budget_seconds": (
+                        attempt.retry.pre_response_budget_seconds
+                    ),
+                    "lifecycle_final_retry_eligible": (
+                        attempt.retry.lifecycle_final_retry_eligible
+                    ),
+                },
                 "fallback_http_statuses": sorted(attempt.fallback_http_statuses),
                 "mutation_summary": [
                     mutation.value for mutation in attempt.mutation_summary
@@ -11598,13 +12112,18 @@ def _route_plan_event_fields(plan: RoutePlan) -> dict[str, Any]:
             for attempt in plan.attempts
         ],
         "wire_format_adapter": plan.wire_format_adapter,
+        "route_plan_primary_wire_format_adapter": (
+            plan.wire_format_adapter
+        ),
+        "caller_request_body_mode": plan.caller_request_body_mode.value,
+        "prepared_request_protocol": plan.prepared_request_protocol.value,
         "codex_semantic_adapter": plan.codex_semantic_adapter,
         "request_kind": plan.request_kind,
         "raw_provider_probe": plan.raw_provider_probe,
         "request_kind_policy": plan.request_kind_policy,
-        "retry_policy": plan.retry_policy,
+        "retry_policy": plan.retry_policy.value,
         "retry_eligibility": plan.retry_eligibility.value,
-        "usage_policy": plan.usage_policy,
+        "usage_policy": plan.usage_policy.value,
         "repair_policy": plan.repair_policy,
         "capability_manifest_version": plan.capability_manifest_version,
         "capability_manifest_hash": plan.capability_manifest_hash,
@@ -11628,6 +12147,11 @@ def _route_plan_event_fields(plan: RoutePlan) -> dict[str, Any]:
         "vision_network_action": plan.vision.network_action.value,
         "vision_input_has_image": plan.vision.input_has_image,
         "vision_target_accepts_images": plan.vision.target_accepts_images,
+        "transparent_tool_loop_guard": plan.transparent_tool_loop_guard,
+        "mutation_summary_scope": "planned_union",
+        "planned_mutation_summary": [
+            mutation.value for mutation in plan.mutation_summary
+        ],
         "mutation_summary": [
             mutation.value for mutation in plan.mutation_summary
         ],
@@ -11636,10 +12160,64 @@ def _route_plan_event_fields(plan: RoutePlan) -> dict[str, Any]:
 
 def _route_attempt_event_fields(attempt: RouteAttemptPlan) -> dict[str, Any]:
     return {
+        "execution_summary_scope": "selected_attempt_plan",
+        "executed_upstream_protocol": attempt.upstream_protocol.value,
+        "executed_wire_format_adapter": attempt.wire_format_adapter,
+        "executed_request_conversion_steps": list(
+            attempt.request_conversion_steps
+        ),
+        "executed_attempt_mutation_summary": [
+            mutation.value for mutation in attempt.mutation_summary
+        ],
         "route_attempt_index": attempt.index,
         "route_attempt_protocol": attempt.upstream_protocol.value,
         "route_attempt_wire_format_adapter": attempt.wire_format_adapter,
+        "route_attempt_request_conversion_steps": list(
+            attempt.request_conversion_steps
+        ),
         "route_attempt_request_body_mode": attempt.request_body_mode.value,
+        "route_attempt_mutation_summary_scope": "attempt_plan",
+        "route_attempt_authentication_strategy": (
+            attempt.authentication_strategy.value
+        ),
+        "route_attempt_streaming_policy": attempt.streaming_policy.value,
+        "route_attempt_usage_policy": attempt.usage_policy.value,
+        "route_attempt_transport_policy": attempt.transport_policy.value,
+        "route_attempt_retry_policy": attempt.retry.policy.value,
+        "route_attempt_retry_eligibility": (
+            attempt.retry.eligibility.value
+        ),
+        "route_attempt_base_open_attempts": (
+            attempt.retry.base_open_attempts
+        ),
+        "route_attempt_base_relay_attempts": (
+            attempt.retry.base_relay_attempts
+        ),
+        "route_attempt_open_attempt_budget": (
+            attempt.retry.open_attempt_budget
+        ),
+        "route_attempt_request_timeout_seconds": (
+            attempt.retry.request_timeout_seconds
+        ),
+        "route_attempt_request_mutation_policy": (
+            attempt.request_mutation_policy.value
+        ),
+        "route_attempt_response_mutation_policy": (
+            attempt.response_mutation_policy.value
+        ),
+        "route_attempt_sse_mutation_policy": (
+            attempt.sse_mutation_policy.value
+        ),
+        "route_attempt_verify_cross_protocol_source": (
+            attempt.verify_cross_protocol_source
+        ),
+        "route_attempt_tool_protocol": attempt.tool_protocol,
+        "route_attempt_tool_surface_strategy": (
+            attempt.tool_surface_strategy
+        ),
+        "route_attempt_native_responses_tool_codec": (
+            attempt.native_responses_tool_codec
+        ),
         "route_attempt_fallback_http_statuses": sorted(
             attempt.fallback_http_statuses
         ),
@@ -11712,8 +12290,14 @@ def upstream_headers(
     drop_content_encoding: bool = False,
     behavior_profile: str | None = None,
     model_id: str | None = None,
+    authentication_strategy: AuthenticationStrategy | None = None,
+    request_mutation_policy: MutationPolicy | None = None,
 ) -> dict[str, str]:
-    auth_mode = upstream.get("auth")
+    auth_mode = (
+        authentication_strategy.value
+        if authentication_strategy is not None
+        else upstream.get("auth")
+    )
     outgoing: dict[str, str] = {}
     upstream_model_id = canonical_model_id(
         str(upstream.get("upstream_model") or model_id or "")
@@ -11749,7 +12333,13 @@ def upstream_headers(
             raise ValueError(f"API key is not set for upstream: {upstream.get('name', 'unknown')}")
         outgoing["Authorization"] = f"Bearer {api_key}"
     elif auth_mode == "codex_auth":
-        strict_official_passthrough = behavior_profile == BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH
+        strict_official_passthrough = (
+            request_mutation_policy
+            == MutationPolicy.OFFICIAL_PASSTHROUGH
+            if request_mutation_policy is not None
+            else behavior_profile
+            == BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH
+        )
         token = codex_access_token()
         outgoing["Authorization"] = f"Bearer {token}"
         # The chatgpt.com backend requires the account id header to identify
@@ -13132,13 +13722,6 @@ def _capacity_retry_elapsed_limit_allows(started_at: float, delay_seconds: int) 
     return (time.monotonic() - started_at + delay_seconds) <= limit_seconds
 
 
-def _stream_retry_elapsed_limit_allows(started_at: float, delay_seconds: int) -> bool:
-    limit_seconds = gateway_stream_retry_elapsed_limit_seconds()
-    if limit_seconds <= 0:
-        return True
-    return (time.monotonic() - started_at + delay_seconds) <= limit_seconds
-
-
 def _upstream_error_retryable(
     exc: BaseException,
     *,
@@ -13653,15 +14236,6 @@ def _parse_gateway_request_input(
     )
 
 
-def _main_generation_pre_response_deadline(
-    started_at: float,
-    request_kind: str,
-) -> float | None:
-    if request_kind != RETRY_REQUEST_MAIN_GENERATION:
-        return None
-    return started_at + DEFAULT_MAIN_GENERATION_PRE_RESPONSE_BUDGET_SECONDS
-
-
 def _remaining_pre_response_budget_seconds(deadline: float | None) -> float | None:
     if deadline is None:
         return None
@@ -13724,13 +14298,30 @@ def _open_upstream_response(
     max_attempts: int | None = None,
     retry_policy: str = RETRY_GATEWAY_FULL,
     retry_http_errors: bool = True,
+    retry_execution: RetryExecutionPlan | None = None,
     transport_policy: TransportPolicy | None = None,
     downstream_exposed: Callable[[], bool] | None = None,
     pre_response_deadline: float | None = None,
     open_attempt_budget: dict[str, int] | None = None,
 ) -> Any:
-    explicit_max_attempts = max_attempts is not None
-    base_retry_attempts = _upstream_retry_attempts(request_kind) if max_attempts is None else max(1, max_attempts)
+    if retry_execution is not None:
+        request_kind = retry_execution.request_kind
+        retry_policy = retry_execution.policy.value
+        retry_http_errors = retry_execution.retry_http_errors
+        timeout = retry_execution.request_timeout_seconds
+        base_retry_attempts = retry_execution.base_open_attempts
+        explicit_max_attempts = (
+            retry_execution.open_attempt_budget is not None
+        )
+        if open_attempt_budget is None:
+            open_attempt_budget = retry_execution.new_open_attempt_budget()
+    else:
+        explicit_max_attempts = max_attempts is not None
+        base_retry_attempts = (
+            _upstream_retry_attempts(request_kind)
+            if max_attempts is None
+            else max(1, max_attempts)
+        )
     if open_attempt_budget is not None:
         remaining_open_attempts = max(
             0,
@@ -13897,11 +14488,26 @@ def _open_upstream_response(
                 model_access_path=model_access_path,
                 failure_phase=retry_safety_failure_phase,
             )
-            retry_attempts = _retry_attempts_for_failure_class(
-                request_kind=request_kind,
-                base_attempts=base_retry_attempts,
-                failure_class=failure_class,
-                explicit_max_attempts=explicit_max_attempts,
+            retry_attempts = (
+                (
+                    min(
+                        base_retry_attempts,
+                        retry_execution.open_attempts_for_failure_class(
+                            failure_class
+                        ),
+                    )
+                    if open_attempt_budget is not None
+                    else retry_execution.open_attempts_for_failure_class(
+                        failure_class
+                    )
+                )
+                if retry_execution is not None
+                else _retry_attempts_for_failure_class(
+                    request_kind=request_kind,
+                    base_attempts=base_retry_attempts,
+                    failure_class=failure_class,
+                    explicit_max_attempts=explicit_max_attempts,
+                )
             )
             error_retry_budget = (
                 open_attempt_budget["max_attempts"]
@@ -13960,14 +14566,36 @@ def _open_upstream_response(
                 ) from exc
             if attempt >= retry_attempts or failure_class == RETRY_FAILURE_PERMANENT:
                 raise
-            delay_seconds = gateway_retry_delay_seconds(
-                request_attempt,
-                failure_class=failure_class,
-                exc=exc,
+            delay_seconds = (
+                retry_execution.retry_delay_seconds(
+                    request_attempt,
+                    failure_class=failure_class,
+                    exc=exc,
+                )
+                if retry_execution is not None
+                else gateway_retry_delay_seconds(
+                    request_attempt,
+                    failure_class=failure_class,
+                    exc=exc,
+                )
+            )
+            retry_elapsed_seconds = max(
+                0.0,
+                time.monotonic() - retry_started_at,
             )
             if (
                 failure_class in CAPACITY_RETRY_FAILURE_CLASSES
-                and not _capacity_retry_elapsed_limit_allows(retry_started_at, delay_seconds)
+                and not (
+                    retry_execution.capacity_elapsed_limit_allows(
+                        retry_elapsed_seconds,
+                        delay_seconds,
+                    )
+                    if retry_execution is not None
+                    else _capacity_retry_elapsed_limit_allows(
+                        retry_started_at,
+                        delay_seconds,
+                    )
+                )
             ):
                 raise
             _require_retry_delay_within_pre_response_budget(
@@ -14942,6 +15570,20 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 model and model_supports_image(model, upstream)
             )
             image_proxy_enabled = gateway_image_proxy_enabled()
+            caller_stream = (
+                inbound_payload.get("stream") is True
+                if isinstance(inbound_payload, Mapping)
+                else True
+            )
+            route_runtime_facts: dict[str, RouteRuntimeFacts] = {
+                request_kind: _route_runtime_facts(request_kind)
+            }
+            if request_kind != RETRY_REQUEST_MAIN_GENERATION:
+                route_runtime_facts[RETRY_REQUEST_MAIN_GENERATION] = (
+                    _route_runtime_facts(
+                        RETRY_REQUEST_MAIN_GENERATION
+                    )
+                )
             route_plan = route_plan_for_request(
                 upstream,
                 request_context,
@@ -14957,19 +15599,18 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 official_http_passthrough_enabled=(
                     gateway_official_http_passthrough_enabled()
                 ),
+                caller_stream=caller_stream,
+                runtime_facts=route_runtime_facts,
             )
             behavior_profile = route_plan.behavior_profile
             upstream_format = route_plan.selected_upstream_format
-            is_official_http_passthrough = route_plan.official_http_passthrough
-            is_transparent_metered = route_plan.transparent_metered
-            is_transparent_same_format = route_plan.transparent_same_format
-            is_transparent_lightweight_fallback = route_plan.transparent_lightweight_fallback
             if request_kind != route_plan.request_kind:
                 request_kind = route_plan.request_kind
                 proxy_request_context = _event_context_with_request_kind(request_context, request_kind)
-            self._pre_response_deadline = _main_generation_pre_response_deadline(
-                started_at,
-                request_kind,
+            self._pre_response_deadline = (
+                route_plan.attempts[0].retry.pre_response_deadline(started_at)
+                if route_plan.attempts
+                else None
             )
             reasoning_policy = _reasoning_policy_for_request(inbound_payload, upstream, model)
             route_policy_event_fields = {
@@ -15033,10 +15674,6 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
             # Capture the caller's desired stream mode and prompt cache key
             # before compatibility helpers can force stream=true or reshape the
             # body for the selected upstream.
-            if isinstance(inbound_payload, Mapping):
-                caller_stream = inbound_payload.get("stream") is True
-            else:
-                caller_stream = True
             prompt_cache_key = None
             if isinstance(inbound_payload, Mapping) and isinstance(inbound_payload.get("prompt_cache_key"), str):
                 prompt_cache_key = inbound_payload["prompt_cache_key"]
@@ -15044,9 +15681,15 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 body=caller_body,
                 codex_home=RUNTIME_CODEX_DIR,
                 upstream=upstream,
-                include_body_hmac=not is_official_http_passthrough,
+                include_body_hmac=(
+                    route_plan.request_mutation_policy
+                    != MutationPolicy.OFFICIAL_PASSTHROUGH
+                ),
                 prompt_cache_key=prompt_cache_key,
-                extract_prompt_cache_key=not is_official_http_passthrough,
+                extract_prompt_cache_key=(
+                    route_plan.request_mutation_policy
+                    != MutationPolicy.OFFICIAL_PASSTHROUGH
+                ),
             )
 
             def emit_request_start_once(observability_fields: Mapping[str, Any]) -> None:
@@ -15086,7 +15729,10 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
             # Convert inbound Chat Completions request to Responses format before routing
             # only for Gateway compatibility paths. Same-format transparent traffic
             # must stay in the caller's wire format.
-            if inbound_format == "chat_completions" and not is_transparent_same_format:
+            if (
+                route_plan.caller_request_body_mode
+                == CallerRequestBodyMode.CONVERT_CHAT_TO_RESPONSES
+            ):
                 body = _chat_completions_request_to_responses_body(body)
             adapter_event_context = {
                 "request_id": request_id,
@@ -15109,14 +15755,20 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 )
 
             usage_capture: dict[str, Any] = {}
-            if is_official_http_passthrough:
+            if (
+                route_plan.request_mutation_policy
+                == MutationPolicy.OFFICIAL_PASSTHROUGH
+            ):
                 body = official_passthrough_request_body(
                     body,
                     inbound_payload,
                     upstream,
                     model_id=model,
                 )
-            elif is_transparent_same_format or is_transparent_lightweight_fallback:
+            elif (
+                route_plan.request_mutation_policy
+                == MutationPolicy.TRANSPARENT
+            ):
                 body = transparent_request_body(
                     body,
                     _safe_json_mapping(body),
@@ -15149,7 +15801,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         schemas_rewritten=tool_schema_rewrites,
                         **proxy_request_context,
                     )
-                if upstream_name != "official" and is_transparent_same_format:
+                if route_plan.transparent_tool_loop_guard:
                     transparent_payload = _safe_json_mapping(body) or {}
                     repeated_count = (
                         _excessive_transparent_responses_tool_loop_count(transparent_payload)
@@ -15176,12 +15828,18 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                     model_id=model,
                     event_context=adapter_event_context,
                     inject_codex_tools=route_plan.tool_exposure.gateway_schema_injection,
-                    behavior_profile=behavior_profile,
+                    tool_protocol_override=(
+                        route_plan.attempts[0].tool_protocol
+                    ),
+                    tool_surface_strategy_override=(
+                        route_plan.attempts[0].tool_surface_strategy
+                    ),
+                    native_responses_tool_codec_override=(
+                        route_plan.attempts[0].native_responses_tool_codec
+                    ),
                 )
             vision_proxy_payload_format = (
-                "chat_completions"
-                if inbound_format == "chat_completions" and is_transparent_same_format
-                else "responses"
+                route_plan.prepared_request_protocol.value
             )
             image_proxy_payload: dict[str, Any] | None = None
             if route_plan.vision.action == VisionAction.PROXY:
@@ -15222,35 +15880,34 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 self.headers,
                 upstream,
                 drop_content_encoding=content_decoded,
-                behavior_profile=behavior_profile,
                 model_id=model,
+                authentication_strategy=(
+                    route_plan.attempts[0].authentication_strategy
+                ),
+                request_mutation_policy=(
+                    route_plan.attempts[0].request_mutation_policy
+                ),
             )
 
             def upstream_body_for_attempt(
                 attempt: RouteAttemptPlan,
                 prepared_body: bytes = responses_body,
             ) -> bytes:
-                if (
-                    attempt.request_body_mode
-                    == AttemptRequestBodyMode.CONVERT_RESPONSES_TO_CHAT
-                ):
-                    return _responses_request_to_chat_completion_body(prepared_body)
-                if (
-                    attempt.request_body_mode
-                    == AttemptRequestBodyMode.PREPARED_DIRECT
-                ):
-                    return prepared_body
-                raise UnsupportedRouteProtocolError(
-                    f"unsupported planned request body mode: {attempt.request_body_mode}"
-                )
+                return attempt.request_body(prepared_body)
 
             upstream_request_observability = proxy_telemetry.enrich_request_observability(
                 body=upstream_body_for_attempt(route_plan.attempts[0]),
                 codex_home=RUNTIME_CODEX_DIR,
                 upstream=upstream,
-                include_body_hmac=not is_official_http_passthrough,
+                include_body_hmac=(
+                    route_plan.request_mutation_policy
+                    != MutationPolicy.OFFICIAL_PASSTHROUGH
+                ),
                 prompt_cache_key=prompt_cache_key,
-                extract_prompt_cache_key=not is_official_http_passthrough,
+                extract_prompt_cache_key=(
+                    route_plan.request_mutation_policy
+                    != MutationPolicy.OFFICIAL_PASSTHROUGH
+                ),
             )
             request_observability = {
                 **upstream_request_observability,
@@ -15259,11 +15916,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
             }
             emit_request_start_once(request_observability)
             emit_retry_to_downstream = (
-                not is_official_http_passthrough
-                and not is_transparent_metered
-                and caller_stream
-                and inbound_format == "responses"
-                and gateway_downstream_retry_notice_enabled()
+                route_plan.attempts[0].retry.emit_downstream_retry_notice
             )
 
             def upstream_request_for_attempt(
@@ -15271,7 +15924,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 lifecycle_final_retry_reason: str | None = None,
             ) -> Request:
                 request_body = responses_body
-                if lifecycle_final_retry_reason and not is_transparent_same_format:
+                if lifecycle_final_retry_reason:
                     request_body = _responses_body_with_lifecycle_final_retry_guidance(
                         responses_body,
                         lifecycle_final_retry_reason,
@@ -15283,17 +15936,8 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         upstream_format=attempt.selected_upstream_format,
                         reason=lifecycle_final_retry_reason,
                     )
-                if attempt.upstream_protocol == RouteProtocol.CHAT_COMPLETIONS:
-                    url = _chat_completions_url(upstream)
-                elif attempt.upstream_protocol == RouteProtocol.RESPONSES:
-                    url = _responses_url(upstream, "/v1/responses")
-                else:
-                    raise UnsupportedRouteProtocolError(
-                        "planned attempt has no executable upstream protocol: "
-                        f"{attempt.upstream_protocol.value}"
-                    )
                 return Request(
-                    url,
+                    attempt.endpoint_url,
                     data=upstream_body_for_attempt(attempt, request_body),
                     headers=headers,
                     method="POST",
@@ -15337,13 +15981,8 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 downstream_sse_started = True
 
             selected_upstream_format = upstream_format
-            official_open_attempt_budget = (
-                {
-                    "max_attempts": official_upstream_open_attempts(),
-                    "attempts_started": 0,
-                }
-                if is_official_http_passthrough
-                else None
+            open_attempt_budget = (
+                route_plan.attempts[0].retry.new_open_attempt_budget()
             )
             for route_attempt in route_plan.attempts:
                 selected_upstream_format = route_attempt.selected_upstream_format
@@ -15351,19 +15990,15 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 proxy_request_context.update(route_attempt_event_fields)
                 if isinstance(adapter_event_context, dict):
                     adapter_event_context.update(route_attempt_event_fields)
-                    adapter_event_context["tool_protocol"] = _external_tool_protocol(
-                        {**upstream, "upstream_format": selected_upstream_format}
+                    adapter_event_context["tool_protocol"] = (
+                        route_attempt.tool_protocol
                     )
-                base_relay_attempts = (
-                    OFFICIAL_PASSTHROUGH_FIRST_EVENT_ATTEMPTS
-                    if is_official_http_passthrough
-                    else _upstream_retry_attempts(request_kind)
-                )
+                base_relay_attempts = route_attempt.retry.base_relay_attempts
                 relay_attempts = base_relay_attempts
                 lifecycle_final_extra_attempts = (
-                    1
-                    if (not is_official_http_passthrough and lifecycle_empty_final_resample_enabled(adapter_event_context, request_kind))
-                    else 0
+                    route_attempt.retry.lifecycle_final_extra_attempts(
+                        adapter_event_context
+                    )
                 )
                 max_relay_attempts = relay_attempts + lifecycle_final_extra_attempts
                 relay_attempt = 1
@@ -15382,23 +16017,18 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                                 request,
                                 upstream_name=upstream_name,
                                 upstream_format=selected_upstream_format,
-                                timeout=upstream_timeout_seconds(),
+                                timeout=(
+                                    route_attempt.retry.request_timeout_seconds
+                                ),
                                 event_context=adapter_event_context,
                                 downstream_retry_callback=emit_downstream_retry if emit_retry_to_downstream else None,
-                                request_kind=request_kind,
-                                max_attempts=(
-                                    official_open_attempt_budget["max_attempts"]
-                                    if official_open_attempt_budget is not None
-                                    else None
-                                ),
-                                retry_policy=route_plan.retry_policy,
-                                retry_http_errors=not is_official_http_passthrough,
-                                transport_policy=route_plan.transport_policy,
+                                retry_execution=route_attempt.retry,
+                                transport_policy=route_attempt.transport_policy,
                                 downstream_exposed=lambda: _downstream_has_been_exposed(self),
                                 pre_response_deadline=(
                                     None if downstream_sse_started else self._pre_response_deadline
                                 ),
-                                open_attempt_budget=official_open_attempt_budget,
+                                open_attempt_budget=open_attempt_budget,
                             ) as response:
                                 seam = _handler_downstream_stream_commit(self)
                                 if seam is not None:
@@ -15418,7 +16048,22 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                                     defer_stream_errors=relay_attempt < relay_attempts,
                                     mark_downstream_sse_started=mark_downstream_sse_started,
                                     response_lifecycle_state=response_lifecycle_state,
-                                    behavior_profile=behavior_profile,
+                                    streaming_policy=(
+                                        route_attempt.streaming_policy
+                                    ),
+                                    usage_policy=route_attempt.usage_policy,
+                                    response_mutation_policy=(
+                                        route_attempt.response_mutation_policy
+                                    ),
+                                    sse_mutation_policy=(
+                                        route_attempt.sse_mutation_policy
+                                    ),
+                                    verify_cross_protocol_source=(
+                                        route_attempt.verify_cross_protocol_source
+                                    ),
+                                    lifecycle_final_retry_enabled=(
+                                        lifecycle_final_extra_attempts > 0
+                                    ),
                                 )
                             break
                         except DownstreamClosedBeforeRetryError:
@@ -15443,6 +16088,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                             )
                             retry_safety_class: str | None = None
                             if lifecycle_retry:
+                                stream_failure = True
                                 retry_exc: BaseException = exc
                                 failure_class = RETRY_FAILURE_QUICK_TRANSIENT
                                 lifecycle_final_retry_reason = "empty" if isinstance(exc, LifecycleEmptyFinalResponseError) else "format"
@@ -15490,15 +16136,15 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                                 is_stream_error_event = isinstance(exc, UpstreamStreamErrorEvent)
                                 retry_exc = exc.cause if isinstance(exc, UpstreamStreamInterruptedError) else exc
                                 failure_class = _upstream_failure_class(retry_exc)
-                                relay_attempts = _retry_attempts_for_failure_class(
-                                    request_kind=request_kind,
-                                    base_attempts=base_relay_attempts,
+                                relay_attempts = route_attempt.retry.relay_attempts_for_failure_class(
                                     failure_class=failure_class,
-                                    explicit_max_attempts=False,
                                     stream_failure=stream_failure,
                                 )
                                 if isinstance(retry_exc, UpstreamEmptyCompletedResponseError):
-                                    relay_attempts = min(relay_attempts, 2)
+                                    relay_attempts = min(
+                                        relay_attempts,
+                                        route_attempt.retry.empty_completed_max_attempts,
+                                    )
                                 max_relay_attempts = relay_attempts + lifecycle_final_extra_attempts
                                 retry_limit = relay_attempts
                                 stream_failure_phase = "stream_body" if (stream_failure or is_stream_error_event) else None
@@ -15562,20 +16208,31 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                                     raise retry_exc
                                 if relay_attempt >= retry_limit or failure_class == RETRY_FAILURE_PERMANENT:
                                     raise retry_exc
-                                delay_seconds = gateway_retry_delay_seconds(
+                                delay_seconds = route_attempt.retry.retry_delay_seconds(
                                     relay_attempt,
                                     failure_class=failure_class,
                                     exc=retry_exc,
                                 )
-                                if failure_class in CAPACITY_RETRY_FAILURE_CLASSES and not _capacity_retry_elapsed_limit_allows(
-                                    started_at,
-                                    delay_seconds,
+                                retry_elapsed_seconds = max(
+                                    0.0,
+                                    time.monotonic() - started_at,
+                                )
+                                if (
+                                    failure_class
+                                    in CAPACITY_RETRY_FAILURE_CLASSES
+                                    and not route_attempt.retry.capacity_elapsed_limit_allows(
+                                        retry_elapsed_seconds,
+                                        delay_seconds,
+                                    )
                                 ):
                                     raise retry_exc
                                 if (
                                     stream_failure
                                     and failure_class == RETRY_FAILURE_QUICK_TRANSIENT
-                                    and not _stream_retry_elapsed_limit_allows(started_at, delay_seconds)
+                                    and not route_attempt.retry.stream_elapsed_limit_allows(
+                                        retry_elapsed_seconds,
+                                        delay_seconds,
+                                    )
                                 ):
                                     raise retry_exc
                             _emit_upstream_retry_event(
@@ -15662,6 +16319,11 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                                 failed_route_attempt_request_body_mode=(
                                     route_attempt.request_body_mode.value
                                 ),
+                                failed_route_attempt_request_conversion_steps=(
+                                    list(
+                                        route_attempt.request_conversion_steps
+                                    )
+                                ),
                                 failed_route_attempt_mutation_summary=[
                                     mutation.value
                                     for mutation in route_attempt.mutation_summary
@@ -15669,6 +16331,11 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                                 next_route_attempt_index=next_attempt.index,
                                 next_route_attempt_request_body_mode=(
                                     next_attempt.request_body_mode.value
+                                ),
+                                next_route_attempt_request_conversion_steps=(
+                                    list(
+                                        next_attempt.request_conversion_steps
+                                    )
                                 ),
                                 next_route_attempt_mutation_summary=[
                                     mutation.value
@@ -17718,7 +18385,64 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
         mark_downstream_sse_started: Callable[[], None] | None = None,
         response_lifecycle_state: dict[str, str] | None = None,
         behavior_profile: str | None = None,
+        streaming_policy: StreamingPolicy | None = None,
+        usage_policy: UsagePolicy | None = None,
+        response_mutation_policy: MutationPolicy | None = None,
+        sse_mutation_policy: MutationPolicy | None = None,
+        verify_cross_protocol_source: bool | None = None,
+        lifecycle_final_retry_enabled: bool | None = None,
     ) -> int:
+        if streaming_policy is None:
+            if (
+                behavior_profile
+                == BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH
+            ):
+                streaming_policy = StreamingPolicy.OFFICIAL_PASSTHROUGH
+            elif (
+                behavior_profile
+                == BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED
+            ):
+                streaming_policy = (
+                    StreamingPolicy.TRANSPARENT
+                    if upstream_format == inbound_format
+                    else StreamingPolicy.TRANSPARENT_CONVERTED
+                )
+            else:
+                streaming_policy = StreamingPolicy.GATEWAY_ADAPTED
+        if usage_policy is None:
+            usage_policy = (
+                UsagePolicy.ASYNC_TAP
+                if (
+                    behavior_profile
+                    == BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED
+                )
+                else UsagePolicy.SYNC_CAPTURE
+            )
+        if response_mutation_policy is None:
+            response_mutation_policy = (
+                MutationPolicy.TRANSPARENT
+                if (
+                    behavior_profile
+                    == BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED
+                )
+                else (
+                    MutationPolicy.OFFICIAL_PASSTHROUGH
+                    if (
+                        behavior_profile
+                        == BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH
+                    )
+                    else MutationPolicy.GATEWAY_COMPATIBILITY
+                )
+            )
+        if sse_mutation_policy is None:
+            sse_mutation_policy = response_mutation_policy
+        if lifecycle_final_retry_enabled is None:
+            lifecycle_final_retry_enabled = (
+                lifecycle_empty_final_resample_enabled(
+                    event_context,
+                    request_kind,
+                )
+            )
         status = getattr(response, "status", None) or getattr(response, "code", 502)
         is_event_stream = _is_event_stream(response.headers)
         # When the caller spoke Chat Completions, the response must be converted
@@ -17760,10 +18484,19 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
         buffer_sse_to_json = is_event_stream and not caller_stream
         buffered_json_response = False
         buffered_chat_sse_to_responses = False
-        verified_source_format = _verified_cross_protocol_source_format(
-            behavior_profile=behavior_profile,
-            upstream_format=upstream_format,
-            inbound_format=inbound_format,
+        verified_source_format = (
+            upstream_format
+            if (
+                verify_cross_protocol_source is True
+                and upstream_format != inbound_format
+            )
+            else None
+            if verify_cross_protocol_source is False
+            else _verified_cross_protocol_source_format(
+                behavior_profile=behavior_profile,
+                upstream_format=upstream_format,
+                inbound_format=inbound_format,
+            )
         )
         usage_context = _usage_observed_context(
             event_context,
@@ -17789,7 +18522,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 response_lifecycle_state["response_id"] = response_id
 
         if (
-            behavior_profile == BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED
+            streaming_policy == StreamingPolicy.TRANSPARENT
             and upstream_format == inbound_format
             and not (is_event_stream and not caller_stream and upstream_format == "responses")
         ):
@@ -17807,7 +18540,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 defer_stream_errors=defer_stream_errors,
             )
         if (
-            behavior_profile == BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH
+            streaming_policy == StreamingPolicy.OFFICIAL_PASSTHROUGH
             and is_event_stream
             and inbound_format == "responses"
             and upstream_format == "responses"
@@ -17829,7 +18562,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
         defer_stream_headers = (
             is_event_stream
             and caller_stream
-            and lifecycle_empty_final_resample_enabled(event_context, request_kind)
+            and lifecycle_final_retry_enabled
         )
 
         def finish_downstream_stream_closed(exc: OSError) -> int:
@@ -17853,7 +18586,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 usage_capture,
                 None,
                 missing_reason="async_usage_pending"
-                if behavior_profile == BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED
+                if usage_policy == UsagePolicy.ASYNC_TAP
                 else "client_disconnected",
             )
             return 499
@@ -18045,7 +18778,10 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         )
                     else:
                         # Upstream returned Responses format; convert to Chat Completions.
-                        if behavior_profile == BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED:
+                        if (
+                            response_mutation_policy
+                            == MutationPolicy.TRANSPARENT
+                        ):
                             body = _response_body_to_chat_completion_body(body)
                         else:
                             body = _response_body_to_chat_completion_body(
@@ -18061,9 +18797,15 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                     else:
                         converted_body = _chat_completion_to_response_body(
                             body,
-                            repair=behavior_profile != BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+                            repair=(
+                                response_mutation_policy
+                                != MutationPolicy.TRANSPARENT
+                            ),
                         )
-                    if behavior_profile == BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED:
+                    if (
+                        response_mutation_policy
+                        == MutationPolicy.TRANSPARENT
+                    ):
                         body = converted_body
                     else:
                         body = compatible_response_body(
@@ -18094,7 +18836,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                     status=status,
                     exc=response if isinstance(response, BaseException) else None,
                 )
-            if behavior_profile == BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED:
+            if usage_policy == UsagePolicy.ASYNC_TAP:
                 _capture_usage(usage_capture, None, missing_reason="async_usage_pending")
                 _offer_usage_observed_body(usage_context, upstream_body_for_usage)
             else:
@@ -18212,7 +18954,10 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         if mark_downstream_sse_started is not None:
                             mark_downstream_sse_started()
                     for event in response_events:
-                        if behavior_profile != BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED:
+                        if (
+                            sse_mutation_policy
+                            != MutationPolicy.TRANSPARENT
+                        ):
                             event, _ = _normalize_third_party_tool_call(event)
                             event, _ = _suppress_bounded_tool_search_calls(
                                 event,
@@ -18242,7 +18987,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         usage_capture,
                         None,
                         missing_reason="async_usage_pending"
-                        if behavior_profile == BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED
+                        if usage_policy == UsagePolicy.ASYNC_TAP
                         else "upstream_missing_usage",
                     )
                     return status
@@ -18300,7 +19045,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
 
         if is_event_stream:
             if (
-                behavior_profile == BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED
+                streaming_policy == StreamingPolicy.TRANSPARENT_CONVERTED
                 and want_chat_output
                 and upstream_format != "chat_completions"
             ):
@@ -18469,7 +19214,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 return status
 
             if (
-                behavior_profile == BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED
+                streaming_policy == StreamingPolicy.TRANSPARENT_CONVERTED
                 and upstream_format == "chat_completions"
                 and not want_chat_output
             ):
@@ -18666,7 +19411,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         if event is None or event == "[DONE]":
                             continue
                         events.append(event)
-                        if behavior_profile == BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED:
+                        if usage_policy == UsagePolicy.ASYNC_TAP:
                             _offer_usage_observed_sse_line(
                                 usage_context,
                                 frame.raw,
@@ -18817,7 +19562,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                     usage_capture,
                     None,
                     missing_reason="async_usage_pending"
-                    if behavior_profile == BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED
+                    if usage_policy == UsagePolicy.ASYNC_TAP
                     else "upstream_missing_usage",
                 )
                 return status
@@ -18843,7 +19588,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                             chunks.append("[DONE]")
                             continue
                         chunks.append(payload)
-                        if behavior_profile == BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED:
+                        if usage_policy == UsagePolicy.ASYNC_TAP:
                             _offer_usage_observed_sse_line(
                                 usage_context,
                                 frame.raw,
@@ -19080,12 +19825,12 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                     usage_capture,
                     None,
                     missing_reason="async_usage_pending"
-                    if behavior_profile == BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED
+                    if usage_policy == UsagePolicy.ASYNC_TAP
                     else "upstream_missing_usage",
                 )
                 return status
 
-            if lifecycle_empty_final_resample_enabled(event_context, request_kind):
+            if lifecycle_final_retry_enabled:
                 reasoning_stats: dict[str, Any] = {
                     "seen": False,
                     "original_event_counts": {},
@@ -19750,7 +20495,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 usage_capture,
                 None,
                 missing_reason="async_usage_pending"
-                if behavior_profile == BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED
+                if usage_policy == UsagePolicy.ASYNC_TAP
                 else "upstream_missing_usage",
             )
             return status
@@ -19764,7 +20509,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
             usage_capture,
             None,
             missing_reason="async_usage_pending"
-            if behavior_profile == BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED
+            if usage_policy == UsagePolicy.ASYNC_TAP
             else "upstream_missing_usage",
         )
         return status

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import argparse
 from copy import deepcopy
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import timezone
 from email.utils import parsedate_to_datetime
 from enum import Enum
@@ -1075,7 +1075,7 @@ class SensitiveValue:
 
 
 class OperationalAuthentication:
-    """Request-scoped auth material captured before route planning completes."""
+    """Request-scoped auth material captured after route viability is proved."""
 
     __slots__ = (
         "strategy",
@@ -2600,6 +2600,7 @@ def _route_capability_metadata(source: Mapping[str, Any]) -> dict[str, Any]:
         "capability_manifest_version",
         "capability_manifest_hash",
         "capability_manifest_state",
+        "capability_binding",
     )
     return {key: source[key] for key in keys if key in source}
 
@@ -11479,6 +11480,36 @@ class RouteAttemptPlan:
 
 
 @dataclass(frozen=True)
+class RouteFailureObservation:
+    """Plan-wide facts used only when no executable attempt exists."""
+
+    upstream_protocol: RouteProtocol
+    wire_format_adapter: str
+    authentication_strategy: AuthenticationStrategy
+    request_kind: str
+    retry_policy: RetryPolicy
+    retry_eligibility: CapabilityState
+    usage_policy: UsagePolicy
+    streaming_policy: StreamingPolicy
+    transport_policy: TransportPolicy
+    request_mutation_policy: MutationPolicy
+    response_mutation_policy: MutationPolicy
+    sse_mutation_policy: MutationPolicy
+
+
+@dataclass(frozen=True)
+class RouteCapabilityBinding:
+    source_present: bool
+    schema_version: int | None
+    provider_id: str | None
+    model_id: str | None
+    configured_upstream_protocol: RouteProtocol
+    binding_upstream_protocol: RouteProtocol
+    route_scope_state: CapabilityState
+    route_scope_failure_reason: str | None
+
+
+@dataclass(frozen=True)
 class RoutePlan:
     schema_version: str
     provider_id: str
@@ -11491,9 +11522,11 @@ class RoutePlan:
     protocol_capability_state: CapabilityState
     protocol_failure_reason: str | None
     attempts: tuple[RouteAttemptPlan, ...]
+    failure_observation: RouteFailureObservation | None
     capability_manifest_version: str | None
     capability_manifest_hash: str | None
     capability_manifest_state: CapabilityState
+    capability_binding: RouteCapabilityBinding
     behavior_profile: str
     caller_request_body_mode: CallerRequestBodyMode
     prepared_request_protocol: RouteProtocol
@@ -11513,6 +11546,17 @@ class RoutePlan:
     transparent_lightweight_fallback: bool
     transparent_tool_loop_guard: bool
 
+    def __post_init__(self) -> None:
+        if bool(self.attempts) == (self.failure_observation is not None):
+            raise ValueError(
+                "route plan must contain either attempts or one failure observation"
+            )
+
+    def _required_failure_observation(self) -> RouteFailureObservation:
+        if self.failure_observation is None:
+            raise RuntimeError("route plan has neither an attempt nor failure facts")
+        return self.failure_observation
+
     @property
     def mutation_summary(self) -> tuple[RouteMutation, ...]:
         return tuple(sorted(self.named_mutations, key=lambda mutation: mutation.value))
@@ -11531,7 +11575,7 @@ class RoutePlan:
         return (
             primary_attempt.retry.request_kind
             if primary_attempt is not None
-            else RETRY_REQUEST_MAIN_GENERATION
+            else self._required_failure_observation().request_kind
         )
 
     @property
@@ -11540,7 +11584,7 @@ class RoutePlan:
         return (
             primary_attempt.authentication_strategy
             if primary_attempt is not None
-            else AuthenticationStrategy.UNKNOWN
+            else self._required_failure_observation().authentication_strategy
         )
 
     @property
@@ -11549,7 +11593,7 @@ class RoutePlan:
         return (
             primary_attempt.upstream_protocol
             if primary_attempt is not None
-            else RouteProtocol.UNKNOWN
+            else self._required_failure_observation().upstream_protocol
         )
 
     @property
@@ -11567,7 +11611,7 @@ class RoutePlan:
         return (
             primary_attempt.wire_format_adapter
             if primary_attempt is not None
-            else WIRE_TRANSPARENT
+            else self._required_failure_observation().wire_format_adapter
         )
 
     @property
@@ -11576,7 +11620,7 @@ class RoutePlan:
         return (
             primary_attempt.retry.policy
             if primary_attempt is not None
-            else RetryPolicy.GATEWAY_FULL
+            else self._required_failure_observation().retry_policy
         )
 
     @property
@@ -11585,7 +11629,7 @@ class RoutePlan:
         return (
             primary_attempt.retry.eligibility
             if primary_attempt is not None
-            else self.protocol_capability_state
+            else self._required_failure_observation().retry_eligibility
         )
 
     @property
@@ -11594,7 +11638,7 @@ class RoutePlan:
         return (
             primary_attempt.usage_policy
             if primary_attempt is not None
-            else UsagePolicy.SYNC_CAPTURE
+            else self._required_failure_observation().usage_policy
         )
 
     @property
@@ -11602,45 +11646,35 @@ class RoutePlan:
         primary_attempt = self.primary_attempt
         if primary_attempt is not None:
             return primary_attempt.streaming_policy
-        if self.official_http_passthrough:
-            return StreamingPolicy.OFFICIAL_PASSTHROUGH
-        return StreamingPolicy.GATEWAY_ADAPTED
+        return self._required_failure_observation().streaming_policy
 
     @property
     def transport_policy(self) -> TransportPolicy:
         primary_attempt = self.primary_attempt
         if primary_attempt is not None:
             return primary_attempt.transport_policy
-        if self.official_http_passthrough:
-            return TransportPolicy.OFFICIAL_KEEPALIVE
-        return TransportPolicy.STANDARD
+        return self._required_failure_observation().transport_policy
 
     @property
     def request_mutation_policy(self) -> MutationPolicy:
         primary_attempt = self.primary_attempt
         if primary_attempt is not None:
             return primary_attempt.request_mutation_policy
-        if self.official_http_passthrough:
-            return MutationPolicy.OFFICIAL_PASSTHROUGH
-        return MutationPolicy.GATEWAY_COMPATIBILITY
+        return self._required_failure_observation().request_mutation_policy
 
     @property
     def response_mutation_policy(self) -> MutationPolicy:
         primary_attempt = self.primary_attempt
         if primary_attempt is not None:
             return primary_attempt.response_mutation_policy
-        if self.official_http_passthrough:
-            return MutationPolicy.OFFICIAL_PASSTHROUGH
-        return MutationPolicy.GATEWAY_COMPATIBILITY
+        return self._required_failure_observation().response_mutation_policy
 
     @property
     def sse_mutation_policy(self) -> MutationPolicy:
         primary_attempt = self.primary_attempt
         if primary_attempt is not None:
             return primary_attempt.sse_mutation_policy
-        if self.official_http_passthrough:
-            return MutationPolicy.OFFICIAL_PASSTHROUGH
-        return MutationPolicy.GATEWAY_COMPATIBILITY
+        return self._required_failure_observation().sse_mutation_policy
 
 
 def behavior_profile_for_request(
@@ -11776,6 +11810,97 @@ def _capability_manifest_identity(
             upstream.get("capability_manifest_state"),
             default=CapabilityState.UNQUALIFIED,
         ),
+    )
+
+
+CAPABILITY_BINDING_SCHEMA_VERSION = 1
+
+
+def _binding_text(value: Any) -> str | None:
+    return value.strip() if isinstance(value, str) and value.strip() else None
+
+
+def _canonical_binding_provider(value: str | None) -> str | None:
+    if value is None:
+        return None
+    return canonical_model_id(value).replace("_", "-").lower()
+
+
+def _canonical_binding_model(value: str | None) -> str | None:
+    if value is None:
+        return None
+    return canonical_model_id(value).lower()
+
+
+def _route_capability_binding(
+    upstream: Mapping[str, Any],
+    *,
+    configured_upstream_protocol: RouteProtocol,
+    provider_id: str,
+    model_id: str | None,
+) -> RouteCapabilityBinding:
+    raw_binding = upstream.get("capability_binding")
+    if not isinstance(raw_binding, Mapping):
+        return RouteCapabilityBinding(
+            source_present=raw_binding is not None,
+            schema_version=None,
+            provider_id=None,
+            model_id=None,
+            configured_upstream_protocol=configured_upstream_protocol,
+            binding_upstream_protocol=RouteProtocol.UNKNOWN,
+            route_scope_state=CapabilityState.UNQUALIFIED,
+            route_scope_failure_reason=(
+                "malformed_capability_binding"
+                if raw_binding is not None
+                else "missing_capability_binding"
+            ),
+        )
+
+    schema_value = raw_binding.get("schema_version")
+    schema_version = (
+        schema_value
+        if isinstance(schema_value, int) and not isinstance(schema_value, bool)
+        else None
+    )
+    binding_provider = _binding_text(raw_binding.get("provider"))
+    binding_model = _binding_text(raw_binding.get("model"))
+    binding_protocol = _route_protocol(
+        raw_binding.get("upstream_protocol")
+    )
+
+    route_scope_failure_reason: str | None = None
+    if schema_version != CAPABILITY_BINDING_SCHEMA_VERSION:
+        route_scope_failure_reason = "unsupported_binding_schema_version"
+    elif (
+        _canonical_binding_provider(binding_provider)
+        != _canonical_binding_provider(provider_id)
+    ):
+        route_scope_failure_reason = "binding_provider_mismatch"
+    elif (
+        model_id is not None
+        and _canonical_binding_model(binding_model)
+        != _canonical_binding_model(model_id)
+    ):
+        route_scope_failure_reason = "binding_model_mismatch"
+    elif binding_protocol != configured_upstream_protocol:
+        route_scope_failure_reason = (
+            "binding_upstream_protocol_mismatch"
+        )
+
+    route_scope_state = (
+        CapabilityState.SUPPORTED
+        if route_scope_failure_reason is None
+        else CapabilityState.UNQUALIFIED
+    )
+    return RouteCapabilityBinding(
+        source_present=True,
+        schema_version=schema_version,
+        provider_id=binding_provider,
+        model_id=binding_model,
+        configured_upstream_protocol=configured_upstream_protocol,
+        binding_upstream_protocol=binding_protocol,
+        route_scope_state=route_scope_state,
+        route_scope_failure_reason=route_scope_failure_reason,
     )
 
 
@@ -12019,9 +12144,6 @@ def route_plan_for_request(
     image_proxy_enabled: bool = False,
     official_http_passthrough_enabled: bool = True,
     caller_stream: bool = True,
-    operational_authentication: OperationalAuthentication | None = None,
-    incoming_headers: Mapping[str, str] | Any | None = None,
-    drop_content_encoding: bool = False,
     runtime_facts: (
         RouteRuntimeFacts
         | Mapping[str, RouteRuntimeFacts]
@@ -12043,7 +12165,44 @@ def route_plan_for_request(
         attempt_protocols = (configured_upstream_protocol,)
     else:
         attempt_protocols = ()
-    if attempt_protocols:
+    requested_model_id = (
+        canonical_model_id(canonical_route_model or model_requested)
+        if canonical_route_model or model_requested
+        else ""
+    )
+    requested_provider, separator, requested_model = (
+        requested_model_id.partition("/")
+    )
+    binding_provider_id = str(
+        upstream.get("provider_id")
+        or upstream.get("provider_alias")
+        or (
+            requested_provider
+            if separator and upstream_name != "official"
+            else upstream_name
+        )
+    )
+    binding_model_id = str(
+        (requested_model if separator else requested_model_id)
+        or upstream.get("upstream_model")
+        or ""
+    )
+    capability_binding = _route_capability_binding(
+        upstream,
+        configured_upstream_protocol=configured_upstream_protocol,
+        provider_id=binding_provider_id,
+        model_id=binding_model_id or None,
+    )
+    binding_scope_failed = (
+        capability_binding.source_present
+        and capability_binding.route_scope_state
+        != CapabilityState.SUPPORTED
+    )
+    if binding_scope_failed:
+        attempt_protocols = ()
+    if binding_scope_failed:
+        protocol_capability_state = CapabilityState.UNQUALIFIED
+    elif attempt_protocols:
         protocol_capability_state = CapabilityState.SUPPORTED
     elif configured_upstream_protocol == RouteProtocol.ANTHROPIC_MESSAGES:
         protocol_capability_state = CapabilityState.UNSUPPORTED
@@ -12168,23 +12327,6 @@ def route_plan_for_request(
         upstream.get("auth") or "unknown"
     )
     request_headers = FrozenRequestHeaders.unmaterialized()
-    if operational_authentication is not None and attempt_protocols:
-        if operational_authentication.strategy != authentication_strategy:
-            raise ValueError(
-                "operational authentication strategy does not match route"
-            )
-        request_headers = FrozenRequestHeaders(
-            upstream_headers(
-                incoming_headers or {},
-                upstream,
-                drop_content_encoding=drop_content_encoding,
-                model_id=canonical_route_model or model_requested,
-                authentication_strategy=authentication_strategy,
-                request_mutation_policy=mutation_policy,
-                operational_authentication=operational_authentication,
-            ),
-            materialized=True,
-        )
     transport_policy = (
         TransportPolicy.OFFICIAL_KEEPALIVE
         if upstream_name == "official"
@@ -12399,15 +12541,41 @@ def route_plan_for_request(
             None
             if attempts
             else (
-                f"unsupported upstream protocol: {configured_upstream_format}"
-                if protocol_capability_state == CapabilityState.UNSUPPORTED
-                else f"unqualified upstream protocol: {configured_upstream_format}"
+                (
+                    "unqualified route capability binding: "
+                    f"{capability_binding.route_scope_failure_reason}"
+                )
+                if binding_scope_failed
+                else (
+                    f"unsupported upstream protocol: {configured_upstream_format}"
+                    if protocol_capability_state == CapabilityState.UNSUPPORTED
+                    else f"unqualified upstream protocol: {configured_upstream_format}"
+                )
             )
         ),
         attempts=tuple(attempts),
+        failure_observation=(
+            None
+            if attempts
+            else RouteFailureObservation(
+                upstream_protocol=configured_upstream_protocol,
+                wire_format_adapter=wire_adapter,
+                authentication_strategy=authentication_strategy,
+                request_kind=effective_request_kind,
+                retry_policy=retry_policy,
+                retry_eligibility=protocol_capability_state,
+                usage_policy=usage_policy,
+                streaming_policy=streaming_policy,
+                transport_policy=transport_policy,
+                request_mutation_policy=mutation_policy,
+                response_mutation_policy=mutation_policy,
+                sse_mutation_policy=mutation_policy,
+            )
+        ),
         capability_manifest_version=manifest_version,
         capability_manifest_hash=manifest_hash,
         capability_manifest_state=manifest_state,
+        capability_binding=capability_binding,
         behavior_profile=behavior_profile,
         caller_request_body_mode=caller_request_body_mode,
         prepared_request_protocol=(
@@ -12485,6 +12653,28 @@ def _route_plan_event_fields(plan: RoutePlan) -> dict[str, Any]:
         "capability_manifest_version": plan.capability_manifest_version,
         "capability_manifest_hash": plan.capability_manifest_hash,
         "capability_manifest_state": plan.capability_manifest_state.value,
+        "capability_binding_source_present": (
+            plan.capability_binding.source_present
+        ),
+        "capability_binding_schema_version": (
+            plan.capability_binding.schema_version
+        ),
+        "capability_binding_provider_id": (
+            plan.capability_binding.provider_id
+        ),
+        "capability_binding_model_id": plan.capability_binding.model_id,
+        "capability_binding_configured_upstream_protocol": (
+            plan.capability_binding.configured_upstream_protocol.value
+        ),
+        "capability_binding_upstream_protocol": (
+            plan.capability_binding.binding_upstream_protocol.value
+        ),
+        "capability_binding_route_scope_state": (
+            plan.capability_binding.route_scope_state.value
+        ),
+        "capability_binding_route_scope_failure_reason": (
+            plan.capability_binding.route_scope_failure_reason
+        ),
         "authentication_strategy": (
             primary_attempt.authentication_strategy.value
             if primary_attempt is not None
@@ -12842,6 +13032,57 @@ def upstream_headers(
         raise ValueError(f"unsupported upstream auth mode: {auth_mode}")
 
     return outgoing
+
+
+def bind_route_plan_operational_authentication(
+    plan: RoutePlan,
+    incoming_headers: Mapping[str, str] | Any,
+    upstream: Mapping[str, Any],
+    operational_authentication: OperationalAuthentication,
+    *,
+    drop_content_encoding: bool = False,
+) -> RoutePlan:
+    """Return a new plan whose attempts freeze one request-scoped auth snapshot."""
+
+    if not plan.attempts:
+        raise ValueError(
+            "cannot materialize authentication for a route plan without attempts"
+        )
+    primary_attempt = plan.attempts[0]
+    if any(
+        attempt.request_headers.materialized
+        for attempt in plan.attempts
+    ):
+        raise ValueError("route attempt authentication was already materialized")
+    if any(
+        attempt.authentication_strategy
+        != operational_authentication.strategy
+        or attempt.request_mutation_policy
+        != primary_attempt.request_mutation_policy
+        for attempt in plan.attempts
+    ):
+        raise ValueError(
+            "route attempts do not share one authentication/header policy"
+        )
+    request_headers = FrozenRequestHeaders(
+        upstream_headers(
+            incoming_headers,
+            upstream,
+            drop_content_encoding=drop_content_encoding,
+            model_id=plan.canonical_model or plan.model_requested,
+            authentication_strategy=primary_attempt.authentication_strategy,
+            request_mutation_policy=primary_attempt.request_mutation_policy,
+            operational_authentication=operational_authentication,
+        ),
+        materialized=True,
+    )
+    return replace(
+        plan,
+        attempts=tuple(
+            replace(attempt, request_headers=request_headers)
+            for attempt in plan.attempts
+        ),
+    )
 
 
 def current_catalog_data() -> dict[str, Any]:
@@ -16054,12 +16295,6 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         RETRY_REQUEST_MAIN_GENERATION
                     )
                 )
-            operational_authentication = (
-                materialize_operational_authentication(
-                    self.headers,
-                    upstream,
-                )
-            )
             route_plan = route_plan_for_request(
                 upstream,
                 request_context,
@@ -16076,9 +16311,6 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                     gateway_official_http_passthrough_enabled()
                 ),
                 caller_stream=caller_stream,
-                operational_authentication=operational_authentication,
-                incoming_headers=self.headers,
-                drop_content_encoding=content_decoded,
                 runtime_facts=route_runtime_facts,
             )
             primary_route_attempt = route_plan.primary_attempt
@@ -16124,6 +16356,20 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 raise ImageProxyError(
                     f"{model_label} does not support image input and Image Proxy is disabled."
                 )
+            operational_authentication = (
+                materialize_operational_authentication(
+                    self.headers,
+                    upstream,
+                )
+            )
+            route_plan = bind_route_plan_operational_authentication(
+                route_plan,
+                self.headers,
+                upstream,
+                operational_authentication,
+                drop_content_encoding=content_decoded,
+            )
+            primary_route_attempt = route_plan.attempts[0]
             model_canonical = canonical_model_id(model) if model else None
             # Create the request-scoped downstream stream-commit seam early so that
             # every production SSE header/body (status, retry, keepalive, converted

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -1012,7 +1012,7 @@ VISION_PROXY_DISABLED = "disabled"
 VISION_PROXY_CODEX_APP_ADAPTER = "codex_app_adapter"
 VISION_PROXY_TRANSPARENT_OVERLAY = "transparent_overlay"
 
-ROUTE_CAPABILITY_MANIFEST_VERSION = "codexhub.route-capabilities.v1"
+ROUTE_PLAN_SCHEMA_VERSION = "codexhub.route-plan.v1"
 
 
 class CapabilityState(str, Enum):
@@ -1024,7 +1024,14 @@ class CapabilityState(str, Enum):
 class RouteProtocol(str, Enum):
     RESPONSES = "responses"
     CHAT_COMPLETIONS = "chat_completions"
+    ANTHROPIC_MESSAGES = "anthropic_messages"
     AUTO = "auto"
+    UNKNOWN = "unknown"
+
+
+class AttemptRequestBodyMode(str, Enum):
+    PREPARED_DIRECT = "prepared_direct"
+    CONVERT_RESPONSES_TO_CHAT = "convert_responses_to_chat"
 
 
 class AuthenticationStrategy(str, Enum):
@@ -1040,7 +1047,19 @@ class ToolExposureMode(str, Enum):
     OFFICIAL_NATIVE = "official_native"
     NATIVE_DEFERRED_SEARCH_CANDIDATE = "native_deferred_search_candidate"
     NATIVE_NO_SEARCH_CANDIDATE = "native_no_search_candidate"
+    UNSUPPORTED = "unsupported"
     UNKNOWN = "unknown"
+
+
+class VisionAction(str, Enum):
+    PASS_THROUGH = "pass_through"
+    PROXY = "proxy"
+    REJECT = "reject"
+
+
+class VisionNetworkAction(str, Enum):
+    NONE = "none"
+    IMAGE_PROXY = "image_proxy"
 
 
 class CollaborationBackend(str, Enum):
@@ -1085,6 +1104,9 @@ class RouteMutation(str, Enum):
     HARD_CODED_SCHEMA_INJECTION = "hard_coded_schema_injection"
     OFFICIAL_TOOL_SEARCH_PRESERVATION = "official_tool_search_preservation"
     SYNTHETIC_TERMINAL_FAILURE = "synthetic_terminal_failure"
+    IMAGE_CONTENT_REPLACEMENT = "image_content_replacement"
+    IMAGE_UNSUPPORTED_REJECTION = "image_unsupported_rejection"
+    UNSUPPORTED_PROTOCOL_REJECTION = "unsupported_protocol_rejection"
 
 
 RETRY_FAILURE_QUICK_TRANSIENT = "quick_transient"
@@ -1328,6 +1350,14 @@ IMAGE_PROXY_CACHE_LOCK = threading.Lock()
 
 class ImageProxyError(Exception):
     """Raised when an image proxy request cannot be prepared safely."""
+
+
+class UnsupportedRouteProtocolError(ValueError):
+    """Raised when a configured route has no executable protocol attempt."""
+
+
+class UnqualifiedRouteProtocolError(ValueError):
+    """Raised when a configured route protocol has no qualified identity."""
 
 
 class CompactEmptyResponseError(RuntimeError):
@@ -1738,18 +1768,6 @@ def gateway_image_proxy_model() -> str:
     if isinstance(settings_value, str) and settings_value.strip():
         return settings_value.strip()
     return os.environ.get("CODEX_PROXY_IMAGE_PROXY_MODEL", "").strip()
-
-
-def gateway_transparent_vision_proxy_enabled() -> bool:
-    settings_value = _runtime_settings_value("gateway_transparent_vision_proxy_enabled")
-    if isinstance(settings_value, bool):
-        return settings_value
-    if isinstance(settings_value, str):
-        return settings_value.strip().lower() not in {"0", "false", "no", "off", ""}
-    raw_value = os.environ.get("CODEX_PROXY_TRANSPARENT_VISION_PROXY_ENABLED")
-    if raw_value is not None:
-        return raw_value.strip().lower() not in {"0", "false", "no", "off", ""}
-    return gateway_image_proxy_enabled()
 
 
 def _observe_gateway_diagnostic(method: str, *args: Any, **kwargs: Any) -> None:
@@ -2318,6 +2336,7 @@ def ollama_cloud_runtime_upstream(model_id: str, policy: Any) -> dict[str, Any] 
         ),
         "reports_cached_input_tokens": False,
         "input_modalities": tuple(runtime_model.get("input_modalities") or ("text",)),
+        **_route_capability_metadata(runtime_model),
     }
     if api_key:
         upstream["api_key"] = api_key
@@ -2348,6 +2367,19 @@ def ollama_cloud_alias_upstream_model(slug: str, policy: Any) -> dict[str, Any] 
         "upstream_model": upstream_model,
         "reports_cached_input_tokens": False,
     }
+
+
+def _route_capability_metadata(source: Mapping[str, Any]) -> dict[str, Any]:
+    keys = (
+        "tool_exposure_mode",
+        "tool_capability_state",
+        "supports_search_tool",
+        "proven_tool_subset",
+        "capability_manifest_version",
+        "capability_manifest_hash",
+        "capability_manifest_state",
+    )
+    return {key: source[key] for key in keys if key in source}
 
 
 def choose_upstream(model_id: str) -> dict[str, Any]:
@@ -2424,6 +2456,7 @@ def choose_upstream(model_id: str) -> dict[str, Any]:
             "supports_developer_role": bool(external_model.get("supports_developer_role", True)),
             "supported_reasoning_levels": tuple(external_model.get("supported_reasoning_levels") or ()),
             "input_modalities": tuple(external_model.get("input_modalities") or ("text",)),
+            **_route_capability_metadata(external_model),
         }
 
     if "/" in slug:
@@ -10932,30 +10965,68 @@ class ToolExposurePolicy:
     supports_search_tool: bool | None
     proven_tool_subset: tuple[str, ...]
     gateway_schema_injection: bool
+    strip_caller_tools: bool
+
+
+@dataclass(frozen=True)
+class VisionPlan:
+    policy: str
+    action: VisionAction
+    network_action: VisionNetworkAction
+    input_has_image: bool
+    target_accepts_images: bool
+    image_proxy_enabled: bool
+
+
+@dataclass(frozen=True)
+class RouteAttemptPlan:
+    index: int
+    upstream_protocol: RouteProtocol
+    selected_upstream_format: str
+    wire_format_adapter: str
+    request_body_mode: AttemptRequestBodyMode
+    request_mutation_policy: MutationPolicy
+    named_mutations: frozenset[RouteMutation]
+    fallback_http_statuses: frozenset[int]
+
+    @property
+    def mutation_summary(self) -> tuple[RouteMutation, ...]:
+        return tuple(sorted(self.named_mutations, key=lambda mutation: mutation.value))
+
+    def allows_protocol_fallback_status(self, status: int | None) -> bool:
+        return isinstance(status, int) and status in self.fallback_http_statuses
 
 
 @dataclass(frozen=True)
 class RoutePlan:
+    schema_version: str
     provider_id: str
     model_requested: str | None
     canonical_model: str | None
     upstream_model: str | None
     authentication_strategy: AuthenticationStrategy
     inbound_protocol: RouteProtocol
+    configured_upstream_protocol_name: str
     configured_upstream_protocol: RouteProtocol
     upstream_protocol: RouteProtocol
-    capability_manifest_version: str
+    protocol_capability_state: CapabilityState
+    protocol_failure_reason: str | None
+    attempts: tuple[RouteAttemptPlan, ...]
+    capability_manifest_version: str | None
+    capability_manifest_hash: str | None
+    capability_manifest_state: CapabilityState
     behavior_profile: str
     selected_upstream_format: str
     wire_format_adapter: str
     codex_semantic_adapter: str
     request_kind: str
+    raw_provider_probe: bool
     request_kind_policy: str
     retry_policy: str
     retry_eligibility: CapabilityState
     usage_policy: str
     repair_policy: str
-    vision_proxy_policy: str
+    vision: VisionPlan
     tool_exposure: ToolExposurePolicy
     codex_compatibility_policy: CodexCompatibilityPolicy
     collaboration_backend: CollaborationBackend
@@ -10975,17 +11046,24 @@ class RoutePlan:
     def mutation_summary(self) -> tuple[RouteMutation, ...]:
         return tuple(sorted(self.named_mutations, key=lambda mutation: mutation.value))
 
+    @property
+    def vision_proxy_policy(self) -> str:
+        return self.vision.policy
+
 
 def behavior_profile_for_request(
     upstream: Mapping[str, Any],
     request_context: Mapping[str, str],
     *,
     inbound_format: str,
+    official_http_passthrough_enabled: bool | None = None,
 ) -> str:
     if str(upstream.get("name")) != "official":
         return BEHAVIOR_EXTERNAL_PROVIDER_GATEWAY
+    if official_http_passthrough_enabled is None:
+        official_http_passthrough_enabled = gateway_official_http_passthrough_enabled()
     if (
-        gateway_official_http_passthrough_enabled()
+        official_http_passthrough_enabled
         and inbound_format == "responses"
         and _is_codex_app_context(request_context)
     ):
@@ -11003,11 +11081,11 @@ def _wire_format_adapter(inbound_format: str, upstream_format: str) -> str:
     return WIRE_TRANSPARENT
 
 
-def _route_protocol(value: Any, *, default: RouteProtocol) -> RouteProtocol:
+def _route_protocol(value: Any) -> RouteProtocol:
     try:
         return RouteProtocol(str(value))
     except ValueError:
-        return default
+        return RouteProtocol.UNKNOWN
 
 
 def _authentication_strategy(value: Any) -> AuthenticationStrategy:
@@ -11015,6 +11093,52 @@ def _authentication_strategy(value: Any) -> AuthenticationStrategy:
         return AuthenticationStrategy(str(value))
     except ValueError:
         return AuthenticationStrategy.UNKNOWN
+
+
+def _capability_state(value: Any, *, default: CapabilityState) -> CapabilityState:
+    try:
+        return CapabilityState(str(value))
+    except ValueError:
+        return default
+
+
+def _vision_plan_for_route(
+    *,
+    codex_app_external: bool,
+    input_has_image: bool,
+    target_accepts_images: bool,
+    image_proxy_enabled: bool,
+) -> VisionPlan:
+    if not input_has_image or target_accepts_images:
+        return VisionPlan(
+            policy=VISION_PROXY_DISABLED,
+            action=VisionAction.PASS_THROUGH,
+            network_action=VisionNetworkAction.NONE,
+            input_has_image=input_has_image,
+            target_accepts_images=target_accepts_images,
+            image_proxy_enabled=image_proxy_enabled,
+        )
+    if image_proxy_enabled:
+        return VisionPlan(
+            policy=(
+                VISION_PROXY_CODEX_APP_ADAPTER
+                if codex_app_external
+                else VISION_PROXY_TRANSPARENT_OVERLAY
+            ),
+            action=VisionAction.PROXY,
+            network_action=VisionNetworkAction.IMAGE_PROXY,
+            input_has_image=True,
+            target_accepts_images=False,
+            image_proxy_enabled=True,
+        )
+    return VisionPlan(
+        policy=VISION_PROXY_DISABLED,
+        action=VisionAction.REJECT,
+        network_action=VisionNetworkAction.NONE,
+        input_has_image=True,
+        target_accepts_images=False,
+        image_proxy_enabled=False,
+    )
 
 
 def _route_supports_transparent_metering(
@@ -11073,6 +11197,8 @@ def _tool_exposure_policy_for_route(
     *,
     upstream_name: str,
     behavior_profile: str,
+    request_kind: str,
+    raw_provider_probe: bool,
 ) -> ToolExposurePolicy:
     raw_requested_mode = upstream.get("tool_exposure_mode")
     if raw_requested_mode is None:
@@ -11104,6 +11230,14 @@ def _tool_exposure_policy_for_route(
             capability_state = CapabilityState(str(raw_state))
         except ValueError:
             capability_state = CapabilityState.UNQUALIFIED
+    if requested_mode in {
+        ToolExposureMode.NATIVE_DEFERRED_SEARCH_CANDIDATE,
+        ToolExposureMode.NATIVE_NO_SEARCH_CANDIDATE,
+        ToolExposureMode.UNKNOWN,
+    }:
+        capability_state = CapabilityState.UNQUALIFIED
+    elif requested_mode == ToolExposureMode.UNSUPPORTED:
+        capability_state = CapabilityState.UNSUPPORTED
 
     raw_subset = upstream.get("proven_tool_subset")
     proven_tool_subset = (
@@ -11127,6 +11261,16 @@ def _tool_exposure_policy_for_route(
     gateway_schema_injection = (
         upstream_name != "official"
         and effective_mode == ToolExposureMode.CURRENT_COMPATIBILITY
+        and request_kind != RETRY_REQUEST_COMPACT
+        and not raw_provider_probe
+    )
+    strip_caller_tools = (
+        request_kind == RETRY_REQUEST_COMPACT
+        and behavior_profile
+        not in {
+            BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH,
+            BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+        }
     )
     return ToolExposurePolicy(
         requested_mode=requested_mode,
@@ -11135,6 +11279,7 @@ def _tool_exposure_policy_for_route(
         supports_search_tool=supports_search_tool,
         proven_tool_subset=proven_tool_subset,
         gateway_schema_injection=gateway_schema_injection,
+        strip_caller_tools=strip_caller_tools,
     )
 
 
@@ -11147,11 +11292,37 @@ def route_plan_for_request(
     model_requested: str | None = None,
     canonical_route_model: str | None = None,
     request_kind: str = RETRY_REQUEST_MAIN_GENERATION,
+    raw_provider_probe: bool = False,
+    input_has_image: bool = False,
+    target_accepts_images: bool = True,
+    image_proxy_enabled: bool = False,
+    official_http_passthrough_enabled: bool = True,
 ) -> RoutePlan:
     upstream_name = str(upstream.get("name") or "")
     configured_upstream_format = str(upstream.get("upstream_format") or "responses")
+    configured_upstream_protocol = _route_protocol(configured_upstream_format)
+    if configured_upstream_protocol == RouteProtocol.AUTO:
+        attempt_protocols = (
+            RouteProtocol.RESPONSES,
+            RouteProtocol.CHAT_COMPLETIONS,
+        )
+    elif configured_upstream_protocol in {
+        RouteProtocol.RESPONSES,
+        RouteProtocol.CHAT_COMPLETIONS,
+    }:
+        attempt_protocols = (configured_upstream_protocol,)
+    else:
+        attempt_protocols = ()
+    if attempt_protocols:
+        protocol_capability_state = CapabilityState.SUPPORTED
+    elif configured_upstream_protocol == RouteProtocol.ANTHROPIC_MESSAGES:
+        protocol_capability_state = CapabilityState.UNSUPPORTED
+    else:
+        protocol_capability_state = CapabilityState.UNQUALIFIED
     selected_upstream_format = (
-        "responses" if configured_upstream_format == "auto" else configured_upstream_format
+        attempt_protocols[0].value
+        if attempt_protocols
+        else configured_upstream_format
     )
     wire_adapter = _wire_format_adapter(inbound_format, selected_upstream_format)
     codex_app_external = upstream_name != "official" and _is_codex_app_context(request_context)
@@ -11181,6 +11352,7 @@ def route_plan_for_request(
             upstream,
             request_context,
             inbound_format=inbound_format,
+            official_http_passthrough_enabled=official_http_passthrough_enabled,
         )
 
     official_http_passthrough = (
@@ -11203,18 +11375,24 @@ def route_plan_for_request(
         RETRY_CONSERVATIVE_PRE_OUTPUT if transparent_metered else RETRY_GATEWAY_FULL
     )
     usage_policy = USAGE_ASYNC_TAP if transparent_metered else USAGE_SYNC_CAPTURE
-    repair_policy = REPAIR_CODEX_SUBAGENT if codex_app_external else REPAIR_NONE
-    if codex_app_external:
-        vision_proxy_policy = VISION_PROXY_CODEX_APP_ADAPTER
-    elif transparent_metered and gateway_transparent_vision_proxy_enabled():
-        vision_proxy_policy = VISION_PROXY_TRANSPARENT_OVERLAY
-    else:
-        vision_proxy_policy = VISION_PROXY_DISABLED
+    repair_policy = (
+        REPAIR_CODEX_SUBAGENT
+        if codex_app_external and not raw_provider_probe
+        else REPAIR_NONE
+    )
+    vision = _vision_plan_for_route(
+        codex_app_external=codex_app_external,
+        input_has_image=input_has_image,
+        target_accepts_images=target_accepts_images,
+        image_proxy_enabled=image_proxy_enabled,
+    )
 
     tool_exposure = _tool_exposure_policy_for_route(
         upstream,
         upstream_name=upstream_name,
         behavior_profile=behavior_profile,
+        request_kind=request_kind,
+        raw_provider_probe=raw_provider_probe,
     )
     if official_http_passthrough:
         codex_compatibility_policy = CodexCompatibilityPolicy.OFFICIAL_NATIVE
@@ -11236,19 +11414,68 @@ def route_plan_for_request(
         streaming_policy = StreamingPolicy.GATEWAY_ADAPTED
         mutation_policy = MutationPolicy.GATEWAY_COMPATIBILITY
 
-    named_mutations = {RouteMutation.MODEL_ALIAS}
-    if wire_adapter != WIRE_TRANSPARENT:
-        named_mutations.add(RouteMutation.WIRE_CONVERSION)
+    base_named_mutations = {RouteMutation.MODEL_ALIAS}
     if tool_exposure.gateway_schema_injection:
-        named_mutations.add(RouteMutation.HARD_CODED_SCHEMA_INJECTION)
+        base_named_mutations.add(RouteMutation.HARD_CODED_SCHEMA_INJECTION)
     if codex_semantic_adapter == CODEX_SEMANTIC_EXTERNAL_ADAPTER:
-        named_mutations.add(RouteMutation.NAMESPACE_FLATTENING)
+        base_named_mutations.add(RouteMutation.NAMESPACE_FLATTENING)
     if repair_policy != REPAIR_NONE:
-        named_mutations.add(RouteMutation.SEMANTIC_REPAIR)
+        base_named_mutations.add(RouteMutation.SEMANTIC_REPAIR)
     if official_http_passthrough:
-        named_mutations.add(RouteMutation.OFFICIAL_TOOL_SEARCH_PRESERVATION)
+        base_named_mutations.add(RouteMutation.OFFICIAL_TOOL_SEARCH_PRESERVATION)
     elif not transparent_metered:
-        named_mutations.add(RouteMutation.SYNTHETIC_TERMINAL_FAILURE)
+        base_named_mutations.add(RouteMutation.SYNTHETIC_TERMINAL_FAILURE)
+    if vision.action == VisionAction.PROXY:
+        base_named_mutations.add(RouteMutation.IMAGE_CONTENT_REPLACEMENT)
+    elif vision.action == VisionAction.REJECT:
+        base_named_mutations.add(RouteMutation.IMAGE_UNSUPPORTED_REJECTION)
+    if not attempt_protocols:
+        base_named_mutations.add(RouteMutation.UNSUPPORTED_PROTOCOL_REJECTION)
+
+    attempts: list[RouteAttemptPlan] = []
+    for index, attempt_protocol in enumerate(attempt_protocols):
+        attempt_wire_adapter = _wire_format_adapter(
+            inbound_format,
+            attempt_protocol.value,
+        )
+        attempt_mutations = set(base_named_mutations)
+        if attempt_wire_adapter != WIRE_TRANSPARENT:
+            attempt_mutations.add(RouteMutation.WIRE_CONVERSION)
+        attempts.append(
+            RouteAttemptPlan(
+                index=index,
+                upstream_protocol=attempt_protocol,
+                selected_upstream_format=attempt_protocol.value,
+                wire_format_adapter=attempt_wire_adapter,
+                request_body_mode=(
+                    AttemptRequestBodyMode.CONVERT_RESPONSES_TO_CHAT
+                    if (
+                        attempt_protocol == RouteProtocol.CHAT_COMPLETIONS
+                        and not (
+                            transparent_same_format
+                            and inbound_format == RouteProtocol.CHAT_COMPLETIONS.value
+                        )
+                    )
+                    else AttemptRequestBodyMode.PREPARED_DIRECT
+                ),
+                request_mutation_policy=mutation_policy,
+                named_mutations=frozenset(attempt_mutations),
+                fallback_http_statuses=(
+                    frozenset(AUTO_UPSTREAM_PROTOCOL_FALLBACK_STATUSES)
+                    if (
+                        configured_upstream_protocol == RouteProtocol.AUTO
+                        and index == 0
+                        and len(attempt_protocols) > 1
+                    )
+                    else frozenset()
+                ),
+            )
+        )
+    named_mutations = (
+        attempts[0].named_mutations
+        if attempts
+        else frozenset(base_named_mutations)
+    )
 
     canonical_model = (
         canonical_model_id(canonical_route_model or model_requested)
@@ -11261,11 +11488,30 @@ def route_plan_for_request(
         if upstream_model_value
         else canonical_model
     )
-    manifest_version = str(
-        upstream.get("capability_manifest_version")
-        or ROUTE_CAPABILITY_MANIFEST_VERSION
+    manifest_version_value = upstream.get("capability_manifest_version")
+    manifest_version = (
+        manifest_version_value.strip()
+        if isinstance(manifest_version_value, str)
+        and manifest_version_value.strip()
+        else None
+    )
+    manifest_hash_value = upstream.get("capability_manifest_hash")
+    manifest_hash = (
+        manifest_hash_value.strip()
+        if isinstance(manifest_hash_value, str)
+        and manifest_hash_value.strip()
+        else None
+    )
+    manifest_state = (
+        _capability_state(
+            upstream.get("capability_manifest_state"),
+            default=CapabilityState.UNQUALIFIED,
+        )
+        if manifest_version is not None or manifest_hash is not None
+        else CapabilityState.UNQUALIFIED
     )
     return RoutePlan(
+        schema_version=ROUTE_PLAN_SCHEMA_VERSION,
         provider_id=upstream_name,
         model_requested=model_requested,
         canonical_model=canonical_model,
@@ -11273,19 +11519,28 @@ def route_plan_for_request(
         authentication_strategy=_authentication_strategy(
             upstream.get("auth") or "unknown"
         ),
-        inbound_protocol=_route_protocol(
-            inbound_format,
-            default=RouteProtocol.RESPONSES,
+        inbound_protocol=_route_protocol(inbound_format),
+        configured_upstream_protocol_name=configured_upstream_format,
+        configured_upstream_protocol=configured_upstream_protocol,
+        upstream_protocol=(
+            attempts[0].upstream_protocol
+            if attempts
+            else RouteProtocol.UNKNOWN
         ),
-        configured_upstream_protocol=_route_protocol(
-            configured_upstream_format,
-            default=RouteProtocol.RESPONSES,
+        protocol_capability_state=protocol_capability_state,
+        protocol_failure_reason=(
+            None
+            if attempts
+            else (
+                f"unsupported upstream protocol: {configured_upstream_format}"
+                if protocol_capability_state == CapabilityState.UNSUPPORTED
+                else f"unqualified upstream protocol: {configured_upstream_format}"
+            )
         ),
-        upstream_protocol=_route_protocol(
-            selected_upstream_format,
-            default=RouteProtocol.RESPONSES,
-        ),
+        attempts=tuple(attempts),
         capability_manifest_version=manifest_version,
+        capability_manifest_hash=manifest_hash,
+        capability_manifest_state=manifest_state,
         behavior_profile=behavior_profile,
         selected_upstream_format=selected_upstream_format,
         wire_format_adapter=wire_adapter,
@@ -11293,12 +11548,13 @@ def route_plan_for_request(
         request_kind=(
             RETRY_REQUEST_MAIN_GENERATION if transparent_metered else request_kind
         ),
+        raw_provider_probe=raw_provider_probe,
         request_kind_policy=request_kind_policy,
         retry_policy=retry_policy,
-        retry_eligibility=CapabilityState.SUPPORTED,
+        retry_eligibility=protocol_capability_state,
         usage_policy=usage_policy,
         repair_policy=repair_policy,
-        vision_proxy_policy=vision_proxy_policy,
+        vision=vision,
         tool_exposure=tool_exposure,
         codex_compatibility_policy=codex_compatibility_policy,
         collaboration_backend=collaboration_backend,
@@ -11322,18 +11578,43 @@ def route_plan_for_request(
 
 def _route_plan_event_fields(plan: RoutePlan) -> dict[str, Any]:
     return {
+        "route_plan_schema_version": plan.schema_version,
+        "configured_upstream_protocol_name": plan.configured_upstream_protocol_name,
+        "configured_upstream_protocol": plan.configured_upstream_protocol.value,
+        "protocol_capability_state": plan.protocol_capability_state.value,
+        "protocol_failure_reason": plan.protocol_failure_reason,
+        "route_attempts": [
+            {
+                "index": attempt.index,
+                "upstream_protocol": attempt.upstream_protocol.value,
+                "wire_format_adapter": attempt.wire_format_adapter,
+                "request_body_mode": attempt.request_body_mode.value,
+                "request_mutation_policy": attempt.request_mutation_policy.value,
+                "fallback_http_statuses": sorted(attempt.fallback_http_statuses),
+                "mutation_summary": [
+                    mutation.value for mutation in attempt.mutation_summary
+                ],
+            }
+            for attempt in plan.attempts
+        ],
         "wire_format_adapter": plan.wire_format_adapter,
         "codex_semantic_adapter": plan.codex_semantic_adapter,
         "request_kind": plan.request_kind,
+        "raw_provider_probe": plan.raw_provider_probe,
         "request_kind_policy": plan.request_kind_policy,
         "retry_policy": plan.retry_policy,
         "retry_eligibility": plan.retry_eligibility.value,
         "usage_policy": plan.usage_policy,
         "repair_policy": plan.repair_policy,
         "capability_manifest_version": plan.capability_manifest_version,
+        "capability_manifest_hash": plan.capability_manifest_hash,
+        "capability_manifest_state": plan.capability_manifest_state.value,
         "authentication_strategy": plan.authentication_strategy.value,
+        "tool_requested_exposure_mode": plan.tool_exposure.requested_mode.value,
         "tool_exposure_mode": plan.tool_exposure.effective_mode.value,
         "tool_capability_state": plan.tool_exposure.capability_state.value,
+        "gateway_schema_injection": plan.tool_exposure.gateway_schema_injection,
+        "strip_caller_tools": plan.tool_exposure.strip_caller_tools,
         "codex_compatibility_policy": plan.codex_compatibility_policy.value,
         "collaboration_backend": plan.collaboration_backend.value,
         "execution_owner": plan.execution_owner.value,
@@ -11342,8 +11623,28 @@ def _route_plan_event_fields(plan: RoutePlan) -> dict[str, Any]:
         "request_mutation_policy": plan.request_mutation_policy.value,
         "response_mutation_policy": plan.response_mutation_policy.value,
         "sse_mutation_policy": plan.sse_mutation_policy.value,
+        "vision_proxy_policy": plan.vision.policy,
+        "vision_action": plan.vision.action.value,
+        "vision_network_action": plan.vision.network_action.value,
+        "vision_input_has_image": plan.vision.input_has_image,
+        "vision_target_accepts_images": plan.vision.target_accepts_images,
         "mutation_summary": [
             mutation.value for mutation in plan.mutation_summary
+        ],
+    }
+
+
+def _route_attempt_event_fields(attempt: RouteAttemptPlan) -> dict[str, Any]:
+    return {
+        "route_attempt_index": attempt.index,
+        "route_attempt_protocol": attempt.upstream_protocol.value,
+        "route_attempt_wire_format_adapter": attempt.wire_format_adapter,
+        "route_attempt_request_body_mode": attempt.request_body_mode.value,
+        "route_attempt_fallback_http_statuses": sorted(
+            attempt.fallback_http_statuses
+        ),
+        "route_attempt_mutation_summary": [
+            mutation.value for mutation in attempt.mutation_summary
         ],
     }
 
@@ -12295,10 +12596,19 @@ def apply_image_proxy_to_responses_payload(
     target_upstream: Mapping[str, Any],
     event_context: Mapping[str, Any] | None = None,
     progress_callback: Callable[[Mapping[str, Any]], bool] | None = None,
+    *,
+    image_proxy_enabled: bool | None = None,
+    target_accepts_images: bool | None = None,
 ) -> bool:
-    if not gateway_image_proxy_enabled():
+    if image_proxy_enabled is None:
+        image_proxy_enabled = gateway_image_proxy_enabled()
+    if not image_proxy_enabled:
         return False
-    if target_model and model_supports_image(target_model, target_upstream):
+    if target_accepts_images is None:
+        target_accepts_images = bool(
+            target_model and model_supports_image(target_model, target_upstream)
+        )
+    if target_accepts_images:
         return False
     if not _value_contains_image(payload.get("input")):
         return False
@@ -12358,10 +12668,19 @@ def apply_image_proxy_to_chat_payload(
     target_upstream: Mapping[str, Any],
     event_context: Mapping[str, Any] | None = None,
     progress_callback: Callable[[Mapping[str, Any]], bool] | None = None,
+    *,
+    image_proxy_enabled: bool | None = None,
+    target_accepts_images: bool | None = None,
 ) -> bool:
-    if not gateway_image_proxy_enabled():
+    if image_proxy_enabled is None:
+        image_proxy_enabled = gateway_image_proxy_enabled()
+    if not image_proxy_enabled:
         return False
-    if target_model and model_supports_image(target_model, target_upstream):
+    if target_accepts_images is None:
+        target_accepts_images = bool(
+            target_model and model_supports_image(target_model, target_upstream)
+        )
+    if target_accepts_images:
         return False
     if not _value_contains_image(payload.get("messages")):
         return False
@@ -12421,6 +12740,8 @@ def apply_vision_proxy_adapter(
     target_model: str | None,
     target_upstream: Mapping[str, Any],
     vision_proxy_policy: str,
+    image_proxy_enabled: bool | None = None,
+    target_accepts_images: bool | None = None,
     event_context: Mapping[str, Any] | None = None,
     progress_callback: Callable[[Mapping[str, Any]], bool] | None = None,
 ) -> bool:
@@ -12434,6 +12755,8 @@ def apply_vision_proxy_adapter(
             target_upstream,
             event_context=proxy_context,
             progress_callback=progress_callback,
+            image_proxy_enabled=image_proxy_enabled,
+            target_accepts_images=target_accepts_images,
         )
     return apply_image_proxy_to_responses_payload(
         payload,
@@ -12441,6 +12764,8 @@ def apply_vision_proxy_adapter(
         target_upstream,
         event_context=proxy_context,
         progress_callback=progress_callback,
+        image_proxy_enabled=image_proxy_enabled,
+        target_accepts_images=target_accepts_images,
     )
 
 
@@ -12450,49 +12775,58 @@ def enforce_text_only_image_boundary(
     inbound_format: str,
     target_model: str | None,
     target_upstream: Mapping[str, Any],
+    vision_plan: VisionPlan,
     event_context: Mapping[str, Any] | None = None,
     progress_callback: Callable[[Mapping[str, Any]], bool] | None = None,
 ) -> bool:
-    if target_model and model_supports_image(target_model, target_upstream):
+    if vision_plan.action == VisionAction.PASS_THROUGH:
         return False
-    image_root = payload.get("messages") if inbound_format == "chat_completions" else payload.get("input")
-    if not _value_contains_image(image_root):
-        return False
-
-    if gateway_image_proxy_enabled():
-        changed = (
-            apply_image_proxy_to_chat_payload(
-                payload,
-                target_model,
-                target_upstream,
-                event_context=event_context,
-                progress_callback=progress_callback,
-            )
-            if inbound_format == "chat_completions"
-            else apply_image_proxy_to_responses_payload(
-                payload,
-                target_model,
-                target_upstream,
-                event_context=event_context,
-                progress_callback=progress_callback,
-            )
+    if vision_plan.action == VisionAction.REJECT:
+        model_label = (
+            canonical_model_id(target_model)
+            if target_model
+            else "the target model"
         )
-        if changed:
-            _write_adapter_event(
-                event_context,
-                "image_proxy_boundary_guard_applied",
-                target_model=canonical_model_id(target_model) if target_model else None,
-                inbound_format=inbound_format,
-            )
-            return True
-        image_root = payload.get("messages") if inbound_format == "chat_completions" else payload.get("input")
-        if not _value_contains_image(image_root):
-            return False
+        raise ImageProxyError(
+            f"{model_label} does not support image input and Image Proxy is disabled."
+        )
+    if vision_plan.network_action != VisionNetworkAction.IMAGE_PROXY:
+        raise ImageProxyError(
+            "The planned Vision action has no executable network action."
+        )
 
-    model_label = canonical_model_id(target_model) if target_model else "the target model"
-    raise ImageProxyError(
-        f"{model_label} does not support image input and Image Proxy is disabled or could not replace the image."
+    changed = apply_vision_proxy_adapter(
+        payload,
+        inbound_format=inbound_format,
+        target_model=target_model,
+        target_upstream=target_upstream,
+        vision_proxy_policy=vision_plan.policy,
+        image_proxy_enabled=vision_plan.image_proxy_enabled,
+        target_accepts_images=vision_plan.target_accepts_images,
+        event_context=event_context,
+        progress_callback=progress_callback,
     )
+    image_root = (
+        payload.get("messages")
+        if inbound_format == RouteProtocol.CHAT_COMPLETIONS.value
+        else payload.get("input")
+    )
+    if _value_contains_image(image_root):
+        raise ImageProxyError(
+            "Image Proxy could not replace the image for the text-only target model."
+        )
+    if changed:
+        _write_adapter_event(
+            event_context,
+            "image_proxy_boundary_guard_applied",
+            target_model=(
+                canonical_model_id(target_model)
+                if target_model
+                else None
+            ),
+            inbound_format=inbound_format,
+        )
+    return changed
 
 
 def _upstream_retry_status(exc: BaseException) -> int | None:
@@ -13245,20 +13579,6 @@ def _json_error_payload_for_inbound_format(
     return payload
 
 
-def _upstream_format_candidates(upstream_format: str) -> tuple[str, ...]:
-    if upstream_format == "chat_completions":
-        return ("chat_completions",)
-    if upstream_format == "anthropic_messages":
-        raise ValueError("Anthropic Messages upstream is detected but Gateway /v1/messages conversion is not implemented yet")
-    if upstream_format == "auto":
-        return ("responses", "chat_completions")
-    return ("responses",)
-
-
-def _auto_protocol_fallback_allowed(exc: HTTPError) -> bool:
-    return _upstream_retry_status(exc) in AUTO_UPSTREAM_PROTOCOL_FALLBACK_STATUSES
-
-
 @dataclass(frozen=True)
 class GatewayRequestInput:
     request_id: str
@@ -13850,6 +14170,12 @@ class _GatewayDownstreamStreamCommit:
             self._close_upstream_response(response)
             return
         self._upstream_response = response
+
+    def set_upstream_format(self, upstream_format: str) -> None:
+        """Update the active protocol before a planned fallback is opened."""
+        if self._downstream_output_started or self._terminal_committed:
+            return
+        self._upstream_format = upstream_format
 
     def mark_downstream_content_exposed(self) -> None:
         """Record that upstream response content has been produced for the client.
@@ -14477,7 +14803,6 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
         route_reason: str | None = None
         route_plan: RoutePlan | None = None
         route_policy_event_fields: dict[str, Any] = {}
-        vision_proxy_policy = VISION_PROXY_DISABLED
         downstream_sse_started = False
         response_lifecycle_state: dict[str, str] = {}
         caller_body = b""
@@ -14609,6 +14934,14 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
             upstream_format = str(upstream.get("upstream_format", "responses"))
             reports_cached_input_tokens = bool(upstream.get("reports_cached_input_tokens"))
             _validate_reasoning_effort_for_upstream(inbound_payload, upstream, model)
+            inbound_has_image = (
+                isinstance(inbound_payload, Mapping)
+                and _value_contains_image(inbound_payload)
+            )
+            target_accepts_images = bool(
+                model and model_supports_image(model, upstream)
+            )
+            image_proxy_enabled = gateway_image_proxy_enabled()
             route_plan = route_plan_for_request(
                 upstream,
                 request_context,
@@ -14617,13 +14950,16 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 model_requested=model_requested,
                 canonical_route_model=model,
                 request_kind=request_kind,
+                raw_provider_probe=raw_provider_probe,
+                input_has_image=inbound_has_image,
+                target_accepts_images=target_accepts_images,
+                image_proxy_enabled=image_proxy_enabled,
+                official_http_passthrough_enabled=(
+                    gateway_official_http_passthrough_enabled()
+                ),
             )
             behavior_profile = route_plan.behavior_profile
-            upstream_format = (
-                route_plan.selected_upstream_format
-                if route_plan.transparent_metered
-                else route_plan.configured_upstream_protocol.value
-            )
+            upstream_format = route_plan.selected_upstream_format
             is_official_http_passthrough = route_plan.official_http_passthrough
             is_transparent_metered = route_plan.transparent_metered
             is_transparent_same_format = route_plan.transparent_same_format
@@ -14635,17 +14971,38 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 started_at,
                 request_kind,
             )
-            vision_proxy_policy = route_plan.vision_proxy_policy
             reasoning_policy = _reasoning_policy_for_request(inbound_payload, upstream, model)
             route_policy_event_fields = {
                 **_route_plan_event_fields(route_plan),
-                "vision_proxy_policy": vision_proxy_policy,
+                **(
+                    _route_attempt_event_fields(route_plan.attempts[0])
+                    if route_plan.attempts
+                    else {}
+                ),
                 **({"reasoning_policy": reasoning_policy} if reasoning_policy else {}),
             }
             proxy_request_context = {
                 **proxy_request_context,
                 **route_policy_event_fields,
             }
+            if not route_plan.attempts:
+                protocol_error = (
+                    UnsupportedRouteProtocolError
+                    if (
+                        route_plan.protocol_capability_state
+                        == CapabilityState.UNSUPPORTED
+                    )
+                    else UnqualifiedRouteProtocolError
+                )
+                raise protocol_error(
+                    route_plan.protocol_failure_reason
+                    or "configured upstream protocol is not executable"
+                )
+            if route_plan.vision.action == VisionAction.REJECT:
+                model_label = canonical_model_id(model) if model else "the target model"
+                raise ImageProxyError(
+                    f"{model_label} does not support image input and Image Proxy is disabled."
+                )
             model_canonical = canonical_model_id(model) if model else None
             # Create the request-scoped downstream stream-commit seam early so that
             # every production SSE header/body (status, retry, keepalive, converted
@@ -14661,9 +15018,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 upstream_format=upstream_format,
             )
             if (
-                request_kind == RETRY_REQUEST_COMPACT
-                and not is_transparent_metered
-                and behavior_profile != BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH
+                route_plan.tool_exposure.strip_caller_tools
                 and isinstance(inbound_payload, dict)
                 and _strip_tools_for_compact_payload(
                     inbound_payload,
@@ -14811,15 +15166,16 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                             )
                         )
             else:
-                compatibility_upstream = upstream
-                if upstream_format == "auto":
-                    compatibility_upstream = {**upstream, "upstream_format": "responses"}
+                compatibility_upstream = {
+                    **upstream,
+                    "upstream_format": route_plan.attempts[0].selected_upstream_format,
+                }
                 body = compatible_request_body(
                     body,
                     compatibility_upstream,
                     model_id=model,
                     event_context=adapter_event_context,
-                    inject_codex_tools=request_kind != RETRY_REQUEST_COMPACT and not raw_provider_probe,
+                    inject_codex_tools=route_plan.tool_exposure.gateway_schema_injection,
                     behavior_profile=behavior_profile,
                 )
             vision_proxy_payload_format = (
@@ -14827,13 +15183,8 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 if inbound_format == "chat_completions" and is_transparent_same_format
                 else "responses"
             )
-            inbound_has_image = isinstance(inbound_payload, Mapping) and _value_contains_image(inbound_payload)
-            target_accepts_images = bool(model and model_supports_image(model, upstream))
-            needs_image_payload_inspection = inbound_has_image and (
-                vision_proxy_policy != VISION_PROXY_DISABLED or not target_accepts_images
-            )
             image_proxy_payload: dict[str, Any] | None = None
-            if needs_image_payload_inspection:
+            if route_plan.vision.action == VisionAction.PROXY:
                 try:
                     parsed_image_proxy_payload = json.loads(body.decode("utf-8-sig"))
                 except (UnicodeDecodeError, json.JSONDecodeError):
@@ -14841,36 +15192,22 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 if isinstance(parsed_image_proxy_payload, dict):
                     image_proxy_payload = parsed_image_proxy_payload
             try:
-                if image_proxy_payload is not None and vision_proxy_policy != VISION_PROXY_DISABLED:
-                    if apply_vision_proxy_adapter(
+                if route_plan.vision.action == VisionAction.PROXY:
+                    if image_proxy_payload is None:
+                        raise ImageProxyError(
+                            "Image Proxy could not inspect the planned image payload."
+                        )
+                    image_proxy_changed = enforce_text_only_image_boundary(
                         image_proxy_payload,
                         inbound_format=vision_proxy_payload_format,
                         target_model=model,
                         target_upstream=upstream,
-                        vision_proxy_policy=vision_proxy_policy,
+                        vision_plan=route_plan.vision,
                         event_context=adapter_event_context,
                         progress_callback=emit_downstream_status if caller_stream else None,
-                    ):
+                    )
+                    if image_proxy_changed:
                         body = json.dumps(image_proxy_payload, ensure_ascii=True, separators=(",", ":")).encode("utf-8")
-                if image_proxy_payload is not None and enforce_text_only_image_boundary(
-                    image_proxy_payload,
-                    inbound_format=vision_proxy_payload_format,
-                    target_model=model,
-                    target_upstream=upstream,
-                    event_context=adapter_event_context,
-                    progress_callback=emit_downstream_status if caller_stream else None,
-                ):
-                    if vision_proxy_policy == VISION_PROXY_DISABLED:
-                        vision_proxy_policy = VISION_PROXY_TRANSPARENT_OVERLAY
-                        proxy_request_context = {
-                            **proxy_request_context,
-                            "vision_proxy_policy": vision_proxy_policy,
-                        }
-                        adapter_event_context = {
-                            **adapter_event_context,
-                            "vision_proxy_policy": vision_proxy_policy,
-                        }
-                    body = json.dumps(image_proxy_payload, ensure_ascii=True, separators=(",", ":")).encode("utf-8")
             except DownstreamClosedDuringImageProxyError:
                 finish_downstream_write_failure()
                 return
@@ -14889,15 +15226,26 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 model_id=model,
             )
 
-            def upstream_body_for_format(selected_format: str) -> bytes:
-                if is_transparent_same_format:
-                    return body
-                if selected_format == "chat_completions":
-                    return _responses_request_to_chat_completion_body(responses_body)
-                return responses_body
+            def upstream_body_for_attempt(
+                attempt: RouteAttemptPlan,
+                prepared_body: bytes = responses_body,
+            ) -> bytes:
+                if (
+                    attempt.request_body_mode
+                    == AttemptRequestBodyMode.CONVERT_RESPONSES_TO_CHAT
+                ):
+                    return _responses_request_to_chat_completion_body(prepared_body)
+                if (
+                    attempt.request_body_mode
+                    == AttemptRequestBodyMode.PREPARED_DIRECT
+                ):
+                    return prepared_body
+                raise UnsupportedRouteProtocolError(
+                    f"unsupported planned request body mode: {attempt.request_body_mode}"
+                )
 
             upstream_request_observability = proxy_telemetry.enrich_request_observability(
-                body=upstream_body_for_format(upstream_format),
+                body=upstream_body_for_attempt(route_plan.attempts[0]),
                 codex_home=RUNTIME_CODEX_DIR,
                 upstream=upstream,
                 include_body_hmac=not is_official_http_passthrough,
@@ -14918,11 +15266,11 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 and gateway_downstream_retry_notice_enabled()
             )
 
-            def upstream_request_for_format(
-                selected_format: str,
+            def upstream_request_for_attempt(
+                attempt: RouteAttemptPlan,
                 lifecycle_final_retry_reason: str | None = None,
             ) -> Request:
-                request_body = body if is_transparent_same_format else responses_body
+                request_body = responses_body
                 if lifecycle_final_retry_reason and not is_transparent_same_format:
                     request_body = _responses_body_with_lifecycle_final_retry_guidance(
                         responses_body,
@@ -14932,31 +15280,21 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         adapter_event_context,
                         "lifecycle_final_retry_guidance_injected",
                         upstream=upstream_name,
-                        upstream_format=selected_format,
+                        upstream_format=attempt.selected_upstream_format,
                         reason=lifecycle_final_retry_reason,
                     )
-                if is_transparent_same_format:
-                    url = (
-                        _chat_completions_url(upstream)
-                        if selected_format == "chat_completions"
-                        else _responses_url(upstream, "/v1/responses")
-                    )
-                    return Request(
-                        url,
-                        data=request_body,
-                        headers=headers,
-                        method="POST",
-                    )
-                if selected_format == "chat_completions":
-                    return Request(
-                        _chat_completions_url(upstream),
-                        data=_responses_request_to_chat_completion_body(request_body),
-                        headers=headers,
-                        method="POST",
+                if attempt.upstream_protocol == RouteProtocol.CHAT_COMPLETIONS:
+                    url = _chat_completions_url(upstream)
+                elif attempt.upstream_protocol == RouteProtocol.RESPONSES:
+                    url = _responses_url(upstream, "/v1/responses")
+                else:
+                    raise UnsupportedRouteProtocolError(
+                        "planned attempt has no executable upstream protocol: "
+                        f"{attempt.upstream_protocol.value}"
                     )
                 return Request(
-                    _responses_url(upstream, "/v1/responses"),
-                    data=request_body,
+                    url,
+                    data=upstream_body_for_attempt(attempt, request_body),
                     headers=headers,
                     method="POST",
                 )
@@ -14998,9 +15336,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 nonlocal downstream_sse_started
                 downstream_sse_started = True
 
-            configured_upstream_format = upstream_format
             selected_upstream_format = upstream_format
-            upstream_format_options = _upstream_format_candidates(configured_upstream_format)
             official_open_attempt_budget = (
                 {
                     "max_attempts": official_upstream_open_attempts(),
@@ -15009,8 +15345,12 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 if is_official_http_passthrough
                 else None
             )
-            for format_index, selected_upstream_format in enumerate(upstream_format_options):
+            for route_attempt in route_plan.attempts:
+                selected_upstream_format = route_attempt.selected_upstream_format
+                route_attempt_event_fields = _route_attempt_event_fields(route_attempt)
+                proxy_request_context.update(route_attempt_event_fields)
                 if isinstance(adapter_event_context, dict):
+                    adapter_event_context.update(route_attempt_event_fields)
                     adapter_event_context["tool_protocol"] = _external_tool_protocol(
                         {**upstream, "upstream_format": selected_upstream_format}
                     )
@@ -15030,8 +15370,11 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 lifecycle_final_retry_reason: str | None = None
                 try:
                     while relay_attempt <= max_relay_attempts:
-                        request = upstream_request_for_format(
-                            selected_upstream_format,
+                        seam = _handler_downstream_stream_commit(self)
+                        if seam is not None:
+                            seam.set_upstream_format(selected_upstream_format)
+                        request = upstream_request_for_attempt(
+                            route_attempt,
                             lifecycle_final_retry_reason,
                         )
                         try:
@@ -15273,13 +15616,18 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                     upstream_format = selected_upstream_format
                     break
                 except HTTPError as exc:
-                    next_format_available = format_index + 1 < len(upstream_format_options)
+                    next_attempt_index = route_attempt.index + 1
+                    next_attempt = (
+                        route_plan.attempts[next_attempt_index]
+                        if next_attempt_index < len(route_plan.attempts)
+                        else None
+                    )
                     fallback_allowed = (
-                        configured_upstream_format == "auto"
-                        and selected_upstream_format == "responses"
-                        and next_format_available
+                        next_attempt is not None
                         and not downstream_sse_started
-                        and _auto_protocol_fallback_allowed(exc)
+                        and route_attempt.allows_protocol_fallback_status(
+                            getattr(exc, "code", None)
+                        )
                     )
                     if fallback_allowed:
                         fallback_model_access_path = _model_access_path_from_event_context(
@@ -15306,10 +15654,26 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                                 upstream=upstream_name,
                                 provider_id=upstream_name,
                                 provider_hint=provider_hint,
-                                upstream_format=configured_upstream_format,
+                                upstream_format=route_plan.configured_upstream_protocol_name,
                                 behavior_profile=behavior_profile,
                                 failed_upstream_format=selected_upstream_format,
-                                next_upstream_format=upstream_format_options[format_index + 1],
+                                next_upstream_format=next_attempt.selected_upstream_format,
+                                failed_route_attempt_index=route_attempt.index,
+                                failed_route_attempt_request_body_mode=(
+                                    route_attempt.request_body_mode.value
+                                ),
+                                failed_route_attempt_mutation_summary=[
+                                    mutation.value
+                                    for mutation in route_attempt.mutation_summary
+                                ],
+                                next_route_attempt_index=next_attempt.index,
+                                next_route_attempt_request_body_mode=(
+                                    next_attempt.request_body_mode.value
+                                ),
+                                next_route_attempt_mutation_summary=[
+                                    mutation.value
+                                    for mutation in next_attempt.mutation_summary
+                                ],
                                 status=getattr(exc, "code", 502),
                                 error="HTTPError",
                                 detail=safe_upstream_error_detail(

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -1047,6 +1047,212 @@ class AuthenticationStrategy(str, Enum):
     UNKNOWN = "unknown"
 
 
+class SensitiveValue:
+    """An immutable secret whose representation and equality never expose value."""
+
+    __slots__ = ("_value",)
+
+    def __init__(self, value: str):
+        object.__setattr__(self, "_value", value)
+
+    def __setattr__(self, name: str, value: Any) -> NoReturn:
+        raise AttributeError(f"{type(self).__name__} is immutable")
+
+    def reveal(self) -> str:
+        return self._value
+
+    def __repr__(self) -> str:
+        return "SensitiveValue(<redacted>)"
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, SensitiveValue)
+
+    def __hash__(self) -> int:
+        return hash(SensitiveValue)
+
+    def __deepcopy__(self, memo: dict[int, Any]) -> SensitiveValue:
+        return self
+
+
+class OperationalAuthentication:
+    """Request-scoped auth material captured before route planning completes."""
+
+    __slots__ = (
+        "strategy",
+        "_authorization",
+        "_account_id",
+        "_generated_session_id",
+        "_generated_client_request_id",
+    )
+
+    def __init__(
+        self,
+        strategy: AuthenticationStrategy,
+        *,
+        authorization: str | None,
+        account_id: str | None = None,
+        generated_session_id: str | None = None,
+        generated_client_request_id: str | None = None,
+    ):
+        object.__setattr__(self, "strategy", strategy)
+        object.__setattr__(
+            self,
+            "_authorization",
+            SensitiveValue(authorization) if authorization else None,
+        )
+        object.__setattr__(
+            self,
+            "_account_id",
+            SensitiveValue(account_id) if account_id else None,
+        )
+        object.__setattr__(
+            self,
+            "_generated_session_id",
+            (
+                SensitiveValue(generated_session_id)
+                if generated_session_id
+                else None
+            ),
+        )
+        object.__setattr__(
+            self,
+            "_generated_client_request_id",
+            (
+                SensitiveValue(generated_client_request_id)
+                if generated_client_request_id
+                else None
+            ),
+        )
+
+    def __setattr__(self, name: str, value: Any) -> NoReturn:
+        raise AttributeError(f"{type(self).__name__} is immutable")
+
+    @property
+    def authorization(self) -> str | None:
+        return (
+            self._authorization.reveal()
+            if self._authorization is not None
+            else None
+        )
+
+    @property
+    def account_id(self) -> str | None:
+        return (
+            self._account_id.reveal()
+            if self._account_id is not None
+            else None
+        )
+
+    @property
+    def generated_session_id(self) -> str | None:
+        return (
+            self._generated_session_id.reveal()
+            if self._generated_session_id is not None
+            else None
+        )
+
+    @property
+    def generated_client_request_id(self) -> str | None:
+        return (
+            self._generated_client_request_id.reveal()
+            if self._generated_client_request_id is not None
+            else None
+        )
+
+    def __repr__(self) -> str:
+        return (
+            "OperationalAuthentication("
+            f"strategy={self.strategy!r}, materialized=True)"
+        )
+
+    def __eq__(self, other: object) -> bool:
+        return (
+            isinstance(other, OperationalAuthentication)
+            and self.strategy == other.strategy
+        )
+
+    def __hash__(self) -> int:
+        return hash((OperationalAuthentication, self.strategy))
+
+    def __deepcopy__(
+        self,
+        memo: dict[int, Any],
+    ) -> OperationalAuthentication:
+        return self
+
+
+class FrozenRequestHeaders:
+    """Deeply immutable outbound headers with redacted values."""
+
+    __slots__ = ("_items", "_materialized")
+
+    def __init__(
+        self,
+        headers: Mapping[str, str] | None = None,
+        *,
+        materialized: bool,
+    ):
+        object.__setattr__(
+            self,
+            "_items",
+            tuple(
+                (str(name), SensitiveValue(str(value)))
+                for name, value in (headers or {}).items()
+            ),
+        )
+        object.__setattr__(self, "_materialized", materialized)
+
+    def __setattr__(self, name: str, value: Any) -> NoReturn:
+        raise AttributeError(f"{type(self).__name__} is immutable")
+
+    @classmethod
+    def unmaterialized(cls) -> FrozenRequestHeaders:
+        return cls(materialized=False)
+
+    @property
+    def materialized(self) -> bool:
+        return self._materialized
+
+    def to_dict(self) -> dict[str, str]:
+        if not self._materialized:
+            raise RuntimeError(
+                "route attempt headers were not materialized before execution"
+            )
+        return {
+            name: sensitive_value.reveal()
+            for name, sensitive_value in self._items
+        }
+
+    def __repr__(self) -> str:
+        return (
+            "FrozenRequestHeaders("
+            f"materialized={self._materialized}, count={len(self._items)})"
+        )
+
+    def __eq__(self, other: object) -> bool:
+        return (
+            isinstance(other, FrozenRequestHeaders)
+            and self._materialized == other._materialized
+            and tuple(name.lower() for name, _value in self._items)
+            == tuple(name.lower() for name, _value in other._items)
+        )
+
+    def __hash__(self) -> int:
+        return hash(
+            (
+                FrozenRequestHeaders,
+                self._materialized,
+                tuple(name.lower() for name, _value in self._items),
+            )
+        )
+
+    def __deepcopy__(
+        self,
+        memo: dict[int, Any],
+    ) -> FrozenRequestHeaders:
+        return self
+
+
 class ToolExposureMode(str, Enum):
     CURRENT_COMPATIBILITY = "current_compatibility"
     OFFICIAL_NATIVE = "official_native"
@@ -11146,6 +11352,45 @@ class RetryExecutionPlan:
             "attempts_started": 0,
         }
 
+    def telemetry_snapshot(self) -> dict[str, Any]:
+        return {
+            "eligibility": self.eligibility.value,
+            "policy": self.policy.value,
+            "request_kind": self.request_kind,
+            "request_timeout_seconds": self.request_timeout_seconds,
+            "base_open_attempts": self.base_open_attempts,
+            "base_relay_attempts": self.base_relay_attempts,
+            "failure_expansion_attempts": self.failure_expansion_attempts,
+            "retry_http_errors": self.retry_http_errors,
+            "open_attempt_budget": self.open_attempt_budget,
+            "capacity_elapsed_limit_seconds": (
+                self.capacity_elapsed_limit_seconds
+            ),
+            "stream_elapsed_limit_seconds": (
+                self.stream_elapsed_limit_seconds
+            ),
+            "emit_downstream_retry_notice": (
+                self.emit_downstream_retry_notice
+            ),
+            "pre_response_budget_seconds": (
+                self.pre_response_budget_seconds
+            ),
+            "lifecycle_final_retry_eligible": (
+                self.lifecycle_final_retry_eligible
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class RelayExecutionPlan:
+    request_kind: str
+    streaming_policy: StreamingPolicy
+    usage_policy: UsagePolicy
+    response_mutation_policy: MutationPolicy
+    sse_mutation_policy: MutationPolicy
+    verify_cross_protocol_source: bool
+    lifecycle_final_retry_enabled: bool
+
 
 @dataclass(frozen=True)
 class RouteAttemptPlan:
@@ -11157,6 +11402,7 @@ class RouteAttemptPlan:
     request_conversion_steps: tuple[str, ...]
     request_body_mode: AttemptRequestBodyMode
     authentication_strategy: AuthenticationStrategy
+    request_headers: FrozenRequestHeaders
     streaming_policy: StreamingPolicy
     usage_policy: UsagePolicy
     transport_policy: TransportPolicy
@@ -11177,6 +11423,62 @@ class RouteAttemptPlan:
 
     def allows_protocol_fallback_status(self, status: int | None) -> bool:
         return isinstance(status, int) and status in self.fallback_http_statuses
+
+    def relay_execution_plan(
+        self,
+        *,
+        lifecycle_final_retry_enabled: bool,
+    ) -> RelayExecutionPlan:
+        return RelayExecutionPlan(
+            request_kind=self.retry.request_kind,
+            streaming_policy=self.streaming_policy,
+            usage_policy=self.usage_policy,
+            response_mutation_policy=self.response_mutation_policy,
+            sse_mutation_policy=self.sse_mutation_policy,
+            verify_cross_protocol_source=(
+                self.verify_cross_protocol_source
+            ),
+            lifecycle_final_retry_enabled=lifecycle_final_retry_enabled,
+        )
+
+    def telemetry_snapshot(self) -> dict[str, Any]:
+        return {
+            "index": self.index,
+            "upstream_protocol": self.upstream_protocol.value,
+            "wire_format_adapter": self.wire_format_adapter,
+            "request_conversion_steps": list(
+                self.request_conversion_steps
+            ),
+            "request_body_mode": self.request_body_mode.value,
+            "authentication_strategy": (
+                self.authentication_strategy.value
+            ),
+            "streaming_policy": self.streaming_policy.value,
+            "usage_policy": self.usage_policy.value,
+            "transport_policy": self.transport_policy.value,
+            "request_mutation_policy": (
+                self.request_mutation_policy.value
+            ),
+            "response_mutation_policy": (
+                self.response_mutation_policy.value
+            ),
+            "sse_mutation_policy": self.sse_mutation_policy.value,
+            "verify_cross_protocol_source": (
+                self.verify_cross_protocol_source
+            ),
+            "tool_protocol": self.tool_protocol,
+            "tool_surface_strategy": self.tool_surface_strategy,
+            "native_responses_tool_codec": (
+                self.native_responses_tool_codec
+            ),
+            "retry": self.retry.telemetry_snapshot(),
+            "fallback_http_statuses": sorted(
+                self.fallback_http_statuses
+            ),
+            "mutation_summary": [
+                mutation.value for mutation in self.mutation_summary
+            ],
+        }
 
     def request_body(self, prepared_body: bytes) -> bytes:
         if self.request_body_mode == AttemptRequestBodyMode.PREPARED_DIRECT:
@@ -11246,6 +11548,10 @@ class RoutePlan:
     @property
     def vision_proxy_policy(self) -> str:
         return self.vision.policy
+
+    @property
+    def primary_attempt(self) -> RouteAttemptPlan | None:
+        return self.attempts[0] if self.attempts else None
 
 
 def behavior_profile_for_request(
@@ -11324,6 +11630,9 @@ def _capability_state(value: Any, *, default: CapabilityState) -> CapabilityStat
 CAPABILITY_MANIFEST_VERSION_RE = re.compile(
     r"[A-Za-z0-9](?:[A-Za-z0-9._-]{0,126}[A-Za-z0-9])?"
 )
+SUPPORTED_CAPABILITY_MANIFEST_VERSIONS = frozenset(
+    {"provider-capabilities.v3"}
+)
 CAPABILITY_MANIFEST_HASH_LENGTHS = {
     "sha256": 64,
     "sha384": 96,
@@ -11332,7 +11641,10 @@ CAPABILITY_MANIFEST_HASH_LENGTHS = {
 
 
 def _valid_capability_manifest_version(value: str) -> bool:
-    return CAPABILITY_MANIFEST_VERSION_RE.fullmatch(value) is not None
+    return (
+        CAPABILITY_MANIFEST_VERSION_RE.fullmatch(value) is not None
+        and value in SUPPORTED_CAPABILITY_MANIFEST_VERSIONS
+    )
 
 
 def _valid_capability_manifest_hash(value: str) -> bool:
@@ -11618,6 +11930,9 @@ def route_plan_for_request(
     image_proxy_enabled: bool = False,
     official_http_passthrough_enabled: bool = True,
     caller_stream: bool = True,
+    operational_authentication: OperationalAuthentication | None = None,
+    incoming_headers: Mapping[str, str] | Any | None = None,
+    drop_content_encoding: bool = False,
     runtime_facts: (
         RouteRuntimeFacts
         | Mapping[str, RouteRuntimeFacts]
@@ -11763,6 +12078,24 @@ def route_plan_for_request(
     authentication_strategy = _authentication_strategy(
         upstream.get("auth") or "unknown"
     )
+    request_headers = FrozenRequestHeaders.unmaterialized()
+    if operational_authentication is not None and attempt_protocols:
+        if operational_authentication.strategy != authentication_strategy:
+            raise ValueError(
+                "operational authentication strategy does not match route"
+            )
+        request_headers = FrozenRequestHeaders(
+            upstream_headers(
+                incoming_headers or {},
+                upstream,
+                drop_content_encoding=drop_content_encoding,
+                model_id=canonical_route_model or model_requested,
+                authentication_strategy=authentication_strategy,
+                request_mutation_policy=mutation_policy,
+                operational_authentication=operational_authentication,
+            ),
+            materialized=True,
+        )
     transport_policy = (
         TransportPolicy.OFFICIAL_KEEPALIVE
         if upstream_name == "official"
@@ -11899,6 +12232,7 @@ def route_plan_for_request(
                 request_conversion_steps=tuple(request_conversion_steps),
                 request_body_mode=request_body_mode,
                 authentication_strategy=authentication_strategy,
+                request_headers=request_headers,
                 streaming_policy=streaming_policy,
                 usage_policy=usage_policy,
                 transport_policy=transport_policy,
@@ -12033,6 +12367,7 @@ def route_plan_for_request(
 
 
 def _route_plan_event_fields(plan: RoutePlan) -> dict[str, Any]:
+    primary_attempt = plan.primary_attempt
     return {
         "route_plan_schema_version": plan.schema_version,
         "route_plan_summary_scope": "planned",
@@ -12041,79 +12376,17 @@ def _route_plan_event_fields(plan: RoutePlan) -> dict[str, Any]:
         "protocol_capability_state": plan.protocol_capability_state.value,
         "protocol_failure_reason": plan.protocol_failure_reason,
         "route_attempts": [
-            {
-                "index": attempt.index,
-                "upstream_protocol": attempt.upstream_protocol.value,
-                "wire_format_adapter": attempt.wire_format_adapter,
-                "request_conversion_steps": list(
-                    attempt.request_conversion_steps
-                ),
-                "request_body_mode": attempt.request_body_mode.value,
-                "authentication_strategy": (
-                    attempt.authentication_strategy.value
-                ),
-                "streaming_policy": attempt.streaming_policy.value,
-                "usage_policy": attempt.usage_policy.value,
-                "transport_policy": attempt.transport_policy.value,
-                "request_mutation_policy": attempt.request_mutation_policy.value,
-                "response_mutation_policy": (
-                    attempt.response_mutation_policy.value
-                ),
-                "sse_mutation_policy": attempt.sse_mutation_policy.value,
-                "verify_cross_protocol_source": (
-                    attempt.verify_cross_protocol_source
-                ),
-                "tool_protocol": attempt.tool_protocol,
-                "tool_surface_strategy": attempt.tool_surface_strategy,
-                "native_responses_tool_codec": (
-                    attempt.native_responses_tool_codec
-                ),
-                "retry": {
-                    "eligibility": attempt.retry.eligibility.value,
-                    "policy": attempt.retry.policy.value,
-                    "request_kind": attempt.retry.request_kind,
-                    "request_timeout_seconds": (
-                        attempt.retry.request_timeout_seconds
-                    ),
-                    "base_open_attempts": attempt.retry.base_open_attempts,
-                    "base_relay_attempts": (
-                        attempt.retry.base_relay_attempts
-                    ),
-                    "failure_expansion_attempts": (
-                        attempt.retry.failure_expansion_attempts
-                    ),
-                    "retry_http_errors": (
-                        attempt.retry.retry_http_errors
-                    ),
-                    "open_attempt_budget": (
-                        attempt.retry.open_attempt_budget
-                    ),
-                    "capacity_elapsed_limit_seconds": (
-                        attempt.retry.capacity_elapsed_limit_seconds
-                    ),
-                    "stream_elapsed_limit_seconds": (
-                        attempt.retry.stream_elapsed_limit_seconds
-                    ),
-                    "emit_downstream_retry_notice": (
-                        attempt.retry.emit_downstream_retry_notice
-                    ),
-                    "pre_response_budget_seconds": (
-                        attempt.retry.pre_response_budget_seconds
-                    ),
-                    "lifecycle_final_retry_eligible": (
-                        attempt.retry.lifecycle_final_retry_eligible
-                    ),
-                },
-                "fallback_http_statuses": sorted(attempt.fallback_http_statuses),
-                "mutation_summary": [
-                    mutation.value for mutation in attempt.mutation_summary
-                ],
-            }
-            for attempt in plan.attempts
+            attempt.telemetry_snapshot() for attempt in plan.attempts
         ],
-        "wire_format_adapter": plan.wire_format_adapter,
+        "wire_format_adapter": (
+            primary_attempt.wire_format_adapter
+            if primary_attempt is not None
+            else plan.wire_format_adapter
+        ),
         "route_plan_primary_wire_format_adapter": (
-            plan.wire_format_adapter
+            primary_attempt.wire_format_adapter
+            if primary_attempt is not None
+            else plan.wire_format_adapter
         ),
         "caller_request_body_mode": plan.caller_request_body_mode.value,
         "prepared_request_protocol": plan.prepared_request_protocol.value,
@@ -12121,14 +12394,30 @@ def _route_plan_event_fields(plan: RoutePlan) -> dict[str, Any]:
         "request_kind": plan.request_kind,
         "raw_provider_probe": plan.raw_provider_probe,
         "request_kind_policy": plan.request_kind_policy,
-        "retry_policy": plan.retry_policy.value,
-        "retry_eligibility": plan.retry_eligibility.value,
-        "usage_policy": plan.usage_policy.value,
+        "retry_policy": (
+            primary_attempt.retry.policy.value
+            if primary_attempt is not None
+            else plan.retry_policy.value
+        ),
+        "retry_eligibility": (
+            primary_attempt.retry.eligibility.value
+            if primary_attempt is not None
+            else plan.retry_eligibility.value
+        ),
+        "usage_policy": (
+            primary_attempt.usage_policy.value
+            if primary_attempt is not None
+            else plan.usage_policy.value
+        ),
         "repair_policy": plan.repair_policy,
         "capability_manifest_version": plan.capability_manifest_version,
         "capability_manifest_hash": plan.capability_manifest_hash,
         "capability_manifest_state": plan.capability_manifest_state.value,
-        "authentication_strategy": plan.authentication_strategy.value,
+        "authentication_strategy": (
+            primary_attempt.authentication_strategy.value
+            if primary_attempt is not None
+            else plan.authentication_strategy.value
+        ),
         "tool_requested_exposure_mode": plan.tool_exposure.requested_mode.value,
         "tool_exposure_mode": plan.tool_exposure.effective_mode.value,
         "tool_capability_state": plan.tool_exposure.capability_state.value,
@@ -12137,11 +12426,31 @@ def _route_plan_event_fields(plan: RoutePlan) -> dict[str, Any]:
         "codex_compatibility_policy": plan.codex_compatibility_policy.value,
         "collaboration_backend": plan.collaboration_backend.value,
         "execution_owner": plan.execution_owner.value,
-        "streaming_policy": plan.streaming_policy.value,
-        "transport_policy": plan.transport_policy.value,
-        "request_mutation_policy": plan.request_mutation_policy.value,
-        "response_mutation_policy": plan.response_mutation_policy.value,
-        "sse_mutation_policy": plan.sse_mutation_policy.value,
+        "streaming_policy": (
+            primary_attempt.streaming_policy.value
+            if primary_attempt is not None
+            else plan.streaming_policy.value
+        ),
+        "transport_policy": (
+            primary_attempt.transport_policy.value
+            if primary_attempt is not None
+            else plan.transport_policy.value
+        ),
+        "request_mutation_policy": (
+            primary_attempt.request_mutation_policy.value
+            if primary_attempt is not None
+            else plan.request_mutation_policy.value
+        ),
+        "response_mutation_policy": (
+            primary_attempt.response_mutation_policy.value
+            if primary_attempt is not None
+            else plan.response_mutation_policy.value
+        ),
+        "sse_mutation_policy": (
+            primary_attempt.sse_mutation_policy.value
+            if primary_attempt is not None
+            else plan.sse_mutation_policy.value
+        ),
         "vision_proxy_policy": plan.vision.policy,
         "vision_action": plan.vision.action.value,
         "vision_network_action": plan.vision.network_action.value,
@@ -12159,71 +12468,69 @@ def _route_plan_event_fields(plan: RoutePlan) -> dict[str, Any]:
 
 
 def _route_attempt_event_fields(attempt: RouteAttemptPlan) -> dict[str, Any]:
+    snapshot = attempt.telemetry_snapshot()
+    retry = snapshot["retry"]
     return {
         "execution_summary_scope": "selected_attempt_plan",
-        "executed_upstream_protocol": attempt.upstream_protocol.value,
-        "executed_wire_format_adapter": attempt.wire_format_adapter,
-        "executed_request_conversion_steps": list(
-            attempt.request_conversion_steps
-        ),
-        "executed_attempt_mutation_summary": [
-            mutation.value for mutation in attempt.mutation_summary
+        "executed_upstream_protocol": snapshot["upstream_protocol"],
+        "executed_wire_format_adapter": snapshot["wire_format_adapter"],
+        "executed_request_conversion_steps": snapshot[
+            "request_conversion_steps"
         ],
-        "route_attempt_index": attempt.index,
-        "route_attempt_protocol": attempt.upstream_protocol.value,
-        "route_attempt_wire_format_adapter": attempt.wire_format_adapter,
-        "route_attempt_request_conversion_steps": list(
-            attempt.request_conversion_steps
-        ),
-        "route_attempt_request_body_mode": attempt.request_body_mode.value,
+        "executed_attempt_mutation_summary": snapshot[
+            "mutation_summary"
+        ],
+        "route_attempt_index": snapshot["index"],
+        "route_attempt_protocol": snapshot["upstream_protocol"],
+        "route_attempt_wire_format_adapter": snapshot[
+            "wire_format_adapter"
+        ],
+        "route_attempt_request_conversion_steps": snapshot[
+            "request_conversion_steps"
+        ],
+        "route_attempt_request_body_mode": snapshot["request_body_mode"],
         "route_attempt_mutation_summary_scope": "attempt_plan",
-        "route_attempt_authentication_strategy": (
-            attempt.authentication_strategy.value
-        ),
-        "route_attempt_streaming_policy": attempt.streaming_policy.value,
-        "route_attempt_usage_policy": attempt.usage_policy.value,
-        "route_attempt_transport_policy": attempt.transport_policy.value,
-        "route_attempt_retry_policy": attempt.retry.policy.value,
-        "route_attempt_retry_eligibility": (
-            attempt.retry.eligibility.value
-        ),
-        "route_attempt_base_open_attempts": (
-            attempt.retry.base_open_attempts
-        ),
-        "route_attempt_base_relay_attempts": (
-            attempt.retry.base_relay_attempts
-        ),
-        "route_attempt_open_attempt_budget": (
-            attempt.retry.open_attempt_budget
-        ),
-        "route_attempt_request_timeout_seconds": (
-            attempt.retry.request_timeout_seconds
-        ),
-        "route_attempt_request_mutation_policy": (
-            attempt.request_mutation_policy.value
-        ),
-        "route_attempt_response_mutation_policy": (
-            attempt.response_mutation_policy.value
-        ),
-        "route_attempt_sse_mutation_policy": (
-            attempt.sse_mutation_policy.value
-        ),
-        "route_attempt_verify_cross_protocol_source": (
-            attempt.verify_cross_protocol_source
-        ),
-        "route_attempt_tool_protocol": attempt.tool_protocol,
-        "route_attempt_tool_surface_strategy": (
-            attempt.tool_surface_strategy
-        ),
-        "route_attempt_native_responses_tool_codec": (
-            attempt.native_responses_tool_codec
-        ),
-        "route_attempt_fallback_http_statuses": sorted(
-            attempt.fallback_http_statuses
-        ),
-        "route_attempt_mutation_summary": [
-            mutation.value for mutation in attempt.mutation_summary
+        "route_attempt_authentication_strategy": snapshot[
+            "authentication_strategy"
         ],
+        "route_attempt_streaming_policy": snapshot["streaming_policy"],
+        "route_attempt_usage_policy": snapshot["usage_policy"],
+        "route_attempt_transport_policy": snapshot["transport_policy"],
+        "route_attempt_retry_policy": retry["policy"],
+        "route_attempt_retry_eligibility": retry["eligibility"],
+        "route_attempt_base_open_attempts": retry["base_open_attempts"],
+        "route_attempt_base_relay_attempts": retry[
+            "base_relay_attempts"
+        ],
+        "route_attempt_open_attempt_budget": retry[
+            "open_attempt_budget"
+        ],
+        "route_attempt_request_timeout_seconds": retry[
+            "request_timeout_seconds"
+        ],
+        "route_attempt_request_mutation_policy": snapshot[
+            "request_mutation_policy"
+        ],
+        "route_attempt_response_mutation_policy": snapshot[
+            "response_mutation_policy"
+        ],
+        "route_attempt_sse_mutation_policy": snapshot[
+            "sse_mutation_policy"
+        ],
+        "route_attempt_verify_cross_protocol_source": snapshot[
+            "verify_cross_protocol_source"
+        ],
+        "route_attempt_tool_protocol": snapshot["tool_protocol"],
+        "route_attempt_tool_surface_strategy": snapshot[
+            "tool_surface_strategy"
+        ],
+        "route_attempt_native_responses_tool_codec": snapshot[
+            "native_responses_tool_codec"
+        ],
+        "route_attempt_fallback_http_statuses": snapshot[
+            "fallback_http_statuses"
+        ],
+        "route_attempt_mutation_summary": snapshot["mutation_summary"],
     }
 
 
@@ -12284,6 +12591,45 @@ def _filtered_response_headers(
     return outgoing
 
 
+def materialize_operational_authentication(
+    incoming_headers: Mapping[str, str] | Any,
+    upstream: Mapping[str, Any],
+) -> OperationalAuthentication:
+    strategy = _authentication_strategy(upstream.get("auth") or "unknown")
+    if strategy == AuthenticationStrategy.INCOMING:
+        return OperationalAuthentication(
+            strategy,
+            authorization=_get_header(incoming_headers, "Authorization"),
+        )
+    if strategy == AuthenticationStrategy.OLLAMA_API_KEY:
+        api_key = os.environ.get("OLLAMA_API_KEY")
+        return OperationalAuthentication(
+            strategy,
+            authorization=f"Bearer {api_key}" if api_key else None,
+        )
+    if strategy == AuthenticationStrategy.API_KEY:
+        api_key = upstream.get("api_key")
+        return OperationalAuthentication(
+            strategy,
+            authorization=f"Bearer {api_key}" if api_key else None,
+        )
+    if strategy == AuthenticationStrategy.CODEX_AUTH:
+        return OperationalAuthentication(
+            strategy,
+            authorization=f"Bearer {codex_access_token()}",
+            account_id=codex_account_id(),
+            generated_session_id=(
+                _get_header(incoming_headers, "Session-id")
+                or str(uuid.uuid4())
+            ),
+            generated_client_request_id=(
+                _get_header(incoming_headers, "X-client-request-id")
+                or str(uuid.uuid4())
+            ),
+        )
+    return OperationalAuthentication(strategy, authorization=None)
+
+
 def upstream_headers(
     incoming_headers: Mapping[str, str] | Any,
     upstream: Mapping[str, Any],
@@ -12292,9 +12638,12 @@ def upstream_headers(
     model_id: str | None = None,
     authentication_strategy: AuthenticationStrategy | None = None,
     request_mutation_policy: MutationPolicy | None = None,
+    operational_authentication: OperationalAuthentication | None = None,
 ) -> dict[str, str]:
     auth_mode = (
-        authentication_strategy.value
+        operational_authentication.strategy.value
+        if operational_authentication is not None
+        else authentication_strategy.value
         if authentication_strategy is not None
         else upstream.get("auth")
     )
@@ -12319,19 +12668,41 @@ def upstream_headers(
         outgoing[key] = value
 
     if auth_mode == "incoming":
-        incoming_auth = _get_header(incoming_headers, "Authorization")
+        incoming_auth = (
+            operational_authentication.authorization
+            if operational_authentication is not None
+            else _get_header(incoming_headers, "Authorization")
+        )
         if incoming_auth:
             outgoing["Authorization"] = incoming_auth
     elif auth_mode == "ollama_api_key":
-        api_key = os.environ.get("OLLAMA_API_KEY")
-        if not api_key:
-            raise ValueError("OLLAMA_API_KEY is not set")
-        outgoing["Authorization"] = f"Bearer {api_key}"
+        if operational_authentication is not None:
+            authorization = operational_authentication.authorization
+            if authorization is None:
+                raise ValueError("OLLAMA_API_KEY is not set")
+        else:
+            api_key = os.environ.get("OLLAMA_API_KEY")
+            if not api_key:
+                raise ValueError("OLLAMA_API_KEY is not set")
+            authorization = f"Bearer {api_key}"
+        outgoing["Authorization"] = authorization
     elif auth_mode == "api_key":
-        api_key = upstream.get("api_key")
-        if not api_key:
-            raise ValueError(f"API key is not set for upstream: {upstream.get('name', 'unknown')}")
-        outgoing["Authorization"] = f"Bearer {api_key}"
+        if operational_authentication is not None:
+            authorization = operational_authentication.authorization
+            if authorization is None:
+                raise ValueError(
+                    "API key is not set for upstream: "
+                    f"{upstream.get('name', 'unknown')}"
+                )
+        else:
+            api_key = upstream.get("api_key")
+            if not api_key:
+                raise ValueError(
+                    "API key is not set for upstream: "
+                    f"{upstream.get('name', 'unknown')}"
+                )
+            authorization = f"Bearer {api_key}"
+        outgoing["Authorization"] = authorization
     elif auth_mode == "codex_auth":
         strict_official_passthrough = (
             request_mutation_policy
@@ -12340,12 +12711,20 @@ def upstream_headers(
             else behavior_profile
             == BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH
         )
-        token = codex_access_token()
-        outgoing["Authorization"] = f"Bearer {token}"
+        authorization = (
+            operational_authentication.authorization
+            if operational_authentication is not None
+            else f"Bearer {codex_access_token()}"
+        )
+        outgoing["Authorization"] = authorization
         # The chatgpt.com backend requires the account id header to identify
         # the subscription. Inject it from auth.json when not already present.
         if not _get_header(outgoing, "Chatgpt-account-id"):
-            account = codex_account_id()
+            account = (
+                operational_authentication.account_id
+                if operational_authentication is not None
+                else codex_account_id()
+            )
             if account:
                 outgoing["Chatgpt-account-id"] = account
         if not strict_official_passthrough:
@@ -12362,14 +12741,31 @@ def upstream_headers(
             # UUIDs when the caller doesn't supply them.
             session_id = _get_header(outgoing, "Session-id")
             if not session_id:
-                session_id = str(uuid.uuid4())
+                session_id = (
+                    operational_authentication.generated_session_id
+                    if operational_authentication is not None
+                    else str(uuid.uuid4())
+                )
+                if not session_id:
+                    raise ValueError(
+                        "materialized Codex auth is missing session identity"
+                    )
                 outgoing["Session-id"] = session_id
             if not _get_header(outgoing, "Thread-id"):
                 outgoing["Thread-id"] = session_id
             if not _get_header(outgoing, "X-codex-window-id"):
                 outgoing["X-codex-window-id"] = f"{session_id}:1"
             if not _get_header(outgoing, "X-client-request-id"):
-                outgoing["X-client-request-id"] = str(uuid.uuid4())
+                client_request_id = (
+                    operational_authentication.generated_client_request_id
+                    if operational_authentication is not None
+                    else str(uuid.uuid4())
+                )
+                if not client_request_id:
+                    raise ValueError(
+                        "materialized Codex auth is missing request identity"
+                    )
+                outgoing["X-client-request-id"] = client_request_id
     else:
         raise ValueError(f"unsupported upstream auth mode: {auth_mode}")
 
@@ -15430,6 +15826,8 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
         behavior_profile = None
         route_reason: str | None = None
         route_plan: RoutePlan | None = None
+        active_route_attempt: RouteAttemptPlan | None = None
+        relay_execution_plan: RelayExecutionPlan | None = None
         route_policy_event_fields: dict[str, Any] = {}
         downstream_sse_started = False
         response_lifecycle_state: dict[str, str] = {}
@@ -15584,6 +15982,12 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         RETRY_REQUEST_MAIN_GENERATION
                     )
                 )
+            operational_authentication = (
+                materialize_operational_authentication(
+                    self.headers,
+                    upstream,
+                )
+            )
             route_plan = route_plan_for_request(
                 upstream,
                 request_context,
@@ -15600,24 +16004,28 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                     gateway_official_http_passthrough_enabled()
                 ),
                 caller_stream=caller_stream,
+                operational_authentication=operational_authentication,
+                incoming_headers=self.headers,
+                drop_content_encoding=content_decoded,
                 runtime_facts=route_runtime_facts,
             )
+            primary_route_attempt = route_plan.primary_attempt
             behavior_profile = route_plan.behavior_profile
             upstream_format = route_plan.selected_upstream_format
             if request_kind != route_plan.request_kind:
                 request_kind = route_plan.request_kind
                 proxy_request_context = _event_context_with_request_kind(request_context, request_kind)
             self._pre_response_deadline = (
-                route_plan.attempts[0].retry.pre_response_deadline(started_at)
-                if route_plan.attempts
+                primary_route_attempt.retry.pre_response_deadline(started_at)
+                if primary_route_attempt is not None
                 else None
             )
             reasoning_policy = _reasoning_policy_for_request(inbound_payload, upstream, model)
             route_policy_event_fields = {
                 **_route_plan_event_fields(route_plan),
                 **(
-                    _route_attempt_event_fields(route_plan.attempts[0])
-                    if route_plan.attempts
+                    _route_attempt_event_fields(primary_route_attempt)
+                    if primary_route_attempt is not None
                     else {}
                 ),
                 **({"reasoning_policy": reasoning_policy} if reasoning_policy else {}),
@@ -15626,7 +16034,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 **proxy_request_context,
                 **route_policy_event_fields,
             }
-            if not route_plan.attempts:
+            if primary_route_attempt is None:
                 protocol_error = (
                     UnsupportedRouteProtocolError
                     if (
@@ -15820,7 +16228,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
             else:
                 compatibility_upstream = {
                     **upstream,
-                    "upstream_format": route_plan.attempts[0].selected_upstream_format,
+                    "upstream_format": primary_route_attempt.selected_upstream_format,
                 }
                 body = compatible_request_body(
                     body,
@@ -15829,13 +16237,13 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                     event_context=adapter_event_context,
                     inject_codex_tools=route_plan.tool_exposure.gateway_schema_injection,
                     tool_protocol_override=(
-                        route_plan.attempts[0].tool_protocol
+                        primary_route_attempt.tool_protocol
                     ),
                     tool_surface_strategy_override=(
-                        route_plan.attempts[0].tool_surface_strategy
+                        primary_route_attempt.tool_surface_strategy
                     ),
                     native_responses_tool_codec_override=(
-                        route_plan.attempts[0].native_responses_tool_codec
+                        primary_route_attempt.native_responses_tool_codec
                     ),
                 )
             vision_proxy_payload_format = (
@@ -15876,53 +16284,62 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 )
                 return
             responses_body = body
-            headers = upstream_headers(
-                self.headers,
-                upstream,
-                drop_content_encoding=content_decoded,
-                model_id=model,
-                authentication_strategy=(
-                    route_plan.attempts[0].authentication_strategy
-                ),
-                request_mutation_policy=(
-                    route_plan.attempts[0].request_mutation_policy
-                ),
-            )
-
             def upstream_body_for_attempt(
                 attempt: RouteAttemptPlan,
                 prepared_body: bytes = responses_body,
             ) -> bytes:
                 return attempt.request_body(prepared_body)
 
-            upstream_request_observability = proxy_telemetry.enrich_request_observability(
-                body=upstream_body_for_attempt(route_plan.attempts[0]),
-                codex_home=RUNTIME_CODEX_DIR,
-                upstream=upstream,
-                include_body_hmac=(
-                    route_plan.request_mutation_policy
-                    != MutationPolicy.OFFICIAL_PASSTHROUGH
-                ),
-                prompt_cache_key=prompt_cache_key,
-                extract_prompt_cache_key=(
-                    route_plan.request_mutation_policy
-                    != MutationPolicy.OFFICIAL_PASSTHROUGH
-                ),
+            def request_observability_for_attempt(
+                attempt: RouteAttemptPlan,
+                attempt_body: bytes,
+            ) -> dict[str, Any]:
+                upstream_observability = (
+                    proxy_telemetry.enrich_request_observability(
+                        body=attempt_body,
+                        codex_home=RUNTIME_CODEX_DIR,
+                        upstream=upstream,
+                        include_body_hmac=(
+                            attempt.request_mutation_policy
+                            != MutationPolicy.OFFICIAL_PASSTHROUGH
+                        ),
+                        prompt_cache_key=prompt_cache_key,
+                        extract_prompt_cache_key=(
+                            attempt.request_mutation_policy
+                            != MutationPolicy.OFFICIAL_PASSTHROUGH
+                        ),
+                    )
+                )
+                return {
+                    **upstream_observability,
+                    **_request_observability_with_prefix(
+                        caller_request_observability,
+                        "caller",
+                    ),
+                    **_request_observability_with_prefix(
+                        upstream_observability,
+                        "upstream",
+                    ),
+                    "request_observability_scope": "executed_attempt",
+                    "request_observability_attempt_index": attempt.index,
+                    "request_observability_upstream_protocol": (
+                        attempt.upstream_protocol.value
+                    ),
+                }
+
+            request_observability = request_observability_for_attempt(
+                primary_route_attempt,
+                upstream_body_for_attempt(primary_route_attempt),
             )
-            request_observability = {
-                **upstream_request_observability,
-                **_request_observability_with_prefix(caller_request_observability, "caller"),
-                **_request_observability_with_prefix(upstream_request_observability, "upstream"),
-            }
             emit_request_start_once(request_observability)
             emit_retry_to_downstream = (
-                route_plan.attempts[0].retry.emit_downstream_retry_notice
+                primary_route_attempt.retry.emit_downstream_retry_notice
             )
 
             def upstream_request_for_attempt(
                 attempt: RouteAttemptPlan,
                 lifecycle_final_retry_reason: str | None = None,
-            ) -> Request:
+            ) -> tuple[Request, dict[str, Any]]:
                 request_body = responses_body
                 if lifecycle_final_retry_reason:
                     request_body = _responses_body_with_lifecycle_final_retry_guidance(
@@ -15936,11 +16353,21 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         upstream_format=attempt.selected_upstream_format,
                         reason=lifecycle_final_retry_reason,
                     )
-                return Request(
-                    attempt.endpoint_url,
-                    data=upstream_body_for_attempt(attempt, request_body),
-                    headers=headers,
-                    method="POST",
+                attempt_body = upstream_body_for_attempt(
+                    attempt,
+                    request_body,
+                )
+                return (
+                    Request(
+                        attempt.endpoint_url,
+                        data=attempt_body,
+                        headers=attempt.request_headers.to_dict(),
+                        method="POST",
+                    ),
+                    request_observability_for_attempt(
+                        attempt,
+                        attempt_body,
+                    ),
                 )
 
             def emit_downstream_retry(payload: Mapping[str, Any]) -> bool:
@@ -15982,9 +16409,10 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
 
             selected_upstream_format = upstream_format
             open_attempt_budget = (
-                route_plan.attempts[0].retry.new_open_attempt_budget()
+                primary_route_attempt.retry.new_open_attempt_budget()
             )
             for route_attempt in route_plan.attempts:
+                active_route_attempt = route_attempt
                 selected_upstream_format = route_attempt.selected_upstream_format
                 route_attempt_event_fields = _route_attempt_event_fields(route_attempt)
                 proxy_request_context.update(route_attempt_event_fields)
@@ -16000,6 +16428,11 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         adapter_event_context
                     )
                 )
+                relay_execution_plan = route_attempt.relay_execution_plan(
+                    lifecycle_final_retry_enabled=(
+                        lifecycle_final_extra_attempts > 0
+                    )
+                )
                 max_relay_attempts = relay_attempts + lifecycle_final_extra_attempts
                 relay_attempt = 1
                 lifecycle_final_retry_reason: str | None = None
@@ -16008,10 +16441,11 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         seam = _handler_downstream_stream_commit(self)
                         if seam is not None:
                             seam.set_upstream_format(selected_upstream_format)
-                        request = upstream_request_for_attempt(
+                        request, request_observability = upstream_request_for_attempt(
                             route_attempt,
                             lifecycle_final_retry_reason,
                         )
+                        emit_request_start_once(request_observability)
                         try:
                             with _open_upstream_response(
                                 request,
@@ -16044,26 +16478,10 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                                     event_context=adapter_event_context,
                                     usage_capture=usage_capture,
                                     headers_already_sent=downstream_sse_started,
-                                    request_kind=request_kind,
                                     defer_stream_errors=relay_attempt < relay_attempts,
                                     mark_downstream_sse_started=mark_downstream_sse_started,
                                     response_lifecycle_state=response_lifecycle_state,
-                                    streaming_policy=(
-                                        route_attempt.streaming_policy
-                                    ),
-                                    usage_policy=route_attempt.usage_policy,
-                                    response_mutation_policy=(
-                                        route_attempt.response_mutation_policy
-                                    ),
-                                    sse_mutation_policy=(
-                                        route_attempt.sse_mutation_policy
-                                    ),
-                                    verify_cross_protocol_source=(
-                                        route_attempt.verify_cross_protocol_source
-                                    ),
-                                    lifecycle_final_retry_enabled=(
-                                        lifecycle_final_extra_attempts > 0
-                                    ),
+                                    relay_execution_plan=relay_execution_plan,
                                 )
                             break
                         except DownstreamClosedBeforeRetryError:
@@ -16302,6 +16720,12 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                             failure_phase="response_headers",
                         )
                         if fallback_retry_safety_class not in _SUPPRESSED_RETRY_SAFETY_CLASSES:
+                            failed_attempt_snapshot = (
+                                route_attempt.telemetry_snapshot()
+                            )
+                            next_attempt_snapshot = (
+                                next_attempt.telemetry_snapshot()
+                            )
                             write_proxy_event(
                                 "upstream_protocol_fallback",
                                 request_id=request_id,
@@ -16315,38 +16739,49 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                                 behavior_profile=behavior_profile,
                                 failed_upstream_format=selected_upstream_format,
                                 next_upstream_format=next_attempt.selected_upstream_format,
-                                failed_route_attempt_index=route_attempt.index,
+                                failed_route_attempt_index=(
+                                    failed_attempt_snapshot["index"]
+                                ),
                                 failed_route_attempt_request_body_mode=(
-                                    route_attempt.request_body_mode.value
+                                    failed_attempt_snapshot[
+                                        "request_body_mode"
+                                    ]
                                 ),
                                 failed_route_attempt_request_conversion_steps=(
-                                    list(
-                                        route_attempt.request_conversion_steps
-                                    )
+                                    failed_attempt_snapshot[
+                                        "request_conversion_steps"
+                                    ]
                                 ),
-                                failed_route_attempt_mutation_summary=[
-                                    mutation.value
-                                    for mutation in route_attempt.mutation_summary
-                                ],
-                                next_route_attempt_index=next_attempt.index,
+                                failed_route_attempt_mutation_summary=(
+                                    failed_attempt_snapshot[
+                                        "mutation_summary"
+                                    ]
+                                ),
+                                next_route_attempt_index=(
+                                    next_attempt_snapshot["index"]
+                                ),
                                 next_route_attempt_request_body_mode=(
-                                    next_attempt.request_body_mode.value
+                                    next_attempt_snapshot[
+                                        "request_body_mode"
+                                    ]
                                 ),
                                 next_route_attempt_request_conversion_steps=(
-                                    list(
-                                        next_attempt.request_conversion_steps
-                                    )
+                                    next_attempt_snapshot[
+                                        "request_conversion_steps"
+                                    ]
                                 ),
-                                next_route_attempt_mutation_summary=[
-                                    mutation.value
-                                    for mutation in next_attempt.mutation_summary
-                                ],
+                                next_route_attempt_mutation_summary=(
+                                    next_attempt_snapshot[
+                                        "mutation_summary"
+                                    ]
+                                ),
                                 status=getattr(exc, "code", 502),
                                 error="HTTPError",
                                 detail=safe_upstream_error_detail(
                                     exc,
                                     redact_identity=_retry_identity_from_context(adapter_event_context),
                                 ),
+                                **request_observability,
                                 **proxy_request_context,
                             )
                             continue
@@ -16547,8 +16982,8 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
             json_error_type = "invalid_request_error" if is_apply_patch_adapter_error else error_code
             sse_error_type = "invalid_request_error" if is_apply_patch_adapter_error else "upstream_error"
             selected_native_responses_tool_codec = (
-                upstream.get("native_responses_tool_codec", "none")
-                if isinstance(upstream, Mapping)
+                active_route_attempt.native_responses_tool_codec
+                if active_route_attempt is not None
                 else "none"
             )
             write_proxy_event(
@@ -16698,6 +17133,11 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 )
                 return
             try:
+                if relay_execution_plan is None:
+                    raise RuntimeError(
+                        "upstream response arrived without a planned relay "
+                        "execution contract"
+                    ) from exc
                 previous_retry_identity = (
                     adapter_event_context.get("_retry_attempt_identity")
                     if isinstance(adapter_event_context, Mapping)
@@ -16721,7 +17161,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                     caller_stream=caller_stream,
                     event_context=adapter_event_context,
                     usage_capture=usage_capture,
-                    behavior_profile=behavior_profile,
+                    relay_execution_plan=relay_execution_plan,
                 )
             except OSError as relay_exc:
                 self.close_connection = True
@@ -17131,6 +17571,15 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
         proxy_request_context = _event_context_with_request_kind(request_context, RETRY_REQUEST_OFFICIAL_CONTROL)
         upstream = official_upstream()
         upstream_name = upstream["name"]
+        relay_execution_plan = RelayExecutionPlan(
+            request_kind=RETRY_REQUEST_OFFICIAL_CONTROL,
+            streaming_policy=StreamingPolicy.GATEWAY_ADAPTED,
+            usage_policy=UsagePolicy.SYNC_CAPTURE,
+            response_mutation_policy=MutationPolicy.GATEWAY_COMPATIBILITY,
+            sse_mutation_policy=MutationPolicy.GATEWAY_COMPATIBILITY,
+            verify_cross_protocol_source=False,
+            lifecycle_final_retry_enabled=False,
+        )
 
         try:
             headers = upstream_headers(self.headers, upstream)
@@ -17159,7 +17608,13 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 event_context=adapter_event_context,
                 request_kind=RETRY_REQUEST_OFFICIAL_CONTROL,
             ) as response:
-                status = self._relay_upstream_response(response, upstream_name, request_id=request_id, model=None)
+                status = self._relay_upstream_response(
+                    response,
+                    upstream_name,
+                    request_id=request_id,
+                    model=None,
+                    relay_execution_plan=relay_execution_plan,
+                )
             write_proxy_event(
                 "request_complete",
                 request_id=request_id,
@@ -17173,7 +17628,13 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
             )
         except HTTPError as exc:
             try:
-                status = self._relay_upstream_response(exc, upstream_name, request_id=request_id, model=None)
+                status = self._relay_upstream_response(
+                    exc,
+                    upstream_name,
+                    request_id=request_id,
+                    model=None,
+                    relay_execution_plan=relay_execution_plan,
+                )
             except OSError as relay_exc:
                 self.close_connection = True
                 write_proxy_event(
@@ -18372,6 +18833,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
         self,
         response: Any,
         upstream_name: str,
+        relay_execution_plan: RelayExecutionPlan,
         request_id: str | None = None,
         model: str | None = None,
         upstream_format: str = "responses",
@@ -18380,69 +18842,23 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
         event_context: Mapping[str, Any] | None = None,
         usage_capture: dict[str, Any] | None = None,
         headers_already_sent: bool = False,
-        request_kind: str = RETRY_REQUEST_MAIN_GENERATION,
         defer_stream_errors: bool = False,
         mark_downstream_sse_started: Callable[[], None] | None = None,
         response_lifecycle_state: dict[str, str] | None = None,
-        behavior_profile: str | None = None,
-        streaming_policy: StreamingPolicy | None = None,
-        usage_policy: UsagePolicy | None = None,
-        response_mutation_policy: MutationPolicy | None = None,
-        sse_mutation_policy: MutationPolicy | None = None,
-        verify_cross_protocol_source: bool | None = None,
-        lifecycle_final_retry_enabled: bool | None = None,
     ) -> int:
-        if streaming_policy is None:
-            if (
-                behavior_profile
-                == BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH
-            ):
-                streaming_policy = StreamingPolicy.OFFICIAL_PASSTHROUGH
-            elif (
-                behavior_profile
-                == BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED
-            ):
-                streaming_policy = (
-                    StreamingPolicy.TRANSPARENT
-                    if upstream_format == inbound_format
-                    else StreamingPolicy.TRANSPARENT_CONVERTED
-                )
-            else:
-                streaming_policy = StreamingPolicy.GATEWAY_ADAPTED
-        if usage_policy is None:
-            usage_policy = (
-                UsagePolicy.ASYNC_TAP
-                if (
-                    behavior_profile
-                    == BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED
-                )
-                else UsagePolicy.SYNC_CAPTURE
-            )
-        if response_mutation_policy is None:
-            response_mutation_policy = (
-                MutationPolicy.TRANSPARENT
-                if (
-                    behavior_profile
-                    == BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED
-                )
-                else (
-                    MutationPolicy.OFFICIAL_PASSTHROUGH
-                    if (
-                        behavior_profile
-                        == BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH
-                    )
-                    else MutationPolicy.GATEWAY_COMPATIBILITY
-                )
-            )
-        if sse_mutation_policy is None:
-            sse_mutation_policy = response_mutation_policy
-        if lifecycle_final_retry_enabled is None:
-            lifecycle_final_retry_enabled = (
-                lifecycle_empty_final_resample_enabled(
-                    event_context,
-                    request_kind,
-                )
-            )
+        request_kind = relay_execution_plan.request_kind
+        streaming_policy = relay_execution_plan.streaming_policy
+        usage_policy = relay_execution_plan.usage_policy
+        response_mutation_policy = (
+            relay_execution_plan.response_mutation_policy
+        )
+        sse_mutation_policy = relay_execution_plan.sse_mutation_policy
+        verify_cross_protocol_source = (
+            relay_execution_plan.verify_cross_protocol_source
+        )
+        lifecycle_final_retry_enabled = (
+            relay_execution_plan.lifecycle_final_retry_enabled
+        )
         status = getattr(response, "status", None) or getattr(response, "code", 502)
         is_event_stream = _is_event_stream(response.headers)
         # When the caller spoke Chat Completions, the response must be converted

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 from dataclasses import dataclass
 from datetime import timezone
 from email.utils import parsedate_to_datetime
+from enum import Enum
 import gzip
 import hashlib
 import hmac
@@ -1010,6 +1011,81 @@ REPAIR_NONE = "none"
 VISION_PROXY_DISABLED = "disabled"
 VISION_PROXY_CODEX_APP_ADAPTER = "codex_app_adapter"
 VISION_PROXY_TRANSPARENT_OVERLAY = "transparent_overlay"
+
+ROUTE_CAPABILITY_MANIFEST_VERSION = "codexhub.route-capabilities.v1"
+
+
+class CapabilityState(str, Enum):
+    SUPPORTED = "Supported"
+    UNSUPPORTED = "Unsupported"
+    UNQUALIFIED = "Unqualified"
+
+
+class RouteProtocol(str, Enum):
+    RESPONSES = "responses"
+    CHAT_COMPLETIONS = "chat_completions"
+    AUTO = "auto"
+
+
+class AuthenticationStrategy(str, Enum):
+    CODEX_AUTH = "codex_auth"
+    API_KEY = "api_key"
+    OLLAMA_API_KEY = "ollama_api_key"
+    INCOMING = "incoming"
+    UNKNOWN = "unknown"
+
+
+class ToolExposureMode(str, Enum):
+    CURRENT_COMPATIBILITY = "current_compatibility"
+    OFFICIAL_NATIVE = "official_native"
+    NATIVE_DEFERRED_SEARCH_CANDIDATE = "native_deferred_search_candidate"
+    NATIVE_NO_SEARCH_CANDIDATE = "native_no_search_candidate"
+    UNKNOWN = "unknown"
+
+
+class CollaborationBackend(str, Enum):
+    CODEX_RUNTIME = "codex_runtime"
+    CLIENT_RUNTIME = "client_runtime"
+    GATEWAY_COMPATIBILITY = "gateway_compatibility"
+
+
+class CodexCompatibilityPolicy(str, Enum):
+    OFFICIAL_NATIVE = "official_native"
+    CURRENT_COMPATIBILITY = "current_compatibility"
+    NONE = "none"
+
+
+class ExecutionOwner(str, Enum):
+    CODEX_CLIENT = "codex_client"
+
+
+class StreamingPolicy(str, Enum):
+    OFFICIAL_PASSTHROUGH = "official_passthrough"
+    TRANSPARENT = "transparent"
+    TRANSPARENT_CONVERTED = "transparent_converted"
+    GATEWAY_ADAPTED = "gateway_adapted"
+
+
+class TransportPolicy(str, Enum):
+    OFFICIAL_KEEPALIVE = "official_keepalive"
+    STANDARD = "standard"
+
+
+class MutationPolicy(str, Enum):
+    OFFICIAL_PASSTHROUGH = "official_passthrough"
+    TRANSPARENT = "transparent"
+    GATEWAY_COMPATIBILITY = "gateway_compatibility"
+
+
+class RouteMutation(str, Enum):
+    MODEL_ALIAS = "model_alias"
+    NAMESPACE_FLATTENING = "namespace_flattening"
+    WIRE_CONVERSION = "wire_conversion"
+    SEMANTIC_REPAIR = "semantic_repair"
+    HARD_CODED_SCHEMA_INJECTION = "hard_coded_schema_injection"
+    OFFICIAL_TOOL_SEARCH_PRESERVATION = "official_tool_search_preservation"
+    SYNTHETIC_TERMINAL_FAILURE = "synthetic_terminal_failure"
+
 
 RETRY_FAILURE_QUICK_TRANSIENT = "quick_transient"
 RETRY_FAILURE_PROVIDER_THROTTLE = "provider_throttle"
@@ -10849,15 +10925,55 @@ def _has_explicit_third_party_client_identity(request_context: Mapping[str, str]
 
 
 @dataclass(frozen=True)
-class RouteDecision:
+class ToolExposurePolicy:
+    requested_mode: ToolExposureMode
+    effective_mode: ToolExposureMode
+    capability_state: CapabilityState
+    supports_search_tool: bool | None
+    proven_tool_subset: tuple[str, ...]
+    gateway_schema_injection: bool
+
+
+@dataclass(frozen=True)
+class RoutePlan:
+    provider_id: str
+    model_requested: str | None
+    canonical_model: str | None
+    upstream_model: str | None
+    authentication_strategy: AuthenticationStrategy
+    inbound_protocol: RouteProtocol
+    configured_upstream_protocol: RouteProtocol
+    upstream_protocol: RouteProtocol
+    capability_manifest_version: str
     behavior_profile: str
     selected_upstream_format: str
     wire_format_adapter: str
     codex_semantic_adapter: str
+    request_kind: str
     request_kind_policy: str
     retry_policy: str
+    retry_eligibility: CapabilityState
     usage_policy: str
     repair_policy: str
+    vision_proxy_policy: str
+    tool_exposure: ToolExposurePolicy
+    codex_compatibility_policy: CodexCompatibilityPolicy
+    collaboration_backend: CollaborationBackend
+    execution_owner: ExecutionOwner
+    streaming_policy: StreamingPolicy
+    transport_policy: TransportPolicy
+    request_mutation_policy: MutationPolicy
+    response_mutation_policy: MutationPolicy
+    sse_mutation_policy: MutationPolicy
+    named_mutations: frozenset[RouteMutation]
+    official_http_passthrough: bool
+    transparent_metered: bool
+    transparent_same_format: bool
+    transparent_lightweight_fallback: bool
+
+    @property
+    def mutation_summary(self) -> tuple[RouteMutation, ...]:
+        return tuple(sorted(self.named_mutations, key=lambda mutation: mutation.value))
 
 
 def behavior_profile_for_request(
@@ -10887,101 +11003,348 @@ def _wire_format_adapter(inbound_format: str, upstream_format: str) -> str:
     return WIRE_TRANSPARENT
 
 
-def route_decision_for_request(
+def _route_protocol(value: Any, *, default: RouteProtocol) -> RouteProtocol:
+    try:
+        return RouteProtocol(str(value))
+    except ValueError:
+        return default
+
+
+def _authentication_strategy(value: Any) -> AuthenticationStrategy:
+    try:
+        return AuthenticationStrategy(str(value))
+    except ValueError:
+        return AuthenticationStrategy.UNKNOWN
+
+
+def _route_supports_transparent_metering(
+    *,
+    upstream_name: str,
+    configured_upstream_format: str,
+    selected_upstream_format: str,
+    inbound_format: str,
+    wire_format_adapter: str,
+    request_context: Mapping[str, str],
+    provider_hint: str | None,
+) -> bool:
+    if _is_codex_app_context(request_context):
+        return False
+    explicit_client = _has_explicit_third_party_client_identity(request_context)
+    provider_scoped = provider_hint is not None
+    standard_external = provider_hint is None and upstream_name != "official" and explicit_client
+    official_responses = provider_hint is None and upstream_name == "official" and explicit_client
+    if not (provider_scoped or standard_external or official_responses):
+        return False
+
+    if official_responses:
+        return selected_upstream_format == "responses" and (
+            (inbound_format == "responses" and wire_format_adapter == WIRE_TRANSPARENT)
+            or (inbound_format == "chat_completions" and wire_format_adapter == WIRE_CHAT_TO_RESPONSES)
+        )
+
+    return (
+        (
+            inbound_format == "chat_completions"
+            and selected_upstream_format == "chat_completions"
+            and wire_format_adapter == WIRE_TRANSPARENT
+        )
+        or (
+            inbound_format == "chat_completions"
+            and configured_upstream_format == "responses"
+            and selected_upstream_format == "responses"
+            and wire_format_adapter == WIRE_CHAT_TO_RESPONSES
+        )
+        or (
+            inbound_format == "responses"
+            and selected_upstream_format == "responses"
+            and wire_format_adapter == WIRE_TRANSPARENT
+        )
+        or (
+            inbound_format == "responses"
+            and configured_upstream_format == "chat_completions"
+            and selected_upstream_format == "chat_completions"
+            and wire_format_adapter == WIRE_RESPONSES_TO_CHAT
+        )
+    )
+
+
+def _tool_exposure_policy_for_route(
+    upstream: Mapping[str, Any],
+    *,
+    upstream_name: str,
+    behavior_profile: str,
+) -> ToolExposurePolicy:
+    raw_requested_mode = upstream.get("tool_exposure_mode")
+    if raw_requested_mode is None:
+        if behavior_profile == BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH:
+            requested_mode = ToolExposureMode.OFFICIAL_NATIVE
+        elif behavior_profile == BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED:
+            requested_mode = ToolExposureMode.UNKNOWN
+        else:
+            requested_mode = ToolExposureMode.CURRENT_COMPATIBILITY
+    else:
+        try:
+            requested_mode = ToolExposureMode(str(raw_requested_mode))
+        except ValueError:
+            requested_mode = ToolExposureMode.UNKNOWN
+
+    raw_state = upstream.get("tool_capability_state")
+    if raw_state is None:
+        capability_state = (
+            CapabilityState.SUPPORTED
+            if requested_mode
+            in {
+                ToolExposureMode.CURRENT_COMPATIBILITY,
+                ToolExposureMode.OFFICIAL_NATIVE,
+            }
+            else CapabilityState.UNQUALIFIED
+        )
+    else:
+        try:
+            capability_state = CapabilityState(str(raw_state))
+        except ValueError:
+            capability_state = CapabilityState.UNQUALIFIED
+
+    raw_subset = upstream.get("proven_tool_subset")
+    proven_tool_subset = (
+        tuple(item for item in raw_subset if isinstance(item, str) and item)
+        if isinstance(raw_subset, (list, tuple))
+        else ()
+    )
+    supports_search_tool = upstream.get("supports_search_tool")
+    if not isinstance(supports_search_tool, bool):
+        supports_search_tool = None
+
+    if behavior_profile == BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH:
+        effective_mode = ToolExposureMode.OFFICIAL_NATIVE
+    elif behavior_profile == BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED:
+        effective_mode = ToolExposureMode.UNKNOWN
+    else:
+        # #57/#58 have not authorized either native candidate. Keeping their
+        # evidence visible while executing the compatibility mode is the
+        # behavior-preserving fail-closed boundary.
+        effective_mode = ToolExposureMode.CURRENT_COMPATIBILITY
+    gateway_schema_injection = (
+        upstream_name != "official"
+        and effective_mode == ToolExposureMode.CURRENT_COMPATIBILITY
+    )
+    return ToolExposurePolicy(
+        requested_mode=requested_mode,
+        effective_mode=effective_mode,
+        capability_state=capability_state,
+        supports_search_tool=supports_search_tool,
+        proven_tool_subset=proven_tool_subset,
+        gateway_schema_injection=gateway_schema_injection,
+    )
+
+
+def route_plan_for_request(
     upstream: Mapping[str, Any],
     request_context: Mapping[str, str],
     *,
     inbound_format: str,
     provider_hint: str | None = None,
-) -> RouteDecision:
+    model_requested: str | None = None,
+    canonical_route_model: str | None = None,
+    request_kind: str = RETRY_REQUEST_MAIN_GENERATION,
+) -> RoutePlan:
     upstream_name = str(upstream.get("name") or "")
-    upstream_format = str(upstream.get("upstream_format") or "responses")
-    if upstream_format == "auto":
-        upstream_format = "responses"
-    wire_adapter = _wire_format_adapter(inbound_format, upstream_format)
-
-    if upstream_name != "official" and _is_codex_app_context(request_context):
-        return RouteDecision(
-            behavior_profile=BEHAVIOR_CODEX_APP_EXTERNAL_ADAPTER,
-            selected_upstream_format=upstream_format,
-            wire_format_adapter=wire_adapter,
-            codex_semantic_adapter=CODEX_SEMANTIC_EXTERNAL_ADAPTER,
-            request_kind_policy=REQUEST_KIND_GATEWAY,
-            retry_policy=RETRY_GATEWAY_FULL,
-            usage_policy=USAGE_SYNC_CAPTURE,
-            repair_policy=REPAIR_CODEX_SUBAGENT,
-        )
-
-    if upstream_name == "official" and request_context.get("client_id") == "unknown":
-        return RouteDecision(
-            behavior_profile=behavior_profile_for_request(
-                upstream,
-                request_context,
-                inbound_format=inbound_format,
-            ),
-            selected_upstream_format=upstream_format,
-            wire_format_adapter=wire_adapter,
-            codex_semantic_adapter=CODEX_SEMANTIC_NONE,
-            request_kind_policy=REQUEST_KIND_GATEWAY,
-            retry_policy=RETRY_GATEWAY_FULL,
-            usage_policy=USAGE_SYNC_CAPTURE,
-            repair_policy=REPAIR_NONE,
-        )
-
-    if (
+    configured_upstream_format = str(upstream.get("upstream_format") or "responses")
+    selected_upstream_format = (
+        "responses" if configured_upstream_format == "auto" else configured_upstream_format
+    )
+    wire_adapter = _wire_format_adapter(inbound_format, selected_upstream_format)
+    codex_app_external = upstream_name != "official" and _is_codex_app_context(request_context)
+    compatibility_external = (
         upstream_name != "official"
         and provider_hint is None
         and not _is_codex_app_context(request_context)
         and not _has_explicit_third_party_client_identity(request_context)
-    ):
-        return RouteDecision(
-            behavior_profile=BEHAVIOR_EXTERNAL_PROVIDER_GATEWAY,
-            selected_upstream_format=upstream_format,
-            wire_format_adapter=wire_adapter,
-            codex_semantic_adapter=CODEX_SEMANTIC_EXTERNAL_ADAPTER,
-            request_kind_policy=REQUEST_KIND_GATEWAY,
-            retry_policy=RETRY_GATEWAY_FULL,
-            usage_policy=USAGE_SYNC_CAPTURE,
-            repair_policy=REPAIR_NONE,
-        )
-
-    if not _is_codex_app_context(request_context):
-        return RouteDecision(
-            behavior_profile=BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
-            selected_upstream_format=upstream_format,
-            wire_format_adapter=wire_adapter,
-            codex_semantic_adapter=CODEX_SEMANTIC_NONE,
-            request_kind_policy=REQUEST_KIND_TRANSPARENT,
-            retry_policy=RETRY_CONSERVATIVE_PRE_OUTPUT,
-            usage_policy=USAGE_ASYNC_TAP,
-            repair_policy=REPAIR_NONE,
-        )
-
-    behavior_profile = behavior_profile_for_request(
-        upstream,
-        request_context,
+    )
+    transparent_metered = _route_supports_transparent_metering(
+        upstream_name=upstream_name,
+        configured_upstream_format=configured_upstream_format,
+        selected_upstream_format=selected_upstream_format,
         inbound_format=inbound_format,
-    )
-    return RouteDecision(
-        behavior_profile=behavior_profile,
-        selected_upstream_format=upstream_format,
         wire_format_adapter=wire_adapter,
-        codex_semantic_adapter=CODEX_SEMANTIC_NONE,
-        request_kind_policy=REQUEST_KIND_GATEWAY,
-        retry_policy=RETRY_GATEWAY_FULL,
-        usage_policy=USAGE_SYNC_CAPTURE,
-        repair_policy=REPAIR_NONE,
+        request_context=request_context,
+        provider_hint=provider_hint,
+    )
+    if codex_app_external:
+        behavior_profile = BEHAVIOR_CODEX_APP_EXTERNAL_ADAPTER
+    elif compatibility_external:
+        behavior_profile = BEHAVIOR_EXTERNAL_PROVIDER_GATEWAY
+    elif transparent_metered:
+        behavior_profile = BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED
+    else:
+        behavior_profile = behavior_profile_for_request(
+            upstream,
+            request_context,
+            inbound_format=inbound_format,
+        )
+
+    official_http_passthrough = (
+        behavior_profile == BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH
+    )
+    transparent_same_format = transparent_metered and wire_adapter == WIRE_TRANSPARENT
+    transparent_lightweight_fallback = transparent_metered and wire_adapter in {
+        WIRE_CHAT_TO_RESPONSES,
+        WIRE_RESPONSES_TO_CHAT,
+    }
+    codex_semantic_adapter = (
+        CODEX_SEMANTIC_EXTERNAL_ADAPTER
+        if codex_app_external or compatibility_external
+        else CODEX_SEMANTIC_NONE
+    )
+    request_kind_policy = (
+        REQUEST_KIND_TRANSPARENT if transparent_metered else REQUEST_KIND_GATEWAY
+    )
+    retry_policy = (
+        RETRY_CONSERVATIVE_PRE_OUTPUT if transparent_metered else RETRY_GATEWAY_FULL
+    )
+    usage_policy = USAGE_ASYNC_TAP if transparent_metered else USAGE_SYNC_CAPTURE
+    repair_policy = REPAIR_CODEX_SUBAGENT if codex_app_external else REPAIR_NONE
+    if codex_app_external:
+        vision_proxy_policy = VISION_PROXY_CODEX_APP_ADAPTER
+    elif transparent_metered and gateway_transparent_vision_proxy_enabled():
+        vision_proxy_policy = VISION_PROXY_TRANSPARENT_OVERLAY
+    else:
+        vision_proxy_policy = VISION_PROXY_DISABLED
+
+    tool_exposure = _tool_exposure_policy_for_route(
+        upstream,
+        upstream_name=upstream_name,
+        behavior_profile=behavior_profile,
+    )
+    if official_http_passthrough:
+        codex_compatibility_policy = CodexCompatibilityPolicy.OFFICIAL_NATIVE
+        collaboration_backend = CollaborationBackend.CODEX_RUNTIME
+        streaming_policy = StreamingPolicy.OFFICIAL_PASSTHROUGH
+        mutation_policy = MutationPolicy.OFFICIAL_PASSTHROUGH
+    elif transparent_metered:
+        codex_compatibility_policy = CodexCompatibilityPolicy.NONE
+        collaboration_backend = CollaborationBackend.CLIENT_RUNTIME
+        streaming_policy = (
+            StreamingPolicy.TRANSPARENT
+            if transparent_same_format
+            else StreamingPolicy.TRANSPARENT_CONVERTED
+        )
+        mutation_policy = MutationPolicy.TRANSPARENT
+    else:
+        codex_compatibility_policy = CodexCompatibilityPolicy.CURRENT_COMPATIBILITY
+        collaboration_backend = CollaborationBackend.GATEWAY_COMPATIBILITY
+        streaming_policy = StreamingPolicy.GATEWAY_ADAPTED
+        mutation_policy = MutationPolicy.GATEWAY_COMPATIBILITY
+
+    named_mutations = {RouteMutation.MODEL_ALIAS}
+    if wire_adapter != WIRE_TRANSPARENT:
+        named_mutations.add(RouteMutation.WIRE_CONVERSION)
+    if tool_exposure.gateway_schema_injection:
+        named_mutations.add(RouteMutation.HARD_CODED_SCHEMA_INJECTION)
+    if codex_semantic_adapter == CODEX_SEMANTIC_EXTERNAL_ADAPTER:
+        named_mutations.add(RouteMutation.NAMESPACE_FLATTENING)
+    if repair_policy != REPAIR_NONE:
+        named_mutations.add(RouteMutation.SEMANTIC_REPAIR)
+    if official_http_passthrough:
+        named_mutations.add(RouteMutation.OFFICIAL_TOOL_SEARCH_PRESERVATION)
+    elif not transparent_metered:
+        named_mutations.add(RouteMutation.SYNTHETIC_TERMINAL_FAILURE)
+
+    canonical_model = (
+        canonical_model_id(canonical_route_model or model_requested)
+        if canonical_route_model or model_requested
+        else None
+    )
+    upstream_model_value = upstream.get("upstream_model")
+    upstream_model = (
+        canonical_model_id(str(upstream_model_value))
+        if upstream_model_value
+        else canonical_model
+    )
+    manifest_version = str(
+        upstream.get("capability_manifest_version")
+        or ROUTE_CAPABILITY_MANIFEST_VERSION
+    )
+    return RoutePlan(
+        provider_id=upstream_name,
+        model_requested=model_requested,
+        canonical_model=canonical_model,
+        upstream_model=upstream_model,
+        authentication_strategy=_authentication_strategy(
+            upstream.get("auth") or "unknown"
+        ),
+        inbound_protocol=_route_protocol(
+            inbound_format,
+            default=RouteProtocol.RESPONSES,
+        ),
+        configured_upstream_protocol=_route_protocol(
+            configured_upstream_format,
+            default=RouteProtocol.RESPONSES,
+        ),
+        upstream_protocol=_route_protocol(
+            selected_upstream_format,
+            default=RouteProtocol.RESPONSES,
+        ),
+        capability_manifest_version=manifest_version,
+        behavior_profile=behavior_profile,
+        selected_upstream_format=selected_upstream_format,
+        wire_format_adapter=wire_adapter,
+        codex_semantic_adapter=codex_semantic_adapter,
+        request_kind=(
+            RETRY_REQUEST_MAIN_GENERATION if transparent_metered else request_kind
+        ),
+        request_kind_policy=request_kind_policy,
+        retry_policy=retry_policy,
+        retry_eligibility=CapabilityState.SUPPORTED,
+        usage_policy=usage_policy,
+        repair_policy=repair_policy,
+        vision_proxy_policy=vision_proxy_policy,
+        tool_exposure=tool_exposure,
+        codex_compatibility_policy=codex_compatibility_policy,
+        collaboration_backend=collaboration_backend,
+        execution_owner=ExecutionOwner.CODEX_CLIENT,
+        streaming_policy=streaming_policy,
+        transport_policy=(
+            TransportPolicy.OFFICIAL_KEEPALIVE
+            if upstream_name == "official"
+            else TransportPolicy.STANDARD
+        ),
+        request_mutation_policy=mutation_policy,
+        response_mutation_policy=mutation_policy,
+        sse_mutation_policy=mutation_policy,
+        named_mutations=frozenset(named_mutations),
+        official_http_passthrough=official_http_passthrough,
+        transparent_metered=transparent_metered,
+        transparent_same_format=transparent_same_format,
+        transparent_lightweight_fallback=transparent_lightweight_fallback,
     )
 
 
-def _route_decision_event_fields(decision: RouteDecision) -> dict[str, str]:
+def _route_plan_event_fields(plan: RoutePlan) -> dict[str, Any]:
     return {
-        "wire_format_adapter": decision.wire_format_adapter,
-        "codex_semantic_adapter": decision.codex_semantic_adapter,
-        "request_kind_policy": decision.request_kind_policy,
-        "retry_policy": decision.retry_policy,
-        "usage_policy": decision.usage_policy,
-        "repair_policy": decision.repair_policy,
+        "wire_format_adapter": plan.wire_format_adapter,
+        "codex_semantic_adapter": plan.codex_semantic_adapter,
+        "request_kind": plan.request_kind,
+        "request_kind_policy": plan.request_kind_policy,
+        "retry_policy": plan.retry_policy,
+        "retry_eligibility": plan.retry_eligibility.value,
+        "usage_policy": plan.usage_policy,
+        "repair_policy": plan.repair_policy,
+        "capability_manifest_version": plan.capability_manifest_version,
+        "authentication_strategy": plan.authentication_strategy.value,
+        "tool_exposure_mode": plan.tool_exposure.effective_mode.value,
+        "tool_capability_state": plan.tool_exposure.capability_state.value,
+        "codex_compatibility_policy": plan.codex_compatibility_policy.value,
+        "collaboration_backend": plan.collaboration_backend.value,
+        "execution_owner": plan.execution_owner.value,
+        "streaming_policy": plan.streaming_policy.value,
+        "transport_policy": plan.transport_policy.value,
+        "request_mutation_policy": plan.request_mutation_policy.value,
+        "response_mutation_policy": plan.response_mutation_policy.value,
+        "sse_mutation_policy": plan.sse_mutation_policy.value,
+        "mutation_summary": [
+            mutation.value for mutation in plan.mutation_summary
+        ],
     }
 
 
@@ -10999,21 +11362,6 @@ def _request_observability_with_prefix(fields: Mapping[str, Any], prefix: str) -
         elif key == "prompt_cache_key_hash":
             renamed[f"{prefix}_prompt_cache_key_hash"] = value
     return renamed
-
-
-def vision_proxy_policy_for_route(decision: RouteDecision, behavior_profile: str | None = None) -> str:
-    active_behavior_profile = behavior_profile or decision.behavior_profile
-    if (
-        active_behavior_profile == BEHAVIOR_CODEX_APP_EXTERNAL_ADAPTER
-        and decision.codex_semantic_adapter == CODEX_SEMANTIC_EXTERNAL_ADAPTER
-    ):
-        return VISION_PROXY_CODEX_APP_ADAPTER
-    if (
-        active_behavior_profile == BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED
-        and gateway_transparent_vision_proxy_enabled()
-    ):
-        return VISION_PROXY_TRANSPARENT_OVERLAY
-    return VISION_PROXY_DISABLED
 
 
 def _is_event_stream(headers: Mapping[str, str] | Any) -> bool:
@@ -13032,8 +13380,14 @@ def _open_upstream_once(
     *,
     upstream_name: str,
     timeout: int | float,
+    transport_policy: TransportPolicy | None = None,
 ) -> Any:
-    if upstream_name == "official":
+    selected_transport = transport_policy or (
+        TransportPolicy.OFFICIAL_KEEPALIVE
+        if upstream_name == "official"
+        else TransportPolicy.STANDARD
+    )
+    if selected_transport == TransportPolicy.OFFICIAL_KEEPALIVE:
         return _official_urlopen(request, timeout=timeout)
     return urlopen(request, timeout=timeout)
 
@@ -13050,6 +13404,7 @@ def _open_upstream_response(
     max_attempts: int | None = None,
     retry_policy: str = RETRY_GATEWAY_FULL,
     retry_http_errors: bool = True,
+    transport_policy: TransportPolicy | None = None,
     downstream_exposed: Callable[[], bool] | None = None,
     pre_response_deadline: float | None = None,
     open_attempt_budget: dict[str, int] | None = None,
@@ -13106,6 +13461,7 @@ def _open_upstream_response(
                 request,
                 upstream_name=upstream_name,
                 timeout=attempt_timeout,
+                transport_policy=transport_policy,
             )
             remaining_budget = _remaining_pre_response_budget_seconds(pre_response_deadline)
             if remaining_budget is not None and remaining_budget <= 0:
@@ -14119,7 +14475,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
         reports_cached_input_tokens = False
         behavior_profile = None
         route_reason: str | None = None
-        route_decision: RouteDecision | None = None
+        route_plan: RoutePlan | None = None
         route_policy_event_fields: dict[str, Any] = {}
         vision_proxy_policy = VISION_PROXY_DISABLED
         downstream_sse_started = False
@@ -14253,127 +14609,36 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
             upstream_format = str(upstream.get("upstream_format", "responses"))
             reports_cached_input_tokens = bool(upstream.get("reports_cached_input_tokens"))
             _validate_reasoning_effort_for_upstream(inbound_payload, upstream, model)
-            route_decision = route_decision_for_request(
+            route_plan = route_plan_for_request(
                 upstream,
                 request_context,
                 inbound_format=inbound_format,
                 provider_hint=provider_hint,
+                model_requested=model_requested,
+                canonical_route_model=model,
+                request_kind=request_kind,
             )
-            configured_upstream_format_for_route = str(upstream.get("upstream_format", "responses"))
-            is_provider_transparent_metered = (
-                provider_hint is not None
-                and not _is_codex_app_context(request_context)
-                and route_decision.behavior_profile == BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED
-                and (
-                    (
-                        inbound_format == "chat_completions"
-                        and route_decision.selected_upstream_format == "chat_completions"
-                        and route_decision.wire_format_adapter == WIRE_TRANSPARENT
-                    )
-                    or (
-                        inbound_format == "chat_completions"
-                        and configured_upstream_format_for_route == "responses"
-                        and route_decision.selected_upstream_format == "responses"
-                        and route_decision.wire_format_adapter == WIRE_CHAT_TO_RESPONSES
-                    )
-                    or (
-                        inbound_format == "responses"
-                        and route_decision.selected_upstream_format == "responses"
-                        and route_decision.wire_format_adapter == WIRE_TRANSPARENT
-                    )
-                    or (
-                        inbound_format == "responses"
-                        and configured_upstream_format_for_route == "chat_completions"
-                        and route_decision.selected_upstream_format == "chat_completions"
-                        and route_decision.wire_format_adapter == WIRE_RESPONSES_TO_CHAT
-                    )
-                )
+            behavior_profile = route_plan.behavior_profile
+            upstream_format = (
+                route_plan.selected_upstream_format
+                if route_plan.transparent_metered
+                else route_plan.configured_upstream_protocol.value
             )
-            is_standard_third_party_transparent_metered = (
-                provider_hint is None
-                and upstream_name != "official"
-                and not _is_codex_app_context(request_context)
-                and _has_explicit_third_party_client_identity(request_context)
-                and route_decision.behavior_profile == BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED
-                and (
-                    (
-                        inbound_format == "chat_completions"
-                        and route_decision.selected_upstream_format == "chat_completions"
-                        and route_decision.wire_format_adapter == WIRE_TRANSPARENT
-                    )
-                    or (
-                        inbound_format == "chat_completions"
-                        and configured_upstream_format_for_route == "responses"
-                        and route_decision.selected_upstream_format == "responses"
-                        and route_decision.wire_format_adapter == WIRE_CHAT_TO_RESPONSES
-                    )
-                    or (
-                        inbound_format == "responses"
-                        and route_decision.selected_upstream_format == "responses"
-                        and route_decision.wire_format_adapter == WIRE_TRANSPARENT
-                    )
-                    or (
-                        inbound_format == "responses"
-                        and configured_upstream_format_for_route == "chat_completions"
-                        and route_decision.selected_upstream_format == "chat_completions"
-                        and route_decision.wire_format_adapter == WIRE_RESPONSES_TO_CHAT
-                    )
-                )
-            )
-            is_official_responses_transparent_metered = (
-                provider_hint is None
-                and upstream_name == "official"
-                and not _is_codex_app_context(request_context)
-                and request_context.get("client_id") != "unknown"
-                and route_decision.behavior_profile == BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED
-                and route_decision.selected_upstream_format == "responses"
-                and (
-                    (
-                        inbound_format == "responses"
-                        and route_decision.wire_format_adapter == WIRE_TRANSPARENT
-                    )
-                    or (
-                        inbound_format == "chat_completions"
-                        and route_decision.wire_format_adapter == WIRE_CHAT_TO_RESPONSES
-                    )
-                )
-            )
-            enable_transparent_metered = (
-                is_provider_transparent_metered
-                or is_standard_third_party_transparent_metered
-                or is_official_responses_transparent_metered
-            )
-            enable_codex_app_external_adapter = (
-                route_decision.codex_semantic_adapter == CODEX_SEMANTIC_EXTERNAL_ADAPTER
-            )
-            behavior_profile = (
-                route_decision.behavior_profile
-                if enable_transparent_metered or enable_codex_app_external_adapter
-                else behavior_profile_for_request(
-                    upstream,
-                    request_context,
-                    inbound_format=inbound_format,
-                )
-            )
-            upstream_format = route_decision.selected_upstream_format if enable_transparent_metered else upstream_format
-            is_official_http_passthrough = behavior_profile == BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH
-            is_transparent_metered = behavior_profile == BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED
-            is_transparent_same_format = is_transparent_metered and route_decision.wire_format_adapter == WIRE_TRANSPARENT
-            is_transparent_lightweight_fallback = (
-                is_transparent_metered
-                and route_decision.wire_format_adapter in {WIRE_CHAT_TO_RESPONSES, WIRE_RESPONSES_TO_CHAT}
-            )
-            if is_transparent_metered:
-                request_kind = RETRY_REQUEST_MAIN_GENERATION
+            is_official_http_passthrough = route_plan.official_http_passthrough
+            is_transparent_metered = route_plan.transparent_metered
+            is_transparent_same_format = route_plan.transparent_same_format
+            is_transparent_lightweight_fallback = route_plan.transparent_lightweight_fallback
+            if request_kind != route_plan.request_kind:
+                request_kind = route_plan.request_kind
                 proxy_request_context = _event_context_with_request_kind(request_context, request_kind)
             self._pre_response_deadline = _main_generation_pre_response_deadline(
                 started_at,
                 request_kind,
             )
-            vision_proxy_policy = vision_proxy_policy_for_route(route_decision, behavior_profile)
+            vision_proxy_policy = route_plan.vision_proxy_policy
             reasoning_policy = _reasoning_policy_for_request(inbound_payload, upstream, model)
             route_policy_event_fields = {
-                **_route_decision_event_fields(route_decision),
+                **_route_plan_event_fields(route_plan),
                 "vision_proxy_policy": vision_proxy_policy,
                 **({"reasoning_policy": reasoning_policy} if reasoning_policy else {}),
             }
@@ -14783,10 +15048,9 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                                     if official_open_attempt_budget is not None
                                     else None
                                 ),
-                                retry_policy=route_decision.retry_policy
-                                if enable_transparent_metered
-                                else RETRY_GATEWAY_FULL,
+                                retry_policy=route_plan.retry_policy,
                                 retry_http_errors=not is_official_http_passthrough,
+                                transport_policy=route_plan.transport_policy,
                                 downstream_exposed=lambda: _downstream_has_been_exposed(self),
                                 pre_response_deadline=(
                                     None if downstream_sse_started else self._pre_response_deadline

--- a/tests/test_chat_completions_gateway.py
+++ b/tests/test_chat_completions_gateway.py
@@ -1975,6 +1975,22 @@ class ChatCompletionsEndpointTests(unittest.TestCase):
             call.kwargs for call in self.write_proxy_event.call_args_list if call.args and call.args[0] == "request_start"
         )
         self.assertEqual(request_start["vision_proxy_policy"], codex_proxy.VISION_PROXY_TRANSPARENT_OVERLAY)
+        self.assertEqual(
+            request_start["vision_action"],
+            codex_proxy.VisionAction.PROXY.value,
+        )
+        self.assertEqual(
+            request_start["vision_network_action"],
+            codex_proxy.VisionNetworkAction.IMAGE_PROXY.value,
+        )
+        self.assertIn(
+            codex_proxy.RouteMutation.IMAGE_CONTENT_REPLACEMENT.value,
+            request_start["mutation_summary"],
+        )
+        self.assertIn(
+            codex_proxy.RouteMutation.IMAGE_CONTENT_REPLACEMENT.value,
+            request_start["route_attempt_mutation_summary"],
+        )
 
     def test_provider_scoped_chat_text_only_image_request_fails_closed_502(self):
         policy = codex_proxy.load_policy(codex_proxy.POLICY_PATH)
@@ -2040,6 +2056,27 @@ class ChatCompletionsEndpointTests(unittest.TestCase):
         self.assertEqual(handler._fake.status, 502)
         written = b"".join(handler.wfile.writes)
         self.assertIn(b"does not support image input", written)
+        request_error = next(
+            call.kwargs
+            for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] == "request_error"
+        )
+        self.assertEqual(
+            request_error["vision_action"],
+            codex_proxy.VisionAction.REJECT.value,
+        )
+        self.assertEqual(
+            request_error["vision_network_action"],
+            codex_proxy.VisionNetworkAction.NONE.value,
+        )
+        self.assertIn(
+            codex_proxy.RouteMutation.IMAGE_UNSUPPORTED_REJECTION.value,
+            request_error["mutation_summary"],
+        )
+        self.assertIn(
+            codex_proxy.RouteMutation.IMAGE_UNSUPPORTED_REJECTION.value,
+            request_error["route_attempt_mutation_summary"],
+        )
 
     def test_provider_scoped_chat_text_only_image_guard_uses_global_image_proxy_switch(self):
         policy = codex_proxy.load_policy(codex_proxy.POLICY_PATH)
@@ -2129,6 +2166,14 @@ class ChatCompletionsEndpointTests(unittest.TestCase):
             call.kwargs for call in self.write_proxy_event.call_args_list if call.args and call.args[0] == "request_start"
         )
         self.assertEqual(request_start["vision_proxy_policy"], codex_proxy.VISION_PROXY_TRANSPARENT_OVERLAY)
+        self.assertEqual(
+            request_start["vision_action"],
+            codex_proxy.VisionAction.PROXY.value,
+        )
+        self.assertEqual(
+            request_start["vision_network_action"],
+            codex_proxy.VisionNetworkAction.IMAGE_PROXY.value,
+        )
 
     def test_transparent_vision_proxy_failure_still_records_request_start(self):
         policy = codex_proxy.load_policy(codex_proxy.POLICY_PATH)
@@ -4280,6 +4325,30 @@ class ChatCompletionsEndpointTests(unittest.TestCase):
         self.assertTrue(mock_urlopen.call_args.args[0].full_url.endswith("/responses"))
         result = json.loads(b"".join(handler.wfile.writes))
         self.assertEqual(result["choices"][0]["message"]["content"], "Responses OK")
+        request_start = next(
+            call.kwargs
+            for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] == "request_start"
+        )
+        request_complete = next(
+            call.kwargs
+            for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] == "request_complete"
+        )
+        self.assertEqual(
+            [
+                attempt["upstream_protocol"]
+                for attempt in request_start["route_attempts"]
+            ],
+            ["responses", "chat_completions"],
+        )
+        for event in (request_start, request_complete):
+            self.assertEqual(event["route_attempt_index"], 0)
+            self.assertEqual(event["route_attempt_protocol"], "responses")
+            self.assertIn(
+                codex_proxy.RouteMutation.WIRE_CONVERSION.value,
+                event["route_attempt_mutation_summary"],
+            )
 
     def test_auto_upstream_format_suppresses_chat_fallback_for_protocol_http_error(self):
         policy = codex_proxy.load_policy(codex_proxy.POLICY_PATH)
@@ -4333,6 +4402,17 @@ class ChatCompletionsEndpointTests(unittest.TestCase):
                 and e["upstream_format"] == "responses"
                 for e in suppressed_events
             )
+        )
+        suppressed = suppressed_events[-1]
+        self.assertEqual(suppressed["route_attempt_index"], 0)
+        self.assertEqual(suppressed["route_attempt_protocol"], "responses")
+        self.assertEqual(
+            suppressed["route_attempt_fallback_http_statuses"],
+            [404, 405, 415, 422],
+        )
+        self.assertIn(
+            codex_proxy.RouteMutation.WIRE_CONVERSION.value,
+            suppressed["route_attempt_mutation_summary"],
         )
         result = json.loads(b"".join(handler.wfile.writes))
         self.assertEqual(result["error"]["type"], "upstream_error")

--- a/tests/test_proxy_shutdown.py
+++ b/tests/test_proxy_shutdown.py
@@ -433,12 +433,12 @@ def test_active_request_receives_a_sanitized_user_requested_shutdown_outcome() -
             patch.object(
                 codex_proxy,
                 "codex_access_token",
-                side_effect=AssertionError("shutdown cancellation must not read Codex auth"),
+                return_value="test-token",
             ) as access_token,
             patch.object(
                 codex_proxy,
                 "codex_account_id",
-                side_effect=AssertionError("shutdown cancellation must not read Codex auth"),
+                return_value="test-account",
             ) as account_id,
             patch.object(codex_proxy, "_open_upstream_response", side_effect=wait_for_shutdown) as open_upstream,
             patch.object(codex_proxy, "write_proxy_event") as write_event,
@@ -462,8 +462,8 @@ def test_active_request_receives_a_sanitized_user_requested_shutdown_outcome() -
             }
             assert open_upstream.call_count == 1
             build_upstream_headers.assert_called_once()
-            access_token.assert_not_called()
-            account_id.assert_not_called()
+            access_token.assert_called_once_with()
+            account_id.assert_called_once_with()
             shutdown_event = next(
                 call.kwargs
                 for call in write_event.call_args_list

--- a/tests/test_proxy_shutdown.py
+++ b/tests/test_proxy_shutdown.py
@@ -212,13 +212,31 @@ def test_shutdown_endpoint_stops_server() -> None:
     try:
         host, port = server.server_address
         connection = HTTPConnection(host, port, timeout=2)
-        connection.request("POST", "/shutdown")
-        response = connection.getresponse()
-        payload = json.loads(response.read().decode("utf-8"))
+        with (
+            patch.object(
+                codex_proxy,
+                "choose_upstream",
+                side_effect=AssertionError(
+                    "shutdown must not select an upstream"
+                ),
+            ) as choose_upstream,
+            patch.object(
+                codex_proxy,
+                "materialize_operational_authentication",
+                side_effect=AssertionError(
+                    "shutdown must not materialize provider credentials"
+                ),
+            ) as materialize_authentication,
+        ):
+            connection.request("POST", "/shutdown")
+            response = connection.getresponse()
+            payload = json.loads(response.read().decode("utf-8"))
         connection.close()
 
         assert response.status == 200
         assert payload["ok"] is True
+        choose_upstream.assert_not_called()
+        materialize_authentication.assert_not_called()
 
         thread.join(timeout=2)
         assert not thread.is_alive()

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -10,7 +10,7 @@ import threading
 import time
 import unittest
 import weakref
-from dataclasses import asdict, replace
+from dataclasses import asdict, dataclass, fields, replace
 from http.client import IncompleteRead
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -367,6 +367,72 @@ def post_handler(path: str, body: bytes, headers: dict[str, str] | None = None):
     return handler, fake
 
 
+@dataclass(frozen=True)
+class RelayPlanFixture:
+    streaming_policy: codex_proxy.StreamingPolicy
+    usage_policy: codex_proxy.UsagePolicy
+    response_mutation_policy: codex_proxy.MutationPolicy
+    sse_mutation_policy: codex_proxy.MutationPolicy
+    verify_cross_protocol_source: bool
+
+    def build(
+        self,
+        *,
+        selected_upstream_format: str,
+        request_kind: str,
+        lifecycle_final_retry_enabled: bool,
+    ) -> codex_proxy.RelayExecutionPlan:
+        return codex_proxy.RelayExecutionPlan(
+            selected_upstream_format=selected_upstream_format,
+            request_kind=request_kind,
+            streaming_policy=self.streaming_policy,
+            usage_policy=self.usage_policy,
+            response_mutation_policy=self.response_mutation_policy,
+            sse_mutation_policy=self.sse_mutation_policy,
+            verify_cross_protocol_source=self.verify_cross_protocol_source,
+            lifecycle_final_retry_enabled=lifecycle_final_retry_enabled,
+        )
+
+
+RELAY_PLAN_FIXTURES = {
+    "gateway": RelayPlanFixture(
+        streaming_policy=codex_proxy.StreamingPolicy.GATEWAY_ADAPTED,
+        usage_policy=codex_proxy.UsagePolicy.SYNC_CAPTURE,
+        response_mutation_policy=codex_proxy.MutationPolicy.GATEWAY_COMPATIBILITY,
+        sse_mutation_policy=codex_proxy.MutationPolicy.GATEWAY_COMPATIBILITY,
+        verify_cross_protocol_source=False,
+    ),
+    "official_passthrough": RelayPlanFixture(
+        streaming_policy=codex_proxy.StreamingPolicy.OFFICIAL_PASSTHROUGH,
+        usage_policy=codex_proxy.UsagePolicy.SYNC_CAPTURE,
+        response_mutation_policy=codex_proxy.MutationPolicy.OFFICIAL_PASSTHROUGH,
+        sse_mutation_policy=codex_proxy.MutationPolicy.OFFICIAL_PASSTHROUGH,
+        verify_cross_protocol_source=False,
+    ),
+    "transparent": RelayPlanFixture(
+        streaming_policy=codex_proxy.StreamingPolicy.TRANSPARENT,
+        usage_policy=codex_proxy.UsagePolicy.ASYNC_TAP,
+        response_mutation_policy=codex_proxy.MutationPolicy.TRANSPARENT,
+        sse_mutation_policy=codex_proxy.MutationPolicy.TRANSPARENT,
+        verify_cross_protocol_source=False,
+    ),
+    "transparent_converted": RelayPlanFixture(
+        streaming_policy=codex_proxy.StreamingPolicy.TRANSPARENT_CONVERTED,
+        usage_policy=codex_proxy.UsagePolicy.ASYNC_TAP,
+        response_mutation_policy=codex_proxy.MutationPolicy.TRANSPARENT,
+        sse_mutation_policy=codex_proxy.MutationPolicy.TRANSPARENT,
+        verify_cross_protocol_source=True,
+    ),
+    "gateway_verified_conversion": RelayPlanFixture(
+        streaming_policy=codex_proxy.StreamingPolicy.GATEWAY_ADAPTED,
+        usage_policy=codex_proxy.UsagePolicy.SYNC_CAPTURE,
+        response_mutation_policy=codex_proxy.MutationPolicy.GATEWAY_COMPATIBILITY,
+        sse_mutation_policy=codex_proxy.MutationPolicy.GATEWAY_COMPATIBILITY,
+        verify_cross_protocol_source=True,
+    ),
+}
+
+
 def relay_upstream_response(
     handler,
     response,
@@ -374,102 +440,46 @@ def relay_upstream_response(
     *args,
     **kwargs,
 ):
-    """Adapt focused relay tests to the production typed execution seam."""
+    """Call the production relay with an explicit typed policy fixture."""
 
-    behavior_profile = kwargs.pop("behavior_profile", None)
-    upstream_format = kwargs.get("upstream_format", "responses")
-    inbound_format = kwargs.get("inbound_format", "responses")
-    event_context = kwargs.get("event_context")
+    legacy_fixture_profile = kwargs.pop("behavior_profile", None)
+    fixture_name = kwargs.pop(
+        "relay_fixture",
+        {
+            None: "gateway",
+            (
+                codex_proxy.BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH
+            ): "official_passthrough",
+            (
+                codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED
+            ): "transparent",
+        }.get(legacy_fixture_profile),
+    )
+    if fixture_name is None:
+        raise AssertionError(
+            f"relay test requires an explicit fixture: {legacy_fixture_profile!r}"
+        )
+    upstream_format = kwargs.pop("upstream_format", "responses")
     request_kind = kwargs.pop(
         "request_kind",
         codex_proxy.RETRY_REQUEST_MAIN_GENERATION,
     )
-    streaming_policy = kwargs.pop("streaming_policy", None)
-    if streaming_policy is None:
-        if (
-            behavior_profile
-            == codex_proxy.BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH
-        ):
-            streaming_policy = (
-                codex_proxy.StreamingPolicy.OFFICIAL_PASSTHROUGH
-            )
-        elif (
-            behavior_profile
-            == codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED
-        ):
-            streaming_policy = (
-                codex_proxy.StreamingPolicy.TRANSPARENT
-                if upstream_format == inbound_format
-                else codex_proxy.StreamingPolicy.TRANSPARENT_CONVERTED
-            )
-        else:
-            streaming_policy = codex_proxy.StreamingPolicy.GATEWAY_ADAPTED
-    usage_policy = kwargs.pop("usage_policy", None)
-    if usage_policy is None:
-        usage_policy = (
-            codex_proxy.UsagePolicy.ASYNC_TAP
-            if (
-                behavior_profile
-                == codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED
-            )
-            else codex_proxy.UsagePolicy.SYNC_CAPTURE
-        )
-    response_mutation_policy = kwargs.pop(
-        "response_mutation_policy",
-        None,
-    )
-    if response_mutation_policy is None:
-        response_mutation_policy = (
-            codex_proxy.MutationPolicy.TRANSPARENT
-            if (
-                behavior_profile
-                == codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED
-            )
-            else (
-                codex_proxy.MutationPolicy.OFFICIAL_PASSTHROUGH
-                if (
-                    behavior_profile
-                    == codex_proxy.BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH
-                )
-                else codex_proxy.MutationPolicy.GATEWAY_COMPATIBILITY
-            )
-        )
-    sse_mutation_policy = kwargs.pop(
-        "sse_mutation_policy",
-        response_mutation_policy,
-    )
+    fixture = RELAY_PLAN_FIXTURES[fixture_name]
     verify_cross_protocol_source = kwargs.pop(
         "verify_cross_protocol_source",
-        None,
+        fixture.verify_cross_protocol_source,
     )
-    if verify_cross_protocol_source is None:
-        verify_cross_protocol_source = (
-            codex_proxy._verified_cross_protocol_source_format(
-                behavior_profile=behavior_profile,
-                upstream_format=upstream_format,
-                inbound_format=inbound_format,
-            )
-            is not None
-        )
     lifecycle_final_retry_enabled = kwargs.pop(
         "lifecycle_final_retry_enabled",
-        None,
+        False,
     )
-    if lifecycle_final_retry_enabled is None:
-        lifecycle_final_retry_enabled = (
-            codex_proxy.lifecycle_empty_final_resample_enabled(
-                event_context,
-                request_kind,
-            )
-        )
-    relay_execution_plan = codex_proxy.RelayExecutionPlan(
-        request_kind=request_kind,
-        streaming_policy=streaming_policy,
-        usage_policy=usage_policy,
-        response_mutation_policy=response_mutation_policy,
-        sse_mutation_policy=sse_mutation_policy,
+    relay_execution_plan = replace(
+        fixture.build(
+            selected_upstream_format=upstream_format,
+            request_kind=request_kind,
+            lifecycle_final_retry_enabled=lifecycle_final_retry_enabled,
+        ),
         verify_cross_protocol_source=verify_cross_protocol_source,
-        lifecycle_final_retry_enabled=lifecycle_final_retry_enabled,
     )
     return CodexProxyHandler._relay_upstream_response(
         handler,
@@ -1263,6 +1273,88 @@ class RoutingTests(unittest.TestCase):
         with self.assertRaises(AttributeError):
             plan.attempts[0].upstream_protocol = codex_proxy.RouteProtocol.CHAT_COMPLETIONS
 
+    def test_route_plan_primary_execution_fields_are_read_only_attempt_views(self):
+        plan = codex_proxy.route_plan_for_request(
+            {
+                "name": "ollama_cloud",
+                "base_url": "https://ollama.example.test/v1",
+                "auth": "ollama_api_key",
+                "upstream_model": "glm-5.2",
+                "upstream_format": "auto",
+            },
+            {"client_id": "codex-app"},
+            inbound_format="responses",
+            model_requested="ollama-cloud/glm-5.2",
+        )
+        duplicate_primary_fields = {
+            "authentication_strategy",
+            "upstream_protocol",
+            "selected_upstream_format",
+            "wire_format_adapter",
+            "request_kind",
+            "retry_policy",
+            "retry_eligibility",
+            "usage_policy",
+            "streaming_policy",
+            "transport_policy",
+            "request_mutation_policy",
+            "response_mutation_policy",
+            "sse_mutation_policy",
+        }
+
+        self.assertTrue(plan.attempts)
+        self.assertTrue(
+            duplicate_primary_fields.isdisjoint(
+                field.name for field in fields(codex_proxy.RoutePlan)
+            )
+        )
+        primary_attempt = plan.attempts[0]
+        self.assertEqual(
+            plan.authentication_strategy,
+            primary_attempt.authentication_strategy,
+        )
+        self.assertEqual(plan.upstream_protocol, primary_attempt.upstream_protocol)
+        self.assertEqual(
+            plan.selected_upstream_format,
+            primary_attempt.selected_upstream_format,
+        )
+        self.assertEqual(
+            plan.wire_format_adapter,
+            primary_attempt.wire_format_adapter,
+        )
+        self.assertEqual(plan.request_kind, primary_attempt.retry.request_kind)
+        self.assertEqual(plan.retry_policy, primary_attempt.retry.policy)
+        self.assertEqual(
+            plan.retry_eligibility,
+            primary_attempt.retry.eligibility,
+        )
+        self.assertEqual(plan.usage_policy, primary_attempt.usage_policy)
+        self.assertEqual(
+            plan.streaming_policy,
+            primary_attempt.streaming_policy,
+        )
+        self.assertEqual(
+            plan.transport_policy,
+            primary_attempt.transport_policy,
+        )
+        self.assertEqual(
+            plan.request_mutation_policy,
+            primary_attempt.request_mutation_policy,
+        )
+        self.assertEqual(
+            plan.response_mutation_policy,
+            primary_attempt.response_mutation_policy,
+        )
+        self.assertEqual(
+            plan.sse_mutation_policy,
+            primary_attempt.sse_mutation_policy,
+        )
+        with self.assertRaises(TypeError):
+            replace(
+                plan,
+                selected_upstream_format="chat_completions",
+            )
+
     def test_route_plan_attempt_retry_execution_uses_only_explicit_runtime_facts(self):
         runtime_facts = codex_proxy.RouteRuntimeFacts(
             request_timeout_seconds=41,
@@ -1823,8 +1915,201 @@ class RoutingTests(unittest.TestCase):
             success_plan.response_mutation_policy,
             codex_proxy.MutationPolicy.TRANSPARENT,
         )
+        self.assertEqual(
+            success_plan.selected_upstream_format,
+            codex_proxy.RouteProtocol.RESPONSES.value,
+        )
         self.assertNotIn("behavior_profile", relayed[0])
         self.assertNotIn("behavior_profile", relayed[1])
+
+    def test_auto_compact_final_http_error_relays_with_the_active_fallback_attempt_format(self):
+        upstream = {
+            "name": "volcengine",
+            "base_url": "https://ark.example.test/v1",
+            "auth": "api_key",
+            "api_key": "test-token",
+            "upstream_model": "glm-5.2",
+            "upstream_format": "auto",
+        }
+        cases = (
+            (
+                "responses",
+                "/v1/responses",
+                {
+                    "model": "volc/glm-5.2",
+                    "input": [
+                        {
+                            "type": "message",
+                            "role": "user",
+                            "content": (
+                                "Create a detailed summary of the conversation so far. "
+                                "This is a compact summary. Respond with text only. "
+                                "The summary should include <summary>."
+                            ),
+                        }
+                    ],
+                    "stream": False,
+                },
+                False,
+            ),
+            (
+                "chat_completions",
+                "/v1/chat/completions",
+                {
+                    "model": "volc/glm-5.2",
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": (
+                                "Create a detailed summary of the conversation so far. "
+                                "This is a compact summary. Respond with text only. "
+                                "The summary should include <summary>."
+                            ),
+                        }
+                    ],
+                    "stream": False,
+                },
+                False,
+            ),
+        )
+
+        for (
+            inbound_format,
+            path,
+            payload,
+            expected_cross_protocol_verification,
+        ) in cases:
+            with self.subTest(inbound_format=inbound_format):
+                body = json.dumps(payload).encode("utf-8")
+                handler, _fake = post_handler(path, body)
+                relayed: list[dict[str, Any]] = []
+                handler._relay_upstream_response = (
+                    lambda response, upstream_name, **kwargs:
+                    relayed.append(kwargs) or getattr(response, "code", 502)
+                )
+                responses_error = HTTPError(
+                    "https://ark.example.test/v1/responses",
+                    404,
+                    "unsupported responses endpoint",
+                    {"Content-Type": "application/json"},
+                    io.BytesIO(b'{"error":"unsupported responses endpoint"}'),
+                )
+                chat_error = HTTPError(
+                    "https://ark.example.test/v1/chat/completions",
+                    400,
+                    "invalid chat request",
+                    {"Content-Type": "application/json"},
+                    io.BytesIO(b'{"error":"invalid chat request"}'),
+                )
+
+                with (
+                    patch("codex_proxy.choose_upstream", return_value=upstream),
+                    patch(
+                        "codex_proxy._open_upstream_response",
+                        side_effect=[responses_error, chat_error],
+                    ),
+                ):
+                    CodexProxyHandler._proxy_post_request(
+                        handler,
+                        inbound_format=inbound_format,
+                    )
+
+                self.assertEqual(len(relayed), 1)
+                relay_plan = relayed[0]["relay_execution_plan"]
+                self.assertEqual(
+                    relay_plan.selected_upstream_format,
+                    codex_proxy.RouteProtocol.CHAT_COMPLETIONS.value,
+                )
+                self.assertEqual(
+                    relay_plan.verify_cross_protocol_source,
+                    expected_cross_protocol_verification,
+                )
+                request_complete = next(
+                    call.kwargs
+                    for call in self.write_proxy_event.call_args_list
+                    if (
+                        call.args
+                        and call.args[0] == "request_complete"
+                        and call.kwargs.get("status") == 400
+                    )
+                )
+                self.assertEqual(
+                    request_complete["upstream_format"],
+                    codex_proxy.RouteProtocol.CHAT_COMPLETIONS.value,
+                )
+                self.write_proxy_event.reset_mock()
+
+    def test_same_format_relay_verification_is_strictly_plan_driven_for_json_and_sse(self):
+        response_body = json.dumps(
+            {
+                "id": "resp_same_format",
+                "object": "response",
+                "status": "completed",
+                "output": [
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [
+                            {"type": "output_text", "text": "ok"}
+                        ],
+                    }
+                ],
+                "usage": {
+                    "input_tokens": 1,
+                    "output_tokens": 1,
+                    "total_tokens": 2,
+                },
+            }
+        ).encode("utf-8")
+        cases = (
+            (
+                "json",
+                FakeResponse(response_body),
+                False,
+            ),
+            (
+                "sse",
+                FakeSseResponse(
+                    [
+                        (
+                            b'data: {"type":"response.created",'
+                            b'"response":{"id":"resp_same_format"}}\n\n'
+                        ),
+                        (
+                            b'data: {"type":"response.output_text.delta",'
+                            b'"delta":"ok"}\n\n'
+                        ),
+                        (
+                            b'data: {"type":"response.completed",'
+                            b'"response":{"id":"resp_same_format",'
+                            b'"status":"completed","output":[]}}\n\n'
+                        ),
+                        b"",
+                    ]
+                ),
+                True,
+            ),
+        )
+
+        for name, response, caller_stream in cases:
+            with self.subTest(case=name):
+                fake = FakeHandler()
+                usage_capture: dict[str, Any] = {}
+                status = relay_upstream_response(
+                    fake,
+                    response,
+                    "volcengine",
+                    request_id=f"req-same-format-{name}",
+                    model="volc/glm-5.2",
+                    upstream_format="responses",
+                    inbound_format="responses",
+                    caller_stream=caller_stream,
+                    verify_cross_protocol_source=True,
+                    usage_capture=usage_capture,
+                )
+
+                self.assertEqual(status, 200)
+                self.assertNotEqual(fake.wfile.writes, [])
 
     def test_open_upstream_response_consumes_planned_retry_execution(self):
         runtime_facts = codex_proxy.RouteRuntimeFacts(
@@ -3049,6 +3334,10 @@ class RoutingTests(unittest.TestCase):
             request_complete["route_attempt_protocol"],
             codex_proxy.RouteProtocol.CHAT_COMPLETIONS.value,
         )
+        self.assertEqual(
+            request_complete["upstream_format"],
+            codex_proxy.RouteProtocol.CHAT_COMPLETIONS.value,
+        )
         self.assertIn(
             codex_proxy.RouteMutation.WIRE_CONVERSION.value,
             request_complete["route_attempt_mutation_summary"],
@@ -3206,6 +3495,10 @@ class RoutingTests(unittest.TestCase):
         )
         self.assertEqual(
             request_complete["executed_upstream_protocol"],
+            codex_proxy.RouteProtocol.CHAT_COMPLETIONS.value,
+        )
+        self.assertEqual(
+            request_complete["upstream_format"],
             codex_proxy.RouteProtocol.CHAT_COMPLETIONS.value,
         )
         self.assertEqual(
@@ -5259,6 +5552,7 @@ class RoutingTests(unittest.TestCase):
             inbound_format="chat_completions",
             caller_stream=True,
             behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+            relay_fixture="transparent_converted",
             usage_capture={},
         )
 
@@ -5298,6 +5592,7 @@ class RoutingTests(unittest.TestCase):
             inbound_format="responses",
             caller_stream=True,
             behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+            relay_fixture="transparent_converted",
             usage_capture={},
         )
 
@@ -5331,6 +5626,7 @@ class RoutingTests(unittest.TestCase):
             inbound_format="chat_completions",
             caller_stream=True,
             behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+            relay_fixture="transparent_converted",
             usage_capture={},
         )
 
@@ -5386,6 +5682,7 @@ class RoutingTests(unittest.TestCase):
                     inbound_format=inbound_format,
                     caller_stream=True,
                     behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+                    relay_fixture="transparent_converted",
                     usage_capture={},
                 )
 
@@ -5567,6 +5864,7 @@ class RoutingTests(unittest.TestCase):
             inbound_format="responses",
             caller_stream=False,
             behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+            relay_fixture="transparent_converted",
             usage_capture={},
         )
 
@@ -5643,6 +5941,7 @@ class RoutingTests(unittest.TestCase):
             inbound_format="responses",
             caller_stream=False,
             behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+            relay_fixture="transparent_converted",
             usage_capture={},
         )
 
@@ -5700,6 +5999,7 @@ class RoutingTests(unittest.TestCase):
             inbound_format="responses",
             caller_stream=False,
             behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+            relay_fixture="transparent_converted",
             usage_capture={},
         )
 
@@ -5776,6 +6076,7 @@ class RoutingTests(unittest.TestCase):
                         inbound_format=inbound_format,
                         caller_stream=True,
                         behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+                        relay_fixture="transparent_converted",
                         usage_capture={},
                     )
                     self.assertEqual(status, 200)
@@ -5853,6 +6154,7 @@ class RoutingTests(unittest.TestCase):
             inbound_format="responses",
             caller_stream=True,
             behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+            relay_fixture="transparent_converted",
             usage_capture={},
         )
 
@@ -6244,6 +6546,8 @@ class RoutingTests(unittest.TestCase):
                     "subagent_lifecycle_complete": True,
                 },
                 behavior_profile=codex_proxy.BEHAVIOR_OFFICIAL_GATEWAY_COMPAT,
+                relay_fixture="gateway_verified_conversion",
+                lifecycle_final_retry_enabled=True,
             )
 
         written = b"".join(handler.wfile.writes)
@@ -12831,7 +13135,10 @@ class RoutingTests(unittest.TestCase):
         self.assertEqual(payload["model"], "glm-5.2")
         self.assertEqual(payload["messages"], [{"role": "user", "content": "hi"}])
         self.assertFalse(payload["stream"])
-        self.assertEqual(relayed[0]["upstream_format"], "chat_completions")
+        self.assertEqual(
+            relayed[0]["relay_execution_plan"].selected_upstream_format,
+            "chat_completions",
+        )
 
     def test_official_auth_injects_codex_subscription_token(self):
         upstream = choose_upstream("gpt-5.5")
@@ -14697,6 +15004,7 @@ class RoutingTests(unittest.TestCase):
             caller_stream=True,
             event_context={"client_id": "omp", "client_inference_source": "header"},
             behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+            relay_fixture="transparent_converted",
         )
 
         self.assertEqual(status, 499)
@@ -20086,6 +20394,7 @@ Execution constraints:
             caller_stream=True,
             event_context=close_context,
             behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+            relay_fixture="transparent_converted",
         )
 
         diagnostic_names = {

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -14,6 +14,7 @@ from dataclasses import replace
 from http.client import IncompleteRead
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
+from typing import Any
 from unittest.mock import Mock, call, patch
 from urllib.error import HTTPError, URLError
 
@@ -1076,6 +1077,8 @@ class RoutingTests(unittest.TestCase):
         plan = codex_proxy.route_plan_for_request(
             {
                 "name": "ollama_cloud",
+                "base_url": "https://ollama.example.test/v1",
+                "auth": "ollama_api_key",
                 "upstream_model": "glm-5.2",
                 "upstream_format": "auto",
             },
@@ -1105,6 +1108,33 @@ class RoutingTests(unittest.TestCase):
                 codex_proxy.AttemptRequestBodyMode.CONVERT_RESPONSES_TO_CHAT,
             ],
         )
+        self.assertEqual(
+            [attempt.endpoint_url for attempt in plan.attempts],
+            [
+                "https://ollama.example.test/v1/responses",
+                "https://ollama.example.test/v1/chat/completions",
+            ],
+        )
+        self.assertTrue(
+            all(
+                attempt.authentication_strategy
+                == codex_proxy.AuthenticationStrategy.OLLAMA_API_KEY
+                for attempt in plan.attempts
+            )
+        )
+        self.assertTrue(
+            all(
+                attempt.streaming_policy
+                == codex_proxy.StreamingPolicy.GATEWAY_ADAPTED
+                for attempt in plan.attempts
+            )
+        )
+        self.assertTrue(
+            all(
+                attempt.usage_policy == codex_proxy.UsagePolicy.SYNC_CAPTURE
+                for attempt in plan.attempts
+            )
+        )
         self.assertTrue(plan.attempts[0].allows_protocol_fallback_status(415))
         self.assertFalse(plan.attempts[0].allows_protocol_fallback_status(429))
         self.assertFalse(plan.attempts[1].fallback_http_statuses)
@@ -1118,6 +1148,407 @@ class RoutingTests(unittest.TestCase):
         )
         with self.assertRaises(AttributeError):
             plan.attempts[0].upstream_protocol = codex_proxy.RouteProtocol.CHAT_COMPLETIONS
+
+    def test_route_plan_attempt_retry_execution_uses_only_explicit_runtime_facts(self):
+        runtime_facts = codex_proxy.RouteRuntimeFacts(
+            request_timeout_seconds=41,
+            request_kind_base_attempts=7,
+            request_kind_attempts_configured=False,
+            failure_expansion_attempts=19,
+            official_open_attempts=2,
+            capacity_elapsed_limit_seconds=83.0,
+            stream_elapsed_limit_seconds=97.0,
+            downstream_retry_notice_enabled=True,
+            pre_response_budget_seconds=109.0,
+        )
+        with (
+            patch(
+                "codex_proxy.upstream_timeout_seconds",
+                side_effect=AssertionError("planner read request timeout"),
+            ),
+            patch(
+                "codex_proxy._upstream_retry_attempts",
+                side_effect=AssertionError("planner read retry attempts"),
+            ),
+            patch(
+                "codex_proxy.gateway_auto_retry_max_attempts",
+                side_effect=AssertionError("planner read retry expansion"),
+            ),
+            patch(
+                "codex_proxy.gateway_capacity_retry_elapsed_limit_seconds",
+                side_effect=AssertionError("planner read capacity budget"),
+            ),
+            patch(
+                "codex_proxy.gateway_stream_retry_elapsed_limit_seconds",
+                side_effect=AssertionError("planner read stream budget"),
+            ),
+        ):
+            plan = codex_proxy.route_plan_for_request(
+                {
+                    "name": "volcengine",
+                    "base_url": "https://ark.example.test/v1",
+                    "auth": "api_key",
+                    "upstream_model": "glm-5.2",
+                    "upstream_format": "responses",
+                },
+                {"client_id": "codex-app"},
+                inbound_format="responses",
+                model_requested="volc/glm-5.2",
+                caller_stream=True,
+                runtime_facts=runtime_facts,
+            )
+
+        retry = plan.attempts[0].retry
+        self.assertEqual(retry.eligibility, codex_proxy.CapabilityState.SUPPORTED)
+        self.assertEqual(retry.policy, codex_proxy.RetryPolicy.GATEWAY_FULL)
+        self.assertEqual(retry.request_timeout_seconds, 41)
+        self.assertEqual(retry.base_open_attempts, 7)
+        self.assertEqual(retry.base_relay_attempts, 7)
+        self.assertEqual(
+            retry.open_attempts_for_failure_class(
+                codex_proxy.RETRY_FAILURE_PROVIDER_THROTTLE
+            ),
+            19,
+        )
+        self.assertEqual(
+            retry.relay_attempts_for_failure_class(
+                codex_proxy.RETRY_FAILURE_QUICK_TRANSIENT,
+                stream_failure=True,
+            ),
+            19,
+        )
+        self.assertTrue(retry.capacity_elapsed_limit_allows(80.0, 3))
+        self.assertFalse(retry.capacity_elapsed_limit_allows(80.1, 3))
+        self.assertTrue(retry.stream_elapsed_limit_allows(94.0, 3))
+        self.assertFalse(retry.stream_elapsed_limit_allows(94.1, 3))
+        self.assertEqual(retry.pre_response_budget_seconds, 109.0)
+        self.assertTrue(retry.emit_downstream_retry_notice)
+        self.assertIsNone(retry.open_attempt_budget)
+
+    def test_transparent_compact_route_uses_effective_main_generation_runtime_facts(self):
+        compact_facts = codex_proxy.RouteRuntimeFacts(
+            request_timeout_seconds=31,
+            request_kind_base_attempts=3,
+            request_kind_attempts_configured=True,
+            failure_expansion_attempts=19,
+            official_open_attempts=2,
+            capacity_elapsed_limit_seconds=83.0,
+            stream_elapsed_limit_seconds=97.0,
+            downstream_retry_notice_enabled=False,
+            pre_response_budget_seconds=109.0,
+        )
+        main_facts = replace(
+            compact_facts,
+            request_timeout_seconds=41,
+            request_kind_base_attempts=5,
+        )
+
+        plan = codex_proxy.route_plan_for_request(
+            {
+                "name": "volcengine",
+                "base_url": "https://ark.example.test/v1",
+                "auth": "api_key",
+                "upstream_model": "glm-5.2",
+                "upstream_format": "chat_completions",
+            },
+            {"client_id": "zcode"},
+            inbound_format="chat_completions",
+            provider_hint="volc",
+            model_requested="volc/glm-5.2",
+            request_kind=codex_proxy.RETRY_REQUEST_COMPACT,
+            runtime_facts={
+                codex_proxy.RETRY_REQUEST_COMPACT: compact_facts,
+                codex_proxy.RETRY_REQUEST_MAIN_GENERATION: main_facts,
+            },
+        )
+
+        self.assertEqual(
+            plan.request_kind,
+            codex_proxy.RETRY_REQUEST_MAIN_GENERATION,
+        )
+        self.assertEqual(plan.attempts[0].retry.request_kind, plan.request_kind)
+        self.assertEqual(plan.attempts[0].retry.request_timeout_seconds, 41)
+        self.assertEqual(plan.attempts[0].retry.base_open_attempts, 5)
+        self.assertEqual(plan.attempts[0].retry.base_relay_attempts, 5)
+
+    def test_handler_consumes_attempt_execution_contract_without_rederiving_policy(self):
+        runtime_facts = codex_proxy.RouteRuntimeFacts(
+            request_timeout_seconds=41,
+            request_kind_base_attempts=7,
+            request_kind_attempts_configured=True,
+            failure_expansion_attempts=19,
+            official_open_attempts=2,
+            capacity_elapsed_limit_seconds=83.0,
+            stream_elapsed_limit_seconds=97.0,
+            downstream_retry_notice_enabled=False,
+            pre_response_budget_seconds=109.0,
+        )
+        planned = codex_proxy.route_plan_for_request(
+            {
+                "name": "volcengine",
+                "base_url": "https://ark.example.test/v1",
+                "auth": "api_key",
+                "upstream_model": "glm-5.2",
+                "upstream_format": "responses",
+            },
+            {"client_id": "codex-app"},
+            inbound_format="responses",
+            model_requested="volc/glm-5.2",
+            runtime_facts=runtime_facts,
+        )
+        planned_attempt = replace(
+            planned.attempts[0],
+            endpoint_url="https://planned.example.test/only",
+        )
+        planned = replace(planned, attempts=(planned_attempt,))
+        body = json.dumps(
+            {
+                "model": "volc/glm-5.2",
+                "input": [
+                    {"type": "message", "role": "user", "content": "hi"}
+                ],
+                "stream": False,
+            }
+        ).encode("utf-8")
+        handler, _fake = post_handler("/v1/responses", body)
+        relayed: list[dict[str, Any]] = []
+        handler._relay_upstream_response = (
+            lambda response, upstream_name, **kwargs:
+            relayed.append(kwargs) or 200
+        )
+
+        with (
+            patch("codex_proxy._route_runtime_facts", return_value=runtime_facts),
+            patch("codex_proxy.route_plan_for_request", return_value=planned),
+            patch(
+                "codex_proxy._responses_url",
+                side_effect=AssertionError("executor derived Responses URL"),
+            ),
+            patch(
+                "codex_proxy._chat_completions_url",
+                side_effect=AssertionError("executor derived Chat URL"),
+            ),
+            patch(
+                "codex_proxy._external_tool_protocol",
+                side_effect=AssertionError("executor derived tool protocol"),
+            ),
+            patch(
+                "codex_proxy._external_tool_surface_strategy",
+                side_effect=AssertionError(
+                    "executor derived tool surface strategy"
+                ),
+            ),
+            patch(
+                "codex_proxy._external_native_responses_tool_codec",
+                side_effect=AssertionError(
+                    "executor derived native tool codec"
+                ),
+            ),
+            patch(
+                "codex_proxy.upstream_timeout_seconds",
+                side_effect=AssertionError("executor read request timeout"),
+            ),
+            patch(
+                "codex_proxy._upstream_retry_attempts",
+                side_effect=AssertionError("executor read retry attempts"),
+            ),
+            patch(
+                "codex_proxy._retry_attempts_for_failure_class",
+                side_effect=AssertionError("executor derived retry count"),
+            ),
+            patch(
+                "codex_proxy.gateway_downstream_retry_notice_enabled",
+                side_effect=AssertionError("executor read retry notice setting"),
+            ),
+            patch(
+                "codex_proxy._open_upstream_response",
+                return_value=FakeContextResponse(
+                    b'{"id":"resp_planned","output":[]}'
+                ),
+            ) as open_upstream,
+            patch(
+                "codex_proxy.upstream_headers",
+                wraps=codex_proxy.upstream_headers,
+            ) as build_headers,
+        ):
+            CodexProxyHandler._proxy_post_request(
+                handler,
+                inbound_format="responses",
+            )
+
+        request = open_upstream.call_args.args[0]
+        self.assertEqual(
+            request.full_url,
+            "https://planned.example.test/only",
+        )
+        self.assertIs(
+            open_upstream.call_args.kwargs["retry_execution"],
+            planned_attempt.retry,
+        )
+        self.assertEqual(
+            open_upstream.call_args.kwargs["timeout"],
+            planned_attempt.retry.request_timeout_seconds,
+        )
+        self.assertEqual(
+            open_upstream.call_args.kwargs["transport_policy"],
+            planned_attempt.transport_policy,
+        )
+        self.assertEqual(
+            build_headers.call_args.kwargs["authentication_strategy"],
+            planned_attempt.authentication_strategy,
+        )
+        self.assertEqual(
+            build_headers.call_args.kwargs["request_mutation_policy"],
+            planned_attempt.request_mutation_policy,
+        )
+        self.assertNotIn("behavior_profile", build_headers.call_args.kwargs)
+        self.assertNotIn("request_kind", open_upstream.call_args.kwargs)
+        self.assertNotIn("behavior_profile", relayed[0])
+        self.assertEqual(
+            relayed[0]["streaming_policy"],
+            planned_attempt.streaming_policy,
+        )
+        self.assertEqual(
+            relayed[0]["usage_policy"],
+            planned_attempt.usage_policy,
+        )
+        self.assertEqual(
+            relayed[0]["response_mutation_policy"],
+            planned_attempt.response_mutation_policy,
+        )
+        self.assertEqual(
+            relayed[0]["sse_mutation_policy"],
+            planned_attempt.sse_mutation_policy,
+        )
+
+    def test_open_upstream_response_consumes_planned_retry_execution(self):
+        runtime_facts = codex_proxy.RouteRuntimeFacts(
+            request_timeout_seconds=41,
+            request_kind_base_attempts=2,
+            request_kind_attempts_configured=True,
+            failure_expansion_attempts=19,
+            official_open_attempts=2,
+            capacity_elapsed_limit_seconds=83.0,
+            stream_elapsed_limit_seconds=97.0,
+            downstream_retry_notice_enabled=False,
+            pre_response_budget_seconds=109.0,
+        )
+        plan = codex_proxy.route_plan_for_request(
+            {
+                "name": "volcengine",
+                "base_url": "https://ark.example.test/v1",
+                "auth": "api_key",
+                "upstream_model": "glm-5.2",
+                "upstream_format": "responses",
+            },
+            {"client_id": "codex-app"},
+            inbound_format="responses",
+            model_requested="volc/glm-5.2",
+            request_kind=codex_proxy.RETRY_REQUEST_COMPACT,
+            runtime_facts=runtime_facts,
+        )
+        retry = plan.attempts[0].retry
+        request = codex_proxy.Request(
+            plan.attempts[0].endpoint_url,
+            data=b"{}",
+            method="POST",
+        )
+        response = FakeContextResponse(b'{"id":"resp_retry","output":[]}')
+
+        with (
+            patch(
+                "codex_proxy._upstream_retry_attempts",
+                side_effect=AssertionError("open path read retry attempts"),
+            ),
+            patch(
+                "codex_proxy._retry_attempts_for_failure_class",
+                side_effect=AssertionError("open path derived retry count"),
+            ),
+            patch(
+                "codex_proxy.gateway_retry_delay_seconds",
+                side_effect=AssertionError("open path derived retry delay"),
+            ),
+            patch(
+                "codex_proxy._capacity_retry_elapsed_limit_allows",
+                side_effect=AssertionError("open path read capacity budget"),
+            ),
+            patch(
+                "codex_proxy._open_upstream_once",
+                side_effect=[URLError(OSError("reset")), response],
+            ) as open_once,
+            patch("codex_proxy._sleep_for_retry_with_gateway_cancellation"),
+        ):
+            opened = codex_proxy._open_upstream_response(
+                request,
+                upstream_name="volcengine",
+                upstream_format="responses",
+                timeout=999,
+                request_kind=codex_proxy.RETRY_REQUEST_MAIN_GENERATION,
+                retry_execution=retry,
+            )
+
+        self.assertIs(opened, response)
+        self.assertEqual(open_once.call_count, 2)
+        self.assertTrue(
+            all(
+                call.kwargs["timeout"] == retry.request_timeout_seconds
+                for call in open_once.call_args_list
+            )
+        )
+
+    def test_route_plan_chat_auto_attempts_report_actual_conversion_chain(self):
+        plan = codex_proxy.route_plan_for_request(
+            {
+                "name": "volcengine",
+                "base_url": "https://ark.example.test/v1",
+                "auth": "api_key",
+                "upstream_model": "glm-5.2",
+                "upstream_format": "auto",
+            },
+            {"client_id": "codex-app"},
+            inbound_format="chat_completions",
+            model_requested="volc/glm-5.2",
+            request_kind=codex_proxy.RETRY_REQUEST_COMPACT,
+        )
+
+        self.assertEqual(
+            plan.caller_request_body_mode,
+            codex_proxy.CallerRequestBodyMode.CONVERT_CHAT_TO_RESPONSES,
+        )
+        self.assertEqual(
+            [attempt.wire_format_adapter for attempt in plan.attempts],
+            [codex_proxy.WIRE_CHAT_TO_RESPONSES, codex_proxy.WIRE_TRANSPARENT],
+        )
+        self.assertEqual(
+            [attempt.request_conversion_steps for attempt in plan.attempts],
+            [
+                (codex_proxy.WIRE_CHAT_TO_RESPONSES,),
+                (
+                    codex_proxy.WIRE_CHAT_TO_RESPONSES,
+                    codex_proxy.WIRE_RESPONSES_TO_CHAT,
+                ),
+            ],
+        )
+        self.assertTrue(
+            all(
+                codex_proxy.RouteMutation.WIRE_CONVERSION
+                in attempt.named_mutations
+                for attempt in plan.attempts
+            )
+        )
+        self.assertTrue(
+            all(
+                codex_proxy.RouteMutation.CALLER_TOOL_STRIPPING
+                in attempt.named_mutations
+                for attempt in plan.attempts
+            )
+        )
+        self.assertEqual(
+            set(plan.mutation_summary),
+            set().union(
+                *(attempt.named_mutations for attempt in plan.attempts)
+            ),
+        )
 
     def test_route_plan_preserves_unsupported_protocol_identity_without_attempts(self):
         cases = (
@@ -1161,6 +1592,7 @@ class RoutingTests(unittest.TestCase):
                 self.assertEqual(plan.attempts, ())
 
     def test_route_plan_separates_schema_identity_from_optional_manifest_evidence(self):
+        valid_manifest_hash = f"sha256:{'a' * 64}"
         unqualified = codex_proxy.route_plan_for_request(
             {
                 "name": "ollama_cloud",
@@ -1177,7 +1609,7 @@ class RoutingTests(unittest.TestCase):
                 "upstream_model": "glm-5.2",
                 "upstream_format": "responses",
                 "capability_manifest_version": "provider-capabilities.v3",
-                "capability_manifest_hash": "sha256:route-qualified",
+                "capability_manifest_hash": valid_manifest_hash,
                 "capability_manifest_state": codex_proxy.CapabilityState.SUPPORTED.value,
             },
             {"client_id": "codex-app"},
@@ -1206,12 +1638,121 @@ class RoutingTests(unittest.TestCase):
         )
         self.assertEqual(
             qualified.capability_manifest_hash,
-            "sha256:route-qualified",
+            valid_manifest_hash,
         )
         self.assertEqual(
             qualified.capability_manifest_state,
             codex_proxy.CapabilityState.SUPPORTED,
         )
+
+    def test_route_plan_capability_manifest_identity_fails_closed_pairwise(self):
+        valid_hash = f"sha256:{'b' * 64}"
+        cases = (
+            {
+                "name": "missing_pair",
+                "version": None,
+                "hash": None,
+                "state": codex_proxy.CapabilityState.SUPPORTED.value,
+                "expected_version": None,
+                "expected_hash": None,
+                "expected_state": codex_proxy.CapabilityState.UNQUALIFIED,
+            },
+            {
+                "name": "version_only",
+                "version": "provider-capabilities.v3",
+                "hash": None,
+                "state": codex_proxy.CapabilityState.SUPPORTED.value,
+                "expected_version": None,
+                "expected_hash": None,
+                "expected_state": codex_proxy.CapabilityState.UNQUALIFIED,
+            },
+            {
+                "name": "hash_only",
+                "version": None,
+                "hash": valid_hash,
+                "state": codex_proxy.CapabilityState.SUPPORTED.value,
+                "expected_version": None,
+                "expected_hash": None,
+                "expected_state": codex_proxy.CapabilityState.UNQUALIFIED,
+            },
+            {
+                "name": "malformed_version",
+                "version": "../provider capabilities",
+                "hash": valid_hash,
+                "state": codex_proxy.CapabilityState.SUPPORTED.value,
+                "expected_version": None,
+                "expected_hash": None,
+                "expected_state": codex_proxy.CapabilityState.UNQUALIFIED,
+            },
+            {
+                "name": "malformed_hash",
+                "version": "provider-capabilities.v3",
+                "hash": "sha256:not-a-digest",
+                "state": codex_proxy.CapabilityState.SUPPORTED.value,
+                "expected_version": None,
+                "expected_hash": None,
+                "expected_state": codex_proxy.CapabilityState.UNQUALIFIED,
+            },
+            {
+                "name": "valid_pair_unqualified",
+                "version": "provider-capabilities.v3",
+                "hash": valid_hash,
+                "state": codex_proxy.CapabilityState.UNQUALIFIED.value,
+                "expected_version": "provider-capabilities.v3",
+                "expected_hash": valid_hash,
+                "expected_state": codex_proxy.CapabilityState.UNQUALIFIED,
+            },
+            {
+                "name": "valid_pair_unsupported",
+                "version": "provider-capabilities.v3",
+                "hash": valid_hash,
+                "state": codex_proxy.CapabilityState.UNSUPPORTED.value,
+                "expected_version": "provider-capabilities.v3",
+                "expected_hash": valid_hash,
+                "expected_state": codex_proxy.CapabilityState.UNSUPPORTED,
+            },
+            {
+                "name": "valid_supported_pair",
+                "version": "provider-capabilities.v3",
+                "hash": valid_hash,
+                "state": codex_proxy.CapabilityState.SUPPORTED.value,
+                "expected_version": "provider-capabilities.v3",
+                "expected_hash": valid_hash,
+                "expected_state": codex_proxy.CapabilityState.SUPPORTED,
+            },
+        )
+
+        for case in cases:
+            with self.subTest(case=case["name"]):
+                upstream = {
+                    "name": "ollama_cloud",
+                    "upstream_model": "glm-5.2",
+                    "upstream_format": "responses",
+                    "capability_manifest_state": case["state"],
+                }
+                if case["version"] is not None:
+                    upstream["capability_manifest_version"] = case["version"]
+                if case["hash"] is not None:
+                    upstream["capability_manifest_hash"] = case["hash"]
+                plan = codex_proxy.route_plan_for_request(
+                    upstream,
+                    {"client_id": "codex-app"},
+                    inbound_format="responses",
+                    model_requested="ollama-cloud/glm-5.2",
+                )
+
+                self.assertEqual(
+                    plan.capability_manifest_version,
+                    case["expected_version"],
+                )
+                self.assertEqual(
+                    plan.capability_manifest_hash,
+                    case["expected_hash"],
+                )
+                self.assertEqual(
+                    plan.capability_manifest_state,
+                    case["expected_state"],
+                )
 
     def test_route_plan_resolves_vision_network_and_mutation_before_execution(self):
         cases = (
@@ -1294,6 +1835,206 @@ class RoutingTests(unittest.TestCase):
                         self.assertIn(
                             case["expected_mutation"],
                             attempt.named_mutations,
+                        )
+
+    def test_handler_executes_planned_vision_matrix_before_main_upstream_io(self):
+        response_body = json.dumps(
+            {
+                "id": "resp_main",
+                "object": "response",
+                "status": "completed",
+                "output": [
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": "ok"}],
+                    }
+                ],
+                "usage": {
+                    "input_tokens": 1,
+                    "output_tokens": 1,
+                    "total_tokens": 2,
+                },
+            }
+        ).encode("utf-8")
+        cases = (
+            {
+                "name": "proxy",
+                "has_image": True,
+                "target_accepts_image": False,
+                "proxy_enabled": True,
+                "vision_error": None,
+                "expected_action": codex_proxy.VisionAction.PROXY,
+                "expected_network": codex_proxy.VisionNetworkAction.IMAGE_PROXY,
+                "expected_vision_calls": 1,
+                "expected_main_calls": 1,
+                "expected_status": 200,
+                "expected_mutation": codex_proxy.RouteMutation.IMAGE_CONTENT_REPLACEMENT,
+            },
+            {
+                "name": "proxy_failure",
+                "has_image": True,
+                "target_accepts_image": False,
+                "proxy_enabled": True,
+                "vision_error": codex_proxy.ImageProxyError("vision unavailable"),
+                "expected_action": codex_proxy.VisionAction.PROXY,
+                "expected_network": codex_proxy.VisionNetworkAction.IMAGE_PROXY,
+                "expected_vision_calls": 1,
+                "expected_main_calls": 0,
+                "expected_status": 502,
+                "expected_mutation": codex_proxy.RouteMutation.IMAGE_CONTENT_REPLACEMENT,
+            },
+            {
+                "name": "reject",
+                "has_image": True,
+                "target_accepts_image": False,
+                "proxy_enabled": False,
+                "vision_error": None,
+                "expected_action": codex_proxy.VisionAction.REJECT,
+                "expected_network": codex_proxy.VisionNetworkAction.NONE,
+                "expected_vision_calls": 0,
+                "expected_main_calls": 0,
+                "expected_status": 502,
+                "expected_mutation": codex_proxy.RouteMutation.IMAGE_UNSUPPORTED_REJECTION,
+            },
+            {
+                "name": "native",
+                "has_image": True,
+                "target_accepts_image": True,
+                "proxy_enabled": True,
+                "vision_error": None,
+                "expected_action": codex_proxy.VisionAction.PASS_THROUGH,
+                "expected_network": codex_proxy.VisionNetworkAction.NONE,
+                "expected_vision_calls": 0,
+                "expected_main_calls": 1,
+                "expected_status": 200,
+                "expected_mutation": None,
+            },
+            {
+                "name": "no_image",
+                "has_image": False,
+                "target_accepts_image": False,
+                "proxy_enabled": True,
+                "vision_error": None,
+                "expected_action": codex_proxy.VisionAction.PASS_THROUGH,
+                "expected_network": codex_proxy.VisionNetworkAction.NONE,
+                "expected_vision_calls": 0,
+                "expected_main_calls": 1,
+                "expected_status": 200,
+                "expected_mutation": None,
+            },
+        )
+
+        for case in cases:
+            with self.subTest(case=case["name"]):
+                self.write_proxy_event.reset_mock()
+                self.external_model["input_modalities"] = (
+                    ("text", "image")
+                    if case["target_accepts_image"]
+                    else ("text",)
+                )
+                content: list[dict[str, Any]] = [
+                    {"type": "input_text", "text": "describe this"}
+                ]
+                if case["has_image"]:
+                    content.append(
+                        {
+                            "type": "input_image",
+                            "image_url": (
+                                "data:image/png;base64,"
+                                f"{case['name'].encode('utf-8').hex()}"
+                            ),
+                        }
+                    )
+                body = json.dumps(
+                    {
+                        "model": "volc/glm-5.2",
+                        "input": [
+                            {
+                                "type": "message",
+                                "role": "user",
+                                "content": content,
+                            }
+                        ],
+                        "stream": False,
+                    }
+                ).encode("utf-8")
+                handler, fake = post_handler("/v1/responses", body)
+                vision_side_effect = case["vision_error"]
+                with (
+                    patch(
+                        "codex_proxy.gateway_image_proxy_enabled",
+                        return_value=case["proxy_enabled"],
+                    ),
+                    patch(
+                        "codex_proxy._image_proxy_vision_upstream",
+                        return_value=(
+                            "minimax-cn/MiniMax-M3",
+                            self.minimax_external_model,
+                        ),
+                    ),
+                    patch("codex_proxy._image_proxy_cache_lookup", return_value=None),
+                    patch("codex_proxy._image_proxy_cache_store"),
+                    patch(
+                        "codex_proxy._call_vision_model_for_image_description",
+                        return_value="a test image",
+                        side_effect=vision_side_effect,
+                    ) as vision_call,
+                    patch(
+                        "codex_proxy._open_upstream_response",
+                        return_value=FakeContextResponse(response_body),
+                    ) as main_open,
+                ):
+                    CodexProxyHandler._proxy_post_request(
+                        handler,
+                        inbound_format="responses",
+                    )
+
+                self.assertEqual(vision_call.call_count, case["expected_vision_calls"])
+                self.assertEqual(main_open.call_count, case["expected_main_calls"])
+                self.assertEqual(fake.status, case["expected_status"])
+                request_event = next(
+                    call.kwargs
+                    for call in self.write_proxy_event.call_args_list
+                    if call.args
+                    and call.args[0]
+                    in {
+                        "request_start",
+                        "request_error",
+                    }
+                )
+                self.assertEqual(
+                    request_event["vision_action"],
+                    case["expected_action"].value,
+                )
+                self.assertEqual(
+                    request_event["vision_network_action"],
+                    case["expected_network"].value,
+                )
+                planned_mutations = request_event["planned_mutation_summary"]
+                if case["expected_mutation"] is None:
+                    self.assertNotIn(
+                        codex_proxy.RouteMutation.IMAGE_CONTENT_REPLACEMENT.value,
+                        planned_mutations,
+                    )
+                    self.assertNotIn(
+                        codex_proxy.RouteMutation.IMAGE_UNSUPPORTED_REJECTION.value,
+                        planned_mutations,
+                    )
+                else:
+                    self.assertIn(
+                        case["expected_mutation"].value,
+                        planned_mutations,
+                    )
+                if case["expected_main_calls"]:
+                    forwarded = json.loads(main_open.call_args.args[0].data)
+                    if case["name"] == "proxy":
+                        self.assertFalse(
+                            codex_proxy._value_contains_image(forwarded)
+                        )
+                    elif case["name"] == "native":
+                        self.assertTrue(
+                            codex_proxy._value_contains_image(forwarded)
                         )
 
     def test_route_plan_uses_only_explicit_runtime_facts(self):
@@ -1782,6 +2523,19 @@ class RoutingTests(unittest.TestCase):
             codex_proxy.RouteMutation.HARD_CODED_SCHEMA_INJECTION.value,
             request_start["mutation_summary"],
         )
+        self.assertIn(
+            codex_proxy.RouteMutation.CALLER_TOOL_STRIPPING.value,
+            request_start["mutation_summary"],
+        )
+        self.assertIn(
+            codex_proxy.RouteMutation.CALLER_TOOL_STRIPPING.value,
+            request_start["route_attempt_mutation_summary"],
+        )
+        self.assertEqual(request_start["mutation_summary_scope"], "planned_union")
+        self.assertEqual(
+            request_start["planned_mutation_summary"],
+            request_start["mutation_summary"],
+        )
 
     def test_auto_compact_executes_planned_chat_fallback_and_updates_attempt_telemetry(self):
         self.external_model["upstream_format"] = "auto"
@@ -1883,6 +2637,184 @@ class RoutingTests(unittest.TestCase):
         )
         self.assertIn(
             codex_proxy.RouteMutation.WIRE_CONVERSION.value,
+            request_complete["route_attempt_mutation_summary"],
+        )
+
+    def test_chat_auto_compact_fallback_telemetry_matches_executed_conversion_chain(self):
+        self.external_model["upstream_format"] = "auto"
+        body = json.dumps(
+            {
+                "model": "volc/glm-5.2",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": (
+                            "Create a detailed summary of the conversation so far. "
+                            "This is a compact summary. Respond with text only. "
+                            "The summary should include <summary>."
+                        ),
+                    }
+                ],
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "caller_tool",
+                            "description": "caller-owned tool",
+                            "parameters": {"type": "object"},
+                        },
+                    }
+                ],
+                "stream": False,
+            }
+        ).encode("utf-8")
+        handler, _fake = post_handler("/v1/chat/completions", body)
+        responses_error = HTTPError(
+            "https://ark.example.test/v1/responses",
+            404,
+            "Not Found",
+            {},
+            io.BytesIO(b'{"error":"unsupported endpoint"}'),
+        )
+        chat_response = FakeContextResponse(
+            json.dumps(
+                {
+                    "id": "chat_fallback",
+                    "object": "chat.completion",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": {
+                                "role": "assistant",
+                                "content": "<summary>fallback summary</summary>",
+                            },
+                            "finish_reason": "stop",
+                        }
+                    ],
+                }
+            ).encode("utf-8")
+        )
+
+        with (
+            patch.dict(
+                os.environ,
+                {"CODEX_PROXY_AUTO_RETRY_ENABLED": "0"},
+                clear=False,
+            ),
+            patch(
+                "codex_proxy.urlopen",
+                side_effect=[responses_error, chat_response],
+            ) as mock_urlopen,
+        ):
+            CodexProxyHandler._proxy_post_request(
+                handler,
+                inbound_format="chat_completions",
+            )
+
+        self.assertEqual(mock_urlopen.call_count, 2)
+        responses_request = mock_urlopen.call_args_list[0].args[0]
+        chat_request = mock_urlopen.call_args_list[1].args[0]
+        self.assertTrue(responses_request.full_url.endswith("/responses"))
+        self.assertTrue(chat_request.full_url.endswith("/chat/completions"))
+        responses_payload = json.loads(responses_request.data)
+        chat_payload = json.loads(chat_request.data)
+        self.assertIn("input", responses_payload)
+        self.assertNotIn("messages", responses_payload)
+        self.assertIn("messages", chat_payload)
+        self.assertNotIn("input", chat_payload)
+        self.assertNotIn("tools", responses_payload)
+        self.assertNotIn("tools", chat_payload)
+
+        request_start = next(
+            call.kwargs
+            for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] == "request_start"
+        )
+        fallback = next(
+            call.kwargs
+            for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] == "upstream_protocol_fallback"
+        )
+        request_complete = next(
+            call.kwargs
+            for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] == "request_complete"
+        )
+
+        self.assertEqual(
+            request_start["caller_request_body_mode"],
+            codex_proxy.CallerRequestBodyMode.CONVERT_CHAT_TO_RESPONSES.value,
+        )
+        self.assertEqual(
+            request_start["route_attempt_wire_format_adapter"],
+            codex_proxy.WIRE_CHAT_TO_RESPONSES,
+        )
+        self.assertEqual(
+            request_start["route_attempt_request_conversion_steps"],
+            [codex_proxy.WIRE_CHAT_TO_RESPONSES],
+        )
+        self.assertEqual(request_start["mutation_summary_scope"], "planned_union")
+        self.assertEqual(
+            request_start["planned_mutation_summary"],
+            request_start["mutation_summary"],
+        )
+        self.assertIn(
+            codex_proxy.RouteMutation.WIRE_CONVERSION.value,
+            request_start["planned_mutation_summary"],
+        )
+        self.assertIn(
+            codex_proxy.RouteMutation.CALLER_TOOL_STRIPPING.value,
+            request_start["planned_mutation_summary"],
+        )
+        self.assertIn(
+            codex_proxy.RouteMutation.WIRE_CONVERSION.value,
+            fallback["failed_route_attempt_mutation_summary"],
+        )
+        self.assertIn(
+            codex_proxy.RouteMutation.WIRE_CONVERSION.value,
+            fallback["next_route_attempt_mutation_summary"],
+        )
+        self.assertEqual(
+            fallback["failed_route_attempt_request_conversion_steps"],
+            [codex_proxy.WIRE_CHAT_TO_RESPONSES],
+        )
+        self.assertEqual(
+            fallback["next_route_attempt_request_conversion_steps"],
+            [
+                codex_proxy.WIRE_CHAT_TO_RESPONSES,
+                codex_proxy.WIRE_RESPONSES_TO_CHAT,
+            ],
+        )
+        self.assertEqual(request_complete["route_attempt_index"], 1)
+        self.assertEqual(
+            request_complete["execution_summary_scope"],
+            "selected_attempt_plan",
+        )
+        self.assertEqual(
+            request_complete["executed_upstream_protocol"],
+            codex_proxy.RouteProtocol.CHAT_COMPLETIONS.value,
+        )
+        self.assertEqual(
+            request_complete["executed_wire_format_adapter"],
+            codex_proxy.WIRE_TRANSPARENT,
+        )
+        self.assertEqual(
+            request_complete["route_attempt_wire_format_adapter"],
+            codex_proxy.WIRE_TRANSPARENT,
+        )
+        self.assertEqual(
+            request_complete["route_attempt_request_conversion_steps"],
+            [
+                codex_proxy.WIRE_CHAT_TO_RESPONSES,
+                codex_proxy.WIRE_RESPONSES_TO_CHAT,
+            ],
+        )
+        self.assertIn(
+            codex_proxy.RouteMutation.WIRE_CONVERSION.value,
+            request_complete["route_attempt_mutation_summary"],
+        )
+        self.assertEqual(
+            request_complete["executed_attempt_mutation_summary"],
             request_complete["route_attempt_mutation_summary"],
         )
 
@@ -2329,7 +3261,15 @@ class RoutingTests(unittest.TestCase):
         ):
             CodexProxyHandler.do_POST(handler)
 
-        self.assertEqual(open_response.call_args.kwargs.get("max_attempts"), codex_proxy.official_upstream_open_attempts())
+        retry_execution = open_response.call_args.kwargs["retry_execution"]
+        self.assertEqual(
+            retry_execution.open_attempt_budget,
+            codex_proxy.official_upstream_open_attempts(),
+        )
+        self.assertEqual(
+            retry_execution.base_open_attempts,
+            codex_proxy.official_upstream_open_attempts(),
+        )
         self.assertIsInstance(open_response.call_args.kwargs.get("pre_response_deadline"), float)
         self.assertEqual(
             open_response.call_args.kwargs.get("open_attempt_budget"),
@@ -2338,7 +3278,7 @@ class RoutingTests(unittest.TestCase):
                 "attempts_started": 0,
             },
         )
-        self.assertFalse(open_response.call_args.kwargs.get("retry_http_errors"))
+        self.assertFalse(retry_execution.retry_http_errors)
         self.assertTrue(relayed[0]["defer_stream_errors"])
         self.assert_no_official_passthrough_gateway_events()
 

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -624,9 +624,9 @@ class RoutingTests(unittest.TestCase):
             codex_proxy.BEHAVIOR_EXTERNAL_PROVIDER_GATEWAY,
         )
 
-    def test_route_decision_codex_app_third_party_chat_upstream_uses_codex_adapter_and_wire_conversion(self):
+    def test_route_plan_codex_app_third_party_chat_upstream_uses_codex_adapter_and_wire_conversion(self):
         upstream = {"name": "volcengine", "upstream_format": "chat_completions"}
-        decision = codex_proxy.route_decision_for_request(
+        decision = codex_proxy.route_plan_for_request(
             upstream,
             {"client_id": "codex-app"},
             inbound_format="responses",
@@ -639,9 +639,9 @@ class RoutingTests(unittest.TestCase):
         self.assertEqual(decision.usage_policy, codex_proxy.USAGE_SYNC_CAPTURE)
         self.assertEqual(decision.repair_policy, codex_proxy.REPAIR_CODEX_SUBAGENT)
 
-    def test_route_decision_third_party_app_provider_same_format_is_transparent_metered(self):
+    def test_route_plan_third_party_app_provider_same_format_is_transparent_metered(self):
         upstream = {"name": "volcengine", "upstream_format": "chat_completions"}
-        decision = codex_proxy.route_decision_for_request(
+        decision = codex_proxy.route_plan_for_request(
             upstream,
             {"client_id": "zcode"},
             inbound_format="chat_completions",
@@ -655,9 +655,9 @@ class RoutingTests(unittest.TestCase):
         self.assertEqual(decision.usage_policy, codex_proxy.USAGE_ASYNC_TAP)
         self.assertEqual(decision.repair_policy, codex_proxy.REPAIR_NONE)
 
-    def test_route_decision_third_party_app_official_responses_is_transparent_metered(self):
+    def test_route_plan_third_party_app_official_responses_is_transparent_metered(self):
         upstream = {"name": "official", "upstream_format": "responses"}
-        decision = codex_proxy.route_decision_for_request(
+        decision = codex_proxy.route_plan_for_request(
             upstream,
             {"client_id": "opencode"},
             inbound_format="responses",
@@ -667,9 +667,9 @@ class RoutingTests(unittest.TestCase):
         self.assertEqual(decision.wire_format_adapter, codex_proxy.WIRE_TRANSPARENT)
         self.assertEqual(decision.usage_policy, codex_proxy.USAGE_ASYNC_TAP)
 
-    def test_route_decision_official_unknown_client_is_gateway_compat(self):
+    def test_route_plan_official_unknown_client_is_gateway_compat(self):
         upstream = {"name": "official", "upstream_format": "responses"}
-        decision = codex_proxy.route_decision_for_request(
+        decision = codex_proxy.route_plan_for_request(
             upstream,
             {"client_id": "unknown"},
             inbound_format="responses",
@@ -682,9 +682,9 @@ class RoutingTests(unittest.TestCase):
         self.assertEqual(decision.usage_policy, codex_proxy.USAGE_SYNC_CAPTURE)
         self.assertEqual(decision.repair_policy, codex_proxy.REPAIR_NONE)
 
-    def test_route_decision_third_party_standard_unknown_client_uses_gateway_profile(self):
+    def test_route_plan_third_party_standard_unknown_client_uses_gateway_profile(self):
         upstream = {"name": "volcengine", "upstream_format": "chat_completions"}
-        decision = codex_proxy.route_decision_for_request(
+        decision = codex_proxy.route_plan_for_request(
             upstream,
             {"client_id": "unknown"},
             inbound_format="chat_completions",
@@ -695,6 +695,284 @@ class RoutingTests(unittest.TestCase):
         self.assertEqual(decision.request_kind_policy, codex_proxy.REQUEST_KIND_GATEWAY)
         self.assertEqual(decision.retry_policy, codex_proxy.RETRY_GATEWAY_FULL)
         self.assertEqual(decision.usage_policy, codex_proxy.USAGE_SYNC_CAPTURE)
+
+    def test_route_plan_fixtures_are_route_qualified_and_decision_complete(self):
+        cases = (
+            {
+                "name": "official_passthrough",
+                "upstream": {
+                    "name": "official",
+                    "auth": "codex_auth",
+                    "upstream_model": "gpt-5.5",
+                    "upstream_format": "responses",
+                },
+                "context": {"client_id": "codex-app"},
+                "inbound_format": "responses",
+                "provider_hint": None,
+                "expected": {
+                    "behavior_profile": codex_proxy.BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH,
+                    "provider_id": "official",
+                    "canonical_model": "openai/gpt-5.5",
+                    "upstream_model": "gpt-5.5",
+                    "inbound_protocol": codex_proxy.RouteProtocol.RESPONSES,
+                    "upstream_protocol": codex_proxy.RouteProtocol.RESPONSES,
+                    "wire_format_adapter": codex_proxy.WIRE_TRANSPARENT,
+                    "tool_mode": codex_proxy.ToolExposureMode.OFFICIAL_NATIVE,
+                    "effective_tool_mode": codex_proxy.ToolExposureMode.OFFICIAL_NATIVE,
+                    "tool_state": codex_proxy.CapabilityState.SUPPORTED,
+                    "supports_search_tool": None,
+                    "codex_compatibility_policy": codex_proxy.CodexCompatibilityPolicy.OFFICIAL_NATIVE,
+                    "collaboration_backend": codex_proxy.CollaborationBackend.CODEX_RUNTIME,
+                    "streaming_policy": codex_proxy.StreamingPolicy.OFFICIAL_PASSTHROUGH,
+                    "transport_policy": codex_proxy.TransportPolicy.OFFICIAL_KEEPALIVE,
+                    "mutations": (
+                        codex_proxy.RouteMutation.MODEL_ALIAS,
+                        codex_proxy.RouteMutation.OFFICIAL_TOOL_SEARCH_PRESERVATION,
+                    ),
+                },
+            },
+            {
+                "name": "codex_app_external_compatibility_without_search",
+                "upstream": {
+                    "name": "ollama_cloud",
+                    "auth": "ollama_api_key",
+                    "upstream_model": "glm-5.2",
+                    "upstream_format": "responses",
+                    "supports_search_tool": False,
+                },
+                "context": {"client_id": "codex-app"},
+                "inbound_format": "responses",
+                "provider_hint": None,
+                "expected": {
+                    "behavior_profile": codex_proxy.BEHAVIOR_CODEX_APP_EXTERNAL_ADAPTER,
+                    "provider_id": "ollama_cloud",
+                    "canonical_model": "ollama-cloud/glm-5.2",
+                    "upstream_model": "glm-5.2",
+                    "inbound_protocol": codex_proxy.RouteProtocol.RESPONSES,
+                    "upstream_protocol": codex_proxy.RouteProtocol.RESPONSES,
+                    "wire_format_adapter": codex_proxy.WIRE_TRANSPARENT,
+                    "tool_mode": codex_proxy.ToolExposureMode.CURRENT_COMPATIBILITY,
+                    "effective_tool_mode": codex_proxy.ToolExposureMode.CURRENT_COMPATIBILITY,
+                    "tool_state": codex_proxy.CapabilityState.SUPPORTED,
+                    "supports_search_tool": False,
+                    "codex_compatibility_policy": codex_proxy.CodexCompatibilityPolicy.CURRENT_COMPATIBILITY,
+                    "collaboration_backend": codex_proxy.CollaborationBackend.GATEWAY_COMPATIBILITY,
+                    "streaming_policy": codex_proxy.StreamingPolicy.GATEWAY_ADAPTED,
+                    "transport_policy": codex_proxy.TransportPolicy.STANDARD,
+                    "mutations": (
+                        codex_proxy.RouteMutation.HARD_CODED_SCHEMA_INJECTION,
+                        codex_proxy.RouteMutation.MODEL_ALIAS,
+                        codex_proxy.RouteMutation.NAMESPACE_FLATTENING,
+                        codex_proxy.RouteMutation.SEMANTIC_REPAIR,
+                        codex_proxy.RouteMutation.SYNTHETIC_TERMINAL_FAILURE,
+                    ),
+                },
+            },
+            {
+                "name": "provider_scoped_responses_to_chat",
+                "upstream": {
+                    "name": "volcengine",
+                    "auth": "api_key",
+                    "upstream_model": "glm-5.2",
+                    "upstream_format": "chat_completions",
+                },
+                "context": {"client_id": "zcode"},
+                "inbound_format": "responses",
+                "provider_hint": "volc",
+                "expected": {
+                    "behavior_profile": codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+                    "provider_id": "volcengine",
+                    "canonical_model": "volc/glm-5.2",
+                    "upstream_model": "glm-5.2",
+                    "inbound_protocol": codex_proxy.RouteProtocol.RESPONSES,
+                    "upstream_protocol": codex_proxy.RouteProtocol.CHAT_COMPLETIONS,
+                    "wire_format_adapter": codex_proxy.WIRE_RESPONSES_TO_CHAT,
+                    "tool_mode": codex_proxy.ToolExposureMode.UNKNOWN,
+                    "effective_tool_mode": codex_proxy.ToolExposureMode.UNKNOWN,
+                    "tool_state": codex_proxy.CapabilityState.UNQUALIFIED,
+                    "supports_search_tool": None,
+                    "codex_compatibility_policy": codex_proxy.CodexCompatibilityPolicy.NONE,
+                    "collaboration_backend": codex_proxy.CollaborationBackend.CLIENT_RUNTIME,
+                    "streaming_policy": codex_proxy.StreamingPolicy.TRANSPARENT_CONVERTED,
+                    "transport_policy": codex_proxy.TransportPolicy.STANDARD,
+                    "mutations": (
+                        codex_proxy.RouteMutation.MODEL_ALIAS,
+                        codex_proxy.RouteMutation.WIRE_CONVERSION,
+                    ),
+                },
+            },
+            {
+                "name": "provider_scoped_responses_same_format",
+                "upstream": {
+                    "name": "volcengine",
+                    "auth": "api_key",
+                    "upstream_model": "glm-5.2",
+                    "upstream_format": "responses",
+                },
+                "context": {"client_id": "zcode"},
+                "inbound_format": "responses",
+                "provider_hint": "volc",
+                "expected": {
+                    "behavior_profile": codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+                    "provider_id": "volcengine",
+                    "canonical_model": "volc/glm-5.2",
+                    "upstream_model": "glm-5.2",
+                    "inbound_protocol": codex_proxy.RouteProtocol.RESPONSES,
+                    "upstream_protocol": codex_proxy.RouteProtocol.RESPONSES,
+                    "wire_format_adapter": codex_proxy.WIRE_TRANSPARENT,
+                    "tool_mode": codex_proxy.ToolExposureMode.UNKNOWN,
+                    "effective_tool_mode": codex_proxy.ToolExposureMode.UNKNOWN,
+                    "tool_state": codex_proxy.CapabilityState.UNQUALIFIED,
+                    "supports_search_tool": None,
+                    "codex_compatibility_policy": codex_proxy.CodexCompatibilityPolicy.NONE,
+                    "collaboration_backend": codex_proxy.CollaborationBackend.CLIENT_RUNTIME,
+                    "streaming_policy": codex_proxy.StreamingPolicy.TRANSPARENT,
+                    "transport_policy": codex_proxy.TransportPolicy.STANDARD,
+                    "mutations": (codex_proxy.RouteMutation.MODEL_ALIAS,),
+                },
+            },
+            {
+                "name": "codex_app_chat_to_responses_compatibility",
+                "upstream": {
+                    "name": "ollama_cloud",
+                    "auth": "ollama_api_key",
+                    "upstream_model": "glm-5.2",
+                    "upstream_format": "responses",
+                    "supports_search_tool": False,
+                },
+                "context": {"client_id": "codex-app"},
+                "inbound_format": "chat_completions",
+                "provider_hint": None,
+                "expected": {
+                    "behavior_profile": codex_proxy.BEHAVIOR_CODEX_APP_EXTERNAL_ADAPTER,
+                    "provider_id": "ollama_cloud",
+                    "canonical_model": "ollama-cloud/glm-5.2",
+                    "upstream_model": "glm-5.2",
+                    "inbound_protocol": codex_proxy.RouteProtocol.CHAT_COMPLETIONS,
+                    "upstream_protocol": codex_proxy.RouteProtocol.RESPONSES,
+                    "wire_format_adapter": codex_proxy.WIRE_CHAT_TO_RESPONSES,
+                    "tool_mode": codex_proxy.ToolExposureMode.CURRENT_COMPATIBILITY,
+                    "effective_tool_mode": codex_proxy.ToolExposureMode.CURRENT_COMPATIBILITY,
+                    "tool_state": codex_proxy.CapabilityState.SUPPORTED,
+                    "supports_search_tool": False,
+                    "codex_compatibility_policy": codex_proxy.CodexCompatibilityPolicy.CURRENT_COMPATIBILITY,
+                    "collaboration_backend": codex_proxy.CollaborationBackend.GATEWAY_COMPATIBILITY,
+                    "streaming_policy": codex_proxy.StreamingPolicy.GATEWAY_ADAPTED,
+                    "transport_policy": codex_proxy.TransportPolicy.STANDARD,
+                    "mutations": (
+                        codex_proxy.RouteMutation.HARD_CODED_SCHEMA_INJECTION,
+                        codex_proxy.RouteMutation.MODEL_ALIAS,
+                        codex_proxy.RouteMutation.NAMESPACE_FLATTENING,
+                        codex_proxy.RouteMutation.SEMANTIC_REPAIR,
+                        codex_proxy.RouteMutation.SYNTHETIC_TERMINAL_FAILURE,
+                        codex_proxy.RouteMutation.WIRE_CONVERSION,
+                    ),
+                },
+            },
+        )
+
+        for case in cases:
+            with self.subTest(case=case["name"]):
+                plan = codex_proxy.route_plan_for_request(
+                    case["upstream"],
+                    case["context"],
+                    inbound_format=case["inbound_format"],
+                    provider_hint=case["provider_hint"],
+                    model_requested=case["expected"]["canonical_model"],
+                )
+
+                expected = case["expected"]
+                self.assertEqual(plan.behavior_profile, expected["behavior_profile"])
+                self.assertEqual(plan.provider_id, expected["provider_id"])
+                self.assertEqual(plan.canonical_model, expected["canonical_model"])
+                self.assertEqual(plan.upstream_model, expected["upstream_model"])
+                self.assertEqual(plan.inbound_protocol, expected["inbound_protocol"])
+                self.assertEqual(plan.upstream_protocol, expected["upstream_protocol"])
+                self.assertEqual(plan.wire_format_adapter, expected["wire_format_adapter"])
+                self.assertEqual(plan.capability_manifest_version, "codexhub.route-capabilities.v1")
+                self.assertEqual(plan.tool_exposure.requested_mode, expected["tool_mode"])
+                self.assertEqual(plan.tool_exposure.effective_mode, expected["effective_tool_mode"])
+                self.assertEqual(plan.tool_exposure.capability_state, expected["tool_state"])
+                self.assertEqual(plan.tool_exposure.supports_search_tool, expected["supports_search_tool"])
+                self.assertEqual(
+                    plan.tool_exposure.gateway_schema_injection,
+                    expected["effective_tool_mode"] == codex_proxy.ToolExposureMode.CURRENT_COMPATIBILITY,
+                )
+                self.assertEqual(plan.codex_compatibility_policy, expected["codex_compatibility_policy"])
+                self.assertEqual(plan.collaboration_backend, expected["collaboration_backend"])
+                self.assertEqual(plan.execution_owner, codex_proxy.ExecutionOwner.CODEX_CLIENT)
+                self.assertEqual(plan.streaming_policy, expected["streaming_policy"])
+                self.assertEqual(plan.retry_eligibility, codex_proxy.CapabilityState.SUPPORTED)
+                self.assertEqual(plan.request_kind, codex_proxy.RETRY_REQUEST_MAIN_GENERATION)
+                self.assertEqual(plan.transport_policy, expected["transport_policy"])
+                self.assertIsInstance(plan.request_mutation_policy, codex_proxy.MutationPolicy)
+                self.assertIsInstance(plan.response_mutation_policy, codex_proxy.MutationPolicy)
+                self.assertIsInstance(plan.sse_mutation_policy, codex_proxy.MutationPolicy)
+                self.assertEqual(plan.mutation_summary, expected["mutations"])
+
+    def test_route_plan_candidate_and_unknown_tool_modes_fail_closed_to_compatibility(self):
+        cases = (
+            (
+                codex_proxy.ToolExposureMode.NATIVE_DEFERRED_SEARCH_CANDIDATE.value,
+                codex_proxy.CapabilityState.UNQUALIFIED,
+                (),
+            ),
+            (
+                codex_proxy.ToolExposureMode.NATIVE_NO_SEARCH_CANDIDATE.value,
+                codex_proxy.CapabilityState.UNQUALIFIED,
+                ("function", "custom"),
+            ),
+            (
+                codex_proxy.ToolExposureMode.UNKNOWN.value,
+                codex_proxy.CapabilityState.UNSUPPORTED,
+                (),
+            ),
+        )
+
+        for requested_mode, capability_state, proven_tool_subset in cases:
+            with self.subTest(requested_mode=requested_mode):
+                plan = codex_proxy.route_plan_for_request(
+                    {
+                        "name": "ollama_cloud",
+                        "auth": "ollama_api_key",
+                        "upstream_model": "glm-5.2",
+                        "upstream_format": "responses",
+                        "tool_exposure_mode": requested_mode,
+                        "tool_capability_state": capability_state.value,
+                        "proven_tool_subset": proven_tool_subset,
+                    },
+                    {"client_id": "codex-app"},
+                    inbound_format="responses",
+                    model_requested="ollama-cloud/glm-5.2",
+                )
+
+                self.assertEqual(plan.tool_exposure.requested_mode.value, requested_mode)
+                self.assertEqual(plan.tool_exposure.effective_mode, codex_proxy.ToolExposureMode.CURRENT_COMPATIBILITY)
+                self.assertEqual(plan.tool_exposure.capability_state, capability_state)
+                self.assertEqual(plan.tool_exposure.proven_tool_subset, proven_tool_subset)
+                self.assertTrue(plan.tool_exposure.gateway_schema_injection)
+                self.assertEqual(plan.behavior_profile, codex_proxy.BEHAVIOR_CODEX_APP_EXTERNAL_ADAPTER)
+                self.assertEqual(plan.repair_policy, codex_proxy.REPAIR_CODEX_SUBAGENT)
+                self.assertIn(codex_proxy.RouteMutation.SEMANTIC_REPAIR, plan.named_mutations)
+                self.assertFalse(plan.official_http_passthrough)
+                self.assertFalse(plan.transparent_metered)
+
+    def test_route_plan_and_nested_tool_policy_are_immutable(self):
+        plan = codex_proxy.route_plan_for_request(
+            {
+                "name": "ollama_cloud",
+                "upstream_model": "glm-5.2",
+                "upstream_format": "responses",
+            },
+            {"client_id": "codex-app"},
+            inbound_format="responses",
+            model_requested="ollama-cloud/glm-5.2",
+        )
+
+        with self.assertRaises(AttributeError):
+            plan.behavior_profile = codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED
+        with self.assertRaises(AttributeError):
+            plan.tool_exposure.gateway_schema_injection = False
 
     def test_third_party_app_official_responses_uses_transparent_metered_runtime_path(self):
         body = json.dumps(
@@ -746,8 +1024,17 @@ class RoutingTests(unittest.TestCase):
             self.assertEqual(fields["codex_semantic_adapter"], codex_proxy.CODEX_SEMANTIC_NONE)
             self.assertEqual(fields["request_kind_policy"], codex_proxy.REQUEST_KIND_TRANSPARENT)
             self.assertEqual(fields["retry_policy"], codex_proxy.RETRY_CONSERVATIVE_PRE_OUTPUT)
+            self.assertEqual(fields["retry_eligibility"], codex_proxy.CapabilityState.SUPPORTED.value)
             self.assertEqual(fields["usage_policy"], codex_proxy.USAGE_ASYNC_TAP)
             self.assertEqual(fields["repair_policy"], codex_proxy.REPAIR_NONE)
+            self.assertEqual(fields["capability_manifest_version"], "codexhub.route-capabilities.v1")
+            self.assertEqual(fields["tool_exposure_mode"], codex_proxy.ToolExposureMode.UNKNOWN.value)
+            self.assertEqual(fields["tool_capability_state"], codex_proxy.CapabilityState.UNQUALIFIED.value)
+            self.assertEqual(fields["collaboration_backend"], codex_proxy.CollaborationBackend.CLIENT_RUNTIME.value)
+            self.assertEqual(fields["execution_owner"], codex_proxy.ExecutionOwner.CODEX_CLIENT.value)
+            self.assertEqual(fields["streaming_policy"], codex_proxy.StreamingPolicy.TRANSPARENT.value)
+            self.assertEqual(fields["transport_policy"], codex_proxy.TransportPolicy.OFFICIAL_KEEPALIVE.value)
+            self.assertEqual(fields["mutation_summary"], [codex_proxy.RouteMutation.MODEL_ALIAS.value])
 
     def test_third_party_app_official_responses_nonstream_buffers_forced_sse(self):
         body = json.dumps(

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -394,43 +394,41 @@ class RelayPlanFixture:
         )
 
 
-RELAY_PLAN_FIXTURES = {
-    "gateway": RelayPlanFixture(
-        streaming_policy=codex_proxy.StreamingPolicy.GATEWAY_ADAPTED,
-        usage_policy=codex_proxy.UsagePolicy.SYNC_CAPTURE,
-        response_mutation_policy=codex_proxy.MutationPolicy.GATEWAY_COMPATIBILITY,
-        sse_mutation_policy=codex_proxy.MutationPolicy.GATEWAY_COMPATIBILITY,
-        verify_cross_protocol_source=False,
-    ),
-    "official_passthrough": RelayPlanFixture(
-        streaming_policy=codex_proxy.StreamingPolicy.OFFICIAL_PASSTHROUGH,
-        usage_policy=codex_proxy.UsagePolicy.SYNC_CAPTURE,
-        response_mutation_policy=codex_proxy.MutationPolicy.OFFICIAL_PASSTHROUGH,
-        sse_mutation_policy=codex_proxy.MutationPolicy.OFFICIAL_PASSTHROUGH,
-        verify_cross_protocol_source=False,
-    ),
-    "transparent": RelayPlanFixture(
-        streaming_policy=codex_proxy.StreamingPolicy.TRANSPARENT,
-        usage_policy=codex_proxy.UsagePolicy.ASYNC_TAP,
-        response_mutation_policy=codex_proxy.MutationPolicy.TRANSPARENT,
-        sse_mutation_policy=codex_proxy.MutationPolicy.TRANSPARENT,
-        verify_cross_protocol_source=False,
-    ),
-    "transparent_converted": RelayPlanFixture(
-        streaming_policy=codex_proxy.StreamingPolicy.TRANSPARENT_CONVERTED,
-        usage_policy=codex_proxy.UsagePolicy.ASYNC_TAP,
-        response_mutation_policy=codex_proxy.MutationPolicy.TRANSPARENT,
-        sse_mutation_policy=codex_proxy.MutationPolicy.TRANSPARENT,
-        verify_cross_protocol_source=True,
-    ),
-    "gateway_verified_conversion": RelayPlanFixture(
-        streaming_policy=codex_proxy.StreamingPolicy.GATEWAY_ADAPTED,
-        usage_policy=codex_proxy.UsagePolicy.SYNC_CAPTURE,
-        response_mutation_policy=codex_proxy.MutationPolicy.GATEWAY_COMPATIBILITY,
-        sse_mutation_policy=codex_proxy.MutationPolicy.GATEWAY_COMPATIBILITY,
-        verify_cross_protocol_source=True,
-    ),
-}
+RELAY_GATEWAY = RelayPlanFixture(
+    streaming_policy=codex_proxy.StreamingPolicy.GATEWAY_ADAPTED,
+    usage_policy=codex_proxy.UsagePolicy.SYNC_CAPTURE,
+    response_mutation_policy=codex_proxy.MutationPolicy.GATEWAY_COMPATIBILITY,
+    sse_mutation_policy=codex_proxy.MutationPolicy.GATEWAY_COMPATIBILITY,
+    verify_cross_protocol_source=False,
+)
+RELAY_OFFICIAL_PASSTHROUGH = RelayPlanFixture(
+    streaming_policy=codex_proxy.StreamingPolicy.OFFICIAL_PASSTHROUGH,
+    usage_policy=codex_proxy.UsagePolicy.SYNC_CAPTURE,
+    response_mutation_policy=codex_proxy.MutationPolicy.OFFICIAL_PASSTHROUGH,
+    sse_mutation_policy=codex_proxy.MutationPolicy.OFFICIAL_PASSTHROUGH,
+    verify_cross_protocol_source=False,
+)
+RELAY_TRANSPARENT = RelayPlanFixture(
+    streaming_policy=codex_proxy.StreamingPolicy.TRANSPARENT,
+    usage_policy=codex_proxy.UsagePolicy.ASYNC_TAP,
+    response_mutation_policy=codex_proxy.MutationPolicy.TRANSPARENT,
+    sse_mutation_policy=codex_proxy.MutationPolicy.TRANSPARENT,
+    verify_cross_protocol_source=False,
+)
+RELAY_TRANSPARENT_CONVERTED = RelayPlanFixture(
+    streaming_policy=codex_proxy.StreamingPolicy.TRANSPARENT_CONVERTED,
+    usage_policy=codex_proxy.UsagePolicy.ASYNC_TAP,
+    response_mutation_policy=codex_proxy.MutationPolicy.TRANSPARENT,
+    sse_mutation_policy=codex_proxy.MutationPolicy.TRANSPARENT,
+    verify_cross_protocol_source=True,
+)
+RELAY_GATEWAY_VERIFIED_CONVERSION = RelayPlanFixture(
+    streaming_policy=codex_proxy.StreamingPolicy.GATEWAY_ADAPTED,
+    usage_policy=codex_proxy.UsagePolicy.SYNC_CAPTURE,
+    response_mutation_policy=codex_proxy.MutationPolicy.GATEWAY_COMPATIBILITY,
+    sse_mutation_policy=codex_proxy.MutationPolicy.GATEWAY_COMPATIBILITY,
+    verify_cross_protocol_source=True,
+)
 
 
 def relay_upstream_response(
@@ -438,48 +436,24 @@ def relay_upstream_response(
     response,
     upstream_name,
     *args,
+    relay_fixture: RelayPlanFixture = RELAY_GATEWAY,
     **kwargs,
 ):
     """Call the production relay with an explicit typed policy fixture."""
 
-    legacy_fixture_profile = kwargs.pop("behavior_profile", None)
-    fixture_name = kwargs.pop(
-        "relay_fixture",
-        {
-            None: "gateway",
-            (
-                codex_proxy.BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH
-            ): "official_passthrough",
-            (
-                codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED
-            ): "transparent",
-        }.get(legacy_fixture_profile),
-    )
-    if fixture_name is None:
-        raise AssertionError(
-            f"relay test requires an explicit fixture: {legacy_fixture_profile!r}"
-        )
     upstream_format = kwargs.pop("upstream_format", "responses")
     request_kind = kwargs.pop(
         "request_kind",
         codex_proxy.RETRY_REQUEST_MAIN_GENERATION,
     )
-    fixture = RELAY_PLAN_FIXTURES[fixture_name]
-    verify_cross_protocol_source = kwargs.pop(
-        "verify_cross_protocol_source",
-        fixture.verify_cross_protocol_source,
-    )
     lifecycle_final_retry_enabled = kwargs.pop(
         "lifecycle_final_retry_enabled",
         False,
     )
-    relay_execution_plan = replace(
-        fixture.build(
-            selected_upstream_format=upstream_format,
-            request_kind=request_kind,
-            lifecycle_final_retry_enabled=lifecycle_final_retry_enabled,
-        ),
-        verify_cross_protocol_source=verify_cross_protocol_source,
+    relay_execution_plan = relay_fixture.build(
+        selected_upstream_format=upstream_format,
+        request_kind=request_kind,
+        lifecycle_final_retry_enabled=lifecycle_final_retry_enabled,
     )
     return CodexProxyHandler._relay_upstream_response(
         handler,
@@ -614,6 +588,25 @@ class RoutingTests(unittest.TestCase):
         }
         event_names = {call.args[0] for call in self.write_proxy_event.call_args_list if call.args}
         self.assertFalse(blocked & event_names, blocked & event_names)
+
+    def test_relay_test_helper_rejects_legacy_behavior_profile_selection(self):
+        with self.assertRaisesRegex(
+            TypeError,
+            "behavior_profile",
+        ):
+            relay_upstream_response(
+                FakeHandler(),
+                FakeResponse(b'{"id":"resp_fixture_contract","output":[]}'),
+                "volcengine",
+                request_id="req-fixture-contract",
+                model="volc/glm-5.2",
+                upstream_format="responses",
+                inbound_format="responses",
+                caller_stream=False,
+                behavior_profile=(
+                    codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED
+                ),
+            )
 
     def _write_official_publication_fence(
         self,
@@ -1502,13 +1495,6 @@ class RoutingTests(unittest.TestCase):
             {"client_id": "codex-app"},
             inbound_format="responses",
             model_requested="volc/glm-5.2",
-            operational_authentication=(
-                codex_proxy.materialize_operational_authentication(
-                    {},
-                    planned_upstream,
-                )
-            ),
-            incoming_headers={},
             runtime_facts=runtime_facts,
         )
         planned_attempt = replace(
@@ -1608,7 +1594,7 @@ class RoutingTests(unittest.TestCase):
             open_upstream.call_args.kwargs["transport_policy"],
             planned_attempt.transport_policy,
         )
-        build_headers.assert_not_called()
+        build_headers.assert_called_once()
         self.assertNotIn("request_kind", open_upstream.call_args.kwargs)
         self.assertNotIn("behavior_profile", relayed[0])
         relay_execution_plan = relayed[0]["relay_execution_plan"]
@@ -1629,7 +1615,7 @@ class RoutingTests(unittest.TestCase):
             planned_attempt.sse_mutation_policy,
         )
 
-    def test_handler_freezes_provider_auth_before_plan_returns_without_secret_exposure(self):
+    def test_handler_plans_before_materializing_and_freezes_provider_auth_without_secret_exposure(self):
         original_key = "route-plan-auth-sentinel-old"
         replacement_key = "route-plan-auth-sentinel-new"
         upstream = {
@@ -1654,16 +1640,35 @@ class RoutingTests(unittest.TestCase):
             lambda response, upstream_name, **kwargs: 200
         )
         plans: list[codex_proxy.RoutePlan] = []
+        bound_plans: list[codex_proxy.RoutePlan] = []
         opened_requests = []
+        execution_order: list[str] = []
         real_planner = codex_proxy.route_plan_for_request
+        real_materializer = codex_proxy.materialize_operational_authentication
+        real_binder = (
+            codex_proxy.bind_route_plan_operational_authentication
+        )
 
-        def plan_then_rotate_key(*args, **kwargs):
+        def record_plan(*args, **kwargs):
+            execution_order.append("plan")
             plan = real_planner(*args, **kwargs)
             plans.append(plan)
-            upstream["api_key"] = replacement_key
             return plan
 
+        def materialize_then_rotate_key(*args, **kwargs):
+            execution_order.append("materialize")
+            authentication = real_materializer(*args, **kwargs)
+            upstream["api_key"] = replacement_key
+            return authentication
+
+        def bind_authentication(*args, **kwargs):
+            execution_order.append("bind")
+            bound_plan = real_binder(*args, **kwargs)
+            bound_plans.append(bound_plan)
+            return bound_plan
+
         def open_upstream(request, **_kwargs):
+            execution_order.append("open")
             opened_requests.append(request)
             return FakeContextResponse(b'{"id":"resp_auth","output":[]}')
 
@@ -1671,7 +1676,23 @@ class RoutingTests(unittest.TestCase):
             patch("codex_proxy.choose_upstream", return_value=upstream),
             patch(
                 "codex_proxy.route_plan_for_request",
-                side_effect=plan_then_rotate_key,
+                side_effect=record_plan,
+            ),
+            patch(
+                "codex_proxy.materialize_operational_authentication",
+                side_effect=materialize_then_rotate_key,
+            ) as materialize_authentication,
+            patch(
+                "codex_proxy.bind_route_plan_operational_authentication",
+                side_effect=bind_authentication,
+            ) as bind_authentication,
+            patch(
+                "codex_proxy.upstream_headers",
+                wraps=codex_proxy.upstream_headers,
+            ) as build_headers,
+            patch(
+                "codex_proxy.codex_access_token",
+                side_effect=AssertionError("API-key route resolved Codex auth"),
             ),
             patch(
                 "codex_proxy._open_upstream_response",
@@ -1684,18 +1705,27 @@ class RoutingTests(unittest.TestCase):
             )
 
         self.assertEqual(
+            execution_order,
+            ["plan", "materialize", "bind", "open"],
+        )
+        materialize_authentication.assert_called_once()
+        bind_authentication.assert_called_once()
+        build_headers.assert_called_once()
+        self.assertEqual(
             opened_requests[0].get_header("Authorization"),
             f"Bearer {original_key}",
         )
-        rendered_plan = repr(plans[0])
-        rendered_copy = repr(asdict(plans[0]))
+        rendered_plan = repr((plans[0], bound_plans[0]))
+        rendered_copy = repr(
+            (asdict(plans[0]), asdict(bound_plans[0]))
+        )
         rendered_events = repr(self.write_proxy_event.call_args_list)
         for secret in (original_key, replacement_key):
             self.assertNotIn(secret, rendered_plan)
             self.assertNotIn(secret, rendered_copy)
             self.assertNotIn(secret, rendered_events)
 
-    def test_operational_auth_snapshot_refreshes_only_on_the_next_plan(self):
+    def test_operational_auth_snapshot_refreshes_only_on_the_next_request_binding(self):
         def planned_headers(upstream, incoming_headers):
             authentication = (
                 codex_proxy.materialize_operational_authentication(
@@ -1708,9 +1738,13 @@ class RoutingTests(unittest.TestCase):
                 {"client_id": "codex-app"},
                 inbound_format="responses",
                 model_requested="volc/glm-5.2",
-                operational_authentication=authentication,
-                incoming_headers=incoming_headers,
                 official_http_passthrough_enabled=False,
+            )
+            plan = codex_proxy.bind_route_plan_operational_authentication(
+                plan,
+                incoming_headers,
+                upstream,
+                authentication,
             )
             return plan, plan.attempts[0].request_headers.to_dict()
 
@@ -1793,18 +1827,30 @@ class RoutingTests(unittest.TestCase):
                 {},
                 inbound_format="responses",
                 model_requested="openai/gpt-5.6-sol",
-                operational_authentication=official_authentication,
-                incoming_headers={},
                 official_http_passthrough_enabled=False,
+            )
+            official_plan = (
+                codex_proxy.bind_route_plan_operational_authentication(
+                    official_plan,
+                    {},
+                    official_provider,
+                    official_authentication,
+                )
             )
             repeated_official_plan = codex_proxy.route_plan_for_request(
                 official_provider,
                 {},
                 inbound_format="responses",
                 model_requested="openai/gpt-5.6-sol",
-                operational_authentication=official_authentication,
-                incoming_headers={},
                 official_http_passthrough_enabled=False,
+            )
+            repeated_official_plan = (
+                codex_proxy.bind_route_plan_operational_authentication(
+                    repeated_official_plan,
+                    {},
+                    official_provider,
+                    official_authentication,
+                )
             )
         official_headers = (
             official_plan.attempts[0].request_headers.to_dict()
@@ -1836,13 +1882,6 @@ class RoutingTests(unittest.TestCase):
             {"client_id": "codex-app"},
             inbound_format="responses",
             model_requested="volc/glm-5.2",
-            operational_authentication=(
-                codex_proxy.materialize_operational_authentication(
-                    {},
-                    upstream,
-                )
-            ),
-            incoming_headers={},
         )
         future_policy_attempt = replace(
             planned.attempts[0],
@@ -2104,7 +2143,7 @@ class RoutingTests(unittest.TestCase):
                     upstream_format="responses",
                     inbound_format="responses",
                     caller_stream=caller_stream,
-                    verify_cross_protocol_source=True,
+                    relay_fixture=RELAY_GATEWAY_VERIFIED_CONVERSION,
                     usage_capture=usage_capture,
                 )
 
@@ -2818,6 +2857,260 @@ class RoutingTests(unittest.TestCase):
                     capability_state.value,
                 )
                 self.assertEqual(request_error["error"], error_name)
+                self.write_proxy_event.reset_mock()
+
+    def test_no_attempt_observation_preserves_compact_api_key_route_facts(self):
+        plan = codex_proxy.route_plan_for_request(
+            {
+                "name": "volcengine",
+                "base_url": "https://ark.example.test/v1",
+                "auth": "api_key",
+                "api_key": "observation-only-secret",
+                "upstream_model": "glm-5.2",
+                "upstream_format": "anthropic_messages",
+            },
+            {"client_id": "codex-app"},
+            inbound_format="responses",
+            model_requested="volc/glm-5.2",
+            request_kind=codex_proxy.RETRY_REQUEST_COMPACT,
+        )
+
+        self.assertEqual(plan.attempts, ())
+        fields = codex_proxy._route_plan_event_fields(plan)
+        self.assertEqual(
+            fields["request_kind"],
+            codex_proxy.RETRY_REQUEST_COMPACT,
+        )
+        self.assertEqual(
+            fields["authentication_strategy"],
+            codex_proxy.AuthenticationStrategy.API_KEY.value,
+        )
+        self.assertNotIn("observation-only-secret", repr(plan))
+        self.assertNotIn("observation-only-secret", repr(fields))
+
+    def test_stale_route_capability_binding_fails_closed_before_auth_mutation_or_io(self):
+        binding = {
+            "schema_version": 1,
+            "provider": "volc",
+            "model": "glm-5.2",
+            "upstream_protocol": "responses",
+            "qualification_state": "supported",
+            "advanced_capabilities_enabled": True,
+        }
+        self.external_model.update(
+            api_key="stale-binding-secret",
+            upstream_format="chat_completions",
+            capability_binding=binding,
+        )
+        upstream = choose_upstream("volc/glm-5.2")
+        self.assertEqual(upstream["capability_binding"], binding)
+        current_binding_upstream = {
+            **upstream,
+            "capability_binding": {
+                **upstream["capability_binding"],
+                "upstream_protocol": "chat_completions",
+            },
+        }
+        current_plan = codex_proxy.route_plan_for_request(
+            current_binding_upstream,
+            {"client_id": "codex-app"},
+            inbound_format="responses",
+            model_requested="volc/glm-5.2",
+        )
+        self.assertEqual(
+            current_plan.capability_binding.route_scope_state,
+            codex_proxy.CapabilityState.SUPPORTED,
+        )
+        self.assertEqual(len(current_plan.attempts), 1)
+
+        plan = codex_proxy.route_plan_for_request(
+            upstream,
+            {"client_id": "codex-app"},
+            inbound_format="responses",
+            model_requested="volc/glm-5.2",
+        )
+
+        self.assertEqual(
+            plan.configured_upstream_protocol,
+            codex_proxy.RouteProtocol.CHAT_COMPLETIONS,
+        )
+        self.assertEqual(
+            plan.capability_binding.binding_upstream_protocol,
+            codex_proxy.RouteProtocol.RESPONSES,
+        )
+        self.assertEqual(
+            plan.capability_binding.route_scope_state,
+            codex_proxy.CapabilityState.UNQUALIFIED,
+        )
+        self.assertEqual(
+            plan.protocol_capability_state,
+            codex_proxy.CapabilityState.UNQUALIFIED,
+        )
+        self.assertEqual(plan.attempts, ())
+        self.assertEqual(
+            plan.tool_exposure.effective_mode,
+            codex_proxy.ToolExposureMode.CURRENT_COMPATIBILITY,
+        )
+        self.assertEqual(
+            plan.capability_binding.route_scope_failure_reason,
+            "binding_upstream_protocol_mismatch",
+        )
+
+        body = json.dumps(
+            {
+                "model": "volc/glm-5.2",
+                "input": [{"role": "user", "content": "hi"}],
+                "stream": False,
+            }
+        ).encode("utf-8")
+        handler, fake = post_handler("/v1/responses", body)
+        with (
+            patch(
+                "codex_proxy.materialize_operational_authentication",
+                side_effect=AssertionError(
+                    "stale binding materialized authentication"
+                ),
+            ) as materialize_authentication,
+            patch(
+                "codex_proxy.compatible_request_body",
+                side_effect=AssertionError("stale binding mutated request"),
+            ) as mutate_request,
+            patch(
+                "codex_proxy._open_upstream_response",
+                side_effect=AssertionError(
+                    "stale binding reached upstream network"
+                ),
+            ) as open_upstream,
+        ):
+            CodexProxyHandler._proxy_post_request(
+                handler,
+                inbound_format="responses",
+            )
+
+        materialize_authentication.assert_not_called()
+        mutate_request.assert_not_called()
+        open_upstream.assert_not_called()
+        self.assertEqual(fake.status, 400)
+        request_error = next(
+            call.kwargs
+            for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] == "request_error"
+        )
+        self.assertEqual(
+            request_error["capability_binding_route_scope_state"],
+            codex_proxy.CapabilityState.UNQUALIFIED.value,
+        )
+        self.assertEqual(
+            request_error["capability_binding_route_scope_failure_reason"],
+            "binding_upstream_protocol_mismatch",
+        )
+        self.assertNotIn("stale-binding-secret", repr(request_error))
+
+    def test_non_executable_official_routes_do_not_materialize_codex_auth_or_open_network(self):
+        official_upstream = {
+            "name": "official",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "auth": "codex_auth",
+            "upstream_model": "gpt-5.5",
+            "upstream_format": "responses",
+            "reports_cached_input_tokens": True,
+        }
+        cases = (
+            {
+                "name": "unsupported_anthropic",
+                "upstream_format": "anthropic_messages",
+                "input": [{"role": "user", "content": "hi"}],
+                "target_accepts_images": True,
+                "expected_error": "UnsupportedRouteProtocolError",
+                "expected_status": 400,
+            },
+            {
+                "name": "vision_reject",
+                "upstream_format": "responses",
+                "input": [
+                    {
+                        "type": "message",
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "input_image",
+                                "image_url": "data:image/png;base64,abc",
+                            }
+                        ],
+                    }
+                ],
+                "target_accepts_images": False,
+                "expected_error": "ImageProxyError",
+                "expected_status": 502,
+            },
+        )
+
+        for case in cases:
+            with self.subTest(case=case["name"]):
+                upstream = {
+                    **official_upstream,
+                    "upstream_format": case["upstream_format"],
+                }
+                body = json.dumps(
+                    {
+                        "model": "openai/gpt-5.5",
+                        "input": case["input"],
+                        "stream": False,
+                    }
+                ).encode("utf-8")
+                handler, fake = post_handler("/v1/responses", body)
+
+                with (
+                    patch("codex_proxy.choose_upstream", return_value=upstream),
+                    patch(
+                        "codex_proxy.model_supports_image",
+                        return_value=case["target_accepts_images"],
+                    ),
+                    patch(
+                        "codex_proxy.gateway_image_proxy_enabled",
+                        return_value=False,
+                    ),
+                    patch(
+                        "codex_proxy.materialize_operational_authentication",
+                        side_effect=AssertionError(
+                            "non-executable route materialized authentication"
+                        ),
+                    ) as materialize_authentication,
+                    patch(
+                        "codex_proxy.codex_access_token",
+                        side_effect=AssertionError(
+                            "non-executable route resolved/refreshed Codex auth"
+                        ),
+                    ) as access_token,
+                    patch(
+                        "codex_proxy.codex_account_id",
+                        side_effect=AssertionError(
+                            "non-executable route read Codex account auth"
+                        ),
+                    ) as account_id,
+                    patch(
+                        "codex_proxy._open_upstream_response",
+                        side_effect=AssertionError(
+                            "non-executable route reached upstream network"
+                        ),
+                    ) as open_upstream,
+                ):
+                    CodexProxyHandler._proxy_post_request(
+                        handler,
+                        inbound_format="responses",
+                    )
+
+                materialize_authentication.assert_not_called()
+                access_token.assert_not_called()
+                account_id.assert_not_called()
+                open_upstream.assert_not_called()
+                self.assertEqual(fake.status, case["expected_status"])
+                request_error = next(
+                    call.kwargs
+                    for call in self.write_proxy_event.call_args_list
+                    if call.args and call.args[0] == "request_error"
+                )
+                self.assertEqual(request_error["error"], case["expected_error"])
                 self.write_proxy_event.reset_mock()
 
     def test_third_party_app_official_responses_uses_transparent_metered_runtime_path(self):
@@ -4439,7 +4732,7 @@ class RoutingTests(unittest.TestCase):
                 upstream_format="responses",
                 inbound_format="responses",
                 caller_stream=True,
-                behavior_profile=codex_proxy.BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH,
+                relay_fixture=RELAY_OFFICIAL_PASSTHROUGH,
                 usage_capture={},
             )
 
@@ -4479,7 +4772,7 @@ class RoutingTests(unittest.TestCase):
             upstream_format="responses",
             inbound_format="responses",
             caller_stream=True,
-            behavior_profile=codex_proxy.BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH,
+            relay_fixture=RELAY_OFFICIAL_PASSTHROUGH,
             usage_capture=usage_capture,
         )
 
@@ -4577,7 +4870,7 @@ class RoutingTests(unittest.TestCase):
             upstream_format="responses",
             inbound_format="responses",
             caller_stream=True,
-            behavior_profile=codex_proxy.BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH,
+            relay_fixture=RELAY_OFFICIAL_PASSTHROUGH,
             usage_capture=usage_capture,
         )
 
@@ -4608,7 +4901,7 @@ class RoutingTests(unittest.TestCase):
             upstream_format="responses",
             inbound_format="responses",
             caller_stream=False,
-            behavior_profile=codex_proxy.BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH,
+            relay_fixture=RELAY_OFFICIAL_PASSTHROUGH,
             usage_capture={},
         )
 
@@ -4735,7 +5028,7 @@ class RoutingTests(unittest.TestCase):
             upstream_format="responses",
             inbound_format="responses",
             caller_stream=True,
-            behavior_profile=codex_proxy.BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH,
+            relay_fixture=RELAY_OFFICIAL_PASSTHROUGH,
             usage_capture={},
         )
 
@@ -4770,7 +5063,7 @@ class RoutingTests(unittest.TestCase):
                 upstream_format="responses",
                 inbound_format="responses",
                 caller_stream=True,
-                behavior_profile=codex_proxy.BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH,
+                relay_fixture=RELAY_OFFICIAL_PASSTHROUGH,
                 usage_capture=usage_capture,
             )
 
@@ -4808,7 +5101,7 @@ class RoutingTests(unittest.TestCase):
             upstream_format="responses",
             inbound_format="responses",
             caller_stream=True,
-            behavior_profile=codex_proxy.BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH,
+            relay_fixture=RELAY_OFFICIAL_PASSTHROUGH,
             usage_capture={},
         )
 
@@ -4841,7 +5134,7 @@ class RoutingTests(unittest.TestCase):
                 upstream_format="responses",
                 inbound_format="responses",
                 caller_stream=True,
-                behavior_profile=codex_proxy.BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH,
+                relay_fixture=RELAY_OFFICIAL_PASSTHROUGH,
                 usage_capture=usage_capture,
             )
 
@@ -4874,7 +5167,7 @@ class RoutingTests(unittest.TestCase):
             upstream_format="responses",
             inbound_format="responses",
             caller_stream=True,
-            behavior_profile=codex_proxy.BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH,
+            relay_fixture=RELAY_OFFICIAL_PASSTHROUGH,
             usage_capture={},
         )
 
@@ -4901,7 +5194,7 @@ class RoutingTests(unittest.TestCase):
                 upstream_format="responses",
                 inbound_format="responses",
                 caller_stream=True,
-                behavior_profile=codex_proxy.BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH,
+                relay_fixture=RELAY_OFFICIAL_PASSTHROUGH,
                 usage_capture={},
             )
 
@@ -4943,7 +5236,7 @@ class RoutingTests(unittest.TestCase):
                 upstream_format="responses",
                 inbound_format="responses",
                 caller_stream=True,
-                behavior_profile=codex_proxy.BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH,
+                relay_fixture=RELAY_OFFICIAL_PASSTHROUGH,
                 usage_capture={},
             )
 
@@ -4985,7 +5278,7 @@ class RoutingTests(unittest.TestCase):
                 upstream_format="responses",
                 inbound_format="responses",
                 caller_stream=True,
-                behavior_profile=codex_proxy.BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH,
+                relay_fixture=RELAY_OFFICIAL_PASSTHROUGH,
                 usage_capture={},
             )
 
@@ -5024,7 +5317,7 @@ class RoutingTests(unittest.TestCase):
                 upstream_format="responses",
                 inbound_format="responses",
                 caller_stream=True,
-                behavior_profile=codex_proxy.BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH,
+                relay_fixture=RELAY_OFFICIAL_PASSTHROUGH,
                 usage_capture={},
             )
 
@@ -5059,7 +5352,7 @@ class RoutingTests(unittest.TestCase):
                 upstream_format="responses",
                 inbound_format="responses",
                 caller_stream=True,
-                behavior_profile=codex_proxy.BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH,
+                relay_fixture=RELAY_OFFICIAL_PASSTHROUGH,
                 usage_capture={},
             )
 
@@ -5093,7 +5386,7 @@ class RoutingTests(unittest.TestCase):
                 upstream_format="responses",
                 inbound_format="responses",
                 caller_stream=True,
-                behavior_profile=codex_proxy.BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH,
+                relay_fixture=RELAY_OFFICIAL_PASSTHROUGH,
                 usage_capture={},
             )
 
@@ -5135,7 +5428,7 @@ class RoutingTests(unittest.TestCase):
                 upstream_format="responses",
                 inbound_format="responses",
                 caller_stream=True,
-                behavior_profile=codex_proxy.BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH,
+                relay_fixture=RELAY_OFFICIAL_PASSTHROUGH,
                 usage_capture={},
             )
 
@@ -5170,7 +5463,7 @@ class RoutingTests(unittest.TestCase):
             upstream_format="responses",
             inbound_format="responses",
             caller_stream=True,
-            behavior_profile=codex_proxy.BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH,
+            relay_fixture=RELAY_OFFICIAL_PASSTHROUGH,
             usage_capture={},
         )
 
@@ -5200,7 +5493,7 @@ class RoutingTests(unittest.TestCase):
             upstream_format="chat_completions",
             inbound_format="chat_completions",
             caller_stream=True,
-            behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+            relay_fixture=RELAY_TRANSPARENT,
             usage_capture={},
         )
 
@@ -5237,7 +5530,7 @@ class RoutingTests(unittest.TestCase):
                     upstream_format="responses",
                     inbound_format="responses",
                     caller_stream=True,
-                    behavior_profile=codex_proxy.BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH,
+                    relay_fixture=RELAY_OFFICIAL_PASSTHROUGH,
                     usage_capture={},
                 )
             thread.join(timeout=1)
@@ -5344,7 +5637,7 @@ class RoutingTests(unittest.TestCase):
                     upstream_format="responses",
                     inbound_format="responses",
                     caller_stream=True,
-                    behavior_profile=codex_proxy.BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH,
+                    relay_fixture=RELAY_OFFICIAL_PASSTHROUGH,
                     usage_capture={},
                 )
             thread.join(timeout=1)
@@ -5397,7 +5690,7 @@ class RoutingTests(unittest.TestCase):
                     upstream_format="responses",
                     inbound_format="responses",
                     caller_stream=True,
-                    behavior_profile=codex_proxy.BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH,
+                    relay_fixture=RELAY_OFFICIAL_PASSTHROUGH,
                     usage_capture={},
                 )
             thread.join(timeout=1)
@@ -5437,7 +5730,7 @@ class RoutingTests(unittest.TestCase):
                 "upstream_name": "official",
                 "upstream_format": "responses",
                 "inbound_format": "responses",
-                "behavior_profile": codex_proxy.BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH,
+                "relay_fixture": RELAY_OFFICIAL_PASSTHROUGH,
                 "lines": response_events,
                 "terminal": b"response.completed",
             },
@@ -5446,7 +5739,7 @@ class RoutingTests(unittest.TestCase):
                 "upstream_name": "official",
                 "upstream_format": "responses",
                 "inbound_format": "chat_completions",
-                "behavior_profile": None,
+                "relay_fixture": RELAY_GATEWAY,
                 "lines": response_events,
                 "terminal": b"data: [DONE]",
             },
@@ -5455,7 +5748,7 @@ class RoutingTests(unittest.TestCase):
                 "upstream_name": "volcengine",
                 "upstream_format": "responses",
                 "inbound_format": "responses",
-                "behavior_profile": codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+                "relay_fixture": RELAY_TRANSPARENT,
                 "lines": response_events,
                 "terminal": b"response.completed",
             },
@@ -5464,7 +5757,7 @@ class RoutingTests(unittest.TestCase):
                 "upstream_name": "ollama_cloud",
                 "upstream_format": "chat_completions",
                 "inbound_format": "chat_completions",
-                "behavior_profile": codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+                "relay_fixture": RELAY_TRANSPARENT,
                 "lines": chat_events,
                 "terminal": b"data: [DONE]",
             },
@@ -5488,7 +5781,7 @@ class RoutingTests(unittest.TestCase):
                     upstream_format=case["upstream_format"],
                     inbound_format=case["inbound_format"],
                     caller_stream=True,
-                    behavior_profile=case["behavior_profile"],
+                    relay_fixture=case["relay_fixture"],
                     usage_capture={},
                 )
                 with result_lock:
@@ -5551,8 +5844,7 @@ class RoutingTests(unittest.TestCase):
             upstream_format="responses",
             inbound_format="chat_completions",
             caller_stream=True,
-            behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
-            relay_fixture="transparent_converted",
+            relay_fixture=RELAY_TRANSPARENT_CONVERTED,
             usage_capture={},
         )
 
@@ -5591,8 +5883,7 @@ class RoutingTests(unittest.TestCase):
             upstream_format="chat_completions",
             inbound_format="responses",
             caller_stream=True,
-            behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
-            relay_fixture="transparent_converted",
+            relay_fixture=RELAY_TRANSPARENT_CONVERTED,
             usage_capture={},
         )
 
@@ -5625,8 +5916,7 @@ class RoutingTests(unittest.TestCase):
             upstream_format="responses",
             inbound_format="chat_completions",
             caller_stream=True,
-            behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
-            relay_fixture="transparent_converted",
+            relay_fixture=RELAY_TRANSPARENT_CONVERTED,
             usage_capture={},
         )
 
@@ -5681,8 +5971,7 @@ class RoutingTests(unittest.TestCase):
                     upstream_format=upstream_format,
                     inbound_format=inbound_format,
                     caller_stream=True,
-                    behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
-                    relay_fixture="transparent_converted",
+                    relay_fixture=RELAY_TRANSPARENT_CONVERTED,
                     usage_capture={},
                 )
 
@@ -5738,7 +6027,7 @@ class RoutingTests(unittest.TestCase):
                     upstream_format=upstream_format,
                     inbound_format=inbound_format,
                     caller_stream=True,
-                    behavior_profile=None,
+                    relay_fixture=RELAY_GATEWAY,
                     usage_capture={},
                 )
 
@@ -5769,7 +6058,7 @@ class RoutingTests(unittest.TestCase):
             upstream_format="responses",
             inbound_format="responses",
             caller_stream=False,
-            behavior_profile=None,
+            relay_fixture=RELAY_GATEWAY,
             usage_capture={},
         )
 
@@ -5863,8 +6152,7 @@ class RoutingTests(unittest.TestCase):
             upstream_format="chat_completions",
             inbound_format="responses",
             caller_stream=False,
-            behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
-            relay_fixture="transparent_converted",
+            relay_fixture=RELAY_TRANSPARENT_CONVERTED,
             usage_capture={},
         )
 
@@ -5940,8 +6228,7 @@ class RoutingTests(unittest.TestCase):
             upstream_format="chat_completions",
             inbound_format="responses",
             caller_stream=False,
-            behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
-            relay_fixture="transparent_converted",
+            relay_fixture=RELAY_TRANSPARENT_CONVERTED,
             usage_capture={},
         )
 
@@ -5998,8 +6285,7 @@ class RoutingTests(unittest.TestCase):
             upstream_format="chat_completions",
             inbound_format="responses",
             caller_stream=False,
-            behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
-            relay_fixture="transparent_converted",
+            relay_fixture=RELAY_TRANSPARENT_CONVERTED,
             usage_capture={},
         )
 
@@ -6075,8 +6361,7 @@ class RoutingTests(unittest.TestCase):
                         upstream_format=upstream_format,
                         inbound_format=inbound_format,
                         caller_stream=True,
-                        behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
-                        relay_fixture="transparent_converted",
+                        relay_fixture=RELAY_TRANSPARENT_CONVERTED,
                         usage_capture={},
                     )
                     self.assertEqual(status, 200)
@@ -6153,8 +6438,7 @@ class RoutingTests(unittest.TestCase):
             upstream_format="chat_completions",
             inbound_format="responses",
             caller_stream=True,
-            behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
-            relay_fixture="transparent_converted",
+            relay_fixture=RELAY_TRANSPARENT_CONVERTED,
             usage_capture={},
         )
 
@@ -6545,8 +6829,7 @@ class RoutingTests(unittest.TestCase):
                     "repair_policy": codex_proxy.REPAIR_CODEX_SUBAGENT,
                     "subagent_lifecycle_complete": True,
                 },
-                behavior_profile=codex_proxy.BEHAVIOR_OFFICIAL_GATEWAY_COMPAT,
-                relay_fixture="gateway_verified_conversion",
+                relay_fixture=RELAY_GATEWAY_VERIFIED_CONVERSION,
                 lifecycle_final_retry_enabled=True,
             )
 
@@ -15003,8 +15286,7 @@ class RoutingTests(unittest.TestCase):
             inbound_format="responses",
             caller_stream=True,
             event_context={"client_id": "omp", "client_inference_source": "header"},
-            behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
-            relay_fixture="transparent_converted",
+            relay_fixture=RELAY_TRANSPARENT_CONVERTED,
         )
 
         self.assertEqual(status, 499)
@@ -15713,7 +15995,7 @@ class RoutingTests(unittest.TestCase):
                 upstream_format="responses",
                 inbound_format="responses",
                 caller_stream=True,
-                behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+                relay_fixture=RELAY_TRANSPARENT,
                 defer_stream_errors=True,
             )
 
@@ -15752,7 +16034,7 @@ class RoutingTests(unittest.TestCase):
                 upstream_format="responses",
                 inbound_format="responses",
                 caller_stream=True,
-                behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+                relay_fixture=RELAY_TRANSPARENT,
                 defer_stream_errors=True,
             )
 
@@ -15782,7 +16064,7 @@ class RoutingTests(unittest.TestCase):
             upstream_format="responses",
             inbound_format="responses",
             caller_stream=True,
-            behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+            relay_fixture=RELAY_TRANSPARENT,
         )
 
         data = b"".join(handler.wfile.writes)
@@ -15825,7 +16107,7 @@ class RoutingTests(unittest.TestCase):
             upstream_format="responses",
             inbound_format="responses",
             caller_stream=True,
-            behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+            relay_fixture=RELAY_TRANSPARENT,
             usage_capture=usage_capture,
         )
 
@@ -15876,7 +16158,7 @@ class RoutingTests(unittest.TestCase):
             upstream_format="responses",
             inbound_format="responses",
             caller_stream=True,
-            behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+            relay_fixture=RELAY_TRANSPARENT,
         )
 
         body = b"".join(handler.wfile.writes)
@@ -15920,7 +16202,7 @@ class RoutingTests(unittest.TestCase):
             upstream_format="responses",
             inbound_format="responses",
             caller_stream=True,
-            behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+            relay_fixture=RELAY_TRANSPARENT,
         )
 
         body = b"".join(handler.wfile.writes)
@@ -15953,7 +16235,7 @@ class RoutingTests(unittest.TestCase):
             upstream_format="responses",
             inbound_format="responses",
             caller_stream=True,
-            behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+            relay_fixture=RELAY_TRANSPARENT,
         )
 
         events = SseEventAssembler().feed(b"".join(handler.wfile.writes))
@@ -15984,7 +16266,7 @@ class RoutingTests(unittest.TestCase):
             upstream_format="responses",
             inbound_format="responses",
             caller_stream=True,
-            behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+            relay_fixture=RELAY_TRANSPARENT,
         )
 
         data = b"".join(handler.wfile.writes)
@@ -16014,7 +16296,7 @@ class RoutingTests(unittest.TestCase):
             upstream_format="responses",
             inbound_format="responses",
             caller_stream=True,
-            behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+            relay_fixture=RELAY_TRANSPARENT,
         )
 
         data = b"".join(handler.wfile.writes)
@@ -16049,7 +16331,7 @@ class RoutingTests(unittest.TestCase):
             upstream_format="chat_completions",
             inbound_format="chat_completions",
             caller_stream=True,
-            behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+            relay_fixture=RELAY_TRANSPARENT,
         )
 
         data = b"".join(handler.wfile.writes)
@@ -16091,7 +16373,7 @@ class RoutingTests(unittest.TestCase):
             upstream_format="chat_completions",
             inbound_format="chat_completions",
             caller_stream=True,
-            behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+            relay_fixture=RELAY_TRANSPARENT,
             usage_capture=usage_capture,
         )
 
@@ -16139,7 +16421,7 @@ class RoutingTests(unittest.TestCase):
             upstream_format="chat_completions",
             inbound_format="chat_completions",
             caller_stream=True,
-            behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+            relay_fixture=RELAY_TRANSPARENT,
         )
 
         data = b"".join(handler.wfile.writes)
@@ -16164,7 +16446,7 @@ class RoutingTests(unittest.TestCase):
             upstream_format="chat_completions",
             inbound_format="chat_completions",
             caller_stream=True,
-            behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+            relay_fixture=RELAY_TRANSPARENT,
         )
 
         data = b"".join(handler.wfile.writes)
@@ -16249,7 +16531,7 @@ class RoutingTests(unittest.TestCase):
             upstream_format="chat_completions",
             inbound_format="chat_completions",
             caller_stream=True,
-            behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
+            relay_fixture=RELAY_TRANSPARENT,
         )
 
         data = b"".join(handler.wfile.writes)
@@ -20393,8 +20675,7 @@ Execution constraints:
             inbound_format="responses",
             caller_stream=True,
             event_context=close_context,
-            behavior_profile=codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
-            relay_fixture="transparent_converted",
+            relay_fixture=RELAY_TRANSPARENT_CONVERTED,
         )
 
         diagnostic_names = {

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -889,7 +889,16 @@ class RoutingTests(unittest.TestCase):
                 self.assertEqual(plan.inbound_protocol, expected["inbound_protocol"])
                 self.assertEqual(plan.upstream_protocol, expected["upstream_protocol"])
                 self.assertEqual(plan.wire_format_adapter, expected["wire_format_adapter"])
-                self.assertEqual(plan.capability_manifest_version, "codexhub.route-capabilities.v1")
+                self.assertEqual(
+                    plan.schema_version,
+                    codex_proxy.ROUTE_PLAN_SCHEMA_VERSION,
+                )
+                self.assertIsNone(plan.capability_manifest_version)
+                self.assertIsNone(plan.capability_manifest_hash)
+                self.assertEqual(
+                    plan.capability_manifest_state,
+                    codex_proxy.CapabilityState.UNQUALIFIED,
+                )
                 self.assertEqual(plan.tool_exposure.requested_mode, expected["tool_mode"])
                 self.assertEqual(plan.tool_exposure.effective_mode, expected["effective_tool_mode"])
                 self.assertEqual(plan.tool_exposure.capability_state, expected["tool_state"])
@@ -915,21 +924,30 @@ class RoutingTests(unittest.TestCase):
             (
                 codex_proxy.ToolExposureMode.NATIVE_DEFERRED_SEARCH_CANDIDATE.value,
                 codex_proxy.CapabilityState.UNQUALIFIED,
+                codex_proxy.CapabilityState.UNQUALIFIED,
                 (),
             ),
             (
                 codex_proxy.ToolExposureMode.NATIVE_NO_SEARCH_CANDIDATE.value,
+                codex_proxy.CapabilityState.UNQUALIFIED,
                 codex_proxy.CapabilityState.UNQUALIFIED,
                 ("function", "custom"),
             ),
             (
                 codex_proxy.ToolExposureMode.UNKNOWN.value,
                 codex_proxy.CapabilityState.UNSUPPORTED,
+                codex_proxy.CapabilityState.UNQUALIFIED,
+                (),
+            ),
+            (
+                codex_proxy.ToolExposureMode.UNSUPPORTED.value,
+                codex_proxy.CapabilityState.UNSUPPORTED,
+                codex_proxy.CapabilityState.UNSUPPORTED,
                 (),
             ),
         )
 
-        for requested_mode, capability_state, proven_tool_subset in cases:
+        for requested_mode, reported_state, expected_state, proven_tool_subset in cases:
             with self.subTest(requested_mode=requested_mode):
                 plan = codex_proxy.route_plan_for_request(
                     {
@@ -938,7 +956,7 @@ class RoutingTests(unittest.TestCase):
                         "upstream_model": "glm-5.2",
                         "upstream_format": "responses",
                         "tool_exposure_mode": requested_mode,
-                        "tool_capability_state": capability_state.value,
+                        "tool_capability_state": reported_state.value,
                         "proven_tool_subset": proven_tool_subset,
                     },
                     {"client_id": "codex-app"},
@@ -948,7 +966,7 @@ class RoutingTests(unittest.TestCase):
 
                 self.assertEqual(plan.tool_exposure.requested_mode.value, requested_mode)
                 self.assertEqual(plan.tool_exposure.effective_mode, codex_proxy.ToolExposureMode.CURRENT_COMPATIBILITY)
-                self.assertEqual(plan.tool_exposure.capability_state, capability_state)
+                self.assertEqual(plan.tool_exposure.capability_state, expected_state)
                 self.assertEqual(plan.tool_exposure.proven_tool_subset, proven_tool_subset)
                 self.assertTrue(plan.tool_exposure.gateway_schema_injection)
                 self.assertEqual(plan.behavior_profile, codex_proxy.BEHAVIOR_CODEX_APP_EXTERNAL_ADAPTER)
@@ -973,6 +991,394 @@ class RoutingTests(unittest.TestCase):
             plan.behavior_profile = codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED
         with self.assertRaises(AttributeError):
             plan.tool_exposure.gateway_schema_injection = False
+
+    def test_route_plan_makes_schema_injection_and_repair_request_scoped(self):
+        cases = (
+            {
+                "name": "normal_compatibility",
+                "request_kind": codex_proxy.RETRY_REQUEST_MAIN_GENERATION,
+                "raw_provider_probe": False,
+                "tool_mode": codex_proxy.ToolExposureMode.CURRENT_COMPATIBILITY.value,
+                "reported_state": codex_proxy.CapabilityState.SUPPORTED.value,
+                "expected_injection": True,
+                "expected_repair": codex_proxy.REPAIR_CODEX_SUBAGENT,
+                "expected_state": codex_proxy.CapabilityState.SUPPORTED,
+            },
+            {
+                "name": "compact",
+                "request_kind": codex_proxy.RETRY_REQUEST_COMPACT,
+                "raw_provider_probe": False,
+                "tool_mode": codex_proxy.ToolExposureMode.CURRENT_COMPATIBILITY.value,
+                "reported_state": codex_proxy.CapabilityState.SUPPORTED.value,
+                "expected_injection": False,
+                "expected_repair": codex_proxy.REPAIR_CODEX_SUBAGENT,
+                "expected_state": codex_proxy.CapabilityState.SUPPORTED,
+            },
+            {
+                "name": "raw_probe",
+                "request_kind": codex_proxy.RETRY_REQUEST_MAIN_GENERATION,
+                "raw_provider_probe": True,
+                "tool_mode": codex_proxy.ToolExposureMode.CURRENT_COMPATIBILITY.value,
+                "reported_state": codex_proxy.CapabilityState.SUPPORTED.value,
+                "expected_injection": False,
+                "expected_repair": codex_proxy.REPAIR_NONE,
+                "expected_state": codex_proxy.CapabilityState.SUPPORTED,
+            },
+            {
+                "name": "unresolved_native_candidate",
+                "request_kind": codex_proxy.RETRY_REQUEST_MAIN_GENERATION,
+                "raw_provider_probe": False,
+                "tool_mode": codex_proxy.ToolExposureMode.NATIVE_DEFERRED_SEARCH_CANDIDATE.value,
+                "reported_state": codex_proxy.CapabilityState.SUPPORTED.value,
+                "expected_injection": True,
+                "expected_repair": codex_proxy.REPAIR_CODEX_SUBAGENT,
+                "expected_state": codex_proxy.CapabilityState.UNQUALIFIED,
+            },
+        )
+
+        for case in cases:
+            with self.subTest(case=case["name"]):
+                plan = codex_proxy.route_plan_for_request(
+                    {
+                        "name": "ollama_cloud",
+                        "upstream_model": "glm-5.2",
+                        "upstream_format": "responses",
+                        "tool_exposure_mode": case["tool_mode"],
+                        "tool_capability_state": case["reported_state"],
+                    },
+                    {"client_id": "codex-app"},
+                    inbound_format="responses",
+                    model_requested="ollama-cloud/glm-5.2",
+                    request_kind=case["request_kind"],
+                    raw_provider_probe=case["raw_provider_probe"],
+                )
+
+                self.assertEqual(
+                    plan.tool_exposure.gateway_schema_injection,
+                    case["expected_injection"],
+                )
+                self.assertEqual(plan.repair_policy, case["expected_repair"])
+                self.assertEqual(
+                    plan.tool_exposure.capability_state,
+                    case["expected_state"],
+                )
+                self.assertEqual(
+                    codex_proxy.RouteMutation.HARD_CODED_SCHEMA_INJECTION
+                    in plan.named_mutations,
+                    case["expected_injection"],
+                )
+                self.assertEqual(
+                    plan.tool_exposure.strip_caller_tools,
+                    case["request_kind"] == codex_proxy.RETRY_REQUEST_COMPACT,
+                )
+
+    def test_route_plan_auto_protocol_contains_immutable_typed_attempts(self):
+        plan = codex_proxy.route_plan_for_request(
+            {
+                "name": "ollama_cloud",
+                "upstream_model": "glm-5.2",
+                "upstream_format": "auto",
+            },
+            {"client_id": "codex-app"},
+            inbound_format="responses",
+            model_requested="ollama-cloud/glm-5.2",
+        )
+
+        self.assertEqual(
+            [attempt.upstream_protocol for attempt in plan.attempts],
+            [
+                codex_proxy.RouteProtocol.RESPONSES,
+                codex_proxy.RouteProtocol.CHAT_COMPLETIONS,
+            ],
+        )
+        self.assertEqual(
+            [attempt.wire_format_adapter for attempt in plan.attempts],
+            [
+                codex_proxy.WIRE_TRANSPARENT,
+                codex_proxy.WIRE_RESPONSES_TO_CHAT,
+            ],
+        )
+        self.assertEqual(
+            [attempt.request_body_mode for attempt in plan.attempts],
+            [
+                codex_proxy.AttemptRequestBodyMode.PREPARED_DIRECT,
+                codex_proxy.AttemptRequestBodyMode.CONVERT_RESPONSES_TO_CHAT,
+            ],
+        )
+        self.assertTrue(plan.attempts[0].allows_protocol_fallback_status(415))
+        self.assertFalse(plan.attempts[0].allows_protocol_fallback_status(429))
+        self.assertFalse(plan.attempts[1].fallback_http_statuses)
+        self.assertNotIn(
+            codex_proxy.RouteMutation.WIRE_CONVERSION,
+            plan.attempts[0].named_mutations,
+        )
+        self.assertIn(
+            codex_proxy.RouteMutation.WIRE_CONVERSION,
+            plan.attempts[1].named_mutations,
+        )
+        with self.assertRaises(AttributeError):
+            plan.attempts[0].upstream_protocol = codex_proxy.RouteProtocol.CHAT_COMPLETIONS
+
+    def test_route_plan_preserves_unsupported_protocol_identity_without_attempts(self):
+        cases = (
+            (
+                "anthropic_messages",
+                codex_proxy.RouteProtocol.ANTHROPIC_MESSAGES,
+                codex_proxy.CapabilityState.UNSUPPORTED,
+            ),
+            (
+                "invalid_wire",
+                codex_proxy.RouteProtocol.UNKNOWN,
+                codex_proxy.CapabilityState.UNQUALIFIED,
+            ),
+        )
+        for configured_protocol, typed_protocol, capability_state in cases:
+            with self.subTest(configured_protocol=configured_protocol):
+                plan = codex_proxy.route_plan_for_request(
+                    {
+                        "name": "ollama_cloud",
+                        "upstream_model": "glm-5.2",
+                        "upstream_format": configured_protocol,
+                    },
+                    {"client_id": "codex-app"},
+                    inbound_format="responses",
+                    model_requested="ollama-cloud/glm-5.2",
+                )
+
+                self.assertEqual(
+                    plan.configured_upstream_protocol_name,
+                    configured_protocol,
+                )
+                self.assertEqual(
+                    plan.configured_upstream_protocol,
+                    typed_protocol,
+                )
+                self.assertEqual(
+                    plan.protocol_capability_state,
+                    capability_state,
+                )
+                self.assertEqual(plan.retry_eligibility, capability_state)
+                self.assertEqual(plan.attempts, ())
+
+    def test_route_plan_separates_schema_identity_from_optional_manifest_evidence(self):
+        unqualified = codex_proxy.route_plan_for_request(
+            {
+                "name": "ollama_cloud",
+                "upstream_model": "glm-5.2",
+                "upstream_format": "responses",
+            },
+            {"client_id": "codex-app"},
+            inbound_format="responses",
+            model_requested="ollama-cloud/glm-5.2",
+        )
+        qualified = codex_proxy.route_plan_for_request(
+            {
+                "name": "ollama_cloud",
+                "upstream_model": "glm-5.2",
+                "upstream_format": "responses",
+                "capability_manifest_version": "provider-capabilities.v3",
+                "capability_manifest_hash": "sha256:route-qualified",
+                "capability_manifest_state": codex_proxy.CapabilityState.SUPPORTED.value,
+            },
+            {"client_id": "codex-app"},
+            inbound_format="responses",
+            model_requested="ollama-cloud/glm-5.2",
+        )
+
+        self.assertEqual(
+            unqualified.schema_version,
+            codex_proxy.ROUTE_PLAN_SCHEMA_VERSION,
+        )
+        self.assertIsNone(unqualified.capability_manifest_version)
+        self.assertIsNone(unqualified.capability_manifest_hash)
+        self.assertEqual(
+            unqualified.capability_manifest_state,
+            codex_proxy.CapabilityState.UNQUALIFIED,
+        )
+        self.assertEqual(
+            unqualified.tool_exposure.effective_mode,
+            codex_proxy.ToolExposureMode.CURRENT_COMPATIBILITY,
+        )
+        self.assertTrue(unqualified.attempts)
+        self.assertEqual(
+            qualified.capability_manifest_version,
+            "provider-capabilities.v3",
+        )
+        self.assertEqual(
+            qualified.capability_manifest_hash,
+            "sha256:route-qualified",
+        )
+        self.assertEqual(
+            qualified.capability_manifest_state,
+            codex_proxy.CapabilityState.SUPPORTED,
+        )
+
+    def test_route_plan_resolves_vision_network_and_mutation_before_execution(self):
+        cases = (
+            {
+                "name": "no_image",
+                "has_image": False,
+                "accepts_image": False,
+                "proxy_enabled": True,
+                "expected_action": codex_proxy.VisionAction.PASS_THROUGH,
+                "expected_network": codex_proxy.VisionNetworkAction.NONE,
+                "expected_mutation": None,
+            },
+            {
+                "name": "native_image",
+                "has_image": True,
+                "accepts_image": True,
+                "proxy_enabled": True,
+                "expected_action": codex_proxy.VisionAction.PASS_THROUGH,
+                "expected_network": codex_proxy.VisionNetworkAction.NONE,
+                "expected_mutation": None,
+            },
+            {
+                "name": "proxy_text_only",
+                "has_image": True,
+                "accepts_image": False,
+                "proxy_enabled": True,
+                "expected_action": codex_proxy.VisionAction.PROXY,
+                "expected_network": codex_proxy.VisionNetworkAction.IMAGE_PROXY,
+                "expected_mutation": codex_proxy.RouteMutation.IMAGE_CONTENT_REPLACEMENT,
+            },
+            {
+                "name": "reject_text_only",
+                "has_image": True,
+                "accepts_image": False,
+                "proxy_enabled": False,
+                "expected_action": codex_proxy.VisionAction.REJECT,
+                "expected_network": codex_proxy.VisionNetworkAction.NONE,
+                "expected_mutation": codex_proxy.RouteMutation.IMAGE_UNSUPPORTED_REJECTION,
+            },
+        )
+
+        for case in cases:
+            with self.subTest(case=case["name"]):
+                with patch(
+                    "codex_proxy.gateway_image_proxy_enabled",
+                    side_effect=AssertionError("planner read runtime state"),
+                ):
+                    plan = codex_proxy.route_plan_for_request(
+                        {
+                            "name": "volcengine",
+                            "upstream_model": "glm-5.2",
+                            "upstream_format": "responses",
+                        },
+                        {"client_id": "zcode"},
+                        inbound_format="responses",
+                        provider_hint="volc",
+                        model_requested="volc/glm-5.2",
+                        input_has_image=case["has_image"],
+                        target_accepts_images=case["accepts_image"],
+                        image_proxy_enabled=case["proxy_enabled"],
+                    )
+
+                self.assertEqual(plan.vision.action, case["expected_action"])
+                self.assertEqual(
+                    plan.vision.network_action,
+                    case["expected_network"],
+                )
+                if case["expected_mutation"] is None:
+                    self.assertNotIn(
+                        codex_proxy.RouteMutation.IMAGE_CONTENT_REPLACEMENT,
+                        plan.named_mutations,
+                    )
+                    self.assertNotIn(
+                        codex_proxy.RouteMutation.IMAGE_UNSUPPORTED_REJECTION,
+                        plan.named_mutations,
+                    )
+                else:
+                    self.assertIn(case["expected_mutation"], plan.named_mutations)
+                    for attempt in plan.attempts:
+                        self.assertIn(
+                            case["expected_mutation"],
+                            attempt.named_mutations,
+                        )
+
+    def test_route_plan_uses_only_explicit_runtime_facts(self):
+        with (
+            patch(
+                "codex_proxy.gateway_official_http_passthrough_enabled",
+                side_effect=AssertionError("planner read passthrough runtime state"),
+            ),
+            patch(
+                "codex_proxy.gateway_image_proxy_enabled",
+                side_effect=AssertionError("planner read image runtime state"),
+            ),
+        ):
+            plan = codex_proxy.route_plan_for_request(
+                {
+                    "name": "official",
+                    "upstream_model": "gpt-5.5",
+                    "upstream_format": "responses",
+                },
+                {"client_id": "codex-app"},
+                inbound_format="responses",
+                model_requested="openai/gpt-5.5",
+                official_http_passthrough_enabled=False,
+                input_has_image=True,
+                target_accepts_images=False,
+                image_proxy_enabled=False,
+            )
+
+        self.assertEqual(
+            plan.behavior_profile,
+            codex_proxy.BEHAVIOR_OFFICIAL_GATEWAY_COMPAT,
+        )
+        self.assertEqual(plan.vision.action, codex_proxy.VisionAction.REJECT)
+
+    def test_unsupported_upstream_protocol_returns_before_upstream_io(self):
+        cases = (
+            (
+                "anthropic_messages",
+                codex_proxy.CapabilityState.UNSUPPORTED,
+                "UnsupportedRouteProtocolError",
+            ),
+            (
+                "invalid_wire",
+                codex_proxy.CapabilityState.UNQUALIFIED,
+                "UnqualifiedRouteProtocolError",
+            ),
+        )
+        for configured_protocol, capability_state, error_name in cases:
+            with self.subTest(configured_protocol=configured_protocol):
+                self.external_model["upstream_format"] = configured_protocol
+                body = json.dumps(
+                    {
+                        "model": "volc/glm-5.2",
+                        "input": [{"role": "user", "content": "hi"}],
+                        "stream": False,
+                    }
+                ).encode("utf-8")
+                handler, fake = post_handler("/v1/responses", body)
+
+                with patch(
+                    "codex_proxy._open_upstream_response",
+                    side_effect=AssertionError("unsupported route reached upstream I/O"),
+                ) as open_upstream:
+                    CodexProxyHandler._proxy_post_request(
+                        handler,
+                        inbound_format="responses",
+                    )
+
+                open_upstream.assert_not_called()
+                self.assertEqual(fake.status, 400)
+                request_error = next(
+                    call.kwargs
+                    for call in self.write_proxy_event.call_args_list
+                    if call.args and call.args[0] == "request_error"
+                )
+                self.assertEqual(
+                    request_error["configured_upstream_protocol_name"],
+                    configured_protocol,
+                )
+                self.assertEqual(
+                    request_error["protocol_capability_state"],
+                    capability_state.value,
+                )
+                self.assertEqual(request_error["error"], error_name)
+                self.write_proxy_event.reset_mock()
 
     def test_third_party_app_official_responses_uses_transparent_metered_runtime_path(self):
         body = json.dumps(
@@ -1027,7 +1433,16 @@ class RoutingTests(unittest.TestCase):
             self.assertEqual(fields["retry_eligibility"], codex_proxy.CapabilityState.SUPPORTED.value)
             self.assertEqual(fields["usage_policy"], codex_proxy.USAGE_ASYNC_TAP)
             self.assertEqual(fields["repair_policy"], codex_proxy.REPAIR_NONE)
-            self.assertEqual(fields["capability_manifest_version"], "codexhub.route-capabilities.v1")
+            self.assertEqual(
+                fields["route_plan_schema_version"],
+                codex_proxy.ROUTE_PLAN_SCHEMA_VERSION,
+            )
+            self.assertIsNone(fields["capability_manifest_version"])
+            self.assertIsNone(fields["capability_manifest_hash"])
+            self.assertEqual(
+                fields["capability_manifest_state"],
+                codex_proxy.CapabilityState.UNQUALIFIED.value,
+            )
             self.assertEqual(fields["tool_exposure_mode"], codex_proxy.ToolExposureMode.UNKNOWN.value)
             self.assertEqual(fields["tool_capability_state"], codex_proxy.CapabilityState.UNQUALIFIED.value)
             self.assertEqual(fields["collaboration_backend"], codex_proxy.CollaborationBackend.CLIENT_RUNTIME.value)
@@ -1346,12 +1761,130 @@ class RoutingTests(unittest.TestCase):
         handler.wfile = fake.wfile
 
         with (
-            patch("codex_proxy._open_upstream_response", return_value=FakeContextResponse(b'{"id":"resp_external","output":[]}')),
+            patch(
+                "codex_proxy._open_upstream_response",
+                return_value=FakeContextResponse(b'{"id":"resp_external","output":[]}'),
+            ) as open_upstream,
             patch("codex_proxy._strip_tools_for_compact_payload", wraps=codex_proxy._strip_tools_for_compact_payload) as strip_tools,
         ):
             CodexProxyHandler.do_POST(handler)
 
         strip_tools.assert_called_once()
+        forwarded = json.loads(open_upstream.call_args.args[0].data)
+        self.assertNotIn("tools", forwarded)
+        request_start = next(
+            call.kwargs
+            for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] == "request_start"
+        )
+        self.assertFalse(request_start["gateway_schema_injection"])
+        self.assertNotIn(
+            codex_proxy.RouteMutation.HARD_CODED_SCHEMA_INJECTION.value,
+            request_start["mutation_summary"],
+        )
+
+    def test_auto_compact_executes_planned_chat_fallback_and_updates_attempt_telemetry(self):
+        self.external_model["upstream_format"] = "auto"
+        body = json.dumps(
+            {
+                "model": "volc/glm-5.2",
+                "input": [
+                    {
+                        "type": "message",
+                        "role": "user",
+                        "content": (
+                            "Create a detailed summary of the conversation so far. "
+                            "This is a compact summary. Respond with text only. "
+                            "The summary should include <summary>."
+                        ),
+                    }
+                ],
+                "stream": False,
+            }
+        ).encode("utf-8")
+        handler, _fake = post_handler("/v1/responses", body)
+        responses_error = HTTPError(
+            "https://ark.example.test/v1/responses",
+            404,
+            "Not Found",
+            {},
+            io.BytesIO(b'{"error":"unsupported endpoint"}'),
+        )
+        chat_response = FakeContextResponse(
+            json.dumps(
+                {
+                    "id": "chat_fallback",
+                    "object": "chat.completion",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": {
+                                "role": "assistant",
+                                "content": "<summary>fallback summary</summary>",
+                            },
+                            "finish_reason": "stop",
+                        }
+                    ],
+                }
+            ).encode("utf-8")
+        )
+
+        with (
+            patch.dict(
+                os.environ,
+                {"CODEX_PROXY_AUTO_RETRY_ENABLED": "0"},
+                clear=False,
+            ),
+            patch(
+                "codex_proxy.urlopen",
+                side_effect=[responses_error, chat_response],
+            ) as mock_urlopen,
+        ):
+            CodexProxyHandler._proxy_post_request(
+                handler,
+                inbound_format="responses",
+            )
+
+        self.assertEqual(mock_urlopen.call_count, 2)
+        self.assertTrue(mock_urlopen.call_args_list[0].args[0].full_url.endswith("/responses"))
+        self.assertTrue(mock_urlopen.call_args_list[1].args[0].full_url.endswith("/chat/completions"))
+        fallback = next(
+            call.kwargs
+            for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] == "upstream_protocol_fallback"
+        )
+        self.assertEqual(fallback["failed_route_attempt_index"], 0)
+        self.assertEqual(fallback["next_route_attempt_index"], 1)
+        self.assertEqual(
+            fallback["failed_route_attempt_request_body_mode"],
+            codex_proxy.AttemptRequestBodyMode.PREPARED_DIRECT.value,
+        )
+        self.assertEqual(
+            fallback["next_route_attempt_request_body_mode"],
+            codex_proxy.AttemptRequestBodyMode.CONVERT_RESPONSES_TO_CHAT.value,
+        )
+        self.assertNotIn(
+            codex_proxy.RouteMutation.WIRE_CONVERSION.value,
+            fallback["failed_route_attempt_mutation_summary"],
+        )
+        self.assertIn(
+            codex_proxy.RouteMutation.WIRE_CONVERSION.value,
+            fallback["next_route_attempt_mutation_summary"],
+        )
+        request_complete = next(
+            call.kwargs
+            for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] == "request_complete"
+        )
+        self.assertEqual(request_complete["route_attempt_index"], 1)
+        self.assertEqual(
+            request_complete["route_attempt_protocol"],
+            codex_proxy.RouteProtocol.CHAT_COMPLETIONS.value,
+        )
+        self.assertIn(
+            codex_proxy.RouteMutation.WIRE_CONVERSION.value,
+            request_complete["route_attempt_mutation_summary"],
+        )
 
     def test_post_request_events_include_behavior_profile_on_success(self):
         body = json.dumps(
@@ -1663,21 +2196,25 @@ class RoutingTests(unittest.TestCase):
         request = mock_urlopen.call_args.args[0]
         self.assertEqual(json.loads(request.data.decode("utf-8"))["model"], "gpt-5.5")
 
-    def test_raw_provider_probe_sets_context_on_request_start(self):
+    def test_raw_provider_probe_executes_without_gateway_injection_or_repair(self):
         body = json.dumps(
             {
                 "model": "volc/glm-5.2",
-                "messages": [{"role": "user", "content": "hi"}],
+                "input": [{"role": "user", "content": "hi"}],
+                "tools": [{"type": "function", "name": "caller_tool"}],
                 "stream": False,
             }
         ).encode("utf-8")
         handler, _fake = post_handler(
-            "/v1/providers/volc/chat/completions?raw_provider_probe=1",
+            "/v1/responses?raw_provider_probe=1",
             body,
         )
 
-        with patch("codex_proxy.urlopen", return_value=FakeContextResponse(b'{"id":"chatcmpl","choices":[]}')):
-            CodexProxyHandler._proxy_post_request(handler, inbound_format="chat_completions", provider_hint="volc")
+        with patch(
+            "codex_proxy.urlopen",
+            return_value=FakeContextResponse(b'{"id":"resp_raw","output":[]}'),
+        ) as mock_urlopen:
+            CodexProxyHandler._proxy_post_request(handler, inbound_format="responses")
 
         request_start = [
             call.kwargs
@@ -1685,6 +2222,66 @@ class RoutingTests(unittest.TestCase):
             if call.args and call.args[0] == "request_start"
         ][0]
         self.assertTrue(request_start["raw_provider_probe"])
+        self.assertFalse(request_start["gateway_schema_injection"])
+        self.assertEqual(request_start["repair_policy"], codex_proxy.REPAIR_NONE)
+        self.assertNotIn(
+            codex_proxy.RouteMutation.HARD_CODED_SCHEMA_INJECTION.value,
+            request_start["mutation_summary"],
+        )
+        forwarded = json.loads(mock_urlopen.call_args.args[0].data)
+        self.assertEqual(
+            forwarded["tools"],
+            [{"type": "function", "name": "caller_tool"}],
+        )
+
+    def test_unresolved_candidate_executes_compatibility_injection_as_unqualified(self):
+        self.external_model.update(
+            {
+                "tool_exposure_mode": codex_proxy.ToolExposureMode.NATIVE_DEFERRED_SEARCH_CANDIDATE.value,
+                "tool_capability_state": codex_proxy.CapabilityState.SUPPORTED.value,
+                "supports_search_tool": True,
+            }
+        )
+        body = json.dumps(
+            {
+                "model": "volc/glm-5.2",
+                "input": [{"role": "user", "content": "hi"}],
+                "stream": False,
+            }
+        ).encode("utf-8")
+        handler, _fake = post_handler("/v1/responses", body)
+
+        with patch(
+            "codex_proxy.urlopen",
+            return_value=FakeContextResponse(b'{"id":"resp_candidate","output":[]}'),
+        ) as mock_urlopen:
+            CodexProxyHandler._proxy_post_request(handler, inbound_format="responses")
+
+        forwarded = json.loads(mock_urlopen.call_args.args[0].data)
+        injected_names = {
+            tool.get("name")
+            for tool in forwarded.get("tools", [])
+            if isinstance(tool, dict)
+        }
+        self.assertIn("multi_agent_v1__spawn_agent", injected_names)
+        request_start = next(
+            call.kwargs
+            for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] == "request_start"
+        )
+        self.assertEqual(
+            request_start["tool_requested_exposure_mode"],
+            codex_proxy.ToolExposureMode.NATIVE_DEFERRED_SEARCH_CANDIDATE.value,
+        )
+        self.assertEqual(
+            request_start["tool_exposure_mode"],
+            codex_proxy.ToolExposureMode.CURRENT_COMPATIBILITY.value,
+        )
+        self.assertEqual(
+            request_start["tool_capability_state"],
+            codex_proxy.CapabilityState.UNQUALIFIED.value,
+        )
+        self.assertTrue(request_start["gateway_schema_injection"])
 
     def test_request_body_over_limit_returns_413_and_logs_limit(self):
         body = json.dumps({"model": "openai/gpt-5.5", "input": "abcdef"}).encode("utf-8")
@@ -8719,16 +9316,25 @@ class RoutingTests(unittest.TestCase):
             ],
         }
         upstream = choose_upstream("volc/glm-5.2")
+        vision_plan = codex_proxy.route_plan_for_request(
+            upstream,
+            {"client_id": "codex-app"},
+            inbound_format="responses",
+            model_requested="volc/glm-5.2",
+            input_has_image=True,
+            target_accepts_images=False,
+            image_proxy_enabled=False,
+        ).vision
 
-        with patch.dict(os.environ, {"CODEX_PROXY_IMAGE_PROXY_ENABLED": "0"}, clear=False):
-            with self.assertRaises(codex_proxy.ImageProxyError) as context:
-                codex_proxy.enforce_text_only_image_boundary(
-                    payload,
-                    inbound_format="responses",
-                    target_model="volc/glm-5.2",
-                    target_upstream=upstream,
-                    event_context={"request_id": "req_img"},
-                )
+        with self.assertRaises(codex_proxy.ImageProxyError) as context:
+            codex_proxy.enforce_text_only_image_boundary(
+                payload,
+                inbound_format="responses",
+                target_model="volc/glm-5.2",
+                target_upstream=upstream,
+                vision_plan=vision_plan,
+                event_context={"request_id": "req_img"},
+            )
 
         self.assertIn("does not support image input", str(context.exception))
         self.assertIn("Image Proxy is disabled", str(context.exception))

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -436,7 +436,7 @@ def relay_upstream_response(
     response,
     upstream_name,
     *args,
-    relay_fixture: RelayPlanFixture = RELAY_GATEWAY,
+    relay_fixture: RelayPlanFixture,
     **kwargs,
 ):
     """Call the production relay with an explicit typed policy fixture."""
@@ -589,6 +589,82 @@ class RoutingTests(unittest.TestCase):
         event_names = {call.args[0] for call in self.write_proxy_event.call_args_list if call.args}
         self.assertFalse(blocked & event_names, blocked & event_names)
 
+    def test_relay_test_helper_requires_explicit_typed_fixture_at_every_call_site(
+        self,
+    ):
+        import ast
+
+        source = Path(__file__).read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        helper = next(
+            node
+            for node in tree.body
+            if isinstance(node, ast.FunctionDef)
+            and node.name == "relay_upstream_response"
+        )
+        relay_fixture_index = next(
+            index
+            for index, argument in enumerate(helper.args.kwonlyargs)
+            if argument.arg == "relay_fixture"
+        )
+        violations = []
+        if helper.args.kw_defaults[relay_fixture_index] is not None:
+            violations.append("relay_fixture parameter has a default")
+
+        typed_fixture_names = {
+            "RELAY_GATEWAY",
+            "RELAY_GATEWAY_VERIFIED_CONVERSION",
+            "RELAY_OFFICIAL_PASSTHROUGH",
+            "RELAY_TRANSPARENT",
+            "RELAY_TRANSPARENT_CONVERTED",
+        }
+
+        def is_typed_fixture_expression(node):
+            if isinstance(node, ast.Name):
+                return node.id in typed_fixture_names
+            return (
+                isinstance(node, ast.Subscript)
+                and isinstance(node.value, ast.Name)
+                and node.value.id == "case"
+                and isinstance(node.slice, ast.Constant)
+                and node.slice.value == "relay_fixture"
+            )
+
+        behavior_profile_calls = []
+        for function in (
+            node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)
+        ):
+            for call_node in (
+                node for node in ast.walk(function) if isinstance(node, ast.Call)
+            ):
+                if not (
+                    isinstance(call_node.func, ast.Name)
+                    and call_node.func.id == "relay_upstream_response"
+                ):
+                    continue
+                keywords = {
+                    keyword.arg: keyword.value
+                    for keyword in call_node.keywords
+                    if keyword.arg is not None
+                }
+                relay_fixture = keywords.get("relay_fixture")
+                if relay_fixture is None:
+                    violations.append(
+                        f"{function.name}:{call_node.lineno} omits relay_fixture"
+                    )
+                elif not is_typed_fixture_expression(relay_fixture):
+                    violations.append(
+                        f"{function.name}:{call_node.lineno} uses a non-typed relay_fixture"
+                    )
+                if "behavior_profile" in keywords:
+                    behavior_profile_calls.append(function.name)
+
+        self.assertEqual(
+            behavior_profile_calls,
+            ["test_relay_test_helper_rejects_legacy_behavior_profile_selection"],
+        )
+        self.assertEqual(violations, [])
+
     def test_relay_test_helper_rejects_legacy_behavior_profile_selection(self):
         with self.assertRaisesRegex(
             TypeError,
@@ -598,6 +674,7 @@ class RoutingTests(unittest.TestCase):
                 FakeHandler(),
                 FakeResponse(b'{"id":"resp_fixture_contract","output":[]}'),
                 "volcengine",
+                relay_fixture=RELAY_GATEWAY,
                 request_id="req-fixture-contract",
                 model="volc/glm-5.2",
                 upstream_format="responses",
@@ -13465,7 +13542,7 @@ class RoutingTests(unittest.TestCase):
         ]
         response = FakeSseResponse(lines)
 
-        relay_upstream_response(handler, response, "official")
+        relay_upstream_response(handler, response, "official", relay_fixture=RELAY_GATEWAY)
 
         self.assertEqual(handler.status, 200)
         self.assertTrue(handler.headers_ended)
@@ -13486,7 +13563,7 @@ class RoutingTests(unittest.TestCase):
         )
 
         with patch.dict(os.environ, {"CODEX_PROXY_SSE_KEEPALIVE_SECONDS": "0.01"}, clear=False):
-            relay_upstream_response(handler, response, "official")
+            relay_upstream_response(handler, response, "official", relay_fixture=RELAY_GATEWAY)
 
         written = b"".join(handler.wfile.writes)
         keepalive_index = written.index(b": codexhub.keepalive\n\n")
@@ -13518,6 +13595,7 @@ class RoutingTests(unittest.TestCase):
                     handler,
                     response,
                     "official",
+                    relay_fixture=RELAY_GATEWAY,
                     request_id="req_keepalive_fail",
                     model="openai/gpt-5.5",
                     upstream_format="responses",
@@ -13547,7 +13625,7 @@ class RoutingTests(unittest.TestCase):
         }
         response = FakeSseResponse([f"data: {json.dumps(event)}\n".encode("utf-8"), b"\n", b""])
 
-        relay_upstream_response(handler, response, "ollama_cloud")
+        relay_upstream_response(handler, response, "ollama_cloud", relay_fixture=RELAY_GATEWAY)
 
         data_line = handler.wfile.writes[0].decode("utf-8")
         payload = json.loads(data_line.removeprefix("data: "))
@@ -13566,7 +13644,7 @@ class RoutingTests(unittest.TestCase):
         }
         response = FakeSseResponse([f"data: {json.dumps(event)}\n".encode("utf-8"), b"\n", b""])
 
-        relay_upstream_response(handler, response, "volcengine")
+        relay_upstream_response(handler, response, "volcengine", relay_fixture=RELAY_GATEWAY)
 
         data_line = handler.wfile.writes[0].decode("utf-8")
         payload = json.loads(data_line.removeprefix("data: "))
@@ -13585,7 +13663,7 @@ class RoutingTests(unittest.TestCase):
         }
         response = FakeSseResponse([f"data: {json.dumps(event)}\n".encode("utf-8"), b"\n", b""])
 
-        relay_upstream_response(handler, response, "volcengine")
+        relay_upstream_response(handler, response, "volcengine", relay_fixture=RELAY_GATEWAY)
 
         data_line = handler.wfile.writes[0].decode("utf-8")
         payload = json.loads(data_line.removeprefix("data: "))
@@ -13611,7 +13689,7 @@ class RoutingTests(unittest.TestCase):
             ]
         )
 
-        status = relay_upstream_response(handler, response, "ollama_cloud")
+        status = relay_upstream_response(handler, response, "ollama_cloud", relay_fixture=RELAY_GATEWAY)
 
         data = b"".join(handler.wfile.writes)
         self.assertEqual(status, 502)
@@ -13640,6 +13718,7 @@ class RoutingTests(unittest.TestCase):
             handler,
             response,
             "ollama_cloud",
+            relay_fixture=RELAY_GATEWAY,
             request_id="req_named_reasoning_summary",
             model="ollama-cloud/glm-5.2",
             upstream_format="responses",
@@ -13678,7 +13757,7 @@ class RoutingTests(unittest.TestCase):
             b"",
         ])
 
-        relay_upstream_response(handler, response, "ollama_cloud")
+        relay_upstream_response(handler, response, "ollama_cloud", relay_fixture=RELAY_GATEWAY)
 
         data_line = handler.wfile.writes[0].decode("utf-8")
         payload = json.loads(data_line.removeprefix("data: "))
@@ -14046,7 +14125,7 @@ class RoutingTests(unittest.TestCase):
         body = b'{"ok":true}'
         response = FakeResponse(body)
 
-        relay_upstream_response(handler, response, "official")
+        relay_upstream_response(handler, response, "official", relay_fixture=RELAY_GATEWAY)
 
         self.assertEqual(handler.status, 200)
         self.assertEqual(handler.wfile.writes, [body])
@@ -14082,6 +14161,7 @@ class RoutingTests(unittest.TestCase):
             handler,
             response,
             "volcengine",
+            relay_fixture=RELAY_GATEWAY,
             upstream_format="chat_completions",
         )
 
@@ -14135,6 +14215,7 @@ class RoutingTests(unittest.TestCase):
             handler,
             response,
             "volcengine",
+            relay_fixture=RELAY_GATEWAY,
             request_id="<sanitized-request-id>",
             model="<third-party-glm>",
             upstream_format="chat_completions",
@@ -14221,6 +14302,7 @@ class RoutingTests(unittest.TestCase):
             handler,
             response,
             "volcengine",
+            relay_fixture=RELAY_GATEWAY,
             request_id="<sanitized-request-id>",
             model="<third-party-glm>",
             upstream_format="responses",
@@ -14792,6 +14874,7 @@ class RoutingTests(unittest.TestCase):
             handler,
             response,
             "volcengine",
+            relay_fixture=RELAY_GATEWAY,
             upstream_format="chat_completions",
             event_context={
                 "repair_policy": codex_proxy.REPAIR_CODEX_SUBAGENT,
@@ -14937,6 +15020,7 @@ class RoutingTests(unittest.TestCase):
             handler,
             response,
             "ollama_cloud",
+            relay_fixture=RELAY_GATEWAY,
             upstream_format="chat_completions",
             inbound_format="chat_completions",
             event_context={"request_id": "req", "repair_policy": codex_proxy.REPAIR_CODEX_SUBAGENT},
@@ -14997,6 +15081,7 @@ class RoutingTests(unittest.TestCase):
             handler,
             response,
             "volcengine",
+            relay_fixture=RELAY_GATEWAY,
             upstream_format="chat_completions",
         )
 
@@ -15045,6 +15130,7 @@ class RoutingTests(unittest.TestCase):
             handler,
             response,
             "volcengine",
+            relay_fixture=RELAY_GATEWAY,
             upstream_format="chat_completions",
         )
 
@@ -15134,6 +15220,7 @@ class RoutingTests(unittest.TestCase):
             handler,
             response,
             "volcengine",
+            relay_fixture=RELAY_GATEWAY,
             upstream_format="chat_completions",
             event_context={
                 "repair_policy": codex_proxy.REPAIR_CODEX_SUBAGENT,
@@ -15206,6 +15293,7 @@ class RoutingTests(unittest.TestCase):
             handler,
             response,
             "ollama_cloud",
+            relay_fixture=RELAY_GATEWAY,
             upstream_format="chat_completions",
             inbound_format="chat_completions",
             event_context={"request_id": "req", "repair_policy": codex_proxy.REPAIR_CODEX_SUBAGENT},
@@ -15251,6 +15339,7 @@ class RoutingTests(unittest.TestCase):
             handler,
             response,
             "volcengine",
+            relay_fixture=RELAY_GATEWAY,
             upstream_format="chat_completions",
         )
 
@@ -15429,6 +15518,7 @@ class RoutingTests(unittest.TestCase):
             handler,
             response,
             "official",
+            relay_fixture=RELAY_GATEWAY,
             request_id="req_incomplete_responses_passthrough",
             model="openai/gpt-5.5",
             upstream_format="responses",
@@ -15455,6 +15545,7 @@ class RoutingTests(unittest.TestCase):
             handler,
             response,
             "ollama_cloud",
+            relay_fixture=RELAY_GATEWAY,
             request_id="req_incomplete_chat_sse",
             model="ollama-cloud/glm-5.2",
             upstream_format="chat_completions",
@@ -15494,6 +15585,7 @@ class RoutingTests(unittest.TestCase):
                 handler,
                 response,
                 "official",
+                relay_fixture=RELAY_GATEWAY,
                 request_id="req_pre_output_idle",
                 model="openai/gpt-5.5",
                 upstream_format="responses",
@@ -15538,6 +15630,7 @@ class RoutingTests(unittest.TestCase):
                 handler,
                 response,
                 "official",
+                relay_fixture=RELAY_GATEWAY,
                 request_id="req_transport_idle",
                 model="openai/gpt-5.5",
                 upstream_format="responses",
@@ -15587,6 +15680,7 @@ class RoutingTests(unittest.TestCase):
                 handler,
                 response,
                 "official",
+                relay_fixture=RELAY_GATEWAY,
                 request_id="req_output_idle",
                 model="openai/gpt-5.5",
                 upstream_format="responses",
@@ -15653,6 +15747,7 @@ class RoutingTests(unittest.TestCase):
                 handler,
                 response,
                 "official",
+                relay_fixture=RELAY_GATEWAY,
                 request_id="req_tool_arg_idle",
                 model="openai/gpt-5.5",
                 upstream_format="responses",
@@ -15708,6 +15803,7 @@ class RoutingTests(unittest.TestCase):
                 handler,
                 response,
                 "official",
+                relay_fixture=RELAY_GATEWAY,
                 request_id="req_custom_tool_idle",
                 model="openai/gpt-5.5",
                 upstream_format="responses",
@@ -15736,7 +15832,7 @@ class RoutingTests(unittest.TestCase):
         ).encode("utf-8")
         response = FakeResponse(body)
 
-        relay_upstream_response(handler, response, "ollama_cloud")
+        relay_upstream_response(handler, response, "ollama_cloud", relay_fixture=RELAY_GATEWAY)
 
         payload = json.loads(handler.wfile.writes[0])
         self.assertNotIn("encrypted_content", payload["output"][0])
@@ -15757,7 +15853,7 @@ class RoutingTests(unittest.TestCase):
         ).encode("utf-8")
         response = FakeResponse(body)
 
-        relay_upstream_response(handler, response, "minimax")
+        relay_upstream_response(handler, response, "minimax", relay_fixture=RELAY_GATEWAY)
 
         payload = json.loads(handler.wfile.writes[0])
         self.assertEqual(payload["output"][0]["summary"], [])
@@ -15779,7 +15875,7 @@ class RoutingTests(unittest.TestCase):
         ).encode("utf-8")
         response = FakeResponse(body)
 
-        relay_upstream_response(handler, response, "volcengine")
+        relay_upstream_response(handler, response, "volcengine", relay_fixture=RELAY_GATEWAY)
 
         payload = json.loads(handler.wfile.writes[0])
         self.assertEqual(payload["output"][0]["type"], "message")
@@ -15799,6 +15895,7 @@ class RoutingTests(unittest.TestCase):
             handler,
             response,
             "official",
+            relay_fixture=RELAY_GATEWAY,
             request_id="req_incomplete_buffer",
             model="openai/gpt-5.5",
             upstream_format="responses",
@@ -15840,6 +15937,7 @@ class RoutingTests(unittest.TestCase):
             handler,
             response,
             "official",
+            relay_fixture=RELAY_GATEWAY,
             request_id="req_incomplete_chat_convert",
             model="openai/gpt-5.5",
             upstream_format="responses",
@@ -15864,6 +15962,7 @@ class RoutingTests(unittest.TestCase):
             handler,
             response,
             "ollama_cloud",
+            relay_fixture=RELAY_GATEWAY,
             request_id="req_incomplete_chat_sse",
             model="ollama-cloud/glm-5.2",
             upstream_format="chat_completions",
@@ -15888,6 +15987,7 @@ class RoutingTests(unittest.TestCase):
             handler,
             response,
             "official",
+            relay_fixture=RELAY_GATEWAY,
             request_id="req_incomplete_responses_passthrough",
             model="openai/gpt-5.5",
             upstream_format="responses",
@@ -15910,6 +16010,7 @@ class RoutingTests(unittest.TestCase):
             handler,
             response,
             "official",
+            relay_fixture=RELAY_GATEWAY,
             request_id="req_empty_responses_passthrough",
             model="openai/gpt-5.5",
             upstream_format="responses",
@@ -15930,6 +16031,7 @@ class RoutingTests(unittest.TestCase):
                 handler,
                 response,
                 "official",
+                relay_fixture=RELAY_GATEWAY,
                 request_id="req_empty_responses_passthrough_retry",
                 model="openai/gpt-5.5",
                 upstream_format="responses",
@@ -15960,6 +16062,7 @@ class RoutingTests(unittest.TestCase):
                 handler,
                 response,
                 "xunfei",
+                relay_fixture=RELAY_GATEWAY,
                 request_id="req_sse_error_defer",
                 model="xunfei/xopglm52",
                 upstream_format="responses",
@@ -16563,6 +16666,7 @@ class RoutingTests(unittest.TestCase):
                 handler,
                 response,
                 "ollama_cloud",
+                relay_fixture=RELAY_GATEWAY,
                 request_id="req_incomplete_tool_input",
                 model="ollama-cloud/glm-5.2",
                 upstream_format="responses",
@@ -16587,6 +16691,7 @@ class RoutingTests(unittest.TestCase):
                 handler,
                 response,
                 "ollama_cloud",
+                relay_fixture=RELAY_GATEWAY,
                 request_id="req_reset_after_created",
                 model="ollama-cloud/glm-5.2",
                 upstream_format="responses",
@@ -16615,6 +16720,7 @@ class RoutingTests(unittest.TestCase):
                 handler,
                 response,
                 "ollama_cloud",
+                relay_fixture=RELAY_GATEWAY,
                 request_id="req_reset_after_reasoning_start",
                 model="ollama-cloud/glm-5.2",
                 upstream_format="responses",
@@ -16643,6 +16749,7 @@ class RoutingTests(unittest.TestCase):
             handler,
             response,
             "xunfei",
+            relay_fixture=RELAY_GATEWAY,
             request_id="req_sse_error_final",
             model="xunfei/xopglm52",
             upstream_format="responses",
@@ -16683,6 +16790,7 @@ class RoutingTests(unittest.TestCase):
             handler,
             response,
             "xunfei",
+            relay_fixture=RELAY_GATEWAY,
             request_id="req_json_stream_fallback",
             model="xunfei/xopglm52",
             upstream_format="responses",
@@ -16718,6 +16826,7 @@ class RoutingTests(unittest.TestCase):
                 handler,
                 response,
                 "ollama_cloud",
+                relay_fixture=RELAY_GATEWAY,
                 upstream_format="responses",
                 inbound_format="chat_completions",
                 caller_stream=False,
@@ -16744,6 +16853,7 @@ class RoutingTests(unittest.TestCase):
             handler,
             response,
             "official",
+            relay_fixture=RELAY_GATEWAY,
             request_id="req_empty_non_compact",
             model="openai/gpt-5.5",
             upstream_format="responses",
@@ -20630,6 +20740,7 @@ Execution constraints:
             handler,
             empty_response,
             "ollama_cloud",
+            relay_fixture=RELAY_GATEWAY,
             request_id="req_diagnostic_empty",
             model="glm-5.2",
             upstream_format="responses",
@@ -20644,6 +20755,7 @@ Execution constraints:
             compact_handler,
             FakeResponse(empty_response.body),
             "ollama_cloud",
+            relay_fixture=RELAY_GATEWAY,
             request_id="req_diagnostic_compact",
             model="glm-5.2",
             upstream_format="responses",
@@ -22963,6 +23075,7 @@ Execution constraints:
             handler,
             self._chat_spawn_sse_response({"agent_type": "worker", "message": "delegate"}),
             "synthetic-provider",
+            relay_fixture=RELAY_GATEWAY,
             upstream_format="chat_completions",
             inbound_format="responses",
             caller_stream=True,
@@ -23008,6 +23121,7 @@ Execution constraints:
                 handler,
                 self._chat_spawn_sse_response({"message": "delegate"}, call_id="chat-missing-selector"),
                 "synthetic-provider",
+                relay_fixture=RELAY_GATEWAY,
                 upstream_format="chat_completions",
                 inbound_format="responses",
                 caller_stream=True,
@@ -23033,6 +23147,7 @@ Execution constraints:
                     call_id="chat-unsupported-selector",
                 ),
                 "synthetic-provider",
+                relay_fixture=RELAY_GATEWAY,
                 upstream_format="chat_completions",
                 inbound_format="responses",
                 caller_stream=True,
@@ -23064,6 +23179,7 @@ Execution constraints:
                     call_id="chat-semantic-unsupported-selector",
                 ),
                 "synthetic-provider",
+                relay_fixture=RELAY_GATEWAY,
                 upstream_format="chat_completions",
                 inbound_format="responses",
                 caller_stream=True,
@@ -23088,6 +23204,7 @@ Execution constraints:
                 call_id="chat-semantic-general-selector",
             ),
             "synthetic-provider",
+            relay_fixture=RELAY_GATEWAY,
             upstream_format="chat_completions",
             inbound_format="responses",
             caller_stream=True,
@@ -23132,6 +23249,7 @@ Execution constraints:
                     tool_name="multi_agent_v1__wait_agent",
                 ),
                 "synthetic-provider",
+                relay_fixture=RELAY_GATEWAY,
                 upstream_format="chat_completions",
                 inbound_format="responses",
                 caller_stream=True,
@@ -25632,6 +25750,7 @@ Use an implementer subagent, then a spec reviewer, then a code quality reviewer.
                 fake,
                 response,
                 "ollama_cloud",
+                relay_fixture=RELAY_GATEWAY,
                 request_id="req-empty-retryable",
                 model="glm-5.2",
                 upstream_format="responses",
@@ -25659,6 +25778,7 @@ Use an implementer subagent, then a spec reviewer, then a code quality reviewer.
                 fake,
                 response,
                 "ollama_cloud",
+                relay_fixture=RELAY_GATEWAY,
                 request_id="req-hidden-reasoning-empty",
                 model="glm-5.2",
                 upstream_format="responses",
@@ -25685,6 +25805,7 @@ Use an implementer subagent, then a spec reviewer, then a code quality reviewer.
                 fake,
                 response,
                 "ollama_cloud",
+                relay_fixture=RELAY_GATEWAY,
                 request_id="req-empty-final",
                 model="glm-5.2",
                 upstream_format="responses",
@@ -25729,6 +25850,7 @@ Use an implementer subagent, then a spec reviewer, then a code quality reviewer.
             fake,
             response,
             "ollama_cloud",
+            relay_fixture=RELAY_GATEWAY,
             request_id="req-tool-only",
             model="glm-5.2",
             upstream_format="responses",
@@ -26145,6 +26267,7 @@ Use an implementer subagent, then a spec reviewer, then a code quality reviewer.
             handler,
             response,
             "ollama_cloud",
+            relay_fixture=RELAY_GATEWAY,
             request_id="req_synth_terminal",
             model="ollama-cloud/glm-5.2",
             upstream_format="responses",

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -10,7 +10,7 @@ import threading
 import time
 import unittest
 import weakref
-from dataclasses import replace
+from dataclasses import asdict, replace
 from http.client import IncompleteRead
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -365,6 +365,120 @@ def post_handler(path: str, body: bytes, headers: dict[str, str] | None = None):
     handler.end_headers = fake.end_headers
     handler.wfile = fake.wfile
     return handler, fake
+
+
+def relay_upstream_response(
+    handler,
+    response,
+    upstream_name,
+    *args,
+    **kwargs,
+):
+    """Adapt focused relay tests to the production typed execution seam."""
+
+    behavior_profile = kwargs.pop("behavior_profile", None)
+    upstream_format = kwargs.get("upstream_format", "responses")
+    inbound_format = kwargs.get("inbound_format", "responses")
+    event_context = kwargs.get("event_context")
+    request_kind = kwargs.pop(
+        "request_kind",
+        codex_proxy.RETRY_REQUEST_MAIN_GENERATION,
+    )
+    streaming_policy = kwargs.pop("streaming_policy", None)
+    if streaming_policy is None:
+        if (
+            behavior_profile
+            == codex_proxy.BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH
+        ):
+            streaming_policy = (
+                codex_proxy.StreamingPolicy.OFFICIAL_PASSTHROUGH
+            )
+        elif (
+            behavior_profile
+            == codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED
+        ):
+            streaming_policy = (
+                codex_proxy.StreamingPolicy.TRANSPARENT
+                if upstream_format == inbound_format
+                else codex_proxy.StreamingPolicy.TRANSPARENT_CONVERTED
+            )
+        else:
+            streaming_policy = codex_proxy.StreamingPolicy.GATEWAY_ADAPTED
+    usage_policy = kwargs.pop("usage_policy", None)
+    if usage_policy is None:
+        usage_policy = (
+            codex_proxy.UsagePolicy.ASYNC_TAP
+            if (
+                behavior_profile
+                == codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED
+            )
+            else codex_proxy.UsagePolicy.SYNC_CAPTURE
+        )
+    response_mutation_policy = kwargs.pop(
+        "response_mutation_policy",
+        None,
+    )
+    if response_mutation_policy is None:
+        response_mutation_policy = (
+            codex_proxy.MutationPolicy.TRANSPARENT
+            if (
+                behavior_profile
+                == codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED
+            )
+            else (
+                codex_proxy.MutationPolicy.OFFICIAL_PASSTHROUGH
+                if (
+                    behavior_profile
+                    == codex_proxy.BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH
+                )
+                else codex_proxy.MutationPolicy.GATEWAY_COMPATIBILITY
+            )
+        )
+    sse_mutation_policy = kwargs.pop(
+        "sse_mutation_policy",
+        response_mutation_policy,
+    )
+    verify_cross_protocol_source = kwargs.pop(
+        "verify_cross_protocol_source",
+        None,
+    )
+    if verify_cross_protocol_source is None:
+        verify_cross_protocol_source = (
+            codex_proxy._verified_cross_protocol_source_format(
+                behavior_profile=behavior_profile,
+                upstream_format=upstream_format,
+                inbound_format=inbound_format,
+            )
+            is not None
+        )
+    lifecycle_final_retry_enabled = kwargs.pop(
+        "lifecycle_final_retry_enabled",
+        None,
+    )
+    if lifecycle_final_retry_enabled is None:
+        lifecycle_final_retry_enabled = (
+            codex_proxy.lifecycle_empty_final_resample_enabled(
+                event_context,
+                request_kind,
+            )
+        )
+    relay_execution_plan = codex_proxy.RelayExecutionPlan(
+        request_kind=request_kind,
+        streaming_policy=streaming_policy,
+        usage_policy=usage_policy,
+        response_mutation_policy=response_mutation_policy,
+        sse_mutation_policy=sse_mutation_policy,
+        verify_cross_protocol_source=verify_cross_protocol_source,
+        lifecycle_final_retry_enabled=lifecycle_final_retry_enabled,
+    )
+    return CodexProxyHandler._relay_upstream_response(
+        handler,
+        response,
+        upstream_name,
+        *args,
+        relay_execution_plan=relay_execution_plan,
+        **kwargs,
+    )
 
 
 class RoutingTests(unittest.TestCase):
@@ -1283,17 +1397,26 @@ class RoutingTests(unittest.TestCase):
             downstream_retry_notice_enabled=False,
             pre_response_budget_seconds=109.0,
         )
+        planned_upstream = {
+            "name": "volcengine",
+            "base_url": "https://ark.example.test/v1",
+            "auth": "api_key",
+            "api_key": "planned-token",
+            "upstream_model": "glm-5.2",
+            "upstream_format": "responses",
+        }
         planned = codex_proxy.route_plan_for_request(
-            {
-                "name": "volcengine",
-                "base_url": "https://ark.example.test/v1",
-                "auth": "api_key",
-                "upstream_model": "glm-5.2",
-                "upstream_format": "responses",
-            },
+            planned_upstream,
             {"client_id": "codex-app"},
             inbound_format="responses",
             model_requested="volc/glm-5.2",
+            operational_authentication=(
+                codex_proxy.materialize_operational_authentication(
+                    {},
+                    planned_upstream,
+                )
+            ),
+            incoming_headers={},
             runtime_facts=runtime_facts,
         )
         planned_attempt = replace(
@@ -1393,33 +1516,315 @@ class RoutingTests(unittest.TestCase):
             open_upstream.call_args.kwargs["transport_policy"],
             planned_attempt.transport_policy,
         )
-        self.assertEqual(
-            build_headers.call_args.kwargs["authentication_strategy"],
-            planned_attempt.authentication_strategy,
-        )
-        self.assertEqual(
-            build_headers.call_args.kwargs["request_mutation_policy"],
-            planned_attempt.request_mutation_policy,
-        )
-        self.assertNotIn("behavior_profile", build_headers.call_args.kwargs)
+        build_headers.assert_not_called()
         self.assertNotIn("request_kind", open_upstream.call_args.kwargs)
         self.assertNotIn("behavior_profile", relayed[0])
+        relay_execution_plan = relayed[0]["relay_execution_plan"]
         self.assertEqual(
-            relayed[0]["streaming_policy"],
+            relay_execution_plan.streaming_policy,
             planned_attempt.streaming_policy,
         )
         self.assertEqual(
-            relayed[0]["usage_policy"],
+            relay_execution_plan.usage_policy,
             planned_attempt.usage_policy,
         )
         self.assertEqual(
-            relayed[0]["response_mutation_policy"],
+            relay_execution_plan.response_mutation_policy,
             planned_attempt.response_mutation_policy,
         )
         self.assertEqual(
-            relayed[0]["sse_mutation_policy"],
+            relay_execution_plan.sse_mutation_policy,
             planned_attempt.sse_mutation_policy,
         )
+
+    def test_handler_freezes_provider_auth_before_plan_returns_without_secret_exposure(self):
+        original_key = "route-plan-auth-sentinel-old"
+        replacement_key = "route-plan-auth-sentinel-new"
+        upstream = {
+            "name": "volcengine",
+            "base_url": "https://ark.example.test/v1",
+            "auth": "api_key",
+            "api_key": original_key,
+            "upstream_model": "glm-5.2",
+            "upstream_format": "responses",
+        }
+        body = json.dumps(
+            {
+                "model": "volc/glm-5.2",
+                "input": [
+                    {"type": "message", "role": "user", "content": "hi"}
+                ],
+                "stream": False,
+            }
+        ).encode("utf-8")
+        handler, _fake = post_handler("/v1/responses", body)
+        handler._relay_upstream_response = (
+            lambda response, upstream_name, **kwargs: 200
+        )
+        plans: list[codex_proxy.RoutePlan] = []
+        opened_requests = []
+        real_planner = codex_proxy.route_plan_for_request
+
+        def plan_then_rotate_key(*args, **kwargs):
+            plan = real_planner(*args, **kwargs)
+            plans.append(plan)
+            upstream["api_key"] = replacement_key
+            return plan
+
+        def open_upstream(request, **_kwargs):
+            opened_requests.append(request)
+            return FakeContextResponse(b'{"id":"resp_auth","output":[]}')
+
+        with (
+            patch("codex_proxy.choose_upstream", return_value=upstream),
+            patch(
+                "codex_proxy.route_plan_for_request",
+                side_effect=plan_then_rotate_key,
+            ),
+            patch(
+                "codex_proxy._open_upstream_response",
+                side_effect=open_upstream,
+            ),
+        ):
+            CodexProxyHandler._proxy_post_request(
+                handler,
+                inbound_format="responses",
+            )
+
+        self.assertEqual(
+            opened_requests[0].get_header("Authorization"),
+            f"Bearer {original_key}",
+        )
+        rendered_plan = repr(plans[0])
+        rendered_copy = repr(asdict(plans[0]))
+        rendered_events = repr(self.write_proxy_event.call_args_list)
+        for secret in (original_key, replacement_key):
+            self.assertNotIn(secret, rendered_plan)
+            self.assertNotIn(secret, rendered_copy)
+            self.assertNotIn(secret, rendered_events)
+
+    def test_operational_auth_snapshot_refreshes_only_on_the_next_plan(self):
+        def planned_headers(upstream, incoming_headers):
+            authentication = (
+                codex_proxy.materialize_operational_authentication(
+                    incoming_headers,
+                    upstream,
+                )
+            )
+            plan = codex_proxy.route_plan_for_request(
+                upstream,
+                {"client_id": "codex-app"},
+                inbound_format="responses",
+                model_requested="volc/glm-5.2",
+                operational_authentication=authentication,
+                incoming_headers=incoming_headers,
+                official_http_passthrough_enabled=False,
+            )
+            return plan, plan.attempts[0].request_headers.to_dict()
+
+        provider = {
+            "name": "volcengine",
+            "base_url": "https://ark.example.test/v1",
+            "auth": "api_key",
+            "api_key": "provider-old",
+            "upstream_model": "glm-5.2",
+            "upstream_format": "responses",
+        }
+        first_plan, first_headers = planned_headers(provider, {})
+        provider["api_key"] = "provider-new"
+        second_plan, second_headers = planned_headers(provider, {})
+        self.assertEqual(first_headers["Authorization"], "Bearer provider-old")
+        self.assertEqual(second_headers["Authorization"], "Bearer provider-new")
+        self.assertEqual(first_plan, second_plan)
+
+        incoming_provider = {
+            **provider,
+            "auth": "incoming",
+        }
+        _empty_plan, empty_headers = planned_headers(incoming_provider, {})
+        _incoming_plan, incoming_headers = planned_headers(
+            incoming_provider,
+            {"Authorization": "Custom incoming-new"},
+        )
+        self.assertNotIn("Authorization", empty_headers)
+        self.assertEqual(
+            incoming_headers["Authorization"],
+            "Custom incoming-new",
+        )
+
+        ollama_provider = {
+            **provider,
+            "auth": "ollama_api_key",
+        }
+        with patch.dict(
+            os.environ,
+            {"OLLAMA_API_KEY": "ollama-old"},
+            clear=False,
+        ):
+            _ollama_plan, ollama_headers = planned_headers(
+                ollama_provider,
+                {},
+            )
+            os.environ["OLLAMA_API_KEY"] = "ollama-new"
+            _next_ollama_plan, next_ollama_headers = planned_headers(
+                ollama_provider,
+                {},
+            )
+        self.assertEqual(
+            ollama_headers["Authorization"],
+            "Bearer ollama-old",
+        )
+        self.assertEqual(
+            next_ollama_headers["Authorization"],
+            "Bearer ollama-new",
+        )
+
+        official_provider = {
+            "name": "official",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "auth": "codex_auth",
+            "upstream_model": "gpt-5.6-sol",
+            "upstream_format": "responses",
+        }
+        with (
+            patch("codex_proxy.codex_access_token", return_value="codex-old"),
+            patch("codex_proxy.codex_account_id", return_value="acct-old"),
+        ):
+            official_authentication = (
+                codex_proxy.materialize_operational_authentication(
+                    {},
+                    official_provider,
+                )
+            )
+            official_plan = codex_proxy.route_plan_for_request(
+                official_provider,
+                {},
+                inbound_format="responses",
+                model_requested="openai/gpt-5.6-sol",
+                operational_authentication=official_authentication,
+                incoming_headers={},
+                official_http_passthrough_enabled=False,
+            )
+            repeated_official_plan = codex_proxy.route_plan_for_request(
+                official_provider,
+                {},
+                inbound_format="responses",
+                model_requested="openai/gpt-5.6-sol",
+                operational_authentication=official_authentication,
+                incoming_headers={},
+                official_http_passthrough_enabled=False,
+            )
+        official_headers = (
+            official_plan.attempts[0].request_headers.to_dict()
+        )
+        repeated_official_headers = (
+            repeated_official_plan.attempts[0].request_headers.to_dict()
+        )
+        self.assertEqual(official_headers, repeated_official_headers)
+        self.assertEqual(
+            official_headers["Authorization"],
+            "Bearer codex-old",
+        )
+        self.assertEqual(
+            official_headers["Chatgpt-account-id"],
+            "acct-old",
+        )
+
+    def test_handler_uses_same_planned_relay_policy_for_success_and_final_http_error(self):
+        upstream = {
+            "name": "volcengine",
+            "base_url": "https://ark.example.test/v1",
+            "auth": "api_key",
+            "api_key": "test-token",
+            "upstream_model": "glm-5.2",
+            "upstream_format": "responses",
+        }
+        planned = codex_proxy.route_plan_for_request(
+            upstream,
+            {"client_id": "codex-app"},
+            inbound_format="responses",
+            model_requested="volc/glm-5.2",
+            operational_authentication=(
+                codex_proxy.materialize_operational_authentication(
+                    {},
+                    upstream,
+                )
+            ),
+            incoming_headers={},
+        )
+        future_policy_attempt = replace(
+            planned.attempts[0],
+            streaming_policy=(
+                codex_proxy.StreamingPolicy.TRANSPARENT_CONVERTED
+            ),
+            usage_policy=codex_proxy.UsagePolicy.ASYNC_TAP,
+            response_mutation_policy=codex_proxy.MutationPolicy.TRANSPARENT,
+            sse_mutation_policy=codex_proxy.MutationPolicy.TRANSPARENT,
+            verify_cross_protocol_source=False,
+        )
+        planned = replace(planned, attempts=(future_policy_attempt,))
+        body = json.dumps(
+            {
+                "model": "volc/glm-5.2",
+                "input": [
+                    {"type": "message", "role": "user", "content": "hi"}
+                ],
+                "stream": False,
+            }
+        ).encode("utf-8")
+        relayed: list[dict[str, Any]] = []
+
+        def run(response_or_error):
+            handler, _fake = post_handler("/v1/responses", body)
+            handler._relay_upstream_response = (
+                lambda response, upstream_name, **kwargs:
+                relayed.append(kwargs) or getattr(response, "code", 200)
+            )
+            with (
+                patch("codex_proxy.choose_upstream", return_value=upstream),
+                patch(
+                    "codex_proxy.route_plan_for_request",
+                    return_value=planned,
+                ),
+                patch(
+                    "codex_proxy._open_upstream_response",
+                    side_effect=[response_or_error],
+                ),
+            ):
+                CodexProxyHandler._proxy_post_request(
+                    handler,
+                    inbound_format="responses",
+                )
+
+        run(FakeContextResponse(b'{"id":"resp_ok","output":[]}'))
+        run(
+            HTTPError(
+                "https://ark.example.test/v1/responses",
+                418,
+                "planned error",
+                {"Content-Type": "application/json"},
+                io.BytesIO(b'{"error":"planned"}'),
+            )
+        )
+
+        self.assertEqual(len(relayed), 2)
+        success_plan = relayed[0]["relay_execution_plan"]
+        error_plan = relayed[1]["relay_execution_plan"]
+        self.assertEqual(success_plan, error_plan)
+        self.assertEqual(
+            success_plan.streaming_policy,
+            codex_proxy.StreamingPolicy.TRANSPARENT_CONVERTED,
+        )
+        self.assertEqual(
+            success_plan.usage_policy,
+            codex_proxy.UsagePolicy.ASYNC_TAP,
+        )
+        self.assertEqual(
+            success_plan.response_mutation_policy,
+            codex_proxy.MutationPolicy.TRANSPARENT,
+        )
+        self.assertNotIn("behavior_profile", relayed[0])
+        self.assertNotIn("behavior_profile", relayed[1])
 
     def test_open_upstream_response_consumes_planned_retry_execution(self):
         runtime_facts = codex_proxy.RouteRuntimeFacts(
@@ -1678,6 +2083,15 @@ class RoutingTests(unittest.TestCase):
             {
                 "name": "malformed_version",
                 "version": "../provider capabilities",
+                "hash": valid_hash,
+                "state": codex_proxy.CapabilityState.SUPPORTED.value,
+                "expected_version": None,
+                "expected_hash": None,
+                "expected_state": codex_proxy.CapabilityState.UNQUALIFIED,
+            },
+            {
+                "name": "future_version",
+                "version": "provider-capabilities.v999",
                 "hash": valid_hash,
                 "state": codex_proxy.CapabilityState.SUPPORTED.value,
                 "expected_version": None,
@@ -2817,6 +3231,57 @@ class RoutingTests(unittest.TestCase):
             request_complete["executed_attempt_mutation_summary"],
             request_complete["route_attempt_mutation_summary"],
         )
+        first_body_hmac = (
+            codex_proxy.proxy_telemetry.enrich_request_observability(
+                body=responses_request.data,
+                codex_home=codex_proxy.RUNTIME_CODEX_DIR,
+            )["request_body_hmac"]
+        )
+        final_body_hmac = (
+            codex_proxy.proxy_telemetry.enrich_request_observability(
+                body=chat_request.data,
+                codex_home=codex_proxy.RUNTIME_CODEX_DIR,
+            )["request_body_hmac"]
+        )
+        self.assertNotEqual(first_body_hmac, final_body_hmac)
+        self.assertEqual(
+            request_start["upstream_request_body_hmac"],
+            first_body_hmac,
+        )
+        self.assertEqual(
+            fallback["upstream_request_body_hmac"],
+            first_body_hmac,
+        )
+        self.assertEqual(
+            request_complete["upstream_request_body_hmac"],
+            final_body_hmac,
+        )
+        self.assertEqual(
+            request_complete["request_observability_scope"],
+            "executed_attempt",
+        )
+        self.assertEqual(
+            request_complete["request_observability_attempt_index"],
+            1,
+        )
+        planned_attempts = request_start["route_attempts"]
+        self.assertEqual(len(planned_attempts), 2)
+        self.assertEqual(
+            fallback["failed_route_attempt_request_conversion_steps"],
+            planned_attempts[0]["request_conversion_steps"],
+        )
+        self.assertEqual(
+            fallback["next_route_attempt_request_conversion_steps"],
+            planned_attempts[1]["request_conversion_steps"],
+        )
+        self.assertEqual(
+            request_complete["route_attempt_request_conversion_steps"],
+            planned_attempts[1]["request_conversion_steps"],
+        )
+        self.assertEqual(
+            request_complete["route_attempt_mutation_summary"],
+            planned_attempts[1]["mutation_summary"],
+        )
 
     def test_post_request_events_include_behavior_profile_on_success(self):
         body = json.dumps(
@@ -3672,7 +4137,7 @@ class RoutingTests(unittest.TestCase):
             patch("codex_proxy.compatible_sse_line", side_effect=AssertionError("official relay rewrote SSE")),
             patch("codex_proxy._offer_official_passthrough_usage_line", side_effect=record_usage_offer, create=True),
         ):
-            status = CodexProxyHandler._relay_upstream_response(
+            status = relay_upstream_response(
                 fake,
                 response,
                 "official",
@@ -3699,7 +4164,7 @@ class RoutingTests(unittest.TestCase):
         fake = FakeHandler()
         usage_capture = {}
 
-        status = CodexProxyHandler._relay_upstream_response(
+        status = relay_upstream_response(
             fake,
             FakeSseResponse(
                 [
@@ -3810,7 +4275,7 @@ class RoutingTests(unittest.TestCase):
             for start, end in zip((0, *split_points), (*split_points, len(raw)))
         ]
 
-        status = CodexProxyHandler._relay_upstream_response(
+        status = relay_upstream_response(
             fake,
             FakeSseResponse([*chunks, b""]),
             "official",
@@ -3841,7 +4306,7 @@ class RoutingTests(unittest.TestCase):
             ]
         )
 
-        status = CodexProxyHandler._relay_upstream_response(
+        status = relay_upstream_response(
             fake,
             response,
             "official",
@@ -3963,7 +4428,7 @@ class RoutingTests(unittest.TestCase):
 
     def test_official_http_passthrough_sse_interruption_writes_terminal_failure(self):
         fake = FakeHandler()
-        status = CodexProxyHandler._relay_upstream_response(
+        status = relay_upstream_response(
             fake,
             FakeSseResponse(
                 [
@@ -4003,7 +4468,7 @@ class RoutingTests(unittest.TestCase):
         )
 
         with patch("codex_proxy.write_proxy_event") as write_event:
-            status = CodexProxyHandler._relay_upstream_response(
+            status = relay_upstream_response(
                 fake,
                 FakeSseResponse([oversized_frame, b""]),
                 "official",
@@ -4041,7 +4506,7 @@ class RoutingTests(unittest.TestCase):
         fake = FakeHandler()
         partial = b'data: {"type":"response.created","response":{"id":"resp_partial"}}'
 
-        status = CodexProxyHandler._relay_upstream_response(
+        status = relay_upstream_response(
             fake,
             FakeSseResponse([partial, URLError("connection reset")]),
             "official",
@@ -4068,7 +4533,7 @@ class RoutingTests(unittest.TestCase):
         usage_capture = {}
 
         with patch("codex_proxy.write_proxy_event") as write_event:
-            status = CodexProxyHandler._relay_upstream_response(
+            status = relay_upstream_response(
                 fake,
                 FakeSseResponse(
                     [
@@ -4107,7 +4572,7 @@ class RoutingTests(unittest.TestCase):
         )
         response.shorten_terminal_drain_timeout = Mock()
 
-        status = CodexProxyHandler._relay_upstream_response(
+        status = relay_upstream_response(
             fake,
             response,
             "official",
@@ -4129,7 +4594,7 @@ class RoutingTests(unittest.TestCase):
         fake = FakeHandler()
 
         with patch("codex_proxy.write_proxy_event") as write_event:
-            status = CodexProxyHandler._relay_upstream_response(
+            status = relay_upstream_response(
                 fake,
                 FakeSseResponse(
                     [
@@ -4171,7 +4636,7 @@ class RoutingTests(unittest.TestCase):
         fake.wfile = FakeWFile(fail_on_write=lambda _data, index: index == 0)
 
         with patch("codex_proxy.write_proxy_event") as write_event:
-            status = CodexProxyHandler._relay_upstream_response(
+            status = relay_upstream_response(
                 fake,
                 FakeSseResponse(
                     [
@@ -4218,7 +4683,7 @@ class RoutingTests(unittest.TestCase):
         )
 
         with patch("codex_proxy.write_proxy_event") as write_event:
-            status = CodexProxyHandler._relay_upstream_response(
+            status = relay_upstream_response(
                 fake,
                 response,
                 "official",
@@ -4257,7 +4722,7 @@ class RoutingTests(unittest.TestCase):
         )
 
         with patch("codex_proxy.write_proxy_event") as write_event:
-            status = CodexProxyHandler._relay_upstream_response(
+            status = relay_upstream_response(
                 fake,
                 response,
                 "official",
@@ -4292,7 +4757,7 @@ class RoutingTests(unittest.TestCase):
         )
 
         with patch("codex_proxy.write_proxy_event") as write_event:
-            status = CodexProxyHandler._relay_upstream_response(
+            status = relay_upstream_response(
                 fake,
                 response,
                 "official",
@@ -4326,7 +4791,7 @@ class RoutingTests(unittest.TestCase):
         )
 
         with patch("codex_proxy.write_proxy_event"):
-            status = CodexProxyHandler._relay_upstream_response(
+            status = relay_upstream_response(
                 fake,
                 response,
                 "official",
@@ -4368,7 +4833,7 @@ class RoutingTests(unittest.TestCase):
         )
 
         with patch("codex_proxy.write_proxy_event") as write_event:
-            status = CodexProxyHandler._relay_upstream_response(
+            status = relay_upstream_response(
                 fake,
                 response,
                 "official",
@@ -4403,7 +4868,7 @@ class RoutingTests(unittest.TestCase):
             ]
         )
 
-        status = CodexProxyHandler._relay_upstream_response(
+        status = relay_upstream_response(
             fake,
             response,
             "official",
@@ -4433,7 +4898,7 @@ class RoutingTests(unittest.TestCase):
             ]
         )
 
-        status = CodexProxyHandler._relay_upstream_response(
+        status = relay_upstream_response(
             fake,
             response,
             "ollama_cloud",
@@ -4470,7 +4935,7 @@ class RoutingTests(unittest.TestCase):
             thread = threading.Thread(target=cancel_soon)
             thread.start()
             with patch("codex_proxy.write_proxy_event") as write_event:
-                status = CodexProxyHandler._relay_upstream_response(
+                status = relay_upstream_response(
                     fake,
                     response,
                     "official",
@@ -4577,7 +5042,7 @@ class RoutingTests(unittest.TestCase):
             thread = threading.Thread(target=cancel_soon)
             thread.start()
             with patch("codex_proxy.write_proxy_event") as write_event:
-                status = CodexProxyHandler._relay_upstream_response(
+                status = relay_upstream_response(
                     fake,
                     response,
                     "official",
@@ -4630,7 +5095,7 @@ class RoutingTests(unittest.TestCase):
             thread = threading.Thread(target=cancel_soon)
             thread.start()
             with patch("codex_proxy.write_proxy_event") as write_event:
-                status = CodexProxyHandler._relay_upstream_response(
+                status = relay_upstream_response(
                     fake,
                     response,
                     "official",
@@ -4721,7 +5186,7 @@ class RoutingTests(unittest.TestCase):
             admission = codex_proxy.GatewayRequestAdmission()
             previous = codex_proxy._activate_gateway_request(admission)
             try:
-                status = CodexProxyHandler._relay_upstream_response(
+                status = relay_upstream_response(
                     handler,
                     response,
                     case["upstream_name"],
@@ -4784,7 +5249,7 @@ class RoutingTests(unittest.TestCase):
             ]
         )
 
-        status = CodexProxyHandler._relay_upstream_response(
+        status = relay_upstream_response(
             fake,
             response,
             "responses_only_provider",
@@ -4823,7 +5288,7 @@ class RoutingTests(unittest.TestCase):
             ]
         )
 
-        status = CodexProxyHandler._relay_upstream_response(
+        status = relay_upstream_response(
             fake,
             response,
             "chat_only_provider",
@@ -4856,7 +5321,7 @@ class RoutingTests(unittest.TestCase):
             ]
         )
 
-        status = CodexProxyHandler._relay_upstream_response(
+        status = relay_upstream_response(
             fake,
             response,
             "responses_only_provider",
@@ -4911,7 +5376,7 @@ class RoutingTests(unittest.TestCase):
                 fake = FakeHandler()
                 response = FakeSseResponse([malformed, later_success, b""])
 
-                status = CodexProxyHandler._relay_upstream_response(
+                status = relay_upstream_response(
                     fake,
                     response,
                     f"{name}_provider",
@@ -4967,7 +5432,7 @@ class RoutingTests(unittest.TestCase):
             with self.subTest(name=name):
                 fake = FakeHandler()
 
-                status = CodexProxyHandler._relay_upstream_response(
+                status = relay_upstream_response(
                     fake,
                     FakeSseResponse(stream),
                     f"{name}_generic_provider",
@@ -4998,7 +5463,7 @@ class RoutingTests(unittest.TestCase):
             ]
         )
 
-        status = CodexProxyHandler._relay_upstream_response(
+        status = relay_upstream_response(
             fake,
             response,
             "responses_provider",
@@ -5092,7 +5557,7 @@ class RoutingTests(unittest.TestCase):
         )
         fake = FakeHandler()
 
-        status = CodexProxyHandler._relay_upstream_response(
+        status = relay_upstream_response(
             fake,
             response,
             "chat_only_provider",
@@ -5168,7 +5633,7 @@ class RoutingTests(unittest.TestCase):
         )
         fake = FakeHandler()
 
-        status = CodexProxyHandler._relay_upstream_response(
+        status = relay_upstream_response(
             fake,
             response,
             "chat_only_provider",
@@ -5220,7 +5685,7 @@ class RoutingTests(unittest.TestCase):
         }
         fake = FakeHandler()
 
-        status = CodexProxyHandler._relay_upstream_response(
+        status = relay_upstream_response(
             fake,
             FakeSseResponse(
                 [
@@ -5301,7 +5766,7 @@ class RoutingTests(unittest.TestCase):
             ):
                 for chunks in partitions:
                     fake = FakeHandler()
-                    status = CodexProxyHandler._relay_upstream_response(
+                    status = relay_upstream_response(
                         fake,
                         FakeSseResponse(chunks),
                         f"{name}_provider",
@@ -5378,7 +5843,7 @@ class RoutingTests(unittest.TestCase):
         )
         fake = FakeHandler()
 
-        status = CodexProxyHandler._relay_upstream_response(
+        status = relay_upstream_response(
             fake,
             response,
             "chat_only_provider",
@@ -5764,7 +6229,7 @@ class RoutingTests(unittest.TestCase):
             {"CODEX_PROXY_SSE_KEEPALIVE_SECONDS": "0.01"},
             clear=False,
         ):
-            result = CodexProxyHandler._relay_upstream_response(
+            result = relay_upstream_response(
                 handler,
                 response,
                 "official",
@@ -12410,7 +12875,7 @@ class RoutingTests(unittest.TestCase):
         ]
         response = FakeSseResponse(lines)
 
-        CodexProxyHandler._relay_upstream_response(handler, response, "official")
+        relay_upstream_response(handler, response, "official")
 
         self.assertEqual(handler.status, 200)
         self.assertTrue(handler.headers_ended)
@@ -12431,7 +12896,7 @@ class RoutingTests(unittest.TestCase):
         )
 
         with patch.dict(os.environ, {"CODEX_PROXY_SSE_KEEPALIVE_SECONDS": "0.01"}, clear=False):
-            CodexProxyHandler._relay_upstream_response(handler, response, "official")
+            relay_upstream_response(handler, response, "official")
 
         written = b"".join(handler.wfile.writes)
         keepalive_index = written.index(b": codexhub.keepalive\n\n")
@@ -12459,7 +12924,7 @@ class RoutingTests(unittest.TestCase):
             with patch.dict(
                 os.environ, {"CODEX_PROXY_SSE_KEEPALIVE_SECONDS": "0.01"}, clear=False
             ):
-                status = CodexProxyHandler._relay_upstream_response(
+                status = relay_upstream_response(
                     handler,
                     response,
                     "official",
@@ -12492,7 +12957,7 @@ class RoutingTests(unittest.TestCase):
         }
         response = FakeSseResponse([f"data: {json.dumps(event)}\n".encode("utf-8"), b"\n", b""])
 
-        CodexProxyHandler._relay_upstream_response(handler, response, "ollama_cloud")
+        relay_upstream_response(handler, response, "ollama_cloud")
 
         data_line = handler.wfile.writes[0].decode("utf-8")
         payload = json.loads(data_line.removeprefix("data: "))
@@ -12511,7 +12976,7 @@ class RoutingTests(unittest.TestCase):
         }
         response = FakeSseResponse([f"data: {json.dumps(event)}\n".encode("utf-8"), b"\n", b""])
 
-        CodexProxyHandler._relay_upstream_response(handler, response, "volcengine")
+        relay_upstream_response(handler, response, "volcengine")
 
         data_line = handler.wfile.writes[0].decode("utf-8")
         payload = json.loads(data_line.removeprefix("data: "))
@@ -12530,7 +12995,7 @@ class RoutingTests(unittest.TestCase):
         }
         response = FakeSseResponse([f"data: {json.dumps(event)}\n".encode("utf-8"), b"\n", b""])
 
-        CodexProxyHandler._relay_upstream_response(handler, response, "volcengine")
+        relay_upstream_response(handler, response, "volcengine")
 
         data_line = handler.wfile.writes[0].decode("utf-8")
         payload = json.loads(data_line.removeprefix("data: "))
@@ -12556,7 +13021,7 @@ class RoutingTests(unittest.TestCase):
             ]
         )
 
-        status = CodexProxyHandler._relay_upstream_response(handler, response, "ollama_cloud")
+        status = relay_upstream_response(handler, response, "ollama_cloud")
 
         data = b"".join(handler.wfile.writes)
         self.assertEqual(status, 502)
@@ -12581,7 +13046,7 @@ class RoutingTests(unittest.TestCase):
             ]
         )
 
-        status = CodexProxyHandler._relay_upstream_response(
+        status = relay_upstream_response(
             handler,
             response,
             "ollama_cloud",
@@ -12623,7 +13088,7 @@ class RoutingTests(unittest.TestCase):
             b"",
         ])
 
-        CodexProxyHandler._relay_upstream_response(handler, response, "ollama_cloud")
+        relay_upstream_response(handler, response, "ollama_cloud")
 
         data_line = handler.wfile.writes[0].decode("utf-8")
         payload = json.loads(data_line.removeprefix("data: "))
@@ -12991,7 +13456,7 @@ class RoutingTests(unittest.TestCase):
         body = b'{"ok":true}'
         response = FakeResponse(body)
 
-        CodexProxyHandler._relay_upstream_response(handler, response, "official")
+        relay_upstream_response(handler, response, "official")
 
         self.assertEqual(handler.status, 200)
         self.assertEqual(handler.wfile.writes, [body])
@@ -13023,7 +13488,7 @@ class RoutingTests(unittest.TestCase):
         ).encode("utf-8")
         response = FakeResponse(body)
 
-        CodexProxyHandler._relay_upstream_response(
+        relay_upstream_response(
             handler,
             response,
             "volcengine",
@@ -13076,7 +13541,7 @@ class RoutingTests(unittest.TestCase):
             + [b"data: [DONE]\n\n", b""]
         )
 
-        status = CodexProxyHandler._relay_upstream_response(
+        status = relay_upstream_response(
             handler,
             response,
             "volcengine",
@@ -13162,7 +13627,7 @@ class RoutingTests(unittest.TestCase):
             [f"data: {json.dumps(event, ensure_ascii=True)}\n\n".encode("utf-8") for event in events] + [b""]
         )
 
-        status = CodexProxyHandler._relay_upstream_response(
+        status = relay_upstream_response(
             handler,
             response,
             "volcengine",
@@ -13733,7 +14198,7 @@ class RoutingTests(unittest.TestCase):
         ).encode("utf-8")
         response = FakeResponse(body)
 
-        CodexProxyHandler._relay_upstream_response(
+        relay_upstream_response(
             handler,
             response,
             "volcengine",
@@ -13878,7 +14343,7 @@ class RoutingTests(unittest.TestCase):
         ).encode("utf-8")
         response = FakeResponse(body)
 
-        CodexProxyHandler._relay_upstream_response(
+        relay_upstream_response(
             handler,
             response,
             "ollama_cloud",
@@ -13938,7 +14403,7 @@ class RoutingTests(unittest.TestCase):
             [f"data: {json.dumps(chunk)}\n\n".encode("utf-8") for chunk in chunks] + [b"data: [DONE]\n\n", b""]
         )
 
-        CodexProxyHandler._relay_upstream_response(
+        relay_upstream_response(
             handler,
             response,
             "volcengine",
@@ -13986,7 +14451,7 @@ class RoutingTests(unittest.TestCase):
             [f"data: {json.dumps(chunk)}\n\n".encode("utf-8") for chunk in chunks] + [b"data: [DONE]\n\n", b""]
         )
 
-        CodexProxyHandler._relay_upstream_response(
+        relay_upstream_response(
             handler,
             response,
             "volcengine",
@@ -14075,7 +14540,7 @@ class RoutingTests(unittest.TestCase):
             [f"data: {json.dumps(chunk)}\n\n".encode("utf-8") for chunk in chunks] + [b"data: [DONE]\n\n", b""]
         )
 
-        CodexProxyHandler._relay_upstream_response(
+        relay_upstream_response(
             handler,
             response,
             "volcengine",
@@ -14147,7 +14612,7 @@ class RoutingTests(unittest.TestCase):
             [f"data: {json.dumps(chunk)}\n\n".encode("utf-8") for chunk in chunks] + [b"data: [DONE]\n\n", b""]
         )
 
-        CodexProxyHandler._relay_upstream_response(
+        relay_upstream_response(
             handler,
             response,
             "ollama_cloud",
@@ -14192,7 +14657,7 @@ class RoutingTests(unittest.TestCase):
             [f"data: {json.dumps(chunk)}\n\n".encode("utf-8") for chunk in chunks] + [b"data: [DONE]\n\n", b""]
         )
 
-        CodexProxyHandler._relay_upstream_response(
+        relay_upstream_response(
             handler,
             response,
             "volcengine",
@@ -14221,7 +14686,7 @@ class RoutingTests(unittest.TestCase):
             [f"data: {json.dumps(chunk)}\n\n".encode("utf-8") for chunk in chunks] + [b"data: [DONE]\n\n", b""]
         )
 
-        status = CodexProxyHandler._relay_upstream_response(
+        status = relay_upstream_response(
             handler,
             response,
             "ollama_cloud",
@@ -14370,7 +14835,7 @@ class RoutingTests(unittest.TestCase):
             ]
         )
 
-        status = CodexProxyHandler._relay_upstream_response(
+        status = relay_upstream_response(
             handler,
             response,
             "official",
@@ -14396,7 +14861,7 @@ class RoutingTests(unittest.TestCase):
             ]
         )
 
-        status = CodexProxyHandler._relay_upstream_response(
+        status = relay_upstream_response(
             handler,
             response,
             "ollama_cloud",
@@ -14435,7 +14900,7 @@ class RoutingTests(unittest.TestCase):
             },
             clear=False,
         ):
-            status = CodexProxyHandler._relay_upstream_response(
+            status = relay_upstream_response(
                 handler,
                 response,
                 "official",
@@ -14479,7 +14944,7 @@ class RoutingTests(unittest.TestCase):
             },
             clear=False,
         ):
-            status = CodexProxyHandler._relay_upstream_response(
+            status = relay_upstream_response(
                 handler,
                 response,
                 "official",
@@ -14528,7 +14993,7 @@ class RoutingTests(unittest.TestCase):
             },
             clear=False,
         ):
-            status = CodexProxyHandler._relay_upstream_response(
+            status = relay_upstream_response(
                 handler,
                 response,
                 "official",
@@ -14594,7 +15059,7 @@ class RoutingTests(unittest.TestCase):
             },
             clear=False,
         ):
-            status = CodexProxyHandler._relay_upstream_response(
+            status = relay_upstream_response(
                 handler,
                 response,
                 "official",
@@ -14649,7 +15114,7 @@ class RoutingTests(unittest.TestCase):
             },
             clear=False,
         ):
-            status = CodexProxyHandler._relay_upstream_response(
+            status = relay_upstream_response(
                 handler,
                 response,
                 "official",
@@ -14681,7 +15146,7 @@ class RoutingTests(unittest.TestCase):
         ).encode("utf-8")
         response = FakeResponse(body)
 
-        CodexProxyHandler._relay_upstream_response(handler, response, "ollama_cloud")
+        relay_upstream_response(handler, response, "ollama_cloud")
 
         payload = json.loads(handler.wfile.writes[0])
         self.assertNotIn("encrypted_content", payload["output"][0])
@@ -14702,7 +15167,7 @@ class RoutingTests(unittest.TestCase):
         ).encode("utf-8")
         response = FakeResponse(body)
 
-        CodexProxyHandler._relay_upstream_response(handler, response, "minimax")
+        relay_upstream_response(handler, response, "minimax")
 
         payload = json.loads(handler.wfile.writes[0])
         self.assertEqual(payload["output"][0]["summary"], [])
@@ -14724,7 +15189,7 @@ class RoutingTests(unittest.TestCase):
         ).encode("utf-8")
         response = FakeResponse(body)
 
-        CodexProxyHandler._relay_upstream_response(handler, response, "volcengine")
+        relay_upstream_response(handler, response, "volcengine")
 
         payload = json.loads(handler.wfile.writes[0])
         self.assertEqual(payload["output"][0]["type"], "message")
@@ -14740,7 +15205,7 @@ class RoutingTests(unittest.TestCase):
             b"",
         ])
 
-        status = CodexProxyHandler._relay_upstream_response(
+        status = relay_upstream_response(
             handler,
             response,
             "official",
@@ -14781,7 +15246,7 @@ class RoutingTests(unittest.TestCase):
             b"",
         ])
 
-        status = CodexProxyHandler._relay_upstream_response(
+        status = relay_upstream_response(
             handler,
             response,
             "official",
@@ -14805,7 +15270,7 @@ class RoutingTests(unittest.TestCase):
             b"",
         ])
 
-        status = CodexProxyHandler._relay_upstream_response(
+        status = relay_upstream_response(
             handler,
             response,
             "ollama_cloud",
@@ -14829,7 +15294,7 @@ class RoutingTests(unittest.TestCase):
             b"",
         ])
 
-        status = CodexProxyHandler._relay_upstream_response(
+        status = relay_upstream_response(
             handler,
             response,
             "official",
@@ -14851,7 +15316,7 @@ class RoutingTests(unittest.TestCase):
         handler = FakeHandler()
         response = FakeSseResponse([b""])
 
-        status = CodexProxyHandler._relay_upstream_response(
+        status = relay_upstream_response(
             handler,
             response,
             "official",
@@ -14871,7 +15336,7 @@ class RoutingTests(unittest.TestCase):
         response = FakeSseResponse([b""])
 
         with self.assertRaises(codex_proxy.UpstreamStreamIncompleteError):
-            CodexProxyHandler._relay_upstream_response(
+            relay_upstream_response(
                 handler,
                 response,
                 "official",
@@ -14901,7 +15366,7 @@ class RoutingTests(unittest.TestCase):
         )
 
         with self.assertRaises(codex_proxy.UpstreamStreamErrorEvent) as raised:
-            CodexProxyHandler._relay_upstream_response(
+            relay_upstream_response(
                 handler,
                 response,
                 "xunfei",
@@ -14931,7 +15396,7 @@ class RoutingTests(unittest.TestCase):
         )
 
         with self.assertRaises(codex_proxy.UpstreamStreamErrorEvent) as raised:
-            CodexProxyHandler._relay_upstream_response(
+            relay_upstream_response(
                 handler,
                 response,
                 "xunfei",
@@ -14970,7 +15435,7 @@ class RoutingTests(unittest.TestCase):
         )
 
         with self.assertRaises(codex_proxy.UpstreamStreamErrorEvent) as raised:
-            CodexProxyHandler._relay_upstream_response(
+            relay_upstream_response(
                 handler,
                 response,
                 "xunfei",
@@ -15000,7 +15465,7 @@ class RoutingTests(unittest.TestCase):
             ]
         )
 
-        status = CodexProxyHandler._relay_upstream_response(
+        status = relay_upstream_response(
             handler,
             response,
             "volcengine",
@@ -15043,7 +15508,7 @@ class RoutingTests(unittest.TestCase):
         forwarded_prefix = b"data: " + (b"x" * 40)
         usage_capture = {}
 
-        status = CodexProxyHandler._relay_upstream_response(
+        status = relay_upstream_response(
             handler,
             FakeSseResponse([forwarded_prefix, (b"y" * 24) + secret, b""]),
             "volcengine",
@@ -15094,7 +15559,7 @@ class RoutingTests(unittest.TestCase):
         completed_cr_event = b"data: first\r\r"
         secret = b"transparent-cr-secret"
 
-        status = CodexProxyHandler._relay_upstream_response(
+        status = relay_upstream_response(
             handler,
             FakeSseResponse([completed_cr_event, (b"x" * 64) + secret, b""]),
             "volcengine",
@@ -15138,7 +15603,7 @@ class RoutingTests(unittest.TestCase):
         secret = b"size-crossing-cr-secret"
         crossing_chunk = b"\rdata: " + (b"x" * 128) + secret
 
-        status = CodexProxyHandler._relay_upstream_response(
+        status = relay_upstream_response(
             handler,
             FakeSseResponse([created_prefix, crossing_chunk, b""]),
             "volcengine",
@@ -15171,7 +15636,7 @@ class RoutingTests(unittest.TestCase):
             + b'"}}\r\r'
         )
 
-        status = CodexProxyHandler._relay_upstream_response(
+        status = relay_upstream_response(
             handler,
             FakeSseResponse([completed_cr_event, URLError("connection reset")]),
             "volcengine",
@@ -15202,7 +15667,7 @@ class RoutingTests(unittest.TestCase):
             ]
         )
 
-        status = CodexProxyHandler._relay_upstream_response(
+        status = relay_upstream_response(
             handler,
             response,
             "volcengine",
@@ -15232,7 +15697,7 @@ class RoutingTests(unittest.TestCase):
             ]
         )
 
-        status = CodexProxyHandler._relay_upstream_response(
+        status = relay_upstream_response(
             handler,
             response,
             "volcengine",
@@ -15267,7 +15732,7 @@ class RoutingTests(unittest.TestCase):
             + [URLError("connection reset")]
         )
 
-        status = CodexProxyHandler._relay_upstream_response(
+        status = relay_upstream_response(
             handler,
             response,
             "ollama_cloud",
@@ -15309,7 +15774,7 @@ class RoutingTests(unittest.TestCase):
         secret = b"transparent-chat-secret"
         usage_capture = {}
 
-        status = CodexProxyHandler._relay_upstream_response(
+        status = relay_upstream_response(
             handler,
             FakeSseResponse([b"data: " + (b"x" * 64) + secret, b""]),
             "ollama_cloud",
@@ -15357,7 +15822,7 @@ class RoutingTests(unittest.TestCase):
             + [b"data: [DONE]\n\n", b""]
         )
 
-        status = CodexProxyHandler._relay_upstream_response(
+        status = relay_upstream_response(
             handler,
             response,
             "ollama_cloud",
@@ -15382,7 +15847,7 @@ class RoutingTests(unittest.TestCase):
         line = b'data: {"id":"chatcmpl_1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":null}]}\n'
         response = FakeSseResponse([line, URLError("connection reset")])
 
-        status = CodexProxyHandler._relay_upstream_response(
+        status = relay_upstream_response(
             handler,
             response,
             "ollama_cloud",
@@ -15467,7 +15932,7 @@ class RoutingTests(unittest.TestCase):
             + [b"data: [DONE]\n", b""]
         )
 
-        status = CodexProxyHandler._relay_upstream_response(
+        status = relay_upstream_response(
             handler,
             response,
             "ollama_cloud",
@@ -15504,7 +15969,7 @@ class RoutingTests(unittest.TestCase):
         )
 
         with self.assertRaises(codex_proxy.UpstreamStreamIncompleteError):
-            CodexProxyHandler._relay_upstream_response(
+            relay_upstream_response(
                 handler,
                 response,
                 "ollama_cloud",
@@ -15528,7 +15993,7 @@ class RoutingTests(unittest.TestCase):
         )
 
         with self.assertRaises(codex_proxy.UpstreamStreamInterruptedError):
-            CodexProxyHandler._relay_upstream_response(
+            relay_upstream_response(
                 handler,
                 response,
                 "ollama_cloud",
@@ -15556,7 +16021,7 @@ class RoutingTests(unittest.TestCase):
         )
 
         with self.assertRaises(codex_proxy.UpstreamStreamInterruptedError):
-            CodexProxyHandler._relay_upstream_response(
+            relay_upstream_response(
                 handler,
                 response,
                 "ollama_cloud",
@@ -15584,7 +16049,7 @@ class RoutingTests(unittest.TestCase):
             ]
         )
 
-        status = CodexProxyHandler._relay_upstream_response(
+        status = relay_upstream_response(
             handler,
             response,
             "xunfei",
@@ -15624,7 +16089,7 @@ class RoutingTests(unittest.TestCase):
         ).encode("utf-8")
         response = FakeResponse(body)
 
-        status = CodexProxyHandler._relay_upstream_response(
+        status = relay_upstream_response(
             handler,
             response,
             "xunfei",
@@ -15659,7 +16124,7 @@ class RoutingTests(unittest.TestCase):
         response = FakeResponse(body)
 
         with self.assertRaises(codex_proxy.CompactEmptyResponseError):
-            CodexProxyHandler._relay_upstream_response(
+            relay_upstream_response(
                 handler,
                 response,
                 "ollama_cloud",
@@ -15685,7 +16150,7 @@ class RoutingTests(unittest.TestCase):
         ).encode("utf-8")
         response = FakeResponse(body)
 
-        status = CodexProxyHandler._relay_upstream_response(
+        status = relay_upstream_response(
             handler,
             response,
             "official",
@@ -19571,7 +20036,7 @@ Execution constraints:
                 }
             ).encode("utf-8")
         )
-        CodexProxyHandler._relay_upstream_response(
+        relay_upstream_response(
             handler,
             empty_response,
             "ollama_cloud",
@@ -19585,7 +20050,7 @@ Execution constraints:
 
         compact_context = guarded_context()
         compact_handler = FakeHandler()
-        CodexProxyHandler._relay_upstream_response(
+        relay_upstream_response(
             compact_handler,
             FakeResponse(empty_response.body),
             "ollama_cloud",
@@ -19610,7 +20075,7 @@ Execution constraints:
             [f"data: {json.dumps(chunk)}\n\n".encode("utf-8") for chunk in close_chunks]
             + [b"data: [DONE]\n\n", b""]
         )
-        CodexProxyHandler._relay_upstream_response(
+        relay_upstream_response(
             close_handler,
             close_response,
             "ollama_cloud",
@@ -21904,7 +22369,7 @@ Execution constraints:
             },
         }
         handler = FakeHandler()
-        status = CodexProxyHandler._relay_upstream_response(
+        status = relay_upstream_response(
             handler,
             self._chat_spawn_sse_response({"agent_type": "worker", "message": "delegate"}),
             "synthetic-provider",
@@ -21949,7 +22414,7 @@ Execution constraints:
     def test_responses_caller_chat_upstream_sse_relay_rejects_missing_selector_before_call(self):
         handler = FakeHandler()
         with self.assertRaises(codex_proxy.UpstreamProtocolTranslationError) as raised:
-            CodexProxyHandler._relay_upstream_response(
+            relay_upstream_response(
                 handler,
                 self._chat_spawn_sse_response({"message": "delegate"}, call_id="chat-missing-selector"),
                 "synthetic-provider",
@@ -21971,7 +22436,7 @@ Execution constraints:
     def test_responses_caller_chat_upstream_sse_relay_rejects_unsupported_selector_before_call(self):
         handler = FakeHandler()
         with self.assertRaises(codex_proxy.UpstreamProtocolTranslationError) as raised:
-            CodexProxyHandler._relay_upstream_response(
+            relay_upstream_response(
                 handler,
                 self._chat_spawn_sse_response(
                     {"agent_type": "synthetic-unknown", "message": "delegate"},
@@ -22002,7 +22467,7 @@ Execution constraints:
             "subagent_exact_spawn_prompts": ["semantic repaired delegation"],
         }
         with self.assertRaises(codex_proxy.UpstreamProtocolTranslationError) as raised:
-            CodexProxyHandler._relay_upstream_response(
+            relay_upstream_response(
                 handler,
                 self._chat_spawn_sse_response(
                     {"agent_type": "synthetic-unknown", "message": "delegate"},
@@ -22026,7 +22491,7 @@ Execution constraints:
 
     def test_responses_caller_chat_upstream_sse_relay_preserves_general_through_semantic_repair(self):
         handler = FakeHandler()
-        status = CodexProxyHandler._relay_upstream_response(
+        status = relay_upstream_response(
             handler,
             self._chat_spawn_sse_response(
                 {"agent_type": "general", "message": "delegate"},
@@ -22069,7 +22534,7 @@ Execution constraints:
             ],
         }
         with self.assertRaises(codex_proxy.UpstreamProtocolTranslationError) as raised:
-            CodexProxyHandler._relay_upstream_response(
+            relay_upstream_response(
                 handler,
                 self._chat_spawn_sse_response(
                     {"targets": ["synthetic-child"], "timeout_ms": 1000},
@@ -24573,7 +25038,7 @@ Use an implementer subagent, then a spec reviewer, then a code quality reviewer.
         )
 
         with self.assertRaisesRegex(codex_proxy.UpstreamStreamIncompleteError, "empty completed"):
-            CodexProxyHandler._relay_upstream_response(
+            relay_upstream_response(
                 fake,
                 response,
                 "ollama_cloud",
@@ -24600,7 +25065,7 @@ Use an implementer subagent, then a spec reviewer, then a code quality reviewer.
         )
 
         with self.assertRaisesRegex(codex_proxy.UpstreamStreamIncompleteError, "empty completed"):
-            CodexProxyHandler._relay_upstream_response(
+            relay_upstream_response(
                 fake,
                 response,
                 "ollama_cloud",
@@ -24626,7 +25091,7 @@ Use an implementer subagent, then a spec reviewer, then a code quality reviewer.
         )
 
         with patch("codex_proxy.compatible_sse_line", wraps=codex_proxy.compatible_sse_line) as rewrite:
-            status = CodexProxyHandler._relay_upstream_response(
+            status = relay_upstream_response(
                 fake,
                 response,
                 "ollama_cloud",
@@ -24670,7 +25135,7 @@ Use an implementer subagent, then a spec reviewer, then a code quality reviewer.
             ]
         )
 
-        status = CodexProxyHandler._relay_upstream_response(
+        status = relay_upstream_response(
             fake,
             response,
             "ollama_cloud",
@@ -25086,7 +25551,7 @@ Use an implementer subagent, then a spec reviewer, then a code quality reviewer.
             b"",
         ])
 
-        status = CodexProxyHandler._relay_upstream_response(
+        status = relay_upstream_response(
             handler,
             response,
             "ollama_cloud",


### PR DESCRIPTION
Closes #61

## Scope

- replace the partial `RouteDecision` seam with one frozen, decision-complete `RoutePlan` produced before request mutation or upstream I/O
- make each immutable `RouteAttemptPlan` execution-complete: endpoint URL, actual request conversion chain, auth/stream/usage/transport/mutation choices, tool protocol choices, cross-protocol verification, fallback statuses, and frozen retry inputs/counts/budgets/eligibility
- capture runtime retry settings into `RouteRuntimeFacts` before planning; handler/open/relay execution consumes the selected attempt contract without re-reading retry configuration
- represent `auto` fallback truthfully: a Chat caller executes Chat→Responses on attempt 0, then Chat→Responses→Chat on the fallback attempt; planned-union telemetry remains distinct from selected/executed-attempt telemetry
- make compact caller-tool removal explicit as `caller_tool_stripping`, while compact/raw/candidate injection policy remains plan-owned and unresolved native candidates fail closed to current compatibility
- fail capability-manifest identity closed unless version and cryptographic hash form a complete valid pair; only a valid pair with explicit `Supported` state reports supported
- bind the effective Vision action/network plan before body mutation or upstream I/O; handler coverage proves PROXY success/failure, REJECT, native image pass-through, and no-image behavior
- fail recognized-but-unimplemented Anthropic routes as typed `Unsupported` and unknown configured protocols as typed `Unqualified`, before upstream I/O
- retain official passthrough, provider-scoped transparent traffic, retry/usage behavior, semantic repair, and official keepalive transport

## Third-review repair verification

- `python -m pytest -q tests/test_routing.py tests/test_chat_completions_gateway.py tests/test_proxy_event_logging.py` — 701 passed, 226 subtests passed in 44.98s (Python 3.13)
- `python -m pytest -q --ignore=tests/test_real_client_e2e.py` — 1,477 passed, 1 skipped, 451 subtests passed in 100.23s with Python 3.13 first on `PATH` for nested PowerShell replays
- the earlier ambient-3.11 nested replay attempt had only two issue-108 parser failures (1,475 passed, 1 skipped); it is recorded as an environment mismatch, not the candidate gate
- `python -m py_compile src-python/codex_proxy.py tests/test_routing.py` — passed
- `git diff --check` — passed (CRLF normalization warnings only)
- `python scripts/report_quality_gates.py --json` — report-only exit 0: 2 unused imports, 83 dead functions, 146 duplicate names, 0 parse errors
- local Standards/Spec delta self-review — clean; no #250 catalog files touched

The synthetic real-client partition is not applicable under `docs/agents/verification-policy.md` because none of its listed contract-surface paths changed. GitHub Actions remains the final PR gate.

Base SHA: `ae927c687390017903435cd9bf4314610b6da229`
Reviewed predecessor SHA: `d6c498fe8fccdfee2bb375605415543e526f773f`
Third-review repair SHA: `76b02adf43efcdee8dcccd502338c63d96c0f77d`