### PR TITLE
test(e2e): add explicit CLI-only verification scope

### DIFF
--- a/docs/agents/real-client-e2e.md
+++ b/docs/agents/real-client-e2e.md
@@ -1,8 +1,10 @@
 # Real-client E2E gate
 
 `scripts/Run-RealClientE2E.ps1` is the release-only Windows gate for proving
-that one candidate Debug build routes six compatible real clients through both
-canonical routes. HTTP/configuration preflight alone is never an E2E pass.
+that one candidate Debug build routes compatible clients through both canonical
+routes. HTTP/configuration preflight alone is never an E2E pass. Beta2 uses the
+explicit `-CliOnly` scope described below; the full GUI matrix remains available
+for a later release qualification.
 
 ## Authoritative host and compatibility baselines
 
@@ -282,6 +284,19 @@ Cloud Native Responses path; the previous Volc Chat Completions
 path remains available as ordinary, non-release regression coverage and is not represented as
 Native Responses evidence in this matrix.
 
+### Beta2 CLI-only verification
+
+Pass `-CliOnly` when the current release gate is limited to command-line
+clients. This mode runs exactly the eight automated cases for Codex CLI,
+OpenCode, Pi, and OMP (Official Luna and Ollama Cloud for each). It does not
+resolve or start Codex Desktop or ZCode, does not inspect GUI seeds, does not
+require `gui_ready = true`, and never creates or waits for
+`manual-evidence.template.json` or `manual-evidence.json`. A CLI-only summary
+has `verification_scope = "cli_only"`, `manual_case_count = 0`, and
+`automated_case_count = 8`; its `pinned_versions` contains only the four CLI
+clients. The eight cases must still pass their normal model, route, streaming,
+tool, terminal, retry, and Gateway-correlation checks.
+
 Each case creates one disposable `sentinel.txt`. The client must use exactly
 one successful read-only read tool, emit the named sentinel once, and finish
 once. The compatibility-baseline client parsers consume their real JSONL
@@ -477,6 +492,11 @@ powershell -NoProfile -File scripts/Run-RealClientE2E.ps1 `
   -ManualEvidenceTimeoutSeconds 900
 ```
 
+For the Beta2 CLI-only gate, add `-CliOnly` to the command. GUI seed
+directories, GUI executables, and manual evidence are not needed in that
+scope; the runner must exit `0` with `verification_scope` `cli_only` and eight
+passed cases.
+
 6. Wait for the template and four case-local GUI launches (Desktop and ZCode,
    each with Luna and Ollama Cloud). Each launch consumes its own #194-applied
    root.
@@ -525,7 +545,7 @@ completion. An outer timeout references only the fixed sanitized
 artifact per case and uses `failure_classification` `none` or `case_failure`.
 
 The success summary uses schema `codexhub.real-client-e2e-summary.v2`. Its
-top-level keys are exactly `schema`, `candidate_sha`,
+top-level keys are exactly `schema`, `verification_scope`, `candidate_sha`,
 `managed_client_config_sha`, `run_binding_sha256`, `outcome`, `failure_classification`, `hashes`,
 `pinned_versions`, `canonical_models`, `counts`, `cases`, and `artifacts`.
 The legacy-named `pinned_versions` object contains the actual normalized versions

--- a/scripts/Run-RealClientE2E.ps1
+++ b/scripts/Run-RealClientE2E.ps1
@@ -33,6 +33,8 @@ param(
     [string]$PiPath = 'pi.exe',
     [string]$OmpPath = 'omp.exe',
 
+    [switch]$CliOnly,
+
     [int]$TimeoutSeconds = 180,
 
     [int]$ManualEvidenceTimeoutSeconds = 900,
@@ -205,6 +207,13 @@ $script:MinimumVersions = [ordered]@{
     pi = '0.80.6'
     omp = '17.0.3'
 }
+$script:CliOnly = [bool]$CliOnly
+$script:VerificationScope = if ($script:CliOnly) { 'cli_only' } else { 'gui_and_cli' }
+$script:VersionKeys = if ($script:CliOnly) {
+    @('codex_cli', 'opencode', 'pi', 'omp')
+} else {
+    @($script:MinimumVersions.Keys)
+}
 $script:ObservedVersions = [ordered]@{}
 $script:MaximumCapturedCharacters = 65536
 $script:MaximumClientEventCharacters = 1048576
@@ -323,7 +332,7 @@ function Write-JsonFile {
 
 function Get-ReportedClientVersions {
     $reported = [ordered]@{}
-    foreach ($name in $script:MinimumVersions.Keys) {
+    foreach ($name in $script:VersionKeys) {
         $reported[$name] = if ($script:ObservedVersions.Contains($name)) {
             [string]$script:ObservedVersions[$name]
         }
@@ -338,6 +347,7 @@ function Get-FailureSummaryValue {
     param([string]$FailureClassification, [string[]]$Artifacts = @())
     return [ordered]@{
         schema = 'codexhub.real-client-e2e-summary.v2'
+        verification_scope = $script:VerificationScope
         candidate_sha = if ($CandidateSha -match '^[0-9a-fA-F]{40}$') { $CandidateSha.ToLowerInvariant() } else { $null }
         managed_client_config_sha = if ($ManagedClientConfigSha -match '^[0-9a-fA-F]{40}$') { $ManagedClientConfigSha.ToLowerInvariant() } else { $null }
         outcome = 'failed'
@@ -448,6 +458,7 @@ function Invoke-RunnerSupervisor {
         OpenCodePath = $OpenCodePath
         PiPath = $PiPath
         OmpPath = $OmpPath
+        CliOnly = [bool]$CliOnly
         TimeoutSeconds = $TimeoutSeconds
         ManualEvidenceTimeoutSeconds = $ManualEvidenceTimeoutSeconds
         OverallTimeoutSeconds = $OverallTimeoutSeconds
@@ -485,6 +496,7 @@ function Invoke-RunnerSupervisor {
   -ThirdPartyModel 'internal' `
   -OutputDirectory '.' `
   -HostEnvironmentManifest '.' `
+  -CliOnly:$false `
   -TimeoutSeconds 1 `
   -ManualEvidenceTimeoutSeconds 1 `
   -OverallTimeoutSeconds 1 `
@@ -2889,7 +2901,7 @@ try {
         'ManagedClientConfigSha', 'LunaModel', 'ThirdPartyModel', 'OutputDirectory',
         'HostEnvironmentManifest', 'TestWindowsInstallMetadataFixture',
         'CodexDesktopPath', 'CodexCliPath', 'ZCodePath', 'OpenCodePath',
-        'PiPath', 'OmpPath', 'TimeoutSeconds', 'ManualEvidenceTimeoutSeconds',
+        'PiPath', 'OmpPath', 'CliOnly', 'TimeoutSeconds', 'ManualEvidenceTimeoutSeconds',
         'OverallTimeoutSeconds'
     ) -Failure 'preflight_supervisor_arguments_invalid'
     $CandidateSha = [string]$forwardedArguments.CandidateSha
@@ -2907,12 +2919,21 @@ try {
     $OpenCodePath = [string]$forwardedArguments.OpenCodePath
     $PiPath = [string]$forwardedArguments.PiPath
     $OmpPath = [string]$forwardedArguments.OmpPath
+    $CliOnly = [bool]$forwardedArguments.CliOnly
     $TimeoutSeconds = [int]$forwardedArguments.TimeoutSeconds
     $ManualEvidenceTimeoutSeconds = [int]$forwardedArguments.ManualEvidenceTimeoutSeconds
     $OverallTimeoutSeconds = [int]$forwardedArguments.OverallTimeoutSeconds
 }
 catch {
     throw 'preflight_supervisor_arguments_invalid'
+}
+
+$script:CliOnly = [bool]$CliOnly
+$script:VerificationScope = if ($script:CliOnly) { 'cli_only' } else { 'gui_and_cli' }
+$script:VersionKeys = if ($script:CliOnly) {
+    @('codex_cli', 'opencode', 'pi', 'omp')
+} else {
+    @($script:MinimumVersions.Keys)
 }
 
 $CandidateSha = $CandidateSha.ToLowerInvariant()
@@ -3042,7 +3063,8 @@ if ([string]$hostEnvironment.schema -cne 'codexhub.real-client-host-environment.
 $profile = Read-JsonObject -Path $accountPath -Failure 'preflight_account_profile_invalid'
 Assert-ExactJsonProperties -Value $profile -Names @('schema', 'dedicated_account', 'codex_login_ready', 'gui_ready', 'host_session_reused') -Failure 'preflight_account_profile_invalid'
 if ([string]$profile.schema -cne 'codexhub.real-client-account.v1' -or
-    [bool]$profile.dedicated_account -ne $true -or [bool]$profile.codex_login_ready -ne $true -or [bool]$profile.gui_ready -ne $true -or
+    [bool]$profile.dedicated_account -ne $true -or [bool]$profile.codex_login_ready -ne $true -or
+    (-not $CliOnly -and [bool]$profile.gui_ready -ne $true) -or
     [bool]$profile.host_session_reused -ne $false) {
     throw 'preflight_account_not_ready'
 }
@@ -3077,12 +3099,14 @@ if (Test-Path -LiteralPath $summaryPath) {
 }
 
 $executables = @{
-    desktop = Resolve-CommandPath -Path $CodexDesktopPath -Name 'desktop'
     'codex-cli' = Resolve-CommandPath -Path $CodexCliPath -Name 'codex_cli'
-    zcode = Resolve-CommandPath -Path $ZCodePath -Name 'zcode'
     opencode = Resolve-CommandPath -Path $OpenCodePath -Name 'opencode'
     pi = Resolve-CommandPath -Path $PiPath -Name 'pi'
     omp = Resolve-CommandPath -Path $OmpPath -Name 'omp'
+}
+if (-not $CliOnly) {
+    $executables.desktop = Resolve-CommandPath -Path $CodexDesktopPath -Name 'desktop'
+    $executables.zcode = Resolve-CommandPath -Path $ZCodePath -Name 'zcode'
 }
 if ($script:WindowsInstallMetadata) {
     $nonFixtureExecutables = @($executables.Values | Where-Object {
@@ -3096,30 +3120,45 @@ if ($script:WindowsInstallMetadata) {
 }
 $actualVersions = [ordered]@{}
 Set-RunnerPhase -Phase 'client_materialization'
-foreach ($versionTarget in @(
-    [pscustomobject]@{ client = 'desktop'; key = 'desktop' },
+$versionTargets = @(
     [pscustomobject]@{ client = 'codex-cli'; key = 'codex_cli' },
-    [pscustomobject]@{ client = 'zcode'; key = 'zcode' },
     [pscustomobject]@{ client = 'opencode'; key = 'opencode' },
     [pscustomobject]@{ client = 'pi'; key = 'pi' },
     [pscustomobject]@{ client = 'omp'; key = 'omp' }
-)) {
+)
+if (-not $CliOnly) {
+    $versionTargets = @(
+        [pscustomobject]@{ client = 'desktop'; key = 'desktop' },
+        $versionTargets[0],
+        [pscustomobject]@{ client = 'zcode'; key = 'zcode' },
+        $versionTargets[1],
+        $versionTargets[2],
+        $versionTargets[3]
+    )
+}
+foreach ($versionTarget in $versionTargets) {
     $actualVersions[$versionTarget.key] = Get-NativeClientVersion -Client $versionTarget.client -Executable $executables[$versionTarget.client] -Minimum $script:MinimumVersions[$versionTarget.key] -ProbeRoot (Join-Path $workRoot "version-$($versionTarget.client)")
     $script:ObservedVersions[$versionTarget.key] = $actualVersions[$versionTarget.key]
 }
-$desktopLaunchExecutable = Copy-DesktopApplicationPayload `
-    -Executable $executables.desktop `
-    -WorkRoot $workRoot `
-    -IsolationRoot $isolationRoot
+if (-not $CliOnly) {
+    $desktopLaunchExecutable = Copy-DesktopApplicationPayload `
+        -Executable $executables.desktop `
+        -WorkRoot $workRoot `
+        -IsolationRoot $isolationRoot
+}
 [void](New-Item -ItemType Directory -Path $artifactRoot)
 [void](New-Item -ItemType Directory -Path (Join-Path $artifactRoot 'cases'))
 
-$manualCases = @(
-    [pscustomobject]@{ case_id = 'desktop-luna'; client = 'desktop'; provider_id = 'official'; diagnostic_provider_id = 'official'; client_selector = 'gpt-5.6-luna'; canonical_model = 'gpt-5.6-luna'; gateway_model = 'gpt-5.6-luna'; endpoint_binding = '/v1/responses'; protocol = 'responses'; seed_slot = 'desktop-luna'; legacy_seed_slot = '' },
-    [pscustomobject]@{ case_id = 'desktop-ollama-cloud'; client = 'desktop'; provider_id = 'ollama-cloud'; diagnostic_provider_id = 'ollama_cloud'; client_selector = 'ollama-cloud/glm-5.2'; canonical_model = 'ollama-cloud/glm-5.2'; gateway_model = 'ollama-cloud/glm-5.2'; endpoint_binding = '/v1/providers/ollama-cloud/responses'; protocol = 'responses'; seed_slot = 'desktop-third-party'; legacy_seed_slot = 'desktop-volc' },
-    [pscustomobject]@{ case_id = 'zcode-luna'; client = 'zcode'; provider_id = 'official'; diagnostic_provider_id = 'official'; client_selector = $LunaModel; canonical_model = $LunaModel; gateway_model = 'openai/gpt-5.6-luna'; endpoint_binding = '/v1/providers/openai/responses'; protocol = 'responses'; seed_slot = 'zcode-luna'; legacy_seed_slot = '' },
-    [pscustomobject]@{ case_id = 'zcode-ollama-cloud'; client = 'zcode'; provider_id = 'ollama-cloud'; diagnostic_provider_id = 'ollama_cloud'; client_selector = $ThirdPartyModel; canonical_model = $ThirdPartyModel; gateway_model = 'ollama-cloud/glm-5.2'; endpoint_binding = '/v1/providers/ollama-cloud/responses'; protocol = 'responses'; seed_slot = 'zcode-third-party'; legacy_seed_slot = 'zcode-volc' }
-)
+$manualCases = if ($CliOnly) {
+    @()
+} else {
+    @(
+        [pscustomobject]@{ case_id = 'desktop-luna'; client = 'desktop'; provider_id = 'official'; diagnostic_provider_id = 'official'; client_selector = 'gpt-5.6-luna'; canonical_model = 'gpt-5.6-luna'; gateway_model = 'gpt-5.6-luna'; endpoint_binding = '/v1/responses'; protocol = 'responses'; seed_slot = 'desktop-luna'; legacy_seed_slot = '' },
+        [pscustomobject]@{ case_id = 'desktop-ollama-cloud'; client = 'desktop'; provider_id = 'ollama-cloud'; diagnostic_provider_id = 'ollama_cloud'; client_selector = 'ollama-cloud/glm-5.2'; canonical_model = 'ollama-cloud/glm-5.2'; gateway_model = 'ollama-cloud/glm-5.2'; endpoint_binding = '/v1/providers/ollama-cloud/responses'; protocol = 'responses'; seed_slot = 'desktop-third-party'; legacy_seed_slot = 'desktop-volc' },
+        [pscustomobject]@{ case_id = 'zcode-luna'; client = 'zcode'; provider_id = 'official'; diagnostic_provider_id = 'official'; client_selector = $LunaModel; canonical_model = $LunaModel; gateway_model = 'openai/gpt-5.6-luna'; endpoint_binding = '/v1/providers/openai/responses'; protocol = 'responses'; seed_slot = 'zcode-luna'; legacy_seed_slot = '' },
+        [pscustomobject]@{ case_id = 'zcode-ollama-cloud'; client = 'zcode'; provider_id = 'ollama-cloud'; diagnostic_provider_id = 'ollama_cloud'; client_selector = $ThirdPartyModel; canonical_model = $ThirdPartyModel; gateway_model = 'ollama-cloud/glm-5.2'; endpoint_binding = '/v1/providers/ollama-cloud/responses'; protocol = 'responses'; seed_slot = 'zcode-third-party'; legacy_seed_slot = 'zcode-volc' }
+    )
+}
 $automatedCases = @(
     [pscustomobject]@{ case_id = 'codex-cli-luna'; client = 'codex-cli'; provider_id = 'official'; diagnostic_provider_id = 'official'; client_selector = 'gpt-5.6-luna'; canonical_model = 'gpt-5.6-luna'; gateway_model = 'gpt-5.6-luna'; endpoint_binding = '/v1/responses'; protocol = 'responses' },
     [pscustomobject]@{ case_id = 'codex-cli-ollama-cloud'; client = 'codex-cli'; provider_id = 'ollama-cloud'; diagnostic_provider_id = 'ollama_cloud'; client_selector = 'ollama-cloud/glm-5.2'; canonical_model = 'ollama-cloud/glm-5.2'; gateway_model = 'ollama-cloud/glm-5.2'; endpoint_binding = '/v1/providers/ollama-cloud/responses'; protocol = 'responses' },
@@ -3132,9 +3171,11 @@ $automatedCases = @(
 )
 
 $runBinding = New-RunBinding
-Write-ManualEvidenceTemplate -Path $manualTemplatePath -ManualCases $manualCases -RunBinding $runBinding
-if (Test-Path -LiteralPath $manualEvidencePath) {
-    throw 'manual_evidence_preexisting'
+if (-not $CliOnly) {
+    Write-ManualEvidenceTemplate -Path $manualTemplatePath -ManualCases $manualCases -RunBinding $runBinding
+    if (Test-Path -LiteralPath $manualEvidencePath) {
+        throw 'manual_evidence_preexisting'
+    }
 }
 $trackedProcesses = [System.Collections.Generic.List[System.Diagnostics.Process]]::new()
 $nativeGuiProcesses = [System.Collections.Generic.List[System.Diagnostics.Process]]::new()
@@ -3219,7 +3260,9 @@ try {
         }
         $caseConfigurations[$case.case_id] = $configuration
     }
-    [void](Initialize-ClientConfiguration -Client 'desktop' -CaseRoot $candidateRoot -Model 'gpt-5.6-luna' -CatalogPath $candidateCatalogPath)
+    if (-not $CliOnly) {
+        [void](Initialize-ClientConfiguration -Client 'desktop' -CaseRoot $candidateRoot -Model 'gpt-5.6-luna' -CatalogPath $candidateCatalogPath)
+    }
     $candidateStartupStopwatch.Stop()
     $candidateStartupStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
     $remainingStartupMilliseconds = $candidateStartupBudgetMilliseconds - [int]$candidateStartupStopwatch.ElapsedMilliseconds
@@ -3240,7 +3283,9 @@ try {
     Wait-CandidateGatewayReady -CandidateProcess $candidateProcess -TimeoutMilliseconds $remainingStartupMilliseconds -ElapsedBeforeWaitMilliseconds $elapsedBeforeWaitMilliseconds
     $candidateStartupStopwatch.Stop()
 
-    Set-RunnerPhase -Phase 'manual_evidence'
+    $manualResults = @()
+    if (-not $CliOnly) {
+        Set-RunnerPhase -Phase 'manual_evidence'
     foreach ($guiCase in $manualCases) {
         $guiClient = $guiCase.client
         $guiRoot = Join-Path $workRoot ("gui-" + $guiClient)
@@ -3315,6 +3360,7 @@ try {
         Start-Sleep -Milliseconds 100
     }
     $manualResults = @(Get-ManualResults -EvidencePath $manualEvidencePath -ManualCases $manualCases -ArtifactRoot $artifactRoot -RunBinding $runBinding)
+    }
 
     Set-RunnerPhase -Phase 'automated_cases'
     $automatedById = @{}
@@ -3325,25 +3371,35 @@ try {
     foreach ($result in $manualResults) {
         $manualById[$result.case_id] = $result
     }
-    $caseOrder = @(
-        'desktop-luna', 'desktop-ollama-cloud',
-        'codex-cli-luna', 'codex-cli-ollama-cloud',
-        'opencode-luna', 'opencode-ollama-cloud',
-        'zcode-luna', 'zcode-ollama-cloud',
-        'pi-luna', 'pi-ollama-cloud',
-        'omp-luna', 'omp-ollama-cloud'
-    )
+    $caseOrder = if ($CliOnly) {
+        @(
+            'codex-cli-luna', 'codex-cli-ollama-cloud',
+            'opencode-luna', 'opencode-ollama-cloud',
+            'pi-luna', 'pi-ollama-cloud',
+            'omp-luna', 'omp-ollama-cloud'
+        )
+    } else {
+        @(
+            'desktop-luna', 'desktop-ollama-cloud',
+            'codex-cli-luna', 'codex-cli-ollama-cloud',
+            'opencode-luna', 'opencode-ollama-cloud',
+            'zcode-luna', 'zcode-ollama-cloud',
+            'pi-luna', 'pi-ollama-cloud',
+            'omp-luna', 'omp-ollama-cloud'
+        )
+    }
     $caseResults = @($caseOrder | ForEach-Object {
         if ($manualById.ContainsKey($_)) { $manualById[$_] } else { $automatedById[$_] }
     })
     $passedCount = @($caseResults | Where-Object { $_.outcome -ceq 'passed' }).Count
     $summary = [ordered]@{
         schema = 'codexhub.real-client-e2e-summary.v2'
+        verification_scope = $script:VerificationScope
         candidate_sha = $CandidateSha
         managed_client_config_sha = $ManagedClientConfigSha
         run_binding_sha256 = $runBinding
-        outcome = if ($passedCount -eq 12) { 'passed' } else { 'failed' }
-        failure_classification = if ($passedCount -eq 12) { 'none' } else { 'case_failure' }
+        outcome = if ($passedCount -eq $caseResults.Count -and $caseResults.Count -gt 0) { 'passed' } else { 'failed' }
+        failure_classification = if ($passedCount -eq $caseResults.Count -and $caseResults.Count -gt 0) { 'none' } else { 'case_failure' }
         hashes = [ordered]@{
             debug_build = Get-Sha256 -Path $DebugBuild
             managed_client_config_build = Get-Sha256 -Path $ManagedClientConfigBuild
@@ -3351,18 +3407,18 @@ try {
         pinned_versions = $actualVersions
         canonical_models = @('gpt-5.6-luna', 'ollama-cloud/glm-5.2', $LunaModel, $ThirdPartyModel)
         counts = [ordered]@{
-            case_count = 12
+            case_count = $caseResults.Count
             passed_count = $passedCount
-            failed_count = 12 - $passedCount
-            manual_case_count = 4
-            automated_case_count = 8
+            failed_count = $caseResults.Count - $passedCount
+            manual_case_count = $manualResults.Count
+            automated_case_count = $automatedCases.Count
         }
         cases = $caseResults
         artifacts = @($caseResults | ForEach-Object { $_.artifact })
     }
     Set-RunnerPhase -Phase 'summary'
     Write-JsonFile -Path $summaryPath -Value $summary
-    if ($passedCount -ne 12) {
+    if ($passedCount -ne $caseResults.Count -or $caseResults.Count -eq 0) {
         exit 1
     }
 }
@@ -3389,6 +3445,7 @@ catch {
     }
     $failureSummary = [ordered]@{
         schema = 'codexhub.real-client-e2e-summary.v2'
+        verification_scope = $script:VerificationScope
         candidate_sha = if ($CandidateSha -match '^[0-9a-f]{40}$') { $CandidateSha } else { $null }
         managed_client_config_sha = if ($ManagedClientConfigSha -match '^[0-9a-f]{40}$') { $ManagedClientConfigSha } else { $null }
         outcome = 'failed'

--- a/tests/test_real_client_e2e.py
+++ b/tests/test_real_client_e2e.py
@@ -29,6 +29,7 @@ MINIMUM_VERSIONS = {
 }
 SUMMARY_KEYS = {
     "schema",
+    "verification_scope",
     "candidate_sha",
     "managed_client_config_sha",
     "run_binding_sha256",
@@ -399,6 +400,7 @@ def _run(
     manual_timeout_seconds: int = 10,
     overall_timeout_seconds: int = 180,
     authoritative_paths_with_spaces: bool = False,
+    cli_only: bool = False,
 ) -> subprocess.CompletedProcess[str]:
     output, isolation, debug_build, materializer_build, host_manifest = _prepare_run(
         tmp_path, candidate_sha, materializer_sha
@@ -418,6 +420,11 @@ def _run(
     }
     for name, fixture_name in (client_fakes or {}).items():
         executable_arguments[name] = FIXTURES / fixture_name
+    if cli_only:
+        # CLI-only mode must not even resolve the GUI clients. Keep these
+        # paths absent so a regression back to GUI preflight fails the test.
+        executable_arguments["CodexDesktopPath"] = tmp_path / "missing-codex-desktop.exe"
+        executable_arguments["ZCodePath"] = tmp_path / "missing-zcode.exe"
     if authoritative_paths_with_spaces:
         candidate_root = tmp_path / "Program Files" / "CodexHub Candidate"
         candidate_root.mkdir(parents=True)
@@ -510,6 +517,8 @@ def _run(
     for name, executable in executable_arguments.items():
         command.extend((f"-{name}", str(executable)))
     command.extend(("-TimeoutSeconds", str(timeout_seconds)))
+    if cli_only:
+        command.append("-CliOnly")
     command.extend(("-ManualEvidenceTimeoutSeconds", str(manual_timeout_seconds)))
     command.extend(("-OverallTimeoutSeconds", str(overall_timeout_seconds)))
     finalizer = None
@@ -1005,7 +1014,10 @@ def test_materializer_build_sidecar_must_match_explicit_current_candidate_sha(tm
 
 def _assert_exact_summary_schema(summary: dict) -> None:
     assert set(summary) == (SUMMARY_KEYS if summary["cases"] else FAILURE_SUMMARY_KEYS)
-    assert set(summary["pinned_versions"]) == set(MINIMUM_VERSIONS)
+    expected_versions = set(MINIMUM_VERSIONS)
+    if summary.get("verification_scope") == "cli_only":
+        expected_versions -= {"desktop", "zcode"}
+    assert set(summary["pinned_versions"]) == expected_versions
     assert set(summary["counts"]) == COUNT_KEYS
     if summary["cases"]:
         assert set(summary["hashes"]) == {
@@ -1040,6 +1052,53 @@ def test_operator_workflow_uses_authoritative_machine_bound_local_host():
     assert "VM snapshot" not in documentation
 
 
+def test_cli_only_matrix_skips_gui_requirements_and_marks_scope(tmp_path):
+    def disable_gui_readiness(_output, isolation, _debug):
+        profile_path = isolation / "account" / "profile.json"
+        profile = json.loads(profile_path.read_text(encoding="utf-8"))
+        profile["gui_ready"] = False
+        profile_path.write_text(json.dumps(profile), encoding="utf-8")
+
+    result = _run(
+        tmp_path,
+        cli_only=True,
+        mutate=disable_gui_readiness,
+        finalize_manual=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    output = tmp_path / "output"
+    summary = json.loads((output / "summary.json").read_text(encoding="utf-8-sig"))
+    _assert_exact_summary_schema(summary)
+    assert summary["verification_scope"] == "cli_only"
+    assert set(summary["pinned_versions"]) == {
+        "codex_cli",
+        "opencode",
+        "pi",
+        "omp",
+    }
+    assert summary["counts"] == {
+        "case_count": 8,
+        "passed_count": 8,
+        "failed_count": 0,
+        "manual_case_count": 0,
+        "automated_case_count": 8,
+    }
+    assert [case["case_id"] for case in summary["cases"]] == [
+        "codex-cli-luna",
+        "codex-cli-ollama-cloud",
+        "opencode-luna",
+        "opencode-ollama-cloud",
+        "pi-luna",
+        "pi-ollama-cloud",
+        "omp-luna",
+        "omp-ollama-cloud",
+    ]
+    assert not (output / "manual-evidence.template.json").exists()
+    assert not (output / "manual-evidence.json").exists()
+    assert not list((output / "isolated" / "work").glob("gui-*.launched"))
+
+
 def test_exact_compatibility_floors_pass_and_emit_one_sanitized_sha_bound_summary(
     tmp_path,
 ):
@@ -1051,6 +1110,7 @@ def test_exact_compatibility_floors_pass_and_emit_one_sanitized_sha_bound_summar
     summary = json.loads(summaries[0].read_text(encoding="utf-8-sig"))
     _assert_exact_summary_schema(summary)
     assert summary["schema"] == "codexhub.real-client-e2e-summary.v2"
+    assert summary["verification_scope"] == "gui_and_cli"
     assert summary["candidate_sha"] == CANDIDATE_SHA
     assert summary["pinned_versions"] == MINIMUM_VERSIONS
     assert summary["counts"] == {


### PR DESCRIPTION
## Summary
- add an explicit `-CliOnly` scope to the real-client E2E runner
- skip Desktop/ZCode resolution, GUI seeds, GUI readiness, and manual evidence in that scope
- mark summaries with `verification_scope=cli_only` and cover the eight CLI cases
- keep the existing 12-case GUI mode unchanged

## Verification
- `python -m pytest -q tests/test_real_client_e2e.py -k "cli_only_matrix or exact_compatibility_floors or runner_invokes_candidate_materializer_for_every_managed_client or baseline_gateway_is_bound_to_exact_current_candidate_materializer"` (4 passed)
- `python -m pytest -q tests/test_real_client_e2e.py -k "operator_commands_have_explicit_outer_and_manual_deadlines or matrix_documentation_declares_native_responses_release_gate or supervisor_start_gate_is_unique_and_fail_closed"` (3 passed)
- PowerShell parser check passed
- formal CLI-only run attempted with isolated credentials; blocked before cases by candidate native model-cache bootstrap timeout (Codex CLI 0.146.0), recorded on #62

Refs #62
