### PR TITLE
0.1.8 Beta2: enforce exact provider/model identity

### DIFF
--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -3130,6 +3130,7 @@ def choose_upstream(model_id: str) -> dict[str, Any]:
             "base_url": ollama_cloud_base_url(),
             "auth": "ollama_api_key",
             "reports_cached_input_tokens": False,
+            "upstream_model": slug,
         }
 
     raise _identity_failure(

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -98,6 +98,7 @@ from catalog import (
     CatalogPolicy,
     canonical_model_id,
     deny_match_model_id,
+    is_internal_model,
     load_catalog_models,
     load_policy,
     should_include_external_provider_model,
@@ -105,6 +106,7 @@ from catalog import (
 )
 from catalog_sync import (
     GENERATED_CATALOG_PATH,
+    LEGACY_GENERATED_CATALOG_PATH,
     POLICY_PATH,
     existing_generated_catalog_path,
     known_official_model_ids as catalog_known_official_model_ids,
@@ -1574,6 +1576,35 @@ class ImageProxyError(Exception):
     """Raised when a Vision Proxy request cannot be prepared safely."""
 
 
+class ModelIdentityResolutionError(ValueError):
+    """Raised when an exact provider/model pair cannot be proven safe.
+
+    ``classification`` is deliberately a small, non-secret vocabulary used by
+    diagnostics and callers.  ``catalog_inconsistency`` means the published
+    snapshot itself is contradictory or ambiguous; ``local_resolution_failure``
+    means the requested identity is absent, internal, stale, or unsupported.
+    """
+
+    CLASSIFICATIONS = frozenset({"catalog_inconsistency", "local_resolution_failure"})
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        classification: str,
+        reason: str,
+        provider_id: str | None = None,
+        model_slug: str | None = None,
+    ) -> None:
+        if classification not in self.CLASSIFICATIONS:
+            raise ValueError(f"unsupported model identity classification: {classification}")
+        self.classification = classification
+        self.reason = reason
+        self.provider_id = provider_id
+        self.model_slug = model_slug
+        super().__init__(message)
+
+
 class UnsupportedRouteProtocolError(ValueError):
     """Raised when a configured route has no executable protocol attempt."""
 
@@ -2405,25 +2436,257 @@ def ollama_cloud_base_url() -> str:
 
 
 def generated_catalog_slugs(path: Path = GENERATED_CATALOG_PATH) -> set[str]:
-    return {
-        canonical_model_id(str(model["slug"]))
-        for model in load_catalog_models(existing_generated_catalog_path(path))
-        if model.get("slug")
-    }
+    return set(generated_catalog_by_slug(path))
 
 
 def generated_catalog_by_slug(path: Path = GENERATED_CATALOG_PATH) -> dict[str, dict[str, Any]]:
+    resolved_path = existing_generated_catalog_path(path)
+    try:
+        if resolved_path.exists():
+            document = json.loads(resolved_path.read_text(encoding="utf-8-sig"))
+            if not isinstance(document, Mapping) or not isinstance(document.get("models"), list):
+                raise ValueError("catalog root must contain a models list")
+        catalog_models = load_catalog_models(resolved_path)
+    except (OSError, ValueError, TypeError, AttributeError) as exc:
+        raise ModelIdentityResolutionError(
+            "published catalog is malformed and cannot authorize routing",
+            classification="catalog_inconsistency",
+            reason="malformed_catalog",
+        ) from exc
     models: dict[str, dict[str, Any]] = {}
-    for model in load_catalog_models(existing_generated_catalog_path(path)):
-        slug = canonical_model_id(str(model.get("slug", "")))
-        if slug:
-            models[slug] = model
+    if not isinstance(catalog_models, list):
+        raise ModelIdentityResolutionError(
+            "published catalog models must be a list",
+            classification="catalog_inconsistency",
+            reason="malformed_catalog",
+        )
+    for model in catalog_models:
+        if not isinstance(model, Mapping):
+            raise ModelIdentityResolutionError(
+                "published catalog contains a non-object model row",
+                classification="catalog_inconsistency",
+                reason="malformed_model_row",
+            )
+        raw_slug_value = model.get("slug")
+        if not isinstance(raw_slug_value, str) or not raw_slug_value.strip():
+            raise ModelIdentityResolutionError(
+                "published catalog contains a model without a slug",
+                classification="catalog_inconsistency",
+                reason="missing_catalog_slug",
+            )
+        raw_slug = canonical_model_id(raw_slug_value)
+        slug = _catalog_identity_slug(raw_slug)
+        if slug in models:
+            raise ModelIdentityResolutionError(
+                "published catalog contains duplicate canonical model identity",
+                classification="catalog_inconsistency",
+                reason="duplicate_canonical_slug",
+                model_slug=slug,
+            )
+        models[slug] = dict(model)
     return models
+
+
+def _catalog_identity_slug(slug: str) -> str:
+    """Return the one route identity key used by the published catalog.
+
+    ``openai/gpt-*`` is a provider-qualified spelling of the same exact
+    Official model slug.  Every other provider namespace remains part of the
+    key; no display name, case-folded alias, or nearest match is introduced.
+    """
+
+    value = canonical_model_id(slug)
+    if value.startswith("openai/gpt-"):
+        return value.removeprefix("openai/")
+    return value
+
+
+def _published_catalog_model(slug: str) -> dict[str, Any] | None:
+    """Resolve one exact slug from the current generated catalog.
+
+    The legacy catalog filename is intentionally not an identity authority.
+    It may still be read by presentation-only compatibility code, but routing
+    refuses to bind a request to it when the current publication is absent.
+    """
+
+    resolved_path = existing_generated_catalog_path(GENERATED_CATALOG_PATH)
+    if resolved_path == LEGACY_GENERATED_CATALOG_PATH:
+        raise ModelIdentityResolutionError(
+            "current generated catalog is missing; legacy catalog cannot authorize routing",
+            classification="catalog_inconsistency",
+            reason="stale_legacy_catalog",
+        )
+    catalog = generated_catalog_by_slug(resolved_path)
+    identity_slug = _catalog_identity_slug(slug)
+    model = catalog.get(identity_slug)
+    if model is None and identity_slug.startswith("gpt-"):
+        # Compatibility with in-memory catalog fixtures that still expose the
+        # pre-#273 provider-qualified key.  On-disk catalogs are normalized by
+        # generated_catalog_by_slug before this branch can be reached.
+        model = catalog.get(f"openai/{identity_slug}")
+    return model
+
+
+def _identity_failure(
+    message: str,
+    *,
+    reason: str,
+    provider_id: str | None = None,
+    model_slug: str | None = None,
+) -> ModelIdentityResolutionError:
+    return ModelIdentityResolutionError(
+        message,
+        classification="local_resolution_failure",
+        reason=reason,
+        provider_id=provider_id,
+        model_slug=model_slug,
+    )
+
+
+def _catalog_failure(
+    message: str,
+    *,
+    reason: str,
+    provider_id: str | None = None,
+    model_slug: str | None = None,
+) -> ModelIdentityResolutionError:
+    return ModelIdentityResolutionError(
+        message,
+        classification="catalog_inconsistency",
+        reason=reason,
+        provider_id=provider_id,
+        model_slug=model_slug,
+    )
+
+
+def _safe_error_identity(value: Any) -> str | None:
+    """Keep credential-like or malformed identities out of error payloads."""
+
+    if not isinstance(value, str):
+        return None
+    candidate = value.strip()
+    if not candidate or len(candidate) > 128 or not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._:/-]*", candidate):
+        return None
+    lowered = candidate.lower()
+    if any(marker in lowered for marker in ("bearer", "secret", "token", "password", "api_key", "api-key", "authorization", "cookie")):
+        return None
+    return candidate
+
+
+def _validate_published_catalog_model_for_provider(
+    model: Mapping[str, Any],
+    *,
+    provider_id: str,
+    model_slug: str,
+    expected_upstream_model: str | None = None,
+) -> None:
+    """Reject catalog rows that are internal, unsupported, or cross-provider."""
+
+    if is_internal_model(model):
+        raise _identity_failure(
+            f"model identity is internal and cannot be routed: {model_slug}",
+            reason="internal_model",
+            provider_id=provider_id,
+            model_slug=model_slug,
+        )
+    if model.get("supported_in_api") is False:
+        raise _identity_failure(
+            f"model identity is not supported in the API: {model_slug}",
+            reason="unsupported_model",
+            provider_id=provider_id,
+            model_slug=model_slug,
+        )
+    raw_slug = model.get("slug")
+    if isinstance(raw_slug, str) and canonical_model_id(raw_slug) != canonical_model_id(model_slug):
+        raise _catalog_failure(
+            "published catalog row slug contradicts the requested model slug",
+            reason="configured_model_mismatch",
+            provider_id=provider_id,
+            model_slug=model_slug,
+        )
+    metadata = model.get("codex_proxy_metadata")
+    if isinstance(metadata, Mapping):
+        catalog_provider = canonical_model_id(str(metadata.get("provider") or ""))
+        allowed_providers = {provider_id, provider_id.replace("-", "_")}
+        if not catalog_provider or catalog_provider not in allowed_providers:
+            raise _catalog_failure(
+                f"model identity belongs to another provider: {model_slug}",
+                reason="provider_mismatch",
+                provider_id=provider_id,
+                model_slug=model_slug,
+            )
+        expected_upstream = canonical_model_id(expected_upstream_model or model_slug)
+        catalog_upstream = metadata.get("upstream_model")
+        if not isinstance(catalog_upstream, str) or canonical_model_id(catalog_upstream) != expected_upstream:
+            raise _catalog_failure(
+                "published catalog row upstream_model contradicts the requested model slug",
+                reason="upstream_model_mismatch",
+                provider_id=provider_id,
+                model_slug=model_slug,
+            )
+        catalog_upstream_name = canonical_model_id(str(metadata.get("upstream_name") or ""))
+        if catalog_upstream_name not in allowed_providers:
+            raise _catalog_failure(
+                "published catalog row upstream_name contradicts the provider identity",
+                reason="upstream_name_mismatch",
+                provider_id=provider_id,
+                model_slug=model_slug,
+            )
+
+
+def _provider_catalog_failure(
+    message: str,
+    *,
+    provider_id: str,
+    model_slug: str,
+) -> ModelIdentityResolutionError:
+    """Wrap provider-index parse/collision failures as stable catalog errors."""
+
+    return _catalog_failure(
+        message,
+        reason="provider_model_index_inconsistency",
+        provider_id=provider_id,
+        model_slug=model_slug,
+    )
+
+
+def _resolve_external_model_alias(slug: str) -> dict[str, Any] | None:
+    """Resolve one configured external model without leaking raw config errors."""
+
+    try:
+        return resolve_external_model_alias(slug)
+    except ModelIdentityResolutionError:
+        raise
+    except ValueError as exc:
+        raise _provider_catalog_failure(
+            "external provider model index is inconsistent",
+            provider_id=slug.partition("/")[0] or "external",
+            model_slug=slug,
+        ) from exc
+
+
+def _resolve_ollama_cloud_model(
+    model_id: str,
+    *,
+    require_api_key: bool,
+) -> tuple[bool, dict[str, Any] | None]:
+    """Resolve Ollama Cloud configuration with catalog-level diagnostics."""
+
+    try:
+        return resolve_ollama_cloud_model(model_id, require_api_key=require_api_key)
+    except ModelIdentityResolutionError:
+        raise
+    except ValueError as exc:
+        raise _provider_catalog_failure(
+            "Ollama Cloud model index is inconsistent",
+            provider_id="ollama-cloud",
+            model_slug=canonical_model_id(model_id),
+        ) from exc
 
 
 def catalog_max_output_tokens(model_id: str) -> int | None:
     slug = canonical_model_id(model_id)
-    model = generated_catalog_by_slug().get(slug)
+    model = generated_catalog_by_slug().get(_catalog_identity_slug(slug))
     if not model:
         cap = UPSTREAM_MAX_OUTPUT_TOKEN_CAPS.get(slug)
         return cap if isinstance(cap, int) and cap > 0 else None
@@ -2455,14 +2718,37 @@ def generated_official_catalog_upstream_model(slug: str, policy: Any) -> str | N
         return None
 
     alias = f"{OFFICIAL_ALIAS_PREFIX}{upstream_model}"
-    catalog = generated_catalog_by_slug()
-    model = catalog.get(upstream_model) or catalog.get(alias)
-    if not model or model.get("supported_in_api") is False:
+    model = _published_catalog_model(upstream_model)
+    if not model:
         return None
+    if is_internal_model(model):
+        raise _identity_failure(
+            f"model identity is internal and cannot be routed: {slug}",
+            reason="internal_model",
+            provider_id="openai",
+            model_slug=upstream_model,
+        )
+    if model.get("supported_in_api") is False:
+        raise _identity_failure(
+            f"model identity is not supported in the API: {slug}",
+            reason="unsupported_model",
+            provider_id="openai",
+            model_slug=upstream_model,
+        )
 
     metadata = model.get("codex_proxy_metadata")
     if not isinstance(metadata, dict):
-        return None
+        # The bundled policy is an authoritative identity for the legacy
+        # gpt-5.5 route.  All newly discovered Official rows must carry the
+        # generated metadata binding.
+        if upstream_model == "gpt-5.5" and should_include_model(upstream_model, policy):
+            return upstream_model
+        raise _catalog_failure(
+            "official catalog row is missing its upstream identity binding",
+            reason="missing_catalog_metadata",
+            provider_id="openai",
+            model_slug=upstream_model,
+        )
     catalog_upstream = canonical_model_id(str(metadata.get("upstream_model", "")))
     if (
         metadata.get("provider") != "openai"
@@ -2470,9 +2756,19 @@ def generated_official_catalog_upstream_model(slug: str, policy: Any) -> str | N
         or catalog_upstream != upstream_model
         or not catalog_upstream.startswith(official_prefixes())
     ):
-        return None
+        raise _catalog_failure(
+            "official catalog row has contradictory upstream identity metadata",
+            reason="upstream_model_mismatch",
+            provider_id="openai",
+            model_slug=upstream_model,
+        )
     if policy_denies_any_model((slug, alias, catalog_upstream), policy):
-        raise ValueError(f"model is not allowed: {slug}")
+        raise _identity_failure(
+            f"model is not allowed: {slug}",
+            reason="denied_model",
+            provider_id="openai",
+            model_slug=upstream_model,
+        )
     return catalog_upstream
 
 
@@ -2481,10 +2777,17 @@ def official_alias_upstream_model(slug: str, policy: Any) -> str | None:
         return None
     upstream_model = slug[len(OFFICIAL_ALIAS_PREFIX) :]
     if policy_denies_any_model((slug, upstream_model), policy):
-        raise ValueError(f"model is not allowed: {slug}")
-    if upstream_model.startswith(official_prefixes()) and should_include_model(upstream_model, policy):
-        return upstream_model
-    return None
+        raise _identity_failure(
+            f"model is not allowed: {slug}",
+            reason="denied_model",
+            provider_id="openai",
+            model_slug=upstream_model,
+        )
+    if not upstream_model.startswith(official_prefixes()):
+        return None
+    # Provider qualification is presentation-neutral only after the exact
+    # bare Official slug is proven by the current catalog.
+    return generated_official_catalog_upstream_model(slug, policy)
 
 
 def official_fast_variant_upstream_model(slug: str, policy: Any) -> str | None:
@@ -2494,10 +2797,18 @@ def official_fast_variant_upstream_model(slug: str, policy: Any) -> str | None:
         return None
     upstream_alias = f"{OFFICIAL_ALIAS_PREFIX}{upstream_model}"
     if policy_denies_any_model((slug, fast_model, upstream_model, upstream_alias), policy):
-        raise ValueError(f"model is not allowed: {slug}")
-    if upstream_model.startswith(official_prefixes()) and should_include_model(upstream_model, policy):
-        return upstream_model
-    return None
+        raise _identity_failure(
+            f"model is not allowed: {slug}",
+            reason="denied_model",
+            provider_id="openai",
+            model_slug=fast_model,
+        )
+    if not upstream_model.startswith(official_prefixes()):
+        return None
+    resolved = generated_official_catalog_upstream_model(upstream_model, policy)
+    if resolved is None:
+        return None
+    return resolved
 
 
 OLLAMA_CLOUD_ALIAS_PREFIX = "ollama-cloud/"
@@ -2532,21 +2843,59 @@ def provider_scoped_route_model(model_id: str | None, provider_hint: str | None)
 
 
 def ollama_cloud_runtime_upstream(model_id: str, policy: Any) -> dict[str, Any] | None:
-    configured, runtime_model = resolve_ollama_cloud_model(model_id, require_api_key=False)
+    configured, runtime_model = _resolve_ollama_cloud_model(
+        model_id,
+        require_api_key=False,
+    )
     if not configured:
         return None
     slug = canonical_model_id(model_id)
     if runtime_model is None:
-        raise ValueError(f"model is not allowed: {slug}")
+        raise _identity_failure(
+            f"model is not allowed: {slug}",
+            reason="unsupported_model",
+            provider_id="ollama-cloud",
+            model_slug=slug,
+        )
 
     policy_alias = runtime_model.get("alias", f"{OLLAMA_CLOUD_ALIAS_PREFIX}{slug}")
-    upstream_model = runtime_model.get("upstream_model", slug)
+    upstream_model = runtime_model.get("upstream_model")
+    if not isinstance(upstream_model, str) or not upstream_model.strip():
+        raise _catalog_failure(
+            "Ollama Cloud configuration is missing upstream_model",
+            reason="missing_upstream_model",
+            provider_id="ollama-cloud",
+            model_slug=slug,
+        )
+    upstream_model = upstream_model.strip()
+    configured_id = canonical_model_id(str(runtime_model.get("model_id") or slug))
+    if configured_id != slug and configured_id != f"{OLLAMA_CLOUD_ALIAS_PREFIX}{slug}":
+        raise _catalog_failure(
+            "Ollama Cloud configuration model identity does not match the request",
+            reason="configured_model_mismatch",
+            provider_id="ollama-cloud",
+            model_slug=slug,
+        )
+    if is_internal_model(runtime_model):
+        raise _identity_failure(
+            f"model identity is internal and cannot be routed: {slug}",
+            reason="internal_model",
+            provider_id="ollama-cloud",
+            model_slug=slug,
+        )
     if policy_denies_any_model((slug, policy_alias, upstream_model), policy):
-        raise ValueError(f"model is not allowed: {slug}")
+        raise _identity_failure(
+            f"model is not allowed: {slug}",
+            reason="denied_model",
+            provider_id="ollama-cloud",
+            model_slug=slug,
+        )
 
     api_key = runtime_model.get("api_key")
     upstream: dict[str, Any] = {
         "name": "ollama_cloud",
+        "provider_id": "ollama-cloud",
+        "model_id": slug,
         "base_url": runtime_model.get("base_url") or ollama_cloud_base_url(),
         "auth": "api_key" if api_key else "ollama_api_key",
         "upstream_model": upstream_model,
@@ -2572,18 +2921,42 @@ def ollama_cloud_alias_upstream_model(slug: str, policy: Any) -> dict[str, Any] 
     if not upstream_model:
         return None
     if policy_denies_any_model((slug, upstream_model), policy):
-        raise ValueError(f"model is not allowed: {slug}")
+        raise _identity_failure(
+            f"model is not allowed: {slug}",
+            reason="denied_model",
+            provider_id="ollama-cloud",
+            model_slug=slug,
+        )
 
     runtime_upstream = ollama_cloud_runtime_upstream(slug, policy)
     if runtime_upstream is not None:
         return runtime_upstream
 
     if not (should_include_model(slug, policy) or should_include_model(upstream_model, policy)):
-        raise ValueError(f"model is not allowed: {slug}")
-    if upstream_model not in generated_catalog_slugs():
-        raise ValueError(f"model is not in the generated cloud catalog: {upstream_model}")
+        raise _identity_failure(
+            f"model is not allowed: {slug}",
+            reason="unsupported_model",
+            provider_id="ollama-cloud",
+            model_slug=slug,
+        )
+    model = _published_catalog_model(slug)
+    if model is None:
+        raise _identity_failure(
+            f"model is not in the generated cloud catalog: {upstream_model}",
+            reason="missing_catalog_model",
+            provider_id="ollama-cloud",
+            model_slug=slug,
+        )
+    _validate_published_catalog_model_for_provider(
+        model,
+        provider_id="ollama-cloud",
+        model_slug=slug,
+        expected_upstream_model=upstream_model,
+    )
     return {
         "name": "ollama_cloud",
+        "provider_id": "ollama-cloud",
+        "model_id": slug,
         "base_url": ollama_cloud_base_url(),
         "auth": "ollama_api_key",
         "upstream_model": upstream_model,
@@ -2615,6 +2988,8 @@ def choose_upstream(model_id: str) -> dict[str, Any]:
     if official_fast_variant is not None:
         return {
             "name": "official",
+            "provider_id": "openai",
+            "model_id": slug,
             "base_url": official_base_url(),
             "auth": "codex_auth",
             "upstream_model": official_fast_variant,
@@ -2626,6 +3001,8 @@ def choose_upstream(model_id: str) -> dict[str, Any]:
     if official_alias is not None:
         return {
             "name": "official",
+            "provider_id": "openai",
+            "model_id": slug,
             "base_url": official_base_url(),
             "auth": "codex_auth",
             "upstream_model": official_alias,
@@ -2636,6 +3013,8 @@ def choose_upstream(model_id: str) -> dict[str, Any]:
     if discovered_official is not None:
         return {
             "name": "official",
+            "provider_id": "openai",
+            "model_id": slug,
             "base_url": official_base_url(),
             "auth": "codex_auth",
             "upstream_model": discovered_official,
@@ -2647,24 +3026,58 @@ def choose_upstream(model_id: str) -> dict[str, Any]:
         return ollama_alias
 
     if slug.startswith(official_prefixes()):
-        if not should_include_model(slug, policy):
-            raise ValueError(f"model is not allowed: {slug}")
-        return {
-            "name": "official",
-            "base_url": official_base_url(),
-            "auth": "codex_auth",
-            "reports_cached_input_tokens": True,
-        }
+        raise _identity_failure(
+            f"model is not in the generated Official catalog: {slug}",
+            reason="missing_catalog_model",
+            provider_id="openai",
+            model_slug=slug,
+        )
 
-    external_model = resolve_external_model_alias(slug)
+    external_model = _resolve_external_model_alias(slug)
     if external_model is not None:
         policy_alias = external_model.get("alias", slug)
         if policy_denies_any_model((slug, policy_alias, external_model.get("matched_alias")), policy):
-            raise ValueError(f"model is not allowed: {slug}")
+            raise _identity_failure(
+                f"model is not allowed: {slug}",
+                reason="denied_model",
+                provider_id=str(external_model.get("provider_alias") or "") or None,
+                model_slug=slug,
+            )
         if not should_include_external_provider_model(policy_alias, policy):
-            raise ValueError(f"model is not allowed: {slug}")
+            raise _identity_failure(
+                f"model is not allowed: {slug}",
+                reason="unsupported_model",
+                provider_id=str(external_model.get("provider_alias") or "") or None,
+                model_slug=slug,
+            )
+        provider_id = canonical_model_id(str(external_model.get("provider_alias") or ""))
+        configured_model = canonical_model_id(str(external_model.get("alias") or ""))
+        upstream_model_value = external_model.get("upstream_model")
+        if not provider_id or not configured_model or not isinstance(upstream_model_value, str) or not upstream_model_value.strip():
+            raise _catalog_failure(
+                "external provider configuration is missing exact model identity",
+                reason="missing_upstream_model",
+                provider_id=provider_id or None,
+                model_slug=slug,
+            )
+        if configured_model != slug:
+            raise _identity_failure(
+                "model aliases are presentation-only and cannot authorize routing",
+                reason="model_alias_not_routable",
+                provider_id=provider_id,
+                model_slug=slug,
+            )
+        if canonical_model_id(upstream_model_value).lower() == "codex-auto-review":
+            raise _identity_failure(
+                f"model identity is internal and cannot be routed: {slug}",
+                reason="internal_model",
+                provider_id=provider_id,
+                model_slug=slug,
+            )
         return {
             "name": external_model["upstream_name"],
+            "provider_id": provider_id,
+            "model_id": slug,
             "base_url": external_model["base_url"],
             "auth": "api_key",
             "api_key": external_model["api_key"],
@@ -2683,29 +3096,54 @@ def choose_upstream(model_id: str) -> dict[str, Any]:
         }
 
     if "/" in slug:
-        raise ValueError(f"external provider model is not configured: {slug}")
+        raise _identity_failure(
+            f"external provider model is not configured: {slug}",
+            reason="unsupported_model",
+            provider_id=slug.partition("/")[0],
+            model_slug=slug,
+        )
 
     runtime_ollama = ollama_cloud_runtime_upstream(slug, policy)
     if runtime_ollama is not None:
         return runtime_ollama
 
     if not should_include_model(slug, policy):
-        raise ValueError(f"model is not allowed: {slug}")
+        raise _identity_failure(
+            f"model is not allowed: {slug}",
+            reason="unsupported_model",
+            provider_id="ollama-cloud",
+            model_slug=slug,
+        )
 
-    if slug in generated_catalog_slugs():
+    model = _published_catalog_model(slug)
+    if model is not None:
+        _validate_published_catalog_model_for_provider(
+            model,
+            provider_id="ollama-cloud",
+            model_slug=slug,
+            expected_upstream_model=slug,
+        )
         return {
             "name": "ollama_cloud",
+            "provider_id": "ollama-cloud",
+            "model_id": slug,
             "base_url": ollama_cloud_base_url(),
             "auth": "ollama_api_key",
             "reports_cached_input_tokens": False,
         }
 
-    raise ValueError(f"model is not in the generated cloud catalog: {slug}")
+    raise _identity_failure(
+        f"model is not in the generated cloud catalog: {slug}",
+        reason="missing_catalog_model",
+        provider_id="ollama-cloud",
+        model_slug=slug,
+    )
 
 
 def official_upstream() -> dict[str, Any]:
     return {
         "name": "official",
+        "provider_id": "openai",
         "base_url": official_base_url(),
         "auth": "codex_auth",
         "reports_cached_input_tokens": True,
@@ -2752,7 +3190,9 @@ def _reasoning_policy_for_request(
         return "explicit"
     levels = upstream.get("supported_reasoning_levels")
     if not levels and model:
-        candidate = generated_catalog_by_slug().get(canonical_model_id(model))
+        candidate = generated_catalog_by_slug().get(
+            _catalog_identity_slug(canonical_model_id(model))
+        )
         if isinstance(candidate, Mapping):
             levels = candidate.get("supported_reasoning_levels")
     if levels:
@@ -11777,6 +12217,75 @@ def _route_protocol(value: Any) -> RouteProtocol:
         return RouteProtocol.UNKNOWN
 
 
+def _route_provider_id(upstream: Mapping[str, Any], requested_provider: str | None = None) -> str:
+    """Return the stable exported provider ID, never the transport name."""
+
+    configured = upstream.get("provider_id") or upstream.get("provider_alias")
+    if isinstance(configured, str) and configured.strip():
+        return canonical_model_id(configured.strip())
+    if requested_provider:
+        return canonical_model_id(requested_provider)
+    return {
+        "official": "openai",
+        "ollama_cloud": "ollama-cloud",
+        "ollama-cloud": "ollama-cloud",
+        "volcengine": "volc",
+        "minimax_cn": "minimax-cn",
+    }.get(str(upstream.get("name") or ""), canonical_model_id(str(upstream.get("name") or "")))
+
+
+def _validate_route_identity(
+    upstream: Mapping[str, Any],
+    *,
+    requested_provider: str,
+    requested_model: str,
+    requested_model_id: str,
+) -> tuple[str, str]:
+    """Validate that route metadata binds exactly to the requested pair."""
+
+    provider_id = _route_provider_id(upstream, requested_provider or None)
+    if requested_provider and provider_id != _route_provider_id({"provider_id": requested_provider}, requested_provider):
+        raise _identity_failure(
+            "resolved upstream provider does not match the requested provider",
+            reason="provider_mismatch",
+            provider_id=requested_provider,
+            model_slug=requested_model_id,
+        )
+    upstream_model_value = upstream.get("upstream_model")
+    if not isinstance(upstream_model_value, str) or not upstream_model_value.strip():
+        raise _identity_failure(
+            "resolved upstream is missing an exact upstream_model binding",
+            reason="missing_upstream_model",
+            provider_id=provider_id or requested_provider or None,
+            model_slug=requested_model_id,
+        )
+    upstream_model = canonical_model_id(upstream_model_value.strip())
+    if not upstream_model:
+        raise _identity_failure(
+            "resolved upstream has an empty upstream_model binding",
+            reason="missing_upstream_model",
+            provider_id=provider_id or requested_provider or None,
+            model_slug=requested_model_id,
+        )
+    if upstream.get("model_id") is not None:
+        configured_model_id = canonical_model_id(str(upstream.get("model_id")))
+        if configured_model_id != requested_model_id:
+            raise _catalog_failure(
+                "resolved upstream model_id contradicts the requested model slug",
+                reason="configured_model_mismatch",
+                provider_id=provider_id,
+                model_slug=requested_model_id,
+            )
+    elif upstream_model != canonical_model_id(requested_model if requested_provider else requested_model_id):
+        raise _catalog_failure(
+            "resolved upstream upstream_model contradicts the requested model slug",
+            reason="configured_model_mismatch",
+            provider_id=provider_id,
+            model_slug=requested_model_id,
+        )
+    return provider_id, upstream_model
+
+
 def _authentication_strategy(value: Any) -> AuthenticationStrategy:
     try:
         return AuthenticationStrategy(str(value))
@@ -12236,17 +12745,21 @@ def route_plan_for_request(
     requested_provider, separator, requested_model = (
         requested_model_id.partition("/")
     )
-    binding_provider_id = str(
-        upstream.get("provider_id")
-        or upstream.get("provider_alias")
-        or (
-            requested_provider
-            if separator and upstream_name != "official"
-            else upstream_name
+    resolved_provider_id = _route_provider_id(upstream, requested_provider if separator else None)
+    resolved_upstream_model: str | None = None
+    if requested_model_id:
+        resolved_provider_id, resolved_upstream_model = _validate_route_identity(
+            upstream,
+            requested_provider=requested_provider if separator else resolved_provider_id,
+            requested_model=requested_model if separator else requested_model_id,
+            requested_model_id=requested_model_id,
         )
+    binding_provider_id = str(
+        resolved_provider_id
     )
     binding_model_id = str(
         (requested_model if separator else requested_model_id)
+        or resolved_upstream_model
         or upstream.get("upstream_model")
         or ""
     )
@@ -12577,12 +13090,7 @@ def route_plan_for_request(
         if canonical_route_model or model_requested
         else None
     )
-    upstream_model_value = upstream.get("upstream_model")
-    upstream_model = (
-        canonical_model_id(str(upstream_model_value))
-        if upstream_model_value
-        else canonical_model
-    )
+    upstream_model = resolved_upstream_model
     (
         manifest_version,
         manifest_hash,
@@ -12592,7 +13100,7 @@ def route_plan_for_request(
     )
     return RoutePlan(
         schema_version=ROUTE_PLAN_SCHEMA_VERSION,
-        provider_id=upstream_name,
+        provider_id=resolved_provider_id,
         model_requested=model_requested,
         canonical_model=canonical_model,
         upstream_model=upstream_model,
@@ -13495,7 +14003,7 @@ def _catalog_input_modalities(model_id: str | None, upstream: Mapping[str, Any] 
 
     catalog = generated_catalog_by_slug()
     for candidate in dict.fromkeys(candidates):
-        model = catalog.get(candidate)
+        model = catalog.get(_catalog_identity_slug(candidate))
         if isinstance(model, Mapping) and "input_modalities" in model:
             return model.get("input_modalities")
     return None
@@ -14595,6 +15103,12 @@ def _typed_error_code(
     exc: BaseException | None,
     status: int | None,
 ) -> str:
+    if isinstance(exc, ModelIdentityResolutionError):
+        return (
+            "catalog.inconsistency"
+            if exc.classification == "catalog_inconsistency"
+            else "gateway.model_resolution"
+        )
     if error_type == "gateway_auth_error":
         return "gateway.auth"
     if error_type == "gateway_pre_response_budget_exhausted":
@@ -14647,6 +15161,15 @@ def _codexhub_error_payload(
         "error": error_code,
         "type": error_type,
     }
+    if isinstance(exc, ModelIdentityResolutionError):
+        details["classification"] = exc.classification
+        details["reason"] = exc.reason
+        safe_provider_id = _safe_error_identity(exc.provider_id)
+        safe_model_slug = _safe_error_identity(exc.model_slug)
+        if safe_provider_id:
+            details["provider_id"] = safe_provider_id
+        if safe_model_slug:
+            details["model_slug"] = safe_model_slug
     if status is not None:
         details["status"] = status
     if resolved_failure_class is not None:
@@ -17296,6 +17819,57 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 detail=detail,
                 redact_identity=identity,
                 error_type=error_code,
+            )
+        except ModelIdentityResolutionError as exc:
+            if admission.cancelled:
+                send_user_requested_shutdown()
+                return
+            error_code = "model_identity_error"
+            identity = _retry_identity_from_context(adapter_event_context)
+            detail = safe_upstream_error_detail(exc, redact_identity=identity)
+            detail = _redact_identity_in_text(detail, exc.model_slug)
+            write_proxy_event(
+                "request_error",
+                request_id=request_id,
+                model=canonical_model_id(model) if model else None,
+                model_requested=model_requested,
+                upstream=upstream_name or "gateway",
+                provider_hint=provider_hint,
+                upstream_format=upstream_format,
+                behavior_profile=behavior_profile,
+                inbound_format=inbound_format,
+                status=400,
+                error=error_code,
+                detail=detail,
+                identity_classification=exc.classification,
+                identity_reason=exc.reason,
+                duration_ms=int((time.monotonic() - started_at) * 1000),
+                **proxy_request_context,
+            )
+            if downstream_sse_started:
+                if not self._write_downstream_sse_error(
+                    inbound_format=inbound_format,
+                    upstream_name=upstream_name or "gateway",
+                    status=400,
+                    exc=exc,
+                    error=error_code,
+                    detail=detail,
+                    error_type=error_code,
+                    redact_identity=identity,
+                    preserve_explicit_error=True,
+                ):
+                    finish_downstream_write_failure()
+                return
+            self._safe_send_downstream_json_error(
+                400,
+                inbound_format=inbound_format,
+                upstream_name=upstream_name or "gateway",
+                request_id=request_id,
+                exc=exc,
+                error=error_code,
+                detail=detail,
+                error_type=error_code,
+                redact_identity=identity,
             )
         except ImageProxyError as exc:
             if admission.cancelled:

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -95,12 +95,14 @@ from codex_semantic_adapter import (
 )
 
 from catalog import (
+    CatalogVisibility,
     CatalogPolicy,
     canonical_model_id,
     deny_match_model_id,
     is_internal_model,
     load_catalog_models,
     load_policy,
+    model_visibility,
     should_include_external_provider_model,
     should_include_model,
 )
@@ -2559,6 +2561,38 @@ def _catalog_failure(
     )
 
 
+def _is_internal_route_identity(value: Any) -> bool:
+    """Return whether any route/config identity reserves the internal reviewer slug."""
+
+    values: list[Any]
+    if isinstance(value, Mapping):
+        if is_internal_model(value):
+            return True
+        values = [
+            value.get(key)
+            for key in (
+                "id",
+                "slug",
+                "model",
+                "name",
+                "alias",
+                "matched_alias",
+                "model_id",
+                "upstream_model",
+            )
+        ]
+    else:
+        values = [value]
+
+    for raw_value in values:
+        if not isinstance(raw_value, str):
+            continue
+        identity = canonical_model_id(raw_value).strip().lower()
+        if identity and any(part.strip() == "codex-auto-review" for part in identity.split("/")):
+            return True
+    return False
+
+
 def _safe_error_identity(value: Any) -> str | None:
     """Keep credential-like or malformed identities out of error payloads."""
 
@@ -2582,10 +2616,18 @@ def _validate_published_catalog_model_for_provider(
 ) -> None:
     """Reject catalog rows that are internal, unsupported, or cross-provider."""
 
-    if is_internal_model(model):
+    if _is_internal_route_identity(model):
         raise _identity_failure(
             f"model identity is internal and cannot be routed: {model_slug}",
             reason="internal_model",
+            provider_id=provider_id,
+            model_slug=model_slug,
+        )
+    visibility = model_visibility(model, missing_is_list=True)
+    if visibility is not CatalogVisibility.LIST:
+        raise _catalog_failure(
+            "published catalog model is not explicitly listable",
+            reason="unsupported_visibility",
             provider_id=provider_id,
             model_slug=model_slug,
         )
@@ -2605,6 +2647,13 @@ def _validate_published_catalog_model_for_provider(
             model_slug=model_slug,
         )
     metadata = model.get("codex_proxy_metadata")
+    if "codex_proxy_metadata" in model and not isinstance(metadata, Mapping):
+        raise _catalog_failure(
+            "published catalog model metadata is malformed",
+            reason="malformed_metadata",
+            provider_id=provider_id,
+            model_slug=model_slug,
+        )
     if isinstance(metadata, Mapping):
         catalog_provider = canonical_model_id(str(metadata.get("provider") or ""))
         allowed_providers = {provider_id, provider_id.replace("-", "_")}
@@ -2721,7 +2770,7 @@ def generated_official_catalog_upstream_model(slug: str, policy: Any) -> str | N
     model = _published_catalog_model(upstream_model)
     if not model:
         return None
-    if is_internal_model(model):
+    if _is_internal_route_identity(model):
         raise _identity_failure(
             f"model identity is internal and cannot be routed: {slug}",
             reason="internal_model",
@@ -2857,6 +2906,20 @@ def ollama_cloud_runtime_upstream(model_id: str, policy: Any) -> dict[str, Any] 
             provider_id="ollama-cloud",
             model_slug=slug,
         )
+    if _is_internal_route_identity(slug) or _is_internal_route_identity(runtime_model):
+        raise _identity_failure(
+            f"model identity is internal and cannot be routed: {slug}",
+            reason="internal_model",
+            provider_id="ollama-cloud",
+            model_slug=slug,
+        )
+    if runtime_model.get("matched_alias"):
+        raise _identity_failure(
+            "model aliases are presentation-only and cannot authorize routing",
+            reason="model_alias_not_routable",
+            provider_id="ollama-cloud",
+            model_slug=slug,
+        )
 
     policy_alias = runtime_model.get("alias", f"{OLLAMA_CLOUD_ALIAS_PREFIX}{slug}")
     upstream_model = runtime_model.get("upstream_model")
@@ -2873,13 +2936,6 @@ def ollama_cloud_runtime_upstream(model_id: str, policy: Any) -> dict[str, Any] 
         raise _catalog_failure(
             "Ollama Cloud configuration model identity does not match the request",
             reason="configured_model_mismatch",
-            provider_id="ollama-cloud",
-            model_slug=slug,
-        )
-    if is_internal_model(runtime_model):
-        raise _identity_failure(
-            f"model identity is internal and cannot be routed: {slug}",
-            reason="internal_model",
             provider_id="ollama-cloud",
             model_slug=slug,
         )
@@ -3035,6 +3091,13 @@ def choose_upstream(model_id: str) -> dict[str, Any]:
 
     external_model = _resolve_external_model_alias(slug)
     if external_model is not None:
+        if _is_internal_route_identity(slug) or _is_internal_route_identity(external_model):
+            raise _identity_failure(
+                f"model identity is internal and cannot be routed: {slug}",
+                reason="internal_model",
+                provider_id=str(external_model.get("provider_alias") or "") or None,
+                model_slug=slug,
+            )
         policy_alias = external_model.get("alias", slug)
         if policy_denies_any_model((slug, policy_alias, external_model.get("matched_alias")), policy):
             raise _identity_failure(

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -2631,6 +2631,13 @@ def _validate_published_catalog_model_for_provider(
             provider_id=provider_id,
             model_slug=model_slug,
         )
+    if "supported_in_api" in model and not isinstance(model["supported_in_api"], bool):
+        raise _catalog_failure(
+            "published catalog model supported_in_api is malformed",
+            reason="malformed_supported_in_api",
+            provider_id=provider_id,
+            model_slug=model_slug,
+        )
     if model.get("supported_in_api") is False:
         raise _identity_failure(
             f"model identity is not supported in the API: {model_slug}",
@@ -2781,6 +2788,13 @@ def generated_official_catalog_upstream_model(slug: str, policy: Any) -> str | N
         raise _catalog_failure(
             "published catalog model is not explicitly listable",
             reason="unsupported_visibility",
+            provider_id="openai",
+            model_slug=upstream_model,
+        )
+    if "supported_in_api" in model and not isinstance(model["supported_in_api"], bool):
+        raise _catalog_failure(
+            "official catalog model supported_in_api is malformed",
+            reason="malformed_supported_in_api",
             provider_id="openai",
             model_slug=upstream_model,
         )

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -2793,7 +2793,14 @@ def generated_official_catalog_upstream_model(slug: str, policy: Any) -> str | N
         )
 
     metadata = model.get("codex_proxy_metadata")
-    if not isinstance(metadata, dict):
+    if "codex_proxy_metadata" in model and not isinstance(metadata, Mapping):
+        raise _catalog_failure(
+            "official catalog model metadata is malformed",
+            reason="malformed_metadata",
+            provider_id="openai",
+            model_slug=upstream_model,
+        )
+    if not isinstance(metadata, Mapping):
         # The bundled policy is an authoritative identity for the legacy
         # gpt-5.5 route.  All newly discovered Official rows must carry the
         # generated metadata binding.

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -2777,6 +2777,13 @@ def generated_official_catalog_upstream_model(slug: str, policy: Any) -> str | N
             provider_id="openai",
             model_slug=upstream_model,
         )
+    if model_visibility(model, missing_is_list=True) is not CatalogVisibility.LIST:
+        raise _catalog_failure(
+            "published catalog model is not explicitly listable",
+            reason="unsupported_visibility",
+            provider_id="openai",
+            model_slug=upstream_model,
+        )
     if model.get("supported_in_api") is False:
         raise _identity_failure(
             f"model identity is not supported in the API: {slug}",

--- a/src-python/providers_config.py
+++ b/src-python/providers_config.py
@@ -245,16 +245,16 @@ def build_external_model_index(
                 "max_output_source": "providers_toml",
                 "priority_base": _provider_priority_base(provider),
             }
-            result[alias] = entry
+            _insert_provider_model_identity(result, alias, entry)
             for model_alias in model.aliases:
                 alias_id = canonical_model_id(model_alias)
                 if not alias_id:
                     continue
                 qualified_alias = alias_id if "/" in alias_id else canonical_model_id(f"{provider_id}/{alias_id}")
-                if qualified_alias and qualified_alias not in result:
+                if qualified_alias:
                     alias_entry = dict(entry)
                     alias_entry["matched_alias"] = qualified_alias
-                    result[qualified_alias] = alias_entry
+                    _insert_provider_model_identity(result, qualified_alias, alias_entry)
     return result
 
 
@@ -325,15 +325,33 @@ def build_ollama_cloud_model_index(
                 "max_output_source": "providers_toml",
                 "priority_base": _provider_priority_base(provider),
             }
-            result[model_id] = entry
-            result[qualified_alias] = entry
+            _insert_provider_model_identity(result, model_id, entry)
+            _insert_provider_model_identity(result, qualified_alias, entry)
             for model_alias in model.aliases:
                 alias_id = canonical_model_id(model_alias)
                 if not alias_id:
                     continue
-                result.setdefault(alias_id, entry)
-                result.setdefault(canonical_model_id(f"{provider_id}/{alias_id}"), entry)
+                _insert_provider_model_identity(result, alias_id, entry)
+                _insert_provider_model_identity(
+                    result,
+                    canonical_model_id(f"{provider_id}/{alias_id}"),
+                    entry,
+                )
     return configured, result
+
+
+def _insert_provider_model_identity(
+    index: dict[str, dict[str, Any]],
+    identity: str,
+    entry: dict[str, Any],
+) -> None:
+    """Insert one exported model identity without silently overwriting it."""
+
+    if not identity:
+        return
+    if identity in index:
+        raise ValueError(f"duplicate provider model identity: {identity}")
+    index[identity] = entry
 
 
 def catalog_visible_ollama_cloud_models(

--- a/src-python/providers_config.py
+++ b/src-python/providers_config.py
@@ -331,12 +331,13 @@ def build_ollama_cloud_model_index(
                 alias_id = canonical_model_id(model_alias)
                 if not alias_id:
                     continue
-                _insert_provider_model_identity(result, alias_id, entry)
-                _insert_provider_model_identity(
-                    result,
-                    canonical_model_id(f"{provider_id}/{alias_id}"),
-                    entry,
-                )
+                alias_entry = dict(entry)
+                alias_entry["matched_alias"] = alias_id
+                _insert_provider_model_identity(result, alias_id, alias_entry)
+                qualified_alias = canonical_model_id(f"{provider_id}/{alias_id}")
+                qualified_alias_entry = dict(entry)
+                qualified_alias_entry["matched_alias"] = qualified_alias
+                _insert_provider_model_identity(result, qualified_alias, qualified_alias_entry)
     return configured, result
 
 

--- a/tests/test_chat_completions_gateway.py
+++ b/tests/test_chat_completions_gateway.py
@@ -29,6 +29,11 @@ from codex_proxy import (
 )
 
 
+def _exact_external_model_resolver(*models):
+    by_alias = {model["alias"]: model for model in models}
+    return lambda model_id: by_alias.get(model_id)
+
+
 class UpstreamUrlTests(unittest.TestCase):
     def test_upstream_urls_accept_complete_responses_endpoint(self):
         upstream = {"base_url": "https://example.test/v1/responses"}
@@ -1907,6 +1912,23 @@ class ChatCompletionsEndpointTests(unittest.TestCase):
             "context_source": "providers_toml",
             "max_output_source": "providers_toml",
         }
+        vision_model = {
+            "alias": "vision-chat/m3",
+            "provider_alias": "vision-chat",
+            "upstream_name": "vision_chat",
+            "display_prefix": "VisionChat",
+            "base_url": "https://vision.example.test/v1",
+            "api_key": "vision-test-token",
+            "upstream_model": "m3",
+            "upstream_format": "chat_completions",
+            "priority_base": 300,
+            "context_window": 1000000,
+            "max_output_tokens": 8192,
+            "input_modalities": ("text", "image"),
+            "context_source": "providers_toml",
+            "max_output_source": "providers_toml",
+        }
+        resolve_external_model = _exact_external_model_resolver(external_model, vision_model)
         image_url = "data:image/png;base64,e2NoYXJ0fQ=="
         body = json.dumps({
             "model": "glm-5.2",
@@ -1959,7 +1981,7 @@ class ChatCompletionsEndpointTests(unittest.TestCase):
                     allowed_provider_models=policy.allowed_provider_models + ("volc/glm-5.2", "vision-chat/m3"),
                 ),
             ),
-            patch("codex_proxy.resolve_external_model_alias", return_value=external_model),
+            patch("codex_proxy.resolve_external_model_alias", side_effect=resolve_external_model),
             patch("codex_proxy._image_proxy_description_for_part", return_value="A chart with rising revenue."),
             patch("codex_proxy.urlopen", return_value=_FakeJsonResponse(upstream_body)) as mock_urlopen,
         ):
@@ -2096,6 +2118,23 @@ class ChatCompletionsEndpointTests(unittest.TestCase):
             "context_source": "providers_toml",
             "max_output_source": "providers_toml",
         }
+        vision_model = {
+            "alias": "vision-chat/m3",
+            "provider_alias": "vision-chat",
+            "upstream_name": "vision_chat",
+            "display_prefix": "VisionChat",
+            "base_url": "https://vision.example.test/v1",
+            "api_key": "vision-test-token",
+            "upstream_model": "m3",
+            "upstream_format": "chat_completions",
+            "priority_base": 300,
+            "context_window": 1000000,
+            "max_output_tokens": 8192,
+            "input_modalities": ("text", "image"),
+            "context_source": "providers_toml",
+            "max_output_source": "providers_toml",
+        }
+        resolve_external_model = _exact_external_model_resolver(external_model, vision_model)
         image_url = "data:image/png;base64,e2NoYXJ0fQ=="
         body = json.dumps({
             "model": "glm-5.2",
@@ -2148,7 +2187,7 @@ class ChatCompletionsEndpointTests(unittest.TestCase):
                     allowed_provider_models=policy.allowed_provider_models + ("volc/glm-5.2", "vision-chat/m3"),
                 ),
             ),
-            patch("codex_proxy.resolve_external_model_alias", return_value=external_model),
+            patch("codex_proxy.resolve_external_model_alias", side_effect=resolve_external_model),
             patch("codex_proxy._image_proxy_description_for_part", return_value="A boundary-guard chart description."),
             patch("codex_proxy.urlopen", return_value=_FakeJsonResponse(upstream_body)) as mock_urlopen,
         ):
@@ -2271,6 +2310,23 @@ class ChatCompletionsEndpointTests(unittest.TestCase):
             "context_source": "providers_toml",
             "max_output_source": "providers_toml",
         }
+        vision_model = {
+            "alias": "vision-chat/m3",
+            "provider_alias": "vision-chat",
+            "upstream_name": "vision_chat",
+            "display_prefix": "VisionChat",
+            "base_url": "https://vision.example.test/v1",
+            "api_key": "vision-test-token",
+            "upstream_model": "m3",
+            "upstream_format": "chat_completions",
+            "priority_base": 300,
+            "context_window": 1000000,
+            "max_output_tokens": 8192,
+            "input_modalities": ("text", "image"),
+            "context_source": "providers_toml",
+            "max_output_source": "providers_toml",
+        }
+        resolve_external_model = _exact_external_model_resolver(external_model, vision_model)
         body = json.dumps({
             "model": "glm-5.2",
             "messages": [{
@@ -2313,7 +2369,7 @@ class ChatCompletionsEndpointTests(unittest.TestCase):
                     allowed_provider_models=policy.allowed_provider_models + ("volc/glm-5.2", "vision-chat/m3"),
                 ),
             ),
-            patch("codex_proxy.resolve_external_model_alias", return_value=external_model),
+            patch("codex_proxy.resolve_external_model_alias", side_effect=resolve_external_model),
             patch("codex_proxy._image_proxy_cache_lookup", return_value=None),
             patch("codex_proxy._image_proxy_description_for_part", side_effect=codex_proxy.ImageProxyError("vision down")),
             patch("codex_proxy.urlopen") as mock_urlopen,
@@ -2345,6 +2401,23 @@ class ChatCompletionsEndpointTests(unittest.TestCase):
             "context_source": "providers_toml",
             "max_output_source": "providers_toml",
         }
+        vision_model = {
+            "alias": "vision-chat/m3",
+            "provider_alias": "vision-chat",
+            "upstream_name": "vision_chat",
+            "display_prefix": "VisionChat",
+            "base_url": "https://vision.example.test/v1",
+            "api_key": "vision-test-token",
+            "upstream_model": "m3",
+            "upstream_format": "chat_completions",
+            "priority_base": 300,
+            "context_window": 1000000,
+            "max_output_tokens": 8192,
+            "input_modalities": ("text", "image"),
+            "context_source": "providers_toml",
+            "max_output_source": "providers_toml",
+        }
+        resolve_external_model = _exact_external_model_resolver(external_model, vision_model)
         image_url = "data:image/png;base64,e2NoYXJ0fQ=="
         body = json.dumps({
             "model": "glm-5.2",
@@ -2399,7 +2472,7 @@ class ChatCompletionsEndpointTests(unittest.TestCase):
                     allowed_provider_models=policy.allowed_provider_models + ("responses-only/glm-5.2", "vision-chat/m3"),
                 ),
             ),
-            patch("codex_proxy.resolve_external_model_alias", return_value=external_model),
+            patch("codex_proxy.resolve_external_model_alias", side_effect=resolve_external_model),
             patch("codex_proxy._image_proxy_description_for_part", return_value="A chart with rising revenue."),
             patch("codex_proxy.urlopen", return_value=_FakeJsonResponse(upstream_body)),
         ):

--- a/tests/test_exact_model_identity.py
+++ b/tests/test_exact_model_identity.py
@@ -242,6 +242,131 @@ def test_bare_ollama_catalog_fallback_includes_exact_upstream_identity():
     assert upstream["upstream_model"] == "glm-5.2"
 
 
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [("visibility", "hide"), ("visibility", "future"), ("hidden", True)],
+)
+def test_ollama_catalog_rejects_non_listable_visibility_before_io(field, value):
+    row = _catalog_row(
+        "ollama-cloud/glm-5.2",
+        provider="ollama-cloud",
+        upstream_model="glm-5.2",
+    )
+    row[field] = value
+    catalog = {"ollama-cloud/glm-5.2": row}
+
+    with (
+        patch("codex_proxy.generated_catalog_by_slug", return_value=catalog),
+        patch("codex_proxy.resolve_ollama_cloud_model", return_value=(False, None)),
+        patch("codex_proxy.urlopen") as urlopen,
+    ):
+        with pytest.raises(codex_proxy.ModelIdentityResolutionError) as failure:
+            codex_proxy.choose_upstream("ollama-cloud/glm-5.2")
+
+    assert failure.value.classification == "catalog_inconsistency"
+    assert failure.value.reason == "unsupported_visibility"
+    urlopen.assert_not_called()
+
+
+def test_ollama_catalog_rejects_malformed_metadata_before_io():
+    row = _catalog_row(
+        "ollama-cloud/glm-5.2",
+        provider="ollama-cloud",
+        upstream_model="glm-5.2",
+    )
+    row["codex_proxy_metadata"] = "not-an-object"
+
+    with (
+        patch("codex_proxy.generated_catalog_by_slug", return_value={"ollama-cloud/glm-5.2": row}),
+        patch("codex_proxy.resolve_ollama_cloud_model", return_value=(False, None)),
+        patch("codex_proxy.urlopen") as urlopen,
+    ):
+        with pytest.raises(codex_proxy.ModelIdentityResolutionError) as failure:
+            codex_proxy.choose_upstream("ollama-cloud/glm-5.2")
+
+    assert failure.value.classification == "catalog_inconsistency"
+    assert failure.value.reason == "malformed_metadata"
+    urlopen.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("requested", "field", "value"),
+    [
+        ("ollama-cloud/codex-auto-review", "alias", "ollama-cloud/codex-auto-review"),
+        ("codex-auto-review", "model_id", "codex-auto-review"),
+    ],
+)
+def test_ollama_runtime_rejects_internal_route_identity_before_io(requested, field, value):
+    runtime_model = {
+        "alias": "ollama-cloud/glm-5.2",
+        "provider_alias": "ollama-cloud",
+        "upstream_name": "ollama_cloud",
+        "base_url": "https://ollama.example.test/v1",
+        "api_key": "ollama-runtime-token",
+        "upstream_model": "glm-5.2",
+        field: value,
+    }
+
+    with (
+        patch("codex_proxy.resolve_ollama_cloud_model", return_value=(True, runtime_model)),
+        patch("codex_proxy.resolve_external_model_alias", return_value=None),
+        patch("codex_proxy.urlopen") as urlopen,
+    ):
+        with pytest.raises(codex_proxy.ModelIdentityResolutionError) as failure:
+            codex_proxy.choose_upstream(requested)
+
+    assert failure.value.classification == "local_resolution_failure"
+    assert failure.value.reason == "internal_model"
+    urlopen.assert_not_called()
+
+
+def test_external_runtime_rejects_provider_qualified_internal_alias_before_io():
+    external = {
+        "alias": "volc/codex-auto-review",
+        "provider_alias": "volc",
+        "upstream_name": "volcengine",
+        "base_url": "https://example.test/v1",
+        "api_key": "test-key",
+        "upstream_model": "glm-5.2",
+    }
+
+    with (
+        patch("codex_proxy.resolve_external_model_alias", return_value=external),
+        patch("codex_proxy.urlopen") as urlopen,
+    ):
+        with pytest.raises(codex_proxy.ModelIdentityResolutionError) as failure:
+            codex_proxy.choose_upstream("volc/codex-auto-review")
+
+    assert failure.value.classification == "local_resolution_failure"
+    assert failure.value.reason == "internal_model"
+    urlopen.assert_not_called()
+
+
+@pytest.mark.parametrize("requested", ["legacy-display", "ollama-cloud/legacy-display"])
+def test_ollama_runtime_alias_is_presentation_only(requested):
+    providers = [
+        ProviderConfig(
+            id="ollama-cloud",
+            name="Ollama",
+            base_url="https://ollama.example.test/v1",
+            api_key="test-key",
+            models=[ModelConfig(id="glm-5.2", aliases=("legacy-display",))],
+        )
+    ]
+    _, index = build_ollama_cloud_model_index(providers, require_api_key=False)
+
+    with (
+        patch("codex_proxy.resolve_ollama_cloud_model", return_value=(True, index[requested])),
+        patch("codex_proxy.urlopen") as urlopen,
+    ):
+        with pytest.raises(codex_proxy.ModelIdentityResolutionError) as failure:
+            codex_proxy.choose_upstream(requested)
+
+    assert failure.value.classification == "local_resolution_failure"
+    assert failure.value.reason == "model_alias_not_routable"
+    urlopen.assert_not_called()
+
+
 def test_provider_model_index_rejects_duplicate_exact_ids_and_alias_collisions():
     providers = [
         ProviderConfig(

--- a/tests/test_exact_model_identity.py
+++ b/tests/test_exact_model_identity.py
@@ -227,6 +227,21 @@ def test_ollama_catalog_rejects_supported_in_api_false_before_io(requested):
     urlopen.assert_not_called()
 
 
+def test_bare_ollama_catalog_fallback_includes_exact_upstream_identity():
+    row = _catalog_row("glm-5.2", provider="ollama-cloud", upstream_model="glm-5.2")
+
+    with (
+        patch("codex_proxy._published_catalog_model", return_value=row),
+        patch("codex_proxy.resolve_ollama_cloud_model", return_value=(False, None)),
+        patch("codex_proxy.should_include_model", return_value=True),
+    ):
+        upstream = codex_proxy.choose_upstream("glm-5.2")
+
+    assert upstream["provider_id"] == "ollama-cloud"
+    assert upstream["model_id"] == "glm-5.2"
+    assert upstream["upstream_model"] == "glm-5.2"
+
+
 def test_provider_model_index_rejects_duplicate_exact_ids_and_alias_collisions():
     providers = [
         ProviderConfig(

--- a/tests/test_exact_model_identity.py
+++ b/tests/test_exact_model_identity.py
@@ -142,6 +142,21 @@ def test_official_catalog_rejects_malformed_legacy_metadata_before_io():
     urlopen.assert_not_called()
 
 
+def test_official_catalog_rejects_malformed_supported_in_api_before_io():
+    row = _catalog_row("gpt-5.6-terra")
+    row["supported_in_api"] = 1
+
+    with patch("codex_proxy.existing_generated_catalog_path", return_value=Path("missing.json")), patch(
+        "codex_proxy.load_catalog_models", return_value=[row]
+    ), patch("codex_proxy.urlopen") as urlopen:
+        with pytest.raises(codex_proxy.ModelIdentityResolutionError) as failure:
+            codex_proxy.choose_upstream("gpt-5.6-terra")
+
+    assert failure.value.classification == "catalog_inconsistency"
+    assert failure.value.reason == "malformed_supported_in_api"
+    urlopen.assert_not_called()
+
+
 @pytest.mark.parametrize(
     "requested",
     [
@@ -317,6 +332,27 @@ def test_ollama_catalog_rejects_malformed_metadata_before_io():
 
     assert failure.value.classification == "catalog_inconsistency"
     assert failure.value.reason == "malformed_metadata"
+    urlopen.assert_not_called()
+
+
+def test_ollama_catalog_rejects_malformed_supported_in_api_before_io():
+    row = _catalog_row(
+        "ollama-cloud/glm-5.2",
+        provider="ollama-cloud",
+        upstream_model="glm-5.2",
+    )
+    row["supported_in_api"] = "true"
+
+    with (
+        patch("codex_proxy.generated_catalog_by_slug", return_value={"ollama-cloud/glm-5.2": row}),
+        patch("codex_proxy.resolve_ollama_cloud_model", return_value=(False, None)),
+        patch("codex_proxy.urlopen") as urlopen,
+    ):
+        with pytest.raises(codex_proxy.ModelIdentityResolutionError) as failure:
+            codex_proxy.choose_upstream("ollama-cloud/glm-5.2")
+
+    assert failure.value.classification == "catalog_inconsistency"
+    assert failure.value.reason == "malformed_supported_in_api"
     urlopen.assert_not_called()
 
 

--- a/tests/test_exact_model_identity.py
+++ b/tests/test_exact_model_identity.py
@@ -127,6 +127,21 @@ def test_official_catalog_rejects_non_listable_visibility_before_io(visibility):
     urlopen.assert_not_called()
 
 
+def test_official_catalog_rejects_malformed_legacy_metadata_before_io():
+    row = _catalog_row("gpt-5.5")
+    row["codex_proxy_metadata"] = ["not-an-object"]
+
+    with patch("codex_proxy.existing_generated_catalog_path", return_value=Path("missing.json")), patch(
+        "codex_proxy.load_catalog_models", return_value=[row]
+    ), patch("codex_proxy.urlopen") as urlopen:
+        with pytest.raises(codex_proxy.ModelIdentityResolutionError) as failure:
+            codex_proxy.choose_upstream("gpt-5.5")
+
+    assert failure.value.classification == "catalog_inconsistency"
+    assert failure.value.reason == "malformed_metadata"
+    urlopen.assert_not_called()
+
+
 @pytest.mark.parametrize(
     "requested",
     [

--- a/tests/test_exact_model_identity.py
+++ b/tests/test_exact_model_identity.py
@@ -111,6 +111,22 @@ def test_catalog_upstream_model_mismatch_is_catalog_inconsistency():
     assert failure.value.reason == "upstream_model_mismatch"
 
 
+@pytest.mark.parametrize("visibility", ["hide", "future"])
+def test_official_catalog_rejects_non_listable_visibility_before_io(visibility):
+    row = _catalog_row("gpt-5.6-terra")
+    row["visibility"] = visibility
+
+    with patch("codex_proxy.existing_generated_catalog_path", return_value=Path("missing.json")), patch(
+        "codex_proxy.load_catalog_models", return_value=[row]
+    ), patch("codex_proxy.urlopen") as urlopen:
+        with pytest.raises(codex_proxy.ModelIdentityResolutionError) as failure:
+            codex_proxy.choose_upstream("gpt-5.6-terra")
+
+    assert failure.value.classification == "catalog_inconsistency"
+    assert failure.value.reason == "unsupported_visibility"
+    urlopen.assert_not_called()
+
+
 @pytest.mark.parametrize(
     "requested",
     [

--- a/tests/test_exact_model_identity.py
+++ b/tests/test_exact_model_identity.py
@@ -1,0 +1,476 @@
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import codex_proxy
+from providers_config import ModelConfig, ProviderConfig, build_external_model_index, build_ollama_cloud_model_index
+from test_routing import post_handler
+
+
+def _catalog_row(slug: str, *, provider: str = "openai", upstream_model: str | None = None):
+    return {
+        "slug": slug,
+        "visibility": "list",
+        "supported_in_api": True,
+        "codex_proxy_metadata": {
+            "provider": provider,
+            "upstream_name": "official" if provider == "openai" else provider,
+            "upstream_model": upstream_model or slug.removeprefix("openai/"),
+        },
+    }
+
+
+def test_official_resolution_rejects_internal_display_name_collision_before_io():
+    catalog = {
+        "models": [
+            {
+                **_catalog_row("gpt-5.6-terra"),
+                "id": "codex-auto-review",
+                "display_name": "GPT-5.6 Terra",
+            }
+        ]
+    }
+
+    with patch("codex_proxy.existing_generated_catalog_path", return_value=Path("missing.json")), patch(
+        "codex_proxy.load_catalog_models", return_value=catalog["models"]
+    ), patch("codex_proxy.urlopen") as urlopen:
+        with pytest.raises(codex_proxy.ModelIdentityResolutionError) as failure:
+            codex_proxy.choose_upstream("openai/gpt-5.6-terra")
+
+    assert failure.value.classification == "local_resolution_failure"
+    assert failure.value.reason == "internal_model"
+    urlopen.assert_not_called()
+
+
+def test_duplicate_canonical_catalog_slug_is_catalog_inconsistency():
+    rows = [_catalog_row("gpt-5.6-terra"), _catalog_row("openai/gpt-5.6-terra")]
+
+    with patch("codex_proxy.existing_generated_catalog_path", return_value=Path("missing.json")), patch(
+        "codex_proxy.load_catalog_models", return_value=rows
+    ):
+        with pytest.raises(codex_proxy.ModelIdentityResolutionError) as failure:
+            codex_proxy.choose_upstream("gpt-5.6-terra")
+
+    assert failure.value.classification == "catalog_inconsistency"
+    assert failure.value.reason == "duplicate_canonical_slug"
+
+
+@pytest.mark.parametrize("malformed_slug", [None, 42, "   "])
+def test_malformed_catalog_slug_is_catalog_inconsistency(malformed_slug):
+    row = {**_catalog_row("gpt-5.6-terra"), "slug": malformed_slug}
+
+    with patch("codex_proxy.existing_generated_catalog_path", return_value=Path("missing.json")), patch(
+        "codex_proxy.load_catalog_models", return_value=[row]
+    ):
+        with pytest.raises(codex_proxy.ModelIdentityResolutionError) as failure:
+            codex_proxy.choose_upstream("gpt-5.6-terra")
+
+    assert failure.value.classification == "catalog_inconsistency"
+    assert failure.value.reason == "missing_catalog_slug"
+
+
+def test_malformed_catalog_document_is_catalog_inconsistency():
+    with patch(
+        "codex_proxy.existing_generated_catalog_path",
+        return_value=Path("malformed.json"),
+    ), patch(
+        "codex_proxy.load_catalog_models",
+        side_effect=ValueError("invalid catalog document"),
+    ):
+        with pytest.raises(codex_proxy.ModelIdentityResolutionError) as failure:
+            codex_proxy.choose_upstream("gpt-5.6-terra")
+
+    assert failure.value.classification == "catalog_inconsistency"
+    assert failure.value.reason == "malformed_catalog"
+
+
+@pytest.mark.parametrize("document", ["{not-json", {"models": {"slug": "bad"}}])
+def test_malformed_catalog_file_is_catalog_inconsistency(tmp_path, document):
+    path = tmp_path / "catalog.json"
+    path.write_text(document if isinstance(document, str) else json.dumps(document), encoding="utf-8")
+
+    with pytest.raises(codex_proxy.ModelIdentityResolutionError) as failure:
+        codex_proxy.generated_catalog_by_slug(path)
+
+    assert failure.value.classification == "catalog_inconsistency"
+    assert failure.value.reason == "malformed_catalog"
+
+
+def test_catalog_upstream_model_mismatch_is_catalog_inconsistency():
+    row = _catalog_row("gpt-5.6-terra", upstream_model="codex-auto-review")
+
+    with patch("codex_proxy.existing_generated_catalog_path", return_value=Path("missing.json")), patch(
+        "codex_proxy.load_catalog_models", return_value=[row]
+    ):
+        with pytest.raises(codex_proxy.ModelIdentityResolutionError) as failure:
+            codex_proxy.choose_upstream("gpt-5.6-terra")
+
+    assert failure.value.classification == "catalog_inconsistency"
+    assert failure.value.reason == "upstream_model_mismatch"
+
+
+@pytest.mark.parametrize(
+    "requested",
+    [
+        "minimax-cn/minimax-m3",  # configured alias for MiniMax-M3
+        "GPT-5.6 Terra",  # display name
+        "codex-auto-review",  # internal reviewer identity
+        "ollama-cloud/gpt-5.6-terra",  # cross-catalog provider fallback
+    ],
+)
+def test_presentation_or_cross_catalog_identity_never_selects_terra(requested: str):
+    with patch("codex_proxy.resolve_external_model_alias", return_value={
+        "alias": "minimax-cn/MiniMax-M3",
+        "provider_alias": "minimax-cn",
+        "upstream_name": "minimax_cn",
+        "base_url": "https://example.test/v1",
+        "api_key": "test-key",
+        "upstream_model": "MiniMax-M3",
+    }), patch("codex_proxy.urlopen") as urlopen:
+        with pytest.raises(codex_proxy.ModelIdentityResolutionError):
+            codex_proxy.choose_upstream(requested)
+
+    urlopen.assert_not_called()
+
+
+def test_external_provider_alias_is_not_a_routable_model_identity():
+    external = {
+        "alias": "minimax-cn/MiniMax-M3",
+        "provider_alias": "minimax-cn",
+        "upstream_name": "minimax_cn",
+        "base_url": "https://example.test/v1",
+        "api_key": "test-key",
+        "upstream_model": "MiniMax-M3",
+    }
+    with patch("codex_proxy.resolve_external_model_alias", return_value=external):
+        with pytest.raises(codex_proxy.ModelIdentityResolutionError) as failure:
+            codex_proxy.choose_upstream("minimax-cn/minimax-m3")
+
+    assert failure.value.reason == "model_alias_not_routable"
+    assert failure.value.classification == "local_resolution_failure"
+
+
+@pytest.mark.parametrize("requested", ["ollama-cloud/glm-5.2", "glm-5.2"])
+def test_ollama_catalog_rejects_unsupported_or_cross_provider_rows_before_io(requested):
+    catalog_slug = requested
+    catalog = {
+        catalog_slug: {
+            "slug": catalog_slug,
+            "supported_in_api": True,
+            "codex_proxy_metadata": {
+                "provider": "openai",
+                "upstream_name": "official",
+                "upstream_model": "codex-auto-review",
+            },
+        }
+    }
+
+    with (
+        patch("codex_proxy.generated_catalog_by_slug", return_value=catalog),
+        patch("codex_proxy.resolve_ollama_cloud_model", return_value=(False, None)),
+        patch("codex_proxy.urlopen") as urlopen,
+    ):
+        with pytest.raises(codex_proxy.ModelIdentityResolutionError) as failure:
+            codex_proxy.choose_upstream(requested)
+
+    assert failure.value.classification == "catalog_inconsistency"
+    assert failure.value.reason == "provider_mismatch"
+    urlopen.assert_not_called()
+
+
+def test_ollama_catalog_rejects_contradictory_upstream_metadata_before_io():
+    catalog = {
+        "ollama-cloud/glm-5.2": {
+            "slug": "ollama-cloud/glm-5.2",
+            "supported_in_api": True,
+            "codex_proxy_metadata": {
+                "provider": "ollama-cloud",
+                "upstream_name": "ollama_cloud",
+                "upstream_model": "codex-auto-review",
+            },
+        }
+    }
+
+    with (
+        patch("codex_proxy.generated_catalog_by_slug", return_value=catalog),
+        patch("codex_proxy.resolve_ollama_cloud_model", return_value=(False, None)),
+        patch("codex_proxy.urlopen") as urlopen,
+    ):
+        with pytest.raises(codex_proxy.ModelIdentityResolutionError) as failure:
+            codex_proxy.choose_upstream("ollama-cloud/glm-5.2")
+
+    assert failure.value.classification == "catalog_inconsistency"
+    assert failure.value.reason == "upstream_model_mismatch"
+    urlopen.assert_not_called()
+
+
+@pytest.mark.parametrize("requested", ["ollama-cloud/glm-5.2", "glm-5.2"])
+def test_ollama_catalog_rejects_supported_in_api_false_before_io(requested):
+    catalog = {
+        requested: {
+            "slug": requested,
+            "supported_in_api": False,
+        }
+    }
+
+    with (
+        patch("codex_proxy.generated_catalog_by_slug", return_value=catalog),
+        patch("codex_proxy.resolve_ollama_cloud_model", return_value=(False, None)),
+        patch("codex_proxy.urlopen") as urlopen,
+    ):
+        with pytest.raises(codex_proxy.ModelIdentityResolutionError) as failure:
+            codex_proxy.choose_upstream(requested)
+
+    assert failure.value.reason == "unsupported_model"
+    urlopen.assert_not_called()
+
+
+def test_provider_model_index_rejects_duplicate_exact_ids_and_alias_collisions():
+    providers = [
+        ProviderConfig(
+            id="volc",
+            name="Volc",
+            base_url="https://example.test/v1",
+            api_key="test-key",
+            models=[ModelConfig(id="glm-5.2"), ModelConfig(id="glm-5.2")],
+        )
+    ]
+    with pytest.raises(ValueError, match="duplicate provider model identity"):
+        build_external_model_index(providers)
+
+    providers[0].models = [
+        ModelConfig(id="glm-5.2", aliases=("shared",)),
+        ModelConfig(id="other", aliases=("shared",)),
+    ]
+    with pytest.raises(ValueError, match="duplicate provider model identity"):
+        build_external_model_index(providers)
+
+
+def test_ollama_cloud_index_rejects_duplicate_exact_ids():
+    providers = [
+        ProviderConfig(
+            id="ollama-cloud",
+            name="Ollama",
+            base_url="https://example.test/v1",
+            api_key="test-key",
+            models=[ModelConfig(id="glm-5.2"), ModelConfig(id="glm-5.2")],
+        )
+    ]
+    with pytest.raises(ValueError, match="duplicate provider model identity"):
+        build_ollama_cloud_model_index(providers)
+
+
+def test_external_provider_index_failure_is_catalog_inconsistency_before_io():
+    with patch(
+        "codex_proxy.resolve_external_model_alias",
+        side_effect=ValueError("duplicate provider model identity: foo/model"),
+    ), patch("codex_proxy.urlopen") as urlopen:
+        with pytest.raises(codex_proxy.ModelIdentityResolutionError) as failure:
+            codex_proxy.choose_upstream("foo/model")
+
+    assert failure.value.classification == "catalog_inconsistency"
+    assert failure.value.reason == "provider_model_index_inconsistency"
+    urlopen.assert_not_called()
+
+
+def test_ollama_provider_index_failure_is_catalog_inconsistency_before_io():
+    with patch(
+        "codex_proxy.resolve_ollama_cloud_model",
+        side_effect=ValueError("duplicate provider model identity: glm-5.2"),
+    ), patch("codex_proxy.urlopen") as urlopen:
+        with pytest.raises(codex_proxy.ModelIdentityResolutionError) as failure:
+            codex_proxy.choose_upstream("ollama-cloud/glm-5.2")
+
+    assert failure.value.classification == "catalog_inconsistency"
+    assert failure.value.reason == "provider_model_index_inconsistency"
+    urlopen.assert_not_called()
+
+
+def test_route_plan_rejects_missing_upstream_identity_without_substitution():
+    with pytest.raises(codex_proxy.ModelIdentityResolutionError) as failure:
+        codex_proxy.route_plan_for_request(
+            {"name": "official", "auth": "codex_auth"},
+            {"client_id": "unknown"},
+            inbound_format="responses",
+            model_requested="gpt-5.6-terra",
+            canonical_route_model="gpt-5.6-terra",
+        )
+
+    assert failure.value.classification == "local_resolution_failure"
+    assert failure.value.reason == "missing_upstream_model"
+
+
+def test_route_plan_retains_exact_provider_id_and_model_slug():
+    plan = codex_proxy.route_plan_for_request(
+        {
+            "name": "volcengine",
+            "provider_id": "volc",
+            "upstream_model": "glm-5.2",
+            "auth": "api_key",
+            "base_url": "https://example.test/v1",
+            "upstream_format": "responses",
+        },
+        {"client_id": "unknown"},
+        inbound_format="responses",
+        model_requested="volc/glm-5.2",
+        canonical_route_model="volc/glm-5.2",
+    )
+
+    assert plan.provider_id == "volc"
+    assert plan.model_requested == "volc/glm-5.2"
+    assert plan.canonical_model == "volc/glm-5.2"
+    assert plan.upstream_model == "glm-5.2"
+
+
+def test_route_plan_preserves_explicit_provider_id_underscores():
+    plan = codex_proxy.route_plan_for_request(
+        {
+            "name": "custom_transport",
+            "provider_id": "foo_bar",
+            "upstream_model": "model-v1",
+            "auth": "api_key",
+            "base_url": "https://example.test/v1",
+            "upstream_format": "responses",
+        },
+        {"client_id": "unknown"},
+        inbound_format="responses",
+        model_requested="foo_bar/model-v1",
+        canonical_route_model="foo_bar/model-v1",
+    )
+
+    assert plan.provider_id == "foo_bar"
+
+
+def test_route_plan_rejects_mismatched_upstream_without_model_id():
+    with patch("codex_proxy.urlopen") as urlopen:
+        with pytest.raises(codex_proxy.ModelIdentityResolutionError) as failure:
+            codex_proxy.route_plan_for_request(
+                {
+                    "name": "volcengine",
+                    "provider_id": "volc",
+                    "upstream_model": "codex-auto-review",
+                    "auth": "api_key",
+                    "base_url": "https://example.test/v1",
+                    "upstream_format": "responses",
+                },
+                {"client_id": "unknown"},
+                inbound_format="responses",
+                model_requested="volc/glm-5.2",
+                canonical_route_model="volc/glm-5.2",
+            )
+
+    assert failure.value.classification == "catalog_inconsistency"
+    assert failure.value.reason == "configured_model_mismatch"
+    urlopen.assert_not_called()
+
+
+def test_identity_error_payload_distinguishes_catalog_and_local_resolution():
+    catalog_error = codex_proxy.ModelIdentityResolutionError(
+        "duplicate canonical slug",
+        classification="catalog_inconsistency",
+        reason="duplicate_canonical_slug",
+    )
+    local_error = codex_proxy.ModelIdentityResolutionError(
+        "model is not supported",
+        classification="local_resolution_failure",
+        reason="unsupported_model",
+    )
+
+    catalog_payload = codex_proxy._codexhub_error_payload(
+        source="gateway",
+        message=str(catalog_error),
+        status=400,
+        exc=catalog_error,
+        error_type="model_identity_error",
+        error="ModelIdentityResolutionError",
+    )
+    local_payload = codex_proxy._codexhub_error_payload(
+        source="gateway",
+        message=str(local_error),
+        status=400,
+        exc=local_error,
+        error_type="model_identity_error",
+        error="ModelIdentityResolutionError",
+    )
+
+    assert catalog_payload["code"] == "catalog.inconsistency"
+    assert catalog_payload["details"]["classification"] == "catalog_inconsistency"
+    assert local_payload["code"] == "gateway.model_resolution"
+    assert local_payload["details"]["classification"] == "local_resolution_failure"
+    assert "codex-auto-review" not in json.dumps(catalog_payload)
+
+
+def test_identity_error_payload_drops_untrusted_provider_and_model_labels():
+    failure = codex_proxy.ModelIdentityResolutionError(
+        "model identity is invalid",
+        classification="local_resolution_failure",
+        reason="unsupported_model",
+        provider_id="Bearer SECRET",
+        model_slug="Bearer SECRET",
+    )
+
+    payload = codex_proxy._codexhub_error_payload(
+        source="gateway",
+        message="model identity is invalid",
+        status=400,
+        exc=failure,
+        error_type="model_identity_error",
+        error="ModelIdentityResolutionError",
+    )
+
+    rendered = json.dumps(payload)
+    assert "SECRET" not in rendered
+    assert "provider_id" not in payload["details"]
+    assert "model_slug" not in payload["details"]
+
+
+def test_handler_rejects_identity_before_auth_or_upstream_io():
+    handler, fake = post_handler(
+        "/v1/responses",
+        json.dumps({"model": "openai/codex-auto-review", "input": []}).encode(),
+    )
+    failure = codex_proxy.ModelIdentityResolutionError(
+        "model identity is internal and cannot be routed",
+        classification="local_resolution_failure",
+        reason="internal_model",
+        provider_id="openai",
+        model_slug="codex-auto-review",
+    )
+
+    with (
+        patch("codex_proxy.choose_upstream", side_effect=failure),
+        patch("codex_proxy.materialize_operational_authentication") as auth,
+        patch("codex_proxy._open_upstream_response") as open_upstream,
+    ):
+        codex_proxy.CodexProxyHandler._proxy_post_request(handler, inbound_format="responses")
+
+    assert fake.status == 400
+    payload = json.loads(fake.wfile.writes[-1].decode())
+    assert payload["codexhub_error"]["code"] == "gateway.model_resolution"
+    assert payload["codexhub_error"]["details"]["reason"] == "internal_model"
+    auth.assert_not_called()
+    open_upstream.assert_not_called()
+
+
+def test_handler_identity_error_detail_uses_bounded_non_secret_reason():
+    handler, fake = post_handler(
+        "/v1/responses",
+        json.dumps({"model": "openai/secret-model", "input": []}).encode(),
+    )
+    failure = codex_proxy.ModelIdentityResolutionError(
+        "Bearer SECRET should never be returned",
+        classification="local_resolution_failure",
+        reason="unsupported_model",
+        provider_id="openai",
+        model_slug="secret-model",
+    )
+
+    with patch("codex_proxy.choose_upstream", side_effect=failure):
+        codex_proxy.CodexProxyHandler._proxy_post_request(handler, inbound_format="responses")
+
+    rendered = fake.wfile.writes[-1].decode()
+    assert "SECRET" not in rendered
+    assert "Bearer " not in rendered
+    assert "unsupported_model" in rendered

--- a/tests/test_proxy_shutdown.py
+++ b/tests/test_proxy_shutdown.py
@@ -445,6 +445,20 @@ def test_active_request_receives_a_sanitized_user_requested_shutdown_outcome() -
         with (
             patch.object(
                 codex_proxy,
+                "choose_upstream",
+                return_value={
+                    "name": "official",
+                    "provider_id": "openai",
+                    "model_id": "gpt-5.6-terra",
+                    "upstream_model": "gpt-5.6-terra",
+                    "auth": "codex_auth",
+                    "base_url": "https://example.test/v1",
+                    "upstream_format": "responses",
+                    "reports_cached_input_tokens": True,
+                },
+            ) as choose_upstream,
+            patch.object(
+                codex_proxy,
                 "upstream_headers",
                 return_value={"Authorization": "Bearer test-token"},
             ) as build_upstream_headers,
@@ -479,6 +493,7 @@ def test_active_request_receives_a_sanitized_user_requested_shutdown_outcome() -
                 "payload": codex_proxy.user_requested_shutdown_payload("responses"),
             }
             assert open_upstream.call_count == 1
+            choose_upstream.assert_called_once()
             build_upstream_headers.assert_called_once()
             access_token.assert_called_once_with()
             account_id.assert_called_once_with()

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -482,6 +482,8 @@ class RoutingTests(unittest.TestCase):
             "codex_proxy.generated_catalog_slugs",
             return_value={
                 "openai/gpt-5.5",
+                "gpt-5.4",
+                "gpt-5.4-mini",
                 "minimax-m3",
                 "glm-5.2",
                 "ollama-cloud/glm-5.2",
@@ -504,6 +506,24 @@ class RoutingTests(unittest.TestCase):
             "codex_proxy.generated_catalog_by_slug",
             return_value={
                 "openai/gpt-5.5": {"slug": "openai/gpt-5.5"},
+                "gpt-5.4": {
+                    "slug": "gpt-5.4",
+                    "supported_in_api": True,
+                    "codex_proxy_metadata": {
+                        "provider": "openai",
+                        "upstream_name": "official",
+                        "upstream_model": "gpt-5.4",
+                    },
+                },
+                "gpt-5.4-mini": {
+                    "slug": "gpt-5.4-mini",
+                    "supported_in_api": True,
+                    "codex_proxy_metadata": {
+                        "provider": "openai",
+                        "upstream_name": "official",
+                        "upstream_model": "gpt-5.4-mini",
+                    },
+                },
                 "minimax-m3": {"slug": "minimax-m3", "max_output_tokens": 524288},
                 "glm-5.2": {"slug": "glm-5.2", "max_output_tokens": 131072},
                 "ollama-cloud/glm-5.2": {"slug": "ollama-cloud/glm-5.2", "max_output_tokens": 131072},
@@ -906,7 +926,7 @@ class RoutingTests(unittest.TestCase):
                 "provider_hint": None,
                 "expected": {
                     "behavior_profile": codex_proxy.BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH,
-                    "provider_id": "official",
+                    "provider_id": "openai",
                     "canonical_model": "openai/gpt-5.5",
                     "upstream_model": "gpt-5.5",
                     "inbound_protocol": codex_proxy.RouteProtocol.RESPONSES,
@@ -940,7 +960,7 @@ class RoutingTests(unittest.TestCase):
                 "provider_hint": None,
                 "expected": {
                     "behavior_profile": codex_proxy.BEHAVIOR_CODEX_APP_EXTERNAL_ADAPTER,
-                    "provider_id": "ollama_cloud",
+                    "provider_id": "ollama-cloud",
                     "canonical_model": "ollama-cloud/glm-5.2",
                     "upstream_model": "glm-5.2",
                     "inbound_protocol": codex_proxy.RouteProtocol.RESPONSES,
@@ -976,7 +996,7 @@ class RoutingTests(unittest.TestCase):
                 "provider_hint": "volc",
                 "expected": {
                     "behavior_profile": codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
-                    "provider_id": "volcengine",
+                    "provider_id": "volc",
                     "canonical_model": "volc/glm-5.2",
                     "upstream_model": "glm-5.2",
                     "inbound_protocol": codex_proxy.RouteProtocol.RESPONSES,
@@ -1009,7 +1029,7 @@ class RoutingTests(unittest.TestCase):
                 "provider_hint": "volc",
                 "expected": {
                     "behavior_profile": codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
-                    "provider_id": "volcengine",
+                    "provider_id": "volc",
                     "canonical_model": "volc/glm-5.2",
                     "upstream_model": "glm-5.2",
                     "inbound_protocol": codex_proxy.RouteProtocol.RESPONSES,
@@ -1040,7 +1060,7 @@ class RoutingTests(unittest.TestCase):
                 "provider_hint": None,
                 "expected": {
                     "behavior_profile": codex_proxy.BEHAVIOR_CODEX_APP_EXTERNAL_ADAPTER,
-                    "provider_id": "ollama_cloud",
+                    "provider_id": "ollama-cloud",
                     "canonical_model": "ollama-cloud/glm-5.2",
                     "upstream_model": "glm-5.2",
                     "inbound_protocol": codex_proxy.RouteProtocol.CHAT_COMPLETIONS,
@@ -4166,7 +4186,14 @@ class RoutingTests(unittest.TestCase):
         handler, fake = post_handler("/v1/responses", body)
 
         with (
-            patch("codex_proxy.choose_upstream", return_value=official_upstream()),
+            patch(
+                "codex_proxy.choose_upstream",
+                return_value={
+                    **official_upstream(),
+                    "model_id": "openai/gpt-5.6-sol",
+                    "upstream_model": "gpt-5.6-sol",
+                },
+            ),
             patch("codex_proxy.codex_access_token", return_value="sub-token"),
             patch("codex_proxy.codex_account_id", return_value="acct-1"),
             patch(
@@ -4193,7 +4220,14 @@ class RoutingTests(unittest.TestCase):
         handler, fake = post_handler("/v1/responses", body)
 
         with (
-            patch("codex_proxy.choose_upstream", return_value=official_upstream()),
+            patch(
+                "codex_proxy.choose_upstream",
+                return_value={
+                    **official_upstream(),
+                    "model_id": "openai/gpt-5.6-terra",
+                    "upstream_model": "gpt-5.6-terra",
+                },
+            ),
             patch("codex_proxy.codex_access_token", return_value="sub-token"),
             patch("codex_proxy.codex_account_id", return_value="acct-1"),
             patch(
@@ -11687,8 +11721,11 @@ class RoutingTests(unittest.TestCase):
         }
 
         with patch("codex_proxy.generated_catalog_by_slug", return_value=catalog):
-            with self.assertRaisesRegex(ValueError, "model is not allowed"):
+            with self.assertRaises(codex_proxy.ModelIdentityResolutionError) as context:
                 choose_upstream("gpt-untrusted")
+
+        self.assertEqual(context.exception.classification, "catalog_inconsistency")
+        self.assertEqual(context.exception.reason, "upstream_model_mismatch")
 
     def test_runtime_official_route_respects_policy_denylist(self):
         policy = codex_proxy.load_policy(codex_proxy.POLICY_PATH)
@@ -12386,11 +12423,9 @@ class RoutingTests(unittest.TestCase):
         self.assertEqual(upstream["auth"], "api_key")
         self.assertEqual(upstream["upstream_model"], "MiniMax-M3")
 
-    def test_external_provider_explicit_alias_routes_without_lowercasing(self):
-        upstream = choose_upstream("minimax-cn/minimax-m3")
-
-        self.assertEqual(upstream["name"], "minimax_cn")
-        self.assertEqual(upstream["upstream_model"], "MiniMax-M3")
+    def test_external_provider_presentation_alias_fails_closed(self):
+        with self.assertRaisesRegex(ValueError, "presentation-only"):
+            choose_upstream("minimax-cn/minimax-m3")
 
     def test_denied_provider_qualified_ollama_alias_is_rejected(self):
         policy = codex_proxy.load_policy(codex_proxy.POLICY_PATH)
@@ -12434,7 +12469,7 @@ class RoutingTests(unittest.TestCase):
         self.assertIn("model is not allowed", str(context.exception))
 
     def test_provider_qualified_ollama_alias_requires_generated_catalog_entry(self):
-        with patch("codex_proxy.generated_catalog_slugs", return_value=set()):
+        with patch("codex_proxy.generated_catalog_by_slug", return_value={}):
             with self.assertRaises(ValueError) as context:
                 choose_upstream("ollama-cloud/glm-5.2")
 
@@ -13009,7 +13044,7 @@ class RoutingTests(unittest.TestCase):
     def test_external_body_converts_compaction_input_to_developer_message(self):
         for model_id, upstream_model in (
             ("volc/glm-5.2", "glm-5.2"),
-            ("minimax-cn/minimax-m3", "MiniMax-M3"),
+            ("minimax-cn/MiniMax-M3", "MiniMax-M3"),
         ):
             with self.subTest(model_id=model_id):
                 upstream = dict(choose_upstream(model_id))
@@ -13220,7 +13255,7 @@ class RoutingTests(unittest.TestCase):
     def test_external_body_converts_custom_tool_items_to_developer_messages(self):
         for model_id, upstream_model in (
             ("volc/glm-5.2", "glm-5.2"),
-            ("minimax-cn/minimax-m3", "MiniMax-M3"),
+            ("minimax-cn/MiniMax-M3", "MiniMax-M3"),
         ):
             with self.subTest(model_id=model_id):
                 upstream = dict(choose_upstream(model_id))
@@ -13265,7 +13300,7 @@ class RoutingTests(unittest.TestCase):
     def test_external_body_normalizes_real_history_artifact_items(self):
         for model_id, upstream_model in (
             ("volc/glm-5.2", "glm-5.2"),
-            ("minimax-cn/minimax-m3", "MiniMax-M3"),
+            ("minimax-cn/MiniMax-M3", "MiniMax-M3"),
         ):
             with self.subTest(model_id=model_id):
                 upstream = dict(choose_upstream(model_id))
@@ -13340,7 +13375,7 @@ class RoutingTests(unittest.TestCase):
         self.assertIn(b'"model":"glm-5.2"', transformed)
         self.assertNotIn(b'"model":"volc/glm-5.2"', transformed)
 
-    def test_default_minimax_provider_rewrites_to_live_upstream_model_case(self):
+    def test_default_minimax_provider_presentation_alias_fails_closed(self):
         from providers_config import DEFAULT_PROVIDERS_PATH
         from providers_config import resolve_external_model_alias as real_resolve_external_model_alias
 
@@ -13351,14 +13386,8 @@ class RoutingTests(unittest.TestCase):
             patch("codex_proxy.resolve_external_model_alias", side_effect=bundled_resolve_external_model_alias),
             patch.dict(os.environ, {"MINIMAX_API_KEY": "minimax-live-case-token"}, clear=False),
         ):
-            upstream = choose_upstream("minimax-cn/minimax-m3")
-
-            body = b'{"model":"minimax-cn/minimax-m3","input":"hi"}'
-            transformed = compatible_request_body(body, upstream, "minimax-cn/minimax-m3")
-
-        self.assertEqual(upstream["name"], "minimax_cn")
-        self.assertEqual(upstream["upstream_model"], "MiniMax-M3")
-        self.assertEqual(json.loads(transformed)["model"], "MiniMax-M3")
+            with self.assertRaisesRegex(ValueError, "presentation-only"):
+                choose_upstream("minimax-cn/minimax-m3")
 
     def test_official_responses_url_preserves_backend_subpath_and_query(self):
         upstream = official_upstream()


### PR DESCRIPTION
Closes #274\n\nSummary:\n- Enforces exact provider/model/upstream identity with no display-name, alias, duplicate, or cross-catalog fallback.\n- Fails closed before upstream I/O for malformed catalogs, hidden/unknown/internal/unsupported identities, contradictory metadata, and unsafe diagnostics.\n- Keeps Ollama presentation aliases non-routable and preserves exact bare-catalog fallback identity.\n- Updates vision-proxy test fixtures to use exact model resolver mappings.\n\nVerification:\n- Python 3.13 targeted identity/routing/provider suites: 649 passed, 223 subtests.\n- Exact SHA dual Spec/Standards review: PASS.\n- py_compile, diff-check, report-only quality gates: complete.\n- Local full-suite baseline comparison shows two pre-existing PowerShell smoke-script failures; Hosted CI / gate is authoritative.\n\nRisk: strict routing/catalog boundary; no API or UI contract changes intended.