### PR TITLE
fix: prevent foreign reasoning IDs from poisoning Official continuation

### DIFF
--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -2891,6 +2891,60 @@ def _sanitize_official_reasoning_items(value: Any) -> bool:
     return changed
 
 
+def _sanitize_official_input_reasoning_items(payload: dict[str, Any]) -> tuple[bool, dict[str, int]]:
+    """Remove non-portable reasoning references at the Official input boundary.
+
+    Codex stores third-party Responses reasoning items in the shared task
+    history.  An Official ``store=false`` request cannot resolve those
+    provider-local IDs, so forwarding the whole item turns a model switch into
+    a permanent 404/reconnect loop.  Only a self-contained Official encrypted
+    item is portable; every other reasoning item is dropped as a whole.  The
+    walk is deliberately limited to input containers so response metadata,
+    tool schemas, and ordinary transcript fields remain untouched.
+    """
+
+    counts = {
+        "removed_non_portable": 0,
+        "kept_official_encrypted": 0,
+    }
+
+    def sanitize_input_list(items: list[Any]) -> tuple[list[Any], bool]:
+        changed = False
+        rewritten: list[Any] = []
+        for item in items:
+            if isinstance(item, dict) and item.get("type") == "reasoning":
+                encrypted_content = item.get("encrypted_content")
+                if _looks_like_official_encrypted_content(encrypted_content):
+                    counts["kept_official_encrypted"] += 1
+                    rewritten.append(item)
+                else:
+                    counts["removed_non_portable"] += 1
+                    changed = True
+                continue
+
+            if isinstance(item, list):
+                nested_items, nested_changed = sanitize_input_list(item)
+                if nested_changed:
+                    item = nested_items
+                    changed = True
+            elif isinstance(item, dict) and isinstance(item.get("input"), list):
+                nested_items, nested_changed = sanitize_input_list(item["input"])
+                if nested_changed:
+                    item = {**item, "input": nested_items}
+                    changed = True
+            rewritten.append(item)
+        return rewritten, changed
+
+    input_items = payload.get("input")
+    if not isinstance(input_items, list):
+        return False, counts
+
+    rewritten_items, changed = sanitize_input_list(input_items)
+    if changed:
+        payload["input"] = rewritten_items
+    return changed, counts
+
+
 def _strip_reasoning_encrypted_content(value: Any) -> bool:
     changed = False
 
@@ -9078,6 +9132,15 @@ def official_passthrough_request_body(
         changed = True
     if next_payload.get("store") is not False:
         next_payload["store"] = False
+        changed = True
+    reasoning_changed, reasoning_counts = _sanitize_official_input_reasoning_items(next_payload)
+    if reasoning_changed:
+        write_proxy_event(
+            "official_reasoning_history_sanitized",
+            upstream="official",
+            reasoning_items_removed=reasoning_counts["removed_non_portable"],
+            reasoning_items_kept_official_encrypted=reasoning_counts["kept_official_encrypted"],
+        )
         changed = True
     if not changed:
         return body

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -13405,6 +13405,114 @@ class RoutingTests(unittest.TestCase):
 
         self.assertEqual(json.loads(transformed)["input"][0]["encrypted_content"], encrypted_content)
 
+    def test_official_passthrough_drops_foreign_reasoning_item_as_a_whole(self):
+        upstream = choose_upstream("gpt-5.5")
+        body = json.dumps(
+            {
+                "model": "gpt-5.5",
+                "store": False,
+                "stream": True,
+                "input": [
+                    {
+                        "type": "reasoning",
+                        "id": "rs_external_not_on_openai",
+                        "summary": [{"type": "summary_text", "text": "foreign summary"}],
+                        "encrypted_content": None,
+                    },
+                    {"type": "message", "role": "user", "content": "continue"},
+                ],
+            }
+        ).encode("utf-8")
+
+        transformed = compatible_request_body(
+            body,
+            upstream,
+            behavior_profile=codex_proxy.BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH,
+        )
+        payload = json.loads(transformed)
+
+        self.assertEqual(payload["input"], [{"type": "message", "role": "user", "content": "continue"}])
+        self.assertNotIn("rs_external_not_on_openai", transformed.decode("utf-8"))
+        self.assertNotIn("foreign summary", transformed.decode("utf-8"))
+
+    def test_official_passthrough_keeps_portable_reasoning_and_tool_history_order(self):
+        upstream = choose_upstream("gpt-5.5")
+        encrypted_content = "gAAAAABqQFxWldgz0tjB8nSg51Eg5_bsIdx_8n85wX2RQLunO8HVW1mm"
+        body = json.dumps(
+            {
+                "model": "gpt-5.5",
+                "store": False,
+                "input": [
+                    {"type": "message", "role": "user", "content": "use the tool"},
+                    {
+                        "type": "function_call",
+                        "call_id": "call_keep_1",
+                        "name": "lookup",
+                        "arguments": "{}",
+                    },
+                    {"type": "function_call_output", "call_id": "call_keep_1", "output": "ok"},
+                    {
+                        "type": "reasoning",
+                        "id": "rs_official_portable",
+                        "summary": [],
+                        "encrypted_content": encrypted_content,
+                    },
+                ],
+            }
+        ).encode("utf-8")
+
+        transformed = compatible_request_body(
+            body,
+            upstream,
+            behavior_profile=codex_proxy.BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH,
+        )
+        payload = json.loads(transformed)
+
+        self.assertEqual([item["type"] for item in payload["input"]], [
+            "message",
+            "function_call",
+            "function_call_output",
+            "reasoning",
+        ])
+        self.assertEqual(payload["input"][1]["call_id"], "call_keep_1")
+        self.assertEqual(payload["input"][2]["call_id"], "call_keep_1")
+        self.assertEqual(payload["input"][3]["encrypted_content"], encrypted_content)
+
+    def test_official_passthrough_sanitizes_reasoning_in_nested_input_containers(self):
+        upstream = choose_upstream("gpt-5.5")
+        body = json.dumps(
+            {
+                "model": "gpt-5.5",
+                "store": False,
+                "input": [
+                    {
+                        "type": "tool_result_container",
+                        "input": [
+                            {
+                                "type": "reasoning",
+                                "id": "rs_nested_external",
+                                "encrypted_content": "provider-local",
+                            },
+                            {"type": "message", "role": "user", "content": "keep"},
+                        ],
+                    }
+                ],
+            }
+        ).encode("utf-8")
+
+        transformed = compatible_request_body(
+            body,
+            upstream,
+            behavior_profile=codex_proxy.BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH,
+        )
+        payload = json.loads(transformed)
+
+        self.assertEqual(
+            payload["input"][0]["input"],
+            [{"type": "message", "role": "user", "content": "keep"}],
+        )
+        self.assertNotIn("rs_nested_external", transformed.decode("utf-8"))
+
     def test_ollama_body_leaves_non_xhigh_reasoning_values_unchanged(self):
         upstream = choose_upstream("glm-5.2")
         for effort in ("low", "medium", "high", "max", "none"):


### PR DESCRIPTION
## Summary

- Sanitize non-portable third-party or synthetic reasoning items at the Official store=false input boundary.
- Keep only self-contained Official encrypted reasoning; remove foreign reasoning items as whole entries.
- Preserve function calls/results, IDs, order, and strict passthrough behavior.
- Add deterministic foreign rs_*, valid encrypted reasoning, nested-input, and tool-history regressions.

## Root cause

A third-party Responses turn can persist provider-local rs_* reasoning IDs. When the same task switches to Official, strict passthrough sent those IDs in a stateless request and Official returned 404/item-not-found, causing reconnect storms.

## Validation

- py -3.13 -m pytest -q tests/test_routing.py -k reasoning (9 passed)
- Python full suite and watchdog-bounded real-client contract passed on the candidate.
- report_quality_gates.py (report-only)
- git diff --check
- Desktop 0.146 manual same-task switch remains required before merge.

Closes #302
