### PR TITLE
fix: enforce official catalog visibility policy

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "vite --host 127.0.0.1",
     "build": "tsc && vite build",
-    "test:ui-contract": "node --test scripts/ui-contract.test.mjs",
+    "test:ui-contract": "node --test scripts/ui-contract.test.mjs scripts/official-models-visibility.test.mjs",
     "test:provider-comparison": "node --test scripts/provider-comparison.test.mjs",
     "preview": "vite preview --host 127.0.0.1"
   },

--- a/frontend/scripts/official-models-visibility.test.mjs
+++ b/frontend/scripts/official-models-visibility.test.mjs
@@ -57,3 +57,12 @@ test("catalog hide vetoes a metadata-only Official model", () => {
 
   assert.deepEqual(combined, []);
 });
+
+test("metadata cannot create an Official model absent from the catalog", () => {
+  const combined = mergeOfficialModelSources(
+    [],
+    [model("gpt-5.6-terra", { visibility: "list" })],
+  );
+
+  assert.deepEqual(combined, []);
+});

--- a/frontend/scripts/official-models-visibility.test.mjs
+++ b/frontend/scripts/official-models-visibility.test.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { readFile } from "node:fs/promises";
+import ts from "typescript";
+
+const source = await readFile(new URL("../src/lib/officialModels.ts", import.meta.url), "utf8");
+const withoutImports = source
+  .replace(/^\s*import[^;]+;\s*$/gm, "")
+  .replace(/export const /g, "const ")
+  .replace(/export function/g, "function");
+const jsOutput = ts.transpileModule(withoutImports, {
+  compilerOptions: {
+    module: ts.ModuleKind.CommonJS,
+    target: ts.ScriptTarget.ES2022,
+    strict: false,
+  },
+}).outputText;
+
+const moduleExports = {};
+const wrappedModule = new Function(
+  "exports",
+  "normalizeOfficialModelId",
+  jsOutput +
+    "\nexports.mergeOfficialModelSources = mergeOfficialModelSources; exports.filterCodexVisibleOfficialModels = filterCodexVisibleOfficialModels;",
+);
+wrappedModule(moduleExports, (value) => value.trim().replace(/^openai\//, ""));
+
+const { mergeOfficialModelSources } = moduleExports;
+
+function model(id, overrides = {}) {
+  return { id, enabled: true, ...overrides };
+}
+
+test("combined Official catalogs exclude hidden, unknown, and internal duplicate Terra models", () => {
+  const combined = mergeOfficialModelSources(
+    [
+      model("gpt-5.6-terra", { visibility: "list" }),
+      model("gpt-5.6-sol", { visibility: "hide" }),
+      model("gpt-5.6-terra", {
+        id: "codex-auto-review",
+        upstream_model: "gpt-5.6-terra",
+        visibility: "list",
+      }),
+      model("gpt-5.6-luna", { visibility: "future" }),
+    ],
+    [model("openai/gpt-5.6-terra", { visibility: "list" })],
+  );
+
+  assert.deepEqual(combined.map((item) => item.id), ["gpt-5.6-terra"]);
+});

--- a/frontend/scripts/official-models-visibility.test.mjs
+++ b/frontend/scripts/official-models-visibility.test.mjs
@@ -48,3 +48,12 @@ test("combined Official catalogs exclude hidden, unknown, and internal duplicate
 
   assert.deepEqual(combined.map((item) => item.id), ["gpt-5.6-terra"]);
 });
+
+test("catalog hide vetoes a metadata-only Official model", () => {
+  const combined = mergeOfficialModelSources(
+    [model("gpt-5.6-terra", { visibility: "hide" })],
+    [model("gpt-5.6-terra", { visibility: "list" })],
+  );
+
+  assert.deepEqual(combined, []);
+});

--- a/frontend/scripts/ui-contract.test.mjs
+++ b/frontend/scripts/ui-contract.test.mjs
@@ -2092,8 +2092,8 @@ test("frontend official merge canonicalizes aliases with fresh metadata winning"
   const merge = providersSource.match(/function mergeOfficialModelSources[\s\S]*?function isOfficialModel/)?.[0] ?? "";
 
   assert.match(merge, /const knownOfficialIds = officialModelIdSet\(catalog, metadata\);/);
-  assert.match(merge, /for \(const model of catalog\.filter\(isOfficialModel\)\)/);
-  assert.match(merge, /for \(const model of metadata\.filter\(isOfficialModel\)\)/);
+  assert.match(merge, /for \(const model of catalog\.filter\(\(item\) => isOfficialModel\(item\) && isCatalogModelListable\(item\)\)\)/);
+  assert.match(merge, /for \(const model of metadata\.filter\(\(item\) => isOfficialModel\(item\) && isCatalogModelListable\(item\)\)\)/);
   assert.match(merge, /const canonicalId = normalizeOfficialModelId\(model\.id, knownOfficialIds\);/);
   assert.match(merge, /\.\.\.existing,[\s\S]*\.\.\.model,[\s\S]*id: canonicalId/);
   assert.match(
@@ -2151,6 +2151,7 @@ test("official alias merge keeps all-false disabled and ORs any true", async () 
     "mergeOfficialModelSources",
     "officialModelIdSet",
     "isOfficialModel",
+    "isCatalogModelListable",
     "filterCodexVisibleOfficialModels",
     "isOfficialGatewayFastVariant",
   ];
@@ -2174,8 +2175,8 @@ test("official alias merge keeps all-false disabled and ORs any true", async () 
   ];
   for (const item of cases) {
     const merged = mergeOfficialModelSources(
-      [{ id: "openai/gpt-5.5", enabled: item.catalog }],
-      [{ id: "gpt-5.5", enabled: item.metadata }],
+      [{ id: "openai/gpt-5.5", enabled: item.catalog, visibility: "list" }],
+      [{ id: "gpt-5.5", enabled: item.metadata, visibility: "list" }],
     );
     assert.equal(merged.length, 1, item.name);
     assert.equal(merged[0].enabled, item.expected, item.name);
@@ -2191,6 +2192,7 @@ test("published Official catalog context limits outrank stale metadata after ref
     "mergeOfficialModelSources",
     "officialModelIdSet",
     "isOfficialModel",
+    "isCatalogModelListable",
     "filterCodexVisibleOfficialModels",
     "isOfficialGatewayFastVariant",
   ];
@@ -2210,6 +2212,7 @@ test("published Official catalog context limits outrank stale metadata after ref
   const [model] = mergeOfficialModelSources(
     [{
       id: "openai/gpt-5.6-terra",
+      visibility: "list",
       context_window: 272000,
       max_context_window: 272000,
       effective_source: "fresh_direct_official_cache_authority",
@@ -2221,6 +2224,7 @@ test("published Official catalog context limits outrank stale metadata after ref
     }],
     [{
       id: "gpt-5.6-terra",
+      visibility: "list",
       context_window: 353400,
       max_context_window: 353400,
       effective_source: "pinned_metadata",

--- a/frontend/src/lib/officialModels.ts
+++ b/frontend/src/lib/officialModels.ts
@@ -93,7 +93,7 @@ export function mergeOfficialModelSources(catalog: Model[], metadata: Model[]) {
     "verified_at",
   ] as const;
   const merged = new Map<string, Model>();
-  for (const model of catalog.filter(isOfficialModel)) {
+  for (const model of catalog.filter((item) => isOfficialModel(item) && isCatalogModelListable(item))) {
     const canonicalId = normalizeOfficialModelId(model.id, knownOfficialIds);
     if (!canonicalId) {
       continue;
@@ -109,7 +109,7 @@ export function mergeOfficialModelSources(catalog: Model[], metadata: Model[]) {
     });
   }
   const publishedCatalogModels = new Map(merged);
-  for (const model of metadata.filter(isOfficialModel)) {
+  for (const model of metadata.filter((item) => isOfficialModel(item) && isCatalogModelListable(item))) {
     const canonicalId = normalizeOfficialModelId(model.id, knownOfficialIds);
     if (!canonicalId) {
       continue;
@@ -152,7 +152,9 @@ export function resolveOfficialModelContextWindow(
 
 export function officialModelIdSet(...groups: Model[][]) {
   const known = new Set<string>();
-  for (const model of groups.flatMap((group) => group).filter(isOfficialModel)) {
+  for (const model of groups
+    .flatMap((group) => group)
+    .filter((item) => isOfficialModel(item) && isCatalogModelListable(item))) {
     const value = model.id.trim();
     const bare = value.startsWith("openai/gpt-") ? value.slice("openai/".length) : value;
     if (bare.startsWith("gpt-")) {
@@ -167,7 +169,20 @@ export function isOfficialModel(model: Model) {
 }
 
 export function filterCodexVisibleOfficialModels(models: Model[]) {
-  return models.filter((model) => !isOfficialGatewayFastVariant(model));
+  return models.filter(
+    (model) => isCatalogModelListable(model) && !isOfficialGatewayFastVariant(model),
+  );
+}
+
+export function isCatalogModelListable(model: Model) {
+  if (model.visibility !== "list") {
+    return false;
+  }
+  const identities = [model.id, model.upstream_model ?? "", ...(model.aliases ?? [])];
+  return !identities.some((value) => {
+    const normalized = value.trim().toLowerCase().replace(/^openai\//, "");
+    return normalized === "codex-auto-review" || normalized.startsWith("codex-auto-review/");
+  });
 }
 
 export function isOfficialGatewayFastVariant(model: Model) {

--- a/frontend/src/lib/officialModels.ts
+++ b/frontend/src/lib/officialModels.ts
@@ -123,7 +123,11 @@ export function mergeOfficialModelSources(catalog: Model[], metadata: Model[]) {
   const publishedCatalogModels = new Map(merged);
   for (const model of metadata.filter((item) => isOfficialModel(item) && isCatalogModelListable(item))) {
     const canonicalId = normalizeOfficialModelId(model.id, knownOfficialIds);
-    if (!canonicalId || blockedOfficialIds.has(canonicalId)) {
+    if (
+      !canonicalId ||
+      blockedOfficialIds.has(canonicalId) ||
+      !publishedCatalogModels.has(canonicalId)
+    ) {
       continue;
     }
     const existing = merged.get(canonicalId);

--- a/frontend/src/lib/officialModels.ts
+++ b/frontend/src/lib/officialModels.ts
@@ -84,6 +84,18 @@ export function refreshedOfficialModelOrder(currentOrder: string[], refreshedMod
 
 export function mergeOfficialModelSources(catalog: Model[], metadata: Model[]) {
   const knownOfficialIds = officialModelIdSet(catalog, metadata);
+  const blockedOfficialIds = new Set<string>();
+  for (const model of catalog) {
+    if (isCatalogModelListable(model)) {
+      continue;
+    }
+    for (const value of [model.id, model.upstream_model ?? "", ...(model.aliases ?? [])]) {
+      const bare = value.trim().toLowerCase().replace(/^openai\//, "");
+      if (bare.startsWith("gpt-")) {
+        blockedOfficialIds.add(bare);
+      }
+    }
+  }
   const resolvedCatalogLimitFields = [
     "context_window",
     "max_context_window",
@@ -111,7 +123,7 @@ export function mergeOfficialModelSources(catalog: Model[], metadata: Model[]) {
   const publishedCatalogModels = new Map(merged);
   for (const model of metadata.filter((item) => isOfficialModel(item) && isCatalogModelListable(item))) {
     const canonicalId = normalizeOfficialModelId(model.id, knownOfficialIds);
-    if (!canonicalId) {
+    if (!canonicalId || blockedOfficialIds.has(canonicalId)) {
       continue;
     }
     const existing = merged.get(canonicalId);
@@ -175,12 +187,16 @@ export function filterCodexVisibleOfficialModels(models: Model[]) {
 }
 
 export function isCatalogModelListable(model: Model) {
-  if (model.visibility !== "list") {
+  if (model.visibility !== "list" || (model as Model & { hidden?: unknown }).hidden === true) {
     return false;
   }
   const identities = [model.id, model.upstream_model ?? "", ...(model.aliases ?? [])];
   return !identities.some((value) => {
-    const normalized = value.trim().toLowerCase().replace(/^openai\//, "");
+    const normalized = value
+      .trim()
+      .toLowerCase()
+      .replace(/^openai\//, "")
+      .replace(/:cloud$/, "");
     return normalized === "codex-auto-review" || normalized.startsWith("codex-auto-review/");
   });
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1,7 +1,9 @@
 export interface Model {
   id: string;
+  visibility?: CatalogVisibility;
   display_name?: string | null;
   upstream_model?: string | null;
+  aliases?: string[];
   tool_surface_strategy?: ToolSurfaceStrategy | null;
   source_kind?: string | null;
   locked?: boolean;
@@ -22,6 +24,8 @@ export interface Model {
   sort_order?: number | null;
   enabled: boolean;
 }
+
+export type CatalogVisibility = "list" | "hide" | "unknown";
 
 export interface OfficialRefreshResult {
   models: Model[];

--- a/src-python/catalog.py
+++ b/src-python/catalog.py
@@ -65,6 +65,8 @@ def model_visibility(
 
     if not isinstance(model, dict):
         return CatalogVisibility.UNKNOWN
+    if model.get("hidden") is True:
+        return CatalogVisibility.HIDE
     if "visibility" in model:
         return catalog_visibility(model.get("visibility"))
     hidden = model.get("hidden")

--- a/src-python/catalog.py
+++ b/src-python/catalog.py
@@ -1,11 +1,24 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from enum import Enum
 import json
 from pathlib import Path
 import re
 import tomllib
 from typing import Any
+
+
+class CatalogVisibility(str, Enum):
+    """The only visibility states accepted at a catalog boundary."""
+
+    LIST = "list"
+    HIDE = "hide"
+    UNKNOWN = "unknown"
+
+
+INTERNAL_MODEL_IDENTIFIERS = frozenset({"codex-auto-review"})
+MAX_VISIBILITY_DIAGNOSTIC_COUNT = 100
 
 
 @dataclass(frozen=True)
@@ -24,6 +37,95 @@ def canonical_model_id(model_id: str) -> str:
     if value.endswith(":cloud"):
         value = value[:-6]
     return value
+
+
+def catalog_visibility(value: Any) -> CatalogVisibility:
+    if isinstance(value, CatalogVisibility):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized == CatalogVisibility.LIST.value:
+            return CatalogVisibility.LIST
+        if normalized == CatalogVisibility.HIDE.value:
+            return CatalogVisibility.HIDE
+    return CatalogVisibility.UNKNOWN
+
+
+def model_visibility(
+    model: Any,
+    *,
+    missing_is_list: bool = False,
+) -> CatalogVisibility:
+    """Resolve upstream visibility without trusting unknown values.
+
+    Older hand-authored catalog fixtures omitted visibility entirely.  Callers
+    that operate on those trusted legacy records can opt into the historical
+    list default; native/upstream ingestion remains fail-closed.
+    """
+
+    if not isinstance(model, dict):
+        return CatalogVisibility.UNKNOWN
+    if "visibility" in model:
+        return catalog_visibility(model.get("visibility"))
+    hidden = model.get("hidden")
+    if isinstance(hidden, bool):
+        return CatalogVisibility.HIDE if hidden else CatalogVisibility.LIST
+    return CatalogVisibility.LIST if missing_is_list else CatalogVisibility.UNKNOWN
+
+
+def model_identity_values(model: Any) -> tuple[str, ...]:
+    if not isinstance(model, dict):
+        return ()
+    values: list[str] = []
+    for key in ("id", "slug", "model", "name", "upstream_model"):
+        value = model.get(key)
+        if not isinstance(value, str) or not value.strip():
+            continue
+        normalized = canonical_model_id(value).lower()
+        if normalized.startswith("openai/"):
+            normalized = normalized.removeprefix("openai/")
+        values.append(normalized)
+    return tuple(values)
+
+
+def is_internal_model(model: Any) -> bool:
+    return any(
+        value in INTERNAL_MODEL_IDENTIFIERS
+        or any(value.startswith(f"{identifier}/") for identifier in INTERNAL_MODEL_IDENTIFIERS)
+        for value in model_identity_values(model)
+    )
+
+
+def is_catalog_model_listable(
+    model: Any,
+    *,
+    missing_is_list: bool = False,
+) -> bool:
+    return (
+        not is_internal_model(model)
+        and model_visibility(model, missing_is_list=missing_is_list) is CatalogVisibility.LIST
+    )
+
+
+def catalog_visibility_diagnostics(models: Any) -> dict[str, int]:
+    """Return bounded aggregate visibility diagnostics without model identities."""
+
+    counts = {"hidden": 0, "unknown": 0, "internal": 0}
+    for model in models if isinstance(models, (list, tuple)) else ():
+        if is_internal_model(model):
+            key = "internal"
+        else:
+            visibility = model_visibility(model, missing_is_list=False)
+            key = (
+                "hidden"
+                if visibility is CatalogVisibility.HIDE
+                else "unknown"
+                if visibility is CatalogVisibility.UNKNOWN
+                else ""
+            )
+        if key:
+            counts[key] = min(MAX_VISIBILITY_DIAGNOSTIC_COUNT, counts[key] + 1)
+    return counts
 
 
 def deny_match_model_id(model_id: str) -> str:

--- a/src-python/catalog_sync.py
+++ b/src-python/catalog_sync.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import argparse
 from copy import deepcopy
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 import json
 import os
@@ -17,6 +17,7 @@ from atomic_io import atomic_write_text
 from catalog import (
     CatalogVisibility,
     CatalogPolicy,
+    MAX_VISIBILITY_DIAGNOSTIC_COUNT,
     canonical_model_id,
     catalog_visibility_diagnostics,
     display_name_for,
@@ -24,7 +25,6 @@ from catalog import (
     is_internal_model,
     load_catalog_models,
     load_policy,
-    model_visibility,
     should_include_external_provider_model,
     should_include_model,
 )
@@ -431,6 +431,10 @@ class OfficialSeedSnapshot:
     models: list[dict[str, Any]]
     source: str
     context_freshness: str
+    source_present: bool = False
+    visibility_diagnostics: dict[str, int] = field(
+        default_factory=lambda: {"hidden": 0, "unknown": 0, "internal": 0}
+    )
 
 
 def _catalog_fetched_at_timestamp(value: Any) -> float | None:
@@ -493,7 +497,36 @@ def load_official_seed_snapshot(
         payload = load_json_file(candidate)
         payload_models = payload.get("models")
         if not isinstance(payload_models, list):
+            if candidate == runtime_path and candidate.exists():
+                freshness = _direct_catalog_context_freshness(payload, now_timestamp)
+                return OfficialSeedSnapshot(
+                    models=[],
+                    source=(
+                        CURRENT_DIRECT_OFFICIAL_SOURCE
+                        if freshness == "fresh"
+                        else "last_known_direct_official"
+                    ),
+                    context_freshness=freshness,
+                    source_present=True,
+                )
             payload_models = []
+        reported_diagnostics = payload.get("visibility_diagnostics")
+        if isinstance(reported_diagnostics, dict):
+            def bounded_reported_count(key: str) -> int:
+                value = reported_diagnostics.get(key)
+                return min(
+                    MAX_VISIBILITY_DIAGNOSTIC_COUNT,
+                    value
+                    if isinstance(value, int) and not isinstance(value, bool) and value >= 0
+                    else 0,
+                )
+
+            visibility_diagnostics = {
+                key: bounded_reported_count(key)
+                for key in ("hidden", "unknown", "internal")
+            }
+        else:
+            visibility_diagnostics = catalog_visibility_diagnostics(payload_models)
         models = []
         for raw_model in payload_models:
             if not isinstance(raw_model, dict):
@@ -509,8 +542,6 @@ def load_official_seed_snapshot(
             model["slug"] = slug
             model["visibility"] = CatalogVisibility.LIST.value
             models.append(model)
-        if not models:
-            continue
         if candidate == runtime_path:
             freshness = _direct_catalog_context_freshness(payload, now_timestamp)
             return OfficialSeedSnapshot(
@@ -521,8 +552,17 @@ def load_official_seed_snapshot(
                     else "last_known_direct_official"
                 ),
                 context_freshness=freshness,
+                source_present=True,
+                visibility_diagnostics=visibility_diagnostics,
             )
-        return OfficialSeedSnapshot(models=models, source="bundled_seed", context_freshness="missing")
+        if candidate.exists():
+            return OfficialSeedSnapshot(
+                models=models,
+                source="bundled_seed",
+                context_freshness="missing",
+                source_present=True,
+                visibility_diagnostics=visibility_diagnostics,
+            )
     return OfficialSeedSnapshot(models=[], source="missing", context_freshness="missing")
 
 
@@ -1511,14 +1551,23 @@ def build_codex_catalog(
     official_context_signals: dict[str, dict[str, Any]] | None = None,
     use_ollama_policy_allowlist: bool = True,
     fetched_at: str | None = None,
+    official_source_present: bool | None = None,
+    visibility_diagnostics: dict[str, int] | None = None,
 ) -> dict[str, Any]:
     models: list[dict[str, Any]] = []
     seen_slugs: set[str] = set()
     official_models = list(official_models)
-    visibility_diagnostics = catalog_visibility_diagnostics(official_models)
+    if official_source_present is None:
+        official_source_present = bool(official_models)
+    if visibility_diagnostics is None:
+        visibility_diagnostics = catalog_visibility_diagnostics(official_models)
     official_by_slug = official_model_index(official_models)
     disabled_official_slugs = {official_model_disable_key(str(model_id)) for model_id in disabled_official_model_ids or []}
-    official_source_slugs = list(official_by_slug.keys()) or list(policy.official_models)
+    official_source_slugs = (
+        list(official_by_slug.keys())
+        if official_source_present
+        else list(policy.official_models)
+    )
     official_slugs = sort_official_slugs(
         [
             slug
@@ -1758,6 +1807,8 @@ def sync_catalog(*, max_age_seconds: int = 0) -> dict[str, Any]:
         disabled_official_model_ids=disabled_official_models,
         official_context_signals=official_context_signals,
         use_ollama_policy_allowlist=not ollama_runtime_configured,
+        official_source_present=official_snapshot.source_present,
+        visibility_diagnostics=official_snapshot.visibility_diagnostics,
     )
     visible_slugs = [str(model["slug"]) for model in catalog["models"] if model.get("slug")]
     previous_visible_slugs = load_previous_visible_models(GENERATED_STATE_PATH)

--- a/src-python/catalog_sync.py
+++ b/src-python/catalog_sync.py
@@ -15,11 +15,16 @@ from urllib.request import Request, urlopen
 
 from atomic_io import atomic_write_text
 from catalog import (
+    CatalogVisibility,
     CatalogPolicy,
     canonical_model_id,
+    catalog_visibility_diagnostics,
     display_name_for,
+    is_catalog_model_listable,
+    is_internal_model,
     load_catalog_models,
     load_policy,
+    model_visibility,
     should_include_external_provider_model,
     should_include_model,
 )
@@ -489,11 +494,21 @@ def load_official_seed_snapshot(
         payload_models = payload.get("models")
         if not isinstance(payload_models, list):
             payload_models = []
-        models = [
-            deepcopy(model)
-            for model in payload_models
-            if isinstance(model, dict) and str(model.get("slug", "")).startswith("gpt-")
-        ]
+        models = []
+        for raw_model in payload_models:
+            if not isinstance(raw_model, dict):
+                continue
+            model = deepcopy(raw_model)
+            if not is_catalog_model_listable(model, missing_is_list=True):
+                continue
+            slug = canonical_model_id(str(model.get("slug", "")))
+            if slug.startswith("openai/gpt-"):
+                slug = slug.removeprefix("openai/")
+            if not slug.startswith("gpt-"):
+                continue
+            model["slug"] = slug
+            model["visibility"] = CatalogVisibility.LIST.value
+            models.append(model)
         if not models:
             continue
         if candidate == runtime_path:
@@ -567,6 +582,8 @@ def _direct_official_model_index(
 ) -> dict[str, dict[str, Any]] | None:
     indexed: dict[str, dict[str, Any]] = {}
     for model in models:
+        if is_internal_model(model):
+            continue
         slug = _direct_official_model_identity(model)
         if slug is None or slug in indexed:
             return None
@@ -586,6 +603,8 @@ def _direct_official_cache_model_index(
 
     indexed: dict[str, dict[str, Any]] = {}
     for model in models:
+        if is_internal_model(model):
+            continue
         identities = _direct_official_model_identities(model)
         if identities is None:
             return None
@@ -1229,6 +1248,7 @@ def build_official_proxy_model(
     model["display_name"] = official_short_display_name(slug, model, policy)
     if source_model is None:
         apply_official_model_defaults(model, slug)
+    model["visibility"] = CatalogVisibility.LIST.value
     normalize_official_responses_lite_opt_in(model)
     apply_pinned_official_catalog_metadata(model, slug)
     normalize_official_upgrade_for_codex(model)
@@ -1297,6 +1317,8 @@ def normalize_official_upgrade_for_codex(model: dict[str, Any]) -> None:
 def official_model_index(official_models: Iterable[dict[str, Any]]) -> dict[str, dict[str, Any]]:
     index: dict[str, dict[str, Any]] = {}
     for model in official_models:
+        if not is_catalog_model_listable(model, missing_is_list=True):
+            continue
         raw_slug = canonical_model_id(str(model.get("slug", "")))
         if not raw_slug:
             continue
@@ -1492,6 +1514,8 @@ def build_codex_catalog(
 ) -> dict[str, Any]:
     models: list[dict[str, Any]] = []
     seen_slugs: set[str] = set()
+    official_models = list(official_models)
+    visibility_diagnostics = catalog_visibility_diagnostics(official_models)
     official_by_slug = official_model_index(official_models)
     disabled_official_slugs = {official_model_disable_key(str(model_id)) for model_id in disabled_official_model_ids or []}
     official_source_slugs = list(official_by_slug.keys()) or list(policy.official_models)
@@ -1547,6 +1571,7 @@ def build_codex_catalog(
     return {
         "fetched_at": fetched_at or utc_now_iso(),
         "client_version": client_version,
+        "visibility_diagnostics": visibility_diagnostics,
         "models": models,
     }
 
@@ -1582,6 +1607,7 @@ def load_cached_state(path: Path = GENERATED_STATE_PATH) -> dict[str, Any]:
         "discovery_status": "cache_missing",
         "discovery_detail": "cached state is missing",
         "metadata_detail": "",
+        "visibility_diagnostics": {"hidden": 0, "unknown": 0, "internal": 0},
         "ollama_model_metadata": {},
         "discovered_ollama_models": [],
         "external_provider_models": [],
@@ -1743,6 +1769,9 @@ def sync_catalog(*, max_age_seconds: int = 0) -> dict[str, Any]:
         "discovery_status": discovery_status,
         "discovery_detail": discovery_detail,
         "metadata_detail": metadata_detail,
+        "visibility_diagnostics": catalog.get(
+            "visibility_diagnostics", {"hidden": 0, "unknown": 0, "internal": 0}
+        ),
         "ollama_model_metadata": ollama_model_metadata,
         "discovered_ollama_models": discovered_slugs,
         "external_provider_models": [str(model["alias"]) for model in external_models],

--- a/src-tauri/src/gateway.rs
+++ b/src-tauri/src/gateway.rs
@@ -2009,6 +2009,9 @@ fn official_models_from_metadata(
                 let mut bare_sources = HashMap::<String, bool>::new();
                 let mut enabled_by_id = HashMap::<String, bool>::new();
                 for model in source_models {
+                    if !models::model_is_catalog_visible(&model) {
+                        continue;
+                    }
                     let source_is_bare = !model.id.trim().starts_with("openai/");
                     let source_enabled = model.enabled;
                     let Some(gateway_model) = official_gateway_model_from_metadata(

--- a/src-tauri/src/gateway.rs
+++ b/src-tauri/src/gateway.rs
@@ -1981,10 +1981,10 @@ fn official_models(settings: &Settings) -> Vec<GatewayModel> {
     // descriptive fields, but must never reintroduce a builtin fallback limit.
     let published_context_windows = official_refresh::published_official_context_windows()
         .unwrap_or_default();
-    let source_models = models::list_cached_official_subscription_models()
-        .ok()
-        .filter(|models| !models.is_empty())
-        .or_else(|| models::list_models().ok().filter(|models| !models.is_empty()));
+    let source_models = match models::list_cached_official_subscription_models_with_presence() {
+        Ok(Some(models)) => Some(models),
+        Ok(None) | Err(_) => models::list_models_with_presence().ok().flatten(),
+    };
     official_models_from_metadata(settings, source_models, &published_context_windows)
 }
 
@@ -2002,7 +2002,7 @@ fn official_models_from_metadata(
         return Vec::new();
     }
     let mut models: Vec<GatewayModel> =
-        match subscription_models.filter(|models| !models.is_empty()) {
+        match subscription_models {
             Some(source_models) => {
                 let mut models = Vec::<GatewayModel>::new();
                 let mut positions = HashMap::<String, usize>::new();
@@ -8042,6 +8042,18 @@ mod tests {
         assert_eq!(models[0].id, "gpt-5.6-sol");
         assert_eq!(models[0].display_name, "5.6 Sol");
         assert_eq!(models[0].context_window, Some(272_000));
+    }
+
+    #[test]
+    fn official_gateway_models_do_not_fallback_when_authoritative_catalog_is_empty() {
+        let published_contexts = published_context_windows(&[("gpt-5.6-terra", 272_000)]);
+        let models = official_models_from_metadata(
+            &Settings::default(),
+            Some(Vec::new()),
+            &published_contexts,
+        );
+
+        assert!(models.is_empty());
     }
 
     #[test]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -49,21 +49,15 @@ struct TrayToast {
     tone: String,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum CatalogVisibility {
+    // Provider models and older persisted metadata were user-listable before
+    // visibility became explicit; upstream parsers assign Unknown explicitly.
+    #[default]
     List,
     Hide,
     Unknown,
-}
-
-impl Default for CatalogVisibility {
-    fn default() -> Self {
-        // Provider models and older persisted metadata were user-listable
-        // before visibility became explicit. Upstream/catalog parsers still
-        // assign Unknown when a record is missing or malformed.
-        Self::List
-    }
 }
 
 impl<'de> Deserialize<'de> for CatalogVisibility {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -49,6 +49,37 @@ struct TrayToast {
     tone: String,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CatalogVisibility {
+    List,
+    Hide,
+    Unknown,
+}
+
+impl Default for CatalogVisibility {
+    fn default() -> Self {
+        // Provider models and older persisted metadata were user-listable
+        // before visibility became explicit. Upstream/catalog parsers still
+        // assign Unknown when a record is missing or malformed.
+        Self::List
+    }
+}
+
+impl<'de> Deserialize<'de> for CatalogVisibility {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = Option::<serde_json::Value>::deserialize(deserializer)?;
+        Ok(match value.as_ref().and_then(serde_json::Value::as_str).map(str::trim).map(str::to_ascii_lowercase).as_deref() {
+            Some("list") => Self::List,
+            Some("hide") => Self::Hide,
+            _ => Self::Unknown,
+        })
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Model {
     pub id: String,
@@ -65,6 +96,8 @@ pub struct Model {
     pub codex_enabled: bool,
     #[serde(default = "default_enabled")]
     pub gateway_exported: bool,
+    #[serde(default)]
+    pub visibility: CatalogVisibility,
     pub context_window: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_context_window: Option<u32>,
@@ -99,6 +132,7 @@ impl Default for Model {
             locked: false,
             codex_enabled: true,
             gateway_exported: true,
+            visibility: CatalogVisibility::default(),
             context_window: None,
             max_context_window: None,
             effective_source: None,

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -1,6 +1,6 @@
 use crate::{
-    config, runtime_paths, safe_file, MetadataProvenance, Model, ModelPricing, Settings,
-    UpstreamFormat,
+    config, runtime_paths, safe_file, CatalogVisibility, MetadataProvenance, Model, ModelPricing,
+    Settings, UpstreamFormat,
 };
 use reqwest::blocking::Client;
 use reqwest::header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE};
@@ -273,11 +273,12 @@ pub fn list_model_metadata() -> Result<Vec<Model>, String> {
         &known_official_models,
     );
     let overrides = read_metadata_overrides(&paths).unwrap_or_default();
-    Ok(merge_metadata_with_overrides(
+    let merged = merge_metadata_with_overrides(
         cached,
         overrides,
         &known_official_models,
-    ))
+    );
+    Ok(merged.into_iter().filter(model_is_catalog_visible).collect())
 }
 
 pub(crate) fn list_cached_official_subscription_models() -> Result<Vec<Model>, String> {
@@ -850,12 +851,74 @@ fn is_pinned_official_legacy_model(slug: &str) -> bool {
     matches!(slug, "gpt-5.5" | "gpt-5.4" | "gpt-5.4-mini")
 }
 
+const INTERNAL_MODEL_IDENTIFIERS: &[&str] = &["codex-auto-review"];
+
+pub(crate) fn model_is_catalog_visible(model: &Model) -> bool {
+    if model.visibility != CatalogVisibility::List {
+        return false;
+    }
+    let mut identities = vec![model.id.as_str()];
+    if let Some(upstream_model) = model.upstream_model.as_deref() {
+        identities.push(upstream_model);
+    }
+    identities.extend(model.aliases.iter().map(String::as_str));
+    !identities.iter().any(|value| {
+        let normalized = value
+            .trim()
+            .strip_prefix("openai/")
+            .unwrap_or(value.trim())
+            .to_ascii_lowercase();
+        INTERNAL_MODEL_IDENTIFIERS.iter().any(|identifier| {
+            normalized == *identifier || normalized.starts_with(&format!("{identifier}/"))
+        })
+    })
+}
+
+fn catalog_visibility_from_item(object: &Map<String, Value>) -> CatalogVisibility {
+    if object.get("hidden").and_then(Value::as_bool) == Some(true) {
+        return CatalogVisibility::Hide;
+    }
+    match object
+        .get("visibility")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .map(|value| value.to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("list") => CatalogVisibility::List,
+        Some("hide") => CatalogVisibility::Hide,
+        Some(_) => CatalogVisibility::Unknown,
+        None if object.get("hidden").and_then(Value::as_bool) == Some(false) => {
+            CatalogVisibility::List
+        }
+        None => CatalogVisibility::Unknown,
+    }
+}
+
+fn item_has_internal_identity(object: &Map<String, Value>) -> bool {
+    object
+        .iter()
+        .filter(|(key, _)| {
+            matches!(
+                key.as_str(),
+                "id" | "slug" | "model" | "name" | "upstream_model"
+            )
+        })
+        .filter_map(|(_, value)| value.as_str())
+        .map(str::trim)
+        .map(|value| value.strip_prefix("openai/").unwrap_or(value))
+        .map(str::to_ascii_lowercase)
+        .any(|value| {
+            INTERNAL_MODEL_IDENTIFIERS.iter().any(|identifier| {
+                value == *identifier || value.starts_with(&format!("{identifier}/"))
+            })
+        })
+}
+
 fn subscription_model_from_item(item: &Value) -> Option<OfficialSubscriptionModel> {
     let object = item.as_object()?;
-    if object
-        .get("hidden")
-        .and_then(Value::as_bool)
-        .unwrap_or(false)
+    if item_has_internal_identity(object)
+        || catalog_visibility_from_item(object) != CatalogVisibility::List
     {
         return None;
     }
@@ -946,6 +1009,7 @@ fn subscription_models_to_metadata_models(
             locked: true,
             codex_enabled: true,
             gateway_exported: true,
+            visibility: CatalogVisibility::List,
             context_window: subscription_model
                 .context_window
                 .or_else(|| defaults.and_then(|model| model.context_window)),
@@ -1054,6 +1118,7 @@ fn write_official_subscription_seed(
 fn official_subscription_seed_model(model: &OfficialSubscriptionModel) -> Value {
     let mut payload = model.raw.as_object().cloned().unwrap_or_default();
     ensure_responses_lite_opt_in(&mut payload);
+    payload.insert("visibility".to_string(), json!(CatalogVisibility::List));
     payload.insert("slug".to_string(), json!(model.slug));
     payload
         .entry("display_name".to_string())
@@ -2011,6 +2076,14 @@ fn merge_model_override(base: &mut Model, override_model: Model) {
     let original_enabled = base.enabled;
     let original_codex_enabled = base.codex_enabled;
     let original_gateway_exported = base.gateway_exported;
+    let original_visibility = base.visibility;
+    let visibility = match (original_visibility, override_model.visibility) {
+        (CatalogVisibility::Hide, _) | (_, CatalogVisibility::Hide) => CatalogVisibility::Hide,
+        (CatalogVisibility::Unknown, _) | (_, CatalogVisibility::Unknown) => {
+            CatalogVisibility::Unknown
+        }
+        _ => CatalogVisibility::List,
+    };
     let aliases = merge_model_aliases(base.aliases.clone(), override_model.aliases);
     *base = Model {
         id: override_model.id,
@@ -2024,6 +2097,7 @@ fn merge_model_override(base: &mut Model, override_model: Model) {
         locked: base.locked || override_model.locked,
         codex_enabled: override_model.codex_enabled && original_codex_enabled,
         gateway_exported: override_model.gateway_exported && original_gateway_exported,
+        visibility,
         context_window: override_model.context_window.or(base.context_window),
         max_context_window: override_model.max_context_window.or(base.max_context_window),
         effective_source: override_model.effective_source.or(base.effective_source.take()),
@@ -2282,6 +2356,19 @@ fn priced_metadata(
 
 fn catalog_model_from_item(item: &Value) -> Option<Model> {
     let object = item.as_object()?;
+    // Generated catalogs predate the typed visibility field and also contain
+    // trusted third-party provider entries that never carried an upstream
+    // visibility flag.  Preserve that legacy list default at this boundary;
+    // raw app-server/upstream ingestion remains fail-closed through
+    // `subscription_model_from_item` and `catalog_visibility_from_item`.
+    let listable = if object.contains_key("visibility") || object.contains_key("hidden") {
+        catalog_visibility_from_item(object) == CatalogVisibility::List
+    } else {
+        true
+    };
+    if item_has_internal_identity(object) || !listable {
+        return None;
+    }
     let id = object
         .get("slug")
         .or_else(|| object.get("id"))
@@ -2353,6 +2440,7 @@ fn catalog_model_from_item(item: &Value) -> Option<Model> {
             .get("gateway_exported")
             .and_then(Value::as_bool)
             .unwrap_or(true),
+        visibility: CatalogVisibility::List,
         pricing: None,
         metadata_provenance: None,
     })
@@ -2770,6 +2858,45 @@ for line in sys.stdin:
         assert_eq!(models[0].display_name.as_deref(), Some("5.4"));
         assert_eq!(models[0].upstream_model.as_deref(), Some("gpt-5.4"));
         assert!(models[0].pricing.is_some());
+    }
+
+    #[test]
+    fn subscription_models_apply_typed_visibility_and_internal_identity_policy() {
+        let subscription_models = subscription_models_from_payload(&json!({
+            "data": [
+                {
+                    "id": "gpt-5.6-terra",
+                    "model": "gpt-5.6-terra",
+                    "visibility": "list",
+                    "hidden": false
+                },
+                {
+                    "id": "gpt-5.6-sol",
+                    "model": "gpt-5.6-sol",
+                    "visibility": "hide",
+                    "hidden": false
+                },
+                {
+                    "id": "codex-auto-review",
+                    "model": "gpt-5.6-terra",
+                    "slug": "gpt-5.6-terra",
+                    "visibility": "list",
+                    "hidden": false
+                },
+                {
+                    "id": "gpt-5.6-luna",
+                    "model": "gpt-5.6-luna",
+                    "visibility": "future",
+                    "hidden": false
+                }
+            ]
+        }))
+        .expect("subscription models");
+
+        let models = subscription_models_to_metadata_models(&subscription_models);
+
+        assert_eq!(model_ids(&models), ["gpt-5.6-terra"]);
+        assert_eq!(models[0].visibility, crate::CatalogVisibility::List);
     }
 
     #[test]

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -19,6 +19,7 @@ const DISCOVERY_TIMEOUT: Duration = Duration::from_secs(20);
 const MODEL_TEST_TIMEOUT: Duration = Duration::from_secs(8);
 const CODEX_APP_SERVER_MODEL_LIST_TIMEOUT: Duration = Duration::from_secs(8);
 const CODEX_APP_SERVER_CACHE_POLL_INTERVAL: Duration = Duration::from_millis(10);
+const MAX_VISIBILITY_DIAGNOSTIC_COUNT: u64 = 100;
 const GENERATED_CATALOG_FILE: &str = "codexhub-model-catalog.json";
 const LEGACY_GENERATED_CATALOG_FILE: &str = "codex-proxy-official-ollama.json";
 const RESOLVED_MODEL_LIMITS_JSON: &str = include_str!("../../config/resolved_model_limits.json");
@@ -253,13 +254,17 @@ pub fn generate_catalog() -> Result<Vec<Model>, String> {
 }
 
 pub fn list_models() -> Result<Vec<Model>, String> {
+    Ok(list_models_with_presence()?.unwrap_or_default())
+}
+
+pub(crate) fn list_models_with_presence() -> Result<Option<Vec<Model>>, String> {
     let paths = ModelPaths::runtime()?;
     let catalog_path = paths.existing_generated_catalog_path();
     if !catalog_path.exists() {
-        return Ok(Vec::new());
+        return Ok(None);
     }
 
-    read_catalog_models(&catalog_path)
+    read_catalog_models(&catalog_path).map(Some)
 }
 
 pub fn list_model_metadata() -> Result<Vec<Model>, String> {
@@ -281,9 +286,10 @@ pub fn list_model_metadata() -> Result<Vec<Model>, String> {
     Ok(merged.into_iter().filter(model_is_catalog_visible).collect())
 }
 
-pub(crate) fn list_cached_official_subscription_models() -> Result<Vec<Model>, String> {
+pub(crate) fn list_cached_official_subscription_models_with_presence(
+) -> Result<Option<Vec<Model>>, String> {
     let paths = ModelPaths::runtime()?;
-    read_official_subscription_models_from_cache(&paths)
+    read_official_subscription_models_from_cache_with_presence(&paths)
 }
 
 pub fn refresh_model_metadata() -> Result<Vec<Model>, String> {
@@ -352,10 +358,54 @@ fn refresh_official_models_direct_with_runner(
 ) -> Result<Vec<Model>, String> {
     let subscription_models = runner
         .read_model_list()
-        .and_then(|payload| subscription_models_from_app_server_payload(&payload))?;
+        .and_then(|payload| {
+            let visibility_diagnostics = visibility_diagnostics_from_payload(&payload);
+            let subscription_models = subscription_models_from_app_server_payload(&payload)?;
+            Ok((subscription_models, visibility_diagnostics))
+        })?;
+    let (subscription_models, visibility_diagnostics) = subscription_models;
     let models = subscription_models_to_metadata_models(&subscription_models);
-    write_official_subscription_caches(paths, &subscription_models, &models)?;
+    write_official_subscription_caches(
+        paths,
+        &subscription_models,
+        &models,
+        &visibility_diagnostics,
+    )?;
     Ok(models)
+}
+
+fn visibility_diagnostics_from_payload(payload: &Value) -> Value {
+    let items = payload
+        .get("data")
+        .or_else(|| payload.get("models"))
+        .and_then(Value::as_array)
+        .or_else(|| payload.as_array());
+    let mut counts = Map::from_iter([
+        ("hidden".to_string(), json!(0u64)),
+        ("unknown".to_string(), json!(0u64)),
+        ("internal".to_string(), json!(0u64)),
+    ]);
+    for item in items.into_iter().flatten() {
+        let Some(object) = item.as_object() else {
+            continue;
+        };
+        let key = if item_has_internal_identity(object) {
+            "internal"
+        } else {
+            match catalog_visibility_from_item(object) {
+                CatalogVisibility::Hide => "hidden",
+                CatalogVisibility::Unknown => "unknown",
+                CatalogVisibility::List => continue,
+            }
+        };
+        if let Some(count) = counts.get(key).and_then(Value::as_u64) {
+            counts.insert(
+                key.to_string(),
+                json!(count.saturating_add(1).min(MAX_VISIBILITY_DIAGNOSTIC_COUNT)),
+            );
+        }
+    }
+    Value::Object(counts)
 }
 
 fn read_codex_app_server_model_list() -> Result<Value, String> {
@@ -868,6 +918,7 @@ pub(crate) fn model_is_catalog_visible(model: &Model) -> bool {
             .strip_prefix("openai/")
             .unwrap_or(value.trim())
             .to_ascii_lowercase();
+        let normalized = normalized.strip_suffix(":cloud").unwrap_or(&normalized);
         INTERNAL_MODEL_IDENTIFIERS.iter().any(|identifier| {
             normalized == *identifier || normalized.starts_with(&format!("{identifier}/"))
         })
@@ -908,6 +959,7 @@ fn item_has_internal_identity(object: &Map<String, Value>) -> bool {
         .map(str::trim)
         .map(|value| value.strip_prefix("openai/").unwrap_or(value))
         .map(str::to_ascii_lowercase)
+        .map(|value| value.strip_suffix(":cloud").unwrap_or(&value).to_string())
         .any(|value| {
             INTERNAL_MODEL_IDENTIFIERS.iter().any(|identifier| {
                 value == *identifier || value.starts_with(&format!("{identifier}/"))
@@ -1069,28 +1121,41 @@ fn write_official_subscription_caches(
     paths: &ModelPaths,
     subscription_models: &[OfficialSubscriptionModel],
     metadata_models: &[Model],
+    visibility_diagnostics: &Value,
 ) -> Result<(), String> {
     write_models_json(&paths.metadata_cache_path(), metadata_models)?;
     write_official_subscription_seed(
         &paths.official_subscription_cache_path(),
         subscription_models,
+        visibility_diagnostics,
     )
 }
 
-fn read_official_subscription_models_from_cache(paths: &ModelPaths) -> Result<Vec<Model>, String> {
+fn read_official_subscription_models_from_cache_with_presence(
+    paths: &ModelPaths,
+) -> Result<Option<Vec<Model>>, String> {
+    if !paths.official_subscription_cache_path().exists() {
+        return Ok(None);
+    }
     let payload = load_json_file(&paths.official_subscription_cache_path())?;
     let subscription_models = subscription_models_from_payload(&payload)?;
-    if subscription_models.is_empty() {
-        return Err(
+    Ok(Some(subscription_models_to_metadata_models(&subscription_models)))
+}
+
+fn read_official_subscription_models_from_cache(paths: &ModelPaths) -> Result<Vec<Model>, String> {
+    match read_official_subscription_models_from_cache_with_presence(paths)? {
+        Some(models) if !models.is_empty() => Ok(models),
+        Some(_) => Err(
             "cached Codex subscription model list did not include visible GPT models".to_string(),
-        );
+        ),
+        None => Err("cached Codex subscription model list is missing".to_string()),
     }
-    Ok(subscription_models_to_metadata_models(&subscription_models))
 }
 
 fn write_official_subscription_seed(
     path: &Path,
     subscription_models: &[OfficialSubscriptionModel],
+    visibility_diagnostics: &Value,
 ) -> Result<(), String> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)
@@ -1103,6 +1168,7 @@ fn write_official_subscription_seed(
     let payload = json!({
         "client_version": env!("CARGO_PKG_VERSION"),
         "fetched_at": current_unix_timestamp(),
+        "visibility_diagnostics": visibility_diagnostics,
         "models": models,
     });
     let text = serde_json::to_string_pretty(&payload)
@@ -2562,8 +2628,8 @@ mod tests {
         provider_models_endpoint, read_models_json, refresh_official_models_from_endpoint,
         refresh_official_models_with_runner, resolve_gateway_api_key_for_settings,
         subscription_models_from_payload, subscription_models_to_metadata_models,
-        test_model_endpoint_with_timeout, AppServerModelListRunner, CatalogCommandOutcome,
-        CatalogSyncRunner, ModelPaths,
+        test_model_endpoint_with_timeout, visibility_diagnostics_from_payload,
+        AppServerModelListRunner, CatalogCommandOutcome, CatalogSyncRunner, ModelPaths,
     };
     use crate::{MetadataProvenance, Model, Settings, ToolSurfaceStrategy, UpstreamFormat};
     use reqwest::blocking::Client;
@@ -2897,6 +2963,23 @@ for line in sys.stdin:
 
         assert_eq!(model_ids(&models), ["gpt-5.6-terra"]);
         assert_eq!(models[0].visibility, crate::CatalogVisibility::List);
+    }
+
+    #[test]
+    fn visibility_diagnostics_are_bounded_and_secret_free() {
+        let diagnostics = visibility_diagnostics_from_payload(&json!({
+            "data": [
+                {"id": "gpt-5.6-sol", "visibility": "hide"},
+                {"id": "gpt-5.6-luna", "visibility": "future"},
+                {"id": "codex-auto-review", "model": "gpt-5.6-terra", "visibility": "list"},
+                {"id": "gpt-5.6-terra", "visibility": "list"}
+            ]
+        }));
+
+        assert_eq!(diagnostics["hidden"], 1);
+        assert_eq!(diagnostics["unknown"], 1);
+        assert_eq!(diagnostics["internal"], 1);
+        assert!(!diagnostics.to_string().contains("gpt-5.6"));
     }
 
     #[test]

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -679,11 +679,7 @@ struct ReasoningLevelEntry {
 fn subscription_models_from_app_server_payload(
     payload: &Value,
 ) -> Result<Vec<OfficialSubscriptionModel>, String> {
-    let models = subscription_models_from_payload(payload)?;
-    if models.is_empty() {
-        return Err("Codex subscription model list did not include visible GPT models".to_string());
-    }
-    Ok(models)
+    subscription_models_from_payload(payload)
 }
 
 fn subscription_models_from_payload(
@@ -2624,7 +2620,8 @@ mod tests {
     use super::{
         desktop_codex_exe_from_local_appdata, discover_provider_models_with_timeout,
         enrich_models_with_ollama_show, generate_catalog_with_runner, list_model_metadata,
-        list_models, merge_metadata_with_overrides, ollama_show_endpoint, provider_api_endpoint,
+        list_models, load_json_file, merge_metadata_with_overrides, ollama_show_endpoint,
+        provider_api_endpoint,
         provider_models_endpoint, read_models_json, refresh_official_models_from_endpoint,
         refresh_official_models_with_runner, resolve_gateway_api_key_for_settings,
         subscription_models_from_payload, subscription_models_to_metadata_models,
@@ -3068,6 +3065,35 @@ for line in sys.stdin:
         assert_eq!(cached_model["display_name"], "GPT Subscription Live");
         assert_eq!(cached_model["additional_speed_tiers"], json!(["fast"]));
         assert_eq!(cached_model["service_tiers"][0]["id"], "priority");
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn subscription_refresh_preserves_empty_visibility_snapshot_and_diagnostics() {
+        let root = temp_root("subscription-empty-visibility-refresh");
+        let paths = test_paths(&root);
+        let runner = StaticAppServerModelListRunner::ok(json!({
+            "data": [
+                {"id": "gpt-hidden", "visibility": "hide"},
+                {"id": "gpt-unknown", "visibility": "future"},
+                {
+                    "id": "codex-auto-review",
+                    "model": "gpt-5.6-terra",
+                    "visibility": "list"
+                }
+            ]
+        }));
+
+        let models = refresh_official_models_with_runner(&paths, &runner)
+            .expect("empty visibility snapshot should publish fail-closed");
+
+        assert!(models.is_empty());
+        let payload = load_json_file(&paths.official_subscription_cache_path())
+            .expect("empty official subscription cache");
+        assert_eq!(payload["models"].as_array().map(Vec::len), Some(0));
+        assert_eq!(payload["visibility_diagnostics"]["hidden"], 1);
+        assert_eq!(payload["visibility_diagnostics"]["unknown"], 1);
+        assert_eq!(payload["visibility_diagnostics"]["internal"], 1);
         let _ = fs::remove_dir_all(root);
     }
 

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -3105,6 +3105,7 @@ for line in sys.stdin:
                     "id": "gpt-5.6-terra",
                     "model": "gpt-5.6-terra",
                     "displayName": "GPT-5.6-Terra",
+                    "hidden": false,
                     "supportedReasoningEfforts": [
                         {"reasoningEffort": "low", "description": "Light"},
                         {"reasoningEffort": "medium", "description": "Medium"},
@@ -3119,6 +3120,7 @@ for line in sys.stdin:
                     "id": "gpt-5.6-sol",
                     "model": "gpt-5.6-sol",
                     "displayName": "GPT-5.6-Sol",
+                    "hidden": false,
                     "context_window": 400000,
                     "supportedReasoningEfforts": [
                         {"reasoningEffort": "low", "description": "Light"},
@@ -3189,12 +3191,13 @@ for line in sys.stdin:
     fn subscription_seed_backfills_pinned_official_planner_metadata_per_model() {
         let subscription_models = subscription_models_from_payload(&json!({
             "data": [
-                {"id": "gpt-5.6-sol", "model": "gpt-5.6-sol"},
-                {"id": "gpt-5.6-terra", "model": "gpt-5.6-terra"},
-                {"id": "gpt-5.6-luna", "model": "gpt-5.6-luna"},
+                {"id": "gpt-5.6-sol", "model": "gpt-5.6-sol", "hidden": false},
+                {"id": "gpt-5.6-terra", "model": "gpt-5.6-terra", "hidden": false},
+                {"id": "gpt-5.6-luna", "model": "gpt-5.6-luna", "hidden": false},
                 {
                     "id": "gpt-5.5",
                     "model": "gpt-5.5",
+                    "hidden": false,
                     "use_responses_lite": true,
                     "tool_mode": "code_mode_only",
                     "multi_agent_version": "v2"
@@ -3202,6 +3205,7 @@ for line in sys.stdin:
                 {
                     "id": "gpt-5.4",
                     "model": "gpt-5.4",
+                    "hidden": false,
                     "use_responses_lite": true,
                     "tool_mode": "code_mode_only",
                     "multi_agent_version": "v2"
@@ -3209,6 +3213,7 @@ for line in sys.stdin:
                 {
                     "id": "gpt-5.4-mini",
                     "model": "gpt-5.4-mini",
+                    "hidden": false,
                     "use_responses_lite": true,
                     "tool_mode": "code_mode_only",
                     "multi_agent_version": "v2"
@@ -3216,12 +3221,14 @@ for line in sys.stdin:
                 {
                     "id": "gpt-5.3-codex-spark",
                     "model": "gpt-5.3-codex-spark",
+                    "hidden": false,
                     "use_responses_lite": true
                 },
-                {"id": "gpt-sparse", "model": "gpt-sparse"},
+                {"id": "gpt-sparse", "model": "gpt-sparse", "hidden": false},
                 {
                     "id": "gpt-explicit-lite",
                     "model": "gpt-explicit-lite",
+                    "hidden": false,
                     "use_responses_lite": true
                 }
             ]
@@ -3327,6 +3334,7 @@ for line in sys.stdin:
                     "id": "gpt-5.6-sol",
                     "model": "gpt-5.6-sol",
                     "displayName": "GPT-5.6-Sol",
+                    "hidden": false,
                     "context_window": 400000,
                     "max_context_window": 999999
                 }
@@ -3351,7 +3359,8 @@ for line in sys.stdin:
             "data": [
                 {
                     "slug": "openai/gpt-5.6-sol",
-                    "displayName": "GPT-5.6-Sol"
+                    "displayName": "GPT-5.6-Sol",
+                    "hidden": false
                 }
             ]
         }))
@@ -3368,6 +3377,7 @@ for line in sys.stdin:
             "id": "openai/gpt-5.6-sol",
             "model": "openai/gpt-5.6-sol",
             "displayName": "Legacy Sol",
+            "hidden": false,
             "context_window": 1,
             "enabled": true
         });
@@ -3375,13 +3385,15 @@ for line in sys.stdin:
             "id": "gpt-5.6-sol",
             "model": "gpt-5.6-sol",
             "displayName": "GPT-5.6-Sol",
+            "hidden": false,
             "context_window": 400000,
             "enabled": false
         });
         let other = json!({
             "id": "gpt-5.5",
             "model": "gpt-5.5",
-            "displayName": "GPT-5.5"
+            "displayName": "GPT-5.5",
+            "hidden": false
         });
 
         for items in [
@@ -3410,11 +3422,13 @@ for line in sys.stdin:
                 {
                     "id": "openai/gpt-5.6-sol",
                     "model": "openai/gpt-5.6-sol",
+                    "hidden": false,
                     "enabled": false
                 },
                 {
                     "id": "gpt-5.6-sol",
                     "model": "gpt-5.6-sol",
+                    "hidden": false,
                     "enabled": false
                 }
             ]
@@ -3438,6 +3452,7 @@ for line in sys.stdin:
                     {
                         "slug": "gpt-cached-subscription",
                         "display_name": "GPT Cached Subscription",
+                        "hidden": false,
                         "input_modalities": ["text"],
                         "supported_reasoning_levels": [
                             {"effort": "medium", "description": "Balanced"}

--- a/tests/test_catalog_sync.py
+++ b/tests/test_catalog_sync.py
@@ -92,6 +92,23 @@ class CatalogSyncTests(unittest.TestCase):
         )
         self.assertEqual(catalog["models"][0]["visibility"], "list")
 
+    def test_hidden_flag_overrides_list_visibility(self):
+        catalog = build_codex_catalog(
+            [
+                {
+                    "slug": "gpt-5.6-terra",
+                    "visibility": "list",
+                    "hidden": True,
+                }
+            ],
+            [],
+            self.policy,
+            "0.144.0",
+        )
+
+        self.assertEqual(catalog["models"], [])
+        self.assertEqual(catalog["visibility_diagnostics"]["hidden"], 1)
+
     def test_official_seed_snapshot_fails_closed_for_unknown_visibility(self):
         with tempfile.TemporaryDirectory() as tmp:
             seed_path = Path(tmp) / "runtime-seed.json"
@@ -132,6 +149,98 @@ class CatalogSyncTests(unittest.TestCase):
 
         self.assertEqual([model["slug"] for model in snapshot.models], ["gpt-5.6-terra"])
         self.assertEqual(snapshot.models[0]["visibility"], "list")
+
+    def test_runtime_seed_all_hidden_does_not_fallback_to_bundled_or_policy_models(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            runtime_path = Path(tmp) / "runtime-seed.json"
+            runtime_path.write_text(
+                json.dumps(
+                    {
+                        "fetched_at": 1_000,
+                        "models": [
+                            {"slug": "gpt-5.6-terra", "visibility": "hide"},
+                            {"slug": "gpt-5.6-sol", "visibility": "future"},
+                            {
+                                "id": "codex-auto-review",
+                                "slug": "gpt-5.6-terra",
+                                "visibility": "list",
+                            },
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            bundled_path = Path(tmp) / "bundled-seed.json"
+            bundled_path.write_text(
+                json.dumps(
+                    {
+                        "models": [
+                            {"slug": "gpt-5.5", "visibility": "list"},
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            snapshot = catalog_sync.load_official_seed_snapshot(
+                bundled_path,
+                runtime_path=runtime_path,
+                now_timestamp=1_001,
+            )
+            catalog = build_codex_catalog(
+                snapshot.models,
+                [],
+                self.policy,
+                "0.144.0",
+                official_source_present=snapshot.source_present,
+                visibility_diagnostics=snapshot.visibility_diagnostics,
+            )
+
+        self.assertEqual(snapshot.models, [])
+        self.assertTrue(snapshot.source_present)
+        self.assertEqual(snapshot.visibility_diagnostics, {"hidden": 1, "unknown": 1, "internal": 1})
+        self.assertEqual([model["slug"] for model in catalog["models"]], [])
+        self.assertEqual(catalog["visibility_diagnostics"], snapshot.visibility_diagnostics)
+
+    def test_seed_uses_bounded_upstream_visibility_diagnostics(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            runtime_path = Path(tmp) / "runtime-seed.json"
+            runtime_path.write_text(
+                json.dumps(
+                    {
+                        "fetched_at": 1_000,
+                        "visibility_diagnostics": {
+                            "hidden": 101,
+                            "unknown": 2,
+                            "internal": 1,
+                        },
+                        "models": [{"slug": "gpt-5.6-terra", "visibility": "list"}],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            snapshot = catalog_sync.load_official_seed_snapshot(
+                Path(tmp) / "missing-bundled.json",
+                runtime_path=runtime_path,
+                now_timestamp=1_001,
+            )
+
+        self.assertEqual(
+            snapshot.visibility_diagnostics,
+            {"hidden": 100, "unknown": 2, "internal": 1},
+        )
+
+    def test_unknown_official_source_does_not_recreate_policy_models(self):
+        catalog = build_codex_catalog(
+            [{"slug": "gpt-5.6-terra", "visibility": "future"}],
+            [],
+            self.policy,
+            "0.144.0",
+        )
+
+        self.assertEqual([model["slug"] for model in catalog["models"]], [])
+        self.assertEqual(catalog["visibility_diagnostics"]["unknown"], 1)
 
     def test_direct_cache_internal_duplicate_terra_is_ignored_for_authority(self):
         fixture_path = Path(__file__).parent / "fixtures" / "codex_0_144_2_direct_models_cache.json"

--- a/tests/test_catalog_sync.py
+++ b/tests/test_catalog_sync.py
@@ -58,6 +58,127 @@ class CatalogSyncTests(unittest.TestCase):
         self.assertNotIn("gpt-5.4", slugs)
         self.assertNotIn("glm-5.1", slugs)
 
+    def test_official_visibility_contract_excludes_hidden_unknown_and_internal_duplicates(self):
+        official = [
+            {
+                "slug": "gpt-5.6-terra",
+                "display_name": "GPT-5.6 Terra",
+                "visibility": "list",
+            },
+            {
+                "slug": "gpt-5.6-sol",
+                "display_name": "GPT-5.6 Sol",
+                "visibility": "hide",
+            },
+            {
+                "id": "codex-auto-review",
+                "model": "gpt-5.6-terra",
+                "slug": "gpt-5.6-terra",
+                "display_name": "GPT-5.6 Terra (review)",
+                "visibility": "list",
+            },
+            {
+                "slug": "gpt-5.6-luna",
+                "display_name": "GPT-5.6 Luna",
+                "visibility": "future",
+            },
+        ]
+
+        catalog = build_codex_catalog(official, [], self.policy, "0.144.0")
+
+        self.assertEqual(
+            [model["slug"] for model in catalog["models"]],
+            ["gpt-5.6-terra"],
+        )
+        self.assertEqual(catalog["models"][0]["visibility"], "list")
+
+    def test_official_seed_snapshot_fails_closed_for_unknown_visibility(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            seed_path = Path(tmp) / "runtime-seed.json"
+            seed_path.write_text(
+                json.dumps(
+                    {
+                        "fetched_at": 1_000,
+                        "models": [
+                            {
+                                "slug": "gpt-5.6-terra",
+                                "visibility": "list",
+                            },
+                            {
+                                "slug": "gpt-5.6-sol",
+                                "visibility": "hide",
+                            },
+                            {
+                                "id": "codex-auto-review",
+                                "slug": "gpt-5.6-terra",
+                                "model": "gpt-5.6-terra",
+                                "visibility": "list",
+                            },
+                            {
+                                "slug": "gpt-5.6-luna",
+                                "visibility": "future",
+                            },
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            snapshot = catalog_sync.load_official_seed_snapshot(
+                Path(tmp) / "missing-bundled.json",
+                runtime_path=seed_path,
+                now_timestamp=1_001,
+            )
+
+        self.assertEqual([model["slug"] for model in snapshot.models], ["gpt-5.6-terra"])
+        self.assertEqual(snapshot.models[0]["visibility"], "list")
+
+    def test_direct_cache_internal_duplicate_terra_is_ignored_for_authority(self):
+        fixture_path = Path(__file__).parent / "fixtures" / "codex_0_144_2_direct_models_cache.json"
+        cache_payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+        cache_payload["models"].append(
+            {
+                "id": "codex-auto-review",
+                "model": "gpt-5.6-terra",
+                "slug": "gpt-5.6-terra",
+                "visibility": "list",
+            }
+        )
+        snapshot = catalog_sync.OfficialSeedSnapshot(
+            models=[
+                {**model, "visibility": "list"}
+                for model in cache_payload["models"]
+                if str(model.get("slug", "")).startswith("gpt-")
+            ],
+            source="current_direct_official",
+            context_freshness="fresh",
+        )
+        cache_timestamp = catalog_sync._catalog_fetched_at_timestamp(cache_payload["fetched_at"])
+        self.assertIsNotNone(cache_timestamp)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            cache_path = Path(tmp) / "models_cache.json"
+            cache_path.write_text(json.dumps(cache_payload), encoding="utf-8")
+            authority = catalog_sync.load_fresh_direct_official_cache_authority(
+                snapshot,
+                cache_path,
+                now_timestamp=cache_timestamp + 1,
+            )
+
+        self.assertEqual(authority.freshness, "fresh")
+        self.assertEqual(
+            sorted(authority.context_by_slug),
+            [
+                "gpt-5.3-codex-spark",
+                "gpt-5.4",
+                "gpt-5.4-mini",
+                "gpt-5.5",
+                "gpt-5.6-luna",
+                "gpt-5.6-sol",
+                "gpt-5.6-terra",
+            ],
+        )
+
     def test_build_catalog_keeps_only_official_and_allowed_cloud_models(self):
         official = [
             {"slug": "gpt-5.5", "display_name": "GPT-5.5", "visibility": "list"},


### PR DESCRIPTION
## Summary\n- enforce typed visibility across Official/native-cache and managed catalogs\n- keep codex-auto-review and unknown/hidden entries out of managed exports, including empty authoritative snapshots\n- keep catalog authoritative over metadata and preserve Direct Official ownership boundaries\n\nCloses #273\n\n## Verification\n- Python catalog targeted: 65 passed, 44 subtests passed\n- Frontend build + UI contract: 145 passed\n- Rust normal full: 523 passed, 0 failed, 1 ignored (89.97s)\n- Rust Clippy: passed with -D warnings\n- Rust debug full: 521 passed, 1 known baseline timing failure in proxy::tests::start_timeout_error_includes_captured_stdout_and_stderr; the same exact test fails on clean origin/dev baseline, while normal full passes\n- diff check and Spec/Standards review: passed\n