### PR TITLE
0.1.8 Beta2: Preserve explicit model-catalog overrides across sync and restart

### DIFF
--- a/frontend/scripts/ui-contract.test.mjs
+++ b/frontend/scripts/ui-contract.test.mjs
@@ -386,6 +386,31 @@ test("provider page state, editors, actions, and shared helpers stay in focused 
   assert.match(formSource, /export const emptyProvider/);
 });
 
+test("catalog override diagnostics stay bounded and disclose the Codex restart", async () => {
+  const [actionsSource, tauriSource, typesSource, mainSource, bridgeSource, enSource, zhSource] =
+    await Promise.all([
+      readFile(providerCatalogActionsPath, "utf8"),
+      readFile(tauriSourcePath, "utf8"),
+      readFile(typesPath, "utf8"),
+      readFile(tauriMainPath, "utf8"),
+      readFile(tauriWebBridgePath, "utf8"),
+      readFile(enLocalePath, "utf8"),
+      readFile(zhLocalePath, "utf8"),
+    ]);
+
+  assert.match(tauriSource, /catalogOverrideDiagnostics: \(\) =>/);
+  assert.match(tauriSource, /get_catalog_override_diagnostics/);
+  assert.match(typesSource, /interface CatalogOverrideDiagnostics/);
+  assert.match(typesSource, /catalog_override_diagnostics\?: CatalogOverrideDiagnostics/);
+  assert.match(actionsSource, /api\.catalogOverrideDiagnostics\(\)/);
+  assert.match(actionsSource, /catalogOverrideDiagnostics/);
+  assert.match(actionsSource, /catalogOverrideRestartCodex/);
+  assert.match(mainSource, /get_catalog_override_diagnostics/);
+  assert.match(bridgeSource, /get_catalog_override_diagnostics/);
+  assert.match(enSource, /Restart Codex App to apply/);
+  assert.match(zhSource, /请重启 Codex App 使其生效/);
+});
+
 test("ui contract keeps ids and paths but no localizable display copy", async () => {
   const contract = await readContract();
 

--- a/frontend/src/hooks/useProviderCatalogActions.ts
+++ b/frontend/src/hooks/useProviderCatalogActions.ts
@@ -18,6 +18,7 @@ import {
 } from "../lib/providerEndpoint";
 import { api, messageFromError } from "../lib/tauri";
 import type {
+  CatalogOverrideDiagnostics,
   GatewayClientSyncSummary,
   Model,
   Provider,
@@ -130,6 +131,22 @@ export function useProviderCatalogActions({
       }));
     }
     await refreshGatewayState();
+    const overrideDiagnostics = await api.catalogOverrideDiagnostics().catch(() => null);
+    if (syncResult) {
+      syncResult = {
+        ...syncResult,
+        catalog_override_diagnostics: overrideDiagnostics,
+      };
+    } else if (overrideDiagnostics) {
+      syncResult = {
+        applied: 0,
+        skipped: 0,
+        failed: 0,
+        results: [],
+        message: "",
+        catalog_override_diagnostics: overrideDiagnostics,
+      };
+    }
     return syncResult;
   }
 
@@ -137,18 +154,36 @@ export function useProviderCatalogActions({
     baseMessage: string | undefined,
     syncResult: GatewayClientSyncSummary | null,
   ) {
+    const overrideMessage = syncResult?.catalog_override_diagnostics
+      ? catalogOverrideToastMessage(syncResult.catalog_override_diagnostics)
+      : null;
     if (syncResult?.failed) {
       const syncMessage = tr("providers.syncClientsFailed", { count: syncResult.failed });
-      return baseMessage ? `${baseMessage}; ${syncMessage}` : syncMessage;
+      return [baseMessage, syncMessage, overrideMessage].filter(Boolean).join("; ") || null;
     }
     if (syncResult?.applied) {
       const syncMessage = tr("providers.syncedClients", {
         count: syncResult.applied,
         plural: syncResult.applied === 1 ? "" : "s",
       });
-      return baseMessage ? `${baseMessage}; ${syncMessage}` : syncMessage;
+      return [baseMessage, syncMessage, overrideMessage].filter(Boolean).join("; ") || null;
     }
-    return baseMessage ?? null;
+    return [baseMessage, overrideMessage].filter(Boolean).join("; ") || null;
+  }
+
+  function catalogOverrideToastMessage(diagnostics: CatalogOverrideDiagnostics): string | null {
+    const accepted = Math.max(0, Math.min(100, diagnostics.accepted));
+    const rejected = Math.max(0, Math.min(100, diagnostics.rejected));
+    const migrated = Math.max(0, Math.min(100, diagnostics.migrated));
+    if (accepted === 0 && rejected === 0 && migrated === 0) {
+      return null;
+    }
+    return t("providers.catalogOverrideDiagnostics", {
+      accepted,
+      rejected,
+      migrated,
+      restart: t("providers.catalogOverrideRestartCodex"),
+    });
   }
 
   async function saveProviders(

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -446,6 +446,8 @@ const enUS = {
     pricingUnknown: "Pricing unknown",
     providerCatalogUpdated: "Provider catalog updated",
     providerCatalogUpdateFailed: "Provider catalog update failed",
+    catalogOverrideDiagnostics: "Catalog overrides: {{accepted}} accepted, {{migrated}} migrated, {{rejected}} rejected. {{restart}}",
+    catalogOverrideRestartCodex: "Restart Codex App to apply",
     providerAdded: "{{name}} added",
     providerAlreadyExists: "Provider already exists: {{name}}",
     providerDeleted: "{{name}} deleted",

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -445,6 +445,8 @@ const zhCN = {
     pricingUnknown: "价格未知",
     providerCatalogUpdated: "供应商目录已更新",
     providerCatalogUpdateFailed: "供应商目录更新失败",
+    catalogOverrideDiagnostics: "模型目录覆盖：接受 {{accepted}} 项，迁移 {{migrated}} 项，拒绝 {{rejected}} 项。{{restart}}",
+    catalogOverrideRestartCodex: "请重启 Codex App 使其生效",
     providerAdded: "{{name}} 已添加",
     providerAlreadyExists: "供应商已存在：{{name}}",
     providerDeleted: "{{name}} 已删除",

--- a/frontend/src/lib/tauri.ts
+++ b/frontend/src/lib/tauri.ts
@@ -8,6 +8,7 @@ import type {
   AppUpdateStatus,
   AppVersionInfo,
   AutostartStatus,
+  CatalogOverrideDiagnostics,
   CodexContextGuardStatus,
   CodexHubError,
   DiagnosticsActionResult,
@@ -302,6 +303,8 @@ export const api = {
     call<GatewayClientSyncSummary>("sync_gateway_clients", { model: model ?? null }),
   subagentMatrixStatus: () => call<SubagentMatrixStatus>("subagent_matrix_status"),
   generateCatalog: () => call<Model[]>("generate_catalog"),
+  catalogOverrideDiagnostics: () =>
+    call<CatalogOverrideDiagnostics>("get_catalog_override_diagnostics"),
   listModels: () => call<Model[]>("list_models"),
   refreshModelMetadata: () => call<Model[]>("refresh_model_metadata"),
   listModelMetadata: () => call<Model[]>("list_model_metadata"),

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -562,4 +562,12 @@ export interface GatewayClientSyncSummary {
   failed: number;
   results: GatewayClientSyncItem[];
   message: string;
+  catalog_override_diagnostics?: CatalogOverrideDiagnostics | null;
+}
+
+export interface CatalogOverrideDiagnostics {
+  accepted: number;
+  rejected: number;
+  migrated: number;
+  reasons: Record<string, number>;
 }

--- a/scripts/codex-mode.ps1
+++ b/scripts/codex-mode.ps1
@@ -141,6 +141,97 @@ function Remove-TopLevelKeys {
     return ($result -join "`n")
 }
 
+function Get-TopLevelConfigValue {
+    param(
+        [Parameter(Mandatory = $true)][string]$Text,
+        [Parameter(Mandatory = $true)][string]$Key
+    )
+
+    $inTopLevel = $true
+    foreach ($line in ($Text -split "`r?`n")) {
+        if ($line -match '^\s*\[') {
+            $inTopLevel = $false
+        }
+        if (-not $inTopLevel) {
+            continue
+        }
+        $match = [regex]::Match($line, "^\s*$([regex]::Escape($Key))\s*=\s*(.*)$")
+        if (-not $match.Success) {
+            continue
+        }
+        $raw = $match.Groups[1].Value.Trim()
+        $quote = ''
+        for ($index = 0; $index -lt $raw.Length; $index++) {
+            $char = $raw[$index]
+            if ($quote -eq "'") {
+                if ($char -eq "'") {
+                    if ($index + 1 -lt $raw.Length -and $raw[$index + 1] -eq "'") {
+                        $index++
+                        continue
+                    }
+                    $quote = ''
+                }
+                continue
+            }
+            if ($quote -eq '"') {
+                if ($char -eq '\') {
+                    $index++
+                    continue
+                }
+                if ($char -eq '"') {
+                    $quote = ''
+                }
+                continue
+            }
+            if ($char -eq "'" -or $char -eq '"') {
+                $quote = [string]$char
+                continue
+            }
+            if ($char -eq '#') {
+                $raw = $raw.Substring(0, $index).Trim()
+                break
+            }
+        }
+        if ($raw.Length -ge 2 -and $raw.StartsWith("'") -and $raw.EndsWith("'")) {
+            return $raw.Substring(1, $raw.Length - 2).Replace("''", "'")
+        }
+        if ($raw.Length -ge 2 -and $raw.StartsWith('"') -and $raw.EndsWith('"')) {
+            try {
+                return ($raw | ConvertFrom-Json)
+            }
+            catch {
+                return $raw.Substring(1, $raw.Length - 2)
+            }
+        }
+        return $raw
+    }
+    return $null
+}
+
+function Test-CodexHubManagedCatalogPath {
+    param([AllowNull()][string]$Value)
+
+    if ([string]::IsNullOrWhiteSpace($Value)) {
+        return $false
+    }
+    $normalized = $Value.Trim().Replace('/', '\').TrimEnd('\')
+    $leaf = Split-Path -Leaf $normalized
+    if ($leaf -notin @('codexhub-model-catalog.json', 'codex-proxy-official-ollama.json')) {
+        return $false
+    }
+    if ($normalized -ieq (Join-Path 'model-catalogs' $leaf)) {
+        return $true
+    }
+    try {
+        $candidate = [System.IO.Path]::GetFullPath($normalized)
+        $managed = [System.IO.Path]::GetFullPath((Join-Path $CodexDir (Join-Path 'model-catalogs' $leaf)))
+        return $candidate -ieq $managed
+    }
+    catch {
+        return $false
+    }
+}
+
 function Remove-TomlSectionsMatching {
     param(
         [Parameter(Mandatory = $true)][string]$Text,
@@ -274,15 +365,27 @@ function Set-ConfigForMode {
         [Parameter(Mandatory = $true)][ValidateSet('official', 'proxy')][string]$TargetMode
     )
 
-    $base = Get-CleanBaseConfig -Text (Read-TextIfExists -Path $ConfigPath)
+    $original = Read-TextIfExists -Path $ConfigPath
+    $existingCatalogValue = Get-TopLevelConfigValue -Text $original -Key 'model_catalog_json'
+    $preserveCatalog = -not [string]::IsNullOrWhiteSpace($existingCatalogValue) -and -not (Test-CodexHubManagedCatalogPath $existingCatalogValue)
+    $base = Get-CleanBaseConfig -Text $original
     Backup-ConfigBeforeWrite -ConfigPath $ConfigPath -TargetMode $TargetMode
     if ($TargetMode -eq 'official') {
-        $prefix = "model = `"gpt-5.5`"`nmodel_provider = `"openai`"`n`n"
+        $prefix = "model = `"gpt-5.5`"`nmodel_provider = `"openai`"`n"
+        if ($preserveCatalog) {
+            $prefix += "model_catalog_json = $(Convert-ToTomlLiteral -Value $existingCatalogValue)`n"
+        }
+        $prefix += "`n"
         Write-Utf8NoBom -Path $ConfigPath -Text ($prefix + $base)
         return
     }
 
-    $catalogValue = Convert-ToTomlLiteral -Value 'model-catalogs/codexhub-model-catalog.json'
+    $catalogValue = if ($preserveCatalog) {
+        Convert-ToTomlLiteral -Value $existingCatalogValue
+    }
+    else {
+        Convert-ToTomlLiteral -Value 'model-catalogs/codexhub-model-catalog.json'
+    }
     $baseUrlValue = Convert-ToTomlLiteral -Value 'http://127.0.0.1:9099/v1'
     $prefix = @(
         '# BEGIN CODEX PROXY CONFIG',

--- a/src-python/catalog_sync.py
+++ b/src-python/catalog_sync.py
@@ -563,7 +563,11 @@ def _planner_override_is_valid(
         # A user override may opt into a different supported multi-agent
         # version, but it must not turn websockets, tool mode, or Responses
         # Lite on/off independently of the model's official contract.
-        if value != expected.get(key):
+        expected_value = expected.get(key)
+        if isinstance(expected_value, bool):
+            if type(value) is not bool or value != expected_value:
+                return False
+        elif value != expected_value:
             return False
     return True
 
@@ -798,8 +802,13 @@ def _managed_baseline_shape_is_valid(payload: Any) -> bool:
                 if field == "multi_agent_version":
                     if not isinstance(value, str) or value not in {"v1", "v2"}:
                         return False
-                elif value != expected.get(field):
-                    return False
+                else:
+                    expected_value = expected.get(field)
+                    if isinstance(expected_value, bool):
+                        if type(value) is not bool or value != expected_value:
+                            return False
+                    elif value != expected_value:
+                        return False
             metadata = model.get("codex_proxy_metadata")
             if isinstance(metadata, dict) and (
                 CATALOG_OWNER_METADATA_KEY in metadata

--- a/src-python/catalog_sync.py
+++ b/src-python/catalog_sync.py
@@ -588,6 +588,8 @@ def _catalog_override_row_is_eligible(
     identity: CatalogModelIdentity,
     model: dict[str, Any],
     baseline_model: dict[str, Any] | None = None,
+    *,
+    allow_markerless_legacy: bool = False,
 ) -> bool:
     """Require the edited row to be a visible, exact managed row.
 
@@ -637,6 +639,24 @@ def _catalog_override_row_is_eligible(
         or CATALOG_OWNER_IDENTITY_KEY in metadata
         or CATALOG_OWNER_SIGNATURE_KEY in metadata
     )
+    if allow_markerless_legacy and baseline_model is not None:
+        # The caller supplied the freshly generated managed catalog as the
+        # legacy migration baseline.  A markerless Beta1 row is accepted only
+        # when every immutable field is byte-for-byte equal to that baseline;
+        # the planner delta is the sole supported user edit.  This prevents a
+        # forged Official-shaped row from entering the migration path.
+        if _catalog_owner_canonical_row(model) != _catalog_owner_canonical_row(baseline_model):
+            return False
+        if not current_has_owner_marker:
+            return True
+        if CATALOG_OWNER_SIGNATURE_KEY not in metadata:
+            return _catalog_owner_metadata_is_valid(
+                metadata,
+                identity,
+                require_signature=False,
+                model=model,
+                baseline_model=baseline_model,
+            )
     if baseline_has_owner_marker or current_has_owner_marker:
         if (
             baseline_model is not None
@@ -677,6 +697,14 @@ def _catalog_override_row_is_eligible(
     # metadata/slug spoof is not a legacy catalog record.
     if not _official_identity(identity):
         return True
+    # A real sync creates the owner key before reconciliation.  Without the
+    # generated legacy baseline supplied by sync_catalog, a markerless row
+    # has no immutable provenance and is not a migration source.
+    try:
+        if _load_catalog_owner_secret(create=False) is not None:
+            return False
+    except ValueError:
+        return False
     required_legacy_keys = (
         "description",
         "shell_type",
@@ -930,7 +958,10 @@ def _delta_override_fields(
     return fields
 
 
-def _collect_catalog_overrides() -> tuple[dict[CatalogModelIdentity, dict[str, Any]], dict[str, Any]]:
+def _collect_catalog_overrides(
+    *,
+    legacy_baseline: dict[str, Any] | None = None,
+) -> tuple[dict[CatalogModelIdentity, dict[str, Any]], dict[str, Any]]:
     """Capture user edits before the effective catalog is replaced.
 
     A baseline sidecar is the ownership boundary for new installations.  If
@@ -965,6 +996,7 @@ def _collect_catalog_overrides() -> tuple[dict[CatalogModelIdentity, dict[str, A
         _record_override_rejection(diagnostics, "invalid_catalog")
 
     baseline_exists = MANAGED_CATALOG_BASELINE_PATH.exists()
+    using_legacy_baseline = not baseline_exists and legacy_baseline is not None
     if baseline_exists:
         try:
             baseline = load_json_file(MANAGED_CATALOG_BASELINE_PATH)
@@ -987,6 +1019,13 @@ def _collect_catalog_overrides() -> tuple[dict[CatalogModelIdentity, dict[str, A
             current = {}
             diagnostics["current_catalog_valid"] = False
             _record_override_rejection(diagnostics, "invalid_catalog")
+    elif legacy_baseline is not None:
+        baseline = deepcopy(legacy_baseline)
+        baseline["schema_version"] = CATALOG_OVERRIDE_SCHEMA_VERSION
+        baseline["managed_baseline"] = True
+        if not _managed_baseline_shape_is_valid(baseline):
+            _record_override_rejection(diagnostics, "invalid_baseline")
+            return {}, diagnostics
     else:
         baseline = {}
 
@@ -1023,11 +1062,16 @@ def _collect_catalog_overrides() -> tuple[dict[CatalogModelIdentity, dict[str, A
             _record_override_rejection(diagnostics, "missing_managed_model")
     for identity, model in current_models.items():
         baseline_model = baseline_models.get(identity)
-        if not _catalog_override_row_is_eligible(identity, model, baseline_model):
+        if not _catalog_override_row_is_eligible(
+            identity,
+            model,
+            baseline_model,
+            allow_markerless_legacy=using_legacy_baseline,
+        ):
             overrides.pop(identity, None)
             _record_override_rejection(diagnostics, "invalid_row_identity")
             continue
-        if baseline_exists and baseline_model is None:
+        if (baseline_exists or using_legacy_baseline) and baseline_model is None:
             # A row unknown to the managed baseline is not an authority for
             # another row; it can be safely ignored during migration.
             overrides.pop(identity, None)
@@ -2664,12 +2708,6 @@ def sync_catalog(*, max_age_seconds: int = 0) -> dict[str, Any]:
     if ollama_runtime_configured:
         ollama_model_metadata.update(ollama_provider_model_metadata(runtime_ollama_models))
 
-    # Read the old effective catalog before publishing a new one.  This is the
-    # only point at which an edit made by the user is distinguishable from the
-    # next managed baseline.  The sidecars are written below in the same
-    # atomic-publication sequence as the catalog itself.
-    catalog_overrides, override_diagnostics = _collect_catalog_overrides()
-
     managed_catalog = build_codex_catalog(
         official_models,
         ollama_catalog_ids,
@@ -2684,6 +2722,13 @@ def sync_catalog(*, max_age_seconds: int = 0) -> dict[str, Any]:
         use_ollama_policy_allowlist=not ollama_runtime_configured,
         official_source_present=official_snapshot.source_present,
         visibility_diagnostics=official_snapshot.visibility_diagnostics,
+    )
+    # Read the old effective catalog before publishing a new one.  Supplying
+    # this freshly generated catalog gives markerless Beta1 migration a
+    # complete immutable provenance check; the sidecars are still written
+    # below in the same atomic-publication sequence as the catalog itself.
+    catalog_overrides, override_diagnostics = _collect_catalog_overrides(
+        legacy_baseline=managed_catalog,
     )
     catalog = _apply_catalog_overrides(
         deepcopy(managed_catalog),

--- a/src-python/catalog_sync.py
+++ b/src-python/catalog_sync.py
@@ -771,11 +771,14 @@ def _catalog_payload_shape_is_valid(
         if require_identity:
             identity = catalog_model_identity(model)
             if identity is not None and _official_identity(identity):
-                if identity[2] not in PINNED_OFFICIAL_MODEL_IDS:
-                    return False
-                if any(
+                # Direct Official snapshots may introduce a visible model
+                # before its planner contract is pinned locally.  Keep that
+                # generated row in the catalog shape, but do not treat it as
+                # an authority for planner overrides (the override validator
+                # remains pinned-only).
+                if identity[2] in PINNED_OFFICIAL_MODEL_IDS and any(
                     field not in model
-                    for field in PINNED_OFFICIAL_MODEL_FIELD_SETS.get(identity[2], ())
+                    for field in PINNED_OFFICIAL_MODEL_FIELD_SETS[identity[2]]
                 ):
                     return False
     return True
@@ -796,7 +799,11 @@ def _managed_baseline_shape_is_valid(payload: Any) -> bool:
             return False
         if _official_identity(identity):
             if identity[2] not in PINNED_OFFICIAL_MODEL_IDS:
-                return False
+                # Unknown Official rows are generated catalog entries, not a
+                # supported planner-override surface.  Preserve them in the
+                # managed baseline while _planner_override_is_valid keeps
+                # their overrides fail-closed.
+                continue
             supported_fields = PINNED_OFFICIAL_MODEL_FIELD_SETS.get(identity[2], ())
             if any(field not in model for field in supported_fields):
                 return False

--- a/src-python/catalog_sync.py
+++ b/src-python/catalog_sync.py
@@ -83,6 +83,10 @@ GENERATED_CATALOG_FILENAME = "codexhub-model-catalog.json"
 LEGACY_GENERATED_CATALOG_FILENAME = "codex-proxy-official-ollama.json"
 GENERATED_CATALOG_PATH = RUNTIME_MODEL_CATALOG_DIR / GENERATED_CATALOG_FILENAME
 LEGACY_GENERATED_CATALOG_PATH = RUNTIME_MODEL_CATALOG_DIR / LEGACY_GENERATED_CATALOG_FILENAME
+MANAGED_CATALOG_BASELINE_FILENAME = "codexhub-model-catalog-baseline.json"
+CATALOG_OVERRIDES_FILENAME = "codexhub-model-catalog-overrides.json"
+MANAGED_CATALOG_BASELINE_PATH = RUNTIME_MODEL_CATALOG_DIR / MANAGED_CATALOG_BASELINE_FILENAME
+CATALOG_OVERRIDES_PATH = RUNTIME_MODEL_CATALOG_DIR / CATALOG_OVERRIDES_FILENAME
 GENERATED_STATE_PATH = RUNTIME_MODEL_CATALOG_DIR / "codex-proxy-state.json"
 SETTINGS_PATH = RUNTIME_CODEX_DIR / "proxy" / "settings.json"
 RESOLVED_MODEL_LIMITS_PATH = REPO_ROOT / "config" / "resolved_model_limits.json"
@@ -298,6 +302,14 @@ PINNED_OFFICIAL_MODEL_FIELD_SETS = {
     "gpt-5.3-codex-spark": ("use_responses_lite",),
 }
 
+# The first version of catalog ownership deliberately supports only planner
+# metadata.  Other model fields are still generated from the current Direct
+# snapshot and must not silently become a second, unvalidated configuration
+# surface.  A user can therefore opt in to a planner change without causing
+# unrelated stale metadata to survive a refresh.
+CATALOG_OVERRIDE_FIELDS = frozenset(PINNED_OFFICIAL_PLANNER_FIELD_SET)
+CATALOG_OVERRIDE_SCHEMA_VERSION = 1
+
 
 def load_pinned_official_catalog_metadata(
     path: Path = OFFICIAL_CATALOG_METADATA_PATH,
@@ -424,6 +436,250 @@ def load_json_file(path: Path) -> dict[str, Any]:
     if not path.exists():
         return {}
     return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+CatalogModelIdentity = tuple[str, str, str]
+
+
+def catalog_model_identity(model: Any) -> CatalogModelIdentity | None:
+    """Return the stable provider/model identity for ownership decisions.
+
+    The generated slug is a display/routing convenience and may be an alias.
+    Ownership must instead follow the provider metadata written alongside the
+    row.  Requiring all three components also prevents a row from one
+    provider being matched to a same-named row from another provider.
+    """
+
+    if not isinstance(model, dict):
+        return None
+    metadata = model.get("codex_proxy_metadata")
+    if not isinstance(metadata, dict):
+        return None
+    provider = metadata.get("provider")
+    upstream_name = metadata.get("upstream_name")
+    upstream_model = metadata.get("upstream_model")
+    if not all(isinstance(value, str) and value.strip() for value in (provider, upstream_name, upstream_model)):
+        return None
+    return (
+        canonical_model_id(provider),
+        canonical_model_id(upstream_name),
+        canonical_model_id(upstream_model),
+    )
+
+
+def _identity_from_payload(value: Any) -> CatalogModelIdentity | None:
+    if isinstance(value, dict):
+        values = (value.get("provider"), value.get("upstream_name"), value.get("upstream_model"))
+    elif isinstance(value, (list, tuple)) and len(value) == 3:
+        values = tuple(value)
+    else:
+        return None
+    if not all(isinstance(item, str) and item.strip() for item in values):
+        return None
+    return tuple(canonical_model_id(str(item)) for item in values)  # type: ignore[return-value]
+
+
+def _official_identity(identity: CatalogModelIdentity | None) -> bool:
+    return bool(
+        identity
+        and identity[0] == OFFICIAL_PROXY_PROVIDER_ALIAS
+        and identity[1] == "official"
+        and identity[2].startswith("gpt-")
+    )
+
+
+def _planner_override_is_valid(
+    identity: CatalogModelIdentity,
+    fields: dict[str, Any],
+) -> bool:
+    """Validate a planner override against the pinned model shape.
+
+    Only Official Code Mode models may carry these fields.  In particular, a
+    user-editable row cannot make an external provider look like an Official
+    model by supplying ``multi_agent_version`` or websocket/tool metadata.
+    """
+
+    if not _official_identity(identity):
+        return False
+    slug = identity[2]
+    if slug not in PINNED_OFFICIAL_MODEL_IDS:
+        return False
+    expected = PINNED_OFFICIAL_CATALOG_METADATA.get(slug)
+    if expected is None:
+        return False
+    if not fields or not set(fields).issubset(CATALOG_OVERRIDE_FIELDS):
+        return False
+    for key, value in fields.items():
+        if key == "multi_agent_version":
+            # v1/v2 are the only native planner versions.  The selected model
+            # must itself be one of the pinned Code Mode rows; legacy Official
+            # rows intentionally have a null version and reject this field.
+            if slug not in PINNED_OFFICIAL_CODE_MODE_MULTI_AGENT_VERSIONS or value not in {"v1", "v2"}:
+                return False
+            continue
+        # Every other planner field is an invariant of the pinned model shape.
+        # A user override may opt into a different supported multi-agent
+        # version, but it must not turn websockets, tool mode, or Responses
+        # Lite on/off independently of the model's official contract.
+        if value != expected.get(key):
+            return False
+    return True
+
+
+def _catalog_models(payload: Any) -> list[dict[str, Any]]:
+    if not isinstance(payload, dict):
+        return []
+    models = payload.get("models")
+    if not isinstance(models, list):
+        return []
+    return [model for model in models if isinstance(model, dict)]
+
+
+def _index_catalog_models(payload: Any) -> dict[CatalogModelIdentity, dict[str, Any]]:
+    indexed: dict[CatalogModelIdentity, dict[str, Any]] = {}
+    for model in _catalog_models(payload):
+        identity = catalog_model_identity(model)
+        if identity is not None and identity not in indexed:
+            indexed[identity] = model
+    return indexed
+
+
+def _load_catalog_override_state(path: Path = CATALOG_OVERRIDES_PATH) -> dict[CatalogModelIdentity, dict[str, Any]]:
+    try:
+        payload = load_json_file(path)
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        return {}
+    if payload.get("schema_version") != CATALOG_OVERRIDE_SCHEMA_VERSION:
+        return {}
+    raw_overrides = payload.get("overrides")
+    if not isinstance(raw_overrides, list):
+        return {}
+    output: dict[CatalogModelIdentity, dict[str, Any]] = {}
+    for entry in raw_overrides:
+        if not isinstance(entry, dict):
+            continue
+        identity = _identity_from_payload(entry)
+        fields = entry.get("fields")
+        if identity is None or not isinstance(fields, dict):
+            continue
+        filtered = {key: value for key, value in fields.items() if key in CATALOG_OVERRIDE_FIELDS}
+        if _planner_override_is_valid(identity, filtered):
+            output[identity] = filtered
+    return output
+
+
+def _write_catalog_override_state(
+    overrides: dict[CatalogModelIdentity, dict[str, Any]],
+) -> dict[str, Any]:
+    entries = []
+    for identity in sorted(overrides):
+        entries.append(
+            {
+                "provider": identity[0],
+                "upstream_name": identity[1],
+                "upstream_model": identity[2],
+                "fields": overrides[identity],
+            }
+        )
+    return {
+        "schema_version": CATALOG_OVERRIDE_SCHEMA_VERSION,
+        "overrides": entries,
+    }
+
+
+def _legacy_override_fields(
+    identity: CatalogModelIdentity,
+    model: dict[str, Any],
+) -> dict[str, Any]:
+    """Extract supported edits from a pre-sidecar single-file catalog."""
+
+    if not _official_identity(identity):
+        return {}
+    slug = identity[2]
+    baseline = PINNED_OFFICIAL_CATALOG_METADATA.get(slug)
+    if baseline is None:
+        return {}
+    fields = {
+        key: model[key]
+        for key in CATALOG_OVERRIDE_FIELDS
+        if key in model and model.get(key) != baseline.get(key)
+    }
+    return fields if _planner_override_is_valid(identity, fields) else {}
+
+
+def _delta_override_fields(
+    identity: CatalogModelIdentity,
+    current: dict[str, Any],
+    baseline: dict[str, Any] | None,
+) -> dict[str, Any]:
+    if baseline is None:
+        return _legacy_override_fields(identity, current)
+    fields = {
+        key: current[key]
+        for key in CATALOG_OVERRIDE_FIELDS
+        if key in current and current.get(key) != baseline.get(key)
+    }
+    return fields if _planner_override_is_valid(identity, fields) else {}
+
+
+def _collect_catalog_overrides() -> tuple[dict[CatalogModelIdentity, dict[str, Any]], dict[str, int]]:
+    """Capture user edits before the effective catalog is replaced.
+
+    A baseline sidecar is the ownership boundary for new installations.  If
+    it is absent, the current generated/legacy catalog is treated as a legacy
+    snapshot and only supported planner deltas against the pinned metadata
+    are migrated.
+    """
+
+    try:
+        current = load_json_file(existing_generated_catalog_path(GENERATED_CATALOG_PATH))
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        current = {}
+    try:
+        baseline = load_json_file(MANAGED_CATALOG_BASELINE_PATH)
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        baseline = {}
+    baseline_models = _index_catalog_models(baseline)
+    overrides = _load_catalog_override_state(CATALOG_OVERRIDES_PATH)
+    diagnostics = {"accepted": 0, "rejected": 0, "migrated": 0}
+    for identity, model in _index_catalog_models(current).items():
+        baseline_model = baseline_models.get(identity)
+        if baseline and baseline_model is None:
+            # A row unknown to the managed baseline is not an authority for
+            # another row; it can be safely ignored during migration.
+            diagnostics["rejected"] += 1
+            continue
+        fields = _delta_override_fields(identity, model, baseline_model)
+        if not fields:
+            # An explicit edit back to the managed value removes the prior
+            # sidecar override instead of making it impossible to opt out.
+            if baseline_model is not None and identity in overrides:
+                overrides.pop(identity, None)
+            continue
+        if _planner_override_is_valid(identity, fields):
+            overrides[identity] = fields
+            diagnostics["accepted"] += 1
+            if not baseline:
+                diagnostics["migrated"] += 1
+        else:
+            overrides.pop(identity, None)
+            diagnostics["rejected"] += 1
+    return overrides, diagnostics
+
+
+def _apply_catalog_overrides(
+    catalog: dict[str, Any],
+    overrides: dict[CatalogModelIdentity, dict[str, Any]],
+    diagnostics: dict[str, int],
+) -> dict[str, Any]:
+    by_identity = _index_catalog_models(catalog)
+    for identity, fields in overrides.items():
+        model = by_identity.get(identity)
+        if model is None or not _planner_override_is_valid(identity, fields):
+            diagnostics["rejected"] = diagnostics.get("rejected", 0) + 1
+            continue
+        model.update(deepcopy(fields))
+    return catalog
 
 
 @dataclass(frozen=True)
@@ -1795,7 +2051,13 @@ def sync_catalog(*, max_age_seconds: int = 0) -> dict[str, Any]:
     if ollama_runtime_configured:
         ollama_model_metadata.update(ollama_provider_model_metadata(runtime_ollama_models))
 
-    catalog = build_codex_catalog(
+    # Read the old effective catalog before publishing a new one.  This is the
+    # only point at which an edit made by the user is distinguishable from the
+    # next managed baseline.  The sidecars are written below in the same
+    # atomic-publication sequence as the catalog itself.
+    catalog_overrides, override_diagnostics = _collect_catalog_overrides()
+
+    managed_catalog = build_codex_catalog(
         official_models,
         ollama_catalog_ids,
         policy,
@@ -1809,6 +2071,11 @@ def sync_catalog(*, max_age_seconds: int = 0) -> dict[str, Any]:
         use_ollama_policy_allowlist=not ollama_runtime_configured,
         official_source_present=official_snapshot.source_present,
         visibility_diagnostics=official_snapshot.visibility_diagnostics,
+    )
+    catalog = _apply_catalog_overrides(
+        deepcopy(managed_catalog),
+        catalog_overrides,
+        override_diagnostics,
     )
     visible_slugs = [str(model["slug"]) for model in catalog["models"] if model.get("slug")]
     previous_visible_slugs = load_previous_visible_models(GENERATED_STATE_PATH)
@@ -1828,9 +2095,19 @@ def sync_catalog(*, max_age_seconds: int = 0) -> dict[str, Any]:
         "external_provider_models": [str(model["alias"]) for model in external_models],
         "visible_models": visible_slugs,
         "diff": diff,
+        "catalog_override_diagnostics": {
+            key: min(max(int(value), 0), MAX_VISIBILITY_DIAGNOSTIC_COUNT)
+            for key, value in override_diagnostics.items()
+        },
     }
 
+    managed_baseline = dict(managed_catalog)
+    managed_baseline["schema_version"] = CATALOG_OVERRIDE_SCHEMA_VERSION
+    managed_baseline["managed_baseline"] = True
+    override_state = _write_catalog_override_state(catalog_overrides)
     write_json(GENERATED_CATALOG_PATH, catalog)
+    write_json(MANAGED_CATALOG_BASELINE_PATH, managed_baseline)
+    write_json(CATALOG_OVERRIDES_PATH, override_state)
     write_json(GENERATED_STATE_PATH, state)
     return state
 

--- a/src-python/catalog_sync.py
+++ b/src-python/catalog_sync.py
@@ -4,6 +4,7 @@ import argparse
 from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -309,6 +310,21 @@ PINNED_OFFICIAL_MODEL_FIELD_SETS = {
 # unrelated stale metadata to survive a refresh.
 CATALOG_OVERRIDE_FIELDS = frozenset(PINNED_OFFICIAL_PLANNER_FIELD_SET)
 CATALOG_OVERRIDE_SCHEMA_VERSION = 1
+CATALOG_OWNER_METADATA_KEY = "catalog_owner"
+CATALOG_OWNER_METADATA_VERSION_KEY = "catalog_owner_version"
+CATALOG_OWNER_IDENTITY_KEY = "catalog_identity_digest"
+CATALOG_OWNER_METADATA_VALUE = "codexhub"
+CATALOG_OWNER_METADATA_VERSION = 1
+CATALOG_OVERRIDE_REJECTION_REASONS = frozenset(
+    {
+        "invalid_sidecar",
+        "invalid_catalog",
+        "invalid_baseline",
+        "invalid_row_identity",
+        "invalid_override_fields",
+        "missing_managed_model",
+    }
+)
 
 
 def load_pinned_official_catalog_metadata(
@@ -401,6 +417,7 @@ def catalog_cache_dependency_paths() -> tuple[Path, ...]:
     return (
         POLICY_PATH,
         OFFICIAL_SEED_PATH,
+        OFFICIAL_CATALOG_METADATA_PATH,
         RUNTIME_OFFICIAL_SEED_PATH,
         DIRECT_OFFICIAL_MODELS_CACHE_PATH,
         OLLAMA_FALLBACK_PATH,
@@ -410,6 +427,8 @@ def catalog_cache_dependency_paths() -> tuple[Path, ...]:
         Path(__file__).resolve(),
         PROXY_DIR / "catalog.py",
         PROXY_DIR / "providers_config.py",
+        MANAGED_CATALOG_BASELINE_PATH,
+        CATALOG_OVERRIDES_PATH,
     )
 
 
@@ -509,6 +528,9 @@ def _planner_override_is_valid(
         return False
     if not fields or not set(fields).issubset(CATALOG_OVERRIDE_FIELDS):
         return False
+    supported_fields = set(PINNED_OFFICIAL_MODEL_FIELD_SETS.get(slug, ()))
+    if not set(fields).issubset(supported_fields):
+        return False
     for key, value in fields.items():
         if key == "multi_agent_version":
             # v1/v2 are the only native planner versions.  The selected model
@@ -526,6 +548,92 @@ def _planner_override_is_valid(
     return True
 
 
+def _record_override_rejection(
+    diagnostics: dict[str, Any] | None,
+    reason: str,
+) -> None:
+    if diagnostics is None:
+        return
+    diagnostics["rejected"] = int(diagnostics.get("rejected", 0)) + 1
+    reasons = diagnostics.setdefault("reasons", {})
+    if not isinstance(reasons, dict):
+        reasons = {}
+        diagnostics["reasons"] = reasons
+    if reason not in CATALOG_OVERRIDE_REJECTION_REASONS:
+        reason = "invalid_sidecar"
+    reasons[reason] = int(reasons.get(reason, 0)) + 1
+
+
+def _catalog_override_row_is_eligible(
+    identity: CatalogModelIdentity,
+    model: dict[str, Any],
+    baseline_model: dict[str, Any] | None = None,
+) -> bool:
+    """Require the edited row to be a visible, exact managed row.
+
+    Metadata alone is not an authority: a user-edited hidden row or a row
+    spoofed to look Official must not seed an override for the next catalog.
+    """
+
+    if not is_catalog_model_listable(model, missing_is_list=False):
+        return False
+    slug = model.get("slug")
+    if not isinstance(slug, str):
+        return False
+    normalized_slug = canonical_model_id(slug)
+    if normalized_slug.startswith("openai/gpt-"):
+        normalized_slug = normalized_slug.removeprefix("openai/")
+    if normalized_slug != identity[2]:
+        return False
+
+    metadata = model.get("codex_proxy_metadata")
+    if not isinstance(metadata, dict):
+        return False
+
+    # New catalogs carry an ownership marker in the generated row. When a
+    # managed baseline has one, require the current row to carry the same
+    # marker; changing only the visible slug/identity cannot turn a replaced
+    # third-party row into an Official authority.
+    baseline_metadata = (
+        baseline_model.get("codex_proxy_metadata")
+        if isinstance(baseline_model, dict)
+        else None
+    )
+    if (
+        isinstance(baseline_metadata, dict)
+        and CATALOG_OWNER_METADATA_KEY in baseline_metadata
+    ) or CATALOG_OWNER_METADATA_KEY in metadata:
+        return (
+            metadata.get(CATALOG_OWNER_METADATA_KEY) == CATALOG_OWNER_METADATA_VALUE
+            and metadata.get(CATALOG_OWNER_METADATA_VERSION_KEY)
+            == CATALOG_OWNER_METADATA_VERSION
+            and metadata.get(CATALOG_OWNER_IDENTITY_KEY)
+            == catalog_identity_digest(identity)
+        )
+
+    # Pre-Beta2 catalogs have no marker. Retain migration compatibility only
+    # for the recognizable generated Official row shape; a hand-authored
+    # metadata/slug spoof is not a legacy catalog record.
+    if not _official_identity(identity):
+        return True
+    required_legacy_keys = (
+        "description",
+        "shell_type",
+        "supported_in_api",
+        "supported_reasoning_levels",
+        "default_reasoning_level",
+        "input_modalities",
+    )
+    if any(key not in model for key in required_legacy_keys):
+        return False
+    return (
+        model.get("shell_type") == "shell_command"
+        and model.get("supported_in_api") is True
+        and isinstance(model.get("supported_reasoning_levels"), list)
+        and isinstance(model.get("input_modalities"), list)
+    )
+
+
 def _catalog_models(payload: Any) -> list[dict[str, Any]]:
     if not isinstance(payload, dict):
         return []
@@ -535,36 +643,169 @@ def _catalog_models(payload: Any) -> list[dict[str, Any]]:
     return [model for model in models if isinstance(model, dict)]
 
 
+def _catalog_payload_shape_is_valid(
+    payload: Any,
+    *,
+    require_identity: bool = False,
+) -> bool:
+    """Validate the minimum generated-catalog envelope before reconciliation."""
+
+    if not isinstance(payload, dict) or not isinstance(payload.get("models"), list):
+        return False
+    if not payload["models"]:
+        return False
+    for model in payload["models"]:
+        if not isinstance(model, dict):
+            return False
+        slug = model.get("slug")
+        if not isinstance(slug, str) or not slug.strip():
+            return False
+        if "visibility" in model and not isinstance(model.get("visibility"), str):
+            return False
+        if "visibility" not in model and not isinstance(model.get("hidden"), bool):
+            return False
+        metadata = model.get("codex_proxy_metadata")
+        if "codex_proxy_metadata" in model and not isinstance(metadata, dict):
+            return False
+        if require_identity and (
+            not isinstance(metadata, dict) or catalog_model_identity(model) is None
+        ):
+            return False
+        if require_identity:
+            identity = catalog_model_identity(model)
+            if identity is not None and _official_identity(identity):
+                if identity[2] not in PINNED_OFFICIAL_MODEL_IDS:
+                    return False
+                if any(
+                    field not in model
+                    for field in PINNED_OFFICIAL_MODEL_FIELD_SETS.get(identity[2], ())
+                ):
+                    return False
+    return True
+
+
+def _managed_baseline_shape_is_valid(payload: Any) -> bool:
+    if (
+        isinstance(payload, dict)
+        and isinstance(payload.get("models"), list)
+        and not payload["models"]
+    ):
+        return True
+    if not _catalog_payload_shape_is_valid(payload, require_identity=True):
+        return False
+    for model in payload["models"]:
+        identity = catalog_model_identity(model)
+        if identity is None:
+            return False
+        if _official_identity(identity):
+            if identity[2] not in PINNED_OFFICIAL_MODEL_IDS:
+                return False
+            supported_fields = PINNED_OFFICIAL_MODEL_FIELD_SETS.get(identity[2], ())
+            if any(field not in model for field in supported_fields):
+                return False
+            expected = PINNED_OFFICIAL_CATALOG_METADATA.get(identity[2], {})
+            for field in supported_fields:
+                value = model.get(field)
+                if field == "multi_agent_version":
+                    if value not in {"v1", "v2"}:
+                        return False
+                elif value != expected.get(field):
+                    return False
+            metadata = model.get("codex_proxy_metadata")
+            if isinstance(metadata, dict) and CATALOG_OWNER_METADATA_KEY in metadata:
+                if (
+                    metadata.get(CATALOG_OWNER_METADATA_KEY) != CATALOG_OWNER_METADATA_VALUE
+                    or metadata.get(CATALOG_OWNER_METADATA_VERSION_KEY)
+                    != CATALOG_OWNER_METADATA_VERSION
+                    or metadata.get(CATALOG_OWNER_IDENTITY_KEY)
+                    != catalog_identity_digest(identity)
+                ):
+                    return False
+    return True
+
+
 def _index_catalog_models(payload: Any) -> dict[CatalogModelIdentity, dict[str, Any]]:
     indexed: dict[CatalogModelIdentity, dict[str, Any]] = {}
+    duplicates: set[CatalogModelIdentity] = set()
     for model in _catalog_models(payload):
         identity = catalog_model_identity(model)
-        if identity is not None and identity not in indexed:
-            indexed[identity] = model
+        if identity is None:
+            continue
+        if identity in indexed:
+            duplicates.add(identity)
+            continue
+        indexed[identity] = model
+    for identity in duplicates:
+        indexed.pop(identity, None)
     return indexed
 
 
-def _load_catalog_override_state(path: Path = CATALOG_OVERRIDES_PATH) -> dict[CatalogModelIdentity, dict[str, Any]]:
+def _duplicate_catalog_identities(payload: Any) -> set[CatalogModelIdentity]:
+    seen: set[CatalogModelIdentity] = set()
+    duplicates: set[CatalogModelIdentity] = set()
+    for model in _catalog_models(payload):
+        identity = catalog_model_identity(model)
+        if identity is None:
+            continue
+        if identity in seen:
+            duplicates.add(identity)
+        else:
+            seen.add(identity)
+    return duplicates
+
+
+def _load_catalog_override_state(
+    path: Path = CATALOG_OVERRIDES_PATH,
+    diagnostics: dict[str, Any] | None = None,
+) -> dict[CatalogModelIdentity, dict[str, Any]]:
     try:
         payload = load_json_file(path)
     except (OSError, UnicodeError, json.JSONDecodeError):
+        _record_override_rejection(diagnostics, "invalid_sidecar")
         return {}
-    if payload.get("schema_version") != CATALOG_OVERRIDE_SCHEMA_VERSION:
+    if not isinstance(payload, dict):
+        _record_override_rejection(diagnostics, "invalid_sidecar")
+        return {}
+    if (
+        type(payload.get("schema_version")) is not int
+        or payload.get("schema_version") != CATALOG_OVERRIDE_SCHEMA_VERSION
+    ):
+        _record_override_rejection(diagnostics, "invalid_sidecar")
+        return {}
+    if set(payload) != {"schema_version", "overrides"}:
+        _record_override_rejection(diagnostics, "invalid_sidecar")
         return {}
     raw_overrides = payload.get("overrides")
     if not isinstance(raw_overrides, list):
+        _record_override_rejection(diagnostics, "invalid_sidecar")
         return {}
     output: dict[CatalogModelIdentity, dict[str, Any]] = {}
     for entry in raw_overrides:
         if not isinstance(entry, dict):
-            continue
+            _record_override_rejection(diagnostics, "invalid_sidecar")
+            return {}
+        if set(entry) != {"provider", "upstream_name", "upstream_model", "fields"}:
+            _record_override_rejection(diagnostics, "invalid_sidecar")
+            return {}
         identity = _identity_from_payload(entry)
         fields = entry.get("fields")
         if identity is None or not isinstance(fields, dict):
-            continue
-        filtered = {key: value for key, value in fields.items() if key in CATALOG_OVERRIDE_FIELDS}
-        if _planner_override_is_valid(identity, filtered):
-            output[identity] = filtered
+            _record_override_rejection(diagnostics, "invalid_sidecar")
+            return {}
+        if not set(fields).issubset(CATALOG_OVERRIDE_FIELDS):
+            _record_override_rejection(diagnostics, "invalid_override_fields")
+            return {}
+        if _planner_override_is_valid(identity, fields):
+            if identity in output:
+                # A duplicate identity has no deterministic ownership
+                # semantics; reject the complete sidecar instead of making
+                # list order a hidden override selector.
+                _record_override_rejection(diagnostics, "invalid_sidecar")
+                return {}
+            output[identity] = {key: fields[key] for key in sorted(fields)}
+        else:
+            _record_override_rejection(diagnostics, "invalid_override_fields")
+            return {}
     return output
 
 
@@ -601,10 +842,10 @@ def _legacy_override_fields(
         return {}
     fields = {
         key: model[key]
-        for key in CATALOG_OVERRIDE_FIELDS
+        for key in sorted(CATALOG_OVERRIDE_FIELDS)
         if key in model and model.get(key) != baseline.get(key)
     }
-    return fields if _planner_override_is_valid(identity, fields) else {}
+    return fields
 
 
 def _delta_override_fields(
@@ -616,13 +857,13 @@ def _delta_override_fields(
         return _legacy_override_fields(identity, current)
     fields = {
         key: current[key]
-        for key in CATALOG_OVERRIDE_FIELDS
+        for key in sorted(CATALOG_OVERRIDE_FIELDS)
         if key in current and current.get(key) != baseline.get(key)
     }
-    return fields if _planner_override_is_valid(identity, fields) else {}
+    return fields
 
 
-def _collect_catalog_overrides() -> tuple[dict[CatalogModelIdentity, dict[str, Any]], dict[str, int]]:
+def _collect_catalog_overrides() -> tuple[dict[CatalogModelIdentity, dict[str, Any]], dict[str, Any]]:
     """Capture user edits before the effective catalog is replaced.
 
     A baseline sidecar is the ownership boundary for new installations.  If
@@ -631,23 +872,99 @@ def _collect_catalog_overrides() -> tuple[dict[CatalogModelIdentity, dict[str, A
     are migrated.
     """
 
+    diagnostics: dict[str, Any] = {
+        "accepted": 0,
+        "rejected": 0,
+        "migrated": 0,
+        "reasons": {},
+        # A malformed effective catalog is not an ownership boundary.  Keep
+        # a valid persisted sidecar available for recovery, but never use the
+        # malformed file as evidence of a new user edit.
+        "current_catalog_valid": True,
+    }
+    current_path = existing_generated_catalog_path(GENERATED_CATALOG_PATH)
+    current_exists = current_path.exists()
+    diagnostics["current_catalog_valid"] = current_exists
     try:
-        current = load_json_file(existing_generated_catalog_path(GENERATED_CATALOG_PATH))
+        current = load_json_file(current_path)
     except (OSError, UnicodeError, json.JSONDecodeError):
         current = {}
-    try:
-        baseline = load_json_file(MANAGED_CATALOG_BASELINE_PATH)
-    except (OSError, UnicodeError, json.JSONDecodeError):
+        if current_exists:
+            diagnostics["current_catalog_valid"] = False
+            _record_override_rejection(diagnostics, "invalid_catalog")
+    if diagnostics["current_catalog_valid"] and not _catalog_payload_shape_is_valid(current):
+        current = {}
+        diagnostics["current_catalog_valid"] = False
+        _record_override_rejection(diagnostics, "invalid_catalog")
+
+    baseline_exists = MANAGED_CATALOG_BASELINE_PATH.exists()
+    if baseline_exists:
+        try:
+            baseline = load_json_file(MANAGED_CATALOG_BASELINE_PATH)
+        except (OSError, UnicodeError, json.JSONDecodeError):
+            _record_override_rejection(diagnostics, "invalid_baseline")
+            return {}, diagnostics
+        if not (
+            isinstance(baseline, dict)
+            and type(baseline.get("schema_version")) is int
+            and baseline.get("schema_version") == CATALOG_OVERRIDE_SCHEMA_VERSION
+            and baseline.get("managed_baseline") is True
+            and _managed_baseline_shape_is_valid(baseline)
+        ):
+            _record_override_rejection(diagnostics, "invalid_baseline")
+            return {}, diagnostics
+        if diagnostics["current_catalog_valid"] and not _catalog_payload_shape_is_valid(
+            current,
+            require_identity=True,
+        ):
+            current = {}
+            diagnostics["current_catalog_valid"] = False
+            _record_override_rejection(diagnostics, "invalid_catalog")
+    else:
         baseline = {}
+
+    baseline_duplicates = _duplicate_catalog_identities(baseline)
+    if baseline_duplicates:
+        _record_override_rejection(diagnostics, "invalid_baseline")
+        return {}, diagnostics
+
     baseline_models = _index_catalog_models(baseline)
-    overrides = _load_catalog_override_state(CATALOG_OVERRIDES_PATH)
-    diagnostics = {"accepted": 0, "rejected": 0, "migrated": 0}
-    for identity, model in _index_catalog_models(current).items():
+    # An override sidecar without its managed baseline has no ownership proof;
+    # ignore it and let the next effective catalog establish a fresh baseline.
+    overrides = (
+        _load_catalog_override_state(CATALOG_OVERRIDES_PATH, diagnostics)
+        if baseline_exists
+        else {}
+    )
+    if not diagnostics["current_catalog_valid"]:
+        # Do not infer a user edit from a missing/corrupt current file. Keep
+        # any already validated sidecar for the rebuilt managed catalog to
+        # consume, and let publication validate the target identity again.
+        return overrides, diagnostics
+    current_duplicates = _duplicate_catalog_identities(current)
+    for identity in current_duplicates:
+        overrides.pop(identity, None)
+        _record_override_rejection(diagnostics, "invalid_row_identity")
+    current_models = _index_catalog_models(current)
+    if diagnostics["current_catalog_valid"]:
+        # A sidecar entry is only valid while the exact managed identity is
+        # still present in the current catalog.  Otherwise a removed model,
+        # provider replacement, or cross-provider row could inherit the old
+        # planner fields on the next generated catalog.
+        for identity in set(overrides).difference(current_models):
+            overrides.pop(identity, None)
+            _record_override_rejection(diagnostics, "missing_managed_model")
+    for identity, model in current_models.items():
         baseline_model = baseline_models.get(identity)
-        if baseline and baseline_model is None:
+        if not _catalog_override_row_is_eligible(identity, model, baseline_model):
+            overrides.pop(identity, None)
+            _record_override_rejection(diagnostics, "invalid_row_identity")
+            continue
+        if baseline_exists and baseline_model is None:
             # A row unknown to the managed baseline is not an authority for
             # another row; it can be safely ignored during migration.
-            diagnostics["rejected"] += 1
+            overrides.pop(identity, None)
+            _record_override_rejection(diagnostics, "invalid_row_identity")
             continue
         fields = _delta_override_fields(identity, model, baseline_model)
         if not fields:
@@ -659,27 +976,54 @@ def _collect_catalog_overrides() -> tuple[dict[CatalogModelIdentity, dict[str, A
         if _planner_override_is_valid(identity, fields):
             overrides[identity] = fields
             diagnostics["accepted"] += 1
-            if not baseline:
+            if not baseline_exists:
                 diagnostics["migrated"] += 1
         else:
             overrides.pop(identity, None)
-            diagnostics["rejected"] += 1
+            _record_override_rejection(diagnostics, "invalid_override_fields")
     return overrides, diagnostics
 
 
 def _apply_catalog_overrides(
     catalog: dict[str, Any],
     overrides: dict[CatalogModelIdentity, dict[str, Any]],
-    diagnostics: dict[str, int],
+    diagnostics: dict[str, Any],
 ) -> dict[str, Any]:
     by_identity = _index_catalog_models(catalog)
-    for identity, fields in overrides.items():
+    for identity, fields in list(overrides.items()):
         model = by_identity.get(identity)
-        if model is None or not _planner_override_is_valid(identity, fields):
-            diagnostics["rejected"] = diagnostics.get("rejected", 0) + 1
+        if model is None:
+            overrides.pop(identity, None)
+            _record_override_rejection(diagnostics, "missing_managed_model")
+            continue
+        if not _catalog_override_row_is_eligible(identity, model):
+            overrides.pop(identity, None)
+            _record_override_rejection(diagnostics, "invalid_row_identity")
+            continue
+        if not _planner_override_is_valid(identity, fields):
+            overrides.pop(identity, None)
+            _record_override_rejection(diagnostics, "invalid_override_fields")
             continue
         model.update(deepcopy(fields))
     return catalog
+
+
+def _bounded_catalog_override_diagnostics(
+    diagnostics: dict[str, Any],
+) -> dict[str, Any]:
+    result = {
+        key: min(max(int(diagnostics.get(key, 0)), 0), MAX_VISIBILITY_DIAGNOSTIC_COUNT)
+        for key in ("accepted", "rejected", "migrated")
+    }
+    raw_reasons = diagnostics.get("reasons")
+    reasons = {}
+    if isinstance(raw_reasons, dict):
+        for reason in sorted(CATALOG_OVERRIDE_REJECTION_REASONS):
+            value = raw_reasons.get(reason, 0)
+            if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+                reasons[reason] = min(value, MAX_VISIBILITY_DIAGNOSTIC_COUNT)
+    result["reasons"] = reasons
+    return result
 
 
 @dataclass(frozen=True)
@@ -1446,6 +1790,21 @@ def normalize_official_responses_lite_opt_in(model: dict[str, Any]) -> None:
         model["use_responses_lite"] = False
 
 
+def catalog_identity_digest(identity: CatalogModelIdentity) -> str:
+    value = "\0".join(identity).encode("utf-8")
+    return hashlib.sha256(value).hexdigest()
+
+
+def stamp_catalog_owner_metadata(model: dict[str, Any]) -> None:
+    metadata = dict(model.get("codex_proxy_metadata", {}))
+    metadata[CATALOG_OWNER_METADATA_KEY] = CATALOG_OWNER_METADATA_VALUE
+    metadata[CATALOG_OWNER_METADATA_VERSION_KEY] = CATALOG_OWNER_METADATA_VERSION
+    identity = catalog_model_identity(model)
+    if identity is not None:
+        metadata[CATALOG_OWNER_IDENTITY_KEY] = catalog_identity_digest(identity)
+    model["codex_proxy_metadata"] = metadata
+
+
 def official_proxy_alias(slug: str) -> str:
     return f"{OFFICIAL_PROXY_PROVIDER_ALIAS}/{slug}"
 
@@ -1585,6 +1944,7 @@ def build_official_proxy_model(
         }
     )
     model["codex_proxy_metadata"] = proxy_metadata
+    stamp_catalog_owner_metadata(model)
     return model
 
 
@@ -1648,12 +2008,33 @@ def build_ollama_model(
     else:
         model = deepcopy(DEFAULT_OLLAMA_MODEL)
 
+    # Planner metadata is an Official-model contract.  A fallback catalog is
+    # shared input for third-party rows and must never be able to make one of
+    # those rows advertise an Official Code Mode/version.
+    for key in PINNED_OFFICIAL_PLANNER_FIELD_SET:
+        model.pop(key, None)
+    model["use_responses_lite"] = False
     model["slug"] = slug
     model["display_name"] = display_name_for(slug, policy)
     model.setdefault("description", DEFAULT_OLLAMA_MODEL["description"])
     model.setdefault("visibility", "list")
     model.setdefault("supported_in_api", True)
     apply_ollama_model_limits(model, slug, model_metadata or {})
+    inherited_metadata = model.get("codex_proxy_metadata")
+    safe_metadata = {
+        key: inherited_metadata[key]
+        for key in ("context_source", "max_output_source")
+        if isinstance(inherited_metadata, dict) and key in inherited_metadata
+    }
+    safe_metadata.update(
+        {
+            "provider": "ollama-cloud",
+            "upstream_name": "ollama_cloud",
+            "upstream_model": slug,
+        }
+    )
+    model["codex_proxy_metadata"] = safe_metadata
+    stamp_catalog_owner_metadata(model)
     return model
 
 
@@ -1719,6 +2100,13 @@ def build_external_provider_model(
         model = deepcopy(fallback_template)
     else:
         model = deepcopy(DEFAULT_OLLAMA_MODEL)
+
+    # Never inherit Official planner fields from the fallback template.  The
+    # third-party catalog may retain the normal explicit false value for
+    # Responses Lite, but it cannot claim a native Official planner contract.
+    for key in PINNED_OFFICIAL_PLANNER_FIELD_SET:
+        model.pop(key, None)
+    model["use_responses_lite"] = False
 
     alias = str(external_model["alias"])
     display_prefix = str(external_model.get("display_prefix") or external_model.get("provider_alias") or "provider")
@@ -1790,6 +2178,7 @@ def build_external_provider_model(
             (str(external_model["provider_alias"]), str(external_model["upstream_model"]))
         ),
     )
+    stamp_catalog_owner_metadata(model)
     return model
 
 
@@ -2095,10 +2484,9 @@ def sync_catalog(*, max_age_seconds: int = 0) -> dict[str, Any]:
         "external_provider_models": [str(model["alias"]) for model in external_models],
         "visible_models": visible_slugs,
         "diff": diff,
-        "catalog_override_diagnostics": {
-            key: min(max(int(value), 0), MAX_VISIBILITY_DIAGNOSTIC_COUNT)
-            for key, value in override_diagnostics.items()
-        },
+        "catalog_override_diagnostics": _bounded_catalog_override_diagnostics(
+            override_diagnostics
+        ),
     }
 
     managed_baseline = dict(managed_catalog)
@@ -2137,6 +2525,16 @@ def main(argv: list[str] | None = None) -> int:
     print(f"visible_models={len(state['visible_models'])}")
     if state.get("cache_status"):
         print(f"cache_status={state['cache_status']}")
+    override_diagnostics = state.get("catalog_override_diagnostics", {})
+    print(f"catalog_override_accepted={override_diagnostics.get('accepted', 0)}")
+    print(f"catalog_override_rejected={override_diagnostics.get('rejected', 0)}")
+    print(f"catalog_override_migrated={override_diagnostics.get('migrated', 0)}")
+    reasons = override_diagnostics.get("reasons", {})
+    if isinstance(reasons, dict):
+        print(
+            "catalog_override_rejection_reasons="
+            + ",".join(f"{key}:{reasons[key]}" for key in sorted(reasons))
+        )
     print(f"added={','.join(diff['added'])}")
     print(f"removed={','.join(diff['removed'])}")
     return 0

--- a/src-python/catalog_sync.py
+++ b/src-python/catalog_sync.py
@@ -644,6 +644,17 @@ def _catalog_override_row_is_eligible(
             != _catalog_owner_canonical_row(baseline_model)
         ):
             return False
+        if baseline_model is None and CATALOG_OWNER_SIGNATURE_KEY not in metadata:
+            # A real sync creates the HMAC key before reconciliation.  An
+            # old public marker without a managed baseline therefore has no
+            # trustworthy immutable-row proof and must not be treated as a
+            # legacy migration source; only truly markerless Beta1 catalogs
+            # use the narrow shape-checked migration below.
+            try:
+                if _load_catalog_owner_secret(create=False) is not None:
+                    return False
+            except ValueError:
+                return False
         require_signature = (
             isinstance(baseline_metadata, dict)
             and CATALOG_OWNER_SIGNATURE_KEY in baseline_metadata

--- a/src-python/catalog_sync.py
+++ b/src-python/catalog_sync.py
@@ -609,7 +609,11 @@ def _catalog_override_row_is_eligible(
     normalized_slug = canonical_model_id(slug)
     if normalized_slug.startswith("openai/gpt-"):
         normalized_slug = normalized_slug.removeprefix("openai/")
-    if normalized_slug != identity[2]:
+    # Official rows use the bare pinned slug as part of their ownership
+    # proof.  Third-party rows may intentionally expose a provider-prefixed
+    # alias (for example ``volc/glm-5.2``) while their stable identity remains
+    # the metadata tuple; planner overrides are not valid for them anyway.
+    if _official_identity(identity) and normalized_slug != identity[2]:
         return False
 
     metadata = model.get("codex_proxy_metadata")

--- a/src-python/catalog_sync.py
+++ b/src-python/catalog_sync.py
@@ -5,16 +5,18 @@ from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 import hashlib
+import hmac
 import json
 import os
 from pathlib import Path
 import re
+import secrets
 import sys
 from typing import Any, Iterable
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
-from atomic_io import atomic_write_text
+from atomic_io import atomic_read_or_create_text, atomic_write_text
 from catalog import (
     CatalogVisibility,
     CatalogPolicy,
@@ -313,8 +315,10 @@ CATALOG_OVERRIDE_SCHEMA_VERSION = 1
 CATALOG_OWNER_METADATA_KEY = "catalog_owner"
 CATALOG_OWNER_METADATA_VERSION_KEY = "catalog_owner_version"
 CATALOG_OWNER_IDENTITY_KEY = "catalog_identity_digest"
+CATALOG_OWNER_SIGNATURE_KEY = "catalog_owner_signature"
 CATALOG_OWNER_METADATA_VALUE = "codexhub"
 CATALOG_OWNER_METADATA_VERSION = 1
+CATALOG_OWNER_SECRET_FILENAME = ".codexhub-catalog-owner-key"
 CATALOG_OVERRIDE_REJECTION_REASONS = frozenset(
     {
         "invalid_sidecar",
@@ -325,6 +329,8 @@ CATALOG_OVERRIDE_REJECTION_REASONS = frozenset(
         "missing_managed_model",
     }
 )
+
+_CATALOG_OWNER_SECRET_CACHE: tuple[Path, bytes] | None = None
 
 
 def load_pinned_official_catalog_metadata(
@@ -429,6 +435,7 @@ def catalog_cache_dependency_paths() -> tuple[Path, ...]:
         PROXY_DIR / "providers_config.py",
         MANAGED_CATALOG_BASELINE_PATH,
         CATALOG_OVERRIDES_PATH,
+        catalog_owner_secret_path(),
     )
 
 
@@ -437,6 +444,8 @@ def catalog_cache_is_fresh(max_age_seconds: int, catalog_path: Path = GENERATED_
         return False
     catalog_mtime = catalog_path.stat().st_mtime
     for dependency in catalog_cache_dependency_paths():
+        if dependency == catalog_owner_secret_path() and not dependency.exists():
+            return False
         if dependency.exists() and dependency.stat().st_mtime > catalog_mtime:
             return False
     age_seconds = datetime.now(timezone.utc).timestamp() - catalog_mtime
@@ -479,9 +488,12 @@ def catalog_model_identity(model: Any) -> CatalogModelIdentity | None:
     upstream_model = metadata.get("upstream_model")
     if not all(isinstance(value, str) and value.strip() for value in (provider, upstream_name, upstream_model)):
         return None
+    # ``:cloud`` is an Ollama model-suffix normalization, not a provider or
+    # upstream-name alias.  Keep the first two components exact so an edited
+    # ``openai:cloud``/``official:cloud`` row cannot collapse into Official.
     return (
-        canonical_model_id(provider),
-        canonical_model_id(upstream_name),
+        provider.strip(),
+        upstream_name.strip(),
         canonical_model_id(upstream_model),
     )
 
@@ -495,7 +507,11 @@ def _identity_from_payload(value: Any) -> CatalogModelIdentity | None:
         return None
     if not all(isinstance(item, str) and item.strip() for item in values):
         return None
-    return tuple(canonical_model_id(str(item)) for item in values)  # type: ignore[return-value]
+    return (
+        str(values[0]).strip(),
+        str(values[1]).strip(),
+        canonical_model_id(str(values[2])),
+    )
 
 
 def _official_identity(identity: CatalogModelIdentity | None) -> bool:
@@ -536,7 +552,11 @@ def _planner_override_is_valid(
             # v1/v2 are the only native planner versions.  The selected model
             # must itself be one of the pinned Code Mode rows; legacy Official
             # rows intentionally have a null version and reject this field.
-            if slug not in PINNED_OFFICIAL_CODE_MODE_MULTI_AGENT_VERSIONS or value not in {"v1", "v2"}:
+            if (
+                slug not in PINNED_OFFICIAL_CODE_MODE_MULTI_AGENT_VERSIONS
+                or not isinstance(value, str)
+                or value not in {"v1", "v2"}
+            ):
                 return False
             continue
         # Every other planner field is an invariant of the pinned model shape.
@@ -599,16 +619,46 @@ def _catalog_override_row_is_eligible(
         if isinstance(baseline_model, dict)
         else None
     )
-    if (
-        isinstance(baseline_metadata, dict)
-        and CATALOG_OWNER_METADATA_KEY in baseline_metadata
-    ) or CATALOG_OWNER_METADATA_KEY in metadata:
-        return (
-            metadata.get(CATALOG_OWNER_METADATA_KEY) == CATALOG_OWNER_METADATA_VALUE
-            and metadata.get(CATALOG_OWNER_METADATA_VERSION_KEY)
-            == CATALOG_OWNER_METADATA_VERSION
-            and metadata.get(CATALOG_OWNER_IDENTITY_KEY)
-            == catalog_identity_digest(identity)
+    if baseline_model is not None and (
+        not isinstance(baseline_metadata, dict)
+        or CATALOG_OWNER_METADATA_KEY not in baseline_metadata
+    ):
+        # Once a managed baseline exists, a markerless row is not an
+        # ownership boundary.  Treating it as a legacy snapshot would let a
+        # hand-authored baseline mint a planner override on the next sync.
+        return False
+    baseline_has_owner_marker = isinstance(baseline_metadata, dict) and (
+        CATALOG_OWNER_METADATA_KEY in baseline_metadata
+        or CATALOG_OWNER_SIGNATURE_KEY in baseline_metadata
+    )
+    current_has_owner_marker = (
+        CATALOG_OWNER_METADATA_KEY in metadata
+        or CATALOG_OWNER_METADATA_VERSION_KEY in metadata
+        or CATALOG_OWNER_IDENTITY_KEY in metadata
+        or CATALOG_OWNER_SIGNATURE_KEY in metadata
+    )
+    if baseline_has_owner_marker or current_has_owner_marker:
+        if (
+            baseline_model is not None
+            and _catalog_owner_canonical_row(model)
+            != _catalog_owner_canonical_row(baseline_model)
+        ):
+            return False
+        require_signature = (
+            isinstance(baseline_metadata, dict)
+            and CATALOG_OWNER_SIGNATURE_KEY in baseline_metadata
+        ) or CATALOG_OWNER_SIGNATURE_KEY in metadata
+        return _catalog_owner_metadata_is_valid(
+            metadata,
+            identity,
+            # A marker-only baseline/current pair may have been written by
+            # the pre-HMAC Beta2 build.  The exact immutable-row comparison
+            # above is the migration proof; the next publication upgrades it
+            # to a signed baseline.  A newly signed side of the pair still
+            # forces signature validation.
+            require_signature=require_signature,
+            model=model,
+            baseline_model=baseline_model,
         )
 
     # Pre-Beta2 catalogs have no marker. Retain migration compatibility only
@@ -707,18 +757,20 @@ def _managed_baseline_shape_is_valid(payload: Any) -> bool:
             for field in supported_fields:
                 value = model.get(field)
                 if field == "multi_agent_version":
-                    if value not in {"v1", "v2"}:
+                    if not isinstance(value, str) or value not in {"v1", "v2"}:
                         return False
                 elif value != expected.get(field):
                     return False
             metadata = model.get("codex_proxy_metadata")
-            if isinstance(metadata, dict) and CATALOG_OWNER_METADATA_KEY in metadata:
-                if (
-                    metadata.get(CATALOG_OWNER_METADATA_KEY) != CATALOG_OWNER_METADATA_VALUE
-                    or metadata.get(CATALOG_OWNER_METADATA_VERSION_KEY)
-                    != CATALOG_OWNER_METADATA_VERSION
-                    or metadata.get(CATALOG_OWNER_IDENTITY_KEY)
-                    != catalog_identity_digest(identity)
+            if isinstance(metadata, dict) and (
+                CATALOG_OWNER_METADATA_KEY in metadata
+                or CATALOG_OWNER_SIGNATURE_KEY in metadata
+            ):
+                if not _catalog_owner_metadata_is_valid(
+                    metadata,
+                    identity,
+                    require_signature=CATALOG_OWNER_SIGNATURE_KEY in metadata,
+                    model=model,
                 ):
                     return False
     return True
@@ -834,7 +886,11 @@ def _legacy_override_fields(
 ) -> dict[str, Any]:
     """Extract supported edits from a pre-sidecar single-file catalog."""
 
-    if not _official_identity(identity):
+    # The legacy migration boundary is deliberately narrow: the reported
+    # Beta2 regression is Luna's explicit v1 -> v2 planner override.  Do not
+    # infer unrelated historical edits for other Official rows while there is
+    # no managed baseline proving their ownership.
+    if not _official_identity(identity) or identity[2] != "gpt-5.6-luna":
         return {}
     slug = identity[2]
     baseline = PINNED_OFFICIAL_CATALOG_METADATA.get(slug)
@@ -845,7 +901,7 @@ def _legacy_override_fields(
         for key in sorted(CATALOG_OVERRIDE_FIELDS)
         if key in model and model.get(key) != baseline.get(key)
     }
-    return fields
+    return fields if fields == {"multi_agent_version": "v2"} else {}
 
 
 def _delta_override_fields(
@@ -1011,8 +1067,15 @@ def _apply_catalog_overrides(
 def _bounded_catalog_override_diagnostics(
     diagnostics: dict[str, Any],
 ) -> dict[str, Any]:
+    def bounded_counter(value: Any) -> int:
+        return (
+            min(value, MAX_VISIBILITY_DIAGNOSTIC_COUNT)
+            if isinstance(value, int) and not isinstance(value, bool) and value > 0
+            else 0
+        )
+
     result = {
-        key: min(max(int(diagnostics.get(key, 0)), 0), MAX_VISIBILITY_DIAGNOSTIC_COUNT)
+        key: bounded_counter(diagnostics.get(key, 0))
         for key in ("accepted", "rejected", "migrated")
     }
     raw_reasons = diagnostics.get("reasons")
@@ -1795,6 +1858,135 @@ def catalog_identity_digest(identity: CatalogModelIdentity) -> str:
     return hashlib.sha256(value).hexdigest()
 
 
+def catalog_owner_secret_path(overrides_path: Path | None = None) -> Path:
+    """Return the per-runtime secret used to authenticate managed rows.
+
+    Keeping the key beside the override sidecar makes the ownership boundary
+    explicit and lets tests redirect the complete catalog state to a temporary
+    directory by patching ``CATALOG_OVERRIDES_PATH``.
+    """
+
+    path = overrides_path if overrides_path is not None else CATALOG_OVERRIDES_PATH
+    return path.with_name(CATALOG_OWNER_SECRET_FILENAME)
+
+
+def _parse_catalog_owner_secret(raw: str, path: Path) -> bytes:
+    try:
+        secret = bytes.fromhex(raw.strip())
+    except ValueError as error:
+        raise ValueError(f"catalog owner secret is invalid: {path}") from error
+    if len(secret) != 32:
+        raise ValueError(f"catalog owner secret has an invalid length: {path}")
+    return secret
+
+
+def _load_catalog_owner_secret(*, create: bool) -> bytes | None:
+    """Load the runtime HMAC key, creating it only for a real sync.
+
+    Direct catalog-builder unit tests should remain pure and must not create a
+    key in the user's Codex directory.  ``sync_catalog`` calls this with
+    ``create=True`` before it builds a publishable catalog; standalone builder
+    calls therefore retain the pre-signature compatibility shape.
+    """
+
+    global _CATALOG_OWNER_SECRET_CACHE
+    path = catalog_owner_secret_path()
+    cached = _CATALOG_OWNER_SECRET_CACHE
+    if cached is not None and cached[0] == path:
+        return cached[1]
+
+    if create:
+        raw = atomic_read_or_create_text(
+            path,
+            lambda: secrets.token_hex(32) + "\n",
+            encoding="ascii",
+            mode=0o600,
+        )
+    else:
+        try:
+            raw = path.read_text(encoding="ascii")
+        except FileNotFoundError:
+            return None
+        except (OSError, UnicodeError) as error:
+            raise ValueError(f"catalog owner secret is unreadable: {path}") from error
+
+    secret = _parse_catalog_owner_secret(raw, path)
+    _CATALOG_OWNER_SECRET_CACHE = (path, secret)
+    return secret
+
+
+def _catalog_owner_canonical_row(model: dict[str, Any]) -> str:
+    """Canonicalize the immutable portion of a managed catalog row.
+
+    Planner fields are the only supported user override surface.  Ownership
+    signatures therefore exclude those fields and the ownership metadata
+    itself, while retaining identity, visibility, limits, descriptions, and
+    every other generated field.  A copied marker cannot authenticate a row
+    whose non-overridable content was replaced.
+    """
+
+    projected = deepcopy(model)
+    for field in CATALOG_OVERRIDE_FIELDS:
+        projected.pop(field, None)
+    metadata = projected.get("codex_proxy_metadata")
+    if isinstance(metadata, dict):
+        metadata = dict(metadata)
+        for key in (
+            CATALOG_OWNER_METADATA_KEY,
+            CATALOG_OWNER_METADATA_VERSION_KEY,
+            CATALOG_OWNER_IDENTITY_KEY,
+            CATALOG_OWNER_SIGNATURE_KEY,
+        ):
+            metadata.pop(key, None)
+        if metadata:
+            projected["codex_proxy_metadata"] = metadata
+        else:
+            projected.pop("codex_proxy_metadata", None)
+    return json.dumps(projected, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def catalog_owner_signature(model: dict[str, Any], secret: bytes) -> str:
+    value = _catalog_owner_canonical_row(model).encode("utf-8")
+    return hmac.new(secret, value, hashlib.sha256).hexdigest()
+
+
+def _catalog_owner_metadata_is_valid(
+    metadata: Any,
+    identity: CatalogModelIdentity,
+    *,
+    require_signature: bool,
+    model: dict[str, Any] | None = None,
+    baseline_model: dict[str, Any] | None = None,
+) -> bool:
+    if not isinstance(metadata, dict):
+        return False
+    if (
+        metadata.get(CATALOG_OWNER_METADATA_KEY) != CATALOG_OWNER_METADATA_VALUE
+        or metadata.get(CATALOG_OWNER_METADATA_VERSION_KEY) != CATALOG_OWNER_METADATA_VERSION
+        or metadata.get(CATALOG_OWNER_IDENTITY_KEY) != catalog_identity_digest(identity)
+    ):
+        return False
+    signature = metadata.get(CATALOG_OWNER_SIGNATURE_KEY)
+    if signature is None:
+        return not require_signature
+    if not isinstance(signature, str) or not re.fullmatch(r"[0-9a-f]{64}", signature):
+        return False
+    try:
+        secret = _load_catalog_owner_secret(create=False)
+    except ValueError:
+        return False
+    if secret is None:
+        return False
+    signed_model = baseline_model or model
+    if signed_model is None:
+        return False
+    if not hmac.compare_digest(signature, catalog_owner_signature(signed_model, secret)):
+        return False
+    if baseline_model is not None and model is not None:
+        return _catalog_owner_canonical_row(model) == _catalog_owner_canonical_row(baseline_model)
+    return True
+
+
 def stamp_catalog_owner_metadata(model: dict[str, Any]) -> None:
     metadata = dict(model.get("codex_proxy_metadata", {}))
     metadata[CATALOG_OWNER_METADATA_KEY] = CATALOG_OWNER_METADATA_VALUE
@@ -1802,6 +1994,16 @@ def stamp_catalog_owner_metadata(model: dict[str, Any]) -> None:
     identity = catalog_model_identity(model)
     if identity is not None:
         metadata[CATALOG_OWNER_IDENTITY_KEY] = catalog_identity_digest(identity)
+        secret = _load_catalog_owner_secret(create=False)
+        if secret is not None:
+            metadata[CATALOG_OWNER_SIGNATURE_KEY] = catalog_owner_signature(model, secret)
+        else:
+            # Standalone builder calls may not have a runtime sidecar yet.
+            # A real sync creates the key before publishing and stamps a
+            # signed row; old unsigned rows remain migration-compatible.
+            metadata.pop(CATALOG_OWNER_SIGNATURE_KEY, None)
+    else:
+        metadata.pop(CATALOG_OWNER_SIGNATURE_KEY, None)
     model["codex_proxy_metadata"] = metadata
 
 
@@ -2155,7 +2357,12 @@ def build_external_provider_model(
     if isinstance(max_output_tokens, int) and max_output_tokens > 0:
         model["max_output_tokens"] = max_output_tokens
 
-    proxy_metadata = dict(model.get("codex_proxy_metadata", {}))
+    inherited_metadata = model.get("codex_proxy_metadata")
+    proxy_metadata = {
+        key: inherited_metadata[key]
+        for key in ("context_source", "max_output_source")
+        if isinstance(inherited_metadata, dict) and key in inherited_metadata
+    }
     proxy_metadata.update(
         {
             "provider": external_model["provider_alias"],
@@ -2390,6 +2597,12 @@ def sync_catalog(*, max_age_seconds: int = 0) -> dict[str, Any]:
         state = load_cached_state(GENERATED_STATE_PATH)
         state["cache_status"] = "fresh"
         return state
+
+    # Ensure every newly published managed row is authenticated before any
+    # builder stamps its ownership metadata.  Legacy catalogs without a key
+    # are migrated by the normal unsigned compatibility path, then receive a
+    # signed baseline/effective catalog in this sync.
+    _load_catalog_owner_secret(create=True)
 
     policy = load_policy(POLICY_PATH)
     include_official = load_include_official_models()

--- a/src-python/catalog_sync.py
+++ b/src-python/catalog_sync.py
@@ -804,7 +804,14 @@ def _managed_baseline_shape_is_valid(payload: Any) -> bool:
             for field in supported_fields:
                 value = model.get(field)
                 if field == "multi_agent_version":
-                    if not isinstance(value, str) or value not in {"v1", "v2"}:
+                    expected_version = expected.get(field)
+                    if expected_version is None:
+                        # Legacy Official rows deliberately carry a null
+                        # multi-agent version.  Keep accepting that pinned
+                        # shape while still rejecting arbitrary values.
+                        if value is not None:
+                            return False
+                    elif not isinstance(value, str) or value != expected_version:
                         return False
                 else:
                     expected_value = expected.get(field)

--- a/src-python/config_overlay.py
+++ b/src-python/config_overlay.py
@@ -92,9 +92,45 @@ def strip_section(text: str, section_name: str) -> str:
     return "".join(result)
 
 
+def _toml_value_without_comment(raw: str) -> str:
+    quote: str | None = None
+    index = 0
+    while index < len(raw):
+        char = raw[index]
+        if quote == "'":
+            if char == "'":
+                if index + 1 < len(raw) and raw[index + 1] == "'":
+                    index += 2
+                    continue
+                quote = None
+        elif quote == '"':
+            if char == "\\":
+                index += 2
+                continue
+            if char == '"':
+                quote = None
+        elif char in {"'", '"'}:
+            quote = char
+        elif char == "#":
+            return raw[:index].rstrip()
+        index += 1
+    return raw.strip()
+
+
+def _decode_toml_string(raw: str) -> str:
+    if len(raw) >= 2 and raw[0] == raw[-1] and raw[0] in {"'", '"'}:
+        if raw[0] == "'":
+            return raw[1:-1].replace("''", "'")
+        try:
+            return json.loads(raw)
+        except (TypeError, ValueError):
+            return raw[1:-1]
+    return raw
+
+
 def top_level_value(text: str, key: str) -> str | None:
     in_top_level = True
-    key_pattern = re.compile(rf"^\s*{re.escape(key)}\s*=\s*(.+?)\s*(?:#.*)?$")
+    key_pattern = re.compile(rf"^\s*{re.escape(key)}\s*=\s*(.*)$")
     for line in text.splitlines():
         if re.match(r"^\s*\[", line):
             in_top_level = False
@@ -103,10 +139,8 @@ def top_level_value(text: str, key: str) -> str | None:
         match = key_pattern.match(line)
         if not match:
             continue
-        raw = match.group(1).strip()
-        if len(raw) >= 2 and raw[0] == raw[-1] and raw[0] in {"'", '"'}:
-            return raw[1:-1]
-        return raw
+        raw = _toml_value_without_comment(match.group(1))
+        return _decode_toml_string(raw)
     return None
 
 
@@ -992,7 +1026,11 @@ def apply_overlay(
         existing_catalog_value
         if existing_catalog_value is not None
         and not is_managed_catalog_path(existing_catalog_value, catalog_path)
-        else (catalog_config_value(config_path, catalog_path) if catalog_path is not None else None)
+        else (
+            catalog_config_value(config_path, catalog_path)
+            if catalog_path is not None
+            else existing_catalog_value
+        )
     )
     catalog_owned = catalog_value is not None and is_managed_catalog_path(catalog_value, catalog_path)
     cleaned = strip_top_level_keys(cleaned)
@@ -1004,6 +1042,15 @@ def apply_overlay(
     ) + cleaned.lstrip()
     updated = insert_provider_section(updated, build_provider_section(base_url, gateway_key))
     atomic_write_text(config_path, updated, encoding="utf-8")
+
+
+def _preserve_user_catalog_path(current: str, restored: str) -> str:
+    current_value = top_level_value(current, "model_catalog_json")
+    if not current_value or is_managed_catalog_path(current_value) or _overlay_marks_managed_catalog(current):
+        return restored
+    if current_value == top_level_value(restored, "model_catalog_json"):
+        return restored
+    return set_top_level_values(restored, {"model_catalog_json": toml_literal(current_value)})
 
 
 def restore_overlay(
@@ -1025,6 +1072,7 @@ def restore_overlay(
             restored,
             context_guard_state_path,
         )
+        restored = _preserve_user_catalog_path(current, restored)
         restore_from_backup = True
         if is_active_takeover_backup(current, restored, backup_path):
             restored_owner = overlay_owner(restored)

--- a/src-python/config_overlay.py
+++ b/src-python/config_overlay.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import argparse
 from dataclasses import dataclass
+import hashlib
 import json
+import os
 from pathlib import Path
 
 from atomic_io import atomic_write_text
@@ -26,6 +28,11 @@ PROXY_FEATURE_FLAGS = {
 PROXY_PROVIDER_ID = "custom"
 PROXY_PROVIDER_NAME = "Codex Proxy"
 UNIFIED_OFFICIAL_PROVIDER_NAME = "OpenAI"
+CATALOG_OWNER_MARKER = "# catalog_owner = codexhub"
+MANAGED_CATALOG_FILENAMES = {
+    "codexhub-model-catalog.json",
+    "codex-proxy-official-ollama.json",
+}
 STALE_PROXY_PROVIDER_SECTIONS = (
     "model_providers.openai",
     "model_providers.custom",
@@ -101,6 +108,67 @@ def top_level_value(text: str, key: str) -> str | None:
             return raw[1:-1]
         return raw
     return None
+
+
+def _looks_like_managed_catalog_path(value: str | None) -> bool:
+    """Recognize only the standard CodexHub catalog location shape.
+
+    A custom path may use the same basename, so a basename alone is not an
+    ownership proof.  The managed catalogs are always emitted below a
+    ``model-catalogs`` directory (or as the documented relative path).
+    """
+
+    if not isinstance(value, str) or not value.strip():
+        return False
+    normalized = value.strip().replace("\\", "/").rstrip("/")
+    parts = [part for part in normalized.split("/") if part]
+    if not parts or parts[-1] not in MANAGED_CATALOG_FILENAMES:
+        return False
+    # The documented relative handoff is unambiguous.  Absolute paths are
+    # owned only when they resolve below the active CODEX_HOME; an unrelated
+    # custom directory containing the same basename remains user-owned.
+    if len(parts) == 2 and parts[0] == "model-catalogs":
+        return True
+    try:
+        codex_home = Path(os.environ.get("CODEX_HOME") or (Path.home() / ".codex"))
+        candidate = Path(value).expanduser().resolve()
+        return candidate == (codex_home / "model-catalogs" / parts[-1]).resolve()
+    except (OSError, RuntimeError, ValueError):
+        return False
+
+
+def _overlay_marks_managed_catalog(text: str) -> bool:
+    marker_pattern = re.compile(
+        rf"(?ms)^\s*{re.escape(MARKER_BEGIN)}\s*$.*?^\s*{re.escape(MARKER_END)}\s*$"
+    )
+    match = marker_pattern.search(text)
+    if not match:
+        return False
+    block = match.group(0)
+    catalog_value = top_level_value(block, "model_catalog_json")
+    if not catalog_value:
+        return False
+    marker = re.search(
+        rf"(?m)^\s*{re.escape(CATALOG_OWNER_MARKER)}:([0-9a-f]{{64}})\s*$",
+        block,
+    )
+    if marker is None:
+        return False
+    digest = hashlib.sha256(catalog_value.encode("utf-8")).hexdigest()
+    return marker.group(1) == digest
+
+
+def is_managed_catalog_path(value: str | None, managed_path: Path | None = None) -> bool:
+    """Return whether a config path is owned by CodexHub's catalog layer."""
+
+    if managed_path is not None and isinstance(value, str) and value.strip():
+        try:
+            candidate = Path(value).expanduser().resolve()
+            if candidate == managed_path.expanduser().resolve():
+                return True
+        except (OSError, RuntimeError, ValueError):
+            pass
+    return _looks_like_managed_catalog_path(value)
 
 
 def set_top_level_values(text: str, values: dict[str, str | None]) -> str:
@@ -534,6 +602,7 @@ class UnifiedConfigState:
     custom_section: dict[str, str] | None
     exact_unified: bool
     managed_gateway: bool
+    managed_catalog: bool
     stale_catalog: bool
 
 
@@ -560,12 +629,14 @@ def is_managed_gateway_provider(values: dict[str, str] | None) -> bool:
 def unified_config_state(text: str) -> UnifiedConfigState:
     provider_id = top_level_value(text, "model_provider")
     custom_section = section_key_values(text, f"model_providers.{PROXY_PROVIDER_ID}")
+    managed_catalog = is_managed_catalog_path(top_level_value(text, "model_catalog_json")) or _overlay_marks_managed_catalog(text)
     return UnifiedConfigState(
         provider_id=provider_id,
         custom_section=custom_section,
         exact_unified=custom_section == unified_official_provider_values(),
         managed_gateway=is_managed_gateway_provider(custom_section),
-        stale_catalog=top_level_value(text, "model_catalog_json") is not None,
+        managed_catalog=managed_catalog,
+        stale_catalog=managed_catalog,
     )
 
 
@@ -611,7 +682,10 @@ def inject_unified_history_config(text: str) -> tuple[str, str]:
     if state.custom_section is not None and not (state.exact_unified or state.managed_gateway):
         return text, "conflicting_custom_provider"
 
-    updated = strip_top_level_keys(text, {"model_provider", "model_catalog_json", "openai_base_url"})
+    keys_to_strip = {"model_provider", "openai_base_url"}
+    if state.managed_catalog:
+        keys_to_strip.add("model_catalog_json")
+    updated = strip_top_level_keys(text, keys_to_strip)
     if state.custom_section is not None:
         updated = strip_section(updated, f"model_providers.{PROXY_PROVIDER_ID}")
     updated = insert_provider_section(updated, build_unified_official_provider_section())
@@ -629,11 +703,15 @@ def inject_unified_history_config(text: str) -> tuple[str, str]:
 
 
 def strip_unified_history_config(text: str) -> str:
+    managed_catalog = is_managed_catalog_path(top_level_value(text, "model_catalog_json")) or _overlay_marks_managed_catalog(text)
     custom_section = section_key_values(text, f"model_providers.{PROXY_PROVIDER_ID}")
     if custom_section != unified_official_provider_values() and not is_managed_gateway_provider(custom_section):
         return text
     stripped = strip_section(text, f"model_providers.{PROXY_PROVIDER_ID}")
-    stripped = strip_top_level_keys(stripped, {"model_provider", "model_catalog_json", "openai_base_url"})
+    keys_to_strip = {"model_provider", "openai_base_url"}
+    if managed_catalog:
+        keys_to_strip.add("model_catalog_json")
+    stripped = strip_top_level_keys(stripped, keys_to_strip)
     return stripped.lstrip() if text.startswith("model_provider") else stripped
 
 
@@ -784,6 +862,7 @@ def build_overlay(
     catalog_value: str | None,
     owner: str,
     context_budget: tuple[int, int] | None = None,
+    catalog_owned: bool = True,
 ) -> str:
     # Context limits are model-scoped catalog metadata.  The old global
     # projection is intentionally ignored even when callers still pass the
@@ -793,6 +872,9 @@ def build_overlay(
         f"# owner = {owner}",
         f'model_provider = "{PROXY_PROVIDER_ID}"',
     ]
+    if catalog_value is not None and catalog_owned:
+        digest = hashlib.sha256(catalog_value.encode("utf-8")).hexdigest()
+        lines.append(f"{CATALOG_OWNER_MARKER}:{digest}")
     if catalog_value is not None:
         lines.append(f"model_catalog_json = {toml_literal(catalog_value)}")
     return "\n".join([*lines, MARKER_END, ""])
@@ -905,11 +987,20 @@ def apply_overlay(
 
     for section in STALE_PROXY_PROVIDER_SECTIONS:
         cleaned = strip_section(cleaned, section)
+    existing_catalog_value = top_level_value(original, "model_catalog_json")
+    catalog_value = (
+        existing_catalog_value
+        if existing_catalog_value is not None
+        and not is_managed_catalog_path(existing_catalog_value, catalog_path)
+        else (catalog_config_value(config_path, catalog_path) if catalog_path is not None else None)
+    )
+    catalog_owned = catalog_value is not None and is_managed_catalog_path(catalog_value, catalog_path)
     cleaned = strip_top_level_keys(cleaned)
     cleaned = set_feature_flags(cleaned, PROXY_FEATURE_FLAGS)
     updated = build_overlay(
-        catalog_config_value(config_path, catalog_path) if catalog_path is not None else None,
+        catalog_value,
         owner,
+        catalog_owned=catalog_owned,
     ) + cleaned.lstrip()
     updated = insert_provider_section(updated, build_provider_section(base_url, gateway_key))
     atomic_write_text(config_path, updated, encoding="utf-8")

--- a/src-python/config_overlay.py
+++ b/src-python/config_overlay.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import argparse
 from dataclasses import dataclass
-import hashlib
+import hmac
 import json
 import os
 from pathlib import Path
+import secrets
 
-from atomic_io import atomic_write_text
+from atomic_io import atomic_read_or_create_text, atomic_write_text
 from model_limits import (
     CURRENT_DIRECT_OFFICIAL_SOURCE,
     DEGRADED_LAST_KNOWN_OFFICIAL_SOURCE,
@@ -29,6 +30,7 @@ PROXY_PROVIDER_ID = "custom"
 PROXY_PROVIDER_NAME = "Codex Proxy"
 UNIFIED_OFFICIAL_PROVIDER_NAME = "OpenAI"
 CATALOG_OWNER_MARKER = "# catalog_owner = codexhub"
+CATALOG_OWNER_SECRET_FILENAME = ".codexhub-catalog-owner-key"
 MANAGED_CATALOG_FILENAMES = {
     "codexhub-model-catalog.json",
     "codex-proxy-official-ollama.json",
@@ -171,6 +173,41 @@ def _looks_like_managed_catalog_path(value: str | None) -> bool:
         return False
 
 
+def _catalog_owner_secret_path(catalog_value: str) -> Path:
+    return Path(catalog_value).expanduser().resolve().parent / CATALOG_OWNER_SECRET_FILENAME
+
+
+def _load_catalog_owner_secret(catalog_value: str, *, create: bool) -> bytes | None:
+    path = _catalog_owner_secret_path(catalog_value)
+    if create:
+        raw = atomic_read_or_create_text(
+            path,
+            lambda: secrets.token_hex(32) + "\n",
+            encoding="ascii",
+            mode=0o600,
+        )
+    else:
+        try:
+            raw = path.read_text(encoding="ascii").strip()
+        except FileNotFoundError:
+            return None
+        except (OSError, UnicodeError):
+            return None
+    try:
+        secret = bytes.fromhex(raw.strip())
+    except ValueError:
+        return None
+    return secret if len(secret) == 32 else None
+
+
+def _catalog_owner_marker_digest(catalog_value: str, *, create: bool) -> str | None:
+    secret = _load_catalog_owner_secret(catalog_value, create=create)
+    if secret is None:
+        return None
+    normalized = str(Path(catalog_value).expanduser().resolve())
+    return hmac.new(secret, normalized.encode("utf-8"), "sha256").hexdigest()
+
+
 def _overlay_marks_managed_catalog(text: str) -> bool:
     marker_pattern = re.compile(
         rf"(?ms)^\s*{re.escape(MARKER_BEGIN)}\s*$.*?^\s*{re.escape(MARKER_END)}\s*$"
@@ -188,8 +225,8 @@ def _overlay_marks_managed_catalog(text: str) -> bool:
     )
     if marker is None:
         return False
-    digest = hashlib.sha256(catalog_value.encode("utf-8")).hexdigest()
-    return marker.group(1) == digest
+    digest = _catalog_owner_marker_digest(catalog_value, create=False)
+    return digest is not None and hmac.compare_digest(marker.group(1), digest)
 
 
 def is_managed_catalog_path(value: str | None, managed_path: Path | None = None) -> bool:
@@ -907,8 +944,9 @@ def build_overlay(
         f'model_provider = "{PROXY_PROVIDER_ID}"',
     ]
     if catalog_value is not None and catalog_owned:
-        digest = hashlib.sha256(catalog_value.encode("utf-8")).hexdigest()
-        lines.append(f"{CATALOG_OWNER_MARKER}:{digest}")
+        digest = _catalog_owner_marker_digest(catalog_value, create=True)
+        if digest is not None:
+            lines.append(f"{CATALOG_OWNER_MARKER}:{digest}")
     if catalog_value is not None:
         lines.append(f"model_catalog_json = {toml_literal(catalog_value)}")
     return "\n".join([*lines, MARKER_END, ""])

--- a/src-tauri/src/catalog.rs
+++ b/src-tauri/src/catalog.rs
@@ -1,10 +1,23 @@
 use crate::{config, models, runtime_paths, Model};
+use serde::Serialize;
+use serde_json::Value;
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
 const GENERATED_CATALOG_FILE: &str = "codexhub-model-catalog.json";
+const GENERATED_STATE_FILE: &str = "codex-proxy-state.json";
 const CODEX_TARGET_HOME_ENV: &str = "CODEXHUB_CODEX_TARGET_HOME";
+const MAX_DIAGNOSTIC_COUNT: u64 = 100;
+
+#[derive(Debug, Clone, Default, Serialize, PartialEq, Eq)]
+pub struct CatalogOverrideDiagnostics {
+    pub accepted: u64,
+    pub rejected: u64,
+    pub migrated: u64,
+    pub reasons: BTreeMap<String, u64>,
+}
 
 pub fn generate_catalog() -> Result<Vec<Model>, String> {
     models::generate_catalog()
@@ -16,6 +29,65 @@ pub fn sync_catalog() -> Result<String, String> {
     let runner = ProcessCatalogSyncCommandRunner;
 
     sync_catalog_with_paths(&paths, &python, &runner)
+}
+
+/// Read the bounded catalog ownership diagnostics emitted by Python sync.
+///
+/// The state file is an implementation detail and may be missing while a
+/// first-run sync is in progress.  A malformed or unknown payload therefore
+/// degrades to an empty diagnostic set instead of turning a successful catalog
+/// publication into a UI error.  Only the whitelisted counters/reasons cross
+/// the Rust/frontend boundary.
+pub fn catalog_override_diagnostics() -> Result<CatalogOverrideDiagnostics, String> {
+    let paths = CatalogPaths::runtime()?;
+    Ok(read_catalog_override_diagnostics(
+        &paths.catalog_state_path(),
+    ))
+}
+
+fn read_catalog_override_diagnostics(path: &Path) -> CatalogOverrideDiagnostics {
+    let Ok(text) = fs::read_to_string(path) else {
+        return CatalogOverrideDiagnostics::default();
+    };
+    let Ok(payload) = serde_json::from_str::<Value>(&text) else {
+        return CatalogOverrideDiagnostics::default();
+    };
+    let Some(diagnostics) = payload.get("catalog_override_diagnostics") else {
+        return CatalogOverrideDiagnostics::default();
+    };
+    let Some(object) = diagnostics.as_object() else {
+        return CatalogOverrideDiagnostics::default();
+    };
+    let mut result = CatalogOverrideDiagnostics {
+        accepted: bounded_count(object.get("accepted")),
+        rejected: bounded_count(object.get("rejected")),
+        migrated: bounded_count(object.get("migrated")),
+        reasons: BTreeMap::new(),
+    };
+    let Some(reasons) = object.get("reasons").and_then(Value::as_object) else {
+        return result;
+    };
+    for reason in [
+        "invalid_sidecar",
+        "invalid_catalog",
+        "invalid_baseline",
+        "invalid_row_identity",
+        "invalid_override_fields",
+        "missing_managed_model",
+    ] {
+        let count = bounded_count(reasons.get(reason));
+        if count > 0 {
+            result.reasons.insert(reason.to_string(), count);
+        }
+    }
+    result
+}
+
+fn bounded_count(value: Option<&Value>) -> u64 {
+    value
+        .and_then(Value::as_u64)
+        .map(|count| count.min(MAX_DIAGNOSTIC_COUNT))
+        .unwrap_or(0)
 }
 
 fn sync_catalog_with_paths(
@@ -97,6 +169,12 @@ impl CatalogPaths {
             .join("model-catalogs")
             .join(GENERATED_CATALOG_FILE)
     }
+
+    fn catalog_state_path(&self) -> PathBuf {
+        self.codex_dir
+            .join("model-catalogs")
+            .join(GENERATED_STATE_FILE)
+    }
 }
 
 type CatalogCommandOutcome = config::CommandOutcome;
@@ -141,8 +219,9 @@ impl CatalogSyncCommandRunner for ProcessCatalogSyncCommandRunner {
 #[cfg(test)]
 mod tests {
     use super::{
-        sync_catalog_with_paths, CatalogCommandOutcome, CatalogPaths, CatalogSyncCommandRunner,
-        CODEX_TARGET_HOME_ENV, GENERATED_CATALOG_FILE,
+        read_catalog_override_diagnostics, sync_catalog_with_paths, CatalogCommandOutcome,
+        CatalogOverrideDiagnostics, CatalogPaths, CatalogSyncCommandRunner, CODEX_TARGET_HOME_ENV,
+        GENERATED_CATALOG_FILE,
     };
     use std::cell::RefCell;
     use std::collections::BTreeMap;
@@ -218,6 +297,48 @@ mod tests {
         assert!(error.contains("--sync"));
         assert!(error.contains("printed stdout"));
         assert!(error.contains("printed stderr"));
+    }
+
+    #[test]
+    fn catalog_override_diagnostics_are_bounded_and_whitelisted() {
+        let root = temp_root("catalog-diagnostics");
+        let path = root.join("codex-proxy-state.json");
+        fs::write(
+            &path,
+            r#"{
+                "catalog_override_diagnostics": {
+                    "accepted": 999,
+                    "rejected": 2,
+                    "migrated": 1,
+                    "reasons": {
+                        "invalid_row_identity": 101,
+                        "unknown": 77
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let diagnostics = read_catalog_override_diagnostics(&path);
+        assert_eq!(diagnostics.accepted, 100);
+        assert_eq!(diagnostics.rejected, 2);
+        assert_eq!(diagnostics.migrated, 1);
+        assert_eq!(diagnostics.reasons.get("invalid_row_identity"), Some(&100));
+        assert!(!diagnostics.reasons.contains_key("unknown"));
+    }
+
+    #[test]
+    fn malformed_or_missing_catalog_override_diagnostics_are_empty() {
+        let root = temp_root("catalog-diagnostics-malformed");
+        let missing = read_catalog_override_diagnostics(&root.join("missing.json"));
+        assert_eq!(missing, CatalogOverrideDiagnostics::default());
+
+        let malformed_path = root.join("malformed.json");
+        fs::write(&malformed_path, "not json").unwrap();
+        assert_eq!(
+            read_catalog_override_diagnostics(&malformed_path),
+            CatalogOverrideDiagnostics::default()
+        );
     }
 
     #[derive(Debug, Clone)]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -617,6 +617,11 @@ async fn generate_catalog() -> Result<Vec<Model>, String> {
 }
 
 #[tauri::command]
+fn get_catalog_override_diagnostics() -> Result<catalog::CatalogOverrideDiagnostics, String> {
+    catalog::catalog_override_diagnostics()
+}
+
+#[tauri::command]
 fn list_models() -> Result<Vec<Model>, String> {
     models::list_models()
 }
@@ -1124,6 +1129,7 @@ fn run_gui() {
             sync_gateway_clients,
             subagent_matrix_status,
             generate_catalog,
+            get_catalog_override_diagnostics,
             list_models,
             refresh_model_metadata,
             list_model_metadata,

--- a/src-tauri/src/web_bridge.rs
+++ b/src-tauri/src/web_bridge.rs
@@ -480,6 +480,7 @@ fn dispatch(request: InvokeRequest, app: Option<AppHandle>) -> Result<Value, Str
         }
         "subagent_matrix_status" => to_value(gateway::subagent_matrix_status()),
         "generate_catalog" => to_value(catalog::generate_catalog()),
+        "get_catalog_override_diagnostics" => to_value(catalog::catalog_override_diagnostics()),
         "list_models" => to_value(models::list_models()),
         "refresh_model_metadata" => to_value(models::refresh_model_metadata()),
         "list_model_metadata" => to_value(models::list_model_metadata()),

--- a/tests/test_catalog_sync.py
+++ b/tests/test_catalog_sync.py
@@ -1221,6 +1221,49 @@ class CatalogSyncTests(unittest.TestCase):
             )
             self.assertEqual(diagnostics["accepted"], 1)
 
+    def test_generated_legacy_baseline_rejects_markerless_forged_row(self):
+        official = [{"slug": "gpt-5.6-luna", "display_name": "GPT-5.6-Luna", "visibility": "list"}]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            overrides_path = root / "overrides.json"
+            current_path = root / "catalog.json"
+            (root / catalog_sync.CATALOG_OWNER_SECRET_FILENAME).write_text(
+                "66" * 32,
+                encoding="ascii",
+            )
+            with (
+                patch.object(catalog_sync, "CATALOG_OVERRIDES_PATH", overrides_path),
+                patch.object(catalog_sync, "_CATALOG_OWNER_SECRET_CACHE", None),
+            ):
+                generated = catalog_sync.build_codex_catalog(official, [], self.policy, "0.146.0")
+                current = json.loads(json.dumps(generated))
+                row = current["models"][0]
+                row["multi_agent_version"] = "v2"
+                row["description"] = "forged Official row"
+                metadata = row["codex_proxy_metadata"]
+                for key in (
+                    catalog_sync.CATALOG_OWNER_METADATA_KEY,
+                    catalog_sync.CATALOG_OWNER_METADATA_VERSION_KEY,
+                    catalog_sync.CATALOG_OWNER_IDENTITY_KEY,
+                    catalog_sync.CATALOG_OWNER_SIGNATURE_KEY,
+                ):
+                    metadata.pop(key, None)
+                current_path.write_text(json.dumps(current), encoding="utf-8")
+                with (
+                    patch.object(catalog_sync, "GENERATED_CATALOG_PATH", current_path),
+                    patch.object(
+                        catalog_sync,
+                        "MANAGED_CATALOG_BASELINE_PATH",
+                        root / "missing-baseline.json",
+                    ),
+                ):
+                    collected, diagnostics = catalog_sync._collect_catalog_overrides(
+                        legacy_baseline=generated,
+                    )
+
+            self.assertEqual(collected, {})
+            self.assertEqual(diagnostics["reasons"]["invalid_row_identity"], 1)
+
     def test_marker_only_catalog_without_baseline_rejects_forged_row_when_key_exists(self):
         official = [{"slug": "gpt-5.6-luna", "display_name": "GPT-5.6-Luna", "visibility": "list"}]
         identity = ("openai", "official", "gpt-5.6-luna")

--- a/tests/test_catalog_sync.py
+++ b/tests/test_catalog_sync.py
@@ -770,8 +770,28 @@ class CatalogSyncTests(unittest.TestCase):
                     return catalog_sync.sync_catalog()
 
             run_sync()
+            # Remove the new sidecars to model a pre-Beta2 single-file
+            # installation.  The next sync must migrate only the supported
+            # same-model planner delta from the edited effective catalog.
+            baseline.unlink()
+            overrides.unlink()
             initial = json.loads(generated.read_text(encoding="utf-8"))
+            # Strip the Beta2 ownership marker so this is a true legacy
+            # single-file migration rather than a modern catalog round-trip.
+            initial_metadata = initial["models"][0]["codex_proxy_metadata"]
+            initial_metadata.pop(catalog_sync.CATALOG_OWNER_METADATA_KEY, None)
+            initial_metadata.pop(catalog_sync.CATALOG_OWNER_METADATA_VERSION_KEY, None)
+            initial_metadata.pop(catalog_sync.CATALOG_OWNER_IDENTITY_KEY, None)
             initial["models"][0]["multi_agent_version"] = "v2"
+            # Pre-Beta2 Ollama rows may not carry proxy identity metadata;
+            # they must not prevent the exact Official legacy migration.
+            initial["models"].append(
+                {
+                    "slug": "glm-5.2",
+                    "visibility": "list",
+                    "use_responses_lite": False,
+                }
+            )
             generated.write_text(json.dumps(initial), encoding="utf-8")
 
             state = run_sync()
@@ -792,6 +812,22 @@ class CatalogSyncTests(unittest.TestCase):
             self.assertEqual(repeated["models"][0]["multi_agent_version"], "v2")
             self.assertEqual(len(repeated_overrides["overrides"]), 1)
 
+            # A hidden source row is not an ownership authority.  The next
+            # sync must fail closed instead of copying its v2 value onto the
+            # newly generated visible row.
+            hidden = json.loads(generated.read_text(encoding="utf-8"))
+            hidden["models"][0]["visibility"] = "hide"
+            generated.write_text(json.dumps(hidden), encoding="utf-8")
+            state = run_sync()
+            effective = json.loads(generated.read_text(encoding="utf-8"))
+            override_state = json.loads(overrides.read_text(encoding="utf-8"))
+            self.assertEqual(effective["models"][0]["multi_agent_version"], "v1")
+            self.assertEqual(override_state["overrides"], [])
+            self.assertEqual(
+                state["catalog_override_diagnostics"]["reasons"].get("invalid_row_identity"),
+                1,
+            )
+
     def test_catalog_override_does_not_copy_official_planner_metadata_to_external_model(self):
         external = {
             "alias": "volc/gpt-5.6-luna",
@@ -799,10 +835,39 @@ class CatalogSyncTests(unittest.TestCase):
             "upstream_name": "volcengine",
             "upstream_model": "gpt-5.6-luna",
         }
-        model = catalog_sync.build_external_provider_model(external, self.policy, None)
+        model = catalog_sync.build_external_provider_model(
+            external,
+            self.policy,
+            {
+                "prefer_websockets": True,
+                "tool_mode": "code_mode_only",
+                "multi_agent_version": "v2",
+                "use_responses_lite": True,
+            },
+        )
         self.assertNotIn("multi_agent_version", model)
         self.assertNotIn("tool_mode", model)
         self.assertNotIn("prefer_websockets", model)
+        self.assertIs(model["use_responses_lite"], False)
+
+        ollama = catalog_sync.build_ollama_model(
+            "glm-5.2",
+            self.policy,
+            {},
+            {
+                "prefer_websockets": True,
+                "tool_mode": "code_mode_only",
+                "multi_agent_version": "v2",
+                "use_responses_lite": True,
+            },
+        )
+        self.assertNotIn("multi_agent_version", ollama)
+        self.assertNotIn("tool_mode", ollama)
+        self.assertNotIn("prefer_websockets", ollama)
+        self.assertIs(ollama["use_responses_lite"], False)
+        self.assertEqual(ollama["codex_proxy_metadata"]["provider"], "ollama-cloud")
+        self.assertEqual(ollama["codex_proxy_metadata"]["upstream_name"], "ollama_cloud")
+        self.assertEqual(ollama["codex_proxy_metadata"]["upstream_model"], "glm-5.2")
 
     def test_catalog_override_rejects_invalid_unknown_and_cross_provider_entries(self):
         valid_identity = ("openai", "official", "gpt-5.6-luna")
@@ -832,13 +897,118 @@ class CatalogSyncTests(unittest.TestCase):
                 json.dumps({"schema_version": 1, "overrides": list(cases.values())}),
                 encoding="utf-8",
             )
-            self.assertEqual(catalog_sync._load_catalog_override_state(path), {})
+            diagnostics = {}
+            self.assertEqual(catalog_sync._load_catalog_override_state(path, diagnostics), {})
+            self.assertEqual(diagnostics["reasons"]["invalid_override_fields"], 1)
             self.assertTrue(
                 catalog_sync._planner_override_is_valid(
                     valid_identity,
                     {"multi_agent_version": "v2"},
                 )
             )
+            path.write_text("[]", encoding="utf-8")
+            self.assertEqual(catalog_sync._load_catalog_override_state(path), {})
+
+            valid_entry = {
+                "provider": valid_identity[0],
+                "upstream_name": valid_identity[1],
+                "upstream_model": valid_identity[2],
+                "fields": {"multi_agent_version": "v2"},
+            }
+            diagnostics = {}
+            path.write_text(
+                json.dumps({"schema_version": True, "overrides": [valid_entry]}),
+                encoding="utf-8",
+            )
+            self.assertEqual(catalog_sync._load_catalog_override_state(path, diagnostics), {})
+            self.assertEqual(diagnostics["reasons"]["invalid_sidecar"], 1)
+
+            diagnostics = {}
+            path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "overrides": [
+                            valid_entry,
+                            {**valid_entry, "unexpected": "field"},
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            self.assertEqual(catalog_sync._load_catalog_override_state(path, diagnostics), {})
+            self.assertEqual(diagnostics["reasons"]["invalid_sidecar"], 1)
+
+            diagnostics = {}
+            path.write_text(
+                json.dumps({"schema_version": 1, "overrides": [valid_entry, valid_entry]}),
+                encoding="utf-8",
+            )
+            self.assertEqual(catalog_sync._load_catalog_override_state(path, diagnostics), {})
+            self.assertEqual(diagnostics["reasons"]["invalid_sidecar"], 1)
+
+    def test_catalog_override_rejects_malformed_managed_baseline_without_legacy_migration(self):
+        identity = ("openai", "official", "gpt-5.6-luna")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            baseline = Path(tmpdir) / "baseline.json"
+            generated = Path(tmpdir) / "catalog.json"
+            baseline.write_text(json.dumps({"models": []}), encoding="utf-8")
+            generated.write_text(
+                json.dumps(
+                    {
+                        "models": [
+                            {
+                                "slug": "gpt-5.6-luna",
+                                "visibility": "list",
+                                "multi_agent_version": "v2",
+                                "codex_proxy_metadata": {
+                                    "provider": identity[0],
+                                    "upstream_name": identity[1],
+                                    "upstream_model": identity[2],
+                                },
+                            }
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+            with (
+                patch.object(catalog_sync, "MANAGED_CATALOG_BASELINE_PATH", baseline),
+                patch.object(catalog_sync, "GENERATED_CATALOG_PATH", generated),
+                patch.object(catalog_sync, "CATALOG_OVERRIDES_PATH", Path(tmpdir) / "overrides.json"),
+            ):
+                overrides, diagnostics = catalog_sync._collect_catalog_overrides()
+            self.assertEqual(overrides, {})
+            self.assertEqual(diagnostics["reasons"]["invalid_baseline"], 1)
+
+            baseline.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "managed_baseline": True,
+                        "models": [
+                            {
+                                "slug": "gpt-5.6-luna",
+                                "visibility": "list",
+                                "codex_proxy_metadata": {
+                                    "provider": identity[0],
+                                    "upstream_name": identity[1],
+                                    "upstream_model": identity[2],
+                                },
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            with (
+                patch.object(catalog_sync, "MANAGED_CATALOG_BASELINE_PATH", baseline),
+                patch.object(catalog_sync, "GENERATED_CATALOG_PATH", generated),
+                patch.object(catalog_sync, "CATALOG_OVERRIDES_PATH", Path(tmpdir) / "overrides.json"),
+            ):
+                overrides, diagnostics = catalog_sync._collect_catalog_overrides()
+            self.assertEqual(overrides, {})
+            self.assertEqual(diagnostics["reasons"]["invalid_baseline"], 1)
 
     def test_catalog_override_matches_exact_identity_not_slug(self):
         official_identity = ("openai", "official", "gpt-5.6-luna")
@@ -858,6 +1028,226 @@ class CatalogSyncTests(unittest.TestCase):
         )
         self.assertNotIn("multi_agent_version", external_model)
 
+    def test_catalog_override_rejects_legacy_official_identity_spoof(self):
+        identity = ("openai", "official", "gpt-5.6-luna")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            current = root / "catalog.json"
+            current.write_text(
+                json.dumps(
+                    {
+                        "models": [
+                            {
+                                "slug": identity[2],
+                                "visibility": "list",
+                                "multi_agent_version": "v2",
+                                "codex_proxy_metadata": {
+                                    "provider": identity[0],
+                                    "upstream_name": identity[1],
+                                    "upstream_model": identity[2],
+                                },
+                            }
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+            with (
+                patch.object(catalog_sync, "MANAGED_CATALOG_BASELINE_PATH", root / "missing-baseline.json"),
+                patch.object(catalog_sync, "GENERATED_CATALOG_PATH", current),
+                patch.object(catalog_sync, "CATALOG_OVERRIDES_PATH", root / "overrides.json"),
+            ):
+                overrides, diagnostics = catalog_sync._collect_catalog_overrides()
+
+            self.assertEqual(overrides, {})
+            self.assertEqual(diagnostics["reasons"]["invalid_row_identity"], 1)
+
+    def test_catalog_override_validates_managed_identity_digest(self):
+        official = [{"slug": "gpt-5.6-luna", "display_name": "GPT-5.6-Luna", "visibility": "list"}]
+        managed = catalog_sync.build_codex_catalog(official, [], self.policy, "0.146.0")
+        current = json.loads(json.dumps(managed))
+        current["models"][0]["multi_agent_version"] = "v2"
+        current["models"][0]["codex_proxy_metadata"][catalog_sync.CATALOG_OWNER_IDENTITY_KEY] = "0" * 64
+        baseline = json.loads(json.dumps(managed))
+        baseline.update({"schema_version": 1, "managed_baseline": True})
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            current_path = root / "catalog.json"
+            baseline_path = root / "baseline.json"
+            current_path.write_text(json.dumps(current), encoding="utf-8")
+            baseline_path.write_text(json.dumps(baseline), encoding="utf-8")
+            with (
+                patch.object(catalog_sync, "GENERATED_CATALOG_PATH", current_path),
+                patch.object(catalog_sync, "MANAGED_CATALOG_BASELINE_PATH", baseline_path),
+                patch.object(catalog_sync, "CATALOG_OVERRIDES_PATH", root / "overrides.json"),
+            ):
+                overrides, diagnostics = catalog_sync._collect_catalog_overrides()
+
+            self.assertEqual(overrides, {})
+            self.assertEqual(diagnostics["reasons"]["invalid_row_identity"], 1)
+
+        target = json.loads(json.dumps(managed["models"][0]))
+        target["codex_proxy_metadata"][catalog_sync.CATALOG_OWNER_IDENTITY_KEY] = "0" * 64
+        catalog = {"models": [target]}
+        diagnostics = {"accepted": 0, "rejected": 0, "reasons": {}}
+        catalog_sync._apply_catalog_overrides(
+            catalog,
+            {("openai", "official", "gpt-5.6-luna"): {"multi_agent_version": "v2"}},
+            diagnostics,
+        )
+        self.assertNotEqual(target.get("multi_agent_version"), "v2")
+        self.assertEqual(diagnostics["reasons"]["invalid_row_identity"], 1)
+
+    def test_catalog_override_purges_sidecar_when_current_identity_is_missing(self):
+        identity = ("openai", "official", "gpt-5.6-luna")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            baseline = root / "baseline.json"
+            current = root / "catalog.json"
+            overrides = root / "overrides.json"
+            baseline.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "managed_baseline": True,
+                        "models": [
+                            {
+                                "slug": "gpt-5.6-luna",
+                                "visibility": "list",
+                                "prefer_websockets": True,
+                                "tool_mode": "code_mode_only",
+                                "multi_agent_version": "v1",
+                                "use_responses_lite": True,
+                                "codex_proxy_metadata": {
+                                    "provider": identity[0],
+                                    "upstream_name": identity[1],
+                                    "upstream_model": identity[2],
+                                },
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            overrides.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "overrides": [
+                            {
+                                "provider": identity[0],
+                                "upstream_name": identity[1],
+                                "upstream_model": identity[2],
+                                "fields": {"multi_agent_version": "v2"},
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            # Same display slug, but a different provider identity.  The old
+            # Official sidecar entry must not cross over to this row.
+            current.write_text(
+                json.dumps(
+                    {
+                        "models": [
+                            {
+                                "slug": "volc/gpt-5.6-luna",
+                                "visibility": "list",
+                                "codex_proxy_metadata": {
+                                    "provider": "volc",
+                                    "upstream_name": "volcengine",
+                                    "upstream_model": "gpt-5.6-luna",
+                                },
+                            }
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with (
+                patch.object(catalog_sync, "MANAGED_CATALOG_BASELINE_PATH", baseline),
+                patch.object(catalog_sync, "GENERATED_CATALOG_PATH", current),
+                patch.object(catalog_sync, "CATALOG_OVERRIDES_PATH", overrides),
+            ):
+                collected, diagnostics = catalog_sync._collect_catalog_overrides()
+
+            self.assertEqual(collected, {})
+            self.assertEqual(diagnostics["reasons"]["missing_managed_model"], 1)
+
+    def test_catalog_override_reports_malformed_current_catalog_without_using_it_as_edit(self):
+        identity = ("openai", "official", "gpt-5.6-luna")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            baseline = root / "baseline.json"
+            current = root / "catalog.json"
+            overrides = root / "overrides.json"
+            baseline.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "managed_baseline": True,
+                        "models": [
+                            {
+                                "slug": "gpt-5.6-luna",
+                                "visibility": "list",
+                                "prefer_websockets": True,
+                                "tool_mode": "code_mode_only",
+                                "multi_agent_version": "v1",
+                                "use_responses_lite": True,
+                                "codex_proxy_metadata": {
+                                    "provider": identity[0],
+                                    "upstream_name": identity[1],
+                                    "upstream_model": identity[2],
+                                },
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            overrides.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "overrides": [
+                            {
+                                "provider": identity[0],
+                                "upstream_name": identity[1],
+                                "upstream_model": identity[2],
+                                "fields": {"multi_agent_version": "v2"},
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            current.write_text("{not json", encoding="utf-8")
+
+            with (
+                patch.object(catalog_sync, "MANAGED_CATALOG_BASELINE_PATH", baseline),
+                patch.object(catalog_sync, "GENERATED_CATALOG_PATH", current),
+                patch.object(catalog_sync, "CATALOG_OVERRIDES_PATH", overrides),
+            ):
+                collected, diagnostics = catalog_sync._collect_catalog_overrides()
+
+            self.assertEqual(collected[identity], {"multi_agent_version": "v2"})
+            self.assertFalse(diagnostics["current_catalog_valid"])
+            self.assertEqual(diagnostics["reasons"]["invalid_catalog"], 1)
+
+            current.write_text(json.dumps({"models": [{}]}), encoding="utf-8")
+            with (
+                patch.object(catalog_sync, "MANAGED_CATALOG_BASELINE_PATH", baseline),
+                patch.object(catalog_sync, "GENERATED_CATALOG_PATH", current),
+                patch.object(catalog_sync, "CATALOG_OVERRIDES_PATH", overrides),
+            ):
+                collected, diagnostics = catalog_sync._collect_catalog_overrides()
+            self.assertEqual(collected[identity], {"multi_agent_version": "v2"})
+            self.assertFalse(diagnostics["current_catalog_valid"])
+            self.assertEqual(diagnostics["reasons"]["invalid_catalog"], 1)
+
     def test_catalog_override_is_removed_when_managed_baseline_catches_up(self):
         identity = ("openai", "official", "gpt-5.6-luna")
         current = {"multi_agent_version": "v2"}
@@ -872,6 +1262,67 @@ class CatalogSyncTests(unittest.TestCase):
             catalog_sync._delta_override_fields(identity, current, new_baseline),
             {},
         )
+
+    def test_catalog_override_survives_managed_baseline_refresh_publication(self):
+        official = [
+            {"slug": "gpt-5.6-luna", "display_name": "GPT-5.6-Luna", "visibility": "list"}
+        ]
+        identity = ("openai", "official", "gpt-5.6-luna")
+        managed_v1 = catalog_sync.build_codex_catalog(official, [], self.policy, "0.146.0")
+        current = json.loads(json.dumps(managed_v1))
+        current["models"][0]["multi_agent_version"] = "v2"
+        baseline_v1 = json.loads(json.dumps(managed_v1))
+        baseline_v1.update({"schema_version": 1, "managed_baseline": True})
+        sidecar_v2 = catalog_sync._write_catalog_override_state(
+            {identity: {"multi_agent_version": "v2"}}
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            current_path = root / "catalog.json"
+            baseline_path = root / "baseline.json"
+            overrides_path = root / "overrides.json"
+            current_path.write_text(json.dumps(current), encoding="utf-8")
+            baseline_path.write_text(json.dumps(baseline_v1), encoding="utf-8")
+            overrides_path.write_text(json.dumps(sidecar_v2), encoding="utf-8")
+            with (
+                patch.object(catalog_sync, "GENERATED_CATALOG_PATH", current_path),
+                patch.object(catalog_sync, "MANAGED_CATALOG_BASELINE_PATH", baseline_path),
+                patch.object(catalog_sync, "CATALOG_OVERRIDES_PATH", overrides_path),
+            ):
+                collected, diagnostics = catalog_sync._collect_catalog_overrides()
+                self.assertEqual(collected[identity], {"multi_agent_version": "v2"})
+
+                pinned_v2 = json.loads(json.dumps(catalog_sync.PINNED_OFFICIAL_CATALOG_METADATA))
+                pinned_v2["gpt-5.6-luna"]["multi_agent_version"] = "v2"
+                with patch.object(catalog_sync, "PINNED_OFFICIAL_CATALOG_METADATA", pinned_v2):
+                    managed_v2 = catalog_sync.build_codex_catalog(
+                        official,
+                        [],
+                        self.policy,
+                        "0.146.0",
+                    )
+                    effective_v2 = catalog_sync._apply_catalog_overrides(
+                        json.loads(json.dumps(managed_v2)),
+                        collected,
+                        diagnostics,
+                    )
+
+                self.assertEqual(effective_v2["models"][0]["multi_agent_version"], "v2")
+                current_path.write_text(json.dumps(effective_v2), encoding="utf-8")
+                baseline_v2 = dict(managed_v2)
+                baseline_v2.update({"schema_version": 1, "managed_baseline": True})
+                baseline_path.write_text(json.dumps(baseline_v2), encoding="utf-8")
+                overrides_path.write_text(json.dumps(catalog_sync._write_catalog_override_state(collected)), encoding="utf-8")
+
+                collected_after, diagnostics_after = catalog_sync._collect_catalog_overrides()
+                self.assertEqual(collected_after, {})
+                effective_after = catalog_sync._apply_catalog_overrides(
+                    json.loads(json.dumps(managed_v2)),
+                    collected_after,
+                    diagnostics_after,
+                )
+                self.assertEqual(effective_after["models"][0]["multi_agent_version"], "v2")
 
     def test_pinned_official_catalog_metadata_rejects_an_incomplete_model_set(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_catalog_sync.py
+++ b/tests/test_catalog_sync.py
@@ -1180,6 +1180,47 @@ class CatalogSyncTests(unittest.TestCase):
             )
             self.assertEqual(diagnostics["accepted"], 1)
 
+    def test_marker_only_legacy_catalog_migrates_against_fresh_generated_baseline(self):
+        official = [{"slug": "gpt-5.6-luna", "display_name": "GPT-5.6-Luna", "visibility": "list"}]
+        identity = ("openai", "official", "gpt-5.6-luna")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            overrides_path = root / "overrides.json"
+            current_path = root / "catalog.json"
+            (root / catalog_sync.CATALOG_OWNER_SECRET_FILENAME).write_text(
+                "55" * 32,
+                encoding="ascii",
+            )
+            with (
+                patch.object(catalog_sync, "CATALOG_OVERRIDES_PATH", overrides_path),
+                patch.object(catalog_sync, "_CATALOG_OWNER_SECRET_CACHE", None),
+            ):
+                generated = catalog_sync.build_codex_catalog(official, [], self.policy, "0.146.0")
+                current = json.loads(json.dumps(generated))
+                current["models"][0]["multi_agent_version"] = "v2"
+                current["models"][0]["codex_proxy_metadata"].pop(
+                    catalog_sync.CATALOG_OWNER_SIGNATURE_KEY,
+                    None,
+                )
+                current_path.write_text(json.dumps(current), encoding="utf-8")
+                with (
+                    patch.object(catalog_sync, "GENERATED_CATALOG_PATH", current_path),
+                    patch.object(
+                        catalog_sync,
+                        "MANAGED_CATALOG_BASELINE_PATH",
+                        root / "missing-baseline.json",
+                    ),
+                ):
+                    collected, diagnostics = catalog_sync._collect_catalog_overrides(
+                        legacy_baseline=generated,
+                    )
+
+            self.assertEqual(
+                collected,
+                {identity: {"multi_agent_version": "v2"}},
+            )
+            self.assertEqual(diagnostics["accepted"], 1)
+
     def test_marker_only_catalog_without_baseline_rejects_forged_row_when_key_exists(self):
         official = [{"slug": "gpt-5.6-luna", "display_name": "GPT-5.6-Luna", "visibility": "list"}]
         identity = ("openai", "official", "gpt-5.6-luna")

--- a/tests/test_catalog_sync.py
+++ b/tests/test_catalog_sync.py
@@ -1377,6 +1377,25 @@ class CatalogSyncTests(unittest.TestCase):
             with self.subTest(slug=slug):
                 self.assertIsNone(by_slug[slug]["multi_agent_version"])
 
+    def test_managed_baseline_accepts_unpinned_official_rows_without_authorizing_overrides(self):
+        official = [
+            {"slug": "gpt-5.6-luna", "display_name": "GPT-5.6-Luna", "visibility": "list"},
+            {"slug": "gpt-sparse", "display_name": "GPT-Sparse", "visibility": "list"},
+        ]
+        baseline = catalog_sync.build_codex_catalog(official, [], self.policy, "0.146.0")
+        baseline.update({"schema_version": 1, "managed_baseline": True})
+
+        self.assertTrue(
+            catalog_sync._catalog_payload_shape_is_valid(baseline, require_identity=True)
+        )
+        self.assertTrue(catalog_sync._managed_baseline_shape_is_valid(baseline))
+        self.assertFalse(
+            catalog_sync._planner_override_is_valid(
+                ("openai", "official", "gpt-sparse"),
+                {"multi_agent_version": "v2"},
+            )
+        )
+
     def test_managed_baseline_rejects_numeric_boolean_planner_values(self):
         official = [{"slug": "gpt-5.6-luna", "display_name": "GPT-5.6-Luna", "visibility": "list"}]
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_catalog_sync.py
+++ b/tests/test_catalog_sync.py
@@ -782,6 +782,7 @@ class CatalogSyncTests(unittest.TestCase):
             initial_metadata.pop(catalog_sync.CATALOG_OWNER_METADATA_KEY, None)
             initial_metadata.pop(catalog_sync.CATALOG_OWNER_METADATA_VERSION_KEY, None)
             initial_metadata.pop(catalog_sync.CATALOG_OWNER_IDENTITY_KEY, None)
+            initial_metadata.pop(catalog_sync.CATALOG_OWNER_SIGNATURE_KEY, None)
             initial["models"][0]["multi_agent_version"] = "v2"
             # Pre-Beta2 Ollama rows may not carry proxy identity metadata;
             # they must not prevent the exact Official legacy migration.
@@ -843,12 +844,18 @@ class CatalogSyncTests(unittest.TestCase):
                 "tool_mode": "code_mode_only",
                 "multi_agent_version": "v2",
                 "use_responses_lite": True,
+                "codex_proxy_metadata": {
+                    "official_context_budget": {"context_window": 272000},
+                    "provider": "openai",
+                },
             },
         )
         self.assertNotIn("multi_agent_version", model)
         self.assertNotIn("tool_mode", model)
         self.assertNotIn("prefer_websockets", model)
         self.assertIs(model["use_responses_lite"], False)
+        self.assertNotIn("official_context_budget", model["codex_proxy_metadata"])
+        self.assertEqual(model["codex_proxy_metadata"]["provider"], "volc")
 
         ollama = catalog_sync.build_ollama_model(
             "glm-5.2",
@@ -1098,6 +1105,161 @@ class CatalogSyncTests(unittest.TestCase):
         )
         self.assertNotEqual(target.get("multi_agent_version"), "v2")
         self.assertEqual(diagnostics["reasons"]["invalid_row_identity"], 1)
+
+    def test_catalog_override_rejects_recomputed_public_digest_without_owner_signature(self):
+        official = [{"slug": "gpt-5.6-luna", "display_name": "GPT-5.6-Luna", "visibility": "list"}]
+        identity = ("openai", "official", "gpt-5.6-luna")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            overrides_path = root / "overrides.json"
+            key_path = root / catalog_sync.CATALOG_OWNER_SECRET_FILENAME
+            key_path.write_text("11" * 32, encoding="ascii")
+            with patch.object(catalog_sync, "CATALOG_OVERRIDES_PATH", overrides_path), patch.object(
+                catalog_sync, "_CATALOG_OWNER_SECRET_CACHE", None
+            ):
+                managed = catalog_sync.build_codex_catalog(official, [], self.policy, "0.146.0")
+                current = json.loads(json.dumps(managed))
+                current["models"][0]["multi_agent_version"] = "v2"
+                current["models"][0]["description"] = "forged Official row"
+                metadata = current["models"][0]["codex_proxy_metadata"]
+                metadata[catalog_sync.CATALOG_OWNER_IDENTITY_KEY] = catalog_sync.catalog_identity_digest(identity)
+                baseline = json.loads(json.dumps(managed))
+                baseline.update({"schema_version": 1, "managed_baseline": True})
+                current_path = root / "catalog.json"
+                baseline_path = root / "baseline.json"
+                current_path.write_text(json.dumps(current), encoding="utf-8")
+                baseline_path.write_text(json.dumps(baseline), encoding="utf-8")
+                with (
+                    patch.object(catalog_sync, "GENERATED_CATALOG_PATH", current_path),
+                    patch.object(catalog_sync, "MANAGED_CATALOG_BASELINE_PATH", baseline_path),
+                ):
+                    collected, diagnostics = catalog_sync._collect_catalog_overrides()
+
+            self.assertEqual(collected, {})
+            self.assertEqual(diagnostics["reasons"]["invalid_row_identity"], 1)
+
+    def test_marker_only_beta2_baseline_migrates_existing_luna_override(self):
+        official = [{"slug": "gpt-5.6-luna", "display_name": "GPT-5.6-Luna", "visibility": "list"}]
+        identity = ("openai", "official", "gpt-5.6-luna")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            overrides_path = root / "overrides.json"
+            (root / catalog_sync.CATALOG_OWNER_SECRET_FILENAME).write_text(
+                "22" * 32,
+                encoding="ascii",
+            )
+            with (
+                patch.object(catalog_sync, "CATALOG_OVERRIDES_PATH", overrides_path),
+                patch.object(catalog_sync, "_CATALOG_OWNER_SECRET_CACHE", None),
+            ):
+                managed = catalog_sync.build_codex_catalog(official, [], self.policy, "0.146.0")
+                # This is the representation emitted by the pre-HMAC Beta2
+                # build: it has CodexHub ownership metadata but no signature.
+                for model in managed["models"]:
+                    model["codex_proxy_metadata"].pop(
+                        catalog_sync.CATALOG_OWNER_SIGNATURE_KEY,
+                        None,
+                    )
+                baseline = json.loads(json.dumps(managed))
+                baseline.update({"schema_version": 1, "managed_baseline": True})
+                current = json.loads(json.dumps(managed))
+                current["models"][0]["multi_agent_version"] = "v2"
+                baseline_path = root / "baseline.json"
+                current_path = root / "catalog.json"
+                baseline_path.write_text(json.dumps(baseline), encoding="utf-8")
+                current_path.write_text(json.dumps(current), encoding="utf-8")
+                with (
+                    patch.object(catalog_sync, "GENERATED_CATALOG_PATH", current_path),
+                    patch.object(catalog_sync, "MANAGED_CATALOG_BASELINE_PATH", baseline_path),
+                ):
+                    collected, diagnostics = catalog_sync._collect_catalog_overrides()
+
+            self.assertEqual(
+                collected,
+                {identity: {"multi_agent_version": "v2"}},
+            )
+            self.assertEqual(diagnostics["accepted"], 1)
+
+    def test_catalog_override_rejects_unhashable_multi_agent_values(self):
+        identity = ("openai", "official", "gpt-5.6-luna")
+        for malformed in ([], {}):
+            with self.subTest(malformed=malformed), tempfile.TemporaryDirectory() as tmpdir:
+                root = Path(tmpdir)
+                path = root / "overrides.json"
+                path.write_text(
+                    json.dumps(
+                        {
+                            "schema_version": 1,
+                            "overrides": [
+                                {
+                                    "provider": identity[0],
+                                    "upstream_name": identity[1],
+                                    "upstream_model": identity[2],
+                                    "fields": {"multi_agent_version": malformed},
+                                }
+                            ],
+                        }
+                    ),
+                    encoding="utf-8",
+                )
+                diagnostics = {}
+                self.assertEqual(catalog_sync._load_catalog_override_state(path, diagnostics), {})
+                self.assertEqual(diagnostics["reasons"]["invalid_override_fields"], 1)
+
+    def test_managed_baseline_rejects_unhashable_multi_agent_value(self):
+        official = [{"slug": "gpt-5.6-luna", "display_name": "GPT-5.6-Luna", "visibility": "list"}]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            baseline = catalog_sync.build_codex_catalog(official, [], self.policy, "0.146.0")
+            baseline.update({"schema_version": 1, "managed_baseline": True})
+            baseline["models"][0]["multi_agent_version"] = []
+            baseline_path = root / "baseline.json"
+            current_path = root / "catalog.json"
+            baseline_path.write_text(json.dumps(baseline), encoding="utf-8")
+            current_path.write_text(json.dumps({"models": baseline["models"]}), encoding="utf-8")
+            with (
+                patch.object(catalog_sync, "MANAGED_CATALOG_BASELINE_PATH", baseline_path),
+                patch.object(catalog_sync, "GENERATED_CATALOG_PATH", current_path),
+                patch.object(catalog_sync, "CATALOG_OVERRIDES_PATH", root / "overrides.json"),
+            ):
+                collected, diagnostics = catalog_sync._collect_catalog_overrides()
+            self.assertEqual(collected, {})
+            self.assertEqual(diagnostics["reasons"]["invalid_baseline"], 1)
+
+    def test_markerless_managed_baseline_cannot_seed_an_official_override(self):
+        identity = ("openai", "official", "gpt-5.6-luna")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            baseline_model = {
+                "slug": identity[2],
+                "visibility": "list",
+                "prefer_websockets": True,
+                "tool_mode": "code_mode_only",
+                "multi_agent_version": "v1",
+                "use_responses_lite": True,
+                "codex_proxy_metadata": {
+                    "provider": identity[0],
+                    "upstream_name": identity[1],
+                    "upstream_model": identity[2],
+                },
+            }
+            current_model = json.loads(json.dumps(baseline_model))
+            current_model["multi_agent_version"] = "v2"
+            baseline_path = root / "baseline.json"
+            current_path = root / "catalog.json"
+            baseline_path.write_text(
+                json.dumps({"schema_version": 1, "managed_baseline": True, "models": [baseline_model]}),
+                encoding="utf-8",
+            )
+            current_path.write_text(json.dumps({"models": [current_model]}), encoding="utf-8")
+            with (
+                patch.object(catalog_sync, "MANAGED_CATALOG_BASELINE_PATH", baseline_path),
+                patch.object(catalog_sync, "GENERATED_CATALOG_PATH", current_path),
+                patch.object(catalog_sync, "CATALOG_OVERRIDES_PATH", root / "overrides.json"),
+            ):
+                collected, diagnostics = catalog_sync._collect_catalog_overrides()
+            self.assertEqual(collected, {})
+            self.assertEqual(diagnostics["reasons"]["invalid_row_identity"], 1)
 
     def test_catalog_override_purges_sidecar_when_current_identity_is_missing(self):
         identity = ("openai", "official", "gpt-5.6-luna")

--- a/tests/test_catalog_sync.py
+++ b/tests/test_catalog_sync.py
@@ -733,6 +733,146 @@ class CatalogSyncTests(unittest.TestCase):
                 self.assertNotIn("tool_mode", by_slug[slug])
                 self.assertNotIn("multi_agent_version", by_slug[slug])
 
+    def test_sync_catalog_preserves_legacy_luna_multi_agent_override_across_restart(self):
+        official = [
+            {"slug": "gpt-5.6-luna", "display_name": "GPT-5.6-Luna", "visibility": "list"},
+        ]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            generated = root / "model-catalogs" / catalog_sync.GENERATED_CATALOG_FILENAME
+            baseline = root / "model-catalogs" / catalog_sync.MANAGED_CATALOG_BASELINE_FILENAME
+            overrides = root / "model-catalogs" / catalog_sync.CATALOG_OVERRIDES_FILENAME
+            state_path = root / "model-catalogs" / "state.json"
+
+            def run_sync() -> dict:
+                with (
+                    patch.object(catalog_sync, "GENERATED_CATALOG_PATH", generated),
+                    patch.object(catalog_sync, "MANAGED_CATALOG_BASELINE_PATH", baseline),
+                    patch.object(catalog_sync, "CATALOG_OVERRIDES_PATH", overrides),
+                    patch.object(catalog_sync, "GENERATED_STATE_PATH", state_path),
+                    patch("catalog_sync.catalog_cache_is_fresh", return_value=False),
+                    patch("catalog_sync.load_policy", return_value=self.policy),
+                    patch("catalog_sync.load_include_official_models", return_value=True),
+                    patch("catalog_sync.load_official_model_sort_order", return_value=[]),
+                    patch("catalog_sync.load_official_disabled_models", return_value=[]),
+                    patch("catalog_sync.load_official_seed_snapshot", return_value=catalog_sync.OfficialSeedSnapshot(official, "direct", "fresh", True)),
+                    patch("catalog_sync.load_previous_official_context_budgets", return_value={}),
+                    patch("catalog_sync.load_fresh_direct_official_cache_authority", return_value=None),
+                    patch("catalog_sync.official_context_signals_from_snapshot", return_value={}),
+                    patch("catalog_sync.load_fallback_catalog_models", return_value=[]),
+                    patch("catalog_sync.read_client_version", return_value="0.146.0"),
+                    patch("catalog_sync.discover_ollama_ids", return_value=([], "test", "ok", "")),
+                    patch("catalog_sync.load_providers", return_value=[]),
+                    patch("catalog_sync.catalog_visible_ollama_cloud_models", return_value=(False, [])),
+                    patch("catalog_sync.catalog_visible_external_models", return_value=[]),
+                    patch("catalog_sync.discover_ollama_model_metadata", return_value=({}, "")),
+                ):
+                    return catalog_sync.sync_catalog()
+
+            run_sync()
+            initial = json.loads(generated.read_text(encoding="utf-8"))
+            initial["models"][0]["multi_agent_version"] = "v2"
+            generated.write_text(json.dumps(initial), encoding="utf-8")
+
+            state = run_sync()
+            effective = json.loads(generated.read_text(encoding="utf-8"))
+            managed = json.loads(baseline.read_text(encoding="utf-8"))
+            override_state = json.loads(overrides.read_text(encoding="utf-8"))
+
+            self.assertEqual(effective["models"][0]["multi_agent_version"], "v2")
+            self.assertEqual(managed["models"][0]["multi_agent_version"], "v1")
+            self.assertEqual(override_state["overrides"][0]["fields"], {"multi_agent_version": "v2"})
+            self.assertEqual(state["catalog_override_diagnostics"]["accepted"], 1)
+
+            # A second restart is idempotent and must not duplicate the sidecar
+            # entry or drift the effective value.
+            run_sync()
+            repeated = json.loads(generated.read_text(encoding="utf-8"))
+            repeated_overrides = json.loads(overrides.read_text(encoding="utf-8"))
+            self.assertEqual(repeated["models"][0]["multi_agent_version"], "v2")
+            self.assertEqual(len(repeated_overrides["overrides"]), 1)
+
+    def test_catalog_override_does_not_copy_official_planner_metadata_to_external_model(self):
+        external = {
+            "alias": "volc/gpt-5.6-luna",
+            "provider_alias": "volc",
+            "upstream_name": "volcengine",
+            "upstream_model": "gpt-5.6-luna",
+        }
+        model = catalog_sync.build_external_provider_model(external, self.policy, None)
+        self.assertNotIn("multi_agent_version", model)
+        self.assertNotIn("tool_mode", model)
+        self.assertNotIn("prefer_websockets", model)
+
+    def test_catalog_override_rejects_invalid_unknown_and_cross_provider_entries(self):
+        valid_identity = ("openai", "official", "gpt-5.6-luna")
+        cases = {
+            "external-provider": {
+                "provider": "volc",
+                "upstream_name": "official",
+                "upstream_model": "gpt-5.6-luna",
+                "fields": {"multi_agent_version": "v2"},
+            },
+            "unknown-official": {
+                "provider": "openai",
+                "upstream_name": "official",
+                "upstream_model": "gpt-9.9-luna",
+                "fields": {"multi_agent_version": "v2"},
+            },
+            "invalid-shape": {
+                "provider": "openai",
+                "upstream_name": "official",
+                "upstream_model": "gpt-5.6-luna",
+                "fields": {"use_responses_lite": False},
+            },
+        }
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "overrides.json"
+            path.write_text(
+                json.dumps({"schema_version": 1, "overrides": list(cases.values())}),
+                encoding="utf-8",
+            )
+            self.assertEqual(catalog_sync._load_catalog_override_state(path), {})
+            self.assertTrue(
+                catalog_sync._planner_override_is_valid(
+                    valid_identity,
+                    {"multi_agent_version": "v2"},
+                )
+            )
+
+    def test_catalog_override_matches_exact_identity_not_slug(self):
+        official_identity = ("openai", "official", "gpt-5.6-luna")
+        external_model = {
+            "slug": "volc/gpt-5.6-luna",
+            "codex_proxy_metadata": {
+                "provider": "volc",
+                "upstream_name": "volcengine",
+                "upstream_model": "gpt-5.6-luna",
+            },
+        }
+        catalog = {"models": [external_model]}
+        catalog_sync._apply_catalog_overrides(
+            catalog,
+            {official_identity: {"multi_agent_version": "v2"}},
+            {"accepted": 0, "rejected": 0},
+        )
+        self.assertNotIn("multi_agent_version", external_model)
+
+    def test_catalog_override_is_removed_when_managed_baseline_catches_up(self):
+        identity = ("openai", "official", "gpt-5.6-luna")
+        current = {"multi_agent_version": "v2"}
+        old_baseline = {"multi_agent_version": "v1"}
+        new_baseline = {"multi_agent_version": "v2"}
+
+        self.assertEqual(
+            catalog_sync._delta_override_fields(identity, current, old_baseline),
+            {"multi_agent_version": "v2"},
+        )
+        self.assertEqual(
+            catalog_sync._delta_override_fields(identity, current, new_baseline),
+            {},
+        )
+
     def test_pinned_official_catalog_metadata_rejects_an_incomplete_model_set(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             path = Path(tmpdir) / "official-models.json"

--- a/tests/test_catalog_sync.py
+++ b/tests/test_catalog_sync.py
@@ -913,6 +913,14 @@ class CatalogSyncTests(unittest.TestCase):
                     {"multi_agent_version": "v2"},
                 )
             )
+            for field in ("prefer_websockets", "use_responses_lite"):
+                with self.subTest(field=field):
+                    self.assertFalse(
+                        catalog_sync._planner_override_is_valid(
+                            valid_identity,
+                            {field: 1},
+                        )
+                    )
             path.write_text("[]", encoding="utf-8")
             self.assertEqual(catalog_sync._load_catalog_override_state(path), {})
 
@@ -1334,6 +1342,26 @@ class CatalogSyncTests(unittest.TestCase):
             baseline = catalog_sync.build_codex_catalog(official, [], self.policy, "0.146.0")
             baseline.update({"schema_version": 1, "managed_baseline": True})
             baseline["models"][0]["multi_agent_version"] = []
+            baseline_path = root / "baseline.json"
+            current_path = root / "catalog.json"
+            baseline_path.write_text(json.dumps(baseline), encoding="utf-8")
+            current_path.write_text(json.dumps({"models": baseline["models"]}), encoding="utf-8")
+            with (
+                patch.object(catalog_sync, "MANAGED_CATALOG_BASELINE_PATH", baseline_path),
+                patch.object(catalog_sync, "GENERATED_CATALOG_PATH", current_path),
+                patch.object(catalog_sync, "CATALOG_OVERRIDES_PATH", root / "overrides.json"),
+            ):
+                collected, diagnostics = catalog_sync._collect_catalog_overrides()
+            self.assertEqual(collected, {})
+            self.assertEqual(diagnostics["reasons"]["invalid_baseline"], 1)
+
+    def test_managed_baseline_rejects_numeric_boolean_planner_values(self):
+        official = [{"slug": "gpt-5.6-luna", "display_name": "GPT-5.6-Luna", "visibility": "list"}]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            baseline = catalog_sync.build_codex_catalog(official, [], self.policy, "0.146.0")
+            baseline.update({"schema_version": 1, "managed_baseline": True})
+            baseline["models"][0]["prefer_websockets"] = 1
             baseline_path = root / "baseline.json"
             current_path = root / "catalog.json"
             baseline_path.write_text(json.dumps(baseline), encoding="utf-8")

--- a/tests/test_catalog_sync.py
+++ b/tests/test_catalog_sync.py
@@ -856,6 +856,14 @@ class CatalogSyncTests(unittest.TestCase):
         self.assertIs(model["use_responses_lite"], False)
         self.assertNotIn("official_context_budget", model["codex_proxy_metadata"])
         self.assertEqual(model["codex_proxy_metadata"]["provider"], "volc")
+        external_identity = catalog_sync.catalog_model_identity(model)
+        self.assertIsNotNone(external_identity)
+        self.assertTrue(
+            catalog_sync._catalog_override_row_is_eligible(
+                external_identity,
+                model,
+            )
+        )
 
         ollama = catalog_sync.build_ollama_model(
             "glm-5.2",

--- a/tests/test_catalog_sync.py
+++ b/tests/test_catalog_sync.py
@@ -1363,6 +1363,20 @@ class CatalogSyncTests(unittest.TestCase):
             self.assertEqual(collected, {})
             self.assertEqual(diagnostics["reasons"]["invalid_baseline"], 1)
 
+    def test_managed_baseline_accepts_pinned_legacy_null_multi_agent_versions(self):
+        official = [
+            {"slug": slug, "display_name": slug, "visibility": "list"}
+            for slug in catalog_sync.PINNED_OFFICIAL_MODEL_IDS
+        ]
+        baseline = catalog_sync.build_codex_catalog(official, [], self.policy, "0.146.0")
+        baseline.update({"schema_version": 1, "managed_baseline": True})
+
+        self.assertTrue(catalog_sync._managed_baseline_shape_is_valid(baseline))
+        by_slug = {model["slug"]: model for model in baseline["models"]}
+        for slug in catalog_sync.PINNED_OFFICIAL_LEGACY_MODEL_IDS:
+            with self.subTest(slug=slug):
+                self.assertIsNone(by_slug[slug]["multi_agent_version"])
+
     def test_managed_baseline_rejects_numeric_boolean_planner_values(self):
         official = [{"slug": "gpt-5.6-luna", "display_name": "GPT-5.6-Luna", "visibility": "list"}]
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_catalog_sync.py
+++ b/tests/test_catalog_sync.py
@@ -1180,6 +1180,43 @@ class CatalogSyncTests(unittest.TestCase):
             )
             self.assertEqual(diagnostics["accepted"], 1)
 
+    def test_marker_only_catalog_without_baseline_rejects_forged_row_when_key_exists(self):
+        official = [{"slug": "gpt-5.6-luna", "display_name": "GPT-5.6-Luna", "visibility": "list"}]
+        identity = ("openai", "official", "gpt-5.6-luna")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            overrides_path = root / "overrides.json"
+            current_path = root / "catalog.json"
+            (root / catalog_sync.CATALOG_OWNER_SECRET_FILENAME).write_text(
+                "33" * 32,
+                encoding="ascii",
+            )
+            with (
+                patch.object(catalog_sync, "CATALOG_OVERRIDES_PATH", overrides_path),
+                patch.object(catalog_sync, "_CATALOG_OWNER_SECRET_CACHE", None),
+            ):
+                managed = catalog_sync.build_codex_catalog(official, [], self.policy, "0.146.0")
+                row = managed["models"][0]
+                row["multi_agent_version"] = "v2"
+                row["description"] = "forged Official row"
+                row["codex_proxy_metadata"].pop(
+                    catalog_sync.CATALOG_OWNER_SIGNATURE_KEY,
+                    None,
+                )
+                current_path.write_text(json.dumps(managed), encoding="utf-8")
+                with (
+                    patch.object(catalog_sync, "GENERATED_CATALOG_PATH", current_path),
+                    patch.object(
+                        catalog_sync,
+                        "MANAGED_CATALOG_BASELINE_PATH",
+                        root / "missing-baseline.json",
+                    ),
+                ):
+                    collected, diagnostics = catalog_sync._collect_catalog_overrides()
+
+            self.assertEqual(collected, {})
+            self.assertEqual(diagnostics["reasons"]["invalid_row_identity"], 1)
+
     def test_catalog_override_rejects_unhashable_multi_agent_values(self):
         identity = ("openai", "official", "gpt-5.6-luna")
         for malformed in ([], {}):

--- a/tests/test_config_overlay.py
+++ b/tests/test_config_overlay.py
@@ -288,6 +288,51 @@ class ConfigOverlayTests(unittest.TestCase):
                 updated,
             )
 
+    def test_restore_overlay_keeps_catalog_path_edited_while_connected(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path = tmp / "config.toml"
+            backup_path = tmp / "config.backup.toml"
+            managed_catalog = tmp / "arbitrary-managed-location" / "catalog.json"
+            config_path.write_text('model = "volc/glm-5.2"\n', encoding="utf-8")
+
+            apply_overlay(config_path, backup_path, managed_catalog, "http://127.0.0.1:9099")
+            edited = config_path.read_text(encoding="utf-8").replace(
+                f"model_catalog_json = '{managed_catalog.resolve()}'",
+                'model_catalog_json = "C:/user/catalogs/edited.json"',
+            )
+            config_path.write_text(edited, encoding="utf-8")
+
+            restore_overlay(config_path, backup_path)
+
+            restored = config_path.read_text(encoding="utf-8")
+            self.assertIn("model_catalog_json = 'C:/user/catalogs/edited.json'", restored)
+
+    def test_apply_overlay_without_catalog_argument_does_not_drop_existing_catalog(self):
+        original = 'model = "volc/glm-5.2"\nmodel_catalog_json = "C:/user/catalogs/custom.json"\n'
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path = tmp / "config.toml"
+            backup_path = tmp / "config.backup.toml"
+            config_path.write_text(original, encoding="utf-8")
+
+            apply_overlay(config_path, backup_path, None, "http://127.0.0.1:9099")
+
+            self.assertIn("model_catalog_json = 'C:/user/catalogs/custom.json'", config_path.read_text(encoding="utf-8"))
+
+    def test_user_owned_catalog_path_with_hash_and_apostrophe_is_preserved(self):
+        original = "model = \"volc/glm-5.2\"\nmodel_catalog_json = \"C:/user/#catalog's/custom.json\"\n"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path = tmp / "config.toml"
+            backup_path = tmp / "config.backup.toml"
+            config_path.write_text(original, encoding="utf-8")
+
+            apply_overlay(config_path, backup_path, None, "http://127.0.0.1:9099")
+
+            active = config_path.read_text(encoding="utf-8")
+            self.assertIn("model_catalog_json = 'C:/user/#catalog''s/custom.json'", active)
+
     def test_overlay_projects_safe_catalog_budget_across_restart_and_missing_catalog_fallback(self):
         original = "\n".join(
             [

--- a/tests/test_config_overlay.py
+++ b/tests/test_config_overlay.py
@@ -217,6 +217,77 @@ class ConfigOverlayTests(unittest.TestCase):
             self.assertEqual(config_path.read_text(encoding="utf-8"), original)
             self.assertFalse(backup_path.exists())
 
+    def test_apply_and_restore_overlay_preserves_user_owned_catalog_path(self):
+        original = (
+            'model = "volc/glm-5.2"\n'
+            'model_catalog_json = "C:/user/catalogs/custom.json"\n'
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path = tmp / "config.toml"
+            backup_path = tmp / "config.backup.toml"
+            managed_catalog = tmp / "model-catalogs" / "codexhub-model-catalog.json"
+            config_path.write_text(original, encoding="utf-8")
+
+            apply_overlay(config_path, backup_path, managed_catalog, "http://127.0.0.1:9099")
+            active = config_path.read_text(encoding="utf-8")
+            self.assertIn("model_catalog_json = 'C:/user/catalogs/custom.json'", active)
+            self.assertNotIn(str(managed_catalog.resolve()), active)
+
+            restore_overlay(config_path, backup_path)
+            self.assertEqual(config_path.read_text(encoding="utf-8"), original)
+
+    def test_unified_history_injection_preserves_user_owned_catalog_path(self):
+        original = (
+            'model_provider = "openai"\n'
+            'model_catalog_json = "C:/user/catalogs/custom.json"\n'
+        )
+
+        updated, status = inject_unified_history_config(original)
+
+        self.assertEqual(status, "injected")
+        self.assertIn('model_catalog_json = "C:/user/catalogs/custom.json"', updated)
+        self.assertNotIn("codexhub-model-catalog.json", updated)
+
+    def test_relative_custom_catalog_with_managed_basename_is_not_claimed(self):
+        original = (
+            'model_provider = "openai"\n'
+            'model_catalog_json = "custom-model-catalogs/codexhub-model-catalog.json"\n'
+        )
+
+        updated, status = inject_unified_history_config(original)
+
+        self.assertEqual(status, "injected")
+        self.assertIn(
+            'model_catalog_json = "custom-model-catalogs/codexhub-model-catalog.json"',
+            updated,
+        )
+
+    def test_user_edit_inside_managed_overlay_invalidates_catalog_owner_marker(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path = tmp / "config.toml"
+            backup_path = tmp / "config.backup.toml"
+            managed_catalog = tmp / "arbitrary-managed-location" / "catalog.json"
+            config_path.write_text('model = "volc/glm-5.2"\n', encoding="utf-8")
+
+            apply_overlay(config_path, backup_path, managed_catalog, "http://127.0.0.1:9099")
+            active = config_path.read_text(encoding="utf-8")
+            active = active.replace(
+                f"model_catalog_json = '{managed_catalog.resolve()}'",
+                'model_catalog_json = "C:/user/catalogs/after-edit.json"',
+            )
+            config_path.write_text(active, encoding="utf-8")
+
+            updated, status = inject_unified_history_config(active)
+
+            self.assertEqual(status, "replaced_managed_gateway")
+            self.assertIn(
+                'model_catalog_json = "C:/user/catalogs/after-edit.json"',
+                updated,
+            )
+
     def test_overlay_projects_safe_catalog_budget_across_restart_and_missing_catalog_fallback(self):
         original = "\n".join(
             [

--- a/tests/test_config_overlay.py
+++ b/tests/test_config_overlay.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from contextlib import redirect_stdout
+import hashlib
 import io
+import re
 import json
 import tempfile
 from pathlib import Path
@@ -11,8 +13,10 @@ from unittest.mock import patch
 from config_overlay import (
     MARKER_BEGIN,
     MARKER_END,
+    CATALOG_OWNER_MARKER,
     _migrate_legacy_context_guard_values,
     _migrate_legacy_context_guard_values_for_backups,
+    _overlay_marks_managed_catalog,
     _selected_official_context_budget,
     apply_overlay,
     context_guard_status,
@@ -287,6 +291,27 @@ class ConfigOverlayTests(unittest.TestCase):
                 'model_catalog_json = "C:/user/catalogs/after-edit.json"',
                 updated,
             )
+
+    def test_public_catalog_owner_digest_cannot_claim_an_overlay_path(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path = tmp / "config.toml"
+            backup_path = tmp / "config.backup.toml"
+            managed_catalog = tmp / "arbitrary-managed-location" / "catalog.json"
+            config_path.write_text('model = "volc/glm-5.2"\n', encoding="utf-8")
+
+            apply_overlay(config_path, backup_path, managed_catalog, "http://127.0.0.1:9099")
+            active = config_path.read_text(encoding="utf-8")
+            public_digest = hashlib.sha256(
+                str(managed_catalog.resolve()).encode("utf-8")
+            ).hexdigest()
+            active = re.sub(
+                r"(?m)^# catalog_owner = codexhub:[0-9a-f]{64}$",
+                f"{CATALOG_OWNER_MARKER}:{public_digest}",
+                active,
+            )
+
+            self.assertFalse(_overlay_marks_managed_catalog(active))
 
     def test_restore_overlay_keeps_catalog_path_edited_while_connected(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_smoke_scripts.py
+++ b/tests/test_smoke_scripts.py
@@ -807,6 +807,15 @@ def test_codex_mode_persists_bare_official_model_ids():
     assert 'model = "openai/gpt-5.5"' not in source
 
 
+def test_codex_mode_preserves_user_owned_catalog_paths():
+    source = (ROOT / "scripts" / "codex-mode.ps1").read_text(encoding="utf-8-sig")
+
+    assert "function Get-TopLevelConfigValue" in source
+    assert "function Test-CodexHubManagedCatalogPath" in source
+    assert "$preserveCatalog" in source
+    assert "model_catalog_json = $(Convert-ToTomlLiteral -Value $existingCatalogValue)" in source
+
+
 def test_active_gateway_diagnostics_default_to_bare_official_model_ids():
     launcher = (ROOT / "scripts" / "launch-codex-proxy-app.ps1").read_text(encoding="utf-8-sig")
     replay = (ROOT / "scripts" / "replay_official_transport.py").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Closes #327.

- Preserve explicit model-catalog overrides across CodexHub sync/restart with a managed baseline, effective catalog, and signed override sidecar.
- Keep custom `model_catalog_json` paths intact across overlay/connect/disconnect/restore.
- Fail closed for forged or malformed ownership metadata and never copy Official planner metadata to third-party models.
- Preserve the supported legacy Luna `multi_agent_version = "v2"` override, including markerless Beta1 migration.
- Accept the pinned legacy Official rows whose `multi_agent_version` is intentionally `null` while keeping strict validation for code-mode versions and planner booleans.
- Add bounded diagnostics/toast and restart guidance.

## Verification before Hosted CI

- `py -3.13 -m pytest -q tests/test_catalog_sync.py tests/test_config_overlay.py` — 151 passed, 56 subtests.
- `cargo test --manifest-path src-tauri/Cargo.toml catalog::tests` — 4 passed.
- `git diff --check` — passed.
- Standards review: PASS for exact SHA `103ba48cd3856124083ef4e16eafca315d5eebfc`.
- Spec/security review: PASS for exact SHA `103ba48cd3856124083ef4e16eafca315d5eebfc`.

Known unrelated Issue #108 smoke failures remain documented and are not changed by this PR.
