### PR TITLE
ci: migrate routine checks to GitHub-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,15 +10,6 @@ on:
       - dev
       - main
   workflow_dispatch:
-    inputs:
-      validation_scope:
-        description: Validation scope
-        required: true
-        default: full
-        type: choice
-        options:
-          - full
-          - runner-smoke
   schedule:
     - cron: '17 3 * * 0'
 
@@ -29,90 +20,22 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  RUST_TOOLCHAIN: 1.97.1
+
 jobs:
-  runner-smoke-windows:
-    name: Runner smoke (Windows)
-    if: github.event_name == 'workflow_dispatch' && inputs.validation_scope == 'runner-smoke'
-    runs-on: [self-hosted, Windows, X64, codexhub-ci-windows-x64]
-    timeout-minutes: 5
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
-
-      - name: Verify dedicated Windows runner toolchain
-        shell: pwsh
-        run: |
-          if ($env:RUNNER_NAME -notlike 'codexhub-*') {
-            throw "Unexpected runner identity."
-          }
-          git --version
-          $pythonVersion = python -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')"
-          if ($pythonVersion -ne "3.13") { throw "Python 3.13 is required." }
-          $nodeVersion = node -p "process.versions.node"
-          if ($nodeVersion -notlike "22.*") { throw "Node.js 22 is required." }
-          python --version
-          node --version
-          npm --version
-          $rustVersion = rustc --version
-          if ($rustVersion -notlike "rustc 1.97.1 *") { throw "Rust 1.97.1 is required." }
-          $components = rustup component list --installed
-          if ($components -notcontains "clippy-x86_64-pc-windows-msvc") {
-            throw "The clippy component is required."
-          }
-          cargo --version
-          $rustVersion
-
-  runner-smoke-linux:
-    name: Runner smoke (Linux)
-    if: github.event_name == 'workflow_dispatch' && inputs.validation_scope == 'runner-smoke'
-    runs-on: [self-hosted, Linux, X64, codexhub-ci-linux-x64]
-    timeout-minutes: 5
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.13'
-
-      - name: Verify dedicated Linux runner toolchain
-        run: |
-          case "$RUNNER_NAME" in
-            codexhub-*) ;;
-            *) echo "Unexpected runner identity." >&2; exit 1 ;;
-          esac
-          git --version
-          test "$(python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')" = "3.13"
-          python --version
-          rustup --version
-          cargo --version
-          case "$(rustc --version)" in
-            "rustc 1.97.1 "*) ;;
-            *) echo "Rust 1.97.1 is required." >&2; exit 1 ;;
-          esac
-          rustup component list --installed | grep -qx 'clippy-x86_64-unknown-linux-gnu'
-          rustup target list --installed | grep -qx 'x86_64-unknown-linux-musl'
-          sysroot="$(rustc --print sysroot)"
-          test -x "$sysroot/lib/rustlib/x86_64-unknown-linux-gnu/bin/rust-lld"
-
   python-core:
     name: Python core
-    if: >-
-      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
-      (github.event_name != 'workflow_dispatch' || inputs.validation_scope != 'runner-smoke')
-    runs-on: [self-hosted, Windows, X64, codexhub-ci-windows-x64]
+    runs-on: windows-2025
     timeout-minutes: 30
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
-      - name: Verify preinstalled Python
-        shell: pwsh
-        run: |
-          $version = python -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')"
-          if ($version -ne "3.13") { throw "Python 3.13 is required." }
-          python --version
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.13'
 
       - name: Create isolated Python environment
         shell: pwsh
@@ -129,7 +52,7 @@ jobs:
 
       - name: Upload Python core JUnit evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: python-core-junit
           path: .pytest-results/junit-core.xml
@@ -137,23 +60,18 @@ jobs:
 
   python-synthetic:
     name: Synthetic real-client contract
-    if: >-
-      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
-      (github.event_name != 'workflow_dispatch' || inputs.validation_scope != 'runner-smoke')
-    runs-on: [self-hosted, Windows, X64, codexhub-ci-windows-x64]
+    runs-on: windows-2025
     timeout-minutes: 75
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - name: Verify preinstalled Python
-        shell: pwsh
-        run: |
-          $version = python -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')"
-          if ($version -ne "3.13") { throw "Python 3.13 is required." }
-          python --version
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.13'
 
       - name: Create isolated Python environment
         shell: pwsh
@@ -186,8 +104,6 @@ jobs:
             }
           }
           if ($acquisitionFailed) {
-            # Remove the file so the planner treats this as missing/unreadable
-            # and fails closed to the full synthetic suite.
             Remove-Item $changedFile -ErrorAction SilentlyContinue
           }
           $plan = python scripts/ci/python_test_plan.py `
@@ -211,7 +127,7 @@ jobs:
 
       - name: Upload synthetic JUnit evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: python-synthetic-junit
           path: .pytest-results/junit-synthetic.xml
@@ -219,25 +135,19 @@ jobs:
 
   frontend:
     name: Frontend build and UI contract
-    if: >-
-      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
-      (github.event_name != 'workflow_dispatch' || inputs.validation_scope != 'runner-smoke')
-    runs-on: [self-hosted, Windows, X64, codexhub-ci-windows-x64]
+    runs-on: windows-2025
     timeout-minutes: 30
     defaults:
       run:
         working-directory: frontend
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
-      - name: Verify preinstalled Node.js
-        shell: pwsh
-        run: |
-          $version = node -p "process.versions.node"
-          if ($version -notlike "22.*") { throw "Node.js 22 is required." }
-          node --version
-          npm --version
+      - name: Set up Node.js 22
+        uses: actions/setup-node@v7
+        with:
+          node-version: '22'
 
       - name: Install dependencies
         run: npm ci
@@ -250,10 +160,7 @@ jobs:
 
   rust-tests:
     name: Rust tests (${{ matrix.flavor }})
-    if: >-
-      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
-      (github.event_name != 'workflow_dispatch' || inputs.validation_scope != 'runner-smoke')
-    runs-on: [self-hosted, Windows, X64, codexhub-ci-windows-x64]
+    runs-on: windows-2025
     timeout-minutes: 75
     strategy:
       fail-fast: false
@@ -268,17 +175,18 @@ jobs:
         working-directory: src-tauri
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
-      - name: Verify preinstalled Rust stable
+      - name: Install Rust 1.97.1 toolchain
         shell: pwsh
         run: |
-          $version = rustc --version
-          if ($version -notlike "rustc 1.97.1 *") { throw "Rust 1.97.1 is required." }
+          rustup toolchain install $env:RUST_TOOLCHAIN --profile minimal --component clippy
+          rustup default $env:RUST_TOOLCHAIN
+          rustc --version
           cargo --version
 
-      - name: Cache cargo artifacts
-        uses: actions/cache@v4
+      - name: Cache Cargo dependencies
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
@@ -288,11 +196,13 @@ jobs:
             ${{ runner.os }}-cargo-deps-v2-test-
 
       - name: Prepare Tauri resource placeholder
+        shell: pwsh
         run: |
           New-Item -ItemType Directory -Force resources/python | Out-Null
           Set-Content -Path resources/python/.ci-placeholder -Value ''
 
       - name: Run cargo tests
+        shell: pwsh
         run: |
           if ("${{ matrix.flavor }}" -eq "debug") {
             cargo test --locked --features debug-diagnostics -- --test-threads=1
@@ -301,6 +211,7 @@ jobs:
           }
 
       - name: Build release-optimized flavor
+        shell: pwsh
         run: |
           if ("${{ matrix.flavor }}" -eq "debug") {
             cargo build --release --locked --features debug-diagnostics
@@ -310,39 +221,37 @@ jobs:
 
   rust-safe-file-linux:
     name: Rust safe_file Linux compile and tests
-    if: >-
-      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
-      (github.event_name != 'workflow_dispatch' || inputs.validation_scope != 'runner-smoke')
-    runs-on: [self-hosted, Linux, X64, codexhub-ci-linux-x64]
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v7
         with:
           python-version: '3.13'
 
-      - name: Verify preinstalled Rust stable
+      - name: Install Rust 1.97.1 toolchain and musl target
         run: |
-          case "$(rustc --version)" in
-            "rustc 1.97.1 "*) ;;
-            *) echo "Rust 1.97.1 is required." >&2; exit 1 ;;
-          esac
+          rustup toolchain install "${RUST_TOOLCHAIN}" --profile minimal --component clippy
+          rustup target add x86_64-unknown-linux-musl --toolchain "${RUST_TOOLCHAIN}"
+          rustup default "${RUST_TOOLCHAIN}"
+          rustc --version
+          cargo --version
           rustup component list --installed | grep -qx 'clippy-x86_64-unknown-linux-gnu'
           rustup target list --installed | grep -qx 'x86_64-unknown-linux-musl'
-          cargo --version
+          test -x "$(rustc --print sysroot)/lib/rustlib/x86_64-unknown-linux-gnu/bin/rust-lld"
 
-      - name: Lint safe_file with clippy for Linux
+      - name: Lint safe_file with Clippy for Linux
         env:
           CARGO_MANIFEST_DIR: ${{ github.workspace }}/src-tauri
-        run: rustup run stable clippy-driver --target x86_64-unknown-linux-musl -C linker=rust-lld --edition=2021 --test src-tauri/src/safe_file.rs -o safe-file-linux-lint -D warnings
+        run: rustup run "${RUST_TOOLCHAIN}" clippy-driver --target x86_64-unknown-linux-musl -C linker=rust-lld --edition=2021 --test src-tauri/src/safe_file.rs -o safe-file-linux-lint -D warnings
 
       - name: Compile safe_file test harness for Linux
         env:
           CARGO_MANIFEST_DIR: ${{ github.workspace }}/src-tauri
-        run: rustc +stable --target x86_64-unknown-linux-musl -C linker=rust-lld --edition=2021 --test src-tauri/src/safe_file.rs -o safe-file-linux-tests
+        run: rustc +"${RUST_TOOLCHAIN}" --target x86_64-unknown-linux-musl -C linker=rust-lld --edition=2021 --test src-tauri/src/safe_file.rs -o safe-file-linux-tests
 
       - name: Run safe_file Linux tests
         env:
@@ -351,14 +260,11 @@ jobs:
 
   release-flavor-contract:
     name: Release flavor contract
-    if: >-
-      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
-      (github.event_name != 'workflow_dispatch' || inputs.validation_scope != 'runner-smoke')
-    runs-on: [self-hosted, Windows, X64, codexhub-ci-windows-x64]
+    runs-on: windows-2025
     timeout-minutes: 15
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Verify normal default and debug parity
         shell: pwsh
@@ -393,31 +299,25 @@ jobs:
 
   rust-clippy:
     name: Rust clippy
-    if: >-
-      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
-      (github.event_name != 'workflow_dispatch' || inputs.validation_scope != 'runner-smoke')
-    runs-on: [self-hosted, Windows, X64, codexhub-ci-windows-x64]
+    runs-on: windows-2025
     timeout-minutes: 45
     defaults:
       run:
         working-directory: src-tauri
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
-      - name: Verify preinstalled Rust stable with clippy
+      - name: Install Rust 1.97.1 toolchain
         shell: pwsh
         run: |
-          $version = rustc --version
-          if ($version -notlike "rustc 1.97.1 *") { throw "Rust 1.97.1 is required." }
-          $components = rustup component list --installed
-          if ($components -notcontains "clippy-x86_64-pc-windows-msvc") {
-            throw "The clippy component is required."
-          }
+          rustup toolchain install $env:RUST_TOOLCHAIN --profile minimal --component clippy
+          rustup default $env:RUST_TOOLCHAIN
+          rustc --version
           cargo --version
 
-      - name: Cache cargo artifacts
-        uses: actions/cache@v4
+      - name: Cache Cargo dependencies
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
@@ -427,9 +327,11 @@ jobs:
             ${{ runner.os }}-cargo-deps-v2-clippy-
 
       - name: Prepare Tauri resource placeholder
+        shell: pwsh
         run: |
           New-Item -ItemType Directory -Force resources/python | Out-Null
           Set-Content -Path resources/python/.ci-placeholder -Value ''
 
       - name: Run clippy
+        shell: pwsh
         run: cargo clippy --locked --all-targets -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,14 +41,13 @@ jobs:
         shell: pwsh
         run: |
           python -m venv .venv-ci
-          "$pwd\.venv-ci\Scripts" >> $env:GITHUB_PATH
 
       - name: Install test dependencies
-        run: python -m pip install --upgrade pip pytest
+        run: .\.venv-ci\Scripts\python.exe -m pip install --upgrade pip pytest
 
       - name: Run Python core partition
         run: |
-          python -m pytest -q --ignore=tests/test_real_client_e2e.py --junitxml=.pytest-results/junit-core.xml --durations=0
+          .\.venv-ci\Scripts\python.exe -m pytest -q --ignore=tests/test_real_client_e2e.py --junitxml=.pytest-results/junit-core.xml --durations=0
 
       - name: Upload Python core JUnit evidence
         if: always()
@@ -77,10 +76,9 @@ jobs:
         shell: pwsh
         run: |
           python -m venv .venv-ci
-          "$pwd\.venv-ci\Scripts" >> $env:GITHUB_PATH
 
       - name: Install test dependencies
-        run: python -m pip install --upgrade pip pytest
+        run: .\.venv-ci\Scripts\python.exe -m pip install --upgrade pip pytest
 
       - name: Plan synthetic partition
         id: plan
@@ -106,7 +104,7 @@ jobs:
           if ($acquisitionFailed) {
             Remove-Item $changedFile -ErrorAction SilentlyContinue
           }
-          $plan = python scripts/ci/python_test_plan.py `
+          $plan = .\.venv-ci\Scripts\python.exe scripts/ci/python_test_plan.py `
             --event $event `
             $(if ($isPr) { '--is-pull-request' }) `
             --changed-paths-file $changedFile `
@@ -120,9 +118,9 @@ jobs:
           if ($plan.synthetic_status -eq 'not_applicable') {
             Write-Host 'Synthetic real-client contract: not applicable'
           } else {
-            python tests/fixtures/real_client_e2e/run-with-windows-watchdog.py `
+            .\.venv-ci\Scripts\python.exe tests/fixtures/real_client_e2e/run-with-windows-watchdog.py `
               --timeout-seconds 3600 `
-              -- python -m pytest @($plan.synthetic_args)
+              -- .\.venv-ci\Scripts\python.exe -m pytest @($plan.synthetic_args)
           }
 
       - name: Upload synthetic JUnit evidence

--- a/docs/agents/ci.md
+++ b/docs/agents/ci.md
@@ -1,57 +1,48 @@
 # CI and manual verification
 
-GitHub Actions runs the required PR validation for same-repository branches
-targeting `dev` and `main`. Final checks use the repository-dedicated
-self-hosted runners in `docs/agents/self-hosted-runner.md`; Actions still owns
-the trigger, exact-SHA logs, artifacts, Check status, and readback. Local
-candidate checks are selected by `docs/agents/verification-policy.md`; they do
-not duplicate every CI job by default.
+GitHub Actions runs the required PR validation for branches targeting `dev`
+and `main` on fresh GitHub-hosted runners. Actions owns the trigger, exact-SHA
+logs, artifacts, Check status, and readback. Local candidate checks are
+selected by `docs/agents/verification-policy.md`; they do not duplicate every
+CI job by default.
 
 ## CI jobs
 
 - **Python core**: `python -m pytest -q --ignore=tests/test_real_client_e2e.py --junitxml=.pytest-results/junit-core.xml --durations=0`. Runs on every PR.
 - **Synthetic real-client contract**: appears on every PR. For unrelated paths it succeeds explicitly as `not applicable` and does not start `scripts/Run-RealClientE2E.ps1`. For relevant paths, and for all non-PR events, it runs the synthetic module through `tests/fixtures/real_client_e2e/run-with-windows-watchdog.py` with an explicit 3600-second outer bound while retaining JUnit and per-test duration output. The planner at `scripts/ci/python_test_plan.py` decides which paths are relevant using the PR merge-base; `python scripts/ci/check_python_test_partitions.py` proves the core and synthetic partitions are disjoint and complete.
 - Frontend build and UI contract: `npm ci`, `npm run build`, `npm run test:ui-contract` in `frontend/`
-- Rust tests (normal and debug flavors): `cargo test --locked` in `src-tauri/`, plus a release-optimized flavor build
+- Rust tests (normal and debug flavors): `cargo test --locked -- --test-threads=1` in `src-tauri/`, plus a release-optimized flavor build
 - Rust clippy: `cargo clippy --locked --all-targets -- -D warnings` in `src-tauri/`
 - Release flavor contract: portable-build dry-run parity for the normal and debug flavors
 - Rust safe_file Linux compile and tests: standalone `rustc --test` compile of
   `src-tauri/src/safe_file.rs` on Ubuntu WSL2, a `clippy-driver -D warnings`
   lint of the same file, and the resulting cross-language test binary. The
-  self-hosted runner uses Rust's official
-  `x86_64-unknown-linux-musl` target with `rust-lld`, avoiding a host-wide C
-  toolchain while still compiling and executing real Linux `cfg(unix)` code.
+  Hosted Linux uses Rust's official `x86_64-unknown-linux-musl` target with
+  `rust-lld`, avoiding a host-wide C toolchain while still compiling and
+  executing real Linux `cfg(unix)` code.
   This job exists because the Windows-only Rust jobs never compile that FFI;
   `safe_file.rs` must stay free of crate dependencies so the standalone compile
   keeps working.
 
 ### Triggers
 
-Same-repository PRs to `dev` and `main` run both Python checks, the frontend
-job, Rust normal/debug tests, Rust clippy, release flavor contract, and Linux
-`safe_file`. Fork PRs are intentionally denied access to the trusted
-self-hosted runners by a host-owned pre-job hook outside the checkout; the
-workflow's matching job conditions are defence-in-depth, not the trust
-boundary. Pushes to `dev` and `main` preserve the same job set.
-`workflow_dispatch` defaults to the full validation and supports the bounded
-`runner-smoke` scope for runner provisioning. The weekly Sunday 03:17 UTC
+Same-repository and fork PRs to `dev` and `main` run both Python checks, the
+frontend job, Rust normal/debug tests, Rust clippy, release flavor contract,
+and Linux `safe_file` on GitHub-hosted runners. Hosted runners are disposable
+and do not depend on the developer machine or a repository self-hosted
+registration. Pushes to `dev` and `main` preserve the same job set.
+`workflow_dispatch` runs the full validation. The weekly Sunday 03:17 UTC
 `schedule` runs the full validation, including the synthetic suite.
 
-The Windows jobs select
-`[self-hosted, Windows, X64, codexhub-ci-windows-x64]`. The Linux-only
-`safe_file` job selects
-`[self-hosted, Linux, X64, codexhub-ci-linux-x64]`, so its `cfg(unix)` code is
-still compiled and exercised on Linux.
-
-Windows jobs use the runner's pre-provisioned Python 3.13, Node.js 22, and Rust
-1.97.1 toolchains and fail closed on version drift. They do not call
-`actions/setup-python` or `actions/setup-node`: those setup actions can require
-machine-level cleanup permissions that a non-administrator runner correctly
-does not have. Python jobs create a checkout-local virtual environment before
-installing test dependencies.
+Windows jobs pin `windows-2025`; the Linux-only `safe_file` job pins
+`ubuntu-24.04`, so its `cfg(unix)` code is compiled and exercised on Linux.
+Each job installs or selects the exact Python 3.13, Node.js 22, and Rust
+1.97.1 toolchains it needs. Python jobs create a checkout-local virtual
+environment before installing test dependencies. Rust jobs force one test
+thread because the suite contains process-wide lifecycle fixtures.
 
 Every final job has an explicit timeout. These are safety bounds, not Worker
-budgets; record the first frozen-SHA self-hosted durations and tighten them in a
+budgets; record the first frozen-SHA Hosted durations and tighten them in a
 separate reviewed change if the observed distribution supports it. Never move
 the complete suite into Worker or Repair rounds to consume the timeout budget
 earlier.
@@ -61,6 +52,20 @@ requires a live Paseo Workspace must either remain a local verification gate or
 return a typed `not_applicable_unmanaged_checkout` result in CI. Missing Paseo
 state in an unmanaged checkout is not a product regression and must not be
 reported as one.
+
+### Hosted runner contract
+
+Routine CI must remain runnable on a clean GitHub-hosted Windows or Linux
+virtual machine. Do not add requirements for a persistent service, desktop
+session, local credentials, or a developer/Paseo workspace. Cargo caches may
+contain only `~/.cargo/registry` and `~/.cargo/git`; never cache
+`src-tauri/target`.
+
+The former repository self-hosted runners are retired. Their historical
+registration and de-registration record is kept in
+`docs/agents/self-hosted-runner.md`; it is not a prerequisite for CI and must
+not be restarted to unblock a PR. True real-client Desktop/CLI E2E remains a
+release-operator procedure documented in `docs/agents/real-client-e2e.md`.
 
 ### Synthetic real-client contract relevant surface
 

--- a/docs/agents/self-hosted-runner.md
+++ b/docs/agents/self-hosted-runner.md
@@ -1,117 +1,41 @@
-# Repository self-hosted Actions runners
+# Retired self-hosted Actions runners
 
-CodexHub final CI uses two repository-scoped runner instances on one trusted
-host. GitHub Actions remains the control plane for workflow triggers,
-exact-commit logs, artifacts, Check results, and readback.
+Routine CodexHub CI no longer uses repository self-hosted runners. The
+workflow runs on GitHub-hosted `windows-2025` and `ubuntu-24.04` virtual
+machines, which are disposable and do not depend on the developer host,
+desktop session, local credentials, or a Paseo workspace.
 
-## Runner inventory
+## Historical inventory
 
-| Runner | Required labels | Purpose |
+The former registrations were:
+
+| Runner | Former purpose | Retirement state |
 |---|---|---|
-| Native Windows x64 | `self-hosted`, `Windows`, `X64`, `codexhub-ci-windows-x64` | Python, synthetic real-client contract, frontend, Rust normal/debug, clippy, and release-flavor checks |
-| Ubuntu WSL2 x64 | `self-hosted`, `Linux`, `X64`, `codexhub-ci-linux-x64` | Linux-only `safe_file` lint, compile, and tests |
+| `codexhub-windows-x64` (id 21) | Python, synthetic, frontend, Rust, Clippy, release checks | Deregister after Hosted CI acceptance |
+| `codexhub-linux-x64` (id 22) | Linux `safe_file` compile, lint, and tests | Deregister after Hosted CI acceptance |
 
-The host runner roots and their `_work` directories must live under a
-dedicated `GitHubActions/CodexHub` root. They must never point at the stable
-developer checkout or a Paseo Worker worktree.
+The registrations, local runner directories, WSL files, and historical logs
+are separate operational state. Do not restart either listener to unblock a
+PR. Deregistration is performed only after the Hosted parity workflow, the
+path-aware `CI / gate`, branch protection, and all Beta1 PRs have passed. The
+first retirement pass removes the GitHub registrations but does not delete
+`D:\GitHubActions\CodexHub\windows`, WSL data, or logs.
 
-Each runner is registered at repository scope with the normal OS/architecture
-labels plus its repository-specific label. Registration tokens are short-lived secrets:
-obtain them immediately before configuration, pass them only to the runner
-configuration command, and never write or echo them in the repository, issue
-comments, logs, or artifacts.
+## Hosted CI invariants
 
-The WSL2 listener keeps its runner package and user-local runtime dependencies
-inside its dedicated Linux root. The Actions runner's .NET runtime uses a
-user-local Ubuntu ICU package through `LD_LIBRARY_PATH`; no system package
-installation is required. Rust uses the official
-`x86_64-unknown-linux-musl` standard library and `rust-lld`, so the standalone
-Linux gate does not require a host-wide C compiler.
+- Routine jobs use only GitHub-hosted labels and install/select their exact
+  toolchains in the job.
+- Cargo caches may contain `~/.cargo/registry` and `~/.cargo/git`; never cache
+  `src-tauri/target`.
+- No routine job may require a persistent Windows service, desktop GUI
+  session, local account credentials, or a developer/Paseo workspace.
+- Real-client Desktop/CLI E2E remains local release evidence documented in
+  `docs/agents/real-client-e2e.md`.
 
-The Windows listener is started with a dedicated portable Node.js 22 directory
-at the front of `PATH`. Python 3.13 and Rust 1.97.1 are also provisioned before
-the listener starts. Workflows verify these versions instead of using setup
-actions that can attempt machine-level registry or installation cleanup on a
-non-administrator runner. Test dependencies belong in job-local environments,
-not the host toolchain.
+## If a self-hosted runner is ever reconsidered
 
-## Public-repository boundary
-
-The repository is public, so arbitrary fork code must not run on the trusted
-host. Job-level `if` conditions in a `pull_request` workflow are only
-defence-in-depth: the pull request can change that workflow. Each runner
-therefore has a host-owned pre-job guard configured with
-`ACTIONS_RUNNER_HOOK_JOB_STARTED` in the runner application's `.env` file.
-The guard executes before checkout or any workflow step and fails closed
-unless all of the following are true:
-
-- `GITHUB_REPOSITORY` is exactly `NOirBRight/CodexHub`;
-- the event is one of `pull_request`, `push`, `workflow_dispatch`, or
-  `schedule`;
-- a `pull_request` event has base and head repositories both exactly
-  `NOirBRight/CodexHub`;
-- a `push` event targets `refs/heads/dev` or `refs/heads/main`;
-- the event payload exists and parses when repository identity must be read.
-
-The hook lives under the dedicated host `GitHubActions/CodexHub/hooks`
-directory, outside both the runner application and its `_work` directory.
-It is not sourced from the checkout. A non-zero hook exit prevents the job
-from running and is visible in the Actions `Set up runner` log. Restart the
-listener after installing or changing `.env`, then exercise the guard locally
-with accepted same-repository and rejected fork payload fixtures before smoke.
-
-Every final job also verifies that a pull request head belongs to this
-repository before selecting a self-hosted runner. Pushes to `dev`/`main`,
-manual dispatches, and the scheduled full validation remain eligible. The
-host hook is the authoritative boundary; workflow conditions are only an
-additional readable assertion.
-
-External contributions require a maintainer-controlled same-repository branch
-before CI. Do not replace this guard with `pull_request_target`, which would
-mix privileged repository context with untrusted changes.
-
-## Provisioning and smoke
-
-1. Install the current GitHub Actions runner package separately for Windows
-   and Linux x64, verifying the published package digest.
-2. Configure distinct runner names and work directories with the exact labels
-   above.
-3. Start both listeners under the dedicated host account. Installing them as
-   system services is a separate administrator action; interactive/background
-   listeners are sufficient for bounded provisioning evidence.
-4. Read back the repository runner inventory and require both runners to be
-   `online`.
-5. Dispatch `CI` with `validation_scope=runner-smoke` against the exact
-   candidate ref. The two five-minute smoke jobs verify checkout, runner
-   identity, Python, Git, and the required native toolchain. Windows proves
-   Node.js 22, Rust 1.97.1, and Clippy. Linux proves Python 3.13, Rust 1.97.1,
-   Clippy, the musl target, and the actual `rust-lld` executable.
-6. After the workflow candidate has passed local review and is frozen, dispatch
-   `validation_scope=full` once and require all existing final Check names to
-   succeed on that exact SHA.
-
-The smoke and full run must also prove that an unmanaged Actions checkout does
-not masquerade as a Paseo-managed Workspace. Live Paseo probes remain local; if
-such a probe is ever collected by CI, it must emit the typed
-`not_applicable_unmanaged_checkout` classification rather than a failure.
-
-Do not use the smoke as acceptance evidence for product changes. Worker and
-repair iterations continue to run only the affected local checks; the complete
-Actions matrix is reserved for the reviewed frozen SHA.
-
-## Operations
-
-- Keep one listener per configured runner directory. Never run two listeners
-  from the same runner configuration or `_work` directory.
-- Allow the runner's built-in self-update. If an update fails, stop scheduling
-  work, update the package in place, and repeat the bounded smoke.
-- Runner workspaces are disposable checkouts. Preserve Actions logs and
-  artifacts in GitHub, not local `_work` contents.
-- Record per-job wall time from each frozen-SHA run. The checked-in timeouts are
-  hard safety bounds; adjust them only from measured evidence in a separate
-  reviewed candidate.
-- Stop both listeners before deleting a runner registration or its directory.
-- Removing or rotating a runner must not change Actions budget or the account
-  `Stop usage` setting.
-- A runner that is offline, busy without an associated job, has label drift, or
-  points at a developer/Paseo worktree fails the final gate closed.
+This requires a separate architecture decision and security review. It must
+not be reintroduced by adding a `self-hosted` label to the current workflow.
+The review must cover public-repository fork isolation, host-owned pre-job
+guards, registration-token handling, service lifecycle, workspace isolation,
+toolchain provisioning, and an explicit rollback to the Hosted workflow.

--- a/docs/agents/verification-policy.md
+++ b/docs/agents/verification-policy.md
@@ -53,16 +53,15 @@ not block PR, merge, or release under the current policy.
 
 ## CI authority
 
-GitHub Actions runs every repository job for every same-repository PR to `dev`
-or `main` regardless of local verification class (Python core, synthetic
-real-client contract, frontend build and UI contract, Rust tests for both
-flavors, Rust clippy, release flavor contract, and the safe_file Linux
-compile/lint/tests). These checks run on the repository-dedicated self-hosted
-Windows and Linux runners described in
-`docs/agents/self-hosted-runner.md`. Because the repository is public, fork PR
-code is never scheduled on those trusted-host runners. That boundary is
-enforced by the host-owned pre-job hook before checkout; a job-level workflow
-condition alone is not accepted as the security boundary.
+GitHub Actions runs every repository job for every PR to `dev` or `main`
+regardless of local verification class (Python core, synthetic real-client
+contract, frontend build and UI contract, Rust tests for both flavors, Rust
+clippy, release flavor contract, and the safe_file Linux compile/lint/tests).
+Routine checks run on fresh GitHub-hosted Windows and Linux runners. Because
+the repository is public, fork PR code is allowed to run only on those
+disposable hosted VMs; it never receives access to a persistent developer or
+self-hosted machine. True real-client Desktop/CLI evidence remains a local
+release-operator procedure.
 Local risk selection reduces duplicate work; it does not weaken CI. When CI is
 unavailable and a merge must proceed, reproduce the full fallback in
 `docs/agents/ci.md`.

--- a/scripts/Run-RealClientE2E.ps1
+++ b/scripts/Run-RealClientE2E.ps1
@@ -103,6 +103,9 @@ public static class CodexHubE2EJob
     private static extern bool AssignProcessToJobObject(IntPtr job, IntPtr process);
 
     [DllImport("kernel32.dll")]
+    private static extern bool TerminateJobObject(IntPtr job, uint exitCode);
+
+    [DllImport("kernel32.dll")]
     private static extern bool QueryInformationJobObject(
         IntPtr job,
         int informationClass,
@@ -162,6 +165,11 @@ public static class CodexHubE2EJob
         {
             Marshal.FreeHGlobal(pointer);
         }
+    }
+
+    public static bool Terminate(IntPtr job, uint exitCode)
+    {
+        return job != IntPtr.Zero && TerminateJobObject(job, exitCode);
     }
 
     public static void Close(IntPtr job)
@@ -364,9 +372,11 @@ function Invoke-RunnerSupervisor {
     [void](New-Item -ItemType Directory -Force -Path $supervisorOutput)
     $summaryPath = Join-Path $supervisorOutput 'summary.json'
     $statePath = Join-Path $supervisorOutput 'runner-watchdog-state'
+    $startGatePath = Join-Path $supervisorOutput 'runner-start-gate'
     $stdoutPath = Join-Path $supervisorOutput 'runner-watchdog.stdout'
     $stderrPath = Join-Path $supervisorOutput 'runner-watchdog.stderr'
     [System.IO.File]::WriteAllText($statePath, 'preflight', $script:Utf8NoBom)
+    Remove-Item -LiteralPath $startGatePath -Force -ErrorAction SilentlyContinue
     foreach ($path in @($stdoutPath, $stderrPath)) {
         [System.IO.File]::WriteAllText($path, '', $script:Utf8NoBom)
     }
@@ -402,6 +412,17 @@ function Invoke-RunnerSupervisor {
         [System.Text.Encoding]::UTF8.GetBytes($forwardedJson)
     )
     $workerBootstrap = @'
+& {
+  $gate = [string]$env:CODEXHUB_E2E_SUPERVISOR_START_GATE
+  $deadline = [DateTime]::UtcNow.AddSeconds(30)
+  while (-not (Test-Path -LiteralPath $gate -PathType Leaf)) {
+    if ([DateTime]::UtcNow -ge $deadline) {
+      exit 125
+    }
+    Start-Sleep -Milliseconds 10
+  }
+  Remove-Item -LiteralPath $gate -Force -ErrorAction SilentlyContinue
+}
 & $env:CODEXHUB_E2E_SUPERVISOR_SCRIPT `
   -CandidateSha '0000000000000000000000000000000000000000' `
   -DebugBuild '.' `
@@ -432,6 +453,7 @@ exit $LASTEXITCODE
         CODEXHUB_E2E_SUPERVISOR_TOKEN = $token
         CODEXHUB_E2E_SUPERVISOR_SCRIPT = $PSCommandPath
         CODEXHUB_E2E_SUPERVISOR_ARGUMENTS = $forwardedPayload
+        CODEXHUB_E2E_SUPERVISOR_START_GATE = $startGatePath
     }
     $previousEnvironment = @{}
     foreach ($entry in $supervisorEnvironment.GetEnumerator()) {
@@ -473,9 +495,28 @@ exit $LASTEXITCODE
             Write-JsonFile -Path $summaryPath -Value (Get-FailureSummaryValue -FailureClassification 'preflight_process_supervision_unavailable')
             return 1
         }
+        # The worker waits on this file before invoking the real runner.  This
+        # closes the short Start-Process/AssignProcessToJobObject race: every
+        # candidate and client process is created only after the worker belongs
+        # to the kill-on-close job.
+        [System.IO.File]::WriteAllText($startGatePath, 'ready', $script:Utf8NoBom)
         $completed = $process.WaitForExit($OverallTimeoutSeconds * 1000)
         if (-not $completed) {
+            # Terminate first and keep the handle open long enough to observe
+            # the Job Object quiesce.  Closing the handle immediately makes
+            # Windows kill descendants asynchronously, which can expose a
+            # still-running PID to the caller for a short, nondeterministic
+            # window even though the timeout cleanup has succeeded.
             $counts = [CodexHubE2EJob]::GetProcessCounts($job)
+            [void][CodexHubE2EJob]::Terminate($job, 1)
+            $terminationDeadline = [DateTime]::UtcNow.AddSeconds(2)
+            do {
+                $remainingCounts = [CodexHubE2EJob]::GetProcessCounts($job)
+                if ([int]$remainingCounts[1] -eq 0 -or [DateTime]::UtcNow -ge $terminationDeadline) {
+                    break
+                }
+                Start-Sleep -Milliseconds 25
+            } while ($true)
             [CodexHubE2EJob]::Close($job)
             $job = [IntPtr]::Zero
             [void]$process.WaitForExit(2000)
@@ -532,6 +573,7 @@ exit $LASTEXITCODE
             Remove-Item -LiteralPath $stream.path -Force -ErrorAction SilentlyContinue
         }
         Remove-Item -LiteralPath $statePath -Force -ErrorAction SilentlyContinue
+        Remove-Item -LiteralPath $startGatePath -Force -ErrorAction SilentlyContinue
     }
 }
 

--- a/tests/test_ci_python_plan.py
+++ b/tests/test_ci_python_plan.py
@@ -380,7 +380,7 @@ def test_pr_rename_from_unrelated_to_relevant_runs_synthetic(plan):
     assert p.synthetic_status == "run"
 
 
-def test_ci_yaml_routes_final_jobs_to_repo_dedicated_self_hosted_labels():
+def test_ci_yaml_routes_final_jobs_to_github_hosted_runners():
     workflow_text = (ROOT / ".github" / "workflows" / "ci.yml").read_text(
         encoding="utf-8"
     )
@@ -394,12 +394,11 @@ def test_ci_yaml_routes_final_jobs_to_repo_dedicated_self_hosted_labels():
     )
     for job_name in windows_jobs:
         job = _workflow_job_text(workflow_text, job_name)
-        assert (
-            "runs-on: [self-hosted, Windows, X64, codexhub-ci-windows-x64]" in job
-        ), job_name
+        assert "runs-on: windows-2025" in job, job_name
 
     linux_job = _workflow_job_text(workflow_text, "rust-safe-file-linux")
-    assert "runs-on: [self-hosted, Linux, X64, codexhub-ci-linux-x64]" in linux_job
+    assert "runs-on: ubuntu-24.04" in linux_job
+    assert "self-hosted" not in workflow_text
 
 
 def test_ci_yaml_preserves_final_check_names():
@@ -420,7 +419,7 @@ def test_ci_yaml_preserves_final_check_names():
         assert f"name: {check_name}" in job, job_name
 
 
-def test_ci_yaml_self_hosted_jobs_deny_fork_prs_and_smoke_only_dispatch():
+def test_ci_yaml_hosted_jobs_have_no_self_hosted_guards_or_smoke_dispatch():
     workflow_text = (ROOT / ".github" / "workflows" / "ci.yml").read_text(
         encoding="utf-8"
     )
@@ -435,43 +434,20 @@ def test_ci_yaml_self_hosted_jobs_deny_fork_prs_and_smoke_only_dispatch():
     )
     for job_name in final_jobs:
         job = _workflow_job_text(workflow_text, job_name)
-        assert "github.event.pull_request.head.repo.full_name == github.repository" in job
-        assert "inputs.validation_scope != 'runner-smoke'" in job
+        assert "github.event.pull_request.head.repo.full_name" not in job
+        assert "runner-smoke" not in job
 
-    runner_doc = (
-        ROOT / "docs" / "agents" / "self-hosted-runner.md"
-    ).read_text(encoding="utf-8")
-    assert "ACTIONS_RUNNER_HOOK_JOB_STARTED" in runner_doc
-    assert "host-owned pre-job guard" in runner_doc
-    assert "host hook is the authoritative boundary" in runner_doc
-    assert "additional readable assertion" in runner_doc
-    assert "head repositories both exactly" in runner_doc
+    assert "validation_scope" not in workflow_text
+    assert "runner-smoke" not in workflow_text
+    assert "workflow_dispatch:" in workflow_text
 
 
-def test_ci_yaml_has_bounded_windows_and_linux_runner_smoke_jobs():
+def test_ci_yaml_has_no_runner_smoke_jobs():
     workflow_text = (ROOT / ".github" / "workflows" / "ci.yml").read_text(
         encoding="utf-8"
     )
-    assert "validation_scope:" in workflow_text
-    assert "runner-smoke" in workflow_text
-
-    windows_smoke = _workflow_job_text(workflow_text, "runner-smoke-windows")
-    assert "name: Runner smoke (Windows)" in windows_smoke
-    assert "runs-on: [self-hosted, Windows, X64, codexhub-ci-windows-x64]" in windows_smoke
-    assert "timeout-minutes: 5" in windows_smoke
-    assert "inputs.validation_scope == 'runner-smoke'" in windows_smoke
-
-    linux_smoke = _workflow_job_text(workflow_text, "runner-smoke-linux")
-    assert "name: Runner smoke (Linux)" in linux_smoke
-    assert "runs-on: [self-hosted, Linux, X64, codexhub-ci-linux-x64]" in linux_smoke
-    assert "timeout-minutes: 5" in linux_smoke
-    assert "inputs.validation_scope == 'runner-smoke'" in linux_smoke
-    assert "Rust 1.97.1 is required." in linux_smoke
-    assert "clippy-x86_64-unknown-linux-gnu" in linux_smoke
-    assert "x86_64-unknown-linux-musl" in linux_smoke
-    assert "rust-lld" in linux_smoke
-
-    assert "clippy-x86_64-pc-windows-msvc" in windows_smoke
+    assert "runner-smoke-windows" not in workflow_text
+    assert "runner-smoke-linux" not in workflow_text
 
 
 def test_ci_yaml_linux_safe_file_uses_self_contained_linux_target():
@@ -485,26 +461,27 @@ def test_ci_yaml_linux_safe_file_uses_self_contained_linux_target():
     assert linux_job.count("-C linker=rust-lld") == 2
 
 
-def test_ci_yaml_windows_jobs_use_verified_preinstalled_toolchains():
+def test_ci_yaml_hosted_jobs_install_pinned_toolchains():
     workflow_text = (ROOT / ".github" / "workflows" / "ci.yml").read_text(
         encoding="utf-8"
     )
-    windows_python_jobs = (
-        _workflow_job_text(workflow_text, "runner-smoke-windows"),
-        _workflow_job_text(workflow_text, "python-core"),
-        _workflow_job_text(workflow_text, "python-synthetic"),
-    )
-    for job in windows_python_jobs:
-        assert "actions/setup-python" not in job
-        assert "Python 3.13 is required." in job
+    for job_name in ("python-core", "python-synthetic"):
+        job = _workflow_job_text(workflow_text, job_name)
+        assert "actions/setup-python@v7" in job
+        assert "python-version: '3.13'" in job
 
     frontend_job = _workflow_job_text(workflow_text, "frontend")
-    assert "actions/setup-node" not in frontend_job
-    assert "Node.js 22 is required." in frontend_job
+    assert "actions/setup-node@v7" in frontend_job
+    assert "node-version: '22'" in frontend_job
 
-    for job_name in ("runner-smoke-windows", "rust-tests", "rust-clippy"):
+    for job_name in ("rust-tests", "rust-clippy"):
         job = _workflow_job_text(workflow_text, job_name)
-        assert "Rust 1.97.1 is required." in job
+        assert "rustup toolchain install" in job
+        assert "1.97.1" in job
+
+    linux_job = _workflow_job_text(workflow_text, "rust-safe-file-linux")
+    assert "actions/setup-python@v7" in linux_job
+    assert "rustup toolchain install" in linux_job
 
 
 def test_ci_yaml_rust_caches_exclude_build_outputs():
@@ -517,7 +494,7 @@ def test_ci_yaml_rust_caches_exclude_build_outputs():
     }
     for job_name, key_prefix in expected_key_prefixes.items():
         job = _workflow_job_text(workflow_text, job_name)
-        assert "uses: actions/cache@v4" in job
+        assert "uses: actions/cache@v6" in job
         assert "~/.cargo/registry" in job
         assert "~/.cargo/git" in job
         assert key_prefix in job
@@ -545,3 +522,22 @@ def test_ci_docs_type_unmanaged_paseo_checkout_as_not_applicable():
     ci_doc = (ROOT / "docs" / "agents" / "ci.md").read_text(encoding="utf-8")
     assert "not_applicable_unmanaged_checkout" in ci_doc
     assert "not a product regression" in ci_doc
+
+
+def test_ci_yaml_uses_current_official_action_majors():
+    workflow_text = (ROOT / ".github" / "workflows" / "ci.yml").read_text(
+        encoding="utf-8"
+    )
+    assert "actions/checkout@v7" in workflow_text
+    assert "actions/setup-python@v7" in workflow_text
+    assert "actions/setup-node@v7" in workflow_text
+    assert "actions/cache@v6" in workflow_text
+    assert "actions/upload-artifact@v7" in workflow_text
+
+
+def test_ci_yaml_rust_jobs_force_serial_test_execution():
+    workflow_text = (ROOT / ".github" / "workflows" / "ci.yml").read_text(
+        encoding="utf-8"
+    )
+    rust_job = _workflow_job_text(workflow_text, "rust-tests")
+    assert "--test-threads=1" in rust_job

--- a/tests/test_ci_python_plan.py
+++ b/tests/test_ci_python_plan.py
@@ -313,7 +313,7 @@ def test_ci_yaml_synthetic_run_uses_watchdog_with_3600s_bound():
     )
     timeout_idx = normalized.find("--timeout-seconds 3600")
     separator_idx = normalized.find("-- ")
-    pytest_idx = normalized.find("python -m pytest")
+    pytest_idx = normalized.find("python.exe -m pytest")
     assert -1 < watchdog_idx < timeout_idx < separator_idx < pytest_idx, normalized
 
 

--- a/tests/test_diagnostic_control.py
+++ b/tests/test_diagnostic_control.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 import tempfile
 from unittest import TestCase
+from unittest.mock import patch
 
 import diagnostic_control
 import diagnostic_recorder
@@ -79,7 +80,13 @@ class DiagnosticControlTests(TestCase):
         self.assertEqual(marked["result"], {"accepted": True, "incident_id": "i000001"})
 
     def test_delete_and_status_are_deterministic_after_the_tail_freezes(self) -> None:
-        marked = self._request("mark")
+        # Drive the freeze synchronously below.  The production recorder starts
+        # a maintenance thread after a marker is created; with the fake clock,
+        # that thread can race the explicit process_due_incidents() call and
+        # either freeze twice or advance the incident counter before the
+        # response is read.
+        with patch.object(diagnostic_recorder.DiagnosticRecorder, "_ensure_control_thread_locked"):
+            marked = self._request("mark")
         self.assertEqual(marked["result"]["incident_id"], "i000001")
         self.clock.advance(1)
         self.assertEqual(self.recorder.process_due_incidents(), 1)


### PR DESCRIPTION
Closes #292

## Summary
- migrate routine CI from the retired self-hosted registrations to GitHub-hosted `windows-2025` and `ubuntu-24.04`
- install/select Python 3.13, Node.js 22, Rust 1.97.1, Clippy, musl, and rust-lld in jobs
- upgrade official Actions to checkout@v7, setup-python@v7, setup-node@v7, cache@v6, and upload-artifact@v7
- remove runner-smoke jobs, self-hosted labels, and trusted-host fork guards while preserving the stable formal check names and synthetic watchdog
- update CI, verification, and retired-runner documentation
- make the diagnostic-control fake-clock test deterministic and force Rust tests to one thread so Hosted runs do not inherit the known process-wide fixture races

## Local verification
- `py -3.13 -m pytest -q tests/test_ci_python_plan.py` — 44 passed
- `py -3.13 scripts/report_quality_gates.py --json` — report-only exit 0; baseline findings unchanged
- `git diff --check` — passed

The full Hosted matrix is the merge gate. This PR intentionally does not add path-aware scheduling or `CI / gate`; those are tracked by #293 and depend on this parity migration.