### PR TITLE
ci: remove remote Cargo dependency caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,16 +277,6 @@ jobs:
           if ($version -notlike "rustc 1.97.1 *") { throw "Rust 1.97.1 is required." }
           cargo --version
 
-      - name: Cache cargo artifacts
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: ${{ runner.os }}-cargo-deps-v2-test-${{ hashFiles('src-tauri/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-deps-v2-test-
-
       - name: Prepare Tauri resource placeholder
         run: |
           New-Item -ItemType Directory -Force resources/python | Out-Null
@@ -415,16 +405,6 @@ jobs:
             throw "The clippy component is required."
           }
           cargo --version
-
-      - name: Cache cargo artifacts
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: ${{ runner.os }}-cargo-deps-v2-clippy-${{ hashFiles('src-tauri/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-deps-v2-clippy-
 
       - name: Prepare Tauri resource placeholder
         run: |

--- a/tests/test_ci_python_plan.py
+++ b/tests/test_ci_python_plan.py
@@ -507,21 +507,21 @@ def test_ci_yaml_windows_jobs_use_verified_preinstalled_toolchains():
         assert "Rust 1.97.1 is required." in job
 
 
-def test_ci_yaml_rust_caches_exclude_build_outputs():
+def test_ci_yaml_rust_jobs_do_not_use_remote_cargo_caches():
     workflow_text = (ROOT / ".github" / "workflows" / "ci.yml").read_text(
         encoding="utf-8"
     )
-    expected_key_prefixes = {
-        "rust-tests": "cargo-deps-v2-test-",
-        "rust-clippy": "cargo-deps-v2-clippy-",
-    }
-    for job_name, key_prefix in expected_key_prefixes.items():
+    rust_tests = _workflow_job_text(workflow_text, "rust-tests")
+    assert "- normal" in rust_tests
+    assert "- debug" in rust_tests
+
+    for job_name in ("rust-tests", "rust-clippy"):
         job = _workflow_job_text(workflow_text, job_name)
-        assert "uses: actions/cache@v4" in job
-        assert "~/.cargo/registry" in job
-        assert "~/.cargo/git" in job
-        assert key_prefix in job
-        assert "src-tauri/target" not in job
+        assert "actions/cache" not in job, job_name
+        assert "Cache cargo artifacts" not in job, job_name
+        assert "~/.cargo/registry" not in job, job_name
+        assert "~/.cargo/git" not in job, job_name
+        assert "src-tauri/target" not in job, job_name
 
 
 def test_ci_yaml_final_jobs_have_explicit_safety_timeouts():


### PR DESCRIPTION
Closes #271

## Scope

- Remove remote `actions/cache` steps from the normal/debug Rust test matrix and Clippy job.
- Preserve the persistent runner's local Cargo home; do not clear or redirect `CARGO_HOME`.
- Add a CI contract test that rejects reintroduction of Cargo registry/git/target caches in those jobs.
- Leave all unrelated workflow jobs unchanged.

## Local verification

- TDD red before the workflow change, green after it.
- `python -m pytest -q tests/test_ci_python_plan.py`: 42 passed.
- Workflow YAML parses with 9 jobs.
- `git diff --check`: clean.
- Report-only quality gates: baseline only.

## Independent review

- Standards: PASS, 0 P0–P3 findings.
- Spec: PASS, 0 P0–P3 findings.
- Exact candidate tree: `9124f043af69d7ae537c0dba81749c95c464a81d`.

## Remaining gate

Exact-head GitHub Actions must be green and the job steps must contain no cache/post-cache step before merge.