### PR TITLE
ci: make toolchain and path authority fail closed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ concurrency:
 
 env:
   RUST_TOOLCHAIN: 1.97.1
+  RUSTUP_TOOLCHAIN: 1.97.1
 
 jobs:
   classifier:

--- a/docs/agents/ci.md
+++ b/docs/agents/ci.md
@@ -24,7 +24,7 @@ does not pass.
 - Rust clippy: `cargo clippy --locked --all-targets -- -D warnings` in `src-tauri/`
 - Release flavor contract: portable-build dry-run parity for the normal and debug flavors
 - Rust safe_file Linux compile and tests: standalone `rustc --test` compile of
-  `src-tauri/src/safe_file.rs` on Ubuntu WSL2, a `clippy-driver -D warnings`
+  `src-tauri/src/safe_file.rs` on the Hosted `ubuntu-24.04` runner, a `clippy-driver -D warnings`
   lint of the same file, and the resulting cross-language test binary. The
   Hosted Linux uses Rust's official `x86_64-unknown-linux-musl` target with
   `rust-lld`, avoiding a host-wide C toolchain while still compiling and
@@ -87,8 +87,10 @@ A PR is considered relevant for the synthetic check when it touches any of the f
 - `tests/fixtures/real_client_e2e/**` (E2E fixtures and the Windows watchdog runner)
 - `docs/agents/real-client-e2e.md` (real-client operator documentation)
 - `.github/workflows/ci.yml`
+- `scripts/ci/ci_change_plan.py`
 - `scripts/ci/python_test_plan.py`
 - `scripts/ci/check_python_test_partitions.py`
+- `tests/test_ci_change_plan.py`
 - `tests/test_ci_python_plan.py`
 - `pytest.ini`
 
@@ -138,11 +140,11 @@ python scripts/ci/check_python_test_partitions.py
 This executes the core suite, the watchdog-bounded synthetic suite, and proves
 the two partitions are disjoint and complete.
 
-To verify only the planner/path logic and collection completeness without
-executing `tests/test_real_client_e2e.py`, use:
+To verify only the planner/path logic, unified/legacy synthetic parity, and
+collection completeness without executing `tests/test_real_client_e2e.py`, use:
 
 ```powershell
-python -m pytest -q tests/test_ci_python_plan.py && python scripts/ci/check_python_test_partitions.py
+python -m pytest -q tests/test_ci_python_plan.py tests/test_ci_change_plan.py && python scripts/ci/check_python_test_partitions.py
 ```
 
 Do not commit generated frontend output, local Tauri resource placeholders, or `dist/` artifacts.

--- a/scripts/ci/ci_change_plan.py
+++ b/scripts/ci/ci_change_plan.py
@@ -123,6 +123,8 @@ SAFE_FILE_EXACT = frozenset(
         "rust-toolchain.toml",
         "src-tauri/rust-toolchain",
         "src-tauri/rust-toolchain.toml",
+        "src-tauri/.cargo/config",
+        "src-tauri/.cargo/config.toml",
         ".cargo/config",
         ".cargo/config.toml",
     }

--- a/scripts/ci/ci_change_plan.py
+++ b/scripts/ci/ci_change_plan.py
@@ -128,6 +128,15 @@ SAFE_FILE_EXACT = frozenset(
     }
 )
 
+RUST_CONTROL_EXACT = frozenset(
+    {
+        "rust-toolchain",
+        "rust-toolchain.toml",
+        ".cargo/config",
+        ".cargo/config.toml",
+    }
+)
+
 FULL_EXACT = frozenset(
     {
         ".github/workflows/ci.yml",
@@ -245,6 +254,7 @@ def _classify_path(path: str) -> tuple[frozenset[str], bool]:
         or normalized in {"cargo.toml", "cargo.lock"}
         or normalized.endswith("/cargo.toml")
         or normalized.endswith("/cargo.lock")
+        or _matches(path, RUST_CONTROL_EXACT)
     ):
         categories.add("rust")
     if _matches(path, SAFE_FILE_EXACT) or normalized.endswith("/safe_file.rs"):

--- a/scripts/ci/python_test_plan.py
+++ b/scripts/ci/python_test_plan.py
@@ -31,7 +31,9 @@ RELEVANT_SYNTHETIC_PATHS = [
     ".github/workflows/ci.yml",
     "scripts/ci/python_test_plan.py",
     "scripts/ci/check_python_test_partitions.py",
+    "scripts/ci/ci_change_plan.py",
     "tests/test_ci_python_plan.py",
+    "tests/test_ci_change_plan.py",
     "pytest.ini",
 ]
 

--- a/tests/test_ci_change_plan.py
+++ b/tests/test_ci_change_plan.py
@@ -125,7 +125,13 @@ def test_legacy_and_unified_synthetic_surface_have_bidirectional_parity(
         for path in legacy_planner.RELEVANT_SYNTHETIC_PATHS
         if not path.endswith("/")
     }
+    legacy_prefixes = {
+        path.lower()
+        for path in legacy_planner.RELEVANT_SYNTHETIC_PATHS
+        if path.endswith("/")
+    }
     assert planner.SYNTHETIC_EXACT <= legacy_exact
+    assert set(planner.SYNTHETIC_PREFIXES) <= legacy_prefixes
 
     for path in ("scripts/ci/ci_change_plan.py", "tests/test_ci_change_plan.py"):
         assert legacy_planner.is_relevant_synthetic_path(path), path

--- a/tests/test_ci_change_plan.py
+++ b/tests/test_ci_change_plan.py
@@ -9,11 +9,21 @@ import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 PLANNER_PATH = ROOT / "scripts" / "ci" / "ci_change_plan.py"
+LEGACY_PLANNER_PATH = ROOT / "scripts" / "ci" / "python_test_plan.py"
 
 
 @pytest.fixture(scope="module")
 def planner():
     spec = importlib.util.spec_from_file_location("ci_change_plan", PLANNER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def legacy_planner():
+    spec = importlib.util.spec_from_file_location("python_test_plan", LEGACY_PLANNER_PATH)
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)
@@ -86,6 +96,26 @@ def test_safe_file_selects_rust_and_linux_safe_file(planner):
     assert plan.rust is True
     assert plan.rust_safe_file_linux is True
     assert plan.release_flavor is False
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["rust-toolchain", "rust-toolchain.toml", ".cargo/config", ".cargo/config.toml"],
+)
+def test_rust_control_paths_select_rust_and_linux_safe_file(planner, path):
+    plan = planner.build_plan("pull_request", True, [path])
+    assert plan.rust is True
+    assert plan.rust_safe_file_linux is True
+
+
+def test_unified_planner_covers_every_legacy_synthetic_dependency(
+    planner, legacy_planner
+):
+    for path in legacy_planner.RELEVANT_SYNTHETIC_PATHS:
+        probe = f"{path}fixture" if path.endswith("/") else path
+        plan = planner.build_plan("pull_request", True, [probe])
+        assert plan.python_synthetic, path
+        assert plan.full is (path in planner.FULL_EXACT), path
 
 
 def test_release_path_selects_release_and_rust(planner):

--- a/tests/test_ci_change_plan.py
+++ b/tests/test_ci_change_plan.py
@@ -100,12 +100,38 @@ def test_safe_file_selects_rust_and_linux_safe_file(planner):
 
 @pytest.mark.parametrize(
     "path",
-    ["rust-toolchain", "rust-toolchain.toml", ".cargo/config", ".cargo/config.toml"],
+    [
+        "rust-toolchain",
+        "rust-toolchain.toml",
+        ".cargo/config",
+        ".cargo/config.toml",
+        "src-tauri/rust-toolchain",
+        "src-tauri/rust-toolchain.toml",
+        "src-tauri/.cargo/config",
+        "src-tauri/.cargo/config.toml",
+    ],
 )
 def test_rust_control_paths_select_rust_and_linux_safe_file(planner, path):
     plan = planner.build_plan("pull_request", True, [path])
     assert plan.rust is True
     assert plan.rust_safe_file_linux is True
+
+
+def test_legacy_and_unified_synthetic_surface_have_bidirectional_parity(
+    planner, legacy_planner
+):
+    legacy_exact = {
+        path.lower()
+        for path in legacy_planner.RELEVANT_SYNTHETIC_PATHS
+        if not path.endswith("/")
+    }
+    assert planner.SYNTHETIC_EXACT <= legacy_exact
+
+    for path in ("scripts/ci/ci_change_plan.py", "tests/test_ci_change_plan.py"):
+        assert legacy_planner.is_relevant_synthetic_path(path), path
+        plan = planner.build_plan("pull_request", True, [path])
+        assert plan.full is True
+        assert plan.python_synthetic is True
 
 
 def test_unified_planner_covers_every_legacy_synthetic_dependency(

--- a/tests/test_ci_python_plan.py
+++ b/tests/test_ci_python_plan.py
@@ -367,6 +367,23 @@ def test_ci_yaml_classifier_uses_immutable_change_plan():
     assert "CI_PR_BASE_SHA" in classifier_job
 
 
+def test_ci_yaml_rust_jobs_force_the_declared_toolchain():
+    workflow_text = (ROOT / ".github" / "workflows" / "ci.yml").read_text(
+        encoding="utf-8"
+    )
+    assert "RUSTUP_TOOLCHAIN: 1.97.1" in workflow_text
+
+
+def test_ci_md_describes_hosted_linux_and_unified_planner_verification():
+    ci_md = (ROOT / "docs" / "agents" / "ci.md").read_text(encoding="utf-8")
+    assert "Ubuntu WSL2" not in ci_md
+    assert "ubuntu-24.04" in ci_md
+    planner_start = ci_md.find("To verify only the planner/path logic")
+    assert planner_start != -1
+    planner_section = ci_md[planner_start:]
+    assert "tests/test_ci_change_plan.py" in planner_section
+
+
 def test_pr_rename_from_relevant_to_unrelated_runs_synthetic(plan):
     # With --no-renames git diff emits both the old relevant path and the new
     # unrelated path; the old path must keep the check synthetic.


### PR DESCRIPTION
## Summary\n\n- pin Hosted Rust jobs to the exact 1.97.1 toolchain through RUSTUP_TOOLCHAIN\n- route root Rust toolchain/Cargo control files to both Rust and Linux safe-file checks\n- normalize the synthetic real-client path key and enforce legacy/unified planner parity\n- align Hosted CI documentation and planner verification commands\n\n## Why\n\nThe exact-dev planner/CI review found that a directory toolchain override could bypass the documented Rust authority, and root Rust control changes could skip the Rust matrix. Mixed-case synthetic paths could also fall through to fail-closed full routing without proving the intended synthetic selection.\n\nThis is a CI/planner/documentation-only change. Product APIs, config formats, runtime behavior, and job names are unchanged.\n\nCloses #308\nParent: #258\n\n## Verification\n\n- exact SHA Spec review: PASS\n- exact SHA Standards review: PASS\n- planner and CI contract tests: 85 passed\n- git diff --check: PASS