### PR TITLE
ci: stop caching multi-gigabyte Rust target directories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,10 +283,9 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            src-tauri/target
-          key: ${{ runner.os }}-cargo-test-${{ hashFiles('src-tauri/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-deps-v2-test-${{ hashFiles('src-tauri/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-test-
+            ${{ runner.os }}-cargo-deps-v2-test-
 
       - name: Prepare Tauri resource placeholder
         run: |
@@ -423,10 +422,9 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            src-tauri/target
-          key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('src-tauri/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-deps-v2-clippy-${{ hashFiles('src-tauri/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-clippy-
+            ${{ runner.os }}-cargo-deps-v2-clippy-
 
       - name: Prepare Tauri resource placeholder
         run: |

--- a/tests/test_ci_python_plan.py
+++ b/tests/test_ci_python_plan.py
@@ -507,6 +507,23 @@ def test_ci_yaml_windows_jobs_use_verified_preinstalled_toolchains():
         assert "Rust 1.97.1 is required." in job
 
 
+def test_ci_yaml_rust_caches_exclude_build_outputs():
+    workflow_text = (ROOT / ".github" / "workflows" / "ci.yml").read_text(
+        encoding="utf-8"
+    )
+    expected_key_prefixes = {
+        "rust-tests": "cargo-deps-v2-test-",
+        "rust-clippy": "cargo-deps-v2-clippy-",
+    }
+    for job_name, key_prefix in expected_key_prefixes.items():
+        job = _workflow_job_text(workflow_text, job_name)
+        assert "uses: actions/cache@v4" in job
+        assert "~/.cargo/registry" in job
+        assert "~/.cargo/git" in job
+        assert key_prefix in job
+        assert "src-tauri/target" not in job
+
+
 def test_ci_yaml_final_jobs_have_explicit_safety_timeouts():
     workflow_text = (ROOT / ".github" / "workflows" / "ci.yml").read_text(
         encoding="utf-8"


### PR DESCRIPTION
Closes #265

## Summary
- stop caching `src-tauri/target` in Rust test and clippy jobs
- retain Cargo registry/git dependency caches under versioned keys
- add a CI contract test that rejects build-output caching regressions

## Verification
- `py -3.13 -m pytest tests/test_ci_python_plan.py -q` (42 passed)
- workflow YAML parse passed
- `python scripts/report_quality_gates.py` (baseline only; parse errors 0)
- `git diff --check`