### PR TITLE
test: make E2E start gate unique and fail closed

### DIFF
--- a/scripts/Run-RealClientE2E.ps1
+++ b/scripts/Run-RealClientE2E.ps1
@@ -356,6 +356,45 @@ function Get-FailureSummaryValue {
     }
 }
 
+function New-StartGateFile {
+    param([string]$Path)
+    $stream = $null
+    try {
+        $stream = [System.IO.File]::Open(
+            $Path,
+            [System.IO.FileMode]::CreateNew,
+            [System.IO.FileAccess]::Write,
+            [System.IO.FileShare]::None
+        )
+        $bytes = $script:Utf8NoBom.GetBytes('ready')
+        $stream.Write($bytes, 0, $bytes.Length)
+        $stream.Flush()
+        return $true
+    }
+    catch {
+        return $false
+    }
+    finally {
+        if ($null -ne $stream) {
+            $stream.Dispose()
+        }
+    }
+}
+
+function Remove-StartGateFile {
+    param([string]$Path)
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        return $true
+    }
+    try {
+        Remove-Item -LiteralPath $Path -Force -ErrorAction Stop
+        return -not (Test-Path -LiteralPath $Path -PathType Leaf)
+    }
+    catch {
+        return $false
+    }
+}
+
 function Set-RunnerPhase {
     param([string]$Phase)
     if (-not $script:WatchdogStatePath) {
@@ -372,11 +411,10 @@ function Invoke-RunnerSupervisor {
     [void](New-Item -ItemType Directory -Force -Path $supervisorOutput)
     $summaryPath = Join-Path $supervisorOutput 'summary.json'
     $statePath = Join-Path $supervisorOutput 'runner-watchdog-state'
-    $startGatePath = Join-Path $supervisorOutput 'runner-start-gate'
+    $startGatePath = Join-Path $supervisorOutput ('runner-start-gate.' + [Guid]::NewGuid().ToString('N'))
     $stdoutPath = Join-Path $supervisorOutput 'runner-watchdog.stdout'
     $stderrPath = Join-Path $supervisorOutput 'runner-watchdog.stderr'
     [System.IO.File]::WriteAllText($statePath, 'preflight', $script:Utf8NoBom)
-    Remove-Item -LiteralPath $startGatePath -Force -ErrorAction SilentlyContinue
     foreach ($path in @($stdoutPath, $stderrPath)) {
         [System.IO.File]::WriteAllText($path, '', $script:Utf8NoBom)
     }
@@ -421,7 +459,15 @@ function Invoke-RunnerSupervisor {
     }
     Start-Sleep -Milliseconds 10
   }
-  Remove-Item -LiteralPath $gate -Force -ErrorAction SilentlyContinue
+  try {
+    Remove-Item -LiteralPath $gate -Force -ErrorAction Stop
+  }
+  catch {
+    exit 125
+  }
+  if (Test-Path -LiteralPath $gate -PathType Leaf) {
+    exit 125
+  }
 }
 & $env:CODEXHUB_E2E_SUPERVISOR_SCRIPT `
   -CandidateSha '0000000000000000000000000000000000000000' `
@@ -471,6 +517,10 @@ exit $LASTEXITCODE
     $job = [CodexHubE2EJob]::CreateKillOnClose()
     $started = [System.Diagnostics.Stopwatch]::StartNew()
     try {
+        if (Test-Path -LiteralPath $startGatePath -PathType Leaf) {
+            Write-JsonFile -Path $summaryPath -Value (Get-FailureSummaryValue -FailureClassification 'preflight_start_gate_conflict')
+            return 1
+        }
         try {
             $process = Start-Process `
                 -FilePath $powershellPath `
@@ -499,7 +549,11 @@ exit $LASTEXITCODE
         # closes the short Start-Process/AssignProcessToJobObject race: every
         # candidate and client process is created only after the worker belongs
         # to the kill-on-close job.
-        [System.IO.File]::WriteAllText($startGatePath, 'ready', $script:Utf8NoBom)
+        if (-not (New-StartGateFile -Path $startGatePath)) {
+            Stop-ProcessTree -ProcessId $process.Id -TimeoutMilliseconds 2000
+            Write-JsonFile -Path $summaryPath -Value (Get-FailureSummaryValue -FailureClassification 'preflight_start_gate_publish_failed')
+            return 1
+        }
         $completed = $process.WaitForExit($OverallTimeoutSeconds * 1000)
         if (-not $completed) {
             # Terminate first and keep the handle open long enough to observe
@@ -540,10 +594,22 @@ exit $LASTEXITCODE
                 total_process_count = [Math]::Min([int]$counts[0], 1000)
                 active_process_count = [Math]::Min([int]$counts[1], 1000)
             })
+            if (-not (Remove-StartGateFile -Path $startGatePath)) {
+                Write-JsonFile -Path $summaryPath -Value (Get-FailureSummaryValue -FailureClassification 'preflight_start_gate_cleanup_failed')
+                return 1
+            }
             Write-JsonFile -Path $summaryPath -Value (Get-FailureSummaryValue -FailureClassification 'automated_outer_timeout' -Artifacts @($timeoutArtifact))
             return 1
         }
         $exitCode = $process.ExitCode
+        if (Test-Path -LiteralPath $startGatePath -PathType Leaf) {
+            if (-not (Remove-StartGateFile -Path $startGatePath)) {
+                Write-JsonFile -Path $summaryPath -Value (Get-FailureSummaryValue -FailureClassification 'preflight_start_gate_cleanup_failed')
+                return 1
+            }
+            Write-JsonFile -Path $summaryPath -Value (Get-FailureSummaryValue -FailureClassification 'preflight_start_gate_not_consumed')
+            return 1
+        }
         [CodexHubE2EJob]::Close($job)
         $job = [IntPtr]::Zero
         return $exitCode
@@ -573,7 +639,7 @@ exit $LASTEXITCODE
             Remove-Item -LiteralPath $stream.path -Force -ErrorAction SilentlyContinue
         }
         Remove-Item -LiteralPath $statePath -Force -ErrorAction SilentlyContinue
-        Remove-Item -LiteralPath $startGatePath -Force -ErrorAction SilentlyContinue
+        [void](Remove-StartGateFile -Path $startGatePath)
     }
 }
 

--- a/scripts/Run-RealClientE2E.ps1
+++ b/scripts/Run-RealClientE2E.ps1
@@ -358,17 +358,21 @@ function Get-FailureSummaryValue {
 
 function New-StartGateFile {
     param([string]$Path)
+    $temporaryPath = "$Path.$([Guid]::NewGuid().ToString('N')).tmp"
     $stream = $null
     try {
         $stream = [System.IO.File]::Open(
-            $Path,
+            $temporaryPath,
             [System.IO.FileMode]::CreateNew,
             [System.IO.FileAccess]::Write,
             [System.IO.FileShare]::None
         )
         $bytes = $script:Utf8NoBom.GetBytes('ready')
         $stream.Write($bytes, 0, $bytes.Length)
-        $stream.Flush()
+        $stream.Flush($true)
+        $stream.Dispose()
+        $stream = $null
+        [System.IO.File]::Move($temporaryPath, $Path)
         return $true
     }
     catch {
@@ -377,6 +381,9 @@ function New-StartGateFile {
     finally {
         if ($null -ne $stream) {
             $stream.Dispose()
+        }
+        if (Test-Path -LiteralPath $temporaryPath -PathType Leaf) {
+            Remove-Item -LiteralPath $temporaryPath -Force -ErrorAction SilentlyContinue
         }
     }
 }

--- a/tests/test_real_client_e2e.py
+++ b/tests/test_real_client_e2e.py
@@ -3193,6 +3193,31 @@ def test_operator_commands_have_explicit_outer_and_manual_deadlines():
     assert "manual window is finite" in documentation
 
 
+def test_supervisor_start_gate_is_unique_and_fail_closed():
+    runner = SCRIPT.read_text(encoding="utf-8")
+    supervisor_start = runner.index("function Invoke-RunnerSupervisor")
+    supervisor_end = runner.index("function Get-JsonProperty", supervisor_start)
+    supervisor = runner[supervisor_start:supervisor_end]
+    worker_start = supervisor.index("$workerBootstrap = @'")
+    worker_end = supervisor.index("'@", worker_start)
+    worker = supervisor[worker_start:worker_end]
+
+    assert (
+        "$startGatePath = Join-Path $supervisorOutput "
+        "('runner-start-gate.' + [Guid]::NewGuid().ToString('N'))"
+    ) in supervisor
+    assert "function New-StartGateFile" in runner
+    assert "function Remove-StartGateFile" in runner
+    assert "[System.IO.FileMode]::CreateNew" in runner
+    assert "Remove-Item -LiteralPath $gate -Force -ErrorAction Stop" in worker
+    assert "Remove-Item -LiteralPath $startGatePath -Force -ErrorAction SilentlyContinue" not in supervisor
+
+    assignment = supervisor.index("[CodexHubE2EJob]::Assign($job, $process.Handle)")
+    publication = supervisor.index("New-StartGateFile -Path $startGatePath")
+    wait = supervisor.index("$completed = $process.WaitForExit")
+    assert assignment < publication < wait
+
+
 def test_matrix_documentation_declares_native_responses_release_gate():
     documentation = (ROOT / "docs" / "agents" / "real-client-e2e.md").read_text()
 

--- a/tests/test_real_client_e2e.py
+++ b/tests/test_real_client_e2e.py
@@ -3209,6 +3209,8 @@ def test_supervisor_start_gate_is_unique_and_fail_closed():
     assert "function New-StartGateFile" in runner
     assert "function Remove-StartGateFile" in runner
     assert "[System.IO.FileMode]::CreateNew" in runner
+    assert "[System.IO.File]::Move($temporaryPath, $Path)" in runner
+    assert "$stream.Flush($true)" in runner
     assert "Remove-Item -LiteralPath $gate -Force -ErrorAction Stop" in worker
     assert "Remove-Item -LiteralPath $startGatePath -Force -ErrorAction SilentlyContinue" not in supervisor
 
@@ -3216,6 +3218,161 @@ def test_supervisor_start_gate_is_unique_and_fail_closed():
     publication = supervisor.index("New-StartGateFile -Path $startGatePath")
     wait = supervisor.index("$completed = $process.WaitForExit")
     assert assignment < publication < wait
+
+
+def test_supervisor_start_gate_synthetic_lifecycle_is_fail_closed(tmp_path):
+    powershell = _powershell()
+    runner = SCRIPT.read_text(encoding="utf-8")
+    helper_start = runner.index("function New-StartGateFile")
+    helper_end = runner.index("function Set-RunnerPhase", helper_start)
+    helpers = runner[helper_start:helper_end]
+    worker_start = runner.index("$workerBootstrap = @'")
+    worker_body_start = worker_start + len("$workerBootstrap = @'\n")
+    worker_body_end = runner.index("'@", worker_body_start)
+    worker_body = runner[worker_body_start:worker_body_end]
+
+    harness = f"""
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+$script:Utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+{helpers}
+
+$root = Join-Path $env:TEMP ('codexhub-start-gate-synthetic.' + [Guid]::NewGuid().ToString('N'))
+[void](New-Item -ItemType Directory -Force -Path $root)
+$stub = Join-Path $root 'stub.ps1'
+$marker = Join-Path $root 'client-started.marker'
+Set-Content -LiteralPath $stub -Encoding UTF8 -Value @'
+param(
+  [string]$CandidateSha,
+  [string]$DebugBuild,
+  [string]$ManagedClientConfigBuild,
+  [string]$ManagedClientConfigSha,
+  [string]$LunaModel,
+  [string]$ThirdPartyModel,
+  [string]$OutputDirectory,
+  [string]$HostEnvironmentManifest,
+  [int]$TimeoutSeconds,
+  [int]$ManualEvidenceTimeoutSeconds,
+  [int]$OverallTimeoutSeconds,
+  [string]$InternalSupervisorToken
+)
+[System.IO.File]::WriteAllText($env:CODEXHUB_SYNTHETIC_MARKER, 'started')
+exit 0
+'@
+
+$workerBootstrap = @'
+{worker_body}
+'@
+$encodedWorker = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($workerBootstrap))
+function Invoke-SyntheticWorker([string]$Gate, [string]$Supervisor, [string]$MarkerPath) {{
+  $keys = @(
+    'CODEXHUB_E2E_SUPERVISOR_START_GATE',
+    'CODEXHUB_E2E_SUPERVISOR_SCRIPT',
+    'CODEXHUB_E2E_SUPERVISOR_TOKEN',
+    'CODEXHUB_SYNTHETIC_MARKER'
+  )
+  $previous = @{{}}
+  foreach ($key in $keys) {{
+    $previous[$key] = [Environment]::GetEnvironmentVariable($key, 'Process')
+  }}
+  [Environment]::SetEnvironmentVariable('CODEXHUB_E2E_SUPERVISOR_START_GATE', $Gate, 'Process')
+  [Environment]::SetEnvironmentVariable('CODEXHUB_E2E_SUPERVISOR_SCRIPT', $Supervisor, 'Process')
+  [Environment]::SetEnvironmentVariable('CODEXHUB_E2E_SUPERVISOR_TOKEN', 'synthetic-token', 'Process')
+  [Environment]::SetEnvironmentVariable('CODEXHUB_SYNTHETIC_MARKER', $MarkerPath, 'Process')
+  try {{
+    $child = Start-Process -FilePath (Get-Command powershell.exe -ErrorAction Stop).Source `
+      -ArgumentList @('-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-EncodedCommand', $encodedWorker) `
+      -WindowStyle Hidden -Wait -PassThru
+    return $child.ExitCode
+  }}
+  finally {{
+    foreach ($key in $keys) {{
+      [Environment]::SetEnvironmentVariable($key, $previous[$key], 'Process')
+    }}
+  }}
+}}
+
+$gateA = Join-Path $root 'runner-start-gate.a'
+$gateB = Join-Path $root 'runner-start-gate.b'
+$uniqueA = New-StartGateFile -Path $gateA
+$uniqueB = New-StartGateFile -Path $gateB
+$uniquePathsDiffer = $gateA -ne $gateB
+$uniqueFilesReady = (Test-Path -LiteralPath $gateA -PathType Leaf) -and (Test-Path -LiteralPath $gateB -PathType Leaf)
+$uniqueCleanup = (Remove-StartGateFile -Path $gateA) -and (Remove-StartGateFile -Path $gateB)
+
+$lockedGate = Join-Path $root 'runner-start-gate.locked'
+$lockedStream = [System.IO.File]::Open($lockedGate, [System.IO.FileMode]::CreateNew, [System.IO.FileAccess]::ReadWrite, [System.IO.FileShare]::None)
+try {{
+  $lockedPublishFailed = -not (New-StartGateFile -Path $lockedGate)
+  $lockedCleanupFailed = -not (Remove-StartGateFile -Path $lockedGate)
+}} finally {{
+  $lockedStream.Dispose()
+}}
+$lockedReleasedCleanup = Remove-StartGateFile -Path $lockedGate
+
+$workerLockedGate = Join-Path $root 'runner-start-gate.worker-locked'
+$workerLockedStream = [System.IO.File]::Open($workerLockedGate, [System.IO.FileMode]::CreateNew, [System.IO.FileAccess]::ReadWrite, [System.IO.FileShare]::None)
+try {{
+  $lockedWorkerExit = Invoke-SyntheticWorker -Gate $workerLockedGate -Supervisor $stub -MarkerPath $marker
+  $lockedWorkerStarted = Test-Path -LiteralPath $marker -PathType Leaf
+}} finally {{
+  $workerLockedStream.Dispose()
+}}
+$workerLockedCleanup = Remove-StartGateFile -Path $workerLockedGate
+
+$consumedGate = Join-Path $root 'runner-start-gate.consumed'
+$consumedMarker = Join-Path $root 'consumed.marker'
+$consumedPublished = New-StartGateFile -Path $consumedGate
+$consumedWorkerExit = Invoke-SyntheticWorker -Gate $consumedGate -Supervisor $stub -MarkerPath $consumedMarker
+$consumedWorkerStarted = Test-Path -LiteralPath $consumedMarker -PathType Leaf
+$consumedGateRemoved = -not (Test-Path -LiteralPath $consumedGate -PathType Leaf)
+
+[ordered]@{{
+  unique_publish = $uniqueA -and $uniqueB
+  unique_paths_differ = $uniquePathsDiffer
+  unique_files_ready = $uniqueFilesReady
+  unique_cleanup = $uniqueCleanup
+  locked_publish_failed = $lockedPublishFailed
+  locked_cleanup_failed = $lockedCleanupFailed
+  locked_released_cleanup = $lockedReleasedCleanup
+  locked_worker_exit = $lockedWorkerExit
+  locked_worker_started = $lockedWorkerStarted
+  locked_worker_cleanup = $workerLockedCleanup
+  consumed_publish = $consumedPublished
+  consumed_worker_exit = $consumedWorkerExit
+  consumed_worker_started = $consumedWorkerStarted
+  consumed_gate_removed = $consumedGateRemoved
+}} | ConvertTo-Json -Compress
+Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue
+"""
+    harness_path = tmp_path / "start-gate-synthetic.ps1"
+    harness_path.write_text(harness, encoding="utf-8")
+    completed = subprocess.run(
+        [powershell, "-NoProfile", "-NonInteractive", "-File", str(harness_path)],
+        text=True,
+        encoding="utf-8",
+        capture_output=True,
+        cwd=ROOT,
+        timeout=30,
+    )
+    assert completed.returncode == 0, completed.stderr
+    result = json.loads(completed.stdout.strip())
+    assert result == {
+        "unique_publish": True,
+        "unique_paths_differ": True,
+        "unique_files_ready": True,
+        "unique_cleanup": True,
+        "locked_publish_failed": True,
+        "locked_cleanup_failed": True,
+        "locked_released_cleanup": True,
+        "locked_worker_exit": 125,
+        "locked_worker_started": False,
+        "locked_worker_cleanup": True,
+        "consumed_publish": True,
+        "consumed_worker_exit": 0,
+        "consumed_worker_started": True,
+        "consumed_gate_removed": True,
+    }
 
 
 def test_matrix_documentation_declares_native_responses_release_gate():


### PR DESCRIPTION
## Summary\n\n- make each real-client E2E supervisor start gate unique\n- publish the gate atomically only after the worker is assigned to its kill-on-close Job Object\n- fail closed on locked/stale publication, worker consumption, and cleanup contradictions\n- add an executable PowerShell synthetic harness that exercises the production helper/worker without launching a real client\n\n## Root cause\n\nThe former fixed gate was removed with suppressed errors, and the worker could observe a gate before containment was established. The first fix also exposed a publication race: a worker could see the final path while the publisher still held its exclusive write handle.\n\nThe new helper writes a same-directory temporary file, flushes and closes it, then publishes with non-overwriting File.Move. The worker can only observe a complete, unlocked gate.\n\n## Scope\n\nE2E supervisor/test infrastructure only. Watchdog bounds, artifact schema, client invocation, product APIs, configuration formats, credentials, and runtime behavior are unchanged.\n\nCloses #309\nParent: #258\n\n## Verification\n\n- exact SHA Spec review: PASS\n- exact SHA Standards review: PASS\n- start-gate synthetic tests: 2 passed\n- Python partition contract: PASS\n- git diff --check: PASS