### PR TITLE
test: make Beta2 evidence tooling compatible with Codex CLI 0.146

### DIFF
--- a/scripts/e2e_codex_app_transport.py
+++ b/scripts/e2e_codex_app_transport.py
@@ -13,7 +13,9 @@ import threading
 import time
 
 
-_CODEX_CLI_VERSION_FLOOR = (0, 144, 5)
+# Issue #62's runtime inventory raises the evidence floor to the last stable
+# CLI contract already accepted by the Beta2 candidate.
+_CODEX_CLI_VERSION_FLOOR = (0, 145, 0)
 _VERSION_PROBE_TIMEOUT_SECONDS = 10
 _VERSION_PROBE_OUTPUT_LIMIT = 64 * 1024
 

--- a/scripts/e2e_codex_app_transport.py
+++ b/scripts/e2e_codex_app_transport.py
@@ -13,34 +13,48 @@ import threading
 import time
 
 
+_CODEX_CLI_VERSION_FLOOR = (0, 144, 5)
+_VERSION_PROBE_TIMEOUT_SECONDS = 10
+_VERSION_PROBE_OUTPUT_LIMIT = 64 * 1024
+
+
 def resolve_cli_version(codex_command: Path) -> str:
     """Read the version from the exact CLI binary used by app-server.
 
     The app-server initialize payload is part of the evidence identity.  It
     must not retain a historical fixture version when the operator upgrades
-    the App-managed CLI, otherwise the trace is falsely attributed to an old
-    client.  Allowing an explicit value keeps replay/fixture callers
-    deterministic while the live path binds itself to the executable.
+    the CLI, otherwise the trace is falsely attributed to an old client.
     """
 
-    completed = subprocess.run(
+    process = subprocess.Popen(
         [str(codex_command), "--version"],
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
         creationflags=subprocess.CREATE_NO_WINDOW if os.name == "nt" else 0,
     )
-    output = "\n".join((completed.stdout, completed.stderr)).strip()
-    if completed.returncode != 0:
+    try:
+        stdout, stderr = process.communicate(timeout=_VERSION_PROBE_TIMEOUT_SECONDS)
+    except subprocess.TimeoutExpired as error:
+        process.kill()
+        process.communicate()
+        raise RuntimeError("Codex CLI version probe timed out") from error
+    output = b"\n".join((stdout[:_VERSION_PROBE_OUTPUT_LIMIT], stderr[:_VERSION_PROBE_OUTPUT_LIMIT])).decode(
+        "utf-8", errors="replace"
+    ).strip()
+    if process.returncode != 0:
         raise RuntimeError(
-            f"Codex CLI version probe failed with exit code {completed.returncode}"
+            f"Codex CLI version probe failed with exit code {process.returncode}"
         )
-    match = re.search(r"\bcodex-cli\s+([^\s]+)", output, re.IGNORECASE)
+    lines = [line.strip() for line in output.splitlines() if line.strip()]
+    if len(lines) != 1:
+        raise RuntimeError("Codex CLI version probe returned ambiguous output")
+    match = re.fullmatch(r"codex-cli\s+(\d+)\.(\d+)\.(\d+)", lines[0], re.IGNORECASE)
     if match is None:
-        raise RuntimeError("Codex CLI version probe returned no codex-cli version")
-    return match.group(1)
+        raise RuntimeError("Codex CLI version probe returned no stable three-part version")
+    version = tuple(int(part) for part in match.groups())
+    if version < _CODEX_CLI_VERSION_FLOOR:
+        raise RuntimeError("Codex CLI version is below the supported floor")
+    return ".".join(str(part) for part in version)
 
 
 def main() -> int:
@@ -48,17 +62,13 @@ def main() -> int:
     parser.add_argument("--codex", type=Path, required=True)
     parser.add_argument("--home", type=Path, required=True)
     parser.add_argument("--cwd", type=Path, required=True)
-    parser.add_argument(
-        "--client-version",
-        help="Override the app-server clientInfo version (otherwise probe --codex --version).",
-    )
     parser.add_argument("--turns", type=int, default=30)
     parser.add_argument("--timeout", type=float, default=180.0)
     parser.add_argument("--session-jsonl", type=Path)
     parser.add_argument("--tool-calls", type=int, default=0)
     parser.add_argument("--pause-between-turns", type=float, default=0.0)
     args = parser.parse_args()
-    client_version = args.client_version or resolve_cli_version(args.codex.resolve())
+    client_version = resolve_cli_version(args.codex.resolve())
 
     env = os.environ.copy()
     env["CODEX_HOME"] = str(args.home.resolve())

--- a/scripts/e2e_codex_app_transport.py
+++ b/scripts/e2e_codex_app_transport.py
@@ -38,6 +38,8 @@ def resolve_cli_version(codex_command: Path) -> str:
         process.kill()
         process.communicate()
         raise RuntimeError("Codex CLI version probe timed out") from error
+    if len(stdout) > _VERSION_PROBE_OUTPUT_LIMIT or len(stderr) > _VERSION_PROBE_OUTPUT_LIMIT:
+        raise RuntimeError("Codex CLI version probe exceeded its output limit")
     output = b"\n".join((stdout[:_VERSION_PROBE_OUTPUT_LIMIT], stderr[:_VERSION_PROBE_OUTPUT_LIMIT])).decode(
         "utf-8", errors="replace"
     ).strip()

--- a/scripts/e2e_codex_app_transport.py
+++ b/scripts/e2e_codex_app_transport.py
@@ -7,9 +7,40 @@ import json
 import os
 from pathlib import Path
 import queue
+import re
 import subprocess
 import threading
 import time
+
+
+def resolve_cli_version(codex_command: Path) -> str:
+    """Read the version from the exact CLI binary used by app-server.
+
+    The app-server initialize payload is part of the evidence identity.  It
+    must not retain a historical fixture version when the operator upgrades
+    the App-managed CLI, otherwise the trace is falsely attributed to an old
+    client.  Allowing an explicit value keeps replay/fixture callers
+    deterministic while the live path binds itself to the executable.
+    """
+
+    completed = subprocess.run(
+        [str(codex_command), "--version"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+        creationflags=subprocess.CREATE_NO_WINDOW if os.name == "nt" else 0,
+    )
+    output = "\n".join((completed.stdout, completed.stderr)).strip()
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"Codex CLI version probe failed with exit code {completed.returncode}"
+        )
+    match = re.search(r"\bcodex-cli\s+([^\s]+)", output, re.IGNORECASE)
+    if match is None:
+        raise RuntimeError("Codex CLI version probe returned no codex-cli version")
+    return match.group(1)
 
 
 def main() -> int:
@@ -17,12 +48,17 @@ def main() -> int:
     parser.add_argument("--codex", type=Path, required=True)
     parser.add_argument("--home", type=Path, required=True)
     parser.add_argument("--cwd", type=Path, required=True)
+    parser.add_argument(
+        "--client-version",
+        help="Override the app-server clientInfo version (otherwise probe --codex --version).",
+    )
     parser.add_argument("--turns", type=int, default=30)
     parser.add_argument("--timeout", type=float, default=180.0)
     parser.add_argument("--session-jsonl", type=Path)
     parser.add_argument("--tool-calls", type=int, default=0)
     parser.add_argument("--pause-between-turns", type=float, default=0.0)
     args = parser.parse_args()
+    client_version = args.client_version or resolve_cli_version(args.codex.resolve())
 
     env = os.environ.copy()
     env["CODEX_HOME"] = str(args.home.resolve())
@@ -128,7 +164,7 @@ def main() -> int:
                 "clientInfo": {
                     "name": "codex_desktop",
                     "title": "Codex Desktop",
-                    "version": "0.144.0-alpha.4",
+                    "version": client_version,
                 },
                 "capabilities": {
                     "experimentalApi": True,

--- a/scripts/qualify-issue-108-glm-tool-surface.ps1
+++ b/scripts/qualify-issue-108-glm-tool-surface.ps1
@@ -2251,6 +2251,29 @@ def _note_apply_patch_failure(payload):
             return
 
 
+def _sse_output_items(payload):
+    """Yield tool items from both legacy and current Responses SSE shapes.
+
+    Codex CLI 0.146 may wrap a streamed item under ``response.output`` while
+    older clients expose it directly as ``item``.  The qualification harness
+    only needs the tool name, so normalize those envelopes without retaining
+    any request or response content.
+    """
+    if not isinstance(payload, dict):
+        return
+    item = payload.get("item")
+    if isinstance(item, dict):
+        yield item
+    response = payload.get("response")
+    if not isinstance(response, dict):
+        return
+    output = response.get("output")
+    if isinstance(output, list):
+        for candidate in output:
+            if isinstance(candidate, dict):
+                yield candidate
+
+
 def _record_post_success_tool_choice(line):
     global _post_success_tool_choice_recorded
     if not _post_success_apply_patch_pending or _post_success_tool_choice_recorded:
@@ -2261,21 +2284,22 @@ def _record_post_success_tool_choice(line):
         payload = json.loads(line[6:].decode("utf-8"))
     except (UnicodeDecodeError, json.JSONDecodeError):
         return
-    item = payload.get("item") if isinstance(payload, dict) else None
-    if not isinstance(item, dict) or item.get("type") not in {"function_call", "custom_tool_call"}:
+    for item in _sse_output_items(payload):
+        if item.get("type") not in {"function_call", "custom_tool_call"}:
+            continue
+        name = item.get("name")
+        if not isinstance(name, str) or not name:
+            continue
+        _post_success_tool_choice_recorded = True
+        _append_capture_record(
+            {
+                "stage": "post_success_tool_choice",
+                "choice": name,
+                "expected_choice": _expected_post_success_tool_choice,
+                "outcome": "expected" if name == _expected_post_success_tool_choice else "wrong",
+            }
+        )
         return
-    name = item.get("name")
-    if not isinstance(name, str) or not name:
-        return
-    _post_success_tool_choice_recorded = True
-    _append_capture_record(
-        {
-            "stage": "post_success_tool_choice",
-            "choice": name,
-            "expected_choice": _expected_post_success_tool_choice,
-            "outcome": "expected" if name == _expected_post_success_tool_choice else "wrong",
-        }
-    )
 
 
 def _record_tool_search_choice(line):
@@ -2285,13 +2309,10 @@ def _record_tool_search_choice(line):
         payload = json.loads(line[6:].decode("utf-8"))
     except (UnicodeDecodeError, json.JSONDecodeError):
         return
-    item = payload.get("item") if isinstance(payload, dict) else None
-    if (
-        isinstance(item, dict)
-        and item.get("type") in {"function_call", "custom_tool_call"}
-        and item.get("name") == "tool_search"
-    ):
-        _append_capture_record({"stage": "tool_choice", "choice": "tool_search"})
+    for item in _sse_output_items(payload):
+        if item.get("type") in {"function_call", "custom_tool_call"} and item.get("name") == "tool_search":
+            _append_capture_record({"stage": "tool_choice", "choice": "tool_search"})
+            return
 
 
 def _patch_structure(arguments):

--- a/scripts/qualify-issue-108-glm-tool-surface.ps1
+++ b/scripts/qualify-issue-108-glm-tool-surface.ps1
@@ -2573,7 +2573,11 @@ $windowsSandboxConfiguration
     Wait-GatewayHealth -BaseUrl $gatewayBaseUrl -StartupSeconds $GatewayStartupSeconds
 
     $cliArguments = @(
-        '-a', 'never',
+        # Codex CLI 0.146 removed the legacy `-a/--ask-for-approval` option.
+        # Keep this qualification non-interactive by supplying the current
+        # config override before the `exec` subcommand.  Passing the value as
+        # TOML preserves the string form expected by strict-config.
+        '-c', 'approval_policy="never"',
         'exec', '--strict-config', '--ephemeral', '--json',
         '--sandbox', $cliSandbox,
         '-C', $testWorkspace,

--- a/scripts/qualify-issue-108-glm-tool-surface.ps1
+++ b/scripts/qualify-issue-108-glm-tool-surface.ps1
@@ -2598,9 +2598,9 @@ $windowsSandboxConfiguration
     $cliArguments = @(
         # Codex CLI 0.146 removed the legacy `-a/--ask-for-approval` option.
         # Keep this qualification non-interactive by supplying the current
-        # config override before the `exec` subcommand.  Passing the value as
-        # TOML preserves the string form expected by strict-config.
-        '-c', 'approval_policy="never"',
+        # config override before the `exec` subcommand.  The unquoted value
+        # also survives the cmd.exe shim used by npm's codex.cmd launcher.
+        '-c', 'approval_policy=never',
         'exec', '--strict-config', '--ephemeral', '--json',
         '--sandbox', $cliSandbox,
         '-C', $testWorkspace,

--- a/scripts/qualify-issue-108-glm-tool-surface.ps1
+++ b/scripts/qualify-issue-108-glm-tool-surface.ps1
@@ -2191,7 +2191,9 @@ def _is_successful_apply_patch_output(value):
 def _is_exact_apply_patch_history_pair(call, result):
     return (
         isinstance(call, dict)
-        and set(call) == {"type", "status", "call_id", "name", "input"}
+        # CLI 0.146 includes an item id on both sides of the pair.  Match the
+        # stable semantic contract and tolerate additive metadata fields.
+        and {"type", "status", "call_id", "name", "input"}.issubset(call)
         and call.get("type") == "custom_tool_call"
         and call.get("status") == "completed"
         and call.get("name") == "apply_patch"
@@ -2200,7 +2202,7 @@ def _is_exact_apply_patch_history_pair(call, result):
         and isinstance(call.get("input"), str)
         and bool(call["input"].strip())
         and isinstance(result, dict)
-        and set(result) == {"type", "call_id", "output"}
+        and {"type", "call_id", "output"}.issubset(result)
         and result.get("type") == "custom_tool_call_output"
         and result.get("call_id") == call["call_id"]
     )

--- a/tests/fixtures/issue_108_glm_qualification_evidence.json
+++ b/tests/fixtures/issue_108_glm_qualification_evidence.json
@@ -71,26 +71,26 @@
     ],
     "request_surfaces": [
       {
-        "raw_tools_sha256": "sha256:5c697ad0f536d5419e557c5fe4b3208016ec69c2cbe006dba4192210cf1e0294",
-        "canonical_shape_sha256": "sha256:8c3948a5a3eb6204be57b8d9e1e191f83bc08c3ee31e76fcbbfea0089e36bd7f",
+        "raw_tools_sha256": "sha256:0a69a2512db23c06561be489e636440cd76f5350c45c20d9af4b5c5106135da5",
+        "canonical_shape_sha256": "sha256:928b596451cd91c0a9ce953e444c80d6357d55bd4b1eff20078d6179d838b16f",
         "namespace_flattened_count": 0,
         "tool_search_visible": true
       },
       {
-        "raw_tools_sha256": "sha256:5c697ad0f536d5419e557c5fe4b3208016ec69c2cbe006dba4192210cf1e0294",
-        "canonical_shape_sha256": "sha256:8c3948a5a3eb6204be57b8d9e1e191f83bc08c3ee31e76fcbbfea0089e36bd7f",
+        "raw_tools_sha256": "sha256:0a69a2512db23c06561be489e636440cd76f5350c45c20d9af4b5c5106135da5",
+        "canonical_shape_sha256": "sha256:928b596451cd91c0a9ce953e444c80d6357d55bd4b1eff20078d6179d838b16f",
         "namespace_flattened_count": 0,
         "tool_search_visible": true
       },
       {
-        "raw_tools_sha256": "sha256:5c697ad0f536d5419e557c5fe4b3208016ec69c2cbe006dba4192210cf1e0294",
-        "canonical_shape_sha256": "sha256:8c3948a5a3eb6204be57b8d9e1e191f83bc08c3ee31e76fcbbfea0089e36bd7f",
+        "raw_tools_sha256": "sha256:0a69a2512db23c06561be489e636440cd76f5350c45c20d9af4b5c5106135da5",
+        "canonical_shape_sha256": "sha256:928b596451cd91c0a9ce953e444c80d6357d55bd4b1eff20078d6179d838b16f",
         "namespace_flattened_count": 0,
         "tool_search_visible": true
       },
       {
-        "raw_tools_sha256": "sha256:5c697ad0f536d5419e557c5fe4b3208016ec69c2cbe006dba4192210cf1e0294",
-        "canonical_shape_sha256": "sha256:8c3948a5a3eb6204be57b8d9e1e191f83bc08c3ee31e76fcbbfea0089e36bd7f",
+        "raw_tools_sha256": "sha256:0a69a2512db23c06561be489e636440cd76f5350c45c20d9af4b5c5106135da5",
+        "canonical_shape_sha256": "sha256:928b596451cd91c0a9ce953e444c80d6357d55bd4b1eff20078d6179d838b16f",
         "namespace_flattened_count": 0,
         "tool_search_visible": true
       }
@@ -112,9 +112,17 @@
         "keys": ["description", "name", "parameters", "strict", "type"]
       },
       {
-        "type": "custom",
+        "type": "function",
         "name": "apply_patch",
-        "keys": ["description", "format", "name", "type"]
+        "keys": ["description", "name", "parameters", "strict", "type"],
+        "strict": true,
+        "parameter_keys": ["additionalProperties", "properties", "required", "type"],
+        "property_names": ["patch"],
+        "patch_schema_keys": ["minLength", "type"],
+        "patch_type": "string",
+        "patch_min_length": 1,
+        "required": ["patch"],
+        "additional_properties": false
       },
       {
         "type": "function",

--- a/tests/test_smoke_scripts.py
+++ b/tests/test_smoke_scripts.py
@@ -927,6 +927,12 @@ def test_embedded_python_runtime_bundles_zstandard_for_app_request_bodies():
 def test_codex_app_transport_e2e_uses_app_server_and_requires_completed_turns():
     source = (ROOT / "scripts" / "e2e_codex_app_transport.py").read_text(encoding="utf-8")
 
+    assert "--version" in source
+    assert "_VERSION_PROBE_TIMEOUT_SECONDS = 10" in source
+    assert "_VERSION_PROBE_OUTPUT_LIMIT = 64 * 1024" in source
+    assert "re.fullmatch(r\"codex-cli\\s+" in source
+    assert "_CODEX_CLI_VERSION_FLOOR = (0, 144, 5)" in source
+    assert "--client-version" not in source
     assert '"app-server"' in source
     assert '"thread/start"' in source
     assert '"turn/start"' in source

--- a/tests/test_smoke_scripts.py
+++ b/tests/test_smoke_scripts.py
@@ -805,7 +805,7 @@ def test_issue_108_qualification_uses_synthetic_gateway_bearer_and_whitelisted_c
     assert 'sandbox = "elevated"' in source
     assert 'sandbox = "unelevated"' not in source
     assert "'--sandbox', $cliSandbox" in source
-    assert "'-c', 'approval_policy=\"never\"'" in source
+    assert "'-c', 'approval_policy=never'" in source
     assert "'-a', 'never'" not in source
     assert "response.get(\"output\")" in source
     assert "def _sse_output_items(payload):" in source

--- a/tests/test_smoke_scripts.py
+++ b/tests/test_smoke_scripts.py
@@ -805,7 +805,8 @@ def test_issue_108_qualification_uses_synthetic_gateway_bearer_and_whitelisted_c
     assert 'sandbox = "elevated"' in source
     assert 'sandbox = "unelevated"' not in source
     assert "'--sandbox', $cliSandbox" in source
-    assert "'-a', 'never'" in source
+    assert "'-c', 'approval_policy=\"never\"'" in source
+    assert "'-a', 'never'" not in source
     assert "External qualification scratch directory must be outside the repository workspace" in source
     assert "Readiness preflight: use the accepted GLM route" in source
     assert "ReadinessTimeoutSeconds" in source

--- a/tests/test_smoke_scripts.py
+++ b/tests/test_smoke_scripts.py
@@ -930,6 +930,8 @@ def test_codex_app_transport_e2e_uses_app_server_and_requires_completed_turns():
     assert "--version" in source
     assert "_VERSION_PROBE_TIMEOUT_SECONDS = 10" in source
     assert "_VERSION_PROBE_OUTPUT_LIMIT = 64 * 1024" in source
+    assert "len(stdout) > _VERSION_PROBE_OUTPUT_LIMIT" in source
+    assert "len(stderr) > _VERSION_PROBE_OUTPUT_LIMIT" in source
     assert "re.fullmatch(r\"codex-cli\\s+" in source
     assert "_CODEX_CLI_VERSION_FLOOR = (0, 144, 5)" in source
     assert "--client-version" not in source

--- a/tests/test_smoke_scripts.py
+++ b/tests/test_smoke_scripts.py
@@ -551,10 +551,10 @@ def test_issue_108_qualification_evidence_replay_validates_committed_live_fixtur
     assert summary["request_error_count"] == 0
     assert summary["fallback_counts"] == {"luna": 0, "terra": 0}
     assert summary["deferred_payload_digest"] == (
-        "sha256:5c697ad0f536d5419e557c5fe4b3208016ec69c2cbe006dba4192210cf1e0294"
+        "sha256:0a69a2512db23c06561be489e636440cd76f5350c45c20d9af4b5c5106135da5"
     )
     assert summary["canonical_tool_shape_digest"] == (
-        "sha256:8c3948a5a3eb6204be57b8d9e1e191f83bc08c3ee31e76fcbbfea0089e36bd7f"
+        "sha256:928b596451cd91c0a9ce953e444c80d6357d55bd4b1eff20078d6179d838b16f"
     )
     assert (ROOT / "tests" / "fixtures" / "issue_108_glm_qualification_evidence.json").exists()
 

--- a/tests/test_smoke_scripts.py
+++ b/tests/test_smoke_scripts.py
@@ -807,6 +807,8 @@ def test_issue_108_qualification_uses_synthetic_gateway_bearer_and_whitelisted_c
     assert "'--sandbox', $cliSandbox" in source
     assert "'-c', 'approval_policy=\"never\"'" in source
     assert "'-a', 'never'" not in source
+    assert "response.get(\"output\")" in source
+    assert "def _sse_output_items(payload):" in source
     assert "External qualification scratch directory must be outside the repository workspace" in source
     assert "Readiness preflight: use the accepted GLM route" in source
     assert "ReadinessTimeoutSeconds" in source

--- a/tests/test_smoke_scripts.py
+++ b/tests/test_smoke_scripts.py
@@ -933,7 +933,7 @@ def test_codex_app_transport_e2e_uses_app_server_and_requires_completed_turns():
     assert "len(stdout) > _VERSION_PROBE_OUTPUT_LIMIT" in source
     assert "len(stderr) > _VERSION_PROBE_OUTPUT_LIMIT" in source
     assert "re.fullmatch(r\"codex-cli\\s+" in source
-    assert "_CODEX_CLI_VERSION_FLOOR = (0, 144, 5)" in source
+    assert "_CODEX_CLI_VERSION_FLOOR = (0, 145, 0)" in source
     assert "--client-version" not in source
     assert '"app-server"' in source
     assert '"thread/start"' in source

--- a/tests/test_smoke_scripts.py
+++ b/tests/test_smoke_scripts.py
@@ -809,6 +809,8 @@ def test_issue_108_qualification_uses_synthetic_gateway_bearer_and_whitelisted_c
     assert "'-a', 'never'" not in source
     assert "response.get(\"output\")" in source
     assert "def _sse_output_items(payload):" in source
+    assert '{"type", "status", "call_id", "name", "input"}.issubset(call)' in source
+    assert '{"type", "call_id", "output"}.issubset(result)' in source
     assert "External qualification scratch directory must be outside the repository workspace" in source
     assert "Readiness preflight: use the accepted GLM route" in source
     assert "ReadinessTimeoutSeconds" in source

--- a/tests/validate_issue_108_evidence.py
+++ b/tests/validate_issue_108_evidence.py
@@ -22,7 +22,7 @@ _SENSITIVE_VALUE = re.compile(
 _LOCAL_PATH = re.compile(r"(?i)(?:[a-z]:[\\/]|\\\\users\\|/users/|/home/)")
 _RAW_CONTENT = re.compile(r"(?i)(?:automated qualification|\*\*\* begin patch|\*\*\* update file:)")
 DIRECT_TOOL_SURFACE_BUDGET = 64
-_ACCEPTED_DEFERRED_PAYLOAD_SHA256 = "sha256:5c697ad0f536d5419e557c5fe4b3208016ec69c2cbe006dba4192210cf1e0294"
+_ACCEPTED_DEFERRED_PAYLOAD_SHA256 = "sha256:0a69a2512db23c06561be489e636440cd76f5350c45c20d9af4b5c5106135da5"
 _ACCEPTED_QUALIFICATION_REQUEST_COUNT = 4
 _REQUIRED_CORE_TOOL_NAMES = frozenset({"shell_command", "apply_patch"})
 _EXPECTED_DEFERRED_CANONICAL_TOOL_SHAPE = [
@@ -42,9 +42,17 @@ _EXPECTED_DEFERRED_CANONICAL_TOOL_SHAPE = [
         "keys": ["description", "name", "parameters", "strict", "type"],
     },
     {
-        "type": "custom",
+        "type": "function",
         "name": "apply_patch",
-        "keys": ["description", "format", "name", "type"],
+        "keys": ["description", "name", "parameters", "strict", "type"],
+        "strict": True,
+        "parameter_keys": ["additionalProperties", "properties", "required", "type"],
+        "property_names": ["patch"],
+        "patch_schema_keys": ["minLength", "type"],
+        "patch_type": "string",
+        "patch_min_length": 1,
+        "required": ["patch"],
+        "additional_properties": False,
     },
     {
         "type": "function",


### PR DESCRIPTION
## Summary

Refs #62. This PR updates the Issue 108 qualification/evidence tooling for the Codex CLI 0.146 Beta2 candidate; it does not claim to close #62.

- Replace the removed CLI 0.145 `-a never` invocation with `-c approval_policy=never`, including npm `codex.cmd` shim compatibility.
- Bind app-server `clientInfo.version` to the exact CLI executable's bounded `--version` probe (stable three-part version, Beta2 floor 0.145.0, 10s timeout, 64 KiB per-stream limit, fail-closed).
- Accept Codex CLI 0.146 additive tool-history IDs and current Responses SSE output envelopes without logging raw payloads.
- Rebind the sanitized GLM qualification fixture/validator to the observed 0.146 strict function `apply_patch` surface and digests.

## Verification

- Isolated stable `codex-cli 0.146.0` + Python 3.13 + disposable Gateway + Ollama Cloud GLM run passed all Issue108 qualification checks: readiness, route identity, tool sequence, history pair, no retry/fallback, and sanitized evidence validation.
- Targeted Python checks passed.
- Full local Python core: 1722 passed, 1 skipped, 3 pre-existing environment-sensitive failures (ChatCompletions read-error timeout and two PowerShell replay cases using the host Python 3.11; Hosted setup uses Python 3.13). These are not attributed to this patch.
- `git diff --check` passed.

The complete candidate-bound runtime/wire inventory, non-streaming/error/unknown controls, and cleanup evidence remain follow-up work on #62.