### PR TITLE
0.1.8 Beta1: replace the Ollama Cloud K2.6 seed with K2.7

### DIFF
--- a/config/catalog_policy.toml
+++ b/config/catalog_policy.toml
@@ -27,6 +27,7 @@ allowed_provider_models = [
   "ollama-cloud/minimax-m3",
   "ollama-cloud/glm-5.2",
   "ollama-cloud/kimi-k2.6",
+  "ollama-cloud/kimi-k2.7-code",
   "ollama-e2e-responses/glm-5.2",
   "ollama-e2e-responses/kimi-k2.7-code",
   "ollama-e2e-responses/minimax-m3",
@@ -83,6 +84,7 @@ denied_substrings = ["embedding"]
 "ollama-cloud/glm-5.2" = "Ollama GLM-5.2"
 "ollama-cloud/minimax-m3" = "Ollama MiniMax-M3"
 "ollama-cloud/kimi-k2.6" = "Ollama Kimi K2.6"
+"ollama-cloud/kimi-k2.7-code" = "Ollama Kimi K2.7 Code"
 "kimi-k2.7-code" = "Ollama Kimi K2.7 Code"
 "deepseek-v4-pro" = "Ollama DeepSeek V4 Pro"
 "deepseek-v4-flash" = "Ollama DeepSeek V4 Flash"

--- a/config/providers.toml
+++ b/config/providers.toml
@@ -28,13 +28,12 @@ enabled = true
   native_responses_tool_codec = "strict_apply_patch"
 
   [[providers.models]]
-  id = "kimi-k2.6"
-  display_name = "Ollama Kimi K2.6"
-  context_window = 256000
+  id = "kimi-k2.7-code"
+  display_name = "Ollama Kimi K2.7 Code"
+  context_window = 262144
   max_output_tokens = 32768
   sort_order = 3
   enabled = true
-  native_responses_tool_codec = "strict_apply_patch"
 
 [[providers]]
 id = "volc"

--- a/tests/test_catalog_sync.py
+++ b/tests/test_catalog_sync.py
@@ -7,7 +7,7 @@ import unittest
 from unittest.mock import patch
 from urllib.error import HTTPError
 
-from catalog import CatalogPolicy
+from catalog import CatalogPolicy, load_policy
 import catalog_sync
 from catalog_sync import build_codex_catalog, diff_model_state, discover_ollama_ids
 from providers_config import ModelConfig, ProviderConfig
@@ -108,6 +108,28 @@ class CatalogSyncTests(unittest.TestCase):
         self.assertEqual(by_slug["deepseek-v4-pro"]["max_output_tokens"], 393216)
         self.assertEqual(by_slug["deepseek-v4-flash"]["context_window"], 1048576)
         self.assertEqual(by_slug["deepseek-v4-flash"]["max_output_tokens"], 393216)
+
+    def test_discovered_kimi_k26_remains_visible_without_beta1_qualification(self):
+        policy = load_policy(Path("config/catalog_policy.toml"))
+        catalog = build_codex_catalog(
+            [],
+            ["kimi-k2.6:cloud", "kimi-k2.7-code:cloud"],
+            policy,
+            "0.142.0",
+        )
+
+        by_slug = {model["slug"]: model for model in catalog["models"]}
+        self.assertEqual(
+            [model["slug"] for model in catalog["models"] if model["slug"].startswith("kimi-")],
+            ["kimi-k2.6", "kimi-k2.7-code"],
+        )
+        self.assertEqual(by_slug["kimi-k2.6"]["display_name"], "Ollama Kimi K2.6")
+        self.assertEqual(by_slug["kimi-k2.7-code"]["display_name"], "Ollama Kimi K2.7 Code")
+        for slug in ("kimi-k2.6", "kimi-k2.7-code"):
+            with self.subTest(slug=slug):
+                metadata = by_slug[slug].get("codex_proxy_metadata", {})
+                self.assertNotIn("native_responses_tool_codec", metadata)
+                self.assertNotIn("tool_surface_strategy", metadata)
 
     def test_build_catalog_runtime_ollama_models_use_provider_settings_instead_of_static_allowlist(self):
         policy = CatalogPolicy(

--- a/tests/test_providers_config.py
+++ b/tests/test_providers_config.py
@@ -57,14 +57,18 @@ class ProvidersConfigTests(unittest.TestCase):
         ]
 
         self.assertTrue(configured)
-        self.assertEqual(configured_models, ["glm-5.2", "kimi-k2.6"])
+        self.assertEqual(configured_models, ["glm-5.2"])
         self.assertEqual(index["glm-5.2"]["native_responses_tool_codec"], "strict_apply_patch")
         self.assertEqual(index["ollama-cloud/glm-5.2"]["native_responses_tool_codec"], "strict_apply_patch")
-        self.assertEqual(index["kimi-k2.6"]["native_responses_tool_codec"], "strict_apply_patch")
+        self.assertEqual(index["kimi-k2.7-code"]["native_responses_tool_codec"], "none")
         self.assertEqual(
-            index["ollama-cloud/kimi-k2.6"]["native_responses_tool_codec"],
-            "strict_apply_patch",
+            index["ollama-cloud/kimi-k2.7-code"]["native_responses_tool_codec"],
+            "none",
         )
+        self.assertEqual(index["kimi-k2.7-code"]["context_window"], 262144)
+        self.assertEqual(index["kimi-k2.7-code"]["max_output_tokens"], 32768)
+        self.assertNotIn("kimi-k2.6", index)
+        self.assertNotIn("ollama-cloud/kimi-k2.6", index)
         self.assertEqual(index["minimax-m3"]["native_responses_tool_codec"], "none")
 
         external_index = build_external_model_index(providers, require_api_key=False)
@@ -516,12 +520,12 @@ api_key = "ollama-secret"
                 self.assertTrue(qualified_configured)
                 resolved[model_id] = (unqualified, qualified)
 
-        for model_id in ("glm-5.2", "kimi-k2.6"):
+        for model_id in ("glm-5.2",):
             with self.subTest(model_id=model_id):
                 unqualified, qualified = resolved[model_id]
                 self.assertEqual(unqualified["native_responses_tool_codec"], "strict_apply_patch")
                 self.assertEqual(qualified["native_responses_tool_codec"], "strict_apply_patch")
-        for model_id in ("minimax-m3", "kimi-k2.7-code"):
+        for model_id in ("minimax-m3", "kimi-k2.6", "kimi-k2.7-code"):
             with self.subTest(model_id=model_id):
                 unqualified, qualified = resolved[model_id]
                 self.assertEqual(unqualified["native_responses_tool_codec"], "none")
@@ -539,17 +543,17 @@ base_url = "https://ollama.example.test/v1"
 api_key = "ollama-secret"
 
   [[providers.models]]
-  id = "kimi-k2.6"
+  id = "glm-5.2"
   native_responses_tool_codec = "none"
 """.lstrip(),
                 encoding="utf-8",
             )
 
             configured, unqualified = resolve_ollama_cloud_model(
-                "kimi-k2.6", providers_path=path, require_api_key=False
+                "glm-5.2", providers_path=path, require_api_key=False
             )
             qualified_configured, qualified = resolve_ollama_cloud_model(
-                "ollama-cloud/kimi-k2.6", providers_path=path, require_api_key=False
+                "ollama-cloud/glm-5.2", providers_path=path, require_api_key=False
             )
 
         self.assertTrue(configured)
@@ -570,16 +574,16 @@ api_key = "ollama-secret"
 native_responses_tool_codec = "none"
 
   [[providers.models]]
-  id = "kimi-k2.6"
+  id = "glm-5.2"
 """.lstrip(),
                 encoding="utf-8",
             )
 
             configured, unqualified = resolve_ollama_cloud_model(
-                "kimi-k2.6", providers_path=path, require_api_key=False
+                "glm-5.2", providers_path=path, require_api_key=False
             )
             qualified_configured, qualified = resolve_ollama_cloud_model(
-                "ollama-cloud/kimi-k2.6", providers_path=path, require_api_key=False
+                "ollama-cloud/glm-5.2", providers_path=path, require_api_key=False
             )
 
         self.assertTrue(configured)
@@ -1390,6 +1394,7 @@ enabled = true
                 "ollama-cloud/glm-5.2",
                 "ollama-cloud/minimax-m3",
                 "ollama-cloud/kimi-k2.6",
+                "ollama-cloud/kimi-k2.7-code",
                 "volc/ark-code-latest",
                 "volc/doubao-seed-2.0-code",
                 "volc/doubao-seed-2.0-pro",


### PR DESCRIPTION
Closes #250

## Summary

- replace the bundled Ollama Cloud K2.6 model seed with `kimi-k2.7-code`
- keep K2.7 unqualified (`native_responses_tool_codec = none`) so route capability promotion remains owned by #58/#275/#276
- retain K2.6 policy/display metadata for truthful dynamic discovery without Beta1 qualification
- cover bundled aliases, runtime inheritance, and discovered catalog visibility/no-qualification

## Verification

- `py -3.13 -m pytest tests/test_providers_config.py tests/test_catalog.py tests/test_catalog_sync.py -q` — 115 passed, 56 subtests passed
- `git diff --check` — passed
- `python scripts/report_quality_gates.py` — report-only baseline findings only
- `py -3.13 -m pytest -q --ignore=tests/test_real_client_e2e.py` — 1457 passed, 1 skipped, 417 subtests passed; 2 unrelated pre-existing issue-108 smoke replay failures

No Provider/catalog transaction framework or advanced capability is introduced.