### PR TITLE
release: prepare 0.1.8-beta.1

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codexhub-frontend",
-  "version": "0.1.7",
+  "version": "0.1.8-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codexhub-frontend",
-      "version": "0.1.7",
+      "version": "0.1.8-beta.1",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codexhub-frontend",
   "private": true,
-  "version": "0.1.7",
+  "version": "0.1.8-beta.1",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/scripts/New-ReleaseChannelPlan.ps1
+++ b/scripts/New-ReleaseChannelPlan.ps1
@@ -27,7 +27,7 @@ function Resolve-GitCommit([string]$Ref) {
 
 $commitSha = Resolve-GitCommit $Commit
 $mainSha = Resolve-GitCommit "main"
-Assert-ReleaseFlavorVersion -Flavor $Flavor -Version $Version
+$isPrerelease = Test-ReleaseVersionIsPrerelease -Version $Version
 
 if ($commitSha -ne $mainSha) {
     throw "Normal and debug publication requires the exact main commit."
@@ -50,7 +50,7 @@ $plan = [ordered]@{
     }
     immutable_release = [ordered]@{
         tag = "v$Version"
-        prerelease = $false
+        prerelease = $isPrerelease
         assets = @(
             $normalInstaller,
             "$normalInstaller.sig",

--- a/scripts/ReleaseChannel.ps1
+++ b/scripts/ReleaseChannel.ps1
@@ -1,9 +1,6 @@
-function Assert-ReleaseFlavorVersion {
+function Assert-ReleaseVersion {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory = $true)]
-        [ValidateSet("normal", "debug")]
-        [string]$Flavor,
         [Parameter(Mandatory = $true)]
         [string]$Version
     )
@@ -15,10 +12,17 @@ function Assert-ReleaseFlavorVersion {
         throw "Release version must be valid SemVer: $Version"
     }
 
-    $hasPrerelease = $Matches.ContainsKey("prerelease") -and -not [string]::IsNullOrEmpty($Matches["prerelease"])
-    if ($hasPrerelease) {
-        throw "Normal and debug release flavors require a version without a prerelease suffix."
-    }
+}
+
+function Test-ReleaseVersionIsPrerelease {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Version
+    )
+
+    Assert-ReleaseVersion -Version $Version
+    return $Version -match '\A[0-9]+\.[0-9]+\.[0-9]+-'
 }
 
 function Get-ReleaseArtifactName {

--- a/scripts/Test-BuildFlavorReplacement.ps1
+++ b/scripts/Test-BuildFlavorReplacement.ps1
@@ -36,8 +36,7 @@ if ($null -eq $normal -or $null -eq $debug) {
 if ([string]::IsNullOrWhiteSpace($Version)) {
     $Version = [string]$tauriConfig.version
 }
-Assert-ReleaseFlavorVersion -Flavor normal -Version $Version
-Assert-ReleaseFlavorVersion -Flavor debug -Version $Version
+Assert-ReleaseVersion -Version $Version
 
 $sharedIdentityKeys = @(
     "productName",

--- a/scripts/Test-ReleaseManifest.ps1
+++ b/scripts/Test-ReleaseManifest.ps1
@@ -17,7 +17,7 @@ $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
 . (Join-Path $PSScriptRoot "ReleaseChannel.ps1")
 
-Assert-ReleaseFlavorVersion -Flavor $Flavor -Version $Version
+Assert-ReleaseVersion -Version $Version
 
 foreach ($path in @($ManifestPath, $InstallerPath, $SignaturePath)) {
     if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {

--- a/scripts/build-windows-portable.ps1
+++ b/scripts/build-windows-portable.ps1
@@ -27,7 +27,7 @@ $generatedTauriConfigPath = (& (Join-Path $PSScriptRoot "Build-TauriConfig.ps1")
 $generatedTauriConfig = Get-Content -Raw -LiteralPath $generatedTauriConfigPath | ConvertFrom-Json
 $version = [string]$generatedTauriConfig.version
 . (Join-Path $PSScriptRoot "ReleaseChannel.ps1")
-Assert-ReleaseFlavorVersion -Flavor $Flavor -Version $version
+Assert-ReleaseVersion -Version $version
 $targetRoot = Get-FlavorTargetRoot -TauriDir $tauriDir -Flavor $Flavor
 
 $generatedEndpoint = [string]$generatedTauriConfig.plugins.updater.endpoints[0]

--- a/scripts/build-windows-release.ps1
+++ b/scripts/build-windows-release.ps1
@@ -33,7 +33,7 @@ if (-not (Test-Path -LiteralPath $PrivateKeyPath -PathType Leaf)) {
 $tauriConfig = Get-Content -Raw -LiteralPath $tauriConfigPath | ConvertFrom-Json
 $productName = [string]$tauriConfig.productName
 $version = [string]$tauriConfig.version
-Assert-ReleaseFlavorVersion -Flavor $Flavor -Version $version
+Assert-ReleaseVersion -Version $version
 if ([string]::IsNullOrWhiteSpace($ReleaseBaseUrl)) {
     $ReleaseBaseUrl = "https://github.com/NOirBRight/CodexHub/releases/download/v$version"
 }

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "codexhub"
-version = "0.1.7"
+version = "0.1.8-beta.1"
 dependencies = [
  "dirs 5.0.1",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codexhub"
-version = "0.1.7"
+version = "0.1.8-beta.1"
 description = "CodexHub desktop backend and CLI"
 authors = ["CodexHub"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "CodexHub",
-  "version": "0.1.7",
+  "version": "0.1.8-beta.1",
   "identifier": "com.codexhub.app",
   "build": {
     "frontendDist": "../frontend/dist",

--- a/tests/test_release_channel_scripts.py
+++ b/tests/test_release_channel_scripts.py
@@ -20,7 +20,7 @@ def test_official_transport_wheel_is_pinned_and_packaged():
 
 
 def test_release_version_is_consistent_across_manifests():
-    expected = "0.1.7"
+    expected = "0.1.8-beta.1"
     tauri = json.loads((ROOT / "src-tauri" / "tauri.conf.json").read_text(encoding="utf-8"))
     cargo = tomllib.loads((ROOT / "src-tauri" / "Cargo.toml").read_text(encoding="utf-8"))
     cargo_lock = tomllib.loads((ROOT / "src-tauri" / "Cargo.lock").read_text(encoding="utf-8"))
@@ -277,7 +277,8 @@ def test_portable_rejects_invalid_flavor_before_building(tmp_path):
     result = _portable(repo, "invalid")
 
     assert result.returncode != 0
-    assert "Flavor" in result.stderr
+    normalized_error = "".join(result.stderr.split())
+    assert "parameter'Flavor'" in normalized_error
 
 
 def _git(repo: Path, *args: str) -> str:
@@ -351,14 +352,40 @@ def test_release_plan_places_both_flavors_in_one_immutable_release(tmp_path):
     assert plan["channel_release"] is None
 
 
-def test_release_plan_rejects_prerelease_versions_and_non_main_commits(tmp_path):
+def test_release_plan_marks_semver_prerelease_versions_as_prereleases(tmp_path):
+    repo, main_commit, _ = _release_repo(tmp_path)
+
+    result = _plan(repo, "normal", "0.1.8-beta.1", main_commit)
+
+    assert result.returncode == 0, result.stderr
+    plan = json.loads(result.stdout)
+    assert plan["manifest"] == {
+        "name": "latest.json",
+        "asset_url": (
+            "https://github.com/NOirBRight/CodexHub/releases/download/"
+            "v0.1.8-beta.1/CodexHub_0.1.8-beta.1_x64-setup.exe"
+        ),
+    }
+    assert plan["immutable_release"]["tag"] == "v0.1.8-beta.1"
+    assert plan["immutable_release"]["prerelease"] is True
+    assert plan["immutable_release"]["assets"] == [
+        "CodexHub_0.1.8-beta.1_x64-setup.exe",
+        "CodexHub_0.1.8-beta.1_x64-setup.exe.sig",
+        "latest.json",
+        "CodexHub_0.1.8-beta.1_debug_x64-setup.exe",
+        "CodexHub_0.1.8-beta.1_debug_x64-setup.exe.sig",
+        "latest-debug.json",
+    ]
+
+
+def test_release_plan_rejects_invalid_versions_and_non_main_commits(tmp_path):
     repo, main_commit, dev_commit = _release_repo(tmp_path)
 
-    prerelease = _plan(repo, "normal", "0.1.5-beta.1", main_commit)
+    invalid = _plan(repo, "normal", "0.1.8_beta1", main_commit)
     wrong_commit = _plan(repo, "debug", "0.1.5", dev_commit)
 
-    assert prerelease.returncode != 0
-    assert "prerelease suffix" in prerelease.stderr
+    assert invalid.returncode != 0
+    assert "valid SemVer" in invalid.stderr
     assert wrong_commit.returncode != 0
     assert "exact main commit" in wrong_commit.stderr
 
@@ -468,7 +495,8 @@ def test_release_scripts_share_flavor_validation_helpers():
 
     for script in (plan_script, manifest_script):
         assert '. (Join-Path $PSScriptRoot "ReleaseChannel.ps1")' in script
-        assert "Assert-ReleaseFlavorVersion" in script
+    assert "Test-ReleaseVersionIsPrerelease" in plan_script
+    assert "Assert-ReleaseVersion" in manifest_script
     assert "Get-ReleaseArtifactName" in helpers
     assert "Get-ReleaseManifestName" in helpers
     assert "Get-FlavorTargetRoot" in helpers


### PR DESCRIPTION
## What changed

- sets all application manifests and lockfiles to 0.1.8-beta.1
- teaches release planning and validation to accept prerelease SemVer
- plans normal/debug signed installers, signatures, manifests, and the normal Portable ZIP under v0.1.8-beta.1
- preserves the stable updater endpoint so stable Latest remains 0.1.7

## Why

This publishes the reviewed stop-the-bleeding Beta1 candidate after the two maintainer-verified usability fixes in #302 and #303. It does not claim the deferred two-model Responses, Code Mode, tool_search, Collaboration V2, Chat, or RC scope.

Part of #258.

## Review before CI

Exact candidate: df09507b3dbff08c1186c9f6821c4e2a633bbcc3
Base: 00d420af8d37030eff5b0993c7c4151fa5180340

- Spec review: PASS; no P0/P1/P2
- Standards review: PASS; no P0/P1/P2
- reviewer P2 about the misleading flavor/version helper was fixed, amended, and both axes re-reviewed at the exact candidate SHA

## Local verification

- Python core: 1543 passed, 1 skipped, 460 subtests passed
- release-channel regression: 17 passed
- frontend build: passed
- UI contract: 142 passed
- Rust tests: 519 passed, 1 ignored
- Clippy: passed
- report-only quality gate: parse_errors 0
- git diff --check: passed

Hosted CI / gate is the final merge gate after this review.