### PR TITLE
test: remove hosted wall-clock cleanup flake

### DIFF
--- a/src-tauri/src/proxy.rs
+++ b/src-tauri/src/proxy.rs
@@ -30,6 +30,8 @@ use std::os::windows::process::CommandExt;
 use windows_sys::Win32::Foundation::{
     CloseHandle, ERROR_INSUFFICIENT_BUFFER, FILETIME, HANDLE, INVALID_HANDLE_VALUE, NO_ERROR,
 };
+#[cfg(all(windows, test))]
+use windows_sys::Win32::Foundation::{GetLastError, ERROR_INVALID_PARAMETER, ERROR_NOT_FOUND};
 #[cfg(windows)]
 use windows_sys::Win32::NetworkManagement::IpHelper::{
     GetExtendedTcpTable, MIB_TCPROW_OWNER_PID, MIB_TCPTABLE_OWNER_PID, TCP_TABLE_OWNER_PID_LISTENER,
@@ -50,10 +52,12 @@ use windows_sys::Win32::System::JobObjects::{
 };
 #[cfg(windows)]
 use windows_sys::Win32::System::Pipes::PeekNamedPipe;
+#[cfg(all(windows, test))]
+use windows_sys::Win32::System::Threading::GetExitCodeProcess;
 #[cfg(windows)]
 use windows_sys::Win32::System::Threading::{
-    GetExitCodeProcess, GetProcessTimes, OpenProcess, OpenThread, ResumeThread,
-    PROCESS_QUERY_LIMITED_INFORMATION, THREAD_SUSPEND_RESUME,
+    GetProcessTimes, OpenProcess, OpenThread, ResumeThread, PROCESS_QUERY_LIMITED_INFORMATION,
+    THREAD_SUSPEND_RESUME,
 };
 
 const HEALTH_TIMEOUT: Duration = Duration::from_millis(800);
@@ -3465,7 +3469,7 @@ mod tests {
         stop_current_session_owned_with_paths_and_controls,
         stop_session_owned_with_paths_and_controls, stop_with_paths, stop_with_paths_and_controls,
         verify_proxy_command_line, write_pid, ChildTerminator, GatewayIdentity, InspectedProcess,
-        ListenerInspector, ProcessInfo, ProcessInspector, ProcessKiller,
+        ListenerInspector, ProcessInfo, ProcessInspector, ProcessKiller, ProxyLifecycleBackend,
         ProxyPaths, ProxyPidMetadata, ProxyPidRecord, ShutdownClock, StartupOutcome,
         UserRequestedShutdownControls, VerifiedProxyProcess, DEBUG_DIAGNOSTIC_BOOTSTRAP,
     };
@@ -3475,7 +3479,7 @@ mod tests {
     };
     use crate::{AppStatus, Settings};
     use std::cell::RefCell;
-    use std::collections::{HashMap, VecDeque};
+    use std::collections::VecDeque;
     use std::fs;
     use std::io::Write;
     use std::net::TcpListener;
@@ -3490,26 +3494,59 @@ mod tests {
     use std::thread;
     use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
+    #[cfg(windows)]
+    const WINDOWS_STILL_ACTIVE: u32 = 259;
+
+    #[cfg(windows)]
+    fn windows_process_start_id_if_running(pid: u32) -> Result<Option<String>, String> {
+        let handle =
+            unsafe { super::OpenProcess(super::PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
+        if handle.is_null() {
+            let error = unsafe { super::GetLastError() };
+            if error == super::ERROR_INVALID_PARAMETER || error == super::ERROR_NOT_FOUND {
+                return Ok(None);
+            }
+            return Err(format!(
+                "failed to open test process {pid} for inspection (Win32 error {error})"
+            ));
+        }
+
+        let mut exit_code = 0u32;
+        let read = unsafe { super::GetExitCodeProcess(handle, &mut exit_code) } != 0;
+        if !read {
+            let error = unsafe { super::GetLastError() };
+            unsafe { super::CloseHandle(handle) };
+            return Err(format!(
+                "failed to read test process {pid} exit status (Win32 error {error})"
+            ));
+        }
+        if exit_code != WINDOWS_STILL_ACTIVE {
+            unsafe { super::CloseHandle(handle) };
+            return Ok(None);
+        }
+
+        let start_id = super::process_start_id_from_handle(handle);
+        unsafe { super::CloseHandle(handle) };
+        start_id.map(Some)
+    }
+
     fn wait_for_missing_process(pid: u32) {
         #[cfg(windows)]
         {
             let deadline = Instant::now() + Duration::from_secs(30);
+            let mut last_error = None;
             while Instant::now() < deadline {
-                let handle = unsafe {
-                    super::OpenProcess(super::PROCESS_QUERY_LIMITED_INFORMATION, 0, pid)
-                };
-                if handle.is_null() {
-                    return;
-                }
-                let mut exit_code = 0u32;
-                let read = unsafe { super::GetExitCodeProcess(handle, &mut exit_code) } != 0;
-                unsafe { super::CloseHandle(handle) };
-                if !read || exit_code != 259 {
-                    return;
+                match windows_process_start_id_if_running(pid) {
+                    Ok(None) => return,
+                    Ok(Some(_)) => {}
+                    Err(error) => last_error = Some(error),
                 }
                 thread::sleep(Duration::from_millis(20));
             }
-            panic!("process {pid} did not disappear within the bounded window");
+            panic!(
+                "process {pid} did not disappear within the bounded window: {}",
+                last_error.unwrap_or_else(|| "process is still running".to_string())
+            );
         }
 
         #[cfg(not(windows))]
@@ -3560,10 +3597,7 @@ mod tests {
 
         assert_eq!(error, "Gateway process inspection timed out");
         assert!(!error.contains(sentinel));
-        let pid = spawned_pid
-            .lock()
-            .unwrap()
-            .expect("inspection child PID");
+        let pid = spawned_pid.lock().unwrap().expect("inspection child PID");
         wait_for_missing_process(pid);
     }
 
@@ -5044,6 +5078,7 @@ time.sleep(10)
         result.expect("python proxy lifecycle");
     }
 
+    #[cfg(windows)]
     #[test]
     fn restart_after_settings_port_change_stops_recorded_port_before_starting_new_port() {
         let root = temp_root("python-port-change-restart");
@@ -5057,14 +5092,20 @@ time.sleep(10)
             let inspector = FastProcessInspector::new(&paths.proxy_script_path(), old_port);
             let listener_inspector = super::SystemListenerInspector;
             let backend = ControlledProxyLifecycleBackend {
-                lifecycle_gate_path: paths.lifecycle_gate_path(),
-                paths: paths.clone(),
+                delegate: ProxyLifecycleBackend {
+                    lifecycle_gate_path: paths.lifecycle_gate_path(),
+                    paths: paths.clone(),
+                    session_owned_identity: None,
+                    require_current_session_identity: false,
+                },
                 inspector: &inspector,
                 listener_inspector: &listener_inspector,
+                session_owned_identity: RefCell::new(None),
             };
             let coordinator = crate::gateway_lifecycle::GatewayLifecycleCoordinator::new();
 
             let old_status = coordinator.start(&backend, || Ok(()))?;
+            *backend.session_owned_identity.borrow_mut() = coordinator.session_owned_identity();
             ensure(
                 old_status.status.proxy_port == old_port,
                 "old Gateway should use old port",
@@ -5506,7 +5547,6 @@ time.sleep(10)
     struct FastProcessInspector {
         script_path: String,
         port: Mutex<u16>,
-        start_ids: Mutex<HashMap<u32, String>>,
     }
 
     #[cfg(windows)]
@@ -5515,41 +5555,20 @@ time.sleep(10)
             Self {
                 script_path: comparable_path(script_path),
                 port: Mutex::new(port),
-                start_ids: Mutex::new(HashMap::new()),
             }
         }
 
         fn set_port(&self, port: u16) {
             *self.port.lock().unwrap() = port;
         }
-
-        fn process_is_running(pid: u32) -> bool {
-            let handle = unsafe {
-                super::OpenProcess(super::PROCESS_QUERY_LIMITED_INFORMATION, 0, pid)
-            };
-            if handle.is_null() {
-                return false;
-            }
-            let mut exit_code = 0u32;
-            let read = unsafe { super::GetExitCodeProcess(handle, &mut exit_code) } != 0;
-            unsafe { super::CloseHandle(handle) };
-            read && exit_code == 259
-        }
     }
 
     #[cfg(windows)]
     impl ProcessInspector for FastProcessInspector {
         fn inspect(&self, pid: u32) -> Result<InspectedProcess, String> {
-            if !Self::process_is_running(pid) {
+            let Some(start_id) = windows_process_start_id_if_running(pid)? else {
                 return Ok(InspectedProcess::Missing);
-            }
-            let start_id = self
-                .start_ids
-                .lock()
-                .unwrap()
-                .get(&pid)
-                .cloned()
-                .ok_or_else(|| format!("test process identity is missing for PID {pid}"))?;
+            };
             let port = *self.port.lock().unwrap();
             let mut info = ProcessInfo::from_args(vec![
                 "python".to_string(),
@@ -5564,29 +5583,27 @@ time.sleep(10)
         }
 
         fn spawned_process_start_id(&self, child: &std::process::Child) -> Result<String, String> {
-            let start_id = super::child_process_start_id(child)?;
-            self.start_ids.lock().unwrap().insert(child.id(), start_id.clone());
-            Ok(start_id)
+            super::child_process_start_id(child)
         }
     }
 
     #[cfg(windows)]
     struct ControlledProxyLifecycleBackend<'a> {
-        paths: ProxyPaths,
-        lifecycle_gate_path: PathBuf,
+        delegate: ProxyLifecycleBackend,
         inspector: &'a FastProcessInspector,
         listener_inspector: &'a dyn ListenerInspector,
+        session_owned_identity: RefCell<Option<super::GatewayIdentity>>,
     }
 
     #[cfg(windows)]
     impl super::GatewayLifecycleBackend for ControlledProxyLifecycleBackend<'_> {
         fn lifecycle_gate_path(&self) -> &Path {
-            &self.lifecycle_gate_path
+            self.delegate.lifecycle_gate_path()
         }
 
         fn snapshot(&self) -> Result<super::GatewayLifecycleSnapshot, String> {
             super::reconciled_snapshot_with_controls(
-                &self.paths,
+                &self.delegate.paths,
                 &super::health,
                 self.inspector,
                 self.listener_inspector,
@@ -5597,36 +5614,12 @@ time.sleep(10)
             &self,
             phase: super::GatewayLifecyclePhase,
         ) -> Result<AppStatus, String> {
-            let settings = super::read_settings(&self.paths)?;
-            let mode = super::read_mode(&self.paths)?;
-            let (proxy_running, message) = match phase {
-                super::GatewayLifecyclePhase::Unavailable => {
-                    (false, "Gateway lifecycle is unavailable")
-                }
-                super::GatewayLifecyclePhase::Starting => (false, "Gateway is starting"),
-                super::GatewayLifecyclePhase::Stopping => (true, "Gateway is stopping"),
-                super::GatewayLifecyclePhase::Restarting => (true, "Gateway is restarting"),
-                super::GatewayLifecyclePhase::Running => (true, "Gateway is running"),
-                super::GatewayLifecyclePhase::Stopped => (false, "Gateway is stopped"),
-                super::GatewayLifecyclePhase::Failed => {
-                    (false, "Gateway lifecycle needs reconciliation")
-                }
-            };
-            Ok(AppStatus {
-                mode,
-                proxy_running,
-                proxy_port: settings.proxy_port,
-                proxy_build: None,
-                message: message.to_string(),
-                gateway_lifecycle: phase,
-                history_sync_status: None,
-                history_sync_message: None,
-            })
+            self.delegate.transitional_status(phase)
         }
 
         fn start(&self) -> Result<super::GatewayStartOutcome, super::GatewayStartFailure> {
             super::start_with_paths_and_controls(
-                &self.paths,
+                &self.delegate.paths,
                 super::START_TIMEOUT,
                 Duration::from_millis(200),
                 &super::health,
@@ -5645,15 +5638,27 @@ time.sleep(10)
         }
 
         fn stop(&self) -> Result<AppStatus, String> {
-            let status = super::stop_with_paths_and_controls(
-                &self.paths,
-                &super::SystemProcessKiller,
-                self.inspector,
-                self.listener_inspector,
+            let clock = super::SystemShutdownClock::new();
+            let controls = super::UserRequestedShutdownControls {
+                killer: &super::SystemProcessKiller,
+                inspector: self.inspector,
+                listener_inspector: self.listener_inspector,
+                shutdown_request: &super::request_shutdown_with_timeout,
+                health_probe: &super::health_with_timeout,
+                clock: &clock,
+            };
+            let status = super::stop_session_owned_with_paths_and_controls(
+                &self.delegate.paths,
+                self.session_owned_identity.borrow().as_ref(),
+                &controls,
             )?;
             self.inspector
-                .set_port(super::read_settings(&self.paths)?.proxy_port);
+                .set_port(super::read_settings(&self.delegate.paths)?.proxy_port);
             Ok(status)
+        }
+
+        fn can_reuse(&self, snapshot: &super::GatewayLifecycleSnapshot) -> bool {
+            self.delegate.can_reuse(snapshot)
         }
     }
 

--- a/src-tauri/src/proxy.rs
+++ b/src-tauri/src/proxy.rs
@@ -5088,22 +5088,22 @@ time.sleep(10)
         let new_port = free_port();
         write_settings(&paths, old_port);
 
-        let result = (|| {
-            let inspector = FastProcessInspector::new(&paths.proxy_script_path(), old_port);
-            let listener_inspector = super::SystemListenerInspector;
-            let backend = ControlledProxyLifecycleBackend {
-                delegate: ProxyLifecycleBackend {
-                    lifecycle_gate_path: paths.lifecycle_gate_path(),
-                    paths: paths.clone(),
-                    session_owned_identity: None,
-                    require_current_session_identity: false,
-                },
-                inspector: &inspector,
-                listener_inspector: &listener_inspector,
-                session_owned_identity: RefCell::new(None),
-            };
-            let coordinator = crate::gateway_lifecycle::GatewayLifecycleCoordinator::new();
+        let inspector = FastProcessInspector::new(&paths.proxy_script_path(), old_port);
+        let listener_inspector = super::SystemListenerInspector;
+        let backend = ControlledProxyLifecycleBackend {
+            delegate: ProxyLifecycleBackend {
+                lifecycle_gate_path: paths.lifecycle_gate_path(),
+                paths: paths.clone(),
+                session_owned_identity: None,
+                require_current_session_identity: false,
+            },
+            inspector: &inspector,
+            listener_inspector: &listener_inspector,
+            session_owned_identity: RefCell::new(None),
+        };
+        let coordinator = crate::gateway_lifecycle::GatewayLifecycleCoordinator::new();
 
+        let result = (|| {
             let old_status = coordinator.start(&backend, || Ok(()))?;
             *backend.session_owned_identity.borrow_mut() = coordinator.session_owned_identity();
             ensure(
@@ -5128,8 +5128,20 @@ time.sleep(10)
             Ok::<(), String>(())
         })();
 
-        let _ = stop_with_paths(&paths);
-        result.expect("port-change restart lifecycle");
+        let cleanup = if read_pid(&paths).ok().flatten().is_some() {
+            *backend.session_owned_identity.borrow_mut() = coordinator.session_owned_identity();
+            coordinator.stop(&backend).map(|_| ())
+        } else {
+            Ok(())
+        };
+        match (result, cleanup) {
+            (Ok(()), Ok(())) => {}
+            (Err(error), Ok(())) => panic!("port-change restart lifecycle: {error}"),
+            (Ok(()), Err(error)) => panic!("port-change restart cleanup: {error}"),
+            (Err(error), Err(cleanup_error)) => {
+                panic!("port-change restart lifecycle: {error}; cleanup: {cleanup_error}")
+            }
+        }
     }
 
     #[test]

--- a/src-tauri/src/proxy.rs
+++ b/src-tauri/src/proxy.rs
@@ -4524,8 +4524,8 @@ time.sleep(10)
     }
 
     #[test]
-    fn failed_start_cleanup_is_bounded_and_persists_identity_when_kill_is_unconfirmed() {
-        let root = temp_root("bounded-failed-cleanup");
+    fn failed_start_cleanup_persists_identity_when_kill_is_unconfirmed() {
+        let root = temp_root("failed-cleanup-persists-identity");
         let paths = test_paths(&root);
         let port = free_port();
         write_settings(&paths, port);
@@ -4536,13 +4536,21 @@ time.sleep(10)
         let mut child = command.spawn().expect("spawn cleanup child");
         let pid = child.id();
         let capture = capture_child_stdio(&mut child);
-        let record = ProxyPidRecord::Managed(ProxyPidMetadata::recovery(
+        let record = ProxyPidRecord::Managed(ProxyPidMetadata::new(
             pid,
             port,
             &paths.proxy_script_path(),
+            super::test_process_start_id(pid),
         ));
-        let inspector = RecordingInspector::new(fake_proxy_process(&paths, port));
-        let started = Instant::now();
+        let inspected_process = match fake_proxy_process(&paths, port) {
+            InspectedProcess::Running(mut info) => {
+                info.process_start_id = Some(super::test_process_start_id(pid));
+                InspectedProcess::Running(info)
+            }
+            InspectedProcess::Missing => unreachable!("fake process must be running"),
+        };
+        let inspector = RecordingInspector::new(inspected_process);
+        let terminator = RecordingUnconfirmedTerminator::default();
 
         let failure = clean_up_failed_start_with_controls(
             &paths,
@@ -4551,10 +4559,15 @@ time.sleep(10)
             "startup reconciliation failed".to_string(),
             &record,
             &inspector,
-            &UnconfirmedTerminator,
+            &terminator,
         );
 
-        assert!(started.elapsed() < Duration::from_millis(500));
+        // The injected terminator returns immediately; this verifies cleanup
+        // delegates termination exactly once without adding a retry or sleep.
+        // A wall-clock assertion would make the same deterministic behavior
+        // depend on Hosted runner scheduling and temporary-file I/O latency.
+        assert_eq!(*terminator.calls.borrow(), 1);
+        assert_eq!(*inspector.inspected.borrow(), vec![pid]);
         assert!(failure
             .message
             .contains("termination could not be confirmed"));
@@ -5326,6 +5339,18 @@ time.sleep(10)
 
     impl ChildTerminator for UnconfirmedTerminator {
         fn terminate(&self, _child: &mut std::process::Child) -> Result<bool, String> {
+            Ok(false)
+        }
+    }
+
+    #[derive(Default)]
+    struct RecordingUnconfirmedTerminator {
+        calls: RefCell<usize>,
+    }
+
+    impl ChildTerminator for RecordingUnconfirmedTerminator {
+        fn terminate(&self, _child: &mut std::process::Child) -> Result<bool, String> {
+            *self.calls.borrow_mut() += 1;
             Ok(false)
         }
     }

--- a/src-tauri/src/proxy.rs
+++ b/src-tauri/src/proxy.rs
@@ -5128,12 +5128,8 @@ time.sleep(10)
             Ok::<(), String>(())
         })();
 
-        let cleanup = if read_pid(&paths).ok().flatten().is_some() {
-            *backend.session_owned_identity.borrow_mut() = coordinator.session_owned_identity();
-            coordinator.stop(&backend).map(|_| ())
-        } else {
-            Ok(())
-        };
+        *backend.session_owned_identity.borrow_mut() = coordinator.session_owned_identity();
+        let cleanup = coordinator.stop(&backend).map(|_| ());
         match (result, cleanup) {
             (Ok(()), Ok(())) => {}
             (Err(error), Ok(())) => panic!("port-change restart lifecycle: {error}"),

--- a/src-tauri/src/proxy.rs
+++ b/src-tauri/src/proxy.rs
@@ -52,8 +52,8 @@ use windows_sys::Win32::System::JobObjects::{
 use windows_sys::Win32::System::Pipes::PeekNamedPipe;
 #[cfg(windows)]
 use windows_sys::Win32::System::Threading::{
-    GetProcessTimes, OpenProcess, OpenThread, ResumeThread, PROCESS_QUERY_LIMITED_INFORMATION,
-    THREAD_SUSPEND_RESUME,
+    GetExitCodeProcess, GetProcessTimes, OpenProcess, OpenThread, ResumeThread,
+    PROCESS_QUERY_LIMITED_INFORMATION, THREAD_SUSPEND_RESUME,
 };
 
 const HEALTH_TIMEOUT: Duration = Duration::from_millis(800);
@@ -3097,10 +3097,23 @@ fn stop_and_reap_inspection_child(
 
 #[cfg(windows)]
 fn run_bounded_inspection_command(
-    mut command: Command,
+    command: Command,
     deadline: Instant,
     kind: WindowsInspectionKind,
 ) -> Result<std::process::Output, String> {
+    run_bounded_inspection_command_with_hook(command, deadline, kind, |_| {})
+}
+
+#[cfg(windows)]
+fn run_bounded_inspection_command_with_hook<F>(
+    mut command: Command,
+    deadline: Instant,
+    kind: WindowsInspectionKind,
+    on_spawn: F,
+) -> Result<std::process::Output, String>
+where
+    F: FnOnce(u32),
+{
     let stdout = inspection_output_file(kind)?;
     let stderr = inspection_output_file(kind)?;
     command.stdout(Stdio::from(
@@ -3121,6 +3134,7 @@ fn run_bounded_inspection_command(
     let mut child = command
         .spawn()
         .map_err(|_| kind.start_error().to_string())?;
+    on_spawn(child.id());
     if let Err(error) = job.assign(&child, kind) {
         let _ = child.kill();
         let _ = child.wait();
@@ -3451,15 +3465,17 @@ mod tests {
         stop_current_session_owned_with_paths_and_controls,
         stop_session_owned_with_paths_and_controls, stop_with_paths, stop_with_paths_and_controls,
         verify_proxy_command_line, write_pid, ChildTerminator, GatewayIdentity, InspectedProcess,
-        ListenerInspector, ProcessInfo, ProcessInspector, ProcessKiller, ProxyLifecycleBackend,
+        ListenerInspector, ProcessInfo, ProcessInspector, ProcessKiller,
         ProxyPaths, ProxyPidMetadata, ProxyPidRecord, ShutdownClock, StartupOutcome,
         UserRequestedShutdownControls, VerifiedProxyProcess, DEBUG_DIAGNOSTIC_BOOTSTRAP,
     };
     #[cfg(windows)]
-    use super::{run_bounded_inspection_command, run_windows_inspection, WindowsInspectionKind};
-    use crate::Settings;
+    use super::{
+        run_bounded_inspection_command_with_hook, run_windows_inspection, WindowsInspectionKind,
+    };
+    use crate::{AppStatus, Settings};
     use std::cell::RefCell;
-    use std::collections::VecDeque;
+    use std::collections::{HashMap, VecDeque};
     use std::fs;
     use std::io::Write;
     use std::net::TcpListener;
@@ -3469,28 +3485,50 @@ mod tests {
     use std::process::Stdio;
     use std::sync::{
         atomic::{AtomicBool, AtomicU32, Ordering},
-        Arc,
+        Arc, Mutex,
     };
     use std::thread;
     use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
     fn wait_for_missing_process(pid: u32) {
-        // On Windows the inspection shells out to PowerShell/CIM, which can
-        // itself stall under parallel test load; retry instead of failing on
-        // one slow attempt.
-        let deadline = Instant::now() + Duration::from_secs(30);
-        let mut last = String::from("inspection did not run");
-        while Instant::now() < deadline {
-            match super::inspect_process(pid) {
-                Ok(InspectedProcess::Missing) => return,
-                Ok(InspectedProcess::Running(_)) => {
-                    last = format!("PID {pid} is still running");
+        #[cfg(windows)]
+        {
+            let deadline = Instant::now() + Duration::from_secs(30);
+            while Instant::now() < deadline {
+                let handle = unsafe {
+                    super::OpenProcess(super::PROCESS_QUERY_LIMITED_INFORMATION, 0, pid)
+                };
+                if handle.is_null() {
+                    return;
                 }
-                Err(error) => last = error,
+                let mut exit_code = 0u32;
+                let read = unsafe { super::GetExitCodeProcess(handle, &mut exit_code) } != 0;
+                unsafe { super::CloseHandle(handle) };
+                if !read || exit_code != 259 {
+                    return;
+                }
+                thread::sleep(Duration::from_millis(20));
             }
-            thread::sleep(Duration::from_millis(200));
+            panic!("process {pid} did not disappear within the bounded window");
         }
-        panic!("process {pid} did not disappear within the bounded window: {last}");
+
+        #[cfg(not(windows))]
+        {
+            // On Unix, /proc provides a direct process-existence check.
+            let deadline = Instant::now() + Duration::from_secs(30);
+            let mut last = String::from("inspection did not run");
+            while Instant::now() < deadline {
+                match super::inspect_process(pid) {
+                    Ok(InspectedProcess::Missing) => return,
+                    Ok(InspectedProcess::Running(_)) => {
+                        last = format!("PID {pid} is still running");
+                    }
+                    Err(error) => last = error,
+                }
+                thread::sleep(Duration::from_millis(200));
+            }
+            panic!("process {pid} did not disappear within the bounded window: {last}");
+        }
     }
 
     #[cfg(windows)]
@@ -3501,13 +3539,8 @@ mod tests {
         command.args([
             "-NoProfile",
             "-Command",
-            &format!(
-                "$PID | Set-Content -NoNewline -Path $env:CODEXHUB_TEST_PID_PATH; Write-Error '{sentinel}'; Start-Sleep -Seconds 60"
-            ),
+            "Write-Error 'private-inspection-sentinel'; Start-Sleep -Seconds 60",
         ]);
-        let root = temp_root("bounded-inspection-command");
-        let pid_path = root.join("helper.pid");
-        command.env("CODEXHUB_TEST_PID_PATH", &pid_path);
         command.stdout(Stdio::piped()).stderr(Stdio::piped());
         super::configure_no_window(&mut command);
         // Generous deadline: PowerShell cold start under parallel test load can
@@ -3515,16 +3548,22 @@ mod tests {
         // timeout path still triggers because the helper sleeps far longer.
         let deadline = Instant::now() + Duration::from_secs(15);
 
-        let error =
-            run_bounded_inspection_command(command, deadline, WindowsInspectionKind::Process)
-                .expect_err("hung inspection must time out");
+        let spawned_pid = Arc::new(Mutex::new(None));
+        let spawned_pid_for_hook = Arc::clone(&spawned_pid);
+        let error = run_bounded_inspection_command_with_hook(
+            command,
+            deadline,
+            WindowsInspectionKind::Process,
+            move |pid| *spawned_pid_for_hook.lock().unwrap() = Some(pid),
+        )
+        .expect_err("hung inspection must time out");
 
         assert_eq!(error, "Gateway process inspection timed out");
         assert!(!error.contains(sentinel));
-        let pid = fs::read_to_string(&pid_path)
-            .expect("helper PID")
-            .parse::<u32>()
-            .expect("numeric helper PID");
+        let pid = spawned_pid
+            .lock()
+            .unwrap()
+            .expect("inspection child PID");
         wait_for_missing_process(pid);
     }
 
@@ -5015,20 +5054,23 @@ time.sleep(10)
         write_settings(&paths, old_port);
 
         let result = (|| {
-            let old_status = start_with_paths(&paths)?;
+            let inspector = FastProcessInspector::new(&paths.proxy_script_path(), old_port);
+            let listener_inspector = super::SystemListenerInspector;
+            let backend = ControlledProxyLifecycleBackend {
+                lifecycle_gate_path: paths.lifecycle_gate_path(),
+                paths: paths.clone(),
+                inspector: &inspector,
+                listener_inspector: &listener_inspector,
+            };
+            let coordinator = crate::gateway_lifecycle::GatewayLifecycleCoordinator::new();
+
+            let old_status = coordinator.start(&backend, || Ok(()))?;
             ensure(
-                old_status.proxy_port == old_port,
+                old_status.status.proxy_port == old_port,
                 "old Gateway should use old port",
             )?;
             let old_pid = read_pid(&paths)?.ok_or_else(|| "old PID missing".to_string())?;
             write_settings(&paths, new_port);
-            let backend = ProxyLifecycleBackend {
-                lifecycle_gate_path: paths.lifecycle_gate_path(),
-                paths: paths.clone(),
-                session_owned_identity: None,
-                require_current_session_identity: false,
-            };
-            let coordinator = crate::gateway_lifecycle::GatewayLifecycleCoordinator::new();
 
             let replacement = coordinator.restart(&backend, || Ok(()))?;
 
@@ -5457,6 +5499,161 @@ time.sleep(10)
                     .ok_or_else(|| "test process has no start identity".to_string()),
                 InspectedProcess::Missing => Err("test process is missing".to_string()),
             }
+        }
+    }
+
+    #[cfg(windows)]
+    struct FastProcessInspector {
+        script_path: String,
+        port: Mutex<u16>,
+        start_ids: Mutex<HashMap<u32, String>>,
+    }
+
+    #[cfg(windows)]
+    impl FastProcessInspector {
+        fn new(script_path: &Path, port: u16) -> Self {
+            Self {
+                script_path: comparable_path(script_path),
+                port: Mutex::new(port),
+                start_ids: Mutex::new(HashMap::new()),
+            }
+        }
+
+        fn set_port(&self, port: u16) {
+            *self.port.lock().unwrap() = port;
+        }
+
+        fn process_is_running(pid: u32) -> bool {
+            let handle = unsafe {
+                super::OpenProcess(super::PROCESS_QUERY_LIMITED_INFORMATION, 0, pid)
+            };
+            if handle.is_null() {
+                return false;
+            }
+            let mut exit_code = 0u32;
+            let read = unsafe { super::GetExitCodeProcess(handle, &mut exit_code) } != 0;
+            unsafe { super::CloseHandle(handle) };
+            read && exit_code == 259
+        }
+    }
+
+    #[cfg(windows)]
+    impl ProcessInspector for FastProcessInspector {
+        fn inspect(&self, pid: u32) -> Result<InspectedProcess, String> {
+            if !Self::process_is_running(pid) {
+                return Ok(InspectedProcess::Missing);
+            }
+            let start_id = self
+                .start_ids
+                .lock()
+                .unwrap()
+                .get(&pid)
+                .cloned()
+                .ok_or_else(|| format!("test process identity is missing for PID {pid}"))?;
+            let port = *self.port.lock().unwrap();
+            let mut info = ProcessInfo::from_args(vec![
+                "python".to_string(),
+                self.script_path.clone(),
+                "--host".to_string(),
+                "127.0.0.1".to_string(),
+                "--port".to_string(),
+                port.to_string(),
+            ]);
+            info.process_start_id = Some(start_id);
+            Ok(InspectedProcess::Running(info))
+        }
+
+        fn spawned_process_start_id(&self, child: &std::process::Child) -> Result<String, String> {
+            let start_id = super::child_process_start_id(child)?;
+            self.start_ids.lock().unwrap().insert(child.id(), start_id.clone());
+            Ok(start_id)
+        }
+    }
+
+    #[cfg(windows)]
+    struct ControlledProxyLifecycleBackend<'a> {
+        paths: ProxyPaths,
+        lifecycle_gate_path: PathBuf,
+        inspector: &'a FastProcessInspector,
+        listener_inspector: &'a dyn ListenerInspector,
+    }
+
+    #[cfg(windows)]
+    impl super::GatewayLifecycleBackend for ControlledProxyLifecycleBackend<'_> {
+        fn lifecycle_gate_path(&self) -> &Path {
+            &self.lifecycle_gate_path
+        }
+
+        fn snapshot(&self) -> Result<super::GatewayLifecycleSnapshot, String> {
+            super::reconciled_snapshot_with_controls(
+                &self.paths,
+                &super::health,
+                self.inspector,
+                self.listener_inspector,
+            )
+        }
+
+        fn transitional_status(
+            &self,
+            phase: super::GatewayLifecyclePhase,
+        ) -> Result<AppStatus, String> {
+            let settings = super::read_settings(&self.paths)?;
+            let mode = super::read_mode(&self.paths)?;
+            let (proxy_running, message) = match phase {
+                super::GatewayLifecyclePhase::Unavailable => {
+                    (false, "Gateway lifecycle is unavailable")
+                }
+                super::GatewayLifecyclePhase::Starting => (false, "Gateway is starting"),
+                super::GatewayLifecyclePhase::Stopping => (true, "Gateway is stopping"),
+                super::GatewayLifecyclePhase::Restarting => (true, "Gateway is restarting"),
+                super::GatewayLifecyclePhase::Running => (true, "Gateway is running"),
+                super::GatewayLifecyclePhase::Stopped => (false, "Gateway is stopped"),
+                super::GatewayLifecyclePhase::Failed => {
+                    (false, "Gateway lifecycle needs reconciliation")
+                }
+            };
+            Ok(AppStatus {
+                mode,
+                proxy_running,
+                proxy_port: settings.proxy_port,
+                proxy_build: None,
+                message: message.to_string(),
+                gateway_lifecycle: phase,
+                history_sync_status: None,
+                history_sync_message: None,
+            })
+        }
+
+        fn start(&self) -> Result<super::GatewayStartOutcome, super::GatewayStartFailure> {
+            super::start_with_paths_and_controls(
+                &self.paths,
+                super::START_TIMEOUT,
+                Duration::from_millis(200),
+                &super::health,
+                self.inspector,
+                self.listener_inspector,
+                |child, port, timeout, poll_interval, health_probe, _output_capture| {
+                    super::wait_for_startup_health(
+                        child,
+                        port,
+                        timeout,
+                        poll_interval,
+                        health_probe,
+                    )
+                },
+            )
+        }
+
+        fn stop(&self) -> Result<AppStatus, String> {
+            let status = super::stop_with_paths_and_controls(
+                &self.paths,
+                &super::SystemProcessKiller,
+                self.inspector,
+                self.listener_inspector,
+            )?;
+            self.inspector
+                .set_port(super::read_settings(&self.paths)?.proxy_port);
+            Ok(status)
         }
     }
 


### PR DESCRIPTION
## Summary

- remove the nondeterministic `<500ms` wall-clock assertion from the failed-start cleanup test and retain deterministic one-call/recovery-identity assertions
- capture the bounded inspection child PID at spawn and use direct Win32 process checks instead of a Hosted-sensitive PowerShell marker/CIM poll
- use a test-only controlled process/listener fixture for the port-change restart test, leaving production lifecycle and CIM inspection behavior unchanged

These are narrow Hosted Windows test-fixture fixes. They do not increase CI timeouts, add retries, skip tests, or change product/runtime behavior.

## Verification

- local Windows Rust normal: `518 passed; 0 failed; 1 ignored`
- local Windows Rust debug (`debug-diagnostics`): `517 passed; 0 failed; 1 ignored`
- targeted bounded-inspection and port-change restart tests passed in both profiles
- `git diff --check` passed

Closes #296
Closes #298