### PR TITLE
test: add isolated Issue 62 live evidence sidecar

### DIFF
--- a/docs/evidence/issue-62/README.md
+++ b/docs/evidence/issue-62/README.md
@@ -230,3 +230,71 @@ evidence fails closed.
 
 The live-control-required gates remain open until the separately authorized
 live control window documented above captures real evidence for each one.
+
+## Isolated live-evidence sidecar lane
+
+`scripts/capture_issue_62_live_evidence.py` is a standalone, standard-library
+capture sidecar for a future, separately authorized live-control window. It is
+not imported by Desktop or Gateway, has no settings/environment activation
+path, and refuses to listen without `--enable-live-capture`. It accepts only a
+loopback listen address.
+
+Run two independent instances around an isolated Gateway process:
+
+```text
+isolated client -> pre sidecar -> isolated Gateway -> post sidecar -> upstream
+```
+
+The two commands require distinct output directories and a shared, isolated
+32-byte-or-longer HMAC key file. The operator must replace every angle-bracket
+token only after the live window identifies the exact candidate, isolated
+Gateway port, authorized upstream base URL, bounds, and cleanup owner.
+
+```powershell
+py -3.13 scripts/capture_issue_62_live_evidence.py `
+  --enable-live-capture `
+  --hop pre `
+  --listen-host 127.0.0.1 `
+  --listen-port 19162 `
+  --forward-base-url http://127.0.0.1:<ISOLATED_GATEWAY_PORT> `
+  --output-dir <ISOLATED_OUTPUT_ROOT>\pre `
+  --hmac-key-file <ISOLATED_HMAC_KEY_FILE> `
+  --max-request-bytes <AUTHORIZED_REQUEST_CAP> `
+  --max-response-bytes <AUTHORIZED_RESPONSE_CAP> `
+  --connect-timeout-seconds <AUTHORIZED_CONNECT_TIMEOUT> `
+  --read-timeout-seconds <AUTHORIZED_READ_TIMEOUT> `
+  --overall-timeout-seconds <AUTHORIZED_OVERALL_TIMEOUT>
+
+py -3.13 scripts/capture_issue_62_live_evidence.py `
+  --enable-live-capture `
+  --hop post `
+  --listen-host 127.0.0.1 `
+  --listen-port 19163 `
+  --forward-base-url <AUTHORIZED_UPSTREAM_BASE_URL> `
+  --output-dir <ISOLATED_OUTPUT_ROOT>\post `
+  --hmac-key-file <ISOLATED_HMAC_KEY_FILE> `
+  --max-request-bytes <AUTHORIZED_REQUEST_CAP> `
+  --max-response-bytes <AUTHORIZED_RESPONSE_CAP> `
+  --connect-timeout-seconds <AUTHORIZED_CONNECT_TIMEOUT> `
+  --read-timeout-seconds <AUTHORIZED_READ_TIMEOUT> `
+  --overall-timeout-seconds <AUTHORIZED_OVERALL_TIMEOUT>
+```
+
+Each hop writes only an atomic sanitized JSON record: complete application-body
+byte counts, SHA-256/HMAC-SHA-256 values, an ordered SSE-frame digest, bounded
+terminal classifications, or a fixed incomplete failure code. URLs, paths,
+headers, credentials, key material, raw bodies, prompt/tool content, wire
+identifiers, and exception text are never artifact fields. Overflow, timeout,
+cancellation, forwarding failure, incomplete SSE framing, and server lifecycle
+failure cannot produce a complete record and leave no `.partial` artifact.
+
+The focused tests use loopback fake servers only:
+
+```powershell
+py -3.13 -m pytest -q tests/test_issue_62_live_evidence_sidecar.py
+```
+
+A passing test means only `synthetic_lane_verified`. Do not aim these commands
+at the currently running Desktop or Gateway, perform an upstream request,
+change the runtime inventory, or infer Issue #62 qualification without a new
+maintainer-authorized live-control window and artifact readback.

--- a/docs/superpowers/plans/2026-08-02-issue-62-live-evidence-sidecar.md
+++ b/docs/superpowers/plans/2026-08-02-issue-62-live-evidence-sidecar.md
@@ -1,0 +1,232 @@
+# Issue #62 Live-Evidence Sidecar Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a standalone, explicitly enabled loopback sidecar that independently fingerprints complete request, response, and SSE application-body bytes on the pre- and post-Gateway hops without changing production routing.
+
+**Architecture:** One standard-library Python script owns validation, HTTP forwarding, streaming fingerprints, atomic sanitized artifacts, and bounded shutdown. Two independent instances use the same HMAC key and different `pre`/`post` hop labels; focused tests connect them to a real local fake upstream and compare their independently written artifacts.
+
+**Tech Stack:** Python 3.13 standard library, pytest, loopback `http.server`/`http.client`, SHA-256, HMAC-SHA-256, atomic `os.replace`.
+
+## Global Constraints
+
+- The script starts only with `--enable-live-capture` and listens only on IPv4 or IPv6 loopback.
+- Do not modify or import the script from production Gateway, telemetry, diagnostic-recorder, Tauri, Desktop, config, or route handlers.
+- Add no dependency and perform no real upstream request in tests or verification.
+- Persist only sanitized metadata and digests; never persist URLs, paths, headers, credentials, key material, raw bodies, prompts, tool values, or wire identifiers.
+- Request/response byte caps and connect/read/overall timeouts are mandatory and positive.
+- Overflow, timeout, cancellation, forwarding failure, missing SSE terminal, and incomplete SSE framing produce an `incomplete` record and leave no `.partial` file.
+- Synthetic tests prove only `synthetic_lane_verified`; they do not change `docs/evidence/issue-62/runtime-wire-inventory.json` or any qualification state.
+
+---
+
+### Task 1: Activation, configuration, and sanitized atomic artifacts
+
+**Files:**
+- Create: `scripts/capture_issue_62_live_evidence.py`
+- Create: `tests/test_issue_62_live_evidence_sidecar.py`
+
+**Interfaces:**
+- Produces: `SidecarConfig`, `validate_config(config)`, `write_capture_record(output_dir, hop, record)`, and `main(argv=None) -> int`.
+- Consumes: only Python standard-library modules and a pre-existing HMAC key file.
+
+- [x] **Step 1: Write failing activation and artifact tests**
+
+```python
+def test_main_requires_explicit_enable(capsys):
+    assert sidecar.main([]) == 2
+    assert "live capture is disabled" in capsys.readouterr().err
+
+@pytest.mark.parametrize("host", ["0.0.0.0", "192.0.2.10"])
+def test_config_rejects_non_loopback(host, base_config):
+    with pytest.raises(sidecar.ConfigurationError, match="listen_not_loopback"):
+        sidecar.validate_config(dataclasses.replace(base_config, listen_host=host))
+
+def test_atomic_record_is_sanitized_and_leaves_no_partial(tmp_path):
+    record_path = sidecar.write_capture_record(tmp_path, "pre", SAFE_RECORD)
+    assert json.loads(record_path.read_text(encoding="utf-8"))["schema"] == (
+        "codexhub.issue62.live-evidence-lane.v1"
+    )
+    assert not list(tmp_path.glob("*.partial"))
+```
+
+- [x] **Step 2: Run the tests and verify RED**
+
+Run: `py -3.13 -m pytest -q tests/test_issue_62_live_evidence_sidecar.py -k "requires_explicit_enable or rejects_non_loopback or atomic_record"`
+
+Expected: collection fails because `scripts/capture_issue_62_live_evidence.py` does not exist.
+
+- [x] **Step 3: Implement validation and atomic writing**
+
+Implement a frozen `SidecarConfig`, fixed schema/failure vocabularies, loopback `ipaddress.ip_address(...).is_loopback` validation, strict URL/key/bound checks, a default-disabled CLI, recursive allow-listed record validation, and unique `.partial` -> `.json` replacement with cleanup in `finally`.
+
+- [x] **Step 4: Run the focused tests and verify GREEN**
+
+Run: `py -3.13 -m pytest -q tests/test_issue_62_live_evidence_sidecar.py -k "requires_explicit_enable or rejects_non_loopback or atomic_record"`
+
+Expected: all selected tests pass.
+
+### Task 2: Complete request/response and SSE fingerprint primitives
+
+**Files:**
+- Modify: `scripts/capture_issue_62_live_evidence.py`
+- Modify: `tests/test_issue_62_live_evidence_sidecar.py`
+
+**Interfaces:**
+- Produces: `BodyFingerprint`, `SseSequenceFingerprint`, and artifact dictionaries with `bytes`, `sha256`, `hmac_sha256`, `complete`, `frame_count`, `frame_bytes`, and allow-listed `terminal_classes`.
+- Consumes: raw byte chunks in their observed order and the pre-loaded HMAC key bytes.
+
+- [x] **Step 1: Write failing literal digest and chunk-boundary tests**
+
+```python
+def test_body_fingerprint_hashes_every_byte():
+    observed = sidecar.BodyFingerprint(KEY, b"request-body")
+    observed.update(b"abc")
+    observed.update(b"\x00def")
+    assert observed.complete() == {
+        "bytes": 7,
+        "sha256": hashlib.sha256(b"abc\x00def").hexdigest(),
+        "hmac_sha256": hmac.new(KEY, b"request-body\0abc\x00def", hashlib.sha256).hexdigest(),
+        "complete": True,
+    }
+
+def test_sse_sequence_digest_is_independent_of_transport_chunks():
+    wire = b'data: {"type":"response.output_text.delta","delta":"secret"}\n\ndata: {"type":"response.completed"}\n\n'
+    one = consume_sse([wire])
+    split = consume_sse([wire[:5], wire[5:41], wire[41:]])
+    assert split == one
+    assert split["frame_count"] == 2
+    assert split["terminal_classes"] == ["response.completed"]
+```
+
+- [x] **Step 2: Run the tests and verify RED**
+
+Run: `py -3.13 -m pytest -q tests/test_issue_62_live_evidence_sidecar.py -k "fingerprint_hashes or sequence_digest"`
+
+Expected: failure because the fingerprint classes are absent.
+
+- [x] **Step 3: Implement minimal incremental fingerprints**
+
+Use `hashlib.sha256()` and `hmac.new(key, domain + b"\0", hashlib.sha256)` for bodies. Split complete LF or CRLF SSE frames independent of read chunks, hash `len(frame).to_bytes(8, "big") + frame` in order, classify only `response.completed`, `response.failed`, `error`, and `[DONE]`, and mark trailing frames or missing terminals incomplete.
+
+- [x] **Step 4: Run the focused tests and verify GREEN**
+
+Run: `py -3.13 -m pytest -q tests/test_issue_62_live_evidence_sidecar.py -k "fingerprint_hashes or sequence_digest"`
+
+Expected: all selected tests pass.
+
+### Task 3: Real loopback forwarding, bounds, cancellation, and cleanup
+
+**Files:**
+- Modify: `scripts/capture_issue_62_live_evidence.py`
+- Modify: `tests/test_issue_62_live_evidence_sidecar.py`
+
+**Interfaces:**
+- Produces: `CaptureSidecarServer`, `start()`/`shutdown()` lifecycle, and one atomic sanitized capture record per request.
+- Consumes: validated `SidecarConfig`; forwards via `http.client.HTTPConnection` or `HTTPSConnection` and strips HTTP hop-by-hop headers.
+
+- [x] **Step 1: Write failing two-hop integration test**
+
+```python
+def test_two_hops_capture_matching_complete_request_response_and_sse(tmp_path):
+    request_body = b'{"input":"private prompt","stream":true}'
+    sse_body = b'data: {"type":"response.output_text.delta","delta":"private output"}\n\ndata: {"type":"response.completed"}\n\n'
+    with fake_upstream(sse_body) as upstream, running_lane(tmp_path, upstream.url) as lane:
+        status, response_body = post_bytes(lane.pre_url + "/responses?opaque=wire-id", request_body)
+    assert status == 200
+    assert response_body == sse_body
+    pre = read_only_record(lane.pre_output)
+    post = read_only_record(lane.post_output)
+    assert pre["request"] == post["request"]
+    assert pre["response"] == post["response"]
+    assert pre["sse"]["sequence_sha256"] == post["sse"]["sequence_sha256"]
+    assert pre["outcome"] == post["outcome"] == "complete"
+```
+
+- [x] **Step 2: Run the integration test and verify RED**
+
+Run: `py -3.13 -m pytest -q tests/test_issue_62_live_evidence_sidecar.py::test_two_hops_capture_matching_complete_request_response_and_sse`
+
+Expected: failure because the HTTP server is absent.
+
+- [x] **Step 3: Implement the minimal server and forwarding path**
+
+Build a `ThreadingHTTPServer` with daemon request threads, exact `Content-Length` request reads, application-body forwarding, response streaming in bounded chunks, deadline checks, fixed sanitized failure codes, and `shutdown()` that closes the listener and joins its serving thread. Do not store exception text.
+
+- [x] **Step 4: Run the integration test and verify GREEN**
+
+Run: `py -3.13 -m pytest -q tests/test_issue_62_live_evidence_sidecar.py::test_two_hops_capture_matching_complete_request_response_and_sse`
+
+Expected: one complete record in each output directory with identical request, response, and SSE digests.
+
+- [x] **Step 5: Write failing bound, timeout, sanitization, and cancellation tests**
+
+```python
+@pytest.mark.parametrize("case", ["request_overflow", "response_overflow", "upstream_timeout", "client_cancel"])
+def test_failure_cases_are_incomplete_sanitized_and_clean(case, tmp_path):
+    result = run_failure_case(case, tmp_path)
+    record = read_only_record(result.output)
+    serialized = json.dumps(record, sort_keys=True)
+    assert record["outcome"] == "incomplete"
+    assert record["failure"] in EXPECTED_FAILURES
+    assert not list(result.output.glob("*.partial"))
+    for sensitive in result.sensitive_values:
+        assert sensitive not in serialized
+```
+
+- [x] **Step 6: Run the failure tests and verify RED**
+
+Run: `py -3.13 -m pytest -q tests/test_issue_62_live_evidence_sidecar.py -k "failure_cases"`
+
+Expected: at least one case fails because its bound or cleanup path is not implemented.
+
+- [x] **Step 7: Implement bounded failure paths and cleanup**
+
+Reject invalid/oversized requests before forwarding, stop response relay at the cap, apply socket and overall deadlines, classify broken downstream writes as `downstream_cancelled`, close every upstream connection in `finally`, null incomplete full-body digests, atomically write the incomplete record, and remove every owned `.partial` file.
+
+- [x] **Step 8: Run the full sidecar test file and verify GREEN**
+
+Run: `py -3.13 -m pytest -q tests/test_issue_62_live_evidence_sidecar.py`
+
+Expected: all sidecar tests pass and no test contacts a non-loopback address.
+
+### Task 4: Usage documentation and candidate verification
+
+**Files:**
+- Modify: `docs/evidence/issue-62/README.md`
+- Modify: `docs/superpowers/plans/2026-08-02-issue-62-live-evidence-sidecar.md`
+
+**Interfaces:**
+- Produces: copyable pre/post commands that remain inert until explicitly enabled and state the exact non-qualification boundary.
+- Consumes: the CLI implemented in Tasks 1-3.
+
+- [x] **Step 1: Add isolated two-process usage commands**
+
+Document distinct output directories and loopback ports, the shared isolated HMAC key file, required bounds/timeouts, and explicit operator-supplied tokens for the separately authorized isolated Gateway/upstream addresses. State that the command must not be aimed at the currently running Desktop/Gateway without a new control-window authorization.
+
+- [x] **Step 2: Run focused and evidence regression checks**
+
+Run:
+
+```powershell
+py -3.13 -m pytest -q tests/test_issue_62_live_evidence_sidecar.py tests/test_diagnostic_recorder.py tests/test_diagnostic_recorder_gateway.py tests/test_issue_62_runtime_trace.py tests/test_issue_62_runtime_audit.py tests/test_issue_62_runtime_inventory.py
+python scripts/build_issue_62_runtime_inventory.py --check-drift
+powershell -NoProfile -ExecutionPolicy Bypass -File scripts/check-codex-thread-tool-surface.ps1
+python scripts/report_quality_gates.py
+git diff --check
+```
+
+Expected: focused tests pass; inventory drift reports a match; PowerShell reports `THREAD_TOOL_SURFACE_COMPLETE` without changing qualification; quality-gate output remains report-only; diff check is clean.
+
+- [x] **Step 3: Confirm the qualification artifact is unchanged**
+
+Run: `git diff origin/dev -- docs/evidence/issue-62/runtime-wire-inventory.json`
+
+Expected: no output.
+
+- [ ] **Step 4: Commit the implementation candidate**
+
+```powershell
+git add scripts/capture_issue_62_live_evidence.py tests/test_issue_62_live_evidence_sidecar.py docs/evidence/issue-62/README.md docs/superpowers/plans/2026-08-02-issue-62-live-evidence-sidecar.md
+git commit -m "test: add isolated Issue 62 live evidence sidecar"
+```

--- a/docs/superpowers/plans/2026-08-02-issue-62-live-evidence-sidecar.md
+++ b/docs/superpowers/plans/2026-08-02-issue-62-live-evidence-sidecar.md
@@ -151,7 +151,7 @@ Expected: failure because the HTTP server is absent.
 
 - [x] **Step 3: Implement the minimal server and forwarding path**
 
-Build a `ThreadingHTTPServer` with daemon request threads, exact `Content-Length` request reads, application-body forwarding, response streaming in bounded chunks, deadline checks, fixed sanitized failure codes, and `shutdown()` that closes the listener and joins its serving thread. Do not store exception text.
+Build a `ThreadingHTTPServer` with tracked request/client/upstream lifecycles, exact `Content-Length` request reads, application-body forwarding, response streaming in bounded chunks, deadline checks, fixed sanitized failure codes, and `shutdown()` that closes the listener and active sockets before a bounded active-handler drain. Do not store exception text.
 
 - [x] **Step 4: Run the integration test and verify GREEN**
 
@@ -210,13 +210,14 @@ Run:
 
 ```powershell
 py -3.13 -m pytest -q tests/test_issue_62_live_evidence_sidecar.py tests/test_diagnostic_recorder.py tests/test_diagnostic_recorder_gateway.py tests/test_issue_62_runtime_trace.py tests/test_issue_62_runtime_audit.py tests/test_issue_62_runtime_inventory.py
+py -3.13 -m pytest -q --ignore=tests/test_real_client_e2e.py
 python scripts/build_issue_62_runtime_inventory.py --check-drift
 powershell -NoProfile -ExecutionPolicy Bypass -File scripts/check-codex-thread-tool-surface.ps1
 python scripts/report_quality_gates.py
 git diff --check
 ```
 
-Expected: focused tests pass; inventory drift reports a match; PowerShell reports `THREAD_TOOL_SURFACE_COMPLETE` without changing qualification; quality-gate output remains report-only; diff check is clean.
+Expected: focused tests pass and the strict Python suite excluding the out-of-scope real-client E2E contract completes without a sidecar regression. Any strict-suite failure must be reproduced at the exact `origin/dev` baseline and reported rather than counted as a pass. Inventory drift reports a match; PowerShell reports `THREAD_TOOL_SURFACE_COMPLETE` without changing qualification; quality-gate output remains report-only; diff check is clean.
 
 - [x] **Step 3: Confirm the qualification artifact is unchanged**
 
@@ -224,7 +225,7 @@ Run: `git diff origin/dev -- docs/evidence/issue-62/runtime-wire-inventory.json`
 
 Expected: no output.
 
-- [ ] **Step 4: Commit the implementation candidate**
+- [x] **Step 4: Commit the implementation candidate**
 
 ```powershell
 git add scripts/capture_issue_62_live_evidence.py tests/test_issue_62_live_evidence_sidecar.py docs/evidence/issue-62/README.md docs/superpowers/plans/2026-08-02-issue-62-live-evidence-sidecar.md

--- a/docs/superpowers/specs/2026-08-02-issue-62-live-evidence-sidecar-design.md
+++ b/docs/superpowers/specs/2026-08-02-issue-62-live-evidence-sidecar-design.md
@@ -1,0 +1,81 @@
+# Issue #62 isolated live-evidence sidecar design
+
+## Scope
+
+Add a standalone, standard-library-only capture sidecar for a separately
+authorized Issue #62 live-control window. The sidecar is evidence tooling, not
+Gateway code. It must not be imported or started by Desktop, Gateway, normal
+builds, or debug builds.
+
+Synthetic tests prove only `synthetic_lane_verified`. They do not update the
+runtime inventory, satisfy a live gate, qualify a model, close Issue #62, or
+unlock a downstream issue.
+
+## Activation and topology
+
+The script refuses to listen unless `--enable-live-capture` is present. Its
+listen address must resolve to IPv4 or IPv6 loopback. Every instance has one
+declared hop (`pre` or `post`), one forward base URL, one isolated output
+directory, and one pre-existing HMAC key file.
+
+An authorized run starts two independent processes:
+
+```text
+isolated client -> pre sidecar -> isolated Gateway -> post sidecar -> upstream
+```
+
+Only temporary, isolated client/Gateway configuration points at the sidecars.
+No production route, telemetry schema, diagnostic recorder, shared config, or
+running Desktop/Gateway process is changed.
+
+## Capture contract
+
+For each request, a sidecar forwards the exact application body bytes while
+incrementally computing:
+
+- full request-body byte count, SHA-256, and keyed HMAC-SHA-256;
+- full response-body byte count, SHA-256, and keyed HMAC-SHA-256; and
+- for an SSE response, an order-sensitive digest over length-prefixed complete
+  SSE frames, plus frame count, byte count, and allow-listed terminal classes.
+
+The HMAC domains are stable across the two hops so equal bytes produce equal
+digests. HTTP hop-by-hop framing is intentionally excluded: fingerprints cover
+the decoded HTTP message body bytes delivered to each application boundary.
+
+The final JSON record contains only the schema, hop, opaque capture id,
+completion outcome, bounded failure code, status, coarse content-type class,
+byte counts, digests, and bounded SSE classifications. It never stores or
+prints a target URL, path, header, credential, HMAC key, raw body, prompt,
+tool argument/result, or wire identifier.
+
+## Bounds and failure behavior
+
+The operator must provide positive request/response byte caps and connect,
+read, and overall timeouts. Invalid content length, request or response
+overflow, upstream timeout, downstream cancellation, forwarding failure, and
+incomplete SSE framing produce a fail-closed `incomplete` record. An incomplete
+record can describe the bounded failure but can never set
+`synthetic_lane_verified=true`.
+
+Each record is written to a unique `.partial` file, flushed, and atomically
+renamed only after serialization succeeds. Every error path removes its
+`.partial` file. Shutdown stops accepting work, closes the listening socket,
+and leaves no partial artifact. No raw-body spool file exists.
+
+## Tests
+
+Focused tests use only real loopback HTTP servers and synthetic fixtures. They
+cover:
+
+1. two sidecars produce matching, independently written full request and
+   response SHA/HMAC values for exact passthrough bytes;
+2. SSE chunk boundaries do not affect the ordered sequence digest;
+3. activation and loopback checks reject default or unsafe startup;
+4. request/response overflow and timeouts fail closed;
+5. prompts, credentials, paths, raw SSE data, and key material never appear in
+   artifacts; and
+6. success, failure, cancellation, and shutdown leave no `.partial` files or
+   listening sidecar threads.
+
+The test fixture summary may say `synthetic_lane_verified`; no test or script
+writes Issue #62 inventory qualification fields.

--- a/scripts/capture_issue_62_live_evidence.py
+++ b/scripts/capture_issue_62_live_evidence.py
@@ -43,7 +43,9 @@ _FAILURES = frozenset(
         "response_overflow",
         "server_start_failed",
         "server_thread_failed",
+        "shutdown_drain_failed",
         "sse_frame_incomplete",
+        "sse_frame_after_terminal",
         "sse_terminal_missing",
         "upstream_timeout",
     }
@@ -201,6 +203,10 @@ class SseSequenceFingerprint:
     def has_trailing_bytes(self) -> bool:
         return bool(self._buffer)
 
+    @property
+    def invalid_after_terminal(self) -> bool:
+        return self._invalid_after_terminal
+
 
 def _classify_sse_terminal(frame: bytes) -> str | None:
     event_name: bytes | None = None
@@ -270,12 +276,7 @@ def validate_config(config: SidecarConfig) -> bytes:
         (config.read_timeout_seconds, "read_timeout_invalid"),
         (config.overall_timeout_seconds, "overall_timeout_invalid"),
     ):
-        if (
-            isinstance(value, bool)
-            or not isinstance(value, (int, float))
-            or not math.isfinite(value)
-            or value <= 0
-        ):
+        if not _is_positive_timeout(value):
             raise ConfigurationError(code)
 
     try:
@@ -285,6 +286,16 @@ def validate_config(config: SidecarConfig) -> bytes:
     if not 32 <= len(key) <= 4096:
         raise ConfigurationError("hmac_key_invalid")
     return key
+
+
+def _is_positive_timeout(value: Any) -> bool:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return False
+    try:
+        numeric = float(value)
+    except (OverflowError, TypeError, ValueError):
+        return False
+    return math.isfinite(numeric) and numeric > 0
 
 
 def _require_exact_fields(value: Mapping[str, Any], expected: frozenset[str], code: str) -> None:
@@ -748,11 +759,12 @@ class CaptureSidecarServer:
             if sse_fingerprint is not None:
                 sse_result = sse_fingerprint.complete()
                 if not sse_result["complete"]:
-                    failure = (
-                        "sse_frame_incomplete"
-                        if sse_fingerprint.has_trailing_bytes
-                        else "sse_terminal_missing"
-                    )
+                    if sse_fingerprint.invalid_after_terminal:
+                        failure = "sse_frame_after_terminal"
+                    elif sse_fingerprint.has_trailing_bytes:
+                        failure = "sse_frame_incomplete"
+                    else:
+                        failure = "sse_terminal_missing"
                     response_complete = False
         except (TimeoutError, socket.timeout):
             failure = "upstream_timeout"
@@ -871,19 +883,25 @@ def main(argv: list[str] | None = None) -> int:
         print(str(error), file=sys.stderr)
         return 2
     server = CaptureSidecarServer(config)
+    result_code = 1
+    failure_code: str | None = None
     try:
         server.start()
-        if not server.wait():
-            print("server_thread_failed", file=sys.stderr)
-            return 1
-        return 0
+        if server.wait():
+            result_code = 0
+        else:
+            failure_code = "server_thread_failed"
     except KeyboardInterrupt:
-        return 0
+        result_code = 0
     except SidecarStartError as error:
-        print(str(error), file=sys.stderr)
-        return 1
+        failure_code = str(error)
     finally:
-        server.shutdown()
+        if not server.shutdown():
+            result_code = 1
+            failure_code = "shutdown_drain_failed"
+    if failure_code is not None:
+        print(failure_code, file=sys.stderr)
+    return result_code
 
 
 if __name__ == "__main__":

--- a/scripts/capture_issue_62_live_evidence.py
+++ b/scripts/capture_issue_62_live_evidence.py
@@ -15,6 +15,7 @@ import http.client
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import ipaddress
 import json
+import math
 import os
 from pathlib import Path
 import re
@@ -143,6 +144,8 @@ class SseSequenceFingerprint:
         self._frame_count = 0
         self._frame_bytes = 0
         self._terminal_classes: set[str] = set()
+        self._terminal_seen = False
+        self._invalid_after_terminal = False
 
     def update(self, chunk: bytes) -> None:
         if not isinstance(chunk, bytes):
@@ -160,8 +163,13 @@ class SseSequenceFingerprint:
             self._hmac_sha256.update(encoded)
             self._frame_count += 1
             self._frame_bytes += len(frame)
+            if self._terminal_seen:
+                self._invalid_after_terminal = True
             terminal = _classify_sse_terminal(frame)
             if terminal is not None:
+                if self._terminal_seen:
+                    self._invalid_after_terminal = True
+                self._terminal_seen = True
                 self._terminal_classes.add(terminal)
 
     def _next_boundary(self) -> tuple[int, int] | None:
@@ -173,7 +181,13 @@ class SseSequenceFingerprint:
         return min(candidates) if candidates else None
 
     def complete(self) -> dict[str, Any]:
-        complete = not self._buffer and bool(self._terminal_classes)
+        complete = not self._buffer and self._terminal_seen and not self._invalid_after_terminal
+        return self._snapshot(complete=complete)
+
+    def incomplete(self) -> dict[str, Any]:
+        return self._snapshot(complete=False)
+
+    def _snapshot(self, *, complete: bool) -> dict[str, Any]:
         return {
             "complete": complete,
             "frame_count": self._frame_count,
@@ -230,6 +244,10 @@ def validate_config(config: SidecarConfig) -> bytes:
         raise ConfigurationError("listen_port_invalid")
 
     target = urlsplit(config.forward_base_url)
+    try:
+        target_port = target.port
+    except ValueError as error:
+        raise ConfigurationError("forward_base_url_invalid") from error
     if (
         target.scheme not in {"http", "https"}
         or not target.hostname
@@ -237,6 +255,7 @@ def validate_config(config: SidecarConfig) -> bytes:
         or target.password is not None
         or target.query
         or target.fragment
+        or (target_port is not None and not 1 <= target_port <= 65535)
     ):
         raise ConfigurationError("forward_base_url_invalid")
 
@@ -251,7 +270,12 @@ def validate_config(config: SidecarConfig) -> bytes:
         (config.read_timeout_seconds, "read_timeout_invalid"),
         (config.overall_timeout_seconds, "overall_timeout_invalid"),
     ):
-        if isinstance(value, bool) or not isinstance(value, (int, float)) or value <= 0:
+        if (
+            isinstance(value, bool)
+            or not isinstance(value, (int, float))
+            or not math.isfinite(value)
+            or value <= 0
+        ):
             raise ConfigurationError(code)
 
     try:
@@ -443,11 +467,31 @@ class _CaptureRequestHandler(BaseHTTPRequestHandler):
     def log_message(self, format: str, *args: object) -> None:
         return None
 
+    def finish(self) -> None:
+        try:
+            super().finish()
+        finally:
+            owner = getattr(self.server, "capture_owner", None)
+            if owner is not None:
+                owner._finish_client(self.connection)
+
 
 class _CaptureThreadingHttpServer(ThreadingHTTPServer):
+    def process_request(self, request: Any, client_address: Any) -> None:
+        owner = getattr(self, "capture_owner", None)
+        if owner is not None:
+            owner._register_client(request)
+        try:
+            super().process_request(request, client_address)
+        except BaseException:
+            if owner is not None:
+                owner._finish_client(request)
+            raise
+
     def handle_error(self, request: Any, client_address: Any) -> None:
         owner = getattr(self, "capture_owner", None)
         if owner is not None:
+            owner._finish_client(request)
             owner._write_control_failure("client_cancelled")
 
 
@@ -465,6 +509,11 @@ class CaptureSidecarServer:
         self._server: ThreadingHTTPServer | None = None
         self._thread: threading.Thread | None = None
         self._thread_failure: str | None = None
+        self._active_condition = threading.Condition()
+        self._active_connections: dict[
+            socket.socket,
+            http.client.HTTPConnection | None,
+        ] = {}
 
     @property
     def listen_host(self) -> str:
@@ -517,7 +566,7 @@ class CaptureSidecarServer:
             self._thread_failure = "server_thread_failed"
             self._write_control_failure("server_thread_failed")
 
-    def shutdown(self) -> None:
+    def shutdown(self) -> bool:
         server = self._server
         thread = self._thread
         self._server = None
@@ -525,9 +574,14 @@ class CaptureSidecarServer:
         if server is not None:
             if thread is not None and thread.is_alive():
                 server.shutdown()
+        self._close_active_connections()
+        if server is not None:
             server.server_close()
+        drain_timeout = min(self._config.overall_timeout_seconds, 5.0)
+        drained = self._wait_for_active_connections(drain_timeout)
         if thread is not None and thread is not threading.current_thread():
-            thread.join(timeout=max(1.0, self._config.overall_timeout_seconds))
+            thread.join(timeout=min(max(0.1, self._config.overall_timeout_seconds), 5.0))
+        return drained and (thread is None or not thread.is_alive())
 
     def wait(self) -> bool:
         thread = self._thread
@@ -546,6 +600,58 @@ class CaptureSidecarServer:
             )
         except Exception:
             return
+
+    def _register_client(self, connection: socket.socket) -> None:
+        with self._active_condition:
+            self._active_connections[connection] = None
+            self._active_condition.notify_all()
+
+    def _set_active_upstream(
+        self,
+        connection: socket.socket,
+        upstream: http.client.HTTPConnection | None,
+    ) -> None:
+        with self._active_condition:
+            if connection in self._active_connections:
+                self._active_connections[connection] = upstream
+
+    def _finish_client(self, connection: socket.socket) -> None:
+        with self._active_condition:
+            self._active_connections.pop(connection, None)
+            self._active_condition.notify_all()
+
+    def _close_active_connections(self) -> None:
+        with self._active_condition:
+            active = list(self._active_connections.items())
+        for connection, upstream in active:
+            if upstream is not None:
+                if upstream.sock is not None:
+                    try:
+                        upstream.sock.shutdown(socket.SHUT_RDWR)
+                    except OSError:
+                        pass
+                try:
+                    upstream.close()
+                except OSError:
+                    pass
+            try:
+                connection.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
+            try:
+                connection.close()
+            except OSError:
+                pass
+
+    def _wait_for_active_connections(self, timeout: float) -> bool:
+        deadline = time.monotonic() + max(0.0, timeout)
+        with self._active_condition:
+            while self._active_connections:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return False
+                self._active_condition.wait(timeout=remaining)
+            return True
 
     def handle_post(self, handler: BaseHTTPRequestHandler) -> None:
         capture_id = _capture_id()
@@ -595,6 +701,7 @@ class CaptureSidecarServer:
                 self._target.port,
                 timeout=self._config.connect_timeout_seconds,
             )
+            self._set_active_upstream(handler.connection, upstream)
             headers = {
                 name: value
                 for name, value in handler.headers.items()
@@ -661,6 +768,7 @@ class CaptureSidecarServer:
                     upstream.close()
                 except OSError:
                     pass
+                self._set_active_upstream(handler.connection, None)
             outcome = "complete" if failure is None and request_complete and response_complete else "incomplete"
             if outcome == "incomplete" and failure is None:
                 failure = "forwarding_failed"
@@ -679,7 +787,15 @@ class CaptureSidecarServer:
                     if response_fingerprint is not None
                     else None
                 ),
-                "sse": sse_fingerprint.complete() if sse_fingerprint is not None else None,
+                "sse": (
+                    (
+                        sse_fingerprint.complete()
+                        if response_complete
+                        else sse_fingerprint.incomplete()
+                    )
+                    if sse_fingerprint is not None
+                    else None
+                ),
             }
             try:
                 write_capture_record(self._config.output_dir, self._config.hop, record)

--- a/scripts/capture_issue_62_live_evidence.py
+++ b/scripts/capture_issue_62_live_evidence.py
@@ -1,0 +1,774 @@
+#!/usr/bin/env python3
+"""Explicitly enabled, standalone Issue #62 live-evidence sidecar.
+
+This module is evidence tooling. Nothing in the Gateway or Desktop imports it,
+and invoking it without ``--enable-live-capture`` cannot open a listener.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import hashlib
+import hmac
+import http.client
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import ipaddress
+import json
+import os
+from pathlib import Path
+import re
+import socket
+import sys
+import threading
+import time
+from typing import Any, Mapping
+from urllib.parse import urlsplit
+import uuid
+
+
+SCHEMA = "codexhub.issue62.live-evidence-lane.v1"
+VERIFICATION_SCOPE = "capture_only_not_qualification"
+_HOPS = frozenset({"pre", "post"})
+_OUTCOMES = frozenset({"complete", "incomplete"})
+_FAILURES = frozenset(
+    {
+        "client_cancelled",
+        "downstream_cancelled",
+        "forwarding_failed",
+        "invalid_content_length",
+        "request_incomplete",
+        "request_overflow",
+        "response_overflow",
+        "server_start_failed",
+        "server_thread_failed",
+        "sse_frame_incomplete",
+        "sse_terminal_missing",
+        "upstream_timeout",
+    }
+)
+_CONTENT_TYPE_CLASSES = frozenset({"event-stream", "json", "other", "absent", "unknown"})
+_TERMINAL_CLASSES = frozenset({"done", "error", "response.completed", "response.failed"})
+_ROOT_FIELDS = frozenset(
+    {
+        "schema",
+        "verification_scope",
+        "capture_id",
+        "hop",
+        "outcome",
+        "failure",
+        "status",
+        "content_type_class",
+        "request",
+        "response",
+        "sse",
+    }
+)
+_BODY_FIELDS = frozenset({"bytes", "sha256", "hmac_sha256", "complete"})
+_SSE_FIELDS = frozenset(
+    {
+        "complete",
+        "frame_count",
+        "frame_bytes",
+        "sequence_sha256",
+        "sequence_hmac_sha256",
+        "terminal_classes",
+    }
+)
+_CAPTURE_ID = re.compile(r"c[0-9a-f]{32}\Z")
+_DIGEST = re.compile(r"[0-9a-f]{64}\Z")
+
+
+class ConfigurationError(ValueError):
+    """A fixed-code startup configuration failure."""
+
+
+class ArtifactValidationError(ValueError):
+    """A fixed-code sanitized-artifact contract failure."""
+
+
+class SidecarStartError(RuntimeError):
+    """The isolated listener failed before it could accept evidence traffic."""
+
+
+@dataclass(frozen=True)
+class SidecarConfig:
+    hop: str
+    listen_host: str
+    listen_port: int
+    forward_base_url: str
+    output_dir: Path
+    hmac_key_file: Path
+    max_request_bytes: int
+    max_response_bytes: int
+    connect_timeout_seconds: float
+    read_timeout_seconds: float
+    overall_timeout_seconds: float
+
+
+class BodyFingerprint:
+    """Incrementally fingerprint exact application-body bytes."""
+
+    def __init__(self, key: bytes, domain: bytes) -> None:
+        self._sha256 = hashlib.sha256()
+        self._hmac_sha256 = hmac.new(key, domain + b"\0", hashlib.sha256)
+        self._bytes = 0
+
+    def update(self, chunk: bytes) -> None:
+        if not isinstance(chunk, bytes):
+            raise TypeError("fingerprint_chunk_not_bytes")
+        self._sha256.update(chunk)
+        self._hmac_sha256.update(chunk)
+        self._bytes += len(chunk)
+
+    def snapshot(self, *, complete: bool) -> dict[str, Any]:
+        return {
+            "bytes": self._bytes,
+            "sha256": self._sha256.hexdigest() if complete else None,
+            "hmac_sha256": self._hmac_sha256.hexdigest() if complete else None,
+            "complete": complete,
+        }
+
+    def complete(self) -> dict[str, Any]:
+        return self.snapshot(complete=True)
+
+
+class SseSequenceFingerprint:
+    """Hash ordered complete SSE frames independent of transport chunking."""
+
+    def __init__(self, key: bytes) -> None:
+        self._sha256 = hashlib.sha256()
+        self._hmac_sha256 = hmac.new(key, b"sse-sequence\0", hashlib.sha256)
+        self._buffer = bytearray()
+        self._frame_count = 0
+        self._frame_bytes = 0
+        self._terminal_classes: set[str] = set()
+
+    def update(self, chunk: bytes) -> None:
+        if not isinstance(chunk, bytes):
+            raise TypeError("sse_chunk_not_bytes")
+        self._buffer.extend(chunk)
+        while True:
+            boundary = self._next_boundary()
+            if boundary is None:
+                return
+            index, width = boundary
+            frame = bytes(self._buffer[:index])
+            del self._buffer[: index + width]
+            encoded = len(frame).to_bytes(8, "big") + frame
+            self._sha256.update(encoded)
+            self._hmac_sha256.update(encoded)
+            self._frame_count += 1
+            self._frame_bytes += len(frame)
+            terminal = _classify_sse_terminal(frame)
+            if terminal is not None:
+                self._terminal_classes.add(terminal)
+
+    def _next_boundary(self) -> tuple[int, int] | None:
+        candidates = [
+            (index, len(marker))
+            for marker in (b"\r\n\r\n", b"\n\n")
+            if (index := self._buffer.find(marker)) >= 0
+        ]
+        return min(candidates) if candidates else None
+
+    def complete(self) -> dict[str, Any]:
+        complete = not self._buffer and bool(self._terminal_classes)
+        return {
+            "complete": complete,
+            "frame_count": self._frame_count,
+            "frame_bytes": self._frame_bytes,
+            "sequence_sha256": self._sha256.hexdigest() if complete else None,
+            "sequence_hmac_sha256": self._hmac_sha256.hexdigest() if complete else None,
+            "terminal_classes": sorted(self._terminal_classes),
+        }
+
+    @property
+    def has_trailing_bytes(self) -> bool:
+        return bool(self._buffer)
+
+
+def _classify_sse_terminal(frame: bytes) -> str | None:
+    event_name: bytes | None = None
+    data_lines: list[bytes] = []
+    for line in frame.splitlines():
+        if line.startswith(b"event:"):
+            event_name = line[6:].lstrip(b" ")
+        elif line.startswith(b"data:"):
+            data_lines.append(line[5:].lstrip(b" "))
+    if event_name == b"error":
+        return "error"
+    data = b"\n".join(data_lines)
+    if data == b"[DONE]":
+        return "done"
+    try:
+        payload = json.loads(data.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, Mapping):
+        return None
+    event_type = payload.get("type")
+    if event_type in {"response.completed", "response.failed", "error"}:
+        return str(event_type)
+    return None
+
+
+def validate_config(config: SidecarConfig) -> bytes:
+    """Validate the isolated lane and return its already-provisioned HMAC key."""
+
+    if config.hop not in _HOPS:
+        raise ConfigurationError("hop_invalid")
+    try:
+        listen_address = ipaddress.ip_address(config.listen_host)
+    except ValueError as error:
+        raise ConfigurationError("listen_not_loopback") from error
+    if not listen_address.is_loopback:
+        raise ConfigurationError("listen_not_loopback")
+    if isinstance(config.listen_port, bool) or not isinstance(config.listen_port, int):
+        raise ConfigurationError("listen_port_invalid")
+    if not 0 <= config.listen_port <= 65535:
+        raise ConfigurationError("listen_port_invalid")
+
+    target = urlsplit(config.forward_base_url)
+    if (
+        target.scheme not in {"http", "https"}
+        or not target.hostname
+        or target.username is not None
+        or target.password is not None
+        or target.query
+        or target.fragment
+    ):
+        raise ConfigurationError("forward_base_url_invalid")
+
+    for value, code in (
+        (config.max_request_bytes, "max_request_bytes_invalid"),
+        (config.max_response_bytes, "max_response_bytes_invalid"),
+    ):
+        if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+            raise ConfigurationError(code)
+    for value, code in (
+        (config.connect_timeout_seconds, "connect_timeout_invalid"),
+        (config.read_timeout_seconds, "read_timeout_invalid"),
+        (config.overall_timeout_seconds, "overall_timeout_invalid"),
+    ):
+        if isinstance(value, bool) or not isinstance(value, (int, float)) or value <= 0:
+            raise ConfigurationError(code)
+
+    try:
+        key = Path(config.hmac_key_file).read_bytes()
+    except OSError as error:
+        raise ConfigurationError("hmac_key_unavailable") from error
+    if not 32 <= len(key) <= 4096:
+        raise ConfigurationError("hmac_key_invalid")
+    return key
+
+
+def _require_exact_fields(value: Mapping[str, Any], expected: frozenset[str], code: str) -> None:
+    if frozenset(value) != expected:
+        raise ArtifactValidationError(code)
+
+
+def _validate_digest(value: Any, code: str) -> None:
+    if value is not None and (not isinstance(value, str) or _DIGEST.fullmatch(value) is None):
+        raise ArtifactValidationError(code)
+
+
+def _validate_body(value: Any, code: str) -> None:
+    if value is None:
+        return
+    if not isinstance(value, Mapping):
+        raise ArtifactValidationError(code)
+    _require_exact_fields(value, _BODY_FIELDS, code)
+    if isinstance(value["bytes"], bool) or not isinstance(value["bytes"], int) or value["bytes"] < 0:
+        raise ArtifactValidationError(code)
+    if not isinstance(value["complete"], bool):
+        raise ArtifactValidationError(code)
+    _validate_digest(value["sha256"], code)
+    _validate_digest(value["hmac_sha256"], code)
+    if value["complete"] != (value["sha256"] is not None and value["hmac_sha256"] is not None):
+        raise ArtifactValidationError(code)
+
+
+def _validate_sse(value: Any) -> None:
+    if value is None:
+        return
+    if not isinstance(value, Mapping):
+        raise ArtifactValidationError("sse_invalid")
+    _require_exact_fields(value, _SSE_FIELDS, "sse_fields_invalid")
+    for key in ("frame_count", "frame_bytes"):
+        if isinstance(value[key], bool) or not isinstance(value[key], int) or value[key] < 0:
+            raise ArtifactValidationError("sse_invalid")
+    if not isinstance(value["complete"], bool):
+        raise ArtifactValidationError("sse_invalid")
+    _validate_digest(value["sequence_sha256"], "sse_invalid")
+    _validate_digest(value["sequence_hmac_sha256"], "sse_invalid")
+    has_digests = value["sequence_sha256"] is not None and value["sequence_hmac_sha256"] is not None
+    if value["complete"] != has_digests:
+        raise ArtifactValidationError("sse_invalid")
+    if not isinstance(value["terminal_classes"], list) or any(
+        item not in _TERMINAL_CLASSES for item in value["terminal_classes"]
+    ):
+        raise ArtifactValidationError("sse_invalid")
+
+
+def validate_capture_record(record: Mapping[str, Any], hop: str) -> None:
+    """Reject any field outside the deliberately tiny sanitized schema."""
+
+    if not isinstance(record, Mapping):
+        raise ArtifactValidationError("record_invalid")
+    _require_exact_fields(record, _ROOT_FIELDS, "record_fields_invalid")
+    if record["schema"] != SCHEMA or record["verification_scope"] != VERIFICATION_SCOPE:
+        raise ArtifactValidationError("record_schema_invalid")
+    if hop not in _HOPS or record["hop"] != hop:
+        raise ArtifactValidationError("record_hop_invalid")
+    capture_id = record["capture_id"]
+    if not isinstance(capture_id, str) or _CAPTURE_ID.fullmatch(capture_id) is None:
+        raise ArtifactValidationError("capture_id_invalid")
+    if record["outcome"] not in _OUTCOMES:
+        raise ArtifactValidationError("record_outcome_invalid")
+    if record["failure"] is not None and record["failure"] not in _FAILURES:
+        raise ArtifactValidationError("record_failure_invalid")
+    if (record["outcome"] == "complete") != (record["failure"] is None):
+        raise ArtifactValidationError("record_completion_invalid")
+    status = record["status"]
+    if status is not None and (isinstance(status, bool) or not isinstance(status, int) or not 100 <= status <= 599):
+        raise ArtifactValidationError("record_status_invalid")
+    if record["content_type_class"] not in _CONTENT_TYPE_CLASSES:
+        raise ArtifactValidationError("record_content_type_invalid")
+    _validate_body(record["request"], "request_fingerprint_invalid")
+    _validate_body(record["response"], "response_fingerprint_invalid")
+    _validate_sse(record["sse"])
+    if record["outcome"] == "complete":
+        request = record["request"]
+        response = record["response"]
+        sse = record["sse"]
+        if (
+            not isinstance(request, Mapping)
+            or request.get("complete") is not True
+            or not isinstance(response, Mapping)
+            or response.get("complete") is not True
+        ):
+            raise ArtifactValidationError("record_completion_invalid")
+        if record["content_type_class"] == "event-stream":
+            if not isinstance(sse, Mapping) or sse.get("complete") is not True:
+                raise ArtifactValidationError("record_completion_invalid")
+        elif sse is not None:
+            raise ArtifactValidationError("record_completion_invalid")
+
+
+def write_capture_record(output_dir: Path, hop: str, record: Mapping[str, Any]) -> Path:
+    """Atomically publish one sanitized record and always remove its partial."""
+
+    validate_capture_record(record, hop)
+    directory = Path(output_dir)
+    directory.mkdir(parents=True, exist_ok=True)
+    capture_id = str(record["capture_id"])
+    target = directory / f"{hop}-{capture_id}.json"
+    partial = directory / f"{hop}-{capture_id}.partial"
+    if target.exists():
+        raise ArtifactValidationError("capture_record_exists")
+    rendered = json.dumps(record, ensure_ascii=True, sort_keys=True, separators=(",", ":")) + "\n"
+    try:
+        with partial.open("x", encoding="ascii", newline="\n") as handle:
+            handle.write(rendered)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(partial, target)
+    finally:
+        try:
+            partial.unlink()
+        except FileNotFoundError:
+            pass
+    return target
+
+
+_HOP_BY_HOP_HEADERS = frozenset(
+    {
+        "connection",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailer",
+        "transfer-encoding",
+        "upgrade",
+    }
+)
+
+
+def _capture_id() -> str:
+    return "c" + uuid.uuid4().hex
+
+
+def _content_type_class(value: str | None) -> str:
+    if not value:
+        return "absent"
+    lowered = value.lower()
+    if "text/event-stream" in lowered:
+        return "event-stream"
+    if "json" in lowered:
+        return "json"
+    return "other"
+
+
+def _empty_record(hop: str, capture_id: str, failure: str) -> dict[str, Any]:
+    return {
+        "schema": SCHEMA,
+        "verification_scope": VERIFICATION_SCOPE,
+        "capture_id": capture_id,
+        "hop": hop,
+        "outcome": "incomplete",
+        "failure": failure,
+        "status": None,
+        "content_type_class": "unknown",
+        "request": None,
+        "response": None,
+        "sse": None,
+    }
+
+
+def _join_target_path(base_path: str, incoming_path: str) -> str:
+    prefix = base_path.rstrip("/")
+    suffix = incoming_path if incoming_path.startswith("/") else f"/{incoming_path}"
+    return f"{prefix}{suffix}" or "/"
+
+
+class _CaptureRequestHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.0"
+
+    def do_POST(self) -> None:
+        owner = self.server.capture_owner  # type: ignore[attr-defined]
+        owner.handle_post(self)
+
+    def log_message(self, format: str, *args: object) -> None:
+        return None
+
+
+class _CaptureThreadingHttpServer(ThreadingHTTPServer):
+    def handle_error(self, request: Any, client_address: Any) -> None:
+        owner = getattr(self, "capture_owner", None)
+        if owner is not None:
+            owner._write_control_failure("client_cancelled")
+
+
+class _ThreadingHttpServerV6(_CaptureThreadingHttpServer):
+    address_family = socket.AF_INET6
+
+
+class CaptureSidecarServer:
+    """One explicitly constructed loopback capture hop."""
+
+    def __init__(self, config: SidecarConfig) -> None:
+        self._config = config
+        self._key = validate_config(config)
+        self._target = urlsplit(config.forward_base_url)
+        self._server: ThreadingHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+        self._thread_failure: str | None = None
+
+    @property
+    def listen_host(self) -> str:
+        return self._config.listen_host
+
+    @property
+    def listen_port(self) -> int:
+        if self._server is None:
+            return self._config.listen_port
+        return int(self._server.server_address[1])
+
+    @property
+    def url(self) -> str:
+        host = f"[{self.listen_host}]" if ":" in self.listen_host else self.listen_host
+        return f"http://{host}:{self.listen_port}"
+
+    def start(self) -> "CaptureSidecarServer":
+        if self._server is not None:
+            raise SidecarStartError("server_already_started")
+        server_type = _ThreadingHttpServerV6 if ":" in self._config.listen_host else _CaptureThreadingHttpServer
+        try:
+            server = server_type(
+                (self._config.listen_host, self._config.listen_port),
+                _CaptureRequestHandler,
+            )
+            server.daemon_threads = True
+            server.capture_owner = self  # type: ignore[attr-defined]
+            thread = threading.Thread(
+                target=self._serve,
+                args=(server,),
+                name=f"issue62-live-evidence-{self._config.hop}",
+                daemon=True,
+            )
+            self._server = server
+            self._thread = thread
+            thread.start()
+        except BaseException as error:
+            if self._server is not None:
+                self._server.server_close()
+            self._server = None
+            self._thread = None
+            self._write_control_failure("server_start_failed")
+            raise SidecarStartError("server_start_failed") from error
+        return self
+
+    def _serve(self, server: ThreadingHTTPServer) -> None:
+        try:
+            server.serve_forever(poll_interval=0.05)
+        except BaseException:
+            self._thread_failure = "server_thread_failed"
+            self._write_control_failure("server_thread_failed")
+
+    def shutdown(self) -> None:
+        server = self._server
+        thread = self._thread
+        self._server = None
+        self._thread = None
+        if server is not None:
+            if thread is not None and thread.is_alive():
+                server.shutdown()
+            server.server_close()
+        if thread is not None and thread is not threading.current_thread():
+            thread.join(timeout=max(1.0, self._config.overall_timeout_seconds))
+
+    def wait(self) -> bool:
+        thread = self._thread
+        if thread is None:
+            return False
+        while thread.is_alive():
+            thread.join(timeout=0.25)
+        return self._thread_failure is None
+
+    def _write_control_failure(self, failure: str) -> None:
+        try:
+            write_capture_record(
+                self._config.output_dir,
+                self._config.hop,
+                _empty_record(self._config.hop, _capture_id(), failure),
+            )
+        except Exception:
+            return
+
+    def handle_post(self, handler: BaseHTTPRequestHandler) -> None:
+        capture_id = _capture_id()
+        started_at = time.monotonic()
+        request_fingerprint = BodyFingerprint(self._key, b"request-body")
+        response_fingerprint: BodyFingerprint | None = None
+        sse_fingerprint: SseSequenceFingerprint | None = None
+        status: int | None = None
+        content_class = "unknown"
+        failure: str | None = None
+        upstream: http.client.HTTPConnection | None = None
+        request_complete = False
+        response_complete = False
+        try:
+            raw_length = handler.headers.get("Content-Length")
+            try:
+                content_length = int(raw_length) if raw_length is not None else -1
+            except ValueError:
+                content_length = -1
+            if content_length < 0:
+                failure = "invalid_content_length"
+                self._send_bounded_error(handler, 400)
+                return
+            if content_length > self._config.max_request_bytes:
+                failure = "request_overflow"
+                self._send_bounded_error(handler, 413)
+                return
+            handler.connection.settimeout(
+                min(self._config.read_timeout_seconds, self._config.overall_timeout_seconds)
+            )
+            request_body = handler.rfile.read(content_length)
+            request_fingerprint.update(request_body)
+            if len(request_body) != content_length:
+                failure = "request_incomplete"
+                self._send_bounded_error(handler, 400)
+                return
+            request_complete = True
+            self._check_deadline(started_at)
+
+            connection_type = (
+                http.client.HTTPSConnection
+                if self._target.scheme == "https"
+                else http.client.HTTPConnection
+            )
+            upstream = connection_type(
+                self._target.hostname,
+                self._target.port,
+                timeout=self._config.connect_timeout_seconds,
+            )
+            headers = {
+                name: value
+                for name, value in handler.headers.items()
+                if name.lower() not in _HOP_BY_HOP_HEADERS | {"host", "content-length"}
+            }
+            target_path = _join_target_path(self._target.path, handler.path)
+            upstream.request("POST", target_path, body=request_body, headers=headers)
+            if upstream.sock is not None:
+                upstream.sock.settimeout(self._remaining_timeout(started_at))
+            upstream_response = upstream.getresponse()
+            status = int(upstream_response.status)
+            content_class = _content_type_class(upstream_response.getheader("Content-Type"))
+            response_fingerprint = BodyFingerprint(self._key, b"response-body")
+            if content_class == "event-stream":
+                sse_fingerprint = SseSequenceFingerprint(self._key)
+
+            handler.send_response(status)
+            for name, value in upstream_response.getheaders():
+                if name.lower() not in _HOP_BY_HOP_HEADERS | {"content-length"}:
+                    handler.send_header(name, value)
+            handler.send_header("Connection", "close")
+            handler.end_headers()
+
+            while True:
+                self._check_deadline(started_at)
+                if upstream.sock is not None:
+                    upstream.sock.settimeout(self._remaining_timeout(started_at))
+                chunk = upstream_response.read(64 * 1024)
+                if not chunk:
+                    break
+                if response_fingerprint.snapshot(complete=False)["bytes"] + len(chunk) > self._config.max_response_bytes:
+                    failure = "response_overflow"
+                    return
+                response_fingerprint.update(chunk)
+                if sse_fingerprint is not None:
+                    sse_fingerprint.update(chunk)
+                try:
+                    handler.wfile.write(chunk)
+                    handler.wfile.flush()
+                except (BrokenPipeError, ConnectionResetError, OSError):
+                    failure = "downstream_cancelled"
+                    return
+            response_complete = True
+            if sse_fingerprint is not None:
+                sse_result = sse_fingerprint.complete()
+                if not sse_result["complete"]:
+                    failure = (
+                        "sse_frame_incomplete"
+                        if sse_fingerprint.has_trailing_bytes
+                        else "sse_terminal_missing"
+                    )
+                    response_complete = False
+        except (TimeoutError, socket.timeout):
+            failure = "upstream_timeout"
+            if status is None:
+                self._send_bounded_error(handler, 504)
+        except (BrokenPipeError, ConnectionResetError):
+            failure = "client_cancelled"
+        except OSError:
+            failure = "forwarding_failed"
+        finally:
+            if upstream is not None:
+                try:
+                    upstream.close()
+                except OSError:
+                    pass
+            outcome = "complete" if failure is None and request_complete and response_complete else "incomplete"
+            if outcome == "incomplete" and failure is None:
+                failure = "forwarding_failed"
+            record = {
+                "schema": SCHEMA,
+                "verification_scope": VERIFICATION_SCOPE,
+                "capture_id": capture_id,
+                "hop": self._config.hop,
+                "outcome": outcome,
+                "failure": failure,
+                "status": status,
+                "content_type_class": content_class,
+                "request": request_fingerprint.snapshot(complete=request_complete),
+                "response": (
+                    response_fingerprint.snapshot(complete=response_complete)
+                    if response_fingerprint is not None
+                    else None
+                ),
+                "sse": sse_fingerprint.complete() if sse_fingerprint is not None else None,
+            }
+            try:
+                write_capture_record(self._config.output_dir, self._config.hop, record)
+            except Exception:
+                return
+
+    def _check_deadline(self, started_at: float) -> None:
+        if time.monotonic() - started_at > self._config.overall_timeout_seconds:
+            raise TimeoutError("capture_deadline")
+
+    def _remaining_timeout(self, started_at: float) -> float:
+        remaining = self._config.overall_timeout_seconds - (time.monotonic() - started_at)
+        if remaining <= 0:
+            raise TimeoutError("capture_deadline")
+        return min(self._config.read_timeout_seconds, remaining)
+
+    @staticmethod
+    def _send_bounded_error(handler: BaseHTTPRequestHandler, status: int) -> None:
+        body = b"isolated evidence sidecar rejected the request\n"
+        try:
+            handler.send_response(status)
+            handler.send_header("Content-Type", "text/plain; charset=utf-8")
+            handler.send_header("Content-Length", str(len(body)))
+            handler.send_header("Connection", "close")
+            handler.end_headers()
+            handler.wfile.write(body)
+        except OSError:
+            return
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run an isolated Issue #62 live-evidence sidecar.")
+    parser.add_argument("--enable-live-capture", action="store_true")
+    parser.add_argument("--hop", choices=sorted(_HOPS), required=True)
+    parser.add_argument("--listen-host", required=True)
+    parser.add_argument("--listen-port", type=int, required=True)
+    parser.add_argument("--forward-base-url", required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--hmac-key-file", type=Path, required=True)
+    parser.add_argument("--max-request-bytes", type=int, required=True)
+    parser.add_argument("--max-response-bytes", type=int, required=True)
+    parser.add_argument("--connect-timeout-seconds", type=float, required=True)
+    parser.add_argument("--read-timeout-seconds", type=float, required=True)
+    parser.add_argument("--overall-timeout-seconds", type=float, required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    arguments = list(sys.argv[1:] if argv is None else argv)
+    if "--enable-live-capture" not in arguments:
+        print("live capture is disabled; pass --enable-live-capture explicitly", file=sys.stderr)
+        return 2
+    options = _build_parser().parse_args(arguments)
+    config = SidecarConfig(
+        hop=options.hop,
+        listen_host=options.listen_host,
+        listen_port=options.listen_port,
+        forward_base_url=options.forward_base_url,
+        output_dir=options.output_dir,
+        hmac_key_file=options.hmac_key_file,
+        max_request_bytes=options.max_request_bytes,
+        max_response_bytes=options.max_response_bytes,
+        connect_timeout_seconds=options.connect_timeout_seconds,
+        read_timeout_seconds=options.read_timeout_seconds,
+        overall_timeout_seconds=options.overall_timeout_seconds,
+    )
+    if config.listen_port == 0:
+        print("listen_port_zero_not_allowed", file=sys.stderr)
+        return 2
+    try:
+        validate_config(config)
+    except ConfigurationError as error:
+        print(str(error), file=sys.stderr)
+        return 2
+    server = CaptureSidecarServer(config)
+    try:
+        server.start()
+        if not server.wait():
+            print("server_thread_failed", file=sys.stderr)
+            return 1
+        return 0
+    except KeyboardInterrupt:
+        return 0
+    except SidecarStartError as error:
+        print(str(error), file=sys.stderr)
+        return 1
+    finally:
+        server.shutdown()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_issue_62_live_evidence_sidecar.py
+++ b/tests/test_issue_62_live_evidence_sidecar.py
@@ -193,6 +193,23 @@ def test_config_rejects_nonfinite_timeouts(field: str, value: float, code: str, 
         sidecar.validate_config(dataclasses.replace(base_config, **{field: value}))
 
 
+@pytest.mark.parametrize(
+    ("field", "code"),
+    [
+        ("connect_timeout_seconds", "connect_timeout_invalid"),
+        ("read_timeout_seconds", "read_timeout_invalid"),
+        ("overall_timeout_seconds", "overall_timeout_invalid"),
+    ],
+)
+def test_config_rejects_arbitrarily_large_positive_integer_timeout(
+    field: str,
+    code: str,
+    base_config,
+) -> None:
+    with pytest.raises(sidecar.ConfigurationError, match=code):
+        sidecar.validate_config(dataclasses.replace(base_config, **{field: 10**1000}))
+
+
 def test_atomic_record_is_sanitized_and_leaves_no_partial(tmp_path: Path) -> None:
     record = {
         "schema": "codexhub.issue62.live-evidence-lane.v1",
@@ -424,6 +441,31 @@ def test_sse_sequence_fails_closed_when_any_frame_follows_terminal() -> None:
     assert observed["sequence_sha256"] is None
     assert observed["sequence_hmac_sha256"] is None
     assert observed["terminal_classes"] == ["response.completed"]
+
+
+def test_terminal_followed_by_frame_uses_fixed_failure_code(
+    tmp_path: Path,
+    hmac_key_file: Path,
+) -> None:
+    response_body = (
+        b'data: {"type":"response.completed"}\n\n'
+        b'data: {"type":"response.output_text.delta","delta":"after"}\n\n'
+    )
+    with _fake_upstream(response_body) as upstream:
+        upstream_url = f"http://127.0.0.1:{upstream.server_address[1]}"
+        config = _sidecar_config(tmp_path, hmac_key_file, upstream_url)
+        with _running_sidecar(config) as server:
+            connection = http.client.HTTPConnection(server.listen_host, server.listen_port, timeout=2)
+            connection.request("POST", "/responses", body=b"{}")
+            response = connection.getresponse()
+            response.read()
+            connection.close()
+
+    record = _read_only_record(config.output_dir)
+    assert record["outcome"] == "incomplete"
+    assert record["failure"] == "sse_frame_after_terminal"
+    assert record["response"]["complete"] is False  # type: ignore[index]
+    assert record["sse"]["complete"] is False  # type: ignore[index]
 
 
 def test_two_hops_capture_matching_complete_request_response_and_sse(
@@ -828,6 +870,81 @@ def test_cli_explicit_enable_starts_and_cleans_up_on_interrupt(
     finally:
         rebound.close()
     assert not list(tmp_path.rglob("*.partial"))
+
+
+def _unused_loopback_port() -> int:
+    probe = socket.socket()
+    try:
+        probe.bind(("127.0.0.1", 0))
+        return int(probe.getsockname()[1])
+    finally:
+        probe.close()
+
+
+def _enabled_cli_args(tmp_path: Path, hmac_key_file: Path, port: int) -> list[str]:
+    return [
+        "--enable-live-capture",
+        "--hop",
+        "pre",
+        "--listen-host",
+        "127.0.0.1",
+        "--listen-port",
+        str(port),
+        "--forward-base-url",
+        "http://127.0.0.1:1",
+        "--output-dir",
+        str(tmp_path / "records"),
+        "--hmac-key-file",
+        str(hmac_key_file),
+        "--max-request-bytes",
+        "1024",
+        "--max-response-bytes",
+        "4096",
+        "--connect-timeout-seconds",
+        "1",
+        "--read-timeout-seconds",
+        "1",
+        "--overall-timeout-seconds",
+        "2",
+    ]
+
+
+def test_cli_reports_false_shutdown_drain_with_fixed_failure(
+    tmp_path: Path,
+    hmac_key_file: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    original_shutdown = sidecar.CaptureSidecarServer.shutdown
+
+    def interrupt_wait(_server: object) -> bool:
+        raise KeyboardInterrupt
+
+    def cleanup_but_report_false(server: object) -> bool:
+        original_shutdown(server)
+        return False
+
+    monkeypatch.setattr(sidecar.CaptureSidecarServer, "wait", interrupt_wait)
+    monkeypatch.setattr(sidecar.CaptureSidecarServer, "shutdown", cleanup_but_report_false)
+
+    result = sidecar.main(_enabled_cli_args(tmp_path, hmac_key_file, _unused_loopback_port()))
+
+    assert result == 1
+    assert capsys.readouterr().err.strip() == "shutdown_drain_failed"
+
+
+def test_cli_reports_server_thread_failure_with_fixed_failure(
+    tmp_path: Path,
+    hmac_key_file: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(sidecar.CaptureSidecarServer, "wait", lambda _server: False)
+
+    result = sidecar.main(_enabled_cli_args(tmp_path, hmac_key_file, _unused_loopback_port()))
+
+    assert result == 1
+    assert capsys.readouterr().err.strip() == "server_thread_failed"
 
 
 def test_shutdown_closes_active_client_and_upstream_and_waits_bounded(

--- a/tests/test_issue_62_live_evidence_sidecar.py
+++ b/tests/test_issue_62_live_evidence_sidecar.py
@@ -46,8 +46,11 @@ class _FakeUpstreamHandler(BaseHTTPRequestHandler):
         chunk_size = self.server.response_chunk_size  # type: ignore[attr-defined]
         for offset in range(0, len(body), chunk_size):
             chunk = body[offset : offset + chunk_size]
-            self.wfile.write(chunk)
-            self.wfile.flush()
+            try:
+                self.wfile.write(chunk)
+                self.wfile.flush()
+            except OSError:
+                return
             if self.server.chunk_delay:  # type: ignore[attr-defined]
                 time.sleep(self.server.chunk_delay)  # type: ignore[attr-defined]
 
@@ -162,6 +165,32 @@ def test_main_requires_explicit_enable(capsys: pytest.CaptureFixture[str]) -> No
 def test_config_rejects_non_loopback(host: str, base_config) -> None:
     with pytest.raises(sidecar.ConfigurationError, match="listen_not_loopback"):
         sidecar.validate_config(dataclasses.replace(base_config, listen_host=host))
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://127.0.0.1:0",
+        "http://127.0.0.1:65536",
+        "http://127.0.0.1:not-a-port",
+    ],
+)
+def test_config_rejects_malformed_or_out_of_range_forward_port(url: str, base_config) -> None:
+    with pytest.raises(sidecar.ConfigurationError, match="forward_base_url_invalid"):
+        sidecar.validate_config(dataclasses.replace(base_config, forward_base_url=url))
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "code"),
+    [
+        ("connect_timeout_seconds", float("nan"), "connect_timeout_invalid"),
+        ("read_timeout_seconds", float("inf"), "read_timeout_invalid"),
+        ("overall_timeout_seconds", float("-inf"), "overall_timeout_invalid"),
+    ],
+)
+def test_config_rejects_nonfinite_timeouts(field: str, value: float, code: str, base_config) -> None:
+    with pytest.raises(sidecar.ConfigurationError, match=code):
+        sidecar.validate_config(dataclasses.replace(base_config, **{field: value}))
 
 
 def test_atomic_record_is_sanitized_and_leaves_no_partial(tmp_path: Path) -> None:
@@ -383,6 +412,20 @@ def test_sse_sequence_fails_closed_without_terminal_or_complete_frame() -> None:
     assert incomplete_frame["sequence_hmac_sha256"] is None
 
 
+def test_sse_sequence_fails_closed_when_any_frame_follows_terminal() -> None:
+    observed = _consume_sse(
+        [
+            b'data: {"type":"response.completed"}\n\n'
+            b'data: {"type":"response.output_text.delta","delta":"after"}\n\n'
+        ]
+    )
+
+    assert observed["complete"] is False
+    assert observed["sequence_sha256"] is None
+    assert observed["sequence_hmac_sha256"] is None
+    assert observed["terminal_classes"] == ["response.completed"]
+
+
 def test_two_hops_capture_matching_complete_request_response_and_sse(
     tmp_path: Path,
     hmac_key_file: Path,
@@ -521,6 +564,57 @@ def test_response_overflow_nulls_partial_response_digests(
     assert record["response"]["sha256"] is None  # type: ignore[index]
     assert record["response"]["hmac_sha256"] is None  # type: ignore[index]
     assert "private-output" not in json.dumps(record, sort_keys=True)
+    assert not list(tmp_path.rglob("*.partial"))
+
+
+def _terminal_first_response(extra: bytes) -> bytes:
+    terminal = b'data: {"type":"response.completed"}\n\n'
+    padding_size = (64 * 1024) - len(terminal) - 3
+    assert padding_size > 0
+    return terminal + b":" + (b"x" * padding_size) + b"\n\n" + extra
+
+
+@pytest.mark.parametrize("failure_mode", ["overflow", "timeout"])
+def test_incomplete_response_invalidates_previously_complete_sse_digest(
+    failure_mode: str,
+    tmp_path: Path,
+    hmac_key_file: Path,
+) -> None:
+    response_body = _terminal_first_response(b":after-terminal\n\n")
+    upstream_options = {"chunk_size": 64 * 1024}
+    config_options: dict[str, object] = {"max_response_bytes": 64 * 1024}
+    expected_failure = "response_overflow"
+    if failure_mode == "timeout":
+        upstream_options["chunk_delay"] = 0.2
+        config_options = {
+            "max_response_bytes": len(response_body) + 1024,
+            "read_timeout_seconds": 0.05,
+            "overall_timeout_seconds": 0.15,
+        }
+        expected_failure = "upstream_timeout"
+    with _fake_upstream(response_body, **upstream_options) as upstream:
+        upstream_url = f"http://127.0.0.1:{upstream.server_address[1]}"
+        config = _sidecar_config(
+            tmp_path,
+            hmac_key_file,
+            upstream_url,
+            **config_options,
+        )
+        with _running_sidecar(config) as server:
+            connection = http.client.HTTPConnection(server.listen_host, server.listen_port, timeout=2)
+            connection.request("POST", "/responses", body=b"{}")
+            response = connection.getresponse()
+            response.read()
+            connection.close()
+
+    record = _read_only_record(config.output_dir)
+    assert record["outcome"] == "incomplete"
+    assert record["failure"] == expected_failure
+    assert record["response"]["complete"] is False  # type: ignore[index]
+    assert record["response"]["sha256"] is None  # type: ignore[index]
+    assert record["sse"]["complete"] is False  # type: ignore[index]
+    assert record["sse"]["sequence_sha256"] is None  # type: ignore[index]
+    assert record["sse"]["sequence_hmac_sha256"] is None  # type: ignore[index]
     assert not list(tmp_path.rglob("*.partial"))
 
 
@@ -733,4 +827,55 @@ def test_cli_explicit_enable_starts_and_cleans_up_on_interrupt(
         rebound.bind(("127.0.0.1", port))
     finally:
         rebound.close()
+    assert not list(tmp_path.rglob("*.partial"))
+
+
+def test_shutdown_closes_active_client_and_upstream_and_waits_bounded(
+    tmp_path: Path,
+    hmac_key_file: Path,
+) -> None:
+    response_body = b'data: {"type":"response.completed"}\n\n'
+    with _fake_upstream(response_body, response_delay=0.25) as upstream:
+        upstream_url = f"http://127.0.0.1:{upstream.server_address[1]}"
+        config = _sidecar_config(
+            tmp_path,
+            hmac_key_file,
+            upstream_url,
+            read_timeout_seconds=5.0,
+            overall_timeout_seconds=5.0,
+        )
+        server = sidecar.CaptureSidecarServer(config)
+        server.start()
+        client_done = threading.Event()
+
+        def request() -> None:
+            connection = http.client.HTTPConnection(server.listen_host, server.listen_port, timeout=6)
+            try:
+                connection.request("POST", "/responses", body=b"{}")
+                response = connection.getresponse()
+                response.read()
+            except OSError:
+                pass
+            finally:
+                connection.close()
+                client_done.set()
+
+        client_thread = threading.Thread(target=request, daemon=True)
+        client_thread.start()
+        deadline = time.monotonic() + 2
+        while upstream.observed_request is None and time.monotonic() < deadline:  # type: ignore[attr-defined]
+            time.sleep(0.01)
+        assert upstream.observed_request == b"{}"  # type: ignore[attr-defined]
+
+        started = time.monotonic()
+        drained = server.shutdown()
+        elapsed = time.monotonic() - started
+        client_thread.join(timeout=1)
+
+    assert drained is True
+    assert elapsed < 1.0
+    assert client_done.is_set()
+    record = _read_only_record(config.output_dir)
+    assert record["outcome"] == "incomplete"
+    assert record["failure"] in {"client_cancelled", "forwarding_failed", "upstream_timeout"}
     assert not list(tmp_path.rglob("*.partial"))

--- a/tests/test_issue_62_live_evidence_sidecar.py
+++ b/tests/test_issue_62_live_evidence_sidecar.py
@@ -1,0 +1,736 @@
+from __future__ import annotations
+
+import dataclasses
+from contextlib import contextmanager
+import hashlib
+import hmac
+import http.client
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import importlib.util
+import json
+from pathlib import Path
+import socket
+import struct
+import sys
+import threading
+import time
+from typing import Iterator
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "capture_issue_62_live_evidence.py"
+SPEC = importlib.util.spec_from_file_location("capture_issue_62_live_evidence", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+sidecar = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = sidecar
+SPEC.loader.exec_module(sidecar)
+
+KEY = b"h" * 32
+
+
+class _FakeUpstreamHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.0"
+
+    def do_POST(self) -> None:
+        length = int(self.headers["Content-Length"])
+        self.server.observed_request = self.rfile.read(length)  # type: ignore[attr-defined]
+        body = self.server.response_body  # type: ignore[attr-defined]
+        delay = self.server.response_delay  # type: ignore[attr-defined]
+        if delay:
+            time.sleep(delay)
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.end_headers()
+        chunk_size = self.server.response_chunk_size  # type: ignore[attr-defined]
+        for offset in range(0, len(body), chunk_size):
+            chunk = body[offset : offset + chunk_size]
+            self.wfile.write(chunk)
+            self.wfile.flush()
+            if self.server.chunk_delay:  # type: ignore[attr-defined]
+                time.sleep(self.server.chunk_delay)  # type: ignore[attr-defined]
+
+    def log_message(self, format: str, *args: object) -> None:
+        return None
+
+
+@contextmanager
+def _fake_upstream(
+    response_body: bytes,
+    *,
+    response_delay: float = 0.0,
+    chunk_size: int = 36,
+    chunk_delay: float = 0.0,
+) -> Iterator[ThreadingHTTPServer]:
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _FakeUpstreamHandler)
+    server.response_body = response_body  # type: ignore[attr-defined]
+    server.observed_request = None  # type: ignore[attr-defined]
+    server.response_delay = response_delay  # type: ignore[attr-defined]
+    server.response_chunk_size = chunk_size  # type: ignore[attr-defined]
+    server.chunk_delay = chunk_delay  # type: ignore[attr-defined]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+@contextmanager
+def _running_sidecar(config):
+    server = sidecar.CaptureSidecarServer(config)
+    server.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+
+
+def _read_only_record(output_dir: Path) -> dict[str, object]:
+    records = list(output_dir.glob("*.json"))
+    assert len(records) == 1
+    return json.loads(records[0].read_text(encoding="utf-8"))
+
+
+def _wait_for_record(output_dir: Path, timeout: float = 3.0) -> dict[str, object]:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        records = list(output_dir.glob("*.json"))
+        if records:
+            assert len(records) == 1
+            return json.loads(records[0].read_text(encoding="utf-8"))
+        time.sleep(0.01)
+    raise AssertionError("capture record was not published")
+
+
+def _sidecar_config(
+    tmp_path: Path,
+    hmac_key_file: Path,
+    forward_base_url: str,
+    **overrides: object,
+):
+    values: dict[str, object] = {
+        "hop": "pre",
+        "listen_host": "127.0.0.1",
+        "listen_port": 0,
+        "forward_base_url": forward_base_url,
+        "output_dir": tmp_path / "records",
+        "hmac_key_file": hmac_key_file,
+        "max_request_bytes": 4096,
+        "max_response_bytes": 8192,
+        "connect_timeout_seconds": 1.0,
+        "read_timeout_seconds": 1.0,
+        "overall_timeout_seconds": 3.0,
+    }
+    values.update(overrides)
+    return sidecar.SidecarConfig(**values)
+
+
+@pytest.fixture
+def hmac_key_file(tmp_path: Path) -> Path:
+    path = tmp_path / "capture.key"
+    path.write_bytes(b"k" * 32)
+    return path
+
+
+@pytest.fixture
+def base_config(tmp_path: Path, hmac_key_file: Path):
+    return sidecar.SidecarConfig(
+        hop="pre",
+        listen_host="127.0.0.1",
+        listen_port=0,
+        forward_base_url="http://127.0.0.1:1",
+        output_dir=tmp_path / "records",
+        hmac_key_file=hmac_key_file,
+        max_request_bytes=1024,
+        max_response_bytes=4096,
+        connect_timeout_seconds=1.0,
+        read_timeout_seconds=1.0,
+        overall_timeout_seconds=2.0,
+    )
+
+
+def test_main_requires_explicit_enable(capsys: pytest.CaptureFixture[str]) -> None:
+    assert sidecar.main([]) == 2
+    assert "live capture is disabled" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("host", ["0.0.0.0", "192.0.2.10"])
+def test_config_rejects_non_loopback(host: str, base_config) -> None:
+    with pytest.raises(sidecar.ConfigurationError, match="listen_not_loopback"):
+        sidecar.validate_config(dataclasses.replace(base_config, listen_host=host))
+
+
+def test_atomic_record_is_sanitized_and_leaves_no_partial(tmp_path: Path) -> None:
+    record = {
+        "schema": "codexhub.issue62.live-evidence-lane.v1",
+        "verification_scope": "capture_only_not_qualification",
+        "capture_id": "c" + "1" * 32,
+        "hop": "pre",
+        "outcome": "complete",
+        "failure": None,
+        "status": 200,
+        "content_type_class": "json",
+        "request": {
+            "bytes": 2,
+            "sha256": "a" * 64,
+            "hmac_sha256": "b" * 64,
+            "complete": True,
+        },
+        "response": {
+            "bytes": 3,
+            "sha256": "c" * 64,
+            "hmac_sha256": "d" * 64,
+            "complete": True,
+        },
+        "sse": None,
+    }
+
+    record_path = sidecar.write_capture_record(tmp_path, "pre", record)
+
+    assert json.loads(record_path.read_text(encoding="utf-8")) == record
+    assert record_path.name.startswith("pre-")
+    assert record_path.suffix == ".json"
+    assert not list(tmp_path.glob("*.partial"))
+
+
+def test_atomic_record_rejects_unapproved_fields(tmp_path: Path) -> None:
+    with pytest.raises(sidecar.ArtifactValidationError, match="record_fields_invalid"):
+        sidecar.write_capture_record(
+            tmp_path,
+            "pre",
+            {
+                "schema": "codexhub.issue62.live-evidence-lane.v1",
+                "verification_scope": "capture_only_not_qualification",
+                "capture_id": "c" + "2" * 32,
+                "hop": "pre",
+                "outcome": "incomplete",
+                "failure": "forwarding_failed",
+                "status": None,
+                "content_type_class": "unknown",
+                "request": None,
+                "response": None,
+                "sse": None,
+                "authorization": "Bearer forbidden",
+            },
+        )
+
+
+def test_atomic_record_rejects_inconsistent_sse_completion(tmp_path: Path) -> None:
+    with pytest.raises(sidecar.ArtifactValidationError, match="sse_invalid"):
+        sidecar.write_capture_record(
+            tmp_path,
+            "post",
+            {
+                "schema": "codexhub.issue62.live-evidence-lane.v1",
+                "verification_scope": "capture_only_not_qualification",
+                "capture_id": "c" + "3" * 32,
+                "hop": "post",
+                "outcome": "incomplete",
+                "failure": "sse_terminal_missing",
+                "status": 200,
+                "content_type_class": "event-stream",
+                "request": None,
+                "response": None,
+                "sse": {
+                    "complete": False,
+                    "frame_count": 1,
+                    "frame_bytes": 12,
+                    "sequence_sha256": "e" * 64,
+                    "sequence_hmac_sha256": "f" * 64,
+                    "terminal_classes": [],
+                },
+            },
+        )
+
+
+@pytest.mark.parametrize(
+    ("content_type_class", "response", "sse"),
+    [
+        ("json", None, None),
+        (
+            "event-stream",
+            {
+                "bytes": 3,
+                "sha256": "c" * 64,
+                "hmac_sha256": "d" * 64,
+                "complete": True,
+            },
+            None,
+        ),
+    ],
+)
+def test_complete_record_requires_complete_response_and_sse_when_streaming(
+    tmp_path: Path,
+    content_type_class: str,
+    response: object,
+    sse: object,
+) -> None:
+    with pytest.raises(sidecar.ArtifactValidationError, match="record_completion_invalid"):
+        sidecar.write_capture_record(
+            tmp_path,
+            "pre",
+            {
+                "schema": "codexhub.issue62.live-evidence-lane.v1",
+                "verification_scope": "capture_only_not_qualification",
+                "capture_id": "c" + ("4" if response is None else "5") * 32,
+                "hop": "pre",
+                "outcome": "complete",
+                "failure": None,
+                "status": 200,
+                "content_type_class": content_type_class,
+                "request": {
+                    "bytes": 2,
+                    "sha256": "a" * 64,
+                    "hmac_sha256": "b" * 64,
+                    "complete": True,
+                },
+                "response": response,
+                "sse": sse,
+            },
+        )
+
+
+def test_cli_rejects_ephemeral_port(
+    tmp_path: Path,
+    hmac_key_file: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    result = sidecar.main(
+        [
+            "--enable-live-capture",
+            "--hop",
+            "pre",
+            "--listen-host",
+            "127.0.0.1",
+            "--listen-port",
+            "0",
+            "--forward-base-url",
+            "http://127.0.0.1:1",
+            "--output-dir",
+            str(tmp_path / "records"),
+            "--hmac-key-file",
+            str(hmac_key_file),
+            "--max-request-bytes",
+            "1024",
+            "--max-response-bytes",
+            "4096",
+            "--connect-timeout-seconds",
+            "1",
+            "--read-timeout-seconds",
+            "1",
+            "--overall-timeout-seconds",
+            "2",
+        ]
+    )
+
+    assert result == 2
+    assert capsys.readouterr().err.strip() == "listen_port_zero_not_allowed"
+
+
+def test_body_fingerprint_hashes_every_byte() -> None:
+    observed = sidecar.BodyFingerprint(KEY, b"request-body")
+    observed.update(b"abc")
+    observed.update(b"\x00def")
+
+    assert observed.complete() == {
+        "bytes": 7,
+        "sha256": hashlib.sha256(b"abc\x00def").hexdigest(),
+        "hmac_sha256": hmac.new(
+            KEY,
+            b"request-body\0abc\x00def",
+            hashlib.sha256,
+        ).hexdigest(),
+        "complete": True,
+    }
+
+
+def _consume_sse(chunks: list[bytes]) -> dict[str, object]:
+    observed = sidecar.SseSequenceFingerprint(KEY)
+    for chunk in chunks:
+        observed.update(chunk)
+    return observed.complete()
+
+
+def test_sse_sequence_digest_is_independent_of_transport_chunks() -> None:
+    wire = (
+        b'data: {"type":"response.output_text.delta","delta":"secret"}\n\n'
+        b'data: {"type":"response.completed"}\n\n'
+    )
+
+    one = _consume_sse([wire])
+    split = _consume_sse([wire[:5], wire[5:41], wire[41:]])
+
+    assert split == one
+    assert split["complete"] is True
+    assert split["frame_count"] == 2
+    assert split["terminal_classes"] == ["response.completed"]
+    assert "secret" not in json.dumps(split, sort_keys=True)
+
+
+def test_sse_sequence_fails_closed_without_terminal_or_complete_frame() -> None:
+    missing_terminal = _consume_sse([b'data: {"type":"response.output_text.delta"}\n\n'])
+    incomplete_frame = _consume_sse([b'data: {"type":"response.completed"}\n'])
+
+    assert missing_terminal["complete"] is False
+    assert incomplete_frame["complete"] is False
+    assert missing_terminal["sequence_sha256"] is None
+    assert missing_terminal["sequence_hmac_sha256"] is None
+    assert incomplete_frame["sequence_sha256"] is None
+    assert incomplete_frame["sequence_hmac_sha256"] is None
+
+
+def test_two_hops_capture_matching_complete_request_response_and_sse(
+    tmp_path: Path,
+    hmac_key_file: Path,
+) -> None:
+    request_body = b'{"input":"private prompt","stream":true}'
+    sse_body = (
+        b'data: {"type":"response.output_text.delta","delta":"private output"}\n\n'
+        b'data: {"type":"response.completed"}\n\n'
+    )
+    post_output = tmp_path / "post-records"
+    pre_output = tmp_path / "pre-records"
+
+    with _fake_upstream(sse_body) as upstream:
+        upstream_url = f"http://127.0.0.1:{upstream.server_address[1]}"
+        post_config = sidecar.SidecarConfig(
+            hop="post",
+            listen_host="127.0.0.1",
+            listen_port=0,
+            forward_base_url=upstream_url,
+            output_dir=post_output,
+            hmac_key_file=hmac_key_file,
+            max_request_bytes=4096,
+            max_response_bytes=8192,
+            connect_timeout_seconds=1.0,
+            read_timeout_seconds=1.0,
+            overall_timeout_seconds=3.0,
+        )
+        with _running_sidecar(post_config) as post:
+            pre_config = dataclasses.replace(
+                post_config,
+                hop="pre",
+                forward_base_url=post.url,
+                output_dir=pre_output,
+            )
+            with _running_sidecar(pre_config) as pre:
+                connection = http.client.HTTPConnection(
+                    pre.listen_host,
+                    pre.listen_port,
+                    timeout=3,
+                )
+                connection.request(
+                    "POST",
+                    "/responses?opaque=wire-id",
+                    body=request_body,
+                    headers={
+                        "Authorization": "Bearer forbidden-token",
+                        "Content-Type": "application/json",
+                    },
+                )
+                response = connection.getresponse()
+                response_body = response.read()
+                status = response.status
+                connection.close()
+
+        assert upstream.observed_request == request_body  # type: ignore[attr-defined]
+
+    assert status == 200
+    assert response_body == sse_body
+    pre_record = _read_only_record(pre_output)
+    post_record = _read_only_record(post_output)
+    assert pre_record["request"] == post_record["request"]
+    assert pre_record["response"] == post_record["response"]
+    assert pre_record["sse"]["sequence_sha256"] == post_record["sse"]["sequence_sha256"]  # type: ignore[index]
+    assert pre_record["sse"]["sequence_hmac_sha256"] == post_record["sse"]["sequence_hmac_sha256"]  # type: ignore[index]
+    assert pre_record["outcome"] == post_record["outcome"] == "complete"
+    serialized = json.dumps([pre_record, post_record], sort_keys=True)
+    for sensitive in (
+        "private prompt",
+        "private output",
+        "forbidden-token",
+        "wire-id",
+        upstream_url,
+        str(pre_output),
+        str(post_output),
+        str(hmac_key_file),
+    ):
+        assert sensitive not in serialized
+    assert not list(tmp_path.rglob("*.partial"))
+
+
+def test_request_overflow_fails_closed_before_forwarding(
+    tmp_path: Path,
+    hmac_key_file: Path,
+) -> None:
+    with _fake_upstream(b'data: {"type":"response.completed"}\n\n') as upstream:
+        upstream_url = f"http://127.0.0.1:{upstream.server_address[1]}"
+        config = _sidecar_config(
+            tmp_path,
+            hmac_key_file,
+            upstream_url,
+            max_request_bytes=4,
+        )
+        with _running_sidecar(config) as server:
+            connection = http.client.HTTPConnection(server.listen_host, server.listen_port, timeout=2)
+            connection.request("POST", "/secret-path", body=b"private-body")
+            response = connection.getresponse()
+            assert response.status == 413
+            response.read()
+            connection.close()
+        assert upstream.observed_request is None  # type: ignore[attr-defined]
+
+    record = _read_only_record(config.output_dir)
+    assert record["outcome"] == "incomplete"
+    assert record["failure"] == "request_overflow"
+    assert record["request"]["complete"] is False  # type: ignore[index]
+    assert record["request"]["sha256"] is None  # type: ignore[index]
+    assert "private-body" not in json.dumps(record, sort_keys=True)
+    assert "secret-path" not in json.dumps(record, sort_keys=True)
+    assert not list(tmp_path.rglob("*.partial"))
+
+
+def test_response_overflow_nulls_partial_response_digests(
+    tmp_path: Path,
+    hmac_key_file: Path,
+) -> None:
+    response_body = b'data: {"type":"response.completed","secret":"private-output"}\n\n'
+    with _fake_upstream(response_body, chunk_size=7) as upstream:
+        upstream_url = f"http://127.0.0.1:{upstream.server_address[1]}"
+        config = _sidecar_config(
+            tmp_path,
+            hmac_key_file,
+            upstream_url,
+            max_response_bytes=8,
+        )
+        with _running_sidecar(config) as server:
+            connection = http.client.HTTPConnection(server.listen_host, server.listen_port, timeout=2)
+            connection.request("POST", "/responses", body=b"{}")
+            response = connection.getresponse()
+            response.read()
+            connection.close()
+
+    record = _read_only_record(config.output_dir)
+    assert record["outcome"] == "incomplete"
+    assert record["failure"] == "response_overflow"
+    assert record["response"]["complete"] is False  # type: ignore[index]
+    assert record["response"]["sha256"] is None  # type: ignore[index]
+    assert record["response"]["hmac_sha256"] is None  # type: ignore[index]
+    assert "private-output" not in json.dumps(record, sort_keys=True)
+    assert not list(tmp_path.rglob("*.partial"))
+
+
+def test_upstream_timeout_is_bounded_and_sanitized(
+    tmp_path: Path,
+    hmac_key_file: Path,
+) -> None:
+    with _fake_upstream(
+        b'data: {"type":"response.completed"}\n\n',
+        response_delay=0.3,
+    ) as upstream:
+        upstream_url = f"http://127.0.0.1:{upstream.server_address[1]}"
+        config = _sidecar_config(
+            tmp_path,
+            hmac_key_file,
+            upstream_url,
+            read_timeout_seconds=0.05,
+            overall_timeout_seconds=0.1,
+        )
+        with _running_sidecar(config) as server:
+            connection = http.client.HTTPConnection(server.listen_host, server.listen_port, timeout=2)
+            connection.request("POST", "/responses", body=b"{}")
+            response = connection.getresponse()
+            response.read()
+            connection.close()
+
+    record = _read_only_record(config.output_dir)
+    assert record["outcome"] == "incomplete"
+    assert record["failure"] == "upstream_timeout"
+    assert upstream_url not in json.dumps(record, sort_keys=True)
+    assert str(config.output_dir) not in json.dumps(record, sort_keys=True)
+    assert str(hmac_key_file) not in json.dumps(record, sort_keys=True)
+    assert not list(tmp_path.rglob("*.partial"))
+
+
+def test_downstream_cancellation_fails_closed_and_cleans_partial(
+    tmp_path: Path,
+    hmac_key_file: Path,
+) -> None:
+    response_body = (
+        b'data: {"type":"response.output_text.delta","delta":"private"}\n\n' * 4096
+        + b'data: {"type":"response.completed"}\n\n'
+    )
+    with _fake_upstream(response_body, chunk_size=1024, chunk_delay=0.001) as upstream:
+        upstream_url = f"http://127.0.0.1:{upstream.server_address[1]}"
+        config = _sidecar_config(
+            tmp_path,
+            hmac_key_file,
+            upstream_url,
+            max_response_bytes=len(response_body) + 1024,
+        )
+        with _running_sidecar(config) as server:
+            client = socket.create_connection((server.listen_host, server.listen_port), timeout=2)
+            client.sendall(
+                b"POST /responses HTTP/1.1\r\n"
+                b"Host: 127.0.0.1\r\n"
+                b"Content-Length: 2\r\n"
+                b"Connection: close\r\n\r\n{}"
+            )
+            client.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, struct.pack("hh", 1, 0))
+            client.close()
+            record = _wait_for_record(config.output_dir)
+
+    assert record["outcome"] == "incomplete"
+    assert record["failure"] in {"client_cancelled", "downstream_cancelled"}
+    assert record["response"] is None or record["response"]["complete"] is False  # type: ignore[index]
+    assert "private" not in json.dumps(record, sort_keys=True)
+    assert not list(tmp_path.rglob("*.partial"))
+
+
+def test_listener_start_failure_writes_bounded_record_without_sensitive_paths(
+    tmp_path: Path,
+    hmac_key_file: Path,
+) -> None:
+    occupied = socket.socket()
+    occupied.bind(("127.0.0.1", 0))
+    occupied.listen()
+    port = occupied.getsockname()[1]
+    config = _sidecar_config(
+        tmp_path,
+        hmac_key_file,
+        "http://user:secret@127.0.0.1:1".replace("user:secret@", ""),
+        listen_port=port,
+    )
+    server = sidecar.CaptureSidecarServer(config)
+    try:
+        with pytest.raises(sidecar.SidecarStartError, match="server_start_failed"):
+            server.start()
+    finally:
+        server.shutdown()
+        occupied.close()
+
+    record = _read_only_record(config.output_dir)
+    assert record["failure"] == "server_start_failed"
+    serialized = json.dumps(record, sort_keys=True)
+    assert config.forward_base_url not in serialized
+    assert str(config.output_dir) not in serialized
+    assert str(hmac_key_file) not in serialized
+    assert not list(tmp_path.rglob("*.partial"))
+
+
+def test_server_thread_failure_writes_bounded_record_and_cleans_partial(
+    tmp_path: Path,
+    hmac_key_file: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def explode(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("private thread detail")
+
+    monkeypatch.setattr(ThreadingHTTPServer, "serve_forever", explode)
+    config = _sidecar_config(tmp_path, hmac_key_file, "http://127.0.0.1:1")
+    server = sidecar.CaptureSidecarServer(config)
+    server.start()
+    assert server.wait() is False
+    server.shutdown()
+
+    record = _read_only_record(config.output_dir)
+    assert record["failure"] == "server_thread_failed"
+    assert "private thread detail" not in json.dumps(record, sort_keys=True)
+    assert not list(tmp_path.rglob("*.partial"))
+
+
+def test_cli_configuration_error_does_not_echo_sensitive_values(
+    tmp_path: Path,
+    hmac_key_file: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    secret_url = "http://user:private-password@127.0.0.1:1"
+    result = sidecar.main(
+        [
+            "--enable-live-capture",
+            "--hop",
+            "pre",
+            "--listen-host",
+            "127.0.0.1",
+            "--listen-port",
+            "1",
+            "--forward-base-url",
+            secret_url,
+            "--output-dir",
+            str(tmp_path / "private-output-path"),
+            "--hmac-key-file",
+            str(hmac_key_file),
+            "--max-request-bytes",
+            "1024",
+            "--max-response-bytes",
+            "4096",
+            "--connect-timeout-seconds",
+            "1",
+            "--read-timeout-seconds",
+            "1",
+            "--overall-timeout-seconds",
+            "2",
+        ]
+    )
+
+    assert result == 2
+    stderr = capsys.readouterr().err.strip()
+    assert stderr == "forward_base_url_invalid"
+    assert "private-password" not in stderr
+    assert "private-output-path" not in stderr
+    assert str(hmac_key_file) not in stderr
+
+
+def test_cli_explicit_enable_starts_and_cleans_up_on_interrupt(
+    tmp_path: Path,
+    hmac_key_file: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    probe = socket.socket()
+    probe.bind(("127.0.0.1", 0))
+    port = probe.getsockname()[1]
+    probe.close()
+
+    def interrupt_wait(_server: object) -> bool:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(sidecar.CaptureSidecarServer, "wait", interrupt_wait)
+    result = sidecar.main(
+        [
+            "--enable-live-capture",
+            "--hop",
+            "pre",
+            "--listen-host",
+            "127.0.0.1",
+            "--listen-port",
+            str(port),
+            "--forward-base-url",
+            "http://127.0.0.1:1",
+            "--output-dir",
+            str(tmp_path / "records"),
+            "--hmac-key-file",
+            str(hmac_key_file),
+            "--max-request-bytes",
+            "1024",
+            "--max-response-bytes",
+            "4096",
+            "--connect-timeout-seconds",
+            "1",
+            "--read-timeout-seconds",
+            "1",
+            "--overall-timeout-seconds",
+            "2",
+        ]
+    )
+
+    assert result == 0
+    rebound = socket.socket()
+    try:
+        rebound.bind(("127.0.0.1", port))
+    finally:
+        rebound.close()
+    assert not list(tmp_path.rglob("*.partial"))


### PR DESCRIPTION
## Summary

- Add an explicitly enabled, loopback-only standalone sidecar for the separately authorized Issue #62 live-evidence window.
- Fingerprint complete pre/post application bodies and SSE frame sequences with sanitized atomic artifacts, bounded caps/timeouts, fixed failure codes, and cleanup.
- Add focused synthetic coverage and document the tooling-only/non-qualification boundary.

## Scope boundary

This is the evidence-tooling slice only. It does not modify Gateway/Desktop routing, telemetry, catalog, or `runtime-wire-inventory.json`; it does not perform a live upstream request and does not close or qualify #62.

## Review and verification

- Base: `origin/dev@cb2b63a8c869ba3d5e1d130ac8090737b03a61c5`
- Candidate: `9ed6b1966249127af29225b0fb2475ae7e4f51b5`
- Standards/Spec review: clean after delta review.
- Sidecar tests: 37 passed.
- Relevant focused checks: 122 passed.
- Strict Python excluding `tests/test_real_client_e2e.py`: 1676 passed, 1 skipped, 2 pre-existing Issue #108 failures reproduced at exact `origin/dev` baseline; not introduced by this PR.
- Inventory drift, thread-tool surface, quality report, and diff checks pass.

The real live capture remains a separately authorized operator step after this tooling is merged.