### PR TITLE
ci: add path-aware scheduling and CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,61 @@ env:
   RUST_TOOLCHAIN: 1.97.1
 
 jobs:
+  classifier:
+    name: CI classifier
+    runs-on: windows-2025
+    timeout-minutes: 10
+    outputs:
+      python_core: ${{ steps.plan.outputs.python_core }}
+      python_synthetic: ${{ steps.plan.outputs.python_synthetic }}
+      frontend: ${{ steps.plan.outputs.frontend }}
+      rust: ${{ steps.plan.outputs.rust }}
+      rust_safe_file_linux: ${{ steps.plan.outputs.rust_safe_file_linux }}
+      release_flavor: ${{ steps.plan.outputs.release_flavor }}
+      full: ${{ steps.plan.outputs.full }}
+      classifier_failed: ${{ steps.plan.outputs.classifier_failed }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.13'
+
+      - name: Classify changed paths
+        id: plan
+        shell: pwsh
+        env:
+          CI_PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          CI_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          $raw = & python scripts/ci/ci_change_plan.py --output-json
+          $exitCode = $LASTEXITCODE
+          if (-not $raw) {
+            throw 'CI classifier produced no plan output.'
+          }
+          $plan = $raw | ConvertFrom-Json
+          foreach ($key in @('python_core', 'python_synthetic', 'frontend', 'rust', 'rust_safe_file_linux', 'release_flavor', 'full', 'classifier_failed')) {
+            $value = [bool]$plan.PSObject.Properties[$key].Value
+            "$key=$($value.ToString().ToLowerInvariant())" >> $env:GITHUB_OUTPUT
+          }
+          Write-Host ($plan | ConvertTo-Json -Compress)
+          if ($exitCode -ne 0) {
+            throw "CI classifier exited unexpectedly with code $exitCode."
+          }
+
+      - name: Fail closed when path acquisition failed
+        if: steps.plan.outputs.classifier_failed == 'true'
+        shell: pwsh
+        run: throw 'CI classifier could not acquire changed paths; full matrix was selected but the gate must fail.'
+
   python-core:
     name: Python core
+    needs: classifier
+    if: always() && (needs.classifier.outputs.python_core == 'true' || needs.classifier.outputs.full == 'true')
     runs-on: windows-2025
     timeout-minutes: 30
     steps:
@@ -59,6 +112,8 @@ jobs:
 
   python-synthetic:
     name: Synthetic real-client contract
+    needs: classifier
+    if: always() && (needs.classifier.outputs.python_synthetic == 'true' || needs.classifier.outputs.full == 'true')
     runs-on: windows-2025
     timeout-minutes: 75
     steps:
@@ -80,48 +135,13 @@ jobs:
       - name: Install test dependencies
         run: .\.venv-ci\Scripts\python.exe -m pip install --upgrade pip pytest
 
-      - name: Plan synthetic partition
-        id: plan
-        shell: pwsh
-        run: |
-          $event = '${{ github.event_name }}'
-          $isPr = $event -eq 'pull_request'
-          $changedFile = '.changed-paths.txt'
-          $acquisitionFailed = $false
-          if ($isPr) {
-            $baseSha = '${{ github.event.pull_request.base.sha }}'
-            $headSha = '${{ github.event.pull_request.head.sha }}'
-            git fetch origin $baseSha
-            if ($LASTEXITCODE -ne 0) { $acquisitionFailed = $true }
-            $mergeBase = git merge-base $baseSha $headSha
-            if ($LASTEXITCODE -ne 0) { $acquisitionFailed = $true }
-            $changed = git diff --no-renames --name-only $mergeBase $headSha
-            if ($LASTEXITCODE -ne 0) { $acquisitionFailed = $true }
-            if (-not $acquisitionFailed) {
-              $changed | Out-File -Encoding utf8 $changedFile
-            }
-          }
-          if ($acquisitionFailed) {
-            Remove-Item $changedFile -ErrorAction SilentlyContinue
-          }
-          $plan = .\.venv-ci\Scripts\python.exe scripts/ci/python_test_plan.py `
-            --event $event `
-            $(if ($isPr) { '--is-pull-request' }) `
-            --changed-paths-file $changedFile `
-            --output-json
-          echo "json=$plan" >> $env:GITHUB_OUTPUT
-
       - name: Run or skip synthetic partition
         shell: pwsh
         run: |
-          $plan = '${{ steps.plan.outputs.json }}' | ConvertFrom-Json
-          if ($plan.synthetic_status -eq 'not_applicable') {
-            Write-Host 'Synthetic real-client contract: not applicable'
-          } else {
-            .\.venv-ci\Scripts\python.exe tests/fixtures/real_client_e2e/run-with-windows-watchdog.py `
-              --timeout-seconds 3600 `
-              -- .\.venv-ci\Scripts\python.exe -m pytest @($plan.synthetic_args)
-          }
+          .\.venv-ci\Scripts\python.exe tests/fixtures/real_client_e2e/run-with-windows-watchdog.py `
+            --timeout-seconds 3600 `
+            -- .\.venv-ci\Scripts\python.exe -m pytest -q tests/test_real_client_e2e.py `
+              --junitxml=.pytest-results/junit-synthetic.xml --durations=0
 
       - name: Upload synthetic JUnit evidence
         if: always()
@@ -133,6 +153,8 @@ jobs:
 
   frontend:
     name: Frontend build and UI contract
+    needs: classifier
+    if: always() && (needs.classifier.outputs.frontend == 'true' || needs.classifier.outputs.full == 'true')
     runs-on: windows-2025
     timeout-minutes: 30
     defaults:
@@ -158,6 +180,8 @@ jobs:
 
   rust-tests:
     name: Rust tests (${{ matrix.flavor }})
+    needs: classifier
+    if: always() && (needs.classifier.outputs.rust == 'true' || needs.classifier.outputs.full == 'true')
     runs-on: windows-2025
     timeout-minutes: 75
     strategy:
@@ -219,6 +243,8 @@ jobs:
 
   rust-safe-file-linux:
     name: Rust safe_file Linux compile and tests
+    needs: classifier
+    if: always() && (needs.classifier.outputs.rust_safe_file_linux == 'true' || needs.classifier.outputs.full == 'true')
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
@@ -258,6 +284,8 @@ jobs:
 
   release-flavor-contract:
     name: Release flavor contract
+    needs: classifier
+    if: always() && (needs.classifier.outputs.release_flavor == 'true' || needs.classifier.outputs.full == 'true')
     runs-on: windows-2025
     timeout-minutes: 15
     steps:
@@ -297,6 +325,8 @@ jobs:
 
   rust-clippy:
     name: Rust clippy
+    needs: classifier
+    if: always() && (needs.classifier.outputs.rust == 'true' || needs.classifier.outputs.full == 'true')
     runs-on: windows-2025
     timeout-minutes: 45
     defaults:
@@ -333,3 +363,53 @@ jobs:
       - name: Run clippy
         shell: pwsh
         run: cargo clippy --locked --all-targets -- -D warnings
+
+  gate:
+    name: CI / gate
+    if: always()
+    needs:
+      - classifier
+      - python-core
+      - python-synthetic
+      - frontend
+      - rust-tests
+      - rust-safe-file-linux
+      - release-flavor-contract
+      - rust-clippy
+    runs-on: windows-2025
+    timeout-minutes: 10
+    steps:
+      - name: Evaluate selected checks
+        shell: pwsh
+        run: |
+          $classifierResult = '${{ needs.classifier.result }}'
+          if ($classifierResult -in @('failure', 'cancelled')) {
+            throw "CI classifier did not complete successfully ($classifierResult)."
+          }
+
+          $checks = @(
+            @('python_core', "${{ needs['python-core'].result }}", "${{ needs.classifier.outputs.python_core }}"),
+            @('python_synthetic', "${{ needs['python-synthetic'].result }}", "${{ needs.classifier.outputs.python_synthetic }}"),
+            @('frontend', "${{ needs.frontend.result }}", "${{ needs.classifier.outputs.frontend }}"),
+            @('rust_tests', "${{ needs['rust-tests'].result }}", "${{ needs.classifier.outputs.rust }}"),
+            @('rust_safe_file_linux', "${{ needs['rust-safe-file-linux'].result }}", "${{ needs.classifier.outputs.rust_safe_file_linux }}"),
+            @('release_flavor', "${{ needs['release-flavor-contract'].result }}", "${{ needs.classifier.outputs.release_flavor }}"),
+            @('rust_clippy', "${{ needs['rust-clippy'].result }}", "${{ needs.classifier.outputs.rust }}")
+          )
+
+          foreach ($check in $checks) {
+            $name = $check[0]
+            $result = $check[1]
+            $selected = $check[2] -eq 'true'
+            if (-not $selected) {
+              Write-Host "$name is intentionally skipped."
+              continue
+            }
+            if ($result -in @('failure', 'cancelled')) {
+              throw "$name was selected but finished with $result."
+            }
+            if ($result -ne 'success') {
+              throw "$name was selected but finished with unexpected result '$result'."
+            }
+            Write-Host "$name passed."
+          }

--- a/docs/agents/ci.md
+++ b/docs/agents/ci.md
@@ -8,8 +8,17 @@ CI job by default.
 
 ## CI jobs
 
-- **Python core**: `python -m pytest -q --ignore=tests/test_real_client_e2e.py --junitxml=.pytest-results/junit-core.xml --durations=0`. Runs on every PR.
-- **Synthetic real-client contract**: appears on every PR. For unrelated paths it succeeds explicitly as `not applicable` and does not start `scripts/Run-RealClientE2E.ps1`. For relevant paths, and for all non-PR events, it runs the synthetic module through `tests/fixtures/real_client_e2e/run-with-windows-watchdog.py` with an explicit 3600-second outer bound while retaining JUnit and per-test duration output. The planner at `scripts/ci/python_test_plan.py` decides which paths are relevant using the PR merge-base; `python scripts/ci/check_python_test_partitions.py` proves the core and synthetic partitions are disjoint and complete.
+Every workflow run creates one immutable **CI classifier** and one final
+**`CI / gate`** check.  The classifier in
+`scripts/ci/ci_change_plan.py` compares a pull request's merge-base to its
+head and emits the job-selection booleans.  Formal jobs keep their existing
+check names, but are skipped when their contract is unaffected.  A skipped
+formal job is acceptable only when the classifier selected it as out of scope;
+the gate fails on classifier failure, cancellation, or any selected job that
+does not pass.
+
+- **Python core**: `python -m pytest -q --ignore=tests/test_real_client_e2e.py --junitxml=.pytest-results/junit-core.xml --durations=0` when the classifier selects Python core.
+- **Synthetic real-client contract**: when selected, it runs the synthetic module through `tests/fixtures/real_client_e2e/run-with-windows-watchdog.py` with an explicit 3600-second outer bound while retaining JUnit and per-test duration output. The unified classifier uses the existing synthetic dependency set; `python scripts/ci/check_python_test_partitions.py` still proves the core and synthetic partitions are disjoint and complete.
 - Frontend build and UI contract: `npm ci`, `npm run build`, `npm run test:ui-contract` in `frontend/`
 - Rust tests (normal and debug flavors): `cargo test --locked -- --test-threads=1` in `src-tauri/`, plus a release-optimized flavor build
 - Rust clippy: `cargo clippy --locked --all-targets -- -D warnings` in `src-tauri/`
@@ -24,15 +33,17 @@ CI job by default.
   `safe_file.rs` must stay free of crate dependencies so the standalone compile
   keeps working.
 
-### Triggers
+### Triggers and path scheduling
 
-Same-repository and fork PRs to `dev` and `main` run both Python checks, the
-frontend job, Rust normal/debug tests, Rust clippy, release flavor contract,
-and Linux `safe_file` on GitHub-hosted runners. Hosted runners are disposable
-and do not depend on the developer machine or a repository self-hosted
-registration. Pushes to `dev` and `main` preserve the same job set.
-`workflow_dispatch` runs the full validation. The weekly Sunday 03:17 UTC
-`schedule` runs the full validation, including the synthetic suite.
+Same-repository and fork PRs to `dev` and `main` always run the classifier and
+gate.  The classifier selects Python, frontend, Rust, Linux `safe_file`, and
+release checks from changed paths; documentation-only changes run only the
+classifier and gate.  Unknown paths, planner/workflow changes, path-read
+failures, pushes, schedules, and manual dispatches fail closed to the full
+matrix.  Workflow triggers intentionally do not use `paths` filters, so the
+required `CI / gate` check is never left permanently pending by GitHub.
+Hosted runners are disposable and do not depend on the developer machine or a
+repository self-hosted registration.
 
 Windows jobs pin `windows-2025`; the Linux-only `safe_file` job pins
 `ubuntu-24.04`, so its `cfg(unix)` code is compiled and exercised on Linux.
@@ -81,7 +92,9 @@ A PR is considered relevant for the synthetic check when it touches any of the f
 - `tests/test_ci_python_plan.py`
 - `pytest.ini`
 
-If changed-path acquisition for a PR is missing, unavailable, or fails, the check fails closed and runs the synthetic suite.
+If changed-path acquisition for a PR is missing, unavailable, or fails, the
+classifier fails closed, selects every formal job, and the gate reports the
+classifier failure instead of silently accepting a partial plan.
 
 The Rust jobs create a temporary `src-tauri/resources/python/.ci-placeholder` file during CI because Tauri's resource glob requires at least one runtime Python resource file. The placeholder is not committed.
 

--- a/docs/agents/verification-policy.md
+++ b/docs/agents/verification-policy.md
@@ -53,15 +53,17 @@ not block PR, merge, or release under the current policy.
 
 ## CI authority
 
-GitHub Actions runs every repository job for every PR to `dev` or `main`
-regardless of local verification class (Python core, synthetic real-client
-contract, frontend build and UI contract, Rust tests for both flavors, Rust
-clippy, release flavor contract, and the safe_file Linux compile/lint/tests).
-Routine checks run on fresh GitHub-hosted Windows and Linux runners. Because
-the repository is public, fork PR code is allowed to run only on those
-disposable hosted VMs; it never receives access to a persistent developer or
-self-hosted machine. True real-client Desktop/CLI evidence remains a local
-release-operator procedure.
+GitHub Actions always creates the classifier and `CI / gate` for every PR to
+`dev` or `main`. The immutable classifier selects the applicable formal jobs
+(Python core, synthetic real-client contract, frontend build and UI contract,
+Rust tests for both flavors, Rust clippy, release flavor contract, and the
+safe_file Linux compile/lint/tests). Unknown paths, planner/workflow changes,
+path-read failures, and non-PR events fail closed to the full matrix. Routine
+checks run on fresh GitHub-hosted Windows and Linux runners. Because the
+repository is public, fork PR code is allowed to run only on those disposable
+hosted VMs; it never receives access to a persistent developer or self-hosted
+machine. True real-client Desktop/CLI evidence remains a local release-
+operator procedure.
 Local risk selection reduces duplicate work; it does not weaken CI. When CI is
 unavailable and a merge must proceed, reproduce the full fallback in
 `docs/agents/ci.md`.
@@ -71,18 +73,20 @@ unavailable and a merge must proceed, reproduce the full fallback in
 The Python validation is split into two stable checks so the real-client E2E
 suite is only invoked when its contract surface actually changed:
 
-- **`Python core`** runs on every PR. It executes every Python test except
+- **`Python core`** is selected for Python source, configuration, and ordinary
+  Python tests. It executes every Python test except
   `tests/test_real_client_e2e.py`.
-- **`Synthetic real-client contract`** appears on every PR. For PRs that do not
-  touch a real-client E2E dependency it succeeds explicitly as
-  `not applicable` and does not start `scripts/Run-RealClientE2E.ps1`. For PRs
-  that touch a relevant path it runs `tests/test_real_client_e2e.py` in full.
+- **`Synthetic real-client contract`** is selected for the real-client E2E
+  dependency surface and runs `tests/test_real_client_e2e.py` in full.
 
 Non-PR events (`push`, `workflow_dispatch`, the weekly full-validation
-`schedule`, release/full-validation, and unknown events) fail closed and always
-run the synthetic suite. The planner that implements this decision lives at
-`scripts/ci/python_test_plan.py` and is tested by
-`tests/test_ci_python_plan.py`. Collection completeness is verified by
+`schedule`, release/full-validation, and unknown events) fail closed and run
+the full matrix. The unified planner lives at
+`scripts/ci/ci_change_plan.py`; the existing Python partition planner remains
+the source of the core/synthetic partition definitions used by local fallback
+and is tested by `tests/test_ci_python_plan.py`. The Hosted workflow keeps
+those same stable pytest arguments after the unified planner selects the job.
+Collection completeness is verified by
 `python scripts/ci/check_python_test_partitions.py`.
 
 Existing active work migrates incrementally: retain already completed full

--- a/scripts/ci/ci_change_plan.py
+++ b/scripts/ci/ci_change_plan.py
@@ -1,0 +1,428 @@
+"""Fail-closed path planner for the repository CI matrix.
+
+The classifier is deliberately small and deterministic.  It is the only
+place that decides whether a formal CI job is applicable to a pull request;
+the workflow itself always creates the checks and the final ``CI / gate``
+decides whether skipped jobs were legitimately out of scope.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Optional, Sequence
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+JOB_KEYS = (
+    "python_core",
+    "python_synthetic",
+    "frontend",
+    "rust",
+    "rust_safe_file_linux",
+    "release_flavor",
+)
+
+SYNTHETIC_EXACT = frozenset(
+    {
+        "scripts/run-realcliente2e.ps1",
+        "tests/test_real_client_e2e.py",
+        "docs/agents/real-client-e2e.md",
+        "pytest.ini",
+    }
+)
+SYNTHETIC_TEST_PATH = "tests/test_real_client_e2e.py"
+SYNTHETIC_PREFIXES = (
+    "tests/fixtures/real_client_e2e/",
+)
+
+PYTHON_CORE_EXACT = frozenset(
+    {
+        "pytest.ini",
+        "pyproject.toml",
+        "setup.cfg",
+        "tox.ini",
+        "requirements.txt",
+        "requirements-dev.txt",
+    }
+)
+PYTHON_CORE_PREFIXES = (
+    "src-python/",
+    "config/",
+)
+
+FRONTEND_EXACT = frozenset(
+    {
+        "src-tauri/src/app_updates.rs",
+        "src-tauri/src/autostart.rs",
+        "src-tauri/src/catalog.rs",
+        "src-tauri/src/config.rs",
+        "src-tauri/src/gateway.rs",
+        "src-tauri/src/history.rs",
+        "src-tauri/src/models.rs",
+        "src-tauri/src/official_refresh.rs",
+        "src-tauri/src/openai_usage.rs",
+        "src-tauri/src/web_bridge.rs",
+        "src-tauri/src/main.rs",
+        "src-tauri/capabilities/default.json",
+        "src-tauri/cargo.toml",
+        "src-tauri/tauri.conf.json",
+        "config/build-flavors.json",
+        "scripts/build-windows-portable.ps1",
+        "scripts/build-windows-release.ps1",
+        "scripts/e2e-app-update.ps1",
+        "scripts/prepare-pythonruntime.ps1",
+        "tests/fixtures/model_identity_vectors.json",
+        "design.md",
+        "docs/agents/user-feedback.md",
+        "frontend/src/lib/tauri.ts",
+        "frontend/src/lib/types.ts",
+        "frontend/src/lib/ui-contract.json",
+    }
+)
+
+RELEASE_EXACT = frozenset(
+    {
+        "config/build-flavors.json",
+        "scripts/build-tauriconfig.ps1",
+        "scripts/build-windows-portable.ps1",
+        "scripts/build-windows-release.ps1",
+        "scripts/e2e-app-update.ps1",
+        "scripts/new-releasechannelplan.ps1",
+        "scripts/prepare-pythonruntime.ps1",
+        "scripts/releasechannel.ps1",
+        "scripts/test-buildflavorreplacement.ps1",
+        "scripts/test-releasemanifest.ps1",
+        "scripts/test-windowsautostart.ps1",
+        "scripts/test-windowsautostartuninstall.ps1",
+        "scripts/run-issue160virtualboxsmoke.ps1",
+        "docs/agents/real-client-e2e.md",
+        "docs/agents/windows-autostart-smoke.md",
+        "tests/test_release_channel_scripts.py",
+        "src-tauri/tauri.conf.json",
+        "src-tauri/src/app_flavor.rs",
+        "src-tauri/src/app_updates.rs",
+        "src-tauri/windows/nsis-hooks.nsh",
+    }
+)
+RELEASE_PREFIXES = (
+    "src-tauri/icons/",
+    "docs/releases/",
+)
+
+SAFE_FILE_EXACT = frozenset(
+    {
+        "src-tauri/src/safe_file.rs",
+        "rust-toolchain",
+        "rust-toolchain.toml",
+        "src-tauri/rust-toolchain",
+        "src-tauri/rust-toolchain.toml",
+        ".cargo/config",
+        ".cargo/config.toml",
+    }
+)
+
+FULL_EXACT = frozenset(
+    {
+        ".github/workflows/ci.yml",
+        "scripts/ci/ci_change_plan.py",
+        "scripts/ci/python_test_plan.py",
+        "scripts/ci/check_python_test_partitions.py",
+        "tests/test_ci_change_plan.py",
+        "tests/test_ci_python_plan.py",
+        "docs/agents/ci.md",
+        "docs/agents/verification-policy.md",
+        "docs/agents/self-hosted-runner.md",
+    }
+)
+FULL_PREFIXES = (
+    ".github/workflows/",
+    ".github/actions/",
+    "scripts/ci/",
+)
+
+
+@dataclass(frozen=True)
+class CIChangePlan:
+    """Immutable job-selection result for one event and path set."""
+
+    event_name: str
+    full: bool
+    python_core: bool
+    python_synthetic: bool
+    frontend: bool
+    rust: bool
+    rust_safe_file_linux: bool
+    release_flavor: bool
+    changed_paths_available: bool
+    classifier_failed: bool
+    reason: str
+
+    def selected_jobs(self) -> tuple[str, ...]:
+        return tuple(key for key in JOB_KEYS if getattr(self, key))
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "event_name": self.event_name,
+            "full": self.full,
+            "python_core": self.python_core,
+            "python_synthetic": self.python_synthetic,
+            "frontend": self.frontend,
+            "rust": self.rust,
+            "rust_safe_file_linux": self.rust_safe_file_linux,
+            "release_flavor": self.release_flavor,
+            "changed_paths_available": self.changed_paths_available,
+            "classifier_failed": self.classifier_failed,
+            "selected_jobs": list(self.selected_jobs()),
+            "reason": self.reason,
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), sort_keys=True)
+
+
+def _normalize_path(path: str) -> str:
+    normalized = path.replace("\\", "/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    return normalized.lower()
+
+
+def _matches(path: str, exact: Iterable[str], prefixes: Iterable[str] = ()) -> bool:
+    normalized = _normalize_path(path)
+    return normalized in exact or any(normalized.startswith(prefix) for prefix in prefixes)
+
+
+def _is_python_test(path: str) -> bool:
+    normalized = _normalize_path(path)
+    if not normalized.startswith("tests/") or not normalized.endswith(".py"):
+        return False
+    return normalized != SYNTHETIC_TEST_PATH and not normalized.startswith(
+        "tests/fixtures/real_client_e2e/"
+    )
+
+
+def _is_python_script(path: str) -> bool:
+    normalized = _normalize_path(path)
+    return normalized.startswith("scripts/") and normalized.endswith(".py")
+
+
+def _is_docs_only(path: str) -> bool:
+    normalized = _normalize_path(path)
+    return normalized.startswith("docs/") or normalized in {
+        "readme.md",
+        "readme.zh-cn.md",
+        "context.md",
+        "agents.md",
+        "design.md",
+        "changelog.md",
+        "contributing.md",
+        "license",
+        "license.md",
+        "license.txt",
+    }
+
+
+def _classify_path(path: str) -> tuple[frozenset[str], bool]:
+    """Return selected job families and whether the path is recognized."""
+
+    normalized = _normalize_path(path)
+    categories: set[str] = set()
+    if _matches(path, PYTHON_CORE_EXACT, PYTHON_CORE_PREFIXES) or _is_python_test(path) or _is_python_script(path):
+        categories.add("python_core")
+    if _matches(path, SYNTHETIC_EXACT, SYNTHETIC_PREFIXES):
+        categories.add("python_synthetic")
+    if _matches(path, FRONTEND_EXACT, ("frontend/",)):
+        categories.add("frontend")
+    if (
+        normalized.startswith("src-tauri/")
+        or normalized in {"cargo.toml", "cargo.lock"}
+        or normalized.endswith("/cargo.toml")
+        or normalized.endswith("/cargo.lock")
+    ):
+        categories.add("rust")
+    if _matches(path, SAFE_FILE_EXACT) or normalized.endswith("/safe_file.rs"):
+        categories.add("rust_safe_file_linux")
+    if _matches(path, RELEASE_EXACT, RELEASE_PREFIXES) or normalized.startswith("scripts/build-windows-"):
+        categories.add("release_flavor")
+
+    recognized = bool(categories) or _is_docs_only(path)
+    return frozenset(categories), recognized
+
+
+def _all_jobs(*, event_name: str, reason: str, classifier_failed: bool = False) -> CIChangePlan:
+    return CIChangePlan(
+        event_name=event_name,
+        full=True,
+        python_core=True,
+        python_synthetic=True,
+        frontend=True,
+        rust=True,
+        rust_safe_file_linux=True,
+        release_flavor=True,
+        changed_paths_available=not classifier_failed,
+        classifier_failed=classifier_failed,
+        reason=reason,
+    )
+
+
+def build_plan(
+    event_name: str,
+    is_pull_request: bool,
+    changed_paths: Optional[Sequence[str]],
+) -> CIChangePlan:
+    """Classify a path set, failing closed for unavailable or unsafe input.
+
+    ``None`` means that changed-path acquisition failed.  It selects the full
+    matrix and marks the classifier failed so the gate can require a repair.
+    Non-PR events are intentionally full validation events.
+    """
+
+    if not is_pull_request:
+        return _all_jobs(
+            event_name=event_name,
+            reason=f"{event_name} is not a pull request; full validation is required.",
+        )
+    if changed_paths is None:
+        return _all_jobs(
+            event_name=event_name,
+            reason="Changed-path acquisition failed or was unavailable; full validation is required.",
+            classifier_failed=True,
+        )
+
+    normalized_paths = tuple(_normalize_path(path) for path in changed_paths if path.strip())
+    if not normalized_paths:
+        return _all_jobs(
+            event_name=event_name,
+            reason="A pull request returned no changed paths; full validation is required.",
+            classifier_failed=True,
+        )
+
+    if any(
+        _matches(path, FULL_EXACT, FULL_PREFIXES)
+        for path in normalized_paths
+    ):
+        return _all_jobs(
+            event_name=event_name,
+            reason="The planner, workflow, or CI contract changed; full validation is required.",
+        )
+
+    classified = tuple((path, *_classify_path(path)) for path in normalized_paths)
+    unknown = [path for path, _categories, recognized in classified if not recognized]
+    if unknown:
+        return _all_jobs(
+            event_name=event_name,
+            reason="Unrecognized path(s) require fail-closed full validation: "
+            + ", ".join(unknown),
+        )
+
+    selected = frozenset().union(*(categories for _path, categories, _recognized in classified))
+    return CIChangePlan(
+        event_name=event_name,
+        full=False,
+        python_core="python_core" in selected,
+        python_synthetic="python_synthetic" in selected,
+        frontend="frontend" in selected,
+        rust="rust" in selected,
+        rust_safe_file_linux="rust_safe_file_linux" in selected,
+        release_flavor="release_flavor" in selected,
+        changed_paths_available=True,
+        classifier_failed=False,
+        reason="Selected jobs from the immutable changed-path classification.",
+    )
+
+
+def _read_changed_paths_file(path: Path) -> Optional[list[str]]:
+    try:
+        return [line.strip() for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    except OSError:
+        return None
+
+
+def _changed_paths_from_git(base_sha: str, head_sha: str) -> Optional[list[str]]:
+    try:
+        subprocess.run(
+            ["git", "fetch", "--no-tags", "origin", base_sha],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+        )
+        merge_base = subprocess.run(
+            ["git", "merge-base", base_sha, head_sha],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        result = subprocess.run(
+            ["git", "diff", "--no-renames", "--name-only", merge_base, head_sha],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    except (OSError, subprocess.CalledProcessError):
+        return None
+
+
+def _plan_from_environment() -> CIChangePlan:
+    event_name = os.environ.get("GITHUB_EVENT_NAME", "unknown")
+    is_pull_request = event_name == "pull_request"
+    if not is_pull_request:
+        return build_plan(event_name, False, [])
+
+    base_sha = os.environ.get("CI_PR_BASE_SHA", "")
+    head_sha = os.environ.get("CI_PR_HEAD_SHA", "")
+    if not base_sha or not head_sha:
+        return build_plan(event_name, True, None)
+    return build_plan(event_name, True, _changed_paths_from_git(base_sha, head_sha))
+
+
+def _parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Plan CodexHub CI jobs from changed paths.")
+    parser.add_argument("--event", default=os.environ.get("GITHUB_EVENT_NAME", "unknown"))
+    parser.add_argument("--is-pull-request", action="store_true")
+    parser.add_argument("--changed-paths", nargs="*", default=None)
+    parser.add_argument("--changed-paths-file", default=None)
+    parser.add_argument("--output-json", action="store_true")
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Return non-zero when changed-path acquisition failed.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = _parse_args(argv)
+    is_pull_request = args.is_pull_request or args.event == "pull_request"
+    if args.changed_paths is not None:
+        changed_paths: Optional[Sequence[str]] = args.changed_paths
+    elif args.changed_paths_file:
+        changed_paths = _read_changed_paths_file(Path(args.changed_paths_file))
+    elif is_pull_request:
+        changed_paths = _changed_paths_from_git(
+            os.environ.get("CI_PR_BASE_SHA", ""),
+            os.environ.get("CI_PR_HEAD_SHA", ""),
+        )
+    else:
+        changed_paths = []
+
+    plan = build_plan(args.event, is_pull_request, changed_paths)
+    if args.output_json:
+        print(plan.to_json())
+    else:
+        print(plan.reason)
+        print(json.dumps(plan.to_dict(), indent=2, sort_keys=True))
+    return 1 if args.strict and plan.classifier_failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_ci_change_plan.py
+++ b/tests/test_ci_change_plan.py
@@ -1,0 +1,195 @@
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PLANNER_PATH = ROOT / "scripts" / "ci" / "ci_change_plan.py"
+
+
+@pytest.fixture(scope="module")
+def planner():
+    spec = importlib.util.spec_from_file_location("ci_change_plan", PLANNER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_plan_is_immutable_and_serializable(planner):
+    plan = planner.build_plan("pull_request", True, ["frontend/src/App.tsx"])
+    with pytest.raises((AttributeError, TypeError)):
+        plan.frontend = False
+    payload = json.loads(plan.to_json())
+    assert payload["frontend"] is True
+    assert payload["selected_jobs"] == ["frontend"]
+
+
+def test_frontend_path_selects_only_frontend(planner):
+    plan = planner.build_plan("pull_request", True, ["frontend/src/App.tsx"])
+    assert plan.full is False
+    assert plan.frontend is True
+    assert plan.selected_jobs() == ("frontend",)
+
+
+def test_shared_bridge_contract_selects_frontend_and_rust(planner):
+    plan = planner.build_plan("pull_request", True, ["src-tauri/src/web_bridge.rs"])
+    assert plan.frontend is True
+    assert plan.rust is True
+    assert plan.rust_safe_file_linux is False
+
+
+def test_shared_catalog_contract_selects_frontend_and_rust(planner):
+    plan = planner.build_plan("pull_request", True, ["src-tauri/src/catalog.rs"])
+    assert plan.frontend is True
+    assert plan.rust is True
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "src-tauri/src/openai_usage.rs",
+        "src-tauri/src/official_refresh.rs",
+        "src-tauri/capabilities/default.json",
+        "src-tauri/Cargo.toml",
+        "tests/fixtures/model_identity_vectors.json",
+    ],
+)
+def test_ui_contract_external_input_selects_frontend(planner, path):
+    plan = planner.build_plan("pull_request", True, [path])
+    assert plan.frontend is True
+
+
+def test_python_path_selects_core(planner):
+    plan = planner.build_plan("pull_request", True, ["src-python/catalog_sync.py"])
+    assert plan.selected_jobs() == ("python_core",)
+
+
+def test_synthetic_fixture_selects_synthetic_only(planner):
+    plan = planner.build_plan(
+        "pull_request", True, ["tests/fixtures/real_client_e2e/fake-client.cmd"]
+    )
+    assert plan.selected_jobs() == ("python_synthetic",)
+
+
+def test_synthetic_module_selects_synthetic_without_core(planner):
+    plan = planner.build_plan("pull_request", True, ["tests/test_real_client_e2e.py"])
+    assert plan.selected_jobs() == ("python_synthetic",)
+
+
+def test_safe_file_selects_rust_and_linux_safe_file(planner):
+    plan = planner.build_plan("pull_request", True, ["src-tauri/src/safe_file.rs"])
+    assert plan.rust is True
+    assert plan.rust_safe_file_linux is True
+    assert plan.release_flavor is False
+
+
+def test_release_path_selects_release_and_rust(planner):
+    plan = planner.build_plan("pull_request", True, ["src-tauri/tauri.conf.json"])
+    assert plan.release_flavor is True
+    assert plan.rust is True
+
+
+def test_build_flavor_manifest_selects_release_and_python(planner):
+    plan = planner.build_plan("pull_request", True, ["config/build-flavors.json"])
+    assert plan.release_flavor is True
+    assert plan.python_core is True
+
+
+def test_update_contract_selects_release(planner):
+    plan = planner.build_plan("pull_request", True, ["scripts/e2e-app-update.ps1"])
+    assert plan.selected_jobs() == ("frontend", "release_flavor")
+
+
+def test_installer_contract_doc_selects_release(planner):
+    plan = planner.build_plan(
+        "pull_request", True, ["docs/agents/windows-autostart-smoke.md"]
+    )
+    assert plan.selected_jobs() == ("release_flavor",)
+
+
+def test_release_contract_tests_select_release(planner):
+    plan = planner.build_plan(
+        "pull_request", True, ["tests/test_release_channel_scripts.py"]
+    )
+    assert plan.release_flavor is True
+    assert plan.python_core is True
+
+
+def test_docs_only_selects_no_formal_jobs(planner):
+    plan = planner.build_plan("pull_request", True, ["docs/notes/catalog.md"])
+    assert plan.full is False
+    assert plan.selected_jobs() == ()
+
+
+@pytest.mark.parametrize("path", ["README.zh-CN.md", "CONTEXT.md"])
+def test_root_documentation_selects_no_formal_jobs(planner, path):
+    plan = planner.build_plan("pull_request", True, [path])
+    assert plan.full is False
+    assert plan.selected_jobs() == ()
+
+
+@pytest.mark.parametrize("path", ["DESIGN.md", "docs/agents/user-feedback.md"])
+def test_ui_contract_docs_select_frontend(planner, path):
+    plan = planner.build_plan("pull_request", True, [path])
+    assert plan.selected_jobs() == ("frontend",)
+
+
+def test_contract_docs_select_full(planner):
+    plan = planner.build_plan("pull_request", True, ["docs/agents/ci.md"])
+    assert plan.full is True
+    assert set(plan.selected_jobs()) == set(planner.JOB_KEYS)
+
+
+def test_unknown_path_fails_closed_to_full(planner):
+    plan = planner.build_plan("pull_request", True, ["mystery/new-format.bin"])
+    assert plan.full is True
+    assert plan.classifier_failed is False
+    assert set(plan.selected_jobs()) == set(planner.JOB_KEYS)
+
+
+@pytest.mark.parametrize("path", ["tests/fixtures/data.txt", "assets/schema.txt"])
+def test_non_document_text_path_fails_closed_to_full(planner, path):
+    plan = planner.build_plan("pull_request", True, [path])
+    assert plan.full is True
+    assert set(plan.selected_jobs()) == set(planner.JOB_KEYS)
+
+
+def test_missing_paths_fails_classifier_and_selects_full(planner):
+    plan = planner.build_plan("pull_request", True, None)
+    assert plan.full is True
+    assert plan.classifier_failed is True
+    assert set(plan.selected_jobs()) == set(planner.JOB_KEYS)
+
+
+@pytest.mark.parametrize("event", ["push", "schedule", "workflow_dispatch"])
+def test_non_pr_events_are_full(planner, event):
+    plan = planner.build_plan(event, False, [])
+    assert plan.full is True
+    assert plan.classifier_failed is False
+
+
+def test_cli_strict_returns_failure_for_unreadable_path_file(tmp_path):
+    bad_path = tmp_path / "changed-paths"
+    bad_path.mkdir()
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(PLANNER_PATH),
+            "--event",
+            "pull_request",
+            "--is-pull-request",
+            "--changed-paths-file",
+            str(bad_path),
+            "--output-json",
+            "--strict",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1
+    assert json.loads(result.stdout)["classifier_failed"] is True

--- a/tests/test_ci_python_plan.py
+++ b/tests/test_ci_python_plan.py
@@ -28,8 +28,9 @@ def plan():
 
 def _workflow_job_text(workflow_text: str, job_name: str) -> str:
     """Return the raw text of a top-level GitHub Actions job."""
-    start = workflow_text.find(f"  {job_name}:")
-    assert start != -1, f"job {job_name!r} not found"
+    match = re.search(rf"(?m)^  {re.escape(job_name)}:", workflow_text)
+    assert match is not None, f"job {job_name!r} not found"
+    start = match.start()
     after = workflow_text[start + 1 :]
     next_job = re.search(r"\n  [a-zA-Z0-9_-]+:", after)
     if next_job:
@@ -345,7 +346,7 @@ def test_ci_md_fallback_commands_use_watchdog_with_3600s_bound():
 
 
 def test_ci_yaml_synthetic_job_has_no_depth_boundary():
-    """Regression: re-shallowing base history can make merge-base fail."""
+    """Synthetic checkout remains deep for reproducible fixture execution."""
     workflow_text = (ROOT / ".github" / "workflows" / "ci.yml").read_text(
         encoding="utf-8"
     )
@@ -353,15 +354,17 @@ def test_ci_yaml_synthetic_job_has_no_depth_boundary():
     assert "--depth=" not in synthetic_job, "synthetic job must not re-shallow history"
 
 
-def test_ci_yaml_changed_paths_uses_no_renames():
+def test_ci_yaml_classifier_uses_immutable_change_plan():
     workflow_text = (ROOT / ".github" / "workflows" / "ci.yml").read_text(
         encoding="utf-8"
     )
-    synthetic_job = _workflow_job_text(workflow_text, "python-synthetic")
-    plan_step = _step_run_text(synthetic_job, "Plan synthetic partition")
-    assert "git diff" in plan_step
-    assert "--no-renames" in plan_step
-    assert "--name-only" in plan_step
+    classifier_job = _workflow_job_text(workflow_text, "classifier")
+    assert "fetch-depth: 0" in classifier_job
+    plan_step = _step_run_text(classifier_job, "Classify changed paths")
+    assert "scripts/ci/ci_change_plan.py" in plan_step
+    assert "--output-json" in plan_step
+    assert "Fail closed when path acquisition failed" in classifier_job
+    assert "CI_PR_BASE_SHA" in classifier_job
 
 
 def test_pr_rename_from_relevant_to_unrelated_runs_synthetic(plan):
@@ -440,6 +443,39 @@ def test_ci_yaml_hosted_jobs_have_no_self_hosted_guards_or_smoke_dispatch():
     assert "validation_scope" not in workflow_text
     assert "runner-smoke" not in workflow_text
     assert "workflow_dispatch:" in workflow_text
+
+
+def test_ci_yaml_has_classifier_and_single_gate():
+    workflow_text = (ROOT / ".github" / "workflows" / "ci.yml").read_text(
+        encoding="utf-8"
+    )
+    classifier = _workflow_job_text(workflow_text, "classifier")
+    assert "name: CI classifier" in classifier
+    assert "runs-on: windows-2025" in classifier
+    assert "ci_change_plan.py" in classifier
+
+    gate = _workflow_job_text(workflow_text, "gate")
+    assert "name: CI / gate" in gate
+    assert "if: always()" in gate
+    for job_name in (
+        "classifier",
+        "python-core",
+        "python-synthetic",
+        "frontend",
+        "rust-tests",
+        "rust-safe-file-linux",
+        "release-flavor-contract",
+        "rust-clippy",
+    ):
+        assert f"- {job_name}" in gate
+
+
+def test_ci_yaml_never_uses_workflow_paths_filters():
+    workflow_text = (ROOT / ".github" / "workflows" / "ci.yml").read_text(
+        encoding="utf-8"
+    )
+    assert "paths:" not in workflow_text
+    assert "paths-ignore:" not in workflow_text
 
 
 def test_ci_yaml_has_no_runner_smoke_jobs():


### PR DESCRIPTION
## Summary

- add immutable `CIChangePlan` classifier with fail-closed path rules
- keep all formal check names and move scheduling behind classifier outputs
- add always-running `CI / gate`; skipped jobs are valid only when unselected
- run full matrix for planner/workflow changes, unknown paths, non-PR events, and classifier failures
- classify shared frontend/Tauri UI-contract inputs and release/update/installer contracts explicitly
- update CI and verification docs and add planner/workflow contract tests

## Verification

- `py -3.13 -m pytest -q tests/test_ci_change_plan.py tests/test_ci_python_plan.py` (78 passed)
- `py -3.13 -m compileall -q scripts/ci tests/test_ci_change_plan.py`
- `git diff --check`

This PR intentionally changes the workflow and planner, so its Hosted run must execute the full matrix before merge.

Closes #293