### PR TITLE
release: promote 0.1.8-beta.2 to main

### DIFF
--- a/docs/agents/real-client-e2e.md
+++ b/docs/agents/real-client-e2e.md
@@ -1,8 +1,10 @@
 # Real-client E2E gate
 
 `scripts/Run-RealClientE2E.ps1` is the release-only Windows gate for proving
-that one candidate Debug build routes six compatible real clients through both
-canonical routes. HTTP/configuration preflight alone is never an E2E pass.
+that one candidate Debug build routes compatible clients through both canonical
+routes. HTTP/configuration preflight alone is never an E2E pass. Beta2 uses the
+explicit `-CliOnly` scope described below; the full GUI matrix remains available
+for a later release qualification.
 
 ## Authoritative host and compatibility baselines
 
@@ -282,6 +284,19 @@ Cloud Native Responses path; the previous Volc Chat Completions
 path remains available as ordinary, non-release regression coverage and is not represented as
 Native Responses evidence in this matrix.
 
+### Beta2 CLI-only verification
+
+Pass `-CliOnly` when the current release gate is limited to command-line
+clients. This mode runs exactly the eight automated cases for Codex CLI,
+OpenCode, Pi, and OMP (Official Luna and Ollama Cloud for each). It does not
+resolve or start Codex Desktop or ZCode, does not inspect GUI seeds, does not
+require `gui_ready = true`, and never creates or waits for
+`manual-evidence.template.json` or `manual-evidence.json`. A CLI-only summary
+has `verification_scope = "cli_only"`, `manual_case_count = 0`, and
+`automated_case_count = 8`; its `pinned_versions` contains only the four CLI
+clients. The eight cases must still pass their normal model, route, streaming,
+tool, terminal, retry, and Gateway-correlation checks.
+
 Each case creates one disposable `sentinel.txt`. The client must use exactly
 one successful read-only read tool, emit the named sentinel once, and finish
 once. The compatibility-baseline client parsers consume their real JSONL
@@ -477,6 +492,11 @@ powershell -NoProfile -File scripts/Run-RealClientE2E.ps1 `
   -ManualEvidenceTimeoutSeconds 900
 ```
 
+For the Beta2 CLI-only gate, add `-CliOnly` to the command. GUI seed
+directories, GUI executables, and manual evidence are not needed in that
+scope; the runner must exit `0` with `verification_scope` `cli_only` and eight
+passed cases.
+
 6. Wait for the template and four case-local GUI launches (Desktop and ZCode,
    each with Luna and Ollama Cloud). Each launch consumes its own #194-applied
    root.
@@ -525,7 +545,7 @@ completion. An outer timeout references only the fixed sanitized
 artifact per case and uses `failure_classification` `none` or `case_failure`.
 
 The success summary uses schema `codexhub.real-client-e2e-summary.v2`. Its
-top-level keys are exactly `schema`, `candidate_sha`,
+top-level keys are exactly `schema`, `verification_scope`, `candidate_sha`,
 `managed_client_config_sha`, `run_binding_sha256`, `outcome`, `failure_classification`, `hashes`,
 `pinned_versions`, `canonical_models`, `counts`, `cases`, and `artifacts`.
 The legacy-named `pinned_versions` object contains the actual normalized versions

--- a/docs/evidence/issue-62/README.md
+++ b/docs/evidence/issue-62/README.md
@@ -224,6 +224,18 @@ consumes planner completeness, current-binding cold-start, full-wire
 fingerprinting, non-streaming, and identity-replay statuses; item dispositions
 alone cannot make an incomplete evidence set ready.
 
+The reconciler also binds every taxonomy item's `evidence_source` to the
+declared fixture path/scope (including advanced and live-control sentinels).
+The `identity_response_ids` source is an explicit pair, written as
+`pre_gateway.response.streaming.response_id|post_gateway.response.streaming.response_id`;
+both pointers must exist and contain equal non-empty aliases.
+Core claims already proven by this bounded capture must remain `preserved` or
+`reversibly_adapted`; `local_consume` and `Unsupported` cannot downgrade those
+claims. Candidate source and Codex source commits must agree, and the trace,
+wire fixture, and capture identity are reopened and compared when an evidence
+root is supplied. Contradictory self-contained candidate metadata is rejected
+even for in-memory replay checks without a live or upstream control.
+
 `identity_control.unknown_tagged_source_count` is recomputed from the bound wire
 fixture during reconciliation; changing the count without changing the source
 evidence fails closed.

--- a/docs/evidence/issue-62/README.md
+++ b/docs/evidence/issue-62/README.md
@@ -230,3 +230,71 @@ evidence fails closed.
 
 The live-control-required gates remain open until the separately authorized
 live control window documented above captures real evidence for each one.
+
+## Isolated live-evidence sidecar lane
+
+`scripts/capture_issue_62_live_evidence.py` is a standalone, standard-library
+capture sidecar for a future, separately authorized live-control window. It is
+not imported by Desktop or Gateway, has no settings/environment activation
+path, and refuses to listen without `--enable-live-capture`. It accepts only a
+loopback listen address.
+
+Run two independent instances around an isolated Gateway process:
+
+```text
+isolated client -> pre sidecar -> isolated Gateway -> post sidecar -> upstream
+```
+
+The two commands require distinct output directories and a shared, isolated
+32-byte-or-longer HMAC key file. The operator must replace every angle-bracket
+token only after the live window identifies the exact candidate, isolated
+Gateway port, authorized upstream base URL, bounds, and cleanup owner.
+
+```powershell
+py -3.13 scripts/capture_issue_62_live_evidence.py `
+  --enable-live-capture `
+  --hop pre `
+  --listen-host 127.0.0.1 `
+  --listen-port 19162 `
+  --forward-base-url http://127.0.0.1:<ISOLATED_GATEWAY_PORT> `
+  --output-dir <ISOLATED_OUTPUT_ROOT>\pre `
+  --hmac-key-file <ISOLATED_HMAC_KEY_FILE> `
+  --max-request-bytes <AUTHORIZED_REQUEST_CAP> `
+  --max-response-bytes <AUTHORIZED_RESPONSE_CAP> `
+  --connect-timeout-seconds <AUTHORIZED_CONNECT_TIMEOUT> `
+  --read-timeout-seconds <AUTHORIZED_READ_TIMEOUT> `
+  --overall-timeout-seconds <AUTHORIZED_OVERALL_TIMEOUT>
+
+py -3.13 scripts/capture_issue_62_live_evidence.py `
+  --enable-live-capture `
+  --hop post `
+  --listen-host 127.0.0.1 `
+  --listen-port 19163 `
+  --forward-base-url <AUTHORIZED_UPSTREAM_BASE_URL> `
+  --output-dir <ISOLATED_OUTPUT_ROOT>\post `
+  --hmac-key-file <ISOLATED_HMAC_KEY_FILE> `
+  --max-request-bytes <AUTHORIZED_REQUEST_CAP> `
+  --max-response-bytes <AUTHORIZED_RESPONSE_CAP> `
+  --connect-timeout-seconds <AUTHORIZED_CONNECT_TIMEOUT> `
+  --read-timeout-seconds <AUTHORIZED_READ_TIMEOUT> `
+  --overall-timeout-seconds <AUTHORIZED_OVERALL_TIMEOUT>
+```
+
+Each hop writes only an atomic sanitized JSON record: complete application-body
+byte counts, SHA-256/HMAC-SHA-256 values, an ordered SSE-frame digest, bounded
+terminal classifications, or a fixed incomplete failure code. URLs, paths,
+headers, credentials, key material, raw bodies, prompt/tool content, wire
+identifiers, and exception text are never artifact fields. Overflow, timeout,
+cancellation, forwarding failure, incomplete SSE framing, and server lifecycle
+failure cannot produce a complete record and leave no `.partial` artifact.
+
+The focused tests use loopback fake servers only:
+
+```powershell
+py -3.13 -m pytest -q tests/test_issue_62_live_evidence_sidecar.py
+```
+
+A passing test means only `synthetic_lane_verified`. Do not aim these commands
+at the currently running Desktop or Gateway, perform an upstream request,
+change the runtime inventory, or infer Issue #62 qualification without a new
+maintainer-authorized live-control window and artifact readback.

--- a/docs/evidence/issue-62/README.md
+++ b/docs/evidence/issue-62/README.md
@@ -137,4 +137,96 @@ The remaining gates require a separately authorized live control: complete
 registered contributor/defer-loading capture, a clean current-binding cold
 start, independently fingerprinted full caller/upstream/downstream requests
 and responses, a real non-streaming request, and observed non-Direct states.
-No such control was run for this audit.
+
+## Versioned runtime/wire inventory
+
+`runtime-wire-inventory.json` is the versioned inventory artifact that feeds
+#249 (the beta.1 capability gate) and #66 (the Chat conversion matrix). It
+records one per-scope disposition for every taxonomy item the Codex CLI
+exposes over the core Responses contract and the explicitly-deferred advanced
+capabilities.
+
+The artifact is bound to CLI floor `0.145.0` and to the candidate identity
+derived from the existing sanitized artifacts (`cli_version=0.144.0-alpha.4`,
+source commit `9e552e9d15ba52bed7077d5357f3e18e330f8f38`, official Responses
+route). Because the captured CLI is below the floor, the generated
+`qualification.ready_for_beta1` is `false` and the candidate is explicitly
+marked `legacy_below_floor`; this evidence cannot be used as the beta.1
+candidate. The generator rejects an explicitly supplied CLI/source value that
+does not match the trace, binds route/provider/model fields across trace and
+wire fixtures (including pre/post models, catalog binding, and route profile),
+and records a canonical-LF SHA-256 manifest for all three input artifacts.  It
+never fabricates a capability disposition for a gate the artifacts do not
+qualify.
+
+The qualification also has a separate `wire_identity_replay` gate. A full
+request/response fingerprint is not treated as replay proof by itself: a
+future capture must record fail-closed identity, mutation, deletion, and loss
+cases as complete/met, with each case observed and bound to the current wire
+fixture SHA-256 plus an output digest. The current sanitized evidence has no
+such wire replay record, so this gate remains `not_captured`. Likewise,
+`sse_identity` requires an independent pre/post stream-sequence digest bound to
+the same wire fixture; full-body request/response equality alone is not enough.
+
+### Disposition vocabulary
+
+| Disposition | Meaning |
+| --- | --- |
+| `preserved` | Observed and carried through unchanged |
+| `reversibly_adapted` | Observed with a documented reversible adaptation |
+| `local_consume` | Observed and consumed locally without upstream I/O |
+| `Unsupported` | Out of scope for the beta.1 core contract |
+| `Unqualified` | The bounded artifacts do not qualify the item; a separately authorized live control window must capture it before any capability claim |
+
+### Taxonomy coverage
+
+Core items (`preserved`/`reversibly_adapted` where the bounded artifacts prove
+them): core text streaming, multi-turn history, item/call IDs, streaming SSE
+event kinds, standard function declaration/call/result, and identity
+(request/response/item/call IDs). Function replay remains `Unqualified`: the
+sanitized call-link fixture proves the shape of call/result pairs, while the
+tool-membership replay does not prove a complete real-wire function replay.
+
+Live-control items are `Unqualified` until a coordinated live window captures
+them: non-streaming text, choice controls (the wire fixture carries a contract
+sentinel; the bounded audit observes `tool_choice`/`parallel_tool_calls` but
+full pre/post choice identity requires a live control), terminal events, errors,
+hosted-only declarations, unknown tagged sentinels, and default runtime fields.
+
+Advanced capabilities (`Unsupported`/`Unqualified`): Code Mode, `tool_search`,
+Collaboration V2, and Chat conversion are explicitly deferred for beta.1 per
+#248/#258 and are not advertised.
+
+### Identity control
+
+The inventory reports `unclassified_core_items: 0` and fails closed on
+mutation, deletion, and loss. Replay cases run through both the Python
+generator (`scripts/build_issue_62_runtime_inventory.py --replay-case`) and
+the PowerShell reconciliation (`scripts/check-codex-thread-tool-surface.ps1
+-InventoryReplayCase`):
+
+```powershell
+python scripts/build_issue_62_runtime_inventory.py
+python scripts/build_issue_62_runtime_inventory.py --check-drift
+python scripts/build_issue_62_runtime_inventory.py --replay-case mutation
+powershell -NoProfile -ExecutionPolicy Bypass -File scripts/check-codex-thread-tool-surface.ps1
+powershell -NoProfile -ExecutionPolicy Bypass -File scripts/check-codex-thread-tool-surface.ps1 -InventoryReplayCase mutation
+```
+
+Regeneration is deterministic and the `--check-drift` mode compares a fresh
+generation to this committed JSON artifact without writing it. The PowerShell
+reconciliation invokes the same drift check, then independently checks the
+input fingerprints, rejects duplicate scopes, and requires each core scope to
+point at its declared evidence path. A zero
+`unclassified_core_items` count therefore describes vocabulary validity only;
+`qualification.ready_for_beta1` is the separate completion gate. That gate also
+consumes planner completeness, current-binding cold-start, full-wire
+fingerprinting, non-streaming, and identity-replay statuses; item dispositions
+alone cannot make an incomplete evidence set ready.
+
+`identity_control.unknown_tagged_source_count` is recomputed from the bound wire
+fixture during reconciliation; changing the count without changing the source
+evidence fails closed.
+
+The live-control-required gates remain open until the separately authorized
+live control window documented above captures real evidence for each one.

--- a/docs/evidence/issue-62/README.md
+++ b/docs/evidence/issue-62/README.md
@@ -243,6 +243,25 @@ evidence fails closed.
 The live-control-required gates remain open until the separately authorized
 live control window documented above captures real evidence for each one.
 
+### Sanitized control manifest
+
+`scripts/build_issue_62_control_manifest.py` joins sanitized pre/post sidecar
+records with the eight live-control labels.  The manifest stores only
+allow-listed shapes, byte/SSE SHA-256/HMAC fingerprints, aggregate reference
+counts, and candidate provenance; it never stores request/response bodies,
+URLs, headers, credentials, prompts, tool arguments, or wire identifiers.
+`synthetic_fixture_only` is always ineligible for Issue #62.  Reconciliation
+validates the canonical manifest schema and fails closed on mutation,
+deletion, loss, missing fingerprints, or route/catalog mismatch.
+
+For Codex CLI `0.146.0`, the package metadata does not include `gitHead`.
+Evidence may use `cli_source_commit: null` with
+`cli_source_commit_status: not_published_by_registry`; a fabricated SHA is
+not acceptable.  If the npm provenance attestation has been independently
+verified, its exact SLSA resolved-dependency commit may instead be recorded
+with status `published` (for `0.146.0`, the attested release commit is
+`e363b08c9175ac1cbe5893615dd2cb9ddf95043b2`).
+
 ## Isolated live-evidence sidecar lane
 
 `scripts/capture_issue_62_live_evidence.py` is a standalone, standard-library

--- a/docs/evidence/issue-62/codexhub-runtime-wire-fixture.json
+++ b/docs/evidence/issue-62/codexhub-runtime-wire-fixture.json
@@ -12,7 +12,20 @@
     "configured_provider_id": "custom",
     "upstream_route": "official",
     "catalog_binding": "official Codex catalog entry for openai/gpt-5.6-sol",
+    "behavior_profile": "official_codex_app_http_passthrough",
+    "route_mode": "official",
+    "wire_format_adapter": "transparent",
+    "codex_semantic_adapter": "none",
+    "repair_policy": "none",
+    "catalog_snapshot_sha256": "307a09f22b0c827ae77192a4beaf7059efcf8a698ec4f252aa4ba4787f8d1876",
+    "catalog_model_entry_id": "gpt-5.6-sol",
+    "catalog_model_supports_search_tool": true,
     "classification_basis": "upstream_route and catalog_binding; never configured_provider_id alone"
+  },
+  "provenance": {
+    "cli_version": "0.144.0-alpha.4",
+    "source_commit": "9e552e9d15ba52bed7077d5357f3e18e330f8f38",
+    "capture_id": "sanitized-current-side-capture"
   },
   "exposure_state_tags": ["Direct", "DirectModelOnly", "Deferred", "Hidden", "hosted-only", "host-unavailable"],
   "pre_gateway": {

--- a/docs/evidence/issue-62/runtime-wire-inventory.json
+++ b/docs/evidence/issue-62/runtime-wire-inventory.json
@@ -139,7 +139,7 @@
     },
     {
       "disposition": "preserved",
-      "evidence_source": "codexhub-runtime-wire-fixture.json#response.streaming.response_id",
+      "evidence_source": "codexhub-runtime-wire-fixture.json#pre_gateway.response.streaming.response_id|post_gateway.response.streaming.response_id",
       "notes": "response_id aliases preserved across pre/post-Gateway replay",
       "scope": "identity_response_ids"
     },

--- a/docs/evidence/issue-62/runtime-wire-inventory.json
+++ b/docs/evidence/issue-62/runtime-wire-inventory.json
@@ -1,0 +1,259 @@
+{
+  "artifact_kind": "runtime_wire_inventory",
+  "candidate_identity": {
+    "catalog_binding": "official Codex catalog entry for openai/gpt-5.6-sol",
+    "catalog_model_entry_id": "gpt-5.6-sol",
+    "catalog_snapshot_sha256": "307a09f22b0c827ae77192a4beaf7059efcf8a698ec4f252aa4ba4787f8d1876",
+    "cli_version": "0.144.0-alpha.4",
+    "codex_source_commit": "9e552e9d15ba52bed7077d5357f3e18e330f8f38",
+    "configured_provider_id": "custom",
+    "evidence_manifest_sha256": "9dfb5f48f52f27603d4d27066d0ed8a2e300600bcdbdff9a24f594a9892e5c22",
+    "inbound_format": "responses",
+    "model": "gpt-5.6-sol",
+    "route_behavior_profile": "official_codex_app_http_passthrough",
+    "route_upstream": "official",
+    "source_commit": "9e552e9d15ba52bed7077d5357f3e18e330f8f38",
+    "upstream_format": "responses"
+  },
+  "cli_version_floor": "0.145.0",
+  "disposition_vocabulary": [
+    "preserved",
+    "reversibly_adapted",
+    "local_consume",
+    "Unsupported",
+    "Unqualified"
+  ],
+  "evidence_binding": {
+    "audit": {
+      "file": "read-only-gate-audit.json",
+      "sha256": "a27f27622f89436f9530e2a7ca31f4b1b48872a31bbced8426302682f8516fa0"
+    },
+    "trace": {
+      "file": "current-codexhub-thread-tool-surface.json",
+      "sha256": "a4367f96fc2aceaa419577ee43f91870fb3fcca4cc95644bc3347cbdd4206ee3"
+    },
+    "wire_fixture": {
+      "file": "codexhub-runtime-wire-fixture.json",
+      "sha256": "3a8654854539799b526bc013c50bc9f16c40c09319cff8da716b75e6deecbc3a"
+    }
+  },
+  "evidence_sources": {
+    "audit": "read-only-gate-audit.json",
+    "trace": "current-codexhub-thread-tool-surface.json",
+    "wire_fixture": "codexhub-runtime-wire-fixture.json"
+  },
+  "feeds": {
+    "capability_gate": "#249",
+    "chat_conversion_matrix": "#66"
+  },
+  "identity_control": {
+    "fail_closed": true,
+    "replay_cases": [
+      "identity",
+      "mutation",
+      "deletion",
+      "loss"
+    ],
+    "unclassified_core_items": 0,
+    "unclassified_scopes": [],
+    "unknown_tagged_source_count": 2
+  },
+  "items": [
+    {
+      "disposition": "preserved",
+      "evidence_source": "codexhub-runtime-wire-fixture.json#response.streaming.captured",
+      "notes": "streaming response text observed and preserved across the official Responses route",
+      "scope": "core_text_streaming"
+    },
+    {
+      "disposition": "Unqualified",
+      "evidence_source": "codexhub-runtime-wire-fixture.json#response.non_streaming.captured",
+      "notes": "non-streaming response text is only qualified when a real captured fixture is present",
+      "scope": "core_text_non_streaming"
+    },
+    {
+      "disposition": "preserved",
+      "evidence_source": "codexhub-runtime-wire-fixture.json#history.captured_source_counts.paired_calls",
+      "notes": "multi-turn history with paired call/output rows observed",
+      "scope": "core_history_multiturn"
+    },
+    {
+      "disposition": "preserved",
+      "evidence_source": "codexhub-runtime-wire-fixture.json#history.call_links",
+      "notes": "call_item_id and output_item_id aliases preserved per link",
+      "scope": "core_history_item_ids"
+    },
+    {
+      "disposition": "preserved",
+      "evidence_source": "codexhub-runtime-wire-fixture.json#history.required_call_ids",
+      "notes": "call_id aliases preserved and reconciled with call links",
+      "scope": "core_history_call_ids"
+    },
+    {
+      "disposition": "reversibly_adapted",
+      "evidence_source": "codexhub-runtime-wire-fixture.json#response.streaming.events",
+      "notes": "observed SSE event kinds sanitized to redacted payloads with stable event sequence",
+      "scope": "core_sse_streaming_events"
+    },
+    {
+      "disposition": "Unqualified",
+      "evidence_source": "read-only-gate-audit.json#gateway_identity_route.observed_sse_event_type_counts",
+      "notes": "terminal event classification requires independently captured full response-body evidence",
+      "scope": "core_sse_terminal_events"
+    },
+    {
+      "disposition": "Unqualified",
+      "evidence_source": "read-only-gate-audit.json#gate_classification.full_pre_post_request_response",
+      "notes": "error classification requires independently fingerprinted pre/post response bodies",
+      "scope": "core_sse_errors"
+    },
+    {
+      "disposition": "preserved",
+      "evidence_source": "codexhub-runtime-wire-fixture.json#pre_gateway.tool_surface.namespaces",
+      "notes": "Direct and Deferred function declarations observed for the codex_app namespace",
+      "scope": "core_function_declaration"
+    },
+    {
+      "disposition": "preserved",
+      "evidence_source": "codexhub-runtime-wire-fixture.json#history.call_links",
+      "notes": "function_call items with call_id and arguments aliases observed",
+      "scope": "core_function_call"
+    },
+    {
+      "disposition": "preserved",
+      "evidence_source": "codexhub-runtime-wire-fixture.json#history.call_links",
+      "notes": "function_call_output items with call_id and output aliases observed",
+      "scope": "core_function_result"
+    },
+    {
+      "disposition": "Unqualified",
+      "evidence_source": "codexhub-runtime-wire-fixture.json#history.call_links",
+      "notes": "call/result links are present, but the bounded tool-membership replay does not prove a complete function replay across the real wire",
+      "scope": "core_function_replay"
+    },
+    {
+      "disposition": "preserved",
+      "evidence_source": "codexhub-runtime-wire-fixture.json#history.call_links",
+      "notes": "item/call id aliases preserved across pre/post-Gateway replay",
+      "scope": "identity_item_call_ids"
+    },
+    {
+      "disposition": "preserved",
+      "evidence_source": "codexhub-runtime-wire-fixture.json#response.streaming.response_id",
+      "notes": "response_id aliases preserved across pre/post-Gateway replay",
+      "scope": "identity_response_ids"
+    },
+    {
+      "disposition": "preserved",
+      "evidence_source": "codexhub-runtime-wire-fixture.json#pre_gateway.request_id",
+      "notes": "request_id aliases preserved and equal across pre/post-Gateway replay",
+      "scope": "identity_request_ids"
+    },
+    {
+      "disposition": "Unqualified",
+      "evidence_source": "codexhub-runtime-wire-fixture.json#pre_gateway.choice_controls.captured=false",
+      "notes": "choice controls are a contract sentinel in the wire fixture; the bounded audit observes tool_choice/parallel_tool_calls but full pre/post choice identity requires a live control",
+      "scope": "choice_controls"
+    },
+    {
+      "disposition": "Unqualified",
+      "evidence_source": "read-only-gate-audit.json#gate_classification.full_pre_post_request_response=live_control_required",
+      "notes": "terminal event classification requires a real captured response body fingerprint",
+      "scope": "terminal_events"
+    },
+    {
+      "disposition": "Unqualified",
+      "evidence_source": "read-only-gate-audit.json#gate_classification.full_pre_post_request_response=live_control_required",
+      "notes": "error classification requires independently captured pre/post response evidence",
+      "scope": "errors"
+    },
+    {
+      "disposition": "Unqualified",
+      "evidence_source": "current-codexhub-thread-tool-surface.json#exposure_state_catalog",
+      "notes": "hosted-only and host-unavailable are tagged reconciliation sentinels; no runtime-observed host binding",
+      "scope": "hosted_only_declarations"
+    },
+    {
+      "disposition": "Unqualified",
+      "evidence_source": "codexhub-runtime-wire-fixture.json#response.streaming.events.tag=unknown",
+      "notes": "unknown tagged sentinels are preserved as opaque replay sentinels; live runtime dispositions require a real unknown item",
+      "scope": "unknown_tagged_sentinels"
+    },
+    {
+      "disposition": "Unqualified",
+      "evidence_source": "read-only-gate-audit.json#model_visible_request_plan.top_level_field_presence",
+      "notes": "default runtime field classification requires an independently captured full request body",
+      "scope": "default_runtime_fields"
+    },
+    {
+      "disposition": "Unsupported",
+      "evidence_source": "issue-248#beta.1-scope",
+      "notes": "Code Mode is beta.2 scope (#251/#279/#280); not advertised in beta.1",
+      "scope": "code_mode"
+    },
+    {
+      "disposition": "Unqualified",
+      "evidence_source": "current-codexhub-thread-tool-surface.json#planner_gates.caller_request",
+      "notes": "client-executed tool_search is observed in the caller request but model non-selection is owned by #63; beta.2 scope",
+      "scope": "tool_search"
+    },
+    {
+      "disposition": "Unsupported",
+      "evidence_source": "issue-248#beta.3-scope",
+      "notes": "Collaboration V2 is beta.3 scope (#64/#282/#283); observed multi_agent_version='v2' is not advertised in beta.1",
+      "scope": "collaboration_v2"
+    },
+    {
+      "disposition": "Unsupported",
+      "evidence_source": "issue-248#beta.4-scope",
+      "notes": "Chat conversion is beta.4 scope (#66/#253/#254); not advertised in beta.1",
+      "scope": "chat_conversion"
+    }
+  ],
+  "qualification": {
+    "blocking_gates": [
+      "clean_cold_start_current_binding",
+      "complete_model_visible_plan",
+      "error_events",
+      "full_pre_post_request_response",
+      "full_request_fingerprint",
+      "full_response_fingerprint",
+      "identity_replay",
+      "non_streaming",
+      "non_streaming_fixture",
+      "sse_identity",
+      "terminal_events",
+      "wire_identity_replay"
+    ],
+    "blocking_scopes": [
+      "choice_controls",
+      "core_function_replay",
+      "core_sse_errors",
+      "core_sse_terminal_events",
+      "core_text_non_streaming",
+      "default_runtime_fields",
+      "errors",
+      "hosted_only_declarations",
+      "terminal_events",
+      "unknown_tagged_sentinels"
+    ],
+    "candidate_version_eligible": false,
+    "candidate_version_status": "legacy_below_floor",
+    "evidence_gates": {
+      "clean_cold_start_current_binding": "not_run",
+      "complete_model_visible_plan": "partial",
+      "error_events": "not_captured",
+      "full_pre_post_request_response": "live_control_required",
+      "full_request_fingerprint": "not_captured",
+      "full_response_fingerprint": "not_captured",
+      "identity_replay": "partial",
+      "non_streaming": "live_control_required",
+      "non_streaming_fixture": "not_captured",
+      "sse_identity": "not_captured",
+      "terminal_events": "not_captured",
+      "wire_identity_replay": "not_captured"
+    },
+    "ready_for_beta1": false
+  },
+  "schema_version": 1
+}

--- a/docs/superpowers/plans/2026-08-02-issue-62-live-evidence-sidecar.md
+++ b/docs/superpowers/plans/2026-08-02-issue-62-live-evidence-sidecar.md
@@ -1,0 +1,233 @@
+# Issue #62 Live-Evidence Sidecar Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a standalone, explicitly enabled loopback sidecar that independently fingerprints complete request, response, and SSE application-body bytes on the pre- and post-Gateway hops without changing production routing.
+
+**Architecture:** One standard-library Python script owns validation, HTTP forwarding, streaming fingerprints, atomic sanitized artifacts, and bounded shutdown. Two independent instances use the same HMAC key and different `pre`/`post` hop labels; focused tests connect them to a real local fake upstream and compare their independently written artifacts.
+
+**Tech Stack:** Python 3.13 standard library, pytest, loopback `http.server`/`http.client`, SHA-256, HMAC-SHA-256, atomic `os.replace`.
+
+## Global Constraints
+
+- The script starts only with `--enable-live-capture` and listens only on IPv4 or IPv6 loopback.
+- Do not modify or import the script from production Gateway, telemetry, diagnostic-recorder, Tauri, Desktop, config, or route handlers.
+- Add no dependency and perform no real upstream request in tests or verification.
+- Persist only sanitized metadata and digests; never persist URLs, paths, headers, credentials, key material, raw bodies, prompts, tool values, or wire identifiers.
+- Request/response byte caps and connect/read/overall timeouts are mandatory and positive.
+- Overflow, timeout, cancellation, forwarding failure, missing SSE terminal, and incomplete SSE framing produce an `incomplete` record and leave no `.partial` file.
+- Synthetic tests prove only `synthetic_lane_verified`; they do not change `docs/evidence/issue-62/runtime-wire-inventory.json` or any qualification state.
+
+---
+
+### Task 1: Activation, configuration, and sanitized atomic artifacts
+
+**Files:**
+- Create: `scripts/capture_issue_62_live_evidence.py`
+- Create: `tests/test_issue_62_live_evidence_sidecar.py`
+
+**Interfaces:**
+- Produces: `SidecarConfig`, `validate_config(config)`, `write_capture_record(output_dir, hop, record)`, and `main(argv=None) -> int`.
+- Consumes: only Python standard-library modules and a pre-existing HMAC key file.
+
+- [x] **Step 1: Write failing activation and artifact tests**
+
+```python
+def test_main_requires_explicit_enable(capsys):
+    assert sidecar.main([]) == 2
+    assert "live capture is disabled" in capsys.readouterr().err
+
+@pytest.mark.parametrize("host", ["0.0.0.0", "192.0.2.10"])
+def test_config_rejects_non_loopback(host, base_config):
+    with pytest.raises(sidecar.ConfigurationError, match="listen_not_loopback"):
+        sidecar.validate_config(dataclasses.replace(base_config, listen_host=host))
+
+def test_atomic_record_is_sanitized_and_leaves_no_partial(tmp_path):
+    record_path = sidecar.write_capture_record(tmp_path, "pre", SAFE_RECORD)
+    assert json.loads(record_path.read_text(encoding="utf-8"))["schema"] == (
+        "codexhub.issue62.live-evidence-lane.v1"
+    )
+    assert not list(tmp_path.glob("*.partial"))
+```
+
+- [x] **Step 2: Run the tests and verify RED**
+
+Run: `py -3.13 -m pytest -q tests/test_issue_62_live_evidence_sidecar.py -k "requires_explicit_enable or rejects_non_loopback or atomic_record"`
+
+Expected: collection fails because `scripts/capture_issue_62_live_evidence.py` does not exist.
+
+- [x] **Step 3: Implement validation and atomic writing**
+
+Implement a frozen `SidecarConfig`, fixed schema/failure vocabularies, loopback `ipaddress.ip_address(...).is_loopback` validation, strict URL/key/bound checks, a default-disabled CLI, recursive allow-listed record validation, and unique `.partial` -> `.json` replacement with cleanup in `finally`.
+
+- [x] **Step 4: Run the focused tests and verify GREEN**
+
+Run: `py -3.13 -m pytest -q tests/test_issue_62_live_evidence_sidecar.py -k "requires_explicit_enable or rejects_non_loopback or atomic_record"`
+
+Expected: all selected tests pass.
+
+### Task 2: Complete request/response and SSE fingerprint primitives
+
+**Files:**
+- Modify: `scripts/capture_issue_62_live_evidence.py`
+- Modify: `tests/test_issue_62_live_evidence_sidecar.py`
+
+**Interfaces:**
+- Produces: `BodyFingerprint`, `SseSequenceFingerprint`, and artifact dictionaries with `bytes`, `sha256`, `hmac_sha256`, `complete`, `frame_count`, `frame_bytes`, and allow-listed `terminal_classes`.
+- Consumes: raw byte chunks in their observed order and the pre-loaded HMAC key bytes.
+
+- [x] **Step 1: Write failing literal digest and chunk-boundary tests**
+
+```python
+def test_body_fingerprint_hashes_every_byte():
+    observed = sidecar.BodyFingerprint(KEY, b"request-body")
+    observed.update(b"abc")
+    observed.update(b"\x00def")
+    assert observed.complete() == {
+        "bytes": 7,
+        "sha256": hashlib.sha256(b"abc\x00def").hexdigest(),
+        "hmac_sha256": hmac.new(KEY, b"request-body\0abc\x00def", hashlib.sha256).hexdigest(),
+        "complete": True,
+    }
+
+def test_sse_sequence_digest_is_independent_of_transport_chunks():
+    wire = b'data: {"type":"response.output_text.delta","delta":"secret"}\n\ndata: {"type":"response.completed"}\n\n'
+    one = consume_sse([wire])
+    split = consume_sse([wire[:5], wire[5:41], wire[41:]])
+    assert split == one
+    assert split["frame_count"] == 2
+    assert split["terminal_classes"] == ["response.completed"]
+```
+
+- [x] **Step 2: Run the tests and verify RED**
+
+Run: `py -3.13 -m pytest -q tests/test_issue_62_live_evidence_sidecar.py -k "fingerprint_hashes or sequence_digest"`
+
+Expected: failure because the fingerprint classes are absent.
+
+- [x] **Step 3: Implement minimal incremental fingerprints**
+
+Use `hashlib.sha256()` and `hmac.new(key, domain + b"\0", hashlib.sha256)` for bodies. Split complete LF or CRLF SSE frames independent of read chunks, hash `len(frame).to_bytes(8, "big") + frame` in order, classify only `response.completed`, `response.failed`, `error`, and `[DONE]`, and mark trailing frames or missing terminals incomplete.
+
+- [x] **Step 4: Run the focused tests and verify GREEN**
+
+Run: `py -3.13 -m pytest -q tests/test_issue_62_live_evidence_sidecar.py -k "fingerprint_hashes or sequence_digest"`
+
+Expected: all selected tests pass.
+
+### Task 3: Real loopback forwarding, bounds, cancellation, and cleanup
+
+**Files:**
+- Modify: `scripts/capture_issue_62_live_evidence.py`
+- Modify: `tests/test_issue_62_live_evidence_sidecar.py`
+
+**Interfaces:**
+- Produces: `CaptureSidecarServer`, `start()`/`shutdown()` lifecycle, and one atomic sanitized capture record per request.
+- Consumes: validated `SidecarConfig`; forwards via `http.client.HTTPConnection` or `HTTPSConnection` and strips HTTP hop-by-hop headers.
+
+- [x] **Step 1: Write failing two-hop integration test**
+
+```python
+def test_two_hops_capture_matching_complete_request_response_and_sse(tmp_path):
+    request_body = b'{"input":"private prompt","stream":true}'
+    sse_body = b'data: {"type":"response.output_text.delta","delta":"private output"}\n\ndata: {"type":"response.completed"}\n\n'
+    with fake_upstream(sse_body) as upstream, running_lane(tmp_path, upstream.url) as lane:
+        status, response_body = post_bytes(lane.pre_url + "/responses?opaque=wire-id", request_body)
+    assert status == 200
+    assert response_body == sse_body
+    pre = read_only_record(lane.pre_output)
+    post = read_only_record(lane.post_output)
+    assert pre["request"] == post["request"]
+    assert pre["response"] == post["response"]
+    assert pre["sse"]["sequence_sha256"] == post["sse"]["sequence_sha256"]
+    assert pre["outcome"] == post["outcome"] == "complete"
+```
+
+- [x] **Step 2: Run the integration test and verify RED**
+
+Run: `py -3.13 -m pytest -q tests/test_issue_62_live_evidence_sidecar.py::test_two_hops_capture_matching_complete_request_response_and_sse`
+
+Expected: failure because the HTTP server is absent.
+
+- [x] **Step 3: Implement the minimal server and forwarding path**
+
+Build a `ThreadingHTTPServer` with tracked request/client/upstream lifecycles, exact `Content-Length` request reads, application-body forwarding, response streaming in bounded chunks, deadline checks, fixed sanitized failure codes, and `shutdown()` that closes the listener and active sockets before a bounded active-handler drain. Do not store exception text.
+
+- [x] **Step 4: Run the integration test and verify GREEN**
+
+Run: `py -3.13 -m pytest -q tests/test_issue_62_live_evidence_sidecar.py::test_two_hops_capture_matching_complete_request_response_and_sse`
+
+Expected: one complete record in each output directory with identical request, response, and SSE digests.
+
+- [x] **Step 5: Write failing bound, timeout, sanitization, and cancellation tests**
+
+```python
+@pytest.mark.parametrize("case", ["request_overflow", "response_overflow", "upstream_timeout", "client_cancel"])
+def test_failure_cases_are_incomplete_sanitized_and_clean(case, tmp_path):
+    result = run_failure_case(case, tmp_path)
+    record = read_only_record(result.output)
+    serialized = json.dumps(record, sort_keys=True)
+    assert record["outcome"] == "incomplete"
+    assert record["failure"] in EXPECTED_FAILURES
+    assert not list(result.output.glob("*.partial"))
+    for sensitive in result.sensitive_values:
+        assert sensitive not in serialized
+```
+
+- [x] **Step 6: Run the failure tests and verify RED**
+
+Run: `py -3.13 -m pytest -q tests/test_issue_62_live_evidence_sidecar.py -k "failure_cases"`
+
+Expected: at least one case fails because its bound or cleanup path is not implemented.
+
+- [x] **Step 7: Implement bounded failure paths and cleanup**
+
+Reject invalid/oversized requests before forwarding, stop response relay at the cap, apply socket and overall deadlines, classify broken downstream writes as `downstream_cancelled`, close every upstream connection in `finally`, null incomplete full-body digests, atomically write the incomplete record, and remove every owned `.partial` file.
+
+- [x] **Step 8: Run the full sidecar test file and verify GREEN**
+
+Run: `py -3.13 -m pytest -q tests/test_issue_62_live_evidence_sidecar.py`
+
+Expected: all sidecar tests pass and no test contacts a non-loopback address.
+
+### Task 4: Usage documentation and candidate verification
+
+**Files:**
+- Modify: `docs/evidence/issue-62/README.md`
+- Modify: `docs/superpowers/plans/2026-08-02-issue-62-live-evidence-sidecar.md`
+
+**Interfaces:**
+- Produces: copyable pre/post commands that remain inert until explicitly enabled and state the exact non-qualification boundary.
+- Consumes: the CLI implemented in Tasks 1-3.
+
+- [x] **Step 1: Add isolated two-process usage commands**
+
+Document distinct output directories and loopback ports, the shared isolated HMAC key file, required bounds/timeouts, and explicit operator-supplied tokens for the separately authorized isolated Gateway/upstream addresses. State that the command must not be aimed at the currently running Desktop/Gateway without a new control-window authorization.
+
+- [x] **Step 2: Run focused and evidence regression checks**
+
+Run:
+
+```powershell
+py -3.13 -m pytest -q tests/test_issue_62_live_evidence_sidecar.py tests/test_diagnostic_recorder.py tests/test_diagnostic_recorder_gateway.py tests/test_issue_62_runtime_trace.py tests/test_issue_62_runtime_audit.py tests/test_issue_62_runtime_inventory.py
+py -3.13 -m pytest -q --ignore=tests/test_real_client_e2e.py
+python scripts/build_issue_62_runtime_inventory.py --check-drift
+powershell -NoProfile -ExecutionPolicy Bypass -File scripts/check-codex-thread-tool-surface.ps1
+python scripts/report_quality_gates.py
+git diff --check
+```
+
+Expected: focused tests pass and the strict Python suite excluding the out-of-scope real-client E2E contract completes without a sidecar regression. Any strict-suite failure must be reproduced at the exact `origin/dev` baseline and reported rather than counted as a pass. Inventory drift reports a match; PowerShell reports `THREAD_TOOL_SURFACE_COMPLETE` without changing qualification; quality-gate output remains report-only; diff check is clean.
+
+- [x] **Step 3: Confirm the qualification artifact is unchanged**
+
+Run: `git diff origin/dev -- docs/evidence/issue-62/runtime-wire-inventory.json`
+
+Expected: no output.
+
+- [x] **Step 4: Commit the implementation candidate**
+
+```powershell
+git add scripts/capture_issue_62_live_evidence.py tests/test_issue_62_live_evidence_sidecar.py docs/evidence/issue-62/README.md docs/superpowers/plans/2026-08-02-issue-62-live-evidence-sidecar.md
+git commit -m "test: add isolated Issue 62 live evidence sidecar"
+```

--- a/docs/superpowers/specs/2026-08-02-issue-62-live-evidence-sidecar-design.md
+++ b/docs/superpowers/specs/2026-08-02-issue-62-live-evidence-sidecar-design.md
@@ -1,0 +1,81 @@
+# Issue #62 isolated live-evidence sidecar design
+
+## Scope
+
+Add a standalone, standard-library-only capture sidecar for a separately
+authorized Issue #62 live-control window. The sidecar is evidence tooling, not
+Gateway code. It must not be imported or started by Desktop, Gateway, normal
+builds, or debug builds.
+
+Synthetic tests prove only `synthetic_lane_verified`. They do not update the
+runtime inventory, satisfy a live gate, qualify a model, close Issue #62, or
+unlock a downstream issue.
+
+## Activation and topology
+
+The script refuses to listen unless `--enable-live-capture` is present. Its
+listen address must resolve to IPv4 or IPv6 loopback. Every instance has one
+declared hop (`pre` or `post`), one forward base URL, one isolated output
+directory, and one pre-existing HMAC key file.
+
+An authorized run starts two independent processes:
+
+```text
+isolated client -> pre sidecar -> isolated Gateway -> post sidecar -> upstream
+```
+
+Only temporary, isolated client/Gateway configuration points at the sidecars.
+No production route, telemetry schema, diagnostic recorder, shared config, or
+running Desktop/Gateway process is changed.
+
+## Capture contract
+
+For each request, a sidecar forwards the exact application body bytes while
+incrementally computing:
+
+- full request-body byte count, SHA-256, and keyed HMAC-SHA-256;
+- full response-body byte count, SHA-256, and keyed HMAC-SHA-256; and
+- for an SSE response, an order-sensitive digest over length-prefixed complete
+  SSE frames, plus frame count, byte count, and allow-listed terminal classes.
+
+The HMAC domains are stable across the two hops so equal bytes produce equal
+digests. HTTP hop-by-hop framing is intentionally excluded: fingerprints cover
+the decoded HTTP message body bytes delivered to each application boundary.
+
+The final JSON record contains only the schema, hop, opaque capture id,
+completion outcome, bounded failure code, status, coarse content-type class,
+byte counts, digests, and bounded SSE classifications. It never stores or
+prints a target URL, path, header, credential, HMAC key, raw body, prompt,
+tool argument/result, or wire identifier.
+
+## Bounds and failure behavior
+
+The operator must provide positive request/response byte caps and connect,
+read, and overall timeouts. Invalid content length, request or response
+overflow, upstream timeout, downstream cancellation, forwarding failure, and
+incomplete SSE framing produce a fail-closed `incomplete` record. An incomplete
+record can describe the bounded failure but can never set
+`synthetic_lane_verified=true`.
+
+Each record is written to a unique `.partial` file, flushed, and atomically
+renamed only after serialization succeeds. Every error path removes its
+`.partial` file. Shutdown stops accepting work, closes the listening socket,
+and leaves no partial artifact. No raw-body spool file exists.
+
+## Tests
+
+Focused tests use only real loopback HTTP servers and synthetic fixtures. They
+cover:
+
+1. two sidecars produce matching, independently written full request and
+   response SHA/HMAC values for exact passthrough bytes;
+2. SSE chunk boundaries do not affect the ordered sequence digest;
+3. activation and loopback checks reject default or unsafe startup;
+4. request/response overflow and timeouts fail closed;
+5. prompts, credentials, paths, raw SSE data, and key material never appear in
+   artifacts; and
+6. success, failure, cancellation, and shutdown leave no `.partial` files or
+   listening sidecar threads.
+
+The test fixture summary may say `synthetic_lane_verified`; no test or script
+writes Issue #62 inventory qualification fields.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codexhub-frontend",
-  "version": "0.1.8-beta.1",
+  "version": "0.1.8-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codexhub-frontend",
-      "version": "0.1.8-beta.1",
+      "version": "0.1.8-beta.2",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "vite --host 127.0.0.1",
     "build": "tsc && vite build",
-    "test:ui-contract": "node --test scripts/ui-contract.test.mjs",
+    "test:ui-contract": "node --test scripts/ui-contract.test.mjs scripts/official-models-visibility.test.mjs",
     "test:provider-comparison": "node --test scripts/provider-comparison.test.mjs",
     "preview": "vite preview --host 127.0.0.1"
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codexhub-frontend",
   "private": true,
-  "version": "0.1.8-beta.1",
+  "version": "0.1.8-beta.2",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/frontend/scripts/official-models-visibility.test.mjs
+++ b/frontend/scripts/official-models-visibility.test.mjs
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { readFile } from "node:fs/promises";
+import ts from "typescript";
+
+const source = await readFile(new URL("../src/lib/officialModels.ts", import.meta.url), "utf8");
+const withoutImports = source
+  .replace(/^\s*import[^;]+;\s*$/gm, "")
+  .replace(/export const /g, "const ")
+  .replace(/export function/g, "function");
+const jsOutput = ts.transpileModule(withoutImports, {
+  compilerOptions: {
+    module: ts.ModuleKind.CommonJS,
+    target: ts.ScriptTarget.ES2022,
+    strict: false,
+  },
+}).outputText;
+
+const moduleExports = {};
+const wrappedModule = new Function(
+  "exports",
+  "normalizeOfficialModelId",
+  jsOutput +
+    "\nexports.mergeOfficialModelSources = mergeOfficialModelSources; exports.filterCodexVisibleOfficialModels = filterCodexVisibleOfficialModels;",
+);
+wrappedModule(moduleExports, (value) => value.trim().replace(/^openai\//, ""));
+
+const { mergeOfficialModelSources } = moduleExports;
+
+function model(id, overrides = {}) {
+  return { id, enabled: true, ...overrides };
+}
+
+test("combined Official catalogs exclude hidden, unknown, and internal duplicate Terra models", () => {
+  const combined = mergeOfficialModelSources(
+    [
+      model("gpt-5.6-terra", { visibility: "list" }),
+      model("gpt-5.6-sol", { visibility: "hide" }),
+      model("gpt-5.6-terra", {
+        id: "codex-auto-review",
+        upstream_model: "gpt-5.6-terra",
+        visibility: "list",
+      }),
+      model("gpt-5.6-luna", { visibility: "future" }),
+    ],
+    [model("openai/gpt-5.6-terra", { visibility: "list" })],
+  );
+
+  assert.deepEqual(combined.map((item) => item.id), ["gpt-5.6-terra"]);
+});
+
+test("catalog hide vetoes a metadata-only Official model", () => {
+  const combined = mergeOfficialModelSources(
+    [model("gpt-5.6-terra", { visibility: "hide" })],
+    [model("gpt-5.6-terra", { visibility: "list" })],
+  );
+
+  assert.deepEqual(combined, []);
+});
+
+test("metadata cannot create an Official model absent from the catalog", () => {
+  const combined = mergeOfficialModelSources(
+    [],
+    [model("gpt-5.6-terra", { visibility: "list" })],
+  );
+
+  assert.deepEqual(combined, []);
+});

--- a/frontend/scripts/ui-contract.test.mjs
+++ b/frontend/scripts/ui-contract.test.mjs
@@ -2092,8 +2092,8 @@ test("frontend official merge canonicalizes aliases with fresh metadata winning"
   const merge = providersSource.match(/function mergeOfficialModelSources[\s\S]*?function isOfficialModel/)?.[0] ?? "";
 
   assert.match(merge, /const knownOfficialIds = officialModelIdSet\(catalog, metadata\);/);
-  assert.match(merge, /for \(const model of catalog\.filter\(isOfficialModel\)\)/);
-  assert.match(merge, /for \(const model of metadata\.filter\(isOfficialModel\)\)/);
+  assert.match(merge, /for \(const model of catalog\.filter\(\(item\) => isOfficialModel\(item\) && isCatalogModelListable\(item\)\)\)/);
+  assert.match(merge, /for \(const model of metadata\.filter\(\(item\) => isOfficialModel\(item\) && isCatalogModelListable\(item\)\)\)/);
   assert.match(merge, /const canonicalId = normalizeOfficialModelId\(model\.id, knownOfficialIds\);/);
   assert.match(merge, /\.\.\.existing,[\s\S]*\.\.\.model,[\s\S]*id: canonicalId/);
   assert.match(
@@ -2151,6 +2151,7 @@ test("official alias merge keeps all-false disabled and ORs any true", async () 
     "mergeOfficialModelSources",
     "officialModelIdSet",
     "isOfficialModel",
+    "isCatalogModelListable",
     "filterCodexVisibleOfficialModels",
     "isOfficialGatewayFastVariant",
   ];
@@ -2174,8 +2175,8 @@ test("official alias merge keeps all-false disabled and ORs any true", async () 
   ];
   for (const item of cases) {
     const merged = mergeOfficialModelSources(
-      [{ id: "openai/gpt-5.5", enabled: item.catalog }],
-      [{ id: "gpt-5.5", enabled: item.metadata }],
+      [{ id: "openai/gpt-5.5", enabled: item.catalog, visibility: "list" }],
+      [{ id: "gpt-5.5", enabled: item.metadata, visibility: "list" }],
     );
     assert.equal(merged.length, 1, item.name);
     assert.equal(merged[0].enabled, item.expected, item.name);
@@ -2191,6 +2192,7 @@ test("published Official catalog context limits outrank stale metadata after ref
     "mergeOfficialModelSources",
     "officialModelIdSet",
     "isOfficialModel",
+    "isCatalogModelListable",
     "filterCodexVisibleOfficialModels",
     "isOfficialGatewayFastVariant",
   ];
@@ -2210,6 +2212,7 @@ test("published Official catalog context limits outrank stale metadata after ref
   const [model] = mergeOfficialModelSources(
     [{
       id: "openai/gpt-5.6-terra",
+      visibility: "list",
       context_window: 272000,
       max_context_window: 272000,
       effective_source: "fresh_direct_official_cache_authority",
@@ -2221,6 +2224,7 @@ test("published Official catalog context limits outrank stale metadata after ref
     }],
     [{
       id: "gpt-5.6-terra",
+      visibility: "list",
       context_window: 353400,
       max_context_window: 353400,
       effective_source: "pinned_metadata",

--- a/frontend/scripts/ui-contract.test.mjs
+++ b/frontend/scripts/ui-contract.test.mjs
@@ -386,6 +386,31 @@ test("provider page state, editors, actions, and shared helpers stay in focused 
   assert.match(formSource, /export const emptyProvider/);
 });
 
+test("catalog override diagnostics stay bounded and disclose the Codex restart", async () => {
+  const [actionsSource, tauriSource, typesSource, mainSource, bridgeSource, enSource, zhSource] =
+    await Promise.all([
+      readFile(providerCatalogActionsPath, "utf8"),
+      readFile(tauriSourcePath, "utf8"),
+      readFile(typesPath, "utf8"),
+      readFile(tauriMainPath, "utf8"),
+      readFile(tauriWebBridgePath, "utf8"),
+      readFile(enLocalePath, "utf8"),
+      readFile(zhLocalePath, "utf8"),
+    ]);
+
+  assert.match(tauriSource, /catalogOverrideDiagnostics: \(\) =>/);
+  assert.match(tauriSource, /get_catalog_override_diagnostics/);
+  assert.match(typesSource, /interface CatalogOverrideDiagnostics/);
+  assert.match(typesSource, /catalog_override_diagnostics\?: CatalogOverrideDiagnostics/);
+  assert.match(actionsSource, /api\.catalogOverrideDiagnostics\(\)/);
+  assert.match(actionsSource, /catalogOverrideDiagnostics/);
+  assert.match(actionsSource, /catalogOverrideRestartCodex/);
+  assert.match(mainSource, /get_catalog_override_diagnostics/);
+  assert.match(bridgeSource, /get_catalog_override_diagnostics/);
+  assert.match(enSource, /Restart Codex App to apply/);
+  assert.match(zhSource, /请重启 Codex App 使其生效/);
+});
+
 test("ui contract keeps ids and paths but no localizable display copy", async () => {
   const contract = await readContract();
 

--- a/frontend/src/hooks/useProviderCatalogActions.ts
+++ b/frontend/src/hooks/useProviderCatalogActions.ts
@@ -18,6 +18,7 @@ import {
 } from "../lib/providerEndpoint";
 import { api, messageFromError } from "../lib/tauri";
 import type {
+  CatalogOverrideDiagnostics,
   GatewayClientSyncSummary,
   Model,
   Provider,
@@ -130,6 +131,22 @@ export function useProviderCatalogActions({
       }));
     }
     await refreshGatewayState();
+    const overrideDiagnostics = await api.catalogOverrideDiagnostics().catch(() => null);
+    if (syncResult) {
+      syncResult = {
+        ...syncResult,
+        catalog_override_diagnostics: overrideDiagnostics,
+      };
+    } else if (overrideDiagnostics) {
+      syncResult = {
+        applied: 0,
+        skipped: 0,
+        failed: 0,
+        results: [],
+        message: "",
+        catalog_override_diagnostics: overrideDiagnostics,
+      };
+    }
     return syncResult;
   }
 
@@ -137,18 +154,36 @@ export function useProviderCatalogActions({
     baseMessage: string | undefined,
     syncResult: GatewayClientSyncSummary | null,
   ) {
+    const overrideMessage = syncResult?.catalog_override_diagnostics
+      ? catalogOverrideToastMessage(syncResult.catalog_override_diagnostics)
+      : null;
     if (syncResult?.failed) {
       const syncMessage = tr("providers.syncClientsFailed", { count: syncResult.failed });
-      return baseMessage ? `${baseMessage}; ${syncMessage}` : syncMessage;
+      return [baseMessage, syncMessage, overrideMessage].filter(Boolean).join("; ") || null;
     }
     if (syncResult?.applied) {
       const syncMessage = tr("providers.syncedClients", {
         count: syncResult.applied,
         plural: syncResult.applied === 1 ? "" : "s",
       });
-      return baseMessage ? `${baseMessage}; ${syncMessage}` : syncMessage;
+      return [baseMessage, syncMessage, overrideMessage].filter(Boolean).join("; ") || null;
     }
-    return baseMessage ?? null;
+    return [baseMessage, overrideMessage].filter(Boolean).join("; ") || null;
+  }
+
+  function catalogOverrideToastMessage(diagnostics: CatalogOverrideDiagnostics): string | null {
+    const accepted = Math.max(0, Math.min(100, diagnostics.accepted));
+    const rejected = Math.max(0, Math.min(100, diagnostics.rejected));
+    const migrated = Math.max(0, Math.min(100, diagnostics.migrated));
+    if (accepted === 0 && rejected === 0 && migrated === 0) {
+      return null;
+    }
+    return t("providers.catalogOverrideDiagnostics", {
+      accepted,
+      rejected,
+      migrated,
+      restart: t("providers.catalogOverrideRestartCodex"),
+    });
   }
 
   async function saveProviders(

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -446,6 +446,8 @@ const enUS = {
     pricingUnknown: "Pricing unknown",
     providerCatalogUpdated: "Provider catalog updated",
     providerCatalogUpdateFailed: "Provider catalog update failed",
+    catalogOverrideDiagnostics: "Catalog overrides: {{accepted}} accepted, {{migrated}} migrated, {{rejected}} rejected. {{restart}}",
+    catalogOverrideRestartCodex: "Restart Codex App to apply",
     providerAdded: "{{name}} added",
     providerAlreadyExists: "Provider already exists: {{name}}",
     providerDeleted: "{{name}} deleted",

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -445,6 +445,8 @@ const zhCN = {
     pricingUnknown: "价格未知",
     providerCatalogUpdated: "供应商目录已更新",
     providerCatalogUpdateFailed: "供应商目录更新失败",
+    catalogOverrideDiagnostics: "模型目录覆盖：接受 {{accepted}} 项，迁移 {{migrated}} 项，拒绝 {{rejected}} 项。{{restart}}",
+    catalogOverrideRestartCodex: "请重启 Codex App 使其生效",
     providerAdded: "{{name}} 已添加",
     providerAlreadyExists: "供应商已存在：{{name}}",
     providerDeleted: "{{name}} 已删除",

--- a/frontend/src/lib/officialModels.ts
+++ b/frontend/src/lib/officialModels.ts
@@ -84,6 +84,18 @@ export function refreshedOfficialModelOrder(currentOrder: string[], refreshedMod
 
 export function mergeOfficialModelSources(catalog: Model[], metadata: Model[]) {
   const knownOfficialIds = officialModelIdSet(catalog, metadata);
+  const blockedOfficialIds = new Set<string>();
+  for (const model of catalog) {
+    if (isCatalogModelListable(model)) {
+      continue;
+    }
+    for (const value of [model.id, model.upstream_model ?? "", ...(model.aliases ?? [])]) {
+      const bare = value.trim().toLowerCase().replace(/^openai\//, "");
+      if (bare.startsWith("gpt-")) {
+        blockedOfficialIds.add(bare);
+      }
+    }
+  }
   const resolvedCatalogLimitFields = [
     "context_window",
     "max_context_window",
@@ -93,7 +105,7 @@ export function mergeOfficialModelSources(catalog: Model[], metadata: Model[]) {
     "verified_at",
   ] as const;
   const merged = new Map<string, Model>();
-  for (const model of catalog.filter(isOfficialModel)) {
+  for (const model of catalog.filter((item) => isOfficialModel(item) && isCatalogModelListable(item))) {
     const canonicalId = normalizeOfficialModelId(model.id, knownOfficialIds);
     if (!canonicalId) {
       continue;
@@ -109,9 +121,13 @@ export function mergeOfficialModelSources(catalog: Model[], metadata: Model[]) {
     });
   }
   const publishedCatalogModels = new Map(merged);
-  for (const model of metadata.filter(isOfficialModel)) {
+  for (const model of metadata.filter((item) => isOfficialModel(item) && isCatalogModelListable(item))) {
     const canonicalId = normalizeOfficialModelId(model.id, knownOfficialIds);
-    if (!canonicalId) {
+    if (
+      !canonicalId ||
+      blockedOfficialIds.has(canonicalId) ||
+      !publishedCatalogModels.has(canonicalId)
+    ) {
       continue;
     }
     const existing = merged.get(canonicalId);
@@ -152,7 +168,9 @@ export function resolveOfficialModelContextWindow(
 
 export function officialModelIdSet(...groups: Model[][]) {
   const known = new Set<string>();
-  for (const model of groups.flatMap((group) => group).filter(isOfficialModel)) {
+  for (const model of groups
+    .flatMap((group) => group)
+    .filter((item) => isOfficialModel(item) && isCatalogModelListable(item))) {
     const value = model.id.trim();
     const bare = value.startsWith("openai/gpt-") ? value.slice("openai/".length) : value;
     if (bare.startsWith("gpt-")) {
@@ -167,7 +185,24 @@ export function isOfficialModel(model: Model) {
 }
 
 export function filterCodexVisibleOfficialModels(models: Model[]) {
-  return models.filter((model) => !isOfficialGatewayFastVariant(model));
+  return models.filter(
+    (model) => isCatalogModelListable(model) && !isOfficialGatewayFastVariant(model),
+  );
+}
+
+export function isCatalogModelListable(model: Model) {
+  if (model.visibility !== "list" || (model as Model & { hidden?: unknown }).hidden === true) {
+    return false;
+  }
+  const identities = [model.id, model.upstream_model ?? "", ...(model.aliases ?? [])];
+  return !identities.some((value) => {
+    const normalized = value
+      .trim()
+      .toLowerCase()
+      .replace(/^openai\//, "")
+      .replace(/:cloud$/, "");
+    return normalized === "codex-auto-review" || normalized.startsWith("codex-auto-review/");
+  });
 }
 
 export function isOfficialGatewayFastVariant(model: Model) {

--- a/frontend/src/lib/tauri.ts
+++ b/frontend/src/lib/tauri.ts
@@ -8,6 +8,7 @@ import type {
   AppUpdateStatus,
   AppVersionInfo,
   AutostartStatus,
+  CatalogOverrideDiagnostics,
   CodexContextGuardStatus,
   CodexHubError,
   DiagnosticsActionResult,
@@ -302,6 +303,8 @@ export const api = {
     call<GatewayClientSyncSummary>("sync_gateway_clients", { model: model ?? null }),
   subagentMatrixStatus: () => call<SubagentMatrixStatus>("subagent_matrix_status"),
   generateCatalog: () => call<Model[]>("generate_catalog"),
+  catalogOverrideDiagnostics: () =>
+    call<CatalogOverrideDiagnostics>("get_catalog_override_diagnostics"),
   listModels: () => call<Model[]>("list_models"),
   refreshModelMetadata: () => call<Model[]>("refresh_model_metadata"),
   listModelMetadata: () => call<Model[]>("list_model_metadata"),

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -562,4 +562,12 @@ export interface GatewayClientSyncSummary {
   failed: number;
   results: GatewayClientSyncItem[];
   message: string;
+  catalog_override_diagnostics?: CatalogOverrideDiagnostics | null;
+}
+
+export interface CatalogOverrideDiagnostics {
+  accepted: number;
+  rejected: number;
+  migrated: number;
+  reasons: Record<string, number>;
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1,7 +1,9 @@
 export interface Model {
   id: string;
+  visibility?: CatalogVisibility;
   display_name?: string | null;
   upstream_model?: string | null;
+  aliases?: string[];
   tool_surface_strategy?: ToolSurfaceStrategy | null;
   source_kind?: string | null;
   locked?: boolean;
@@ -22,6 +24,8 @@ export interface Model {
   sort_order?: number | null;
   enabled: boolean;
 }
+
+export type CatalogVisibility = "list" | "hide" | "unknown";
 
 export interface OfficialRefreshResult {
   models: Model[];

--- a/scripts/Run-RealClientE2E.ps1
+++ b/scripts/Run-RealClientE2E.ps1
@@ -33,6 +33,8 @@ param(
     [string]$PiPath = 'pi.exe',
     [string]$OmpPath = 'omp.exe',
 
+    [switch]$CliOnly,
+
     [int]$TimeoutSeconds = 180,
 
     [int]$ManualEvidenceTimeoutSeconds = 900,
@@ -205,6 +207,13 @@ $script:MinimumVersions = [ordered]@{
     pi = '0.80.6'
     omp = '17.0.3'
 }
+$script:CliOnly = [bool]$CliOnly
+$script:VerificationScope = if ($script:CliOnly) { 'cli_only' } else { 'gui_and_cli' }
+$script:VersionKeys = if ($script:CliOnly) {
+    @('codex_cli', 'opencode', 'pi', 'omp')
+} else {
+    @($script:MinimumVersions.Keys)
+}
 $script:ObservedVersions = [ordered]@{}
 $script:MaximumCapturedCharacters = 65536
 $script:MaximumClientEventCharacters = 1048576
@@ -323,7 +332,7 @@ function Write-JsonFile {
 
 function Get-ReportedClientVersions {
     $reported = [ordered]@{}
-    foreach ($name in $script:MinimumVersions.Keys) {
+    foreach ($name in $script:VersionKeys) {
         $reported[$name] = if ($script:ObservedVersions.Contains($name)) {
             [string]$script:ObservedVersions[$name]
         }
@@ -338,6 +347,7 @@ function Get-FailureSummaryValue {
     param([string]$FailureClassification, [string[]]$Artifacts = @())
     return [ordered]@{
         schema = 'codexhub.real-client-e2e-summary.v2'
+        verification_scope = $script:VerificationScope
         candidate_sha = if ($CandidateSha -match '^[0-9a-fA-F]{40}$') { $CandidateSha.ToLowerInvariant() } else { $null }
         managed_client_config_sha = if ($ManagedClientConfigSha -match '^[0-9a-fA-F]{40}$') { $ManagedClientConfigSha.ToLowerInvariant() } else { $null }
         outcome = 'failed'
@@ -448,6 +458,7 @@ function Invoke-RunnerSupervisor {
         OpenCodePath = $OpenCodePath
         PiPath = $PiPath
         OmpPath = $OmpPath
+        CliOnly = [bool]$CliOnly
         TimeoutSeconds = $TimeoutSeconds
         ManualEvidenceTimeoutSeconds = $ManualEvidenceTimeoutSeconds
         OverallTimeoutSeconds = $OverallTimeoutSeconds
@@ -485,6 +496,7 @@ function Invoke-RunnerSupervisor {
   -ThirdPartyModel 'internal' `
   -OutputDirectory '.' `
   -HostEnvironmentManifest '.' `
+  -CliOnly:$false `
   -TimeoutSeconds 1 `
   -ManualEvidenceTimeoutSeconds 1 `
   -OverallTimeoutSeconds 1 `
@@ -2889,7 +2901,7 @@ try {
         'ManagedClientConfigSha', 'LunaModel', 'ThirdPartyModel', 'OutputDirectory',
         'HostEnvironmentManifest', 'TestWindowsInstallMetadataFixture',
         'CodexDesktopPath', 'CodexCliPath', 'ZCodePath', 'OpenCodePath',
-        'PiPath', 'OmpPath', 'TimeoutSeconds', 'ManualEvidenceTimeoutSeconds',
+        'PiPath', 'OmpPath', 'CliOnly', 'TimeoutSeconds', 'ManualEvidenceTimeoutSeconds',
         'OverallTimeoutSeconds'
     ) -Failure 'preflight_supervisor_arguments_invalid'
     $CandidateSha = [string]$forwardedArguments.CandidateSha
@@ -2907,12 +2919,21 @@ try {
     $OpenCodePath = [string]$forwardedArguments.OpenCodePath
     $PiPath = [string]$forwardedArguments.PiPath
     $OmpPath = [string]$forwardedArguments.OmpPath
+    $CliOnly = [bool]$forwardedArguments.CliOnly
     $TimeoutSeconds = [int]$forwardedArguments.TimeoutSeconds
     $ManualEvidenceTimeoutSeconds = [int]$forwardedArguments.ManualEvidenceTimeoutSeconds
     $OverallTimeoutSeconds = [int]$forwardedArguments.OverallTimeoutSeconds
 }
 catch {
     throw 'preflight_supervisor_arguments_invalid'
+}
+
+$script:CliOnly = [bool]$CliOnly
+$script:VerificationScope = if ($script:CliOnly) { 'cli_only' } else { 'gui_and_cli' }
+$script:VersionKeys = if ($script:CliOnly) {
+    @('codex_cli', 'opencode', 'pi', 'omp')
+} else {
+    @($script:MinimumVersions.Keys)
 }
 
 $CandidateSha = $CandidateSha.ToLowerInvariant()
@@ -3042,7 +3063,8 @@ if ([string]$hostEnvironment.schema -cne 'codexhub.real-client-host-environment.
 $profile = Read-JsonObject -Path $accountPath -Failure 'preflight_account_profile_invalid'
 Assert-ExactJsonProperties -Value $profile -Names @('schema', 'dedicated_account', 'codex_login_ready', 'gui_ready', 'host_session_reused') -Failure 'preflight_account_profile_invalid'
 if ([string]$profile.schema -cne 'codexhub.real-client-account.v1' -or
-    [bool]$profile.dedicated_account -ne $true -or [bool]$profile.codex_login_ready -ne $true -or [bool]$profile.gui_ready -ne $true -or
+    [bool]$profile.dedicated_account -ne $true -or [bool]$profile.codex_login_ready -ne $true -or
+    (-not $CliOnly -and [bool]$profile.gui_ready -ne $true) -or
     [bool]$profile.host_session_reused -ne $false) {
     throw 'preflight_account_not_ready'
 }
@@ -3077,12 +3099,14 @@ if (Test-Path -LiteralPath $summaryPath) {
 }
 
 $executables = @{
-    desktop = Resolve-CommandPath -Path $CodexDesktopPath -Name 'desktop'
     'codex-cli' = Resolve-CommandPath -Path $CodexCliPath -Name 'codex_cli'
-    zcode = Resolve-CommandPath -Path $ZCodePath -Name 'zcode'
     opencode = Resolve-CommandPath -Path $OpenCodePath -Name 'opencode'
     pi = Resolve-CommandPath -Path $PiPath -Name 'pi'
     omp = Resolve-CommandPath -Path $OmpPath -Name 'omp'
+}
+if (-not $CliOnly) {
+    $executables.desktop = Resolve-CommandPath -Path $CodexDesktopPath -Name 'desktop'
+    $executables.zcode = Resolve-CommandPath -Path $ZCodePath -Name 'zcode'
 }
 if ($script:WindowsInstallMetadata) {
     $nonFixtureExecutables = @($executables.Values | Where-Object {
@@ -3096,30 +3120,45 @@ if ($script:WindowsInstallMetadata) {
 }
 $actualVersions = [ordered]@{}
 Set-RunnerPhase -Phase 'client_materialization'
-foreach ($versionTarget in @(
-    [pscustomobject]@{ client = 'desktop'; key = 'desktop' },
+$versionTargets = @(
     [pscustomobject]@{ client = 'codex-cli'; key = 'codex_cli' },
-    [pscustomobject]@{ client = 'zcode'; key = 'zcode' },
     [pscustomobject]@{ client = 'opencode'; key = 'opencode' },
     [pscustomobject]@{ client = 'pi'; key = 'pi' },
     [pscustomobject]@{ client = 'omp'; key = 'omp' }
-)) {
+)
+if (-not $CliOnly) {
+    $versionTargets = @(
+        [pscustomobject]@{ client = 'desktop'; key = 'desktop' },
+        $versionTargets[0],
+        [pscustomobject]@{ client = 'zcode'; key = 'zcode' },
+        $versionTargets[1],
+        $versionTargets[2],
+        $versionTargets[3]
+    )
+}
+foreach ($versionTarget in $versionTargets) {
     $actualVersions[$versionTarget.key] = Get-NativeClientVersion -Client $versionTarget.client -Executable $executables[$versionTarget.client] -Minimum $script:MinimumVersions[$versionTarget.key] -ProbeRoot (Join-Path $workRoot "version-$($versionTarget.client)")
     $script:ObservedVersions[$versionTarget.key] = $actualVersions[$versionTarget.key]
 }
-$desktopLaunchExecutable = Copy-DesktopApplicationPayload `
-    -Executable $executables.desktop `
-    -WorkRoot $workRoot `
-    -IsolationRoot $isolationRoot
+if (-not $CliOnly) {
+    $desktopLaunchExecutable = Copy-DesktopApplicationPayload `
+        -Executable $executables.desktop `
+        -WorkRoot $workRoot `
+        -IsolationRoot $isolationRoot
+}
 [void](New-Item -ItemType Directory -Path $artifactRoot)
 [void](New-Item -ItemType Directory -Path (Join-Path $artifactRoot 'cases'))
 
-$manualCases = @(
-    [pscustomobject]@{ case_id = 'desktop-luna'; client = 'desktop'; provider_id = 'official'; diagnostic_provider_id = 'official'; client_selector = 'gpt-5.6-luna'; canonical_model = 'gpt-5.6-luna'; gateway_model = 'gpt-5.6-luna'; endpoint_binding = '/v1/responses'; protocol = 'responses'; seed_slot = 'desktop-luna'; legacy_seed_slot = '' },
-    [pscustomobject]@{ case_id = 'desktop-ollama-cloud'; client = 'desktop'; provider_id = 'ollama-cloud'; diagnostic_provider_id = 'ollama_cloud'; client_selector = 'ollama-cloud/glm-5.2'; canonical_model = 'ollama-cloud/glm-5.2'; gateway_model = 'ollama-cloud/glm-5.2'; endpoint_binding = '/v1/providers/ollama-cloud/responses'; protocol = 'responses'; seed_slot = 'desktop-third-party'; legacy_seed_slot = 'desktop-volc' },
-    [pscustomobject]@{ case_id = 'zcode-luna'; client = 'zcode'; provider_id = 'official'; diagnostic_provider_id = 'official'; client_selector = $LunaModel; canonical_model = $LunaModel; gateway_model = 'openai/gpt-5.6-luna'; endpoint_binding = '/v1/providers/openai/responses'; protocol = 'responses'; seed_slot = 'zcode-luna'; legacy_seed_slot = '' },
-    [pscustomobject]@{ case_id = 'zcode-ollama-cloud'; client = 'zcode'; provider_id = 'ollama-cloud'; diagnostic_provider_id = 'ollama_cloud'; client_selector = $ThirdPartyModel; canonical_model = $ThirdPartyModel; gateway_model = 'ollama-cloud/glm-5.2'; endpoint_binding = '/v1/providers/ollama-cloud/responses'; protocol = 'responses'; seed_slot = 'zcode-third-party'; legacy_seed_slot = 'zcode-volc' }
-)
+$manualCases = if ($CliOnly) {
+    @()
+} else {
+    @(
+        [pscustomobject]@{ case_id = 'desktop-luna'; client = 'desktop'; provider_id = 'official'; diagnostic_provider_id = 'official'; client_selector = 'gpt-5.6-luna'; canonical_model = 'gpt-5.6-luna'; gateway_model = 'gpt-5.6-luna'; endpoint_binding = '/v1/responses'; protocol = 'responses'; seed_slot = 'desktop-luna'; legacy_seed_slot = '' },
+        [pscustomobject]@{ case_id = 'desktop-ollama-cloud'; client = 'desktop'; provider_id = 'ollama-cloud'; diagnostic_provider_id = 'ollama_cloud'; client_selector = 'ollama-cloud/glm-5.2'; canonical_model = 'ollama-cloud/glm-5.2'; gateway_model = 'ollama-cloud/glm-5.2'; endpoint_binding = '/v1/providers/ollama-cloud/responses'; protocol = 'responses'; seed_slot = 'desktop-third-party'; legacy_seed_slot = 'desktop-volc' },
+        [pscustomobject]@{ case_id = 'zcode-luna'; client = 'zcode'; provider_id = 'official'; diagnostic_provider_id = 'official'; client_selector = $LunaModel; canonical_model = $LunaModel; gateway_model = 'openai/gpt-5.6-luna'; endpoint_binding = '/v1/providers/openai/responses'; protocol = 'responses'; seed_slot = 'zcode-luna'; legacy_seed_slot = '' },
+        [pscustomobject]@{ case_id = 'zcode-ollama-cloud'; client = 'zcode'; provider_id = 'ollama-cloud'; diagnostic_provider_id = 'ollama_cloud'; client_selector = $ThirdPartyModel; canonical_model = $ThirdPartyModel; gateway_model = 'ollama-cloud/glm-5.2'; endpoint_binding = '/v1/providers/ollama-cloud/responses'; protocol = 'responses'; seed_slot = 'zcode-third-party'; legacy_seed_slot = 'zcode-volc' }
+    )
+}
 $automatedCases = @(
     [pscustomobject]@{ case_id = 'codex-cli-luna'; client = 'codex-cli'; provider_id = 'official'; diagnostic_provider_id = 'official'; client_selector = 'gpt-5.6-luna'; canonical_model = 'gpt-5.6-luna'; gateway_model = 'gpt-5.6-luna'; endpoint_binding = '/v1/responses'; protocol = 'responses' },
     [pscustomobject]@{ case_id = 'codex-cli-ollama-cloud'; client = 'codex-cli'; provider_id = 'ollama-cloud'; diagnostic_provider_id = 'ollama_cloud'; client_selector = 'ollama-cloud/glm-5.2'; canonical_model = 'ollama-cloud/glm-5.2'; gateway_model = 'ollama-cloud/glm-5.2'; endpoint_binding = '/v1/providers/ollama-cloud/responses'; protocol = 'responses' },
@@ -3132,9 +3171,11 @@ $automatedCases = @(
 )
 
 $runBinding = New-RunBinding
-Write-ManualEvidenceTemplate -Path $manualTemplatePath -ManualCases $manualCases -RunBinding $runBinding
-if (Test-Path -LiteralPath $manualEvidencePath) {
-    throw 'manual_evidence_preexisting'
+if (-not $CliOnly) {
+    Write-ManualEvidenceTemplate -Path $manualTemplatePath -ManualCases $manualCases -RunBinding $runBinding
+    if (Test-Path -LiteralPath $manualEvidencePath) {
+        throw 'manual_evidence_preexisting'
+    }
 }
 $trackedProcesses = [System.Collections.Generic.List[System.Diagnostics.Process]]::new()
 $nativeGuiProcesses = [System.Collections.Generic.List[System.Diagnostics.Process]]::new()
@@ -3219,7 +3260,9 @@ try {
         }
         $caseConfigurations[$case.case_id] = $configuration
     }
-    [void](Initialize-ClientConfiguration -Client 'desktop' -CaseRoot $candidateRoot -Model 'gpt-5.6-luna' -CatalogPath $candidateCatalogPath)
+    if (-not $CliOnly) {
+        [void](Initialize-ClientConfiguration -Client 'desktop' -CaseRoot $candidateRoot -Model 'gpt-5.6-luna' -CatalogPath $candidateCatalogPath)
+    }
     $candidateStartupStopwatch.Stop()
     $candidateStartupStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
     $remainingStartupMilliseconds = $candidateStartupBudgetMilliseconds - [int]$candidateStartupStopwatch.ElapsedMilliseconds
@@ -3240,7 +3283,9 @@ try {
     Wait-CandidateGatewayReady -CandidateProcess $candidateProcess -TimeoutMilliseconds $remainingStartupMilliseconds -ElapsedBeforeWaitMilliseconds $elapsedBeforeWaitMilliseconds
     $candidateStartupStopwatch.Stop()
 
-    Set-RunnerPhase -Phase 'manual_evidence'
+    $manualResults = @()
+    if (-not $CliOnly) {
+        Set-RunnerPhase -Phase 'manual_evidence'
     foreach ($guiCase in $manualCases) {
         $guiClient = $guiCase.client
         $guiRoot = Join-Path $workRoot ("gui-" + $guiClient)
@@ -3315,6 +3360,7 @@ try {
         Start-Sleep -Milliseconds 100
     }
     $manualResults = @(Get-ManualResults -EvidencePath $manualEvidencePath -ManualCases $manualCases -ArtifactRoot $artifactRoot -RunBinding $runBinding)
+    }
 
     Set-RunnerPhase -Phase 'automated_cases'
     $automatedById = @{}
@@ -3325,25 +3371,35 @@ try {
     foreach ($result in $manualResults) {
         $manualById[$result.case_id] = $result
     }
-    $caseOrder = @(
-        'desktop-luna', 'desktop-ollama-cloud',
-        'codex-cli-luna', 'codex-cli-ollama-cloud',
-        'opencode-luna', 'opencode-ollama-cloud',
-        'zcode-luna', 'zcode-ollama-cloud',
-        'pi-luna', 'pi-ollama-cloud',
-        'omp-luna', 'omp-ollama-cloud'
-    )
+    $caseOrder = if ($CliOnly) {
+        @(
+            'codex-cli-luna', 'codex-cli-ollama-cloud',
+            'opencode-luna', 'opencode-ollama-cloud',
+            'pi-luna', 'pi-ollama-cloud',
+            'omp-luna', 'omp-ollama-cloud'
+        )
+    } else {
+        @(
+            'desktop-luna', 'desktop-ollama-cloud',
+            'codex-cli-luna', 'codex-cli-ollama-cloud',
+            'opencode-luna', 'opencode-ollama-cloud',
+            'zcode-luna', 'zcode-ollama-cloud',
+            'pi-luna', 'pi-ollama-cloud',
+            'omp-luna', 'omp-ollama-cloud'
+        )
+    }
     $caseResults = @($caseOrder | ForEach-Object {
         if ($manualById.ContainsKey($_)) { $manualById[$_] } else { $automatedById[$_] }
     })
     $passedCount = @($caseResults | Where-Object { $_.outcome -ceq 'passed' }).Count
     $summary = [ordered]@{
         schema = 'codexhub.real-client-e2e-summary.v2'
+        verification_scope = $script:VerificationScope
         candidate_sha = $CandidateSha
         managed_client_config_sha = $ManagedClientConfigSha
         run_binding_sha256 = $runBinding
-        outcome = if ($passedCount -eq 12) { 'passed' } else { 'failed' }
-        failure_classification = if ($passedCount -eq 12) { 'none' } else { 'case_failure' }
+        outcome = if ($passedCount -eq $caseResults.Count -and $caseResults.Count -gt 0) { 'passed' } else { 'failed' }
+        failure_classification = if ($passedCount -eq $caseResults.Count -and $caseResults.Count -gt 0) { 'none' } else { 'case_failure' }
         hashes = [ordered]@{
             debug_build = Get-Sha256 -Path $DebugBuild
             managed_client_config_build = Get-Sha256 -Path $ManagedClientConfigBuild
@@ -3351,18 +3407,18 @@ try {
         pinned_versions = $actualVersions
         canonical_models = @('gpt-5.6-luna', 'ollama-cloud/glm-5.2', $LunaModel, $ThirdPartyModel)
         counts = [ordered]@{
-            case_count = 12
+            case_count = $caseResults.Count
             passed_count = $passedCount
-            failed_count = 12 - $passedCount
-            manual_case_count = 4
-            automated_case_count = 8
+            failed_count = $caseResults.Count - $passedCount
+            manual_case_count = $manualResults.Count
+            automated_case_count = $automatedCases.Count
         }
         cases = $caseResults
         artifacts = @($caseResults | ForEach-Object { $_.artifact })
     }
     Set-RunnerPhase -Phase 'summary'
     Write-JsonFile -Path $summaryPath -Value $summary
-    if ($passedCount -ne 12) {
+    if ($passedCount -ne $caseResults.Count -or $caseResults.Count -eq 0) {
         exit 1
     }
 }
@@ -3389,6 +3445,7 @@ catch {
     }
     $failureSummary = [ordered]@{
         schema = 'codexhub.real-client-e2e-summary.v2'
+        verification_scope = $script:VerificationScope
         candidate_sha = if ($CandidateSha -match '^[0-9a-f]{40}$') { $CandidateSha } else { $null }
         managed_client_config_sha = if ($ManagedClientConfigSha -match '^[0-9a-f]{40}$') { $ManagedClientConfigSha } else { $null }
         outcome = 'failed'

--- a/scripts/build_issue_62_control_manifest.py
+++ b/scripts/build_issue_62_control_manifest.py
@@ -1,0 +1,1065 @@
+#!/usr/bin/env python3
+"""Build a sanitized, candidate-bound control manifest for Issue #62.
+
+The live sidecar deliberately records only byte/SSE fingerprints.  This
+evidence-only helper joins one pre-hop and one post-hop sidecar record with a
+small, already-sanitized semantic summary produced by the control harness.
+It never opens a network connection and never reads or writes a raw request,
+response, header, URL, credential, prompt, tool argument, or wire identifier.
+
+The resulting manifest is a binding artifact, not a qualification by itself.
+``synthetic_fixture_only`` is permanently ineligible for the Issue #62 gate;
+an operator must explicitly use ``authorized_live_control`` after an
+authorized isolated run and independently review the artifact.
+
+Candidate provenance is explicit: the npm package version and SHA-256 are
+bound, while the registry's missing Codex source commit is represented as
+``cli_source_commit: null`` with
+``cli_source_commit_status: not_published_by_registry``.  A placeholder hash
+must never be used in place of an unavailable source commit.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+from pathlib import Path
+import re
+from typing import Any, Iterable, Mapping
+
+
+SCHEMA = "codexhub.issue62.control-manifest.v1"
+SYNTHETIC_SCOPE = "synthetic_fixture_only"
+LIVE_SCOPE = "authorized_live_control"
+VERIFICATION_SCOPES = frozenset({SYNTHETIC_SCOPE, LIVE_SCOPE})
+QUALIFICATION_REASONS = {
+    SYNTHETIC_SCOPE: "synthetic_fixture_only",
+    LIVE_SCOPE: "wire replay and final inventory reconciliation required",
+}
+MANIFEST_FIELDS = frozenset(
+    {
+        "schema",
+        "verification_scope",
+        "candidate_identity",
+        "controls",
+        "identity_control",
+        "capture_manifest_sha256",
+        "qualification",
+    }
+)
+
+# These are deliberately semantic labels, not arbitrary response/event text.
+CONTROL_NAMES = (
+    "streaming_text",
+    "streaming_function_history",
+    "non_streaming_text",
+    "choice_auto",
+    "choice_none",
+    "terminal_success",
+    "terminal_error",
+    "error_json",
+)
+CONTROL_NAME_SET = frozenset(CONTROL_NAMES)
+IDENTITY_BOOLEAN_FIELDS = (
+    "request_pair_preserved",
+    "response_ref_preserved",
+    "item_refs_preserved",
+    "call_links_preserved",
+)
+TERMINAL_CLASSES = frozenset(
+    {"response.completed", "response.failed", "error", "json_response"}
+)
+SSE_TERMINAL_CLASSES = frozenset(
+    {"response.completed", "response.failed", "error", "done"}
+)
+CONTENT_TYPE_CLASSES = frozenset({"event-stream", "json"})
+TOOL_CHOICES = frozenset({"auto", "none", "required", "function", None})
+STATUS_CLASSES = frozenset({"2xx", "4xx", "5xx"})
+EVENT_TYPES = frozenset(
+    {
+        "response.in_progress",
+        "response.output_text.delta",
+        "response.output_text.done",
+        "response.function_call_arguments.delta",
+        "response.function_call_arguments.done",
+        "response.completed",
+        "response.failed",
+        "error",
+        "unknown",
+    }
+)
+ITEM_TYPES = frozenset(
+    {
+        "message",
+        "function_call",
+        "function_call_output",
+        "custom_tool_call",
+        "custom_tool_call_output",
+        "unknown",
+    }
+)
+
+_HEX64 = re.compile(r"[0-9a-f]{64}\Z")
+_SHA1 = re.compile(r"[0-9a-f]{40}\Z")
+_SEMVER = re.compile(r"0\.(?:\d+)\.(?:\d+)(?:-[0-9A-Za-z.-]+)?\Z")
+
+_SIDEcar_ROOT_FIELDS = frozenset(
+    {
+        "schema",
+        "verification_scope",
+        "capture_id",
+        "hop",
+        "outcome",
+        "failure",
+        "status",
+        "content_type_class",
+        "request",
+        "response",
+        "sse",
+    }
+)
+_BODY_FIELDS = frozenset({"bytes", "sha256", "hmac_sha256", "complete"})
+_SSE_FIELDS = frozenset(
+    {
+        "complete",
+        "frame_count",
+        "frame_bytes",
+        "sequence_sha256",
+        "sequence_hmac_sha256",
+        "terminal_classes",
+    }
+)
+
+
+class ManifestValidationError(ValueError):
+    """A fixed, sanitized manifest validation failure."""
+
+
+def _require_exact_fields(value: Mapping[str, Any], expected: frozenset[str], code: str) -> None:
+    if frozenset(value) != expected:
+        raise ManifestValidationError(code)
+
+
+def _require_hex(value: Any, pattern: re.Pattern[str], code: str) -> str:
+    if not isinstance(value, str) or pattern.fullmatch(value) is None:
+        raise ManifestValidationError(code)
+    return value
+
+
+def _require_bool(value: Any, code: str) -> bool:
+    if not isinstance(value, bool):
+        raise ManifestValidationError(code)
+    return value
+
+
+def _require_nonnegative_int(value: Any, code: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ManifestValidationError(code)
+    return value
+
+
+def _digest_summary(value: Any, code: str) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    if not isinstance(value, Mapping):
+        raise ManifestValidationError(code)
+    _require_exact_fields(value, _BODY_FIELDS, code)
+    complete = _require_bool(value.get("complete"), code)
+    bytes_count = _require_nonnegative_int(value.get("bytes"), code)
+    sha = value.get("sha256")
+    hmac_sha = value.get("hmac_sha256")
+    if complete:
+        _require_hex(sha, _HEX64, code)
+        _require_hex(hmac_sha, _HEX64, code)
+    elif sha is not None or hmac_sha is not None:
+        raise ManifestValidationError(code)
+    # Do not retain capture ids or any input mapping; these are the only body
+    # facts needed to prove independent pre/post byte equality.
+    return {
+        "bytes": bytes_count,
+        "sha256": sha,
+        "hmac_sha256": hmac_sha,
+        "complete": complete,
+    }
+
+
+def _sse_summary(value: Any, code: str) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    if not isinstance(value, Mapping):
+        raise ManifestValidationError(code)
+    _require_exact_fields(value, _SSE_FIELDS, code)
+    complete = _require_bool(value.get("complete"), code)
+    frame_count = _require_nonnegative_int(value.get("frame_count"), code)
+    frame_bytes = _require_nonnegative_int(value.get("frame_bytes"), code)
+    sequence_sha = value.get("sequence_sha256")
+    sequence_hmac = value.get("sequence_hmac_sha256")
+    if complete:
+        _require_hex(sequence_sha, _HEX64, code)
+        _require_hex(sequence_hmac, _HEX64, code)
+    elif sequence_sha is not None or sequence_hmac is not None:
+        raise ManifestValidationError(code)
+    terminal_classes = value.get("terminal_classes")
+    if (
+        not isinstance(terminal_classes, list)
+        or any(item not in SSE_TERMINAL_CLASSES for item in terminal_classes)
+        or terminal_classes != sorted(set(terminal_classes))
+    ):
+        raise ManifestValidationError(code)
+    return {
+        "complete": complete,
+        "frame_count": frame_count,
+        "frame_bytes": frame_bytes,
+        "sequence_sha256": sequence_sha,
+        "sequence_hmac_sha256": sequence_hmac,
+        "terminal_classes": list(terminal_classes),
+    }
+
+
+def sanitize_sidecar_record(record: Mapping[str, Any], *, expected_hop: str) -> dict[str, Any]:
+    """Return the sidecar facts safe for a control manifest.
+
+    ``capture_id`` is validated but intentionally discarded.  The caller
+    binds the two hops by control ordinal/label in a separate manifest rather
+    than persisting opaque transport identifiers.
+    """
+
+    if not isinstance(record, Mapping):
+        raise ManifestValidationError("sidecar_record_invalid")
+    _require_exact_fields(record, _SIDEcar_ROOT_FIELDS, "sidecar_record_fields_invalid")
+    if record.get("schema") != "codexhub.issue62.live-evidence-lane.v1":
+        raise ManifestValidationError("sidecar_record_schema_invalid")
+    if record.get("verification_scope") != "capture_only_not_qualification":
+        raise ManifestValidationError("sidecar_record_scope_invalid")
+    if record.get("hop") != expected_hop:
+        raise ManifestValidationError("sidecar_record_hop_invalid")
+    capture_id = record.get("capture_id")
+    if not isinstance(capture_id, str) or not re.fullmatch(r"c[0-9a-f]{32}\Z", capture_id):
+        raise ManifestValidationError("sidecar_record_capture_id_invalid")
+    outcome = record.get("outcome")
+    if outcome not in {"complete", "incomplete"}:
+        raise ManifestValidationError("sidecar_record_outcome_invalid")
+    failure = record.get("failure")
+    if outcome == "complete" and failure is not None:
+        raise ManifestValidationError("sidecar_record_completion_invalid")
+    if outcome == "incomplete" and not isinstance(failure, str):
+        raise ManifestValidationError("sidecar_record_failure_invalid")
+    status = record.get("status")
+    if status is not None and (
+        isinstance(status, bool) or not isinstance(status, int) or not 100 <= status <= 599
+    ):
+        raise ManifestValidationError("sidecar_record_status_invalid")
+    content_type = record.get("content_type_class")
+    if content_type not in {"event-stream", "json", "other", "absent", "unknown"}:
+        raise ManifestValidationError("sidecar_record_content_type_invalid")
+    return {
+        "outcome": outcome,
+        "failure": failure,
+        "status": status,
+        "content_type_class": content_type,
+        "request": _digest_summary(record.get("request"), "sidecar_record_request_invalid"),
+        "response": _digest_summary(record.get("response"), "sidecar_record_response_invalid"),
+        "sse": _sse_summary(record.get("sse"), "sidecar_record_sse_invalid"),
+    }
+
+
+_SANITIZED_SIDECAR_FIELDS = frozenset(
+    {"outcome", "failure", "status", "content_type_class", "request", "response", "sse"}
+)
+
+
+def _validate_sanitized_sidecar(record: Any, *, code_prefix: str) -> dict[str, Any]:
+    """Validate one sidecar already embedded in a manifest.
+
+    ``sanitize_sidecar_record`` intentionally drops transport-only fields such
+    as ``capture_id`` and ``hop``.  A generated manifest therefore cannot be
+    sent through that raw-record validator during reconciliation.  Keep a
+    separate validator for the canonical, seven-field sidecar representation
+    and normalize it to a fresh mapping so callers never retain untrusted
+    nested objects.
+    """
+
+    if not isinstance(record, Mapping):
+        raise ManifestValidationError(f"{code_prefix}_invalid")
+    _require_exact_fields(record, _SANITIZED_SIDECAR_FIELDS, f"{code_prefix}_fields_invalid")
+    outcome = record.get("outcome")
+    if outcome not in {"complete", "incomplete"}:
+        raise ManifestValidationError(f"{code_prefix}_outcome_invalid")
+    failure = record.get("failure")
+    if outcome == "complete" and failure is not None:
+        raise ManifestValidationError(f"{code_prefix}_completion_invalid")
+    if outcome == "incomplete" and not isinstance(failure, str):
+        raise ManifestValidationError(f"{code_prefix}_failure_invalid")
+    status = record.get("status")
+    if status is not None and (
+        isinstance(status, bool) or not isinstance(status, int) or not 100 <= status <= 599
+    ):
+        raise ManifestValidationError(f"{code_prefix}_status_invalid")
+    content_type = record.get("content_type_class")
+    if content_type not in {"event-stream", "json", "other", "absent", "unknown"}:
+        raise ManifestValidationError(f"{code_prefix}_content_type_invalid")
+    return {
+        "outcome": outcome,
+        "failure": failure,
+        "status": status,
+        "content_type_class": content_type,
+        "request": _digest_summary(record.get("request"), f"{code_prefix}_request_invalid"),
+        "response": _digest_summary(record.get("response"), f"{code_prefix}_response_invalid"),
+        "sse": _sse_summary(record.get("sse"), f"{code_prefix}_sse_invalid"),
+    }
+
+
+def _sanitize_name_list(value: Any, allowed: frozenset[str], code: str) -> list[str]:
+    if not isinstance(value, list) or any(not isinstance(item, str) or item not in allowed for item in value):
+        raise ManifestValidationError(code)
+    if value != sorted(set(value)):
+        raise ManifestValidationError(code)
+    return list(value)
+
+
+def _sanitize_request_shape(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ManifestValidationError("request_shape_invalid")
+    expected = frozenset(
+        {
+            "model",
+            "stream",
+            "tool_choice",
+            "parallel_tool_calls",
+            "input_item_types",
+            "tool_names",
+            "additional_tools_present",
+        }
+    )
+    _require_exact_fields(value, expected, "request_shape_fields_invalid")
+    model = value.get("model")
+    if not isinstance(model, str) or not model or "/" in model or model.startswith("http"):
+        raise ManifestValidationError("request_shape_model_invalid")
+    stream = _require_bool(value.get("stream"), "request_shape_stream_invalid")
+    tool_choice = value.get("tool_choice")
+    if tool_choice not in TOOL_CHOICES:
+        raise ManifestValidationError("request_shape_choice_invalid")
+    parallel = value.get("parallel_tool_calls")
+    if parallel is not None:
+        _require_bool(parallel, "request_shape_parallel_invalid")
+    input_item_types = value.get("input_item_types")
+    if not isinstance(input_item_types, list):
+        raise ManifestValidationError("request_shape_input_types_invalid")
+    sanitized_input_types: list[dict[str, Any]] = []
+    for item in input_item_types:
+        if not isinstance(item, Mapping) or frozenset(item) != {"type", "count"}:
+            raise ManifestValidationError("request_shape_input_type_entry_invalid")
+        item_type = item.get("type")
+        if item_type not in ITEM_TYPES:
+            raise ManifestValidationError("request_shape_input_type_invalid")
+        sanitized_input_types.append(
+            {"type": item_type, "count": _require_nonnegative_int(item.get("count"), "request_shape_input_count_invalid")}
+        )
+    if sanitized_input_types != sorted(sanitized_input_types, key=lambda item: item["type"]):
+        raise ManifestValidationError("request_shape_input_types_unsorted")
+    tool_names = _sanitize_name_list(value.get("tool_names"), frozenset({"shell_command", "apply_patch", "tool_search", "function"}), "request_shape_tools_invalid")
+    return {
+        "model": model,
+        "stream": stream,
+        "tool_choice": tool_choice,
+        "parallel_tool_calls": parallel,
+        "input_item_types": sanitized_input_types,
+        "tool_names": tool_names,
+        "additional_tools_present": _require_bool(value.get("additional_tools_present"), "request_shape_additional_tools_invalid"),
+    }
+
+
+def _sanitize_response_shape(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ManifestValidationError("response_shape_invalid")
+    expected = frozenset(
+        {
+            "content_type_class",
+            "status_class",
+            "terminal",
+            "event_types",
+            "item_types",
+            "unknown_tag_count",
+            "response_ref_present",
+            "item_ref_count",
+            "call_link_count",
+        }
+    )
+    _require_exact_fields(value, expected, "response_shape_fields_invalid")
+    content_type = value.get("content_type_class")
+    if content_type not in CONTENT_TYPE_CLASSES:
+        raise ManifestValidationError("response_shape_content_type_invalid")
+    status_class = value.get("status_class")
+    if status_class not in STATUS_CLASSES:
+        raise ManifestValidationError("response_shape_status_invalid")
+    terminal = value.get("terminal")
+    if terminal not in TERMINAL_CLASSES:
+        raise ManifestValidationError("response_shape_terminal_invalid")
+    event_types = value.get("event_types")
+    if (
+        not isinstance(event_types, list)
+        or any(not isinstance(item, str) or item not in EVENT_TYPES for item in event_types)
+    ):
+        raise ManifestValidationError("response_shape_events_invalid")
+    item_types = _sanitize_name_list(value.get("item_types"), ITEM_TYPES, "response_shape_items_invalid")
+    return {
+        "content_type_class": content_type,
+        "status_class": status_class,
+        "terminal": terminal,
+        # Keep event order: terminal placement and function-call sequencing are
+        # part of the core Responses contract.  The values are an allow-listed
+        # vocabulary, never raw SSE data.
+        "event_types": list(event_types),
+        "item_types": item_types,
+        "unknown_tag_count": _require_nonnegative_int(value.get("unknown_tag_count"), "response_shape_unknown_count_invalid"),
+        # Keep only aggregate reference facts; never retain actual wire IDs.
+        "response_ref_present": _require_bool(value.get("response_ref_present"), "response_shape_response_ref_invalid"),
+        "item_ref_count": _require_nonnegative_int(value.get("item_ref_count"), "response_shape_item_ref_count_invalid"),
+        "call_link_count": _require_nonnegative_int(value.get("call_link_count"), "response_shape_call_link_count_invalid"),
+    }
+
+
+def _sanitize_identity(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ManifestValidationError("identity_invalid")
+    expected = frozenset(
+        {
+            "request_pair_preserved",
+            "response_ref_preserved",
+            "item_refs_preserved",
+            "call_links_preserved",
+            "unclassified_core_items",
+        }
+    )
+    _require_exact_fields(value, expected, "identity_fields_invalid")
+    result = {
+        key: _require_bool(value[key], "identity_boolean_invalid")
+        for key in IDENTITY_BOOLEAN_FIELDS
+    }
+    result["unclassified_core_items"] = _require_nonnegative_int(
+        value.get("unclassified_core_items"), "identity_unclassified_invalid"
+    )
+    return result
+
+
+def _sanitize_route(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ManifestValidationError("route_identity_invalid")
+    expected = frozenset(
+        {
+            "model",
+            "upstream",
+            "route_mode",
+            "behavior_profile",
+            "inbound_format",
+            "upstream_format",
+        }
+    )
+    _require_exact_fields(value, expected, "route_identity_fields_invalid")
+    expected_values = {
+        "upstream": "official",
+        "route_mode": "official",
+        "behavior_profile": "official_codex_app_http_passthrough",
+        "inbound_format": "responses",
+        "upstream_format": "responses",
+    }
+    for key, expected_value in expected_values.items():
+        if value.get(key) != expected_value:
+            raise ManifestValidationError("route_identity_value_invalid")
+    model = value.get("model")
+    if not isinstance(model, str) or not model or "/" in model:
+        raise ManifestValidationError("route_identity_model_invalid")
+    return {key: value[key] for key in expected}
+
+
+def _pair_equal(pre: Mapping[str, Any], post: Mapping[str, Any], key: str) -> bool:
+    left = pre.get(key)
+    right = post.get(key)
+    if left is None or right is None:
+        return left is right
+    return left == right
+
+
+def _require_complete_fingerprints(pre: Mapping[str, Any], post: Mapping[str, Any]) -> None:
+    """Require complete request/response fingerprints for a control pair.
+
+    A complete sidecar with a missing digest cannot prove passthrough.  Treat
+    that as invalid instead of allowing ``None == None`` to appear equal.
+    """
+
+    for side, label in ((pre, "request"), (post, "request")):
+        fingerprint = side.get(label)
+        if fingerprint is None:
+            raise ManifestValidationError("control_request_fingerprint_missing")
+        if not isinstance(fingerprint, Mapping) or fingerprint.get("complete") is not True:
+            raise ManifestValidationError("control_request_fingerprint_incomplete")
+        if not fingerprint.get("sha256") or not fingerprint.get("hmac_sha256"):
+            raise ManifestValidationError("control_request_fingerprint_missing_digest")
+    for side, label in ((pre, "response"), (post, "response")):
+        fingerprint = side.get(label)
+        if fingerprint is None:
+            raise ManifestValidationError("control_response_fingerprint_missing")
+        if not isinstance(fingerprint, Mapping) or fingerprint.get("complete") is not True:
+            raise ManifestValidationError("control_response_fingerprint_incomplete")
+        if not fingerprint.get("sha256") or not fingerprint.get("hmac_sha256"):
+            raise ManifestValidationError("control_response_fingerprint_missing_digest")
+
+
+def _require_complete_sse_fingerprints(pre: Mapping[str, Any], post: Mapping[str, Any]) -> None:
+    """Require complete ordered SSE fingerprints for streaming controls."""
+
+    for side in (pre, post):
+        fingerprint = side.get("sse")
+        if fingerprint is None:
+            raise ManifestValidationError("control_sse_fingerprint_missing")
+        if not isinstance(fingerprint, Mapping) or fingerprint.get("complete") is not True:
+            raise ManifestValidationError("control_sse_fingerprint_incomplete")
+        if not fingerprint.get("sequence_sha256") or not fingerprint.get("sequence_hmac_sha256"):
+            raise ManifestValidationError("control_sse_fingerprint_missing_digest")
+
+
+def _sanitize_control(control: Mapping[str, Any]) -> dict[str, Any]:
+    expected = frozenset(
+        {
+            "name",
+            "pre",
+            "post",
+            "request_shape",
+            "response_shape",
+            "identity",
+            "route_identity",
+        }
+    )
+    if not isinstance(control, Mapping):
+        raise ManifestValidationError("control_invalid")
+    _require_exact_fields(control, expected, "control_fields_invalid")
+    name = control.get("name")
+    if name not in CONTROL_NAME_SET:
+        raise ManifestValidationError("control_name_invalid")
+    pre = sanitize_sidecar_record(control["pre"], expected_hop="pre")
+    post = sanitize_sidecar_record(control["post"], expected_hop="post")
+    if pre["outcome"] != "complete" or post["outcome"] != "complete":
+        raise ManifestValidationError("control_capture_incomplete")
+    _require_complete_fingerprints(pre, post)
+    if not _pair_equal(pre, post, "request") or not _pair_equal(pre, post, "response"):
+        raise ManifestValidationError("control_body_fingerprint_mismatch")
+    if pre["content_type_class"] != post["content_type_class"]:
+        raise ManifestValidationError("control_content_type_mismatch")
+    if pre["content_type_class"] == "event-stream":
+        if pre["sse"] is None or post["sse"] is None or not _pair_equal(pre, post, "sse"):
+            raise ManifestValidationError("control_sse_fingerprint_mismatch")
+        _require_complete_sse_fingerprints(pre, post)
+    elif pre["sse"] is not None or post["sse"] is not None:
+        raise ManifestValidationError("control_json_sse_mismatch")
+    request_shape = _sanitize_request_shape(control.get("request_shape"))
+    response_shape = _sanitize_response_shape(control.get("response_shape"))
+    identity = _sanitize_identity(control.get("identity"))
+    route = _sanitize_route(control.get("route_identity"))
+    if request_shape["model"] != route["model"]:
+        raise ManifestValidationError("control_model_binding_mismatch")
+    if request_shape["stream"] != (pre["content_type_class"] == "event-stream"):
+        raise ManifestValidationError("control_stream_mode_mismatch")
+    if response_shape["content_type_class"] != pre["content_type_class"]:
+        raise ManifestValidationError("control_response_shape_content_mismatch")
+    if response_shape["terminal"] == "json_response" and pre["content_type_class"] != "json":
+        raise ManifestValidationError("control_terminal_content_mismatch")
+    if response_shape["terminal"] != "json_response" and pre["content_type_class"] == "json":
+        raise ManifestValidationError("control_json_terminal_invalid")
+    _validate_control_semantics(name, request_shape, response_shape)
+    if identity["unclassified_core_items"] != 0:
+        raise ManifestValidationError("control_identity_unclassified")
+    return {
+        "name": name,
+        "pre": pre,
+        "post": post,
+        "request_shape": request_shape,
+        "response_shape": response_shape,
+        "identity": identity,
+        "route_identity": route,
+        "body_equality": {
+            "request": True,
+            "response": True,
+            "sse": pre["sse"] is not None,
+        },
+    }
+
+
+def _validate_control_semantics(
+    name: str,
+    request_shape: Mapping[str, Any],
+    response_shape: Mapping[str, Any],
+) -> None:
+    """Bind each control label to its intended request/response contract."""
+
+    stream = request_shape["stream"]
+    choice = request_shape["tool_choice"]
+    parallel = request_shape["parallel_tool_calls"]
+    terminal = response_shape["terminal"]
+    status = response_shape["status_class"]
+    input_types = {item["type"] for item in request_shape["input_item_types"] if item["count"] > 0}
+    response_items = set(response_shape["item_types"])
+    if name in {"streaming_text", "streaming_function_history", "terminal_success", "terminal_error"} and not stream:
+        raise ManifestValidationError("control_label_stream_contract_invalid")
+    if name in {"non_streaming_text", "choice_none", "error_json"} and stream:
+        raise ManifestValidationError("control_label_non_stream_contract_invalid")
+    if name == "choice_auto" and (choice != "auto" or parallel is not True):
+        raise ManifestValidationError("control_label_choice_auto_invalid")
+    if name == "choice_none" and choice != "none":
+        raise ManifestValidationError("control_label_choice_none_invalid")
+    if name == "terminal_success" and (terminal != "response.completed" or status != "2xx"):
+        raise ManifestValidationError("control_label_terminal_success_invalid")
+    if name == "terminal_error" and (terminal != "response.failed" or status not in {"4xx", "5xx"}):
+        raise ManifestValidationError("control_label_terminal_error_invalid")
+    if name == "error_json" and (terminal != "json_response" or status not in {"4xx", "5xx"}):
+        raise ManifestValidationError("control_label_error_json_invalid")
+    if name == "streaming_function_history":
+        required = {"function_call", "function_call_output"}
+        if not required.issubset(input_types) or not required.issubset(response_items):
+            raise ManifestValidationError("control_label_function_history_items_invalid")
+        if response_shape["call_link_count"] < 1:
+            raise ManifestValidationError("control_label_function_history_links_invalid")
+
+
+def _validate_canonical_control(control: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate the canonical control shape stored in a manifest.
+
+    Build inputs contain complete raw sidecar records (including capture-only
+    metadata), while manifests contain the sanitized sidecars returned by
+    ``_sanitize_control`` plus the derived ``body_equality`` field.  These are
+    deliberately different schemas; reconciliation must validate the latter
+    directly instead of trying to feed it back through the raw sanitizer.
+    """
+
+    expected = frozenset(
+        {
+            "name",
+            "pre",
+            "post",
+            "request_shape",
+            "response_shape",
+            "identity",
+            "route_identity",
+            "body_equality",
+        }
+    )
+    if not isinstance(control, Mapping):
+        raise ManifestValidationError("control_invalid")
+    _require_exact_fields(control, expected, "canonical_control_fields_invalid")
+    name = control.get("name")
+    if name not in CONTROL_NAME_SET:
+        raise ManifestValidationError("control_name_invalid")
+    pre = _validate_sanitized_sidecar(control.get("pre"), code_prefix="canonical_pre")
+    post = _validate_sanitized_sidecar(control.get("post"), code_prefix="canonical_post")
+    if pre["outcome"] != "complete" or post["outcome"] != "complete":
+        raise ManifestValidationError("control_capture_incomplete")
+    _require_complete_fingerprints(pre, post)
+    request_equal = _pair_equal(pre, post, "request")
+    response_equal = _pair_equal(pre, post, "response")
+    if not request_equal or not response_equal:
+        raise ManifestValidationError("control_body_fingerprint_mismatch")
+    content_equal = pre["content_type_class"] == post["content_type_class"]
+    if not content_equal:
+        raise ManifestValidationError("control_content_type_mismatch")
+    if pre["content_type_class"] == "event-stream":
+        if pre["sse"] is None or post["sse"] is None or not _pair_equal(pre, post, "sse"):
+            raise ManifestValidationError("control_sse_fingerprint_mismatch")
+        _require_complete_sse_fingerprints(pre, post)
+    elif pre["sse"] is not None or post["sse"] is not None:
+        raise ManifestValidationError("control_json_sse_mismatch")
+
+    request_shape = _sanitize_request_shape(control.get("request_shape"))
+    response_shape = _sanitize_response_shape(control.get("response_shape"))
+    identity = _sanitize_identity(control.get("identity"))
+    route = _sanitize_route(control.get("route_identity"))
+    if request_shape["model"] != route["model"]:
+        raise ManifestValidationError("control_model_binding_mismatch")
+    if request_shape["stream"] != (pre["content_type_class"] == "event-stream"):
+        raise ManifestValidationError("control_stream_mode_mismatch")
+    if response_shape["content_type_class"] != pre["content_type_class"]:
+        raise ManifestValidationError("control_response_shape_content_mismatch")
+    if response_shape["terminal"] == "json_response" and pre["content_type_class"] != "json":
+        raise ManifestValidationError("control_terminal_content_mismatch")
+    if response_shape["terminal"] != "json_response" and pre["content_type_class"] == "json":
+        raise ManifestValidationError("control_json_terminal_invalid")
+    _validate_control_semantics(name, request_shape, response_shape)
+    if identity["unclassified_core_items"] != 0:
+        raise ManifestValidationError("control_identity_unclassified")
+
+    body_equality = control.get("body_equality")
+    if not isinstance(body_equality, Mapping):
+        raise ManifestValidationError("body_equality_invalid")
+    _require_exact_fields(body_equality, frozenset({"request", "response", "sse"}), "body_equality_fields_invalid")
+    expected_equality = {
+        "request": request_equal,
+        "response": response_equal,
+        "sse": pre["sse"] is not None,
+    }
+    if any(body_equality.get(key) is not expected_value for key, expected_value in expected_equality.items()):
+        raise ManifestValidationError("body_equality_mismatch")
+
+    return {
+        "name": name,
+        "pre": pre,
+        "post": post,
+        "request_shape": request_shape,
+        "response_shape": response_shape,
+        "identity": identity,
+        "route_identity": route,
+        "body_equality": expected_equality,
+    }
+
+
+def _validate_candidate(value: Mapping[str, Any]) -> dict[str, Any]:
+    expected = frozenset(
+        {
+            "codexhub_candidate_sha",
+            "cli_version",
+            "cli_source_commit",
+            "cli_source_commit_status",
+            "cli_package_sha256",
+            "catalog_snapshot_sha256",
+            "catalog_model_entry_id",
+        }
+    )
+    if not isinstance(value, Mapping):
+        raise ManifestValidationError("candidate_identity_invalid")
+    _require_exact_fields(value, expected, "candidate_identity_fields_invalid")
+    result = dict(value)
+    _require_hex(result["codexhub_candidate_sha"], _SHA1, "candidate_codexhub_sha_invalid")
+    if not isinstance(result["cli_version"], str) or _SEMVER.fullmatch(result["cli_version"]) is None:
+        raise ManifestValidationError("candidate_cli_version_invalid")
+    source_status = result["cli_source_commit_status"]
+    if source_status not in {"published", "not_published_by_registry"}:
+        raise ManifestValidationError("candidate_cli_source_commit_status_invalid")
+    source_commit = result["cli_source_commit"]
+    if source_status == "published":
+        _require_hex(source_commit, _SHA1, "candidate_cli_source_commit_invalid")
+    elif source_commit is not None:
+        raise ManifestValidationError("candidate_cli_source_commit_unexpected")
+    _require_hex(result["cli_package_sha256"], _HEX64, "candidate_cli_package_sha_invalid")
+    _require_hex(result["catalog_snapshot_sha256"], _HEX64, "candidate_catalog_sha_invalid")
+    if result["catalog_model_entry_id"] != "gpt-5.6-sol":
+        raise ManifestValidationError("candidate_catalog_model_invalid")
+    return result
+
+
+def _canonical_digest(value: Any) -> str:
+    encoded = json.dumps(value, ensure_ascii=True, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _required_control_names(controls: Iterable[Mapping[str, Any]]) -> set[str]:
+    return {str(control.get("name")) for control in controls}
+
+
+def _manifest_core(manifest: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "schema": manifest.get("schema"),
+        "verification_scope": manifest.get("verification_scope"),
+        "candidate_identity": manifest.get("candidate_identity"),
+        "controls": manifest.get("controls"),
+        "identity_control": manifest.get("identity_control"),
+        "qualification": manifest.get("qualification"),
+    }
+
+
+def _validate_qualification(value: Any, *, verification_scope: str) -> dict[str, Any]:
+    expected = frozenset(
+        {
+            "candidate_identity_complete",
+            "all_required_controls_complete",
+            "identity_replay",
+            "ready_for_issue62",
+            "reason",
+        }
+    )
+    if not isinstance(value, Mapping):
+        raise ManifestValidationError("qualification_invalid")
+    _require_exact_fields(value, expected, "qualification_fields_invalid")
+    for key in ("candidate_identity_complete", "all_required_controls_complete", "ready_for_issue62"):
+        _require_bool(value.get(key), "qualification_boolean_invalid")
+    if value.get("identity_replay") not in {"not_captured", "captured"}:
+        raise ManifestValidationError("qualification_identity_replay_invalid")
+    reason = value.get("reason")
+    if reason != QUALIFICATION_REASONS.get(verification_scope):
+        raise ManifestValidationError("qualification_reason_invalid")
+    return {
+        "candidate_identity_complete": value["candidate_identity_complete"],
+        "all_required_controls_complete": value["all_required_controls_complete"],
+        "identity_replay": value["identity_replay"],
+        "ready_for_issue62": value["ready_for_issue62"],
+        "reason": reason,
+    }
+
+
+def _validate_identity_control(value: Any) -> dict[str, Any]:
+    expected = frozenset(
+        {
+            "fail_closed",
+            "unclassified_core_items",
+            "unclassified_controls",
+            "replay_cases",
+            "wire_pairing",
+        }
+    )
+    if not isinstance(value, Mapping):
+        raise ManifestValidationError("identity_control_invalid")
+    _require_exact_fields(value, expected, "identity_control_fields_invalid")
+    if _require_bool(value.get("fail_closed"), "identity_control_fail_closed_invalid") is not True:
+        raise ManifestValidationError("identity_control_fail_closed_invalid")
+    unclassified_count = _require_nonnegative_int(
+        value.get("unclassified_core_items"), "identity_control_unclassified_invalid"
+    )
+    unclassified_controls = value.get("unclassified_controls")
+    if (
+        not isinstance(unclassified_controls, list)
+        or any(item not in CONTROL_NAME_SET for item in unclassified_controls)
+        or unclassified_controls != sorted(set(unclassified_controls))
+    ):
+        raise ManifestValidationError("identity_control_controls_invalid")
+    if unclassified_count != len(unclassified_controls):
+        raise ManifestValidationError("identity_control_count_mismatch")
+    if value.get("replay_cases") != ["identity", "mutation", "deletion", "loss"]:
+        raise ManifestValidationError("identity_control_replay_cases")
+    if value.get("wire_pairing") != "control_label_ordinal_without_wire_identifier":
+        raise ManifestValidationError("identity_control_wire_pairing_invalid")
+    return {
+        "fail_closed": True,
+        "unclassified_core_items": unclassified_count,
+        "unclassified_controls": list(unclassified_controls),
+        "replay_cases": ["identity", "mutation", "deletion", "loss"],
+        "wire_pairing": "control_label_ordinal_without_wire_identifier",
+    }
+
+
+def build_manifest(
+    captures: Iterable[Mapping[str, Any]],
+    *,
+    candidate_identity: Mapping[str, Any],
+    verification_scope: str = SYNTHETIC_SCOPE,
+) -> dict[str, Any]:
+    """Build one deterministic sanitized manifest from control captures."""
+
+    if verification_scope not in VERIFICATION_SCOPES:
+        raise ManifestValidationError("verification_scope_invalid")
+    candidate = _validate_candidate(candidate_identity)
+    controls = [_sanitize_control(capture) for capture in captures]
+    if len({control["name"] for control in controls}) != len(controls):
+        raise ManifestValidationError("duplicate_control_name")
+    missing = sorted(CONTROL_NAME_SET - _required_control_names(controls))
+    if missing:
+        raise ManifestValidationError("missing_control:" + ",".join(missing))
+    route_models = {control["route_identity"]["model"] for control in controls}
+    if route_models != {candidate["catalog_model_entry_id"]}:
+        raise ManifestValidationError("control_route_model_set_invalid")
+    identity_failures = [
+        control["name"]
+        for control in controls
+        if not all(control["identity"][field] for field in IDENTITY_BOOLEAN_FIELDS)
+    ]
+    identity_control = {
+        "fail_closed": True,
+        "unclassified_core_items": len(identity_failures),
+        "unclassified_controls": sorted(identity_failures),
+        "replay_cases": ["identity", "mutation", "deletion", "loss"],
+        "wire_pairing": "control_label_ordinal_without_wire_identifier",
+    }
+    qualification = {
+        "candidate_identity_complete": True,
+        "all_required_controls_complete": not missing,
+        "identity_replay": "not_captured",
+        "ready_for_issue62": False,
+        "reason": (
+            "synthetic_fixture_only"
+            if verification_scope == SYNTHETIC_SCOPE
+            else "wire replay and final inventory reconciliation required"
+        ),
+    }
+    core = {
+        "schema": SCHEMA,
+        "verification_scope": verification_scope,
+        "candidate_identity": candidate,
+        "controls": sorted(controls, key=lambda item: item["name"]),
+        "identity_control": identity_control,
+        "qualification": qualification,
+    }
+    core["capture_manifest_sha256"] = _canonical_digest(core)
+    return core
+
+
+def replay_manifest(manifest: Mapping[str, Any], case: str) -> dict[str, Any]:
+    """Return a sanitized negative replay copy for fail-closed validation."""
+
+    if case not in {"identity", "mutation", "deletion", "loss"}:
+        raise ManifestValidationError("replay_case_invalid")
+    clone = copy.deepcopy(dict(manifest))
+    if case == "identity":
+        return clone
+    if case == "mutation":
+        clone["controls"][0]["body_equality"]["response"] = False
+    elif case == "deletion":
+        clone["controls"] = clone["controls"][1:]
+    elif case == "loss":
+        clone["candidate_identity"].pop("catalog_snapshot_sha256", None)
+    return clone
+
+
+def reconcile_manifest(manifest: Mapping[str, Any]) -> dict[str, Any]:
+    """Reconcile a generated or replayed manifest without reading source bodies."""
+
+    mismatches: list[str] = []
+    if not isinstance(manifest, Mapping):
+        return {"reconciled": False, "mismatches": ["schema_invalid"]}
+    try:
+        _require_exact_fields(manifest, MANIFEST_FIELDS, "manifest_fields_invalid")
+    except ManifestValidationError as exc:
+        mismatches.append(str(exc))
+    if manifest.get("schema") != SCHEMA:
+        mismatches.append("schema_invalid")
+        return {"reconciled": False, "mismatches": ["schema_invalid"]}
+    try:
+        candidate = _validate_candidate(manifest.get("candidate_identity"))
+    except ManifestValidationError as exc:
+        mismatches.append(f"candidate:{exc}")
+        candidate = {}
+    controls = manifest.get("controls")
+    if not isinstance(controls, list):
+        mismatches.append("controls_invalid")
+        controls = []
+    names: list[str] = []
+    canonical_controls: list[dict[str, Any]] = []
+    for raw in controls:
+        try:
+            sanitized = _validate_canonical_control(raw)
+        except ManifestValidationError as exc:
+            mismatches.append(f"control:{exc}")
+            continue
+        name = sanitized["name"]
+        names.append(name)
+        canonical_controls.append(sanitized)
+        if raw != sanitized:
+            mismatches.append(f"control:{name}:derived_fields_or_sanitization_drift")
+    if len(set(names)) != len(names):
+        mismatches.append("duplicate_control_name")
+    missing = sorted(CONTROL_NAME_SET - set(names))
+    if missing:
+        mismatches.append("missing_control:" + ",".join(missing))
+    if candidate:
+        route_models = {control["route_identity"]["model"] for control in canonical_controls}
+        if route_models != {candidate.get("catalog_model_entry_id")}:
+            mismatches.append("control_route_model_set_invalid")
+    try:
+        identity_control = _validate_identity_control(manifest.get("identity_control"))
+    except ManifestValidationError as exc:
+        mismatches.append(f"identity_control:{exc}")
+        identity_control = None
+    if identity_control is not None:
+        observed_unclassified = sorted(
+            control["name"]
+            for control in canonical_controls
+            if not all(control["identity"][field] for field in IDENTITY_BOOLEAN_FIELDS)
+        )
+        if identity_control["unclassified_controls"] != observed_unclassified:
+            mismatches.append("identity_control_consistency")
+        if identity_control["unclassified_core_items"] != len(observed_unclassified):
+            mismatches.append("identity_control_count_consistency")
+    if manifest.get("verification_scope") not in VERIFICATION_SCOPES:
+        mismatches.append("verification_scope_invalid")
+    try:
+        qualification = _validate_qualification(
+            manifest.get("qualification"),
+            verification_scope=manifest.get("verification_scope"),
+        )
+    except ManifestValidationError as exc:
+        mismatches.append(f"qualification:{exc}")
+        qualification = {}
+    if qualification.get("ready_for_issue62") is True:
+        mismatches.append("manifest_qualification_not_performed")
+        if manifest.get("verification_scope") == SYNTHETIC_SCOPE:
+            mismatches.append("synthetic_scope_cannot_qualify")
+    if qualification.get("identity_replay") != "not_captured":
+        mismatches.append("live_provenance_not_captured")
+    expected_digest = manifest.get("capture_manifest_sha256")
+    if not isinstance(expected_digest, str) or _HEX64.fullmatch(expected_digest) is None:
+        mismatches.append("capture_manifest_sha256_invalid")
+    else:
+        core = _manifest_core(manifest)
+        if _canonical_digest(core) != expected_digest:
+            mismatches.append("capture_manifest_sha256_stale")
+    return {"reconciled": not mismatches, "mismatches": mismatches}
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ManifestValidationError("input_json_invalid") from exc
+    if not isinstance(value, dict):
+        raise ManifestValidationError("input_json_root_invalid")
+    return value
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--capture", type=Path, required=True, help="Sanitized control capture input JSON")
+    parser.add_argument("--out", type=Path, required=True, help="Sanitized manifest output JSON")
+    parser.add_argument("--verification-scope", choices=sorted(VERIFICATION_SCOPES), default=SYNTHETIC_SCOPE)
+    parser.add_argument("--codexhub-candidate-sha", required=True)
+    parser.add_argument("--cli-version", required=True)
+    parser.add_argument("--cli-source-commit", default=None)
+    parser.add_argument(
+        "--cli-source-commit-status",
+        choices=("published", "not_published_by_registry"),
+        default="not_published_by_registry",
+    )
+    parser.add_argument("--cli-package-sha256", required=True)
+    parser.add_argument("--catalog-snapshot-sha256", required=True)
+    parser.add_argument("--replay-case", choices=("identity", "mutation", "deletion", "loss"), default="identity")
+    parser.add_argument("--check", action="store_true", help="Reconcile output without writing it")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        source = _load_json(args.capture)
+        captures = source.get("controls")
+        if not isinstance(captures, list):
+            raise ManifestValidationError("capture_controls_invalid")
+        candidate = {
+            "codexhub_candidate_sha": args.codexhub_candidate_sha,
+            "cli_version": args.cli_version,
+            "cli_source_commit": args.cli_source_commit,
+            "cli_source_commit_status": args.cli_source_commit_status,
+            "cli_package_sha256": args.cli_package_sha256,
+            "catalog_snapshot_sha256": args.catalog_snapshot_sha256,
+            "catalog_model_entry_id": source.get("catalog_model_entry_id", "gpt-5.6-sol"),
+        }
+        manifest = build_manifest(
+            captures,
+            candidate_identity=candidate,
+            verification_scope=args.verification_scope,
+        )
+        if args.replay_case != "identity":
+            report = reconcile_manifest(replay_manifest(manifest, args.replay_case))
+            print(json.dumps(report, ensure_ascii=True, indent=2, sort_keys=True))
+            return 0 if not report["reconciled"] else 1
+        report = reconcile_manifest(manifest)
+        if not report["reconciled"]:
+            print(json.dumps(report, ensure_ascii=True, indent=2, sort_keys=True))
+            return 1
+        rendered = json.dumps(manifest, ensure_ascii=True, indent=2, sort_keys=True) + "\n"
+        if not args.check:
+            args.out.parent.mkdir(parents=True, exist_ok=True)
+            args.out.write_text(rendered, encoding="utf-8", newline="\n")
+        print(json.dumps({"reconciled": True, "capture_manifest_sha256": manifest["capture_manifest_sha256"]}, sort_keys=True))
+        return 0
+    except ManifestValidationError as exc:
+        print(f"MANIFEST_INVALID:{exc}")
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_issue_62_runtime_inventory.py
+++ b/scripts/build_issue_62_runtime_inventory.py
@@ -118,6 +118,12 @@ BLOCKING_UNQUALIFIED_SCOPES = frozenset(
 # Evidence references are part of the contract, not free-form annotations.
 # This map lets reconciliation detect a stale or hand-edited inventory that
 # silently points a core claim at an unrelated tool-surface check.
+IDENTITY_RESPONSE_EVIDENCE = (
+    "codexhub-runtime-wire-fixture.json#"
+    "pre_gateway.response.streaming.response_id|"
+    "post_gateway.response.streaming.response_id"
+)
+
 CORE_SCOPE_EVIDENCE = {
     "core_text_streaming": "codexhub-runtime-wire-fixture.json#response.streaming.captured",
     "core_text_non_streaming": "codexhub-runtime-wire-fixture.json#response.non_streaming.captured",
@@ -132,8 +138,122 @@ CORE_SCOPE_EVIDENCE = {
     "core_function_result": "codexhub-runtime-wire-fixture.json#history.call_links",
     "core_function_replay": "codexhub-runtime-wire-fixture.json#history.call_links",
     "identity_item_call_ids": "codexhub-runtime-wire-fixture.json#history.call_links",
-    "identity_response_ids": "codexhub-runtime-wire-fixture.json#response.streaming.response_id",
+    "identity_response_ids": IDENTITY_RESPONSE_EVIDENCE,
     "identity_request_ids": "codexhub-runtime-wire-fixture.json#pre_gateway.request_id",
+}
+
+# Every emitted inventory scope has a fixed evidence reference.  Keeping this
+# separate from the classifier implementation lets reconciliation reject a
+# hand-edited source pointer even when the disposition itself is valid.  The
+# choice-control reference has two historical forms because a future captured
+# fixture may legitimately flip the ``captured`` sentinel to true.
+SCOPE_EVIDENCE_SOURCES = {
+    **CORE_SCOPE_EVIDENCE,
+    "choice_controls": frozenset(
+        {
+            "codexhub-runtime-wire-fixture.json#pre_gateway.choice_controls.captured=false",
+            "codexhub-runtime-wire-fixture.json#pre_gateway.choice_controls.captured=true",
+        }
+    ),
+    "terminal_events": "read-only-gate-audit.json#gate_classification.full_pre_post_request_response=live_control_required",
+    "errors": "read-only-gate-audit.json#gate_classification.full_pre_post_request_response=live_control_required",
+    "hosted_only_declarations": "current-codexhub-thread-tool-surface.json#exposure_state_catalog",
+    "unknown_tagged_sentinels": "codexhub-runtime-wire-fixture.json#response.streaming.events.tag=unknown",
+    "default_runtime_fields": "read-only-gate-audit.json#model_visible_request_plan.top_level_field_presence",
+    "code_mode": "issue-248#beta.1-scope",
+    "tool_search": "current-codexhub-thread-tool-surface.json#planner_gates.caller_request",
+    "collaboration_v2": "issue-248#beta.3-scope",
+    "chat_conversion": "issue-248#beta.4-scope",
+}
+
+# These are the core contract claims for which the retained bounded evidence
+# already proves a final preserved/adapted disposition.  They may not be
+# downgraded to ``Unqualified`` or ``local_consume`` by a hand-edited artifact.
+CORE_REQUIRED_PRESERVED_SCOPES = frozenset(
+    {
+        "core_text_streaming",
+        "core_history_multiturn",
+        "core_history_item_ids",
+        "core_history_call_ids",
+        "core_sse_streaming_events",
+        "core_function_declaration",
+        "core_function_call",
+        "core_function_result",
+        "identity_item_call_ids",
+        "identity_response_ids",
+        "identity_request_ids",
+    }
+)
+
+CORE_FINAL_DISPOSITIONS = frozenset({"preserved", "reversibly_adapted", "Unqualified"})
+
+# JSON paths behind the core evidence references.  Most scopes point at one
+# value; the response identity claim deliberately points at a pre/post pair
+# and additionally requires those two aliases to agree.
+CORE_EVIDENCE_POINTERS = {
+    "core_text_streaming": (
+        "codexhub-runtime-wire-fixture.json",
+        (("response", "streaming", "captured"),),
+    ),
+    "core_text_non_streaming": (
+        "codexhub-runtime-wire-fixture.json",
+        (("response", "non_streaming", "captured"),),
+    ),
+    "core_history_multiturn": (
+        "codexhub-runtime-wire-fixture.json",
+        (("history", "captured_source_counts", "paired_calls"),),
+    ),
+    "core_history_item_ids": (
+        "codexhub-runtime-wire-fixture.json",
+        (("history", "call_links"),),
+    ),
+    "core_history_call_ids": (
+        "codexhub-runtime-wire-fixture.json",
+        (("history", "required_call_ids"),),
+    ),
+    "core_sse_streaming_events": (
+        "codexhub-runtime-wire-fixture.json",
+        (("response", "streaming", "events"),),
+    ),
+    "core_sse_terminal_events": (
+        "read-only-gate-audit.json",
+        (("gateway_identity_route", "observed_sse_event_type_counts"),),
+    ),
+    "core_sse_errors": (
+        "read-only-gate-audit.json",
+        (("gate_classification", "full_pre_post_request_response"),),
+    ),
+    "core_function_declaration": (
+        "codexhub-runtime-wire-fixture.json",
+        (("pre_gateway", "tool_surface", "namespaces"),),
+    ),
+    "core_function_call": (
+        "codexhub-runtime-wire-fixture.json",
+        (("history", "call_links"),),
+    ),
+    "core_function_result": (
+        "codexhub-runtime-wire-fixture.json",
+        (("history", "call_links"),),
+    ),
+    "core_function_replay": (
+        "codexhub-runtime-wire-fixture.json",
+        (("history", "call_links"),),
+    ),
+    "identity_item_call_ids": (
+        "codexhub-runtime-wire-fixture.json",
+        (("history", "call_links"),),
+    ),
+    "identity_response_ids": (
+        "codexhub-runtime-wire-fixture.json",
+        (
+            ("pre_gateway", "response", "streaming", "response_id"),
+            ("post_gateway", "response", "streaming", "response_id"),
+        ),
+    ),
+    "identity_request_ids": (
+        "codexhub-runtime-wire-fixture.json",
+        (("pre_gateway", "request_id"),),
+    ),
 }
 
 REQUIRED_CANDIDATE_FIELDS = (
@@ -210,6 +330,120 @@ def _validate_supported_floor(value: str) -> str:
             f"{SUPPORTED_CLI_FLOOR}, got {value!r}"
         )
     return value
+
+
+def _candidate_identity_mismatches(candidate_identity: Any) -> list[str]:
+    """Validate candidate metadata that is self-contained in the inventory.
+
+    Reconciliation is also used for in-memory replay controls where no evidence
+    root is available.  These checks therefore cover contradictions that can be
+    detected without reopening the source fixtures; the evidence-root path
+    below performs the stronger exact binding against the trace and wire data.
+    """
+
+    mismatches: list[str] = []
+    if not isinstance(candidate_identity, dict):
+        return ["candidate_identity must be an object"]
+
+    candidate_cli_version = candidate_identity.get("cli_version")
+    if not isinstance(candidate_cli_version, str):
+        mismatches.append("candidate_identity.cli_version must be a string")
+    else:
+        try:
+            _version_key(candidate_cli_version)
+        except ValueError:
+            mismatches.append("candidate_identity.cli_version is malformed")
+
+    source_commit = candidate_identity.get("source_commit")
+    codex_source_commit = candidate_identity.get("codex_source_commit")
+    for field, value in (
+        ("source_commit", source_commit),
+        ("codex_source_commit", codex_source_commit),
+    ):
+        if not isinstance(value, str) or not re.fullmatch(r"[0-9a-f]{40}", value):
+            mismatches.append(
+                f"candidate_identity.{field} is not a lowercase 40-character SHA-1"
+            )
+    if (
+        isinstance(source_commit, str)
+        and isinstance(codex_source_commit, str)
+        and source_commit != codex_source_commit
+    ):
+        mismatches.append(
+            "candidate_identity.source_commit and codex_source_commit contradict each other"
+        )
+
+    for field in (
+        "route_upstream",
+        "inbound_format",
+        "upstream_format",
+        "configured_provider_id",
+        "model",
+        "catalog_binding",
+        "catalog_model_entry_id",
+        "route_behavior_profile",
+    ):
+        value = candidate_identity.get(field)
+        if not isinstance(value, str) or not value.strip():
+            mismatches.append(f"candidate_identity.{field} is missing or blank")
+
+    for field in ("catalog_snapshot_sha256", "evidence_manifest_sha256"):
+        value = candidate_identity.get(field)
+        if not isinstance(value, str) or not re.fullmatch(r"[0-9a-f]{64}", value):
+            mismatches.append(
+                f"candidate_identity.{field} is not a lowercase 64-character SHA-256"
+            )
+    return mismatches
+
+
+def _evidence_source_allowed(scope: str, evidence_source: Any) -> bool:
+    expected = SCOPE_EVIDENCE_SOURCES.get(scope)
+    if expected is None:
+        return False
+    if isinstance(expected, frozenset):
+        return evidence_source in expected
+    return evidence_source == expected
+
+
+def _resolve_fixture_pointer(document: Any, path: tuple[str, ...]) -> Any:
+    current = document
+    for segment in path:
+        if not isinstance(current, dict) or segment not in current:
+            raise KeyError(".".join(path))
+        current = current[segment]
+    return current
+
+
+def _validate_core_evidence_pointers(
+    *, wire: dict[str, Any], audit: dict[str, Any]
+) -> None:
+    """Require every core evidence reference to resolve in its bound fixture."""
+
+    documents = {
+        "codexhub-runtime-wire-fixture.json": wire,
+        "read-only-gate-audit.json": audit,
+    }
+    for scope, (filename, pointers) in CORE_EVIDENCE_POINTERS.items():
+        document = documents[filename]
+        values: list[Any] = []
+        for pointer in pointers:
+            try:
+                value = _resolve_fixture_pointer(document, pointer)
+            except KeyError as exc:
+                raise ValueError(
+                    f"evidence pointer for {scope} is missing: {filename}#{exc.args[0]}"
+                ) from exc
+            values.append(value)
+        if scope == "identity_response_ids":
+            if (
+                len(values) != 2
+                or not all(isinstance(value, str) and value for value in values)
+                or values[0] != values[1]
+            ):
+                raise ValueError(
+                    "identity_response_ids evidence pointer must bind equal, non-empty "
+                    "pre_gateway and post_gateway response_id values"
+                )
 
 
 def _load_json(path: Path) -> dict[str, Any]:
@@ -503,8 +737,18 @@ def _classify_core_items(
     items.append(
         _item(
             "identity_response_ids",
-            "preserved" if streaming_captured else "Unqualified",
-            "codexhub-runtime-wire-fixture.json#response.streaming.response_id",
+            "preserved"
+            if streaming_captured
+            and wire.get("pre_gateway", {})
+            .get("response", {})
+            .get("streaming", {})
+            .get("response_id")
+            == wire.get("post_gateway", {})
+            .get("response", {})
+            .get("streaming", {})
+            .get("response_id")
+            else "Unqualified",
+            IDENTITY_RESPONSE_EVIDENCE,
             "response_id aliases preserved across pre/post-Gateway replay",
         )
     )
@@ -803,8 +1047,12 @@ def _validate_candidate_binding(
     planner_gates = trace_data.get("planner_gates", {})
     trace_cli_version = source.get("cli_version")
     trace_source_commit = planner_gates.get("source_commit")
-    if not trace_cli_version or not trace_source_commit:
-        raise ValueError("trace evidence is missing source.cli_version or planner_gates.source_commit")
+    trace_capture_id = source.get("capture_id")
+    if not trace_cli_version or not trace_source_commit or not trace_capture_id:
+        raise ValueError(
+            "trace evidence is missing source.cli_version, source.capture_id, "
+            "or planner_gates.source_commit"
+        )
     if not isinstance(trace_cli_version, str):
         raise ValueError("trace source.cli_version must be a string")
     try:
@@ -889,7 +1137,7 @@ def _validate_candidate_binding(
     if (
         wire_provenance.get("cli_version") != trace_cli_version
         or wire_provenance.get("source_commit") != trace_source_commit
-        or wire_provenance.get("capture_id") != source.get("capture_id")
+        or wire_provenance.get("capture_id") != trace_capture_id
     ):
         raise ValueError("wire provenance is not bound to the trace candidate")
     catalog_snapshot = (
@@ -953,6 +1201,7 @@ def build_inventory(
         or audit_data.get("capture_kind") != "sanitized_bounded_read_only_audit"
     ):
         raise ValueError("Issue #62 evidence schema identity is invalid")
+    _validate_core_evidence_pointers(wire=wire_data, audit=audit_data)
 
     items: list[dict[str, Any]] = []
     items.extend(
@@ -1081,8 +1330,14 @@ def reconcile_inventory(
         mismatches.append("inventory disposition_vocabulary is invalid")
 
     items = inventory.get("items", [])
+    if not isinstance(items, list):
+        mismatches.append("inventory items must be an array")
+        items = []
     seen_scopes: set[str] = set()
     for item in items:
+        if not isinstance(item, dict):
+            mismatches.append("item must be an object")
+            continue
         scope = item.get("scope")
         if not scope:
             mismatches.append("item missing scope")
@@ -1098,16 +1353,26 @@ def reconcile_inventory(
             mismatches.append(
                 f"mutation: {scope}: disposition {disposition!r} not in allowed vocabulary"
             )
-        expected_evidence = CORE_SCOPE_EVIDENCE.get(scope)
-        if expected_evidence and item.get("evidence_source") != expected_evidence:
+        evidence_source = item.get("evidence_source")
+        if not isinstance(evidence_source, str) or not evidence_source:
+            mismatches.append(f"mutation: {scope}: evidence_source is missing")
+        elif not _evidence_source_allowed(scope, evidence_source):
             mismatches.append(
-                f"mutation: {scope}: evidence_source {item.get('evidence_source')!r} "
-                f"does not match required {expected_evidence!r}"
+                f"mutation: {scope}: evidence_source {evidence_source!r} "
+                "does not match the expected fixture path/scope"
             )
-        if scope in CORE_CONTRACT_SCOPES and disposition == "Unsupported":
+        if scope in CORE_CONTRACT_SCOPES and disposition not in CORE_FINAL_DISPOSITIONS:
             mismatches.append(
-                f"mutation: {scope}: core disposition {disposition!r} cannot replace "
-                "preserved, reversibly_adapted, local_consume, or Unqualified"
+                f"mutation: {scope}: core disposition {disposition!r} is not a final "
+                "preserved, reversibly_adapted, or Unqualified disposition"
+            )
+        if (
+            scope in CORE_REQUIRED_PRESERVED_SCOPES
+            and disposition not in {"preserved", "reversibly_adapted"}
+        ):
+            mismatches.append(
+                f"mutation: {scope}: bounded contract evidence requires a preserved "
+                "or reversibly_adapted disposition"
             )
 
     required_scopes = (
@@ -1121,11 +1386,17 @@ def reconcile_inventory(
         mismatches.append(f"deletion: missing scopes {missing}")
 
     candidate_identity = inventory.get("candidate_identity", {})
+    mismatches.extend(_candidate_identity_mismatches(candidate_identity))
+    if not isinstance(candidate_identity, dict):
+        candidate_identity = {}
     for field in REQUIRED_CANDIDATE_FIELDS:
         if field not in candidate_identity:
             mismatches.append(f"loss: candidate_identity.{field} is missing")
 
     qualification = inventory.get("qualification", {})
+    if not isinstance(qualification, dict):
+        mismatches.append("qualification must be an object")
+        qualification = {}
     try:
         _validate_supported_floor(str(inventory.get("cli_version_floor", "")))
     except ValueError as exc:
@@ -1214,6 +1485,9 @@ def reconcile_inventory(
         )
 
     evidence_binding = inventory.get("evidence_binding", {})
+    if not isinstance(evidence_binding, dict):
+        mismatches.append("evidence_binding must be an object")
+        evidence_binding = {}
     for name in ("trace", "wire_fixture", "audit"):
         entry = evidence_binding.get(name, {})
         if not isinstance(entry, dict) or not entry.get("file") or not re.fullmatch(
@@ -1259,6 +1533,11 @@ def reconcile_inventory(
                 or audit_data.get("capture_kind") != "sanitized_bounded_read_only_audit"
             ):
                 mismatches.append("mutation: bound evidence schema identity is invalid")
+                return {"reconciled": False, "mismatches": mismatches}
+            try:
+                _validate_core_evidence_pointers(wire=wire_data, audit=audit_data)
+            except ValueError as exc:
+                mismatches.append(f"mutation: bound evidence pointer validation failed: {exc}")
                 return {"reconciled": False, "mismatches": mismatches}
             try:
                 expected_identity, expected_status_from_evidence = _validate_candidate_binding(
@@ -1318,6 +1597,9 @@ def reconcile_inventory(
                         )
 
     identity_control = inventory.get("identity_control", {})
+    if not isinstance(identity_control, dict):
+        mismatches.append("identity_control must be an object")
+        identity_control = {}
     if identity_control.get("fail_closed") is not True:
         mismatches.append("identity_control.fail_closed must be true")
     if identity_control.get("replay_cases") != [

--- a/scripts/build_issue_62_runtime_inventory.py
+++ b/scripts/build_issue_62_runtime_inventory.py
@@ -1,0 +1,1452 @@
+#!/usr/bin/env python3
+"""Build the versioned Codex runtime/wire inventory for Issue #62.
+
+The inventory records one per-scope disposition for every taxonomy item the
+Codex CLI exposes over the core Responses contract: text, history, streaming
+SSE, standard function tools, identity, terminal events, errors, hosted-only
+declarations, unknown tagged sentinels, default runtime fields, and the
+explicitly-deferred advanced capabilities (Code Mode, ``tool_search``,
+Collaboration V2, Chat conversion).
+
+Each item receives one of:
+
+- ``preserved``           : observed and carried through unchanged
+- ``reversibly_adapted``  : observed with a documented reversible adaptation
+- ``local_consume``       : observed and consumed locally without upstream I/O
+- ``Unsupported``         : explicitly out of scope for the beta.1 core contract
+- ``Unqualified``      : not qualified by accepted evidence; a separately
+  authorized live control window must capture it before any capability claim
+
+The generator reads the existing sanitized Issue #62 evidence artifacts and
+never fabricates a ``Supported`` disposition for a gate the artifacts leave
+unqualified. It feeds #249 (capability gate) and #66 (Chat
+conversion matrix).
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = 1
+ARTIFACT_KIND = "runtime_wire_inventory"
+DEFAULT_CLI_FLOOR = "0.145.0"
+SUPPORTED_CLI_FLOOR = DEFAULT_CLI_FLOOR
+DEFAULT_CANDIDATE_CLI_VERSION = None
+DEFAULT_CANDIDATE_SOURCE_COMMIT = None
+
+ALLOWED_DISPOSITIONS = (
+    "preserved",
+    "reversibly_adapted",
+    "local_consume",
+    "Unsupported",
+    "Unqualified",
+)
+
+# Scopes that must stay live-control-required until a coordinated live window
+# captures real evidence. The bounded read-only audit (read-only-gate-audit)
+# and the sanitized fixtures already classify these as live-control-required
+# or contract sentinels; the inventory must not flip them.
+LIVE_CONTROL_SCOPES = frozenset(
+    {
+        "core_text_non_streaming",
+        "core_sse_terminal_events",
+        "core_sse_errors",
+        "terminal_events",
+        "errors",
+        "hosted_only_declarations",
+        "unknown_tagged_sentinels",
+        "default_runtime_fields",
+    }
+)
+
+# Advanced capabilities explicitly deferred for beta.1 per #248/#258. They are
+# not part of the core Responses contract and must not be advertised.
+ADVANCED_UNSUPPORTED_SCOPES = frozenset(
+    {
+        "code_mode",
+        "tool_search",
+        "collaboration_v2",
+        "chat_conversion",
+    }
+)
+
+# Every core scope is required in the inventory, even when the current
+# evidence only justifies ``Unqualified``.  Keeping this set
+# separate from the disposition vocabulary prevents an incomplete fixture from
+# being mistaken for a completed beta gate.
+CORE_CONTRACT_SCOPES = frozenset(
+    {
+        "core_text_streaming",
+        "core_text_non_streaming",
+        "core_history_multiturn",
+        "core_history_item_ids",
+        "core_history_call_ids",
+        "core_sse_streaming_events",
+        "core_sse_terminal_events",
+        "core_sse_errors",
+        "core_function_declaration",
+        "core_function_call",
+        "core_function_result",
+        "core_function_replay",
+        "identity_item_call_ids",
+        "identity_response_ids",
+        "identity_request_ids",
+    }
+)
+
+KNOWN_SCOPES = (
+    CORE_CONTRACT_SCOPES
+    | LIVE_CONTROL_SCOPES
+    | ADVANCED_UNSUPPORTED_SCOPES
+    | {"choice_controls"}
+)
+
+# An unqualified core/live-control item blocks beta qualification.  Advanced
+# capabilities remain explicitly deferred and therefore do not block the
+# beta.1 core gate merely because they are unqualified.
+BLOCKING_UNQUALIFIED_SCOPES = frozenset(
+    CORE_CONTRACT_SCOPES | LIVE_CONTROL_SCOPES | {"choice_controls"}
+)
+
+# Evidence references are part of the contract, not free-form annotations.
+# This map lets reconciliation detect a stale or hand-edited inventory that
+# silently points a core claim at an unrelated tool-surface check.
+CORE_SCOPE_EVIDENCE = {
+    "core_text_streaming": "codexhub-runtime-wire-fixture.json#response.streaming.captured",
+    "core_text_non_streaming": "codexhub-runtime-wire-fixture.json#response.non_streaming.captured",
+    "core_history_multiturn": "codexhub-runtime-wire-fixture.json#history.captured_source_counts.paired_calls",
+    "core_history_item_ids": "codexhub-runtime-wire-fixture.json#history.call_links",
+    "core_history_call_ids": "codexhub-runtime-wire-fixture.json#history.required_call_ids",
+    "core_sse_streaming_events": "codexhub-runtime-wire-fixture.json#response.streaming.events",
+    "core_sse_terminal_events": "read-only-gate-audit.json#gateway_identity_route.observed_sse_event_type_counts",
+    "core_sse_errors": "read-only-gate-audit.json#gate_classification.full_pre_post_request_response",
+    "core_function_declaration": "codexhub-runtime-wire-fixture.json#pre_gateway.tool_surface.namespaces",
+    "core_function_call": "codexhub-runtime-wire-fixture.json#history.call_links",
+    "core_function_result": "codexhub-runtime-wire-fixture.json#history.call_links",
+    "core_function_replay": "codexhub-runtime-wire-fixture.json#history.call_links",
+    "identity_item_call_ids": "codexhub-runtime-wire-fixture.json#history.call_links",
+    "identity_response_ids": "codexhub-runtime-wire-fixture.json#response.streaming.response_id",
+    "identity_request_ids": "codexhub-runtime-wire-fixture.json#pre_gateway.request_id",
+}
+
+REQUIRED_CANDIDATE_FIELDS = (
+    "cli_version",
+    "source_commit",
+    "route_upstream",
+    "inbound_format",
+    "upstream_format",
+    "configured_provider_id",
+    "model",
+    "catalog_binding",
+    "catalog_snapshot_sha256",
+    "catalog_model_entry_id",
+    "route_behavior_profile",
+    "evidence_manifest_sha256",
+)
+
+
+def _sha256_file(path: Path) -> str:
+    # Evidence is JSON text; hash its canonical LF representation so a
+    # Windows checkout (CRLF) and a Linux checkout (LF) bind to the same
+    # artifact bytes.
+    canonical = path.read_bytes().replace(b"\r\n", b"\n")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def _evidence_manifest_sha256(evidence_binding: dict[str, Any]) -> str:
+    manifest = "\n".join(
+        f"{name}:{evidence_binding[name]['file']}:{evidence_binding[name]['sha256']}"
+        for name in sorted(evidence_binding)
+    )
+    return hashlib.sha256(manifest.encode("utf-8")).hexdigest()
+
+
+def _version_key(value: str) -> tuple[int, int, int, int, str]:
+    """Return a comparable key for Codex's semver-like CLI versions.
+
+    Stable releases sort after prereleases of the same core version.  Build
+    metadata is ignored for eligibility, while malformed values fail closed.
+    """
+
+    match = re.fullmatch(
+        r"(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)"
+        r"(?P<pre>-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?",
+        value,
+    )
+    if not match:
+        raise ValueError(f"invalid Codex CLI version: {value!r}")
+    return (
+        int(match.group("major")),
+        int(match.group("minor")),
+        int(match.group("patch")),
+        0 if match.group("pre") else 1,
+        match.group("pre") or "",
+    )
+
+
+def _candidate_version_status(candidate: str, floor: str) -> str:
+    return "eligible" if _version_key(candidate) >= _version_key(floor) else "legacy_below_floor"
+
+
+def _validate_supported_floor(value: str) -> str:
+    """Require the inventory to bind to the repository's supported CLI floor."""
+
+    if not isinstance(value, str):
+        raise ValueError(f"supported CLI floor must be a string: {value!r}")
+    try:
+        _version_key(value)
+    except ValueError as exc:
+        raise ValueError(f"supported CLI floor is malformed: {value!r}") from exc
+    if value != SUPPORTED_CLI_FLOOR:
+        raise ValueError(
+            "inventory CLI floor must bind to the supported CLI floor "
+            f"{SUPPORTED_CLI_FLOOR}, got {value!r}"
+        )
+    return value
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _item(
+    scope: str,
+    disposition: str,
+    evidence_source: str,
+    notes: str = "",
+) -> dict[str, Any]:
+    if disposition not in ALLOWED_DISPOSITIONS:
+        raise ValueError(f"disposition {disposition!r} not allowed for {scope}")
+    item: dict[str, Any] = {
+        "scope": scope,
+        "disposition": disposition,
+        "evidence_source": evidence_source,
+    }
+    if notes:
+        item["notes"] = notes
+    return item
+
+
+def _gate_is_met(value: Any) -> bool:
+    return value in {"observed", "met", "complete", "pass"}
+
+
+def _gate_is_complete(value: Any) -> bool:
+    return value in {"met", "complete"}
+
+
+def _real_non_streaming_captured(wire: dict[str, Any]) -> bool:
+    non_streaming = wire.get("response", {}).get("non_streaming", {})
+    return (
+        non_streaming.get("captured") is True
+        and non_streaming.get("fixture_kind") != "contract_sentinel"
+        and bool(non_streaming.get("response_items"))
+        and non_streaming.get("request_stream") is False
+    )
+
+
+def _count_unknown_tags(value: Any) -> int:
+    if isinstance(value, dict):
+        own = 1 if value.get("tag") == "unknown" else 0
+        return own + sum(_count_unknown_tags(child) for child in value.values())
+    if isinstance(value, list):
+        return sum(_count_unknown_tags(child) for child in value)
+    return 0
+
+
+def _unknown_tag_mode_counts(wire: dict[str, Any]) -> tuple[int, int]:
+    streaming = _streaming_events(wire)
+    non_streaming = wire.get("response", {}).get("non_streaming", {}).get(
+        "response_items", []
+    )
+    return (
+        sum(1 for item in streaming if item.get("tag") == "unknown"),
+        sum(
+            1
+            for item in non_streaming
+            if isinstance(item, dict) and item.get("tag") == "unknown"
+        ),
+    )
+
+
+def _streaming_events(wire: dict[str, Any]) -> list[dict[str, Any]]:
+    events = wire.get("response", {}).get("streaming", {}).get("events", [])
+    return [event for event in events if isinstance(event, dict)]
+
+
+def _has_terminal_event(wire: dict[str, Any]) -> bool:
+    return any(event.get("event") == "response.completed" for event in _streaming_events(wire))
+
+
+def _has_error_event(wire: dict[str, Any]) -> bool:
+    return any(
+        "error" in str(event.get("event", "")).lower()
+        or event.get("tag") == "error"
+        for event in _streaming_events(wire)
+    )
+
+
+def _wire_identity_replay_status(
+    audit: dict[str, Any], *, expected_wire_sha256: str | None = None
+) -> str:
+    replay = audit.get("wire_identity_replay")
+    if not isinstance(replay, dict):
+        return "not_captured"
+    status = replay.get("status", "not_captured")
+    if status not in {"complete", "met"}:
+        return status
+    cases = replay.get("cases")
+    source_hash = replay.get("wire_fixture_sha256")
+    if (
+        replay.get("fail_closed") is True
+        and isinstance(source_hash, str)
+        and re.fullmatch(r"[0-9a-f]{64}", source_hash)
+        and (expected_wire_sha256 is None or source_hash == expected_wire_sha256)
+        and isinstance(cases, dict)
+        and all(
+            isinstance(cases.get(case), dict)
+            and cases[case].get("status") in {"complete", "met"}
+            and cases[case].get("observed") is True
+            and re.fullmatch(
+                r"[0-9a-f]{64}", str(cases[case].get("output_sha256", ""))
+            )
+            for case in ("identity", "mutation", "deletion", "loss")
+        )
+    ):
+        return status
+    return "not_captured"
+
+
+def _sse_identity_status(
+    audit: dict[str, Any], *, expected_wire_sha256: str | None = None
+) -> str:
+    evidence = audit.get("sse_identity")
+    if not isinstance(evidence, dict):
+        return "not_captured"
+    status = evidence.get("status", "not_captured")
+    if status not in {"complete", "met"}:
+        return status
+    source_hash = evidence.get("wire_fixture_sha256")
+    pre_hash = evidence.get("pre_stream_sequence_sha256")
+    post_hash = evidence.get("post_stream_sequence_sha256")
+    if (
+        evidence.get("fail_closed") is True
+        and isinstance(source_hash, str)
+        and re.fullmatch(r"[0-9a-f]{64}", source_hash)
+        and (expected_wire_sha256 is None or source_hash == expected_wire_sha256)
+        and isinstance(pre_hash, str)
+        and re.fullmatch(r"[0-9a-f]{64}", pre_hash)
+        and post_hash == pre_hash
+        and evidence.get("event_count", 0) > 0
+    ):
+        return status
+    return "not_captured"
+
+
+def _classify_core_items(
+    wire: dict[str, Any],
+    audit: dict[str, Any],
+    *,
+    wire_fixture_sha256: str | None = None,
+) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+
+    streaming_captured = wire.get("response", {}).get("streaming", {}).get("captured") is True
+    non_streaming_captured = _real_non_streaming_captured(wire)
+    full_wire_gate = audit.get("gate_classification", {}).get(
+        "full_pre_post_request_response"
+    )
+    identity_gate = audit.get("gate_classification", {}).get(
+        "zero_unclassified_identity"
+    )
+    wire_replay_gate = _wire_identity_replay_status(
+        audit, expected_wire_sha256=wire_fixture_sha256
+    )
+    items.append(
+        _item(
+            "core_text_streaming",
+            "preserved" if streaming_captured else "Unqualified",
+            "codexhub-runtime-wire-fixture.json#response.streaming.captured",
+            "streaming response text observed and preserved across the official Responses route",
+        )
+    )
+
+    items.append(
+        _item(
+            "core_text_non_streaming",
+            "preserved" if non_streaming_captured else "Unqualified",
+            "codexhub-runtime-wire-fixture.json#response.non_streaming.captured",
+            "non-streaming response text is only qualified when a real captured fixture is present",
+        )
+    )
+
+    history_counts = wire.get("history", {}).get("captured_source_counts", {})
+    paired = history_counts.get("paired_calls", 0)
+    items.append(
+        _item(
+            "core_history_multiturn",
+            "preserved" if paired > 0 else "Unqualified",
+            "codexhub-runtime-wire-fixture.json#history.captured_source_counts.paired_calls",
+            "multi-turn history with paired call/output rows observed",
+        )
+    )
+
+    call_links = wire.get("history", {}).get("call_links", [])
+    items.append(
+        _item(
+            "core_history_item_ids",
+            "preserved" if call_links else "Unqualified",
+            "codexhub-runtime-wire-fixture.json#history.call_links",
+            "call_item_id and output_item_id aliases preserved per link",
+        )
+    )
+    items.append(
+        _item(
+            "core_history_call_ids",
+            "preserved" if call_links else "Unqualified",
+            "codexhub-runtime-wire-fixture.json#history.required_call_ids",
+            "call_id aliases preserved and reconciled with call links",
+        )
+    )
+
+    sse_events = wire.get("response", {}).get("streaming", {}).get("events", [])
+    items.append(
+        _item(
+            "core_sse_streaming_events",
+            "reversibly_adapted" if sse_events else "Unqualified",
+            "codexhub-runtime-wire-fixture.json#response.streaming.events",
+            "observed SSE event kinds sanitized to redacted payloads with stable event sequence",
+        )
+    )
+
+    items.append(
+        _item(
+            "core_sse_terminal_events",
+            "preserved"
+            if _gate_is_complete(full_wire_gate) and _has_terminal_event(wire)
+            else "Unqualified",
+            "read-only-gate-audit.json#gateway_identity_route.observed_sse_event_type_counts",
+            "terminal event classification requires independently captured full response-body evidence",
+        )
+    )
+    items.append(
+        _item(
+            "core_sse_errors",
+            "preserved"
+            if _gate_is_complete(full_wire_gate) and _has_error_event(wire)
+            else "Unqualified",
+            "read-only-gate-audit.json#gate_classification.full_pre_post_request_response",
+            "error classification requires independently fingerprinted pre/post response bodies",
+        )
+    )
+
+    namespaces = (
+        wire.get("pre_gateway", {}).get("tool_surface", {}).get("namespaces", [])
+    )
+    codex_app_ns = next((ns for ns in namespaces if ns.get("name") == "codex_app"), None)
+    items.append(
+        _item(
+            "core_function_declaration",
+            "preserved" if codex_app_ns else "Unqualified",
+            "codexhub-runtime-wire-fixture.json#pre_gateway.tool_surface.namespaces",
+            "Direct and Deferred function declarations observed for the codex_app namespace",
+        )
+    )
+
+    call_links_have_function = any(
+        link.get("call_type") == "function_call" for link in call_links
+    )
+    items.append(
+        _item(
+            "core_function_call",
+            "preserved" if call_links_have_function else "Unqualified",
+            "codexhub-runtime-wire-fixture.json#history.call_links",
+            "function_call items with call_id and arguments aliases observed",
+        )
+    )
+    items.append(
+        _item(
+            "core_function_result",
+            "preserved" if call_links_have_function else "Unqualified",
+            "codexhub-runtime-wire-fixture.json#history.call_links",
+            "function_call_output items with call_id and output aliases observed",
+        )
+    )
+    items.append(
+        _item(
+            "core_function_replay",
+            "preserved"
+            if _gate_is_complete(full_wire_gate)
+            and _gate_is_complete(identity_gate)
+            and _gate_is_complete(wire_replay_gate)
+            else "Unqualified",
+            "codexhub-runtime-wire-fixture.json#history.call_links",
+            "call/result links are present, but the bounded tool-membership replay does not prove a complete function replay across the real wire",
+        )
+    )
+
+    items.append(
+        _item(
+            "identity_item_call_ids",
+            "preserved" if call_links else "Unqualified",
+            "codexhub-runtime-wire-fixture.json#history.call_links",
+            "item/call id aliases preserved across pre/post-Gateway replay",
+        )
+    )
+    items.append(
+        _item(
+            "identity_response_ids",
+            "preserved" if streaming_captured else "Unqualified",
+            "codexhub-runtime-wire-fixture.json#response.streaming.response_id",
+            "response_id aliases preserved across pre/post-Gateway replay",
+        )
+    )
+    pre_request_id = wire.get("pre_gateway", {}).get("request_id")
+    post_request_id = wire.get("post_gateway", {}).get("request_id")
+    items.append(
+        _item(
+            "identity_request_ids",
+            "preserved"
+            if pre_request_id and post_request_id and pre_request_id == post_request_id
+            else "Unqualified",
+            "codexhub-runtime-wire-fixture.json#pre_gateway.request_id",
+            "request_id aliases preserved and equal across pre/post-Gateway replay",
+        )
+    )
+
+    return items
+
+
+def _classify_live_control_items(
+    wire: dict[str, Any],
+    audit: dict[str, Any],
+) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+
+    gate_classification = audit.get("gate_classification", {})
+    full_wire_gate = gate_classification.get("full_pre_post_request_response")
+    non_direct_gate = gate_classification.get("non_direct_states")
+    non_streaming_captured = _real_non_streaming_captured(wire)
+    unknown_tag_count = _count_unknown_tags(wire)
+    unknown_stream_count, unknown_non_stream_count = _unknown_tag_mode_counts(wire)
+
+    choice_captured = (
+        wire.get("pre_gateway", {}).get("choice_controls", {}).get("captured") is True
+    )
+    audit_choice = audit.get("gate_classification", {}).get("choice_controls")
+    items.append(
+        _item(
+            "choice_controls",
+            "Unqualified",
+            "codexhub-runtime-wire-fixture.json#pre_gateway.choice_controls.captured=false",
+            "choice controls are a contract sentinel in the wire fixture; the bounded audit observes tool_choice/parallel_tool_calls but full pre/post choice identity requires a live control",
+        )
+        if not choice_captured
+        else _item(
+            "choice_controls",
+            "preserved",
+            "codexhub-runtime-wire-fixture.json#pre_gateway.choice_controls.captured=true",
+            f"choice controls captured and preserved across pre/post-Gateway replay (audit gate={audit_choice!r})",
+        )
+    )
+
+    items.append(
+        _item(
+            "terminal_events",
+            "preserved"
+            if _gate_is_complete(full_wire_gate) and _has_terminal_event(wire)
+            else "Unqualified",
+            "read-only-gate-audit.json#gate_classification.full_pre_post_request_response=live_control_required",
+            "terminal event classification requires a real captured response body fingerprint",
+        )
+    )
+    items.append(
+        _item(
+            "errors",
+            "preserved"
+            if _gate_is_complete(full_wire_gate) and _has_error_event(wire)
+            else "Unqualified",
+            "read-only-gate-audit.json#gate_classification.full_pre_post_request_response=live_control_required",
+            "error classification requires independently captured pre/post response evidence",
+        )
+    )
+
+    items.append(
+        _item(
+            "hosted_only_declarations",
+            "preserved" if _gate_is_met(non_direct_gate) else "Unqualified",
+            "current-codexhub-thread-tool-surface.json#exposure_state_catalog",
+            "hosted-only and host-unavailable are tagged reconciliation sentinels; no runtime-observed host binding",
+        )
+    )
+
+    items.append(
+        _item(
+            "unknown_tagged_sentinels",
+            "preserved"
+            if unknown_tag_count > 0
+            and unknown_stream_count > 0
+            and unknown_non_stream_count > 0
+            and _gate_is_complete(full_wire_gate)
+            and non_streaming_captured
+            else "Unqualified",
+            "codexhub-runtime-wire-fixture.json#response.streaming.events.tag=unknown",
+            "unknown tagged sentinels are preserved as opaque replay sentinels; live runtime dispositions require a real unknown item",
+        )
+    )
+
+    items.append(
+        _item(
+            "default_runtime_fields",
+            "preserved" if _gate_is_complete(full_wire_gate) else "Unqualified",
+            "read-only-gate-audit.json#model_visible_request_plan.top_level_field_presence",
+            "default runtime field classification requires an independently captured full request body",
+        )
+    )
+
+    return items
+
+
+def _classify_advanced_items(
+    trace: dict[str, Any],
+) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+
+    items.append(
+        _item(
+            "code_mode",
+            "Unsupported",
+            "issue-248#beta.1-scope",
+            "Code Mode is beta.2 scope (#251/#279/#280); not advertised in beta.1",
+        )
+    )
+
+    tool_search = (
+        trace.get("planner_gates", {})
+        .get("caller_request", {})
+        .get("additional_tools_contains_tool_search")
+    )
+    items.append(
+        _item(
+            "tool_search",
+            "Unqualified" if tool_search is True else "Unsupported",
+            "current-codexhub-thread-tool-surface.json#planner_gates.caller_request",
+            "client-executed tool_search is observed in the caller request but model non-selection is owned by #63; beta.2 scope",
+        )
+    )
+
+    multi_agent = trace.get("source", {}).get("multi_agent_version")
+    items.append(
+        _item(
+            "collaboration_v2",
+            "Unsupported",
+            "issue-248#beta.3-scope",
+            f"Collaboration V2 is beta.3 scope (#64/#282/#283); observed multi_agent_version={multi_agent!r} is not advertised in beta.1",
+        )
+    )
+
+    items.append(
+        _item(
+            "chat_conversion",
+            "Unsupported",
+            "issue-248#beta.4-scope",
+            "Chat conversion is beta.4 scope (#66/#253/#254); not advertised in beta.1",
+        )
+    )
+
+    return items
+
+
+def _build_identity_control(
+    items: list[dict[str, Any]], *, unknown_tagged_source_count: int
+) -> dict[str, Any]:
+    by_scope = {item.get("scope"): item for item in items}
+    core_allowed = {
+        "preserved",
+        "reversibly_adapted",
+        "local_consume",
+        "Unqualified",
+    }
+    unclassified = []
+    for scope in sorted(CORE_CONTRACT_SCOPES):
+        item = by_scope.get(scope)
+        if (
+            item is None
+            or item.get("disposition") not in core_allowed
+            or item.get("evidence_source") != CORE_SCOPE_EVIDENCE[scope]
+        ):
+            unclassified.append(scope)
+    return {
+        "unclassified_core_items": len(unclassified),
+        "unclassified_scopes": unclassified,
+        "fail_closed": True,
+        "replay_cases": ["identity", "mutation", "deletion", "loss"],
+        "unknown_tagged_source_count": unknown_tagged_source_count,
+    }
+
+
+def _build_qualification(
+    items: list[dict[str, Any]],
+    candidate_version_status: str,
+    *,
+    trace: dict[str, Any],
+    wire: dict[str, Any],
+    audit: dict[str, Any],
+    wire_fixture_sha256: str | None = None,
+) -> dict[str, Any]:
+    unqualified_scopes = sorted(
+        item["scope"]
+        for item in items
+        if item["scope"] in BLOCKING_UNQUALIFIED_SCOPES
+        and item["disposition"] == "Unqualified"
+    )
+    blocking_scopes = unqualified_scopes
+    candidate_version_eligible = candidate_version_status == "eligible"
+    evidence_gates = {
+        "complete_model_visible_plan": trace.get("capture_coverage", {})
+        .get("complete_model_visible_plan", {})
+        .get("status", "unknown"),
+        "clean_cold_start_current_binding": trace.get("capture_coverage", {})
+        .get("clean_cold_start_current_binding", {})
+        .get("status", "unknown"),
+        "full_pre_post_request_response": audit.get("gate_classification", {}).get(
+            "full_pre_post_request_response", "unknown"
+        ),
+        "full_request_fingerprint": trace.get("gateway_observability", {}).get(
+            "full_request_body_fingerprint", "unknown"
+        ),
+        "full_response_fingerprint": trace.get("gateway_observability", {}).get(
+            "full_response_body_fingerprint", "unknown"
+        ),
+        "sse_identity": (
+            _sse_identity_status(audit, expected_wire_sha256=wire_fixture_sha256)
+        ),
+        "terminal_events": (
+            "met"
+            if _gate_is_complete(audit.get("gate_classification", {}).get(
+                "full_pre_post_request_response"
+            ))
+            and _has_terminal_event(wire)
+            else "not_captured"
+        ),
+        "error_events": (
+            "met"
+            if _gate_is_complete(audit.get("gate_classification", {}).get(
+                "full_pre_post_request_response"
+            ))
+            and _has_error_event(wire)
+            else "not_captured"
+        ),
+        "non_streaming": audit.get("gate_classification", {}).get(
+            "non_streaming", "unknown"
+        ),
+        "non_streaming_fixture": (
+            "met"
+            if _real_non_streaming_captured(wire)
+            else "not_captured"
+        ),
+        "identity_replay": audit.get("gate_classification", {}).get(
+            "zero_unclassified_identity", "unknown"
+        ),
+        "wire_identity_replay": _wire_identity_replay_status(
+            audit, expected_wire_sha256=wire_fixture_sha256
+        ),
+    }
+    accepted_gate_statuses = {
+        "complete_model_visible_plan": {"complete"},
+        "clean_cold_start_current_binding": {"complete", "pass"},
+        "full_pre_post_request_response": {"complete", "met"},
+        "full_request_fingerprint": {"captured", "complete", "met"},
+        "full_response_fingerprint": {"captured", "complete", "met"},
+        "sse_identity": {"complete", "met"},
+        "terminal_events": {"complete", "met"},
+        "error_events": {"complete", "met"},
+        "non_streaming": {"complete", "met"},
+        "non_streaming_fixture": {"captured", "complete", "met"},
+        "identity_replay": {"complete", "met"},
+        "wire_identity_replay": {"complete", "met"},
+    }
+    blocking_gates = sorted(
+        gate
+        for gate, status in evidence_gates.items()
+        if status not in accepted_gate_statuses[gate]
+    )
+    return {
+        "candidate_version_status": candidate_version_status,
+        "candidate_version_eligible": candidate_version_eligible,
+        "blocking_scopes": blocking_scopes,
+        "evidence_gates": evidence_gates,
+        "blocking_gates": blocking_gates,
+        "ready_for_beta1": candidate_version_eligible
+        and not blocking_scopes
+        and not blocking_gates,
+    }
+
+
+def _validate_candidate_binding(
+    *,
+    trace_data: dict[str, Any],
+    wire_data: dict[str, Any],
+    cli_version_floor: str,
+    candidate_cli_version: str | None,
+    candidate_source_commit: str | None,
+) -> tuple[dict[str, Any], str]:
+    _validate_supported_floor(cli_version_floor)
+    source = trace_data.get("source", {})
+    planner_gates = trace_data.get("planner_gates", {})
+    trace_cli_version = source.get("cli_version")
+    trace_source_commit = planner_gates.get("source_commit")
+    if not trace_cli_version or not trace_source_commit:
+        raise ValueError("trace evidence is missing source.cli_version or planner_gates.source_commit")
+    if not isinstance(trace_cli_version, str):
+        raise ValueError("trace source.cli_version must be a string")
+    try:
+        _version_key(trace_cli_version)
+    except ValueError as exc:
+        raise ValueError("trace source.cli_version is malformed") from exc
+    if not isinstance(trace_source_commit, str) or not re.fullmatch(
+        r"[0-9a-f]{40}", trace_source_commit
+    ):
+        raise ValueError(
+            "trace planner_gates.source_commit must be a lowercase 40-character SHA-1"
+        )
+
+    if candidate_cli_version is None:
+        candidate_cli_version = trace_cli_version
+    elif candidate_cli_version != trace_cli_version:
+        raise ValueError(
+            "candidate CLI version does not match trace evidence: "
+            f"requested={candidate_cli_version!r} observed={trace_cli_version!r}"
+        )
+    if not isinstance(candidate_cli_version, str):
+        raise ValueError("candidate CLI version must be a string")
+
+    if candidate_source_commit is None:
+        candidate_source_commit = trace_source_commit
+    elif candidate_source_commit != trace_source_commit:
+        raise ValueError(
+            "candidate source commit does not match trace evidence: "
+            f"requested={candidate_source_commit!r} observed={trace_source_commit!r}"
+        )
+
+    if not isinstance(candidate_source_commit, str) or not re.fullmatch(
+        r"[0-9a-f]{40}", candidate_source_commit
+    ):
+        raise ValueError(f"candidate source commit is not a 40-character SHA-1: {candidate_source_commit!r}")
+    try:
+        _version_key(candidate_cli_version)
+    except ValueError as exc:
+        raise ValueError(
+            f"candidate CLI version is malformed: {candidate_cli_version!r}"
+        ) from exc
+
+    trace_route = trace_data.get("gateway_route", {})
+    wire_route = wire_data.get("route", {})
+    route_fields = (
+        ("route_upstream", wire_route.get("upstream_route"), trace_route.get("upstream")),
+        ("inbound_format", wire_route.get("inbound_format"), trace_route.get("inbound_format")),
+        ("upstream_format", wire_route.get("upstream_format"), trace_route.get("upstream_format")),
+    )
+    for name, wire_value, trace_value in route_fields:
+        if not wire_value or wire_value != trace_value:
+            raise ValueError(
+                f"candidate route field {name} is not consistently bound: "
+                f"wire={wire_value!r} trace={trace_value!r}"
+            )
+
+    profile_fields = (
+        "catalog_binding",
+        "behavior_profile",
+        "route_mode",
+        "wire_format_adapter",
+        "codex_semantic_adapter",
+        "repair_policy",
+    )
+    for field in profile_fields:
+        wire_value = wire_route.get(field)
+        trace_value = trace_route.get(field)
+        if not wire_value or wire_value != trace_value:
+            raise ValueError(
+                f"candidate route profile field {field} is not consistently bound: "
+                f"wire={wire_value!r} trace={trace_value!r}"
+            )
+
+    trace_provider = source.get("configured_provider_id")
+    wire_provider = wire_route.get("configured_provider_id")
+    if not trace_provider or wire_provider != trace_provider:
+        raise ValueError(
+            "candidate provider binding is inconsistent: "
+            f"wire={wire_provider!r} trace={trace_provider!r}"
+        )
+    wire_provenance = wire_data.get("provenance", {})
+    if (
+        wire_provenance.get("cli_version") != trace_cli_version
+        or wire_provenance.get("source_commit") != trace_source_commit
+        or wire_provenance.get("capture_id") != source.get("capture_id")
+    ):
+        raise ValueError("wire provenance is not bound to the trace candidate")
+    catalog_snapshot = (
+        trace_data.get("planner_gates", {})
+        .get("catalog_source", {})
+        .get("read_only_snapshot_validation", {})
+    )
+    if (
+        wire_route.get("catalog_snapshot_sha256") != catalog_snapshot.get("sha256")
+        or wire_route.get("catalog_model_entry_id") != catalog_snapshot.get("model_entry_id")
+        or wire_route.get("catalog_model_supports_search_tool")
+        is not catalog_snapshot.get("model_entry_supports_search_tool")
+    ):
+        raise ValueError("wire catalog snapshot is not bound to the trace catalog evidence")
+    trace_model = source.get("model")
+    pre_wire_model = wire_data.get("pre_gateway", {}).get("model")
+    post_wire_model = wire_data.get("post_gateway", {}).get("model")
+    if not trace_model or pre_wire_model != trace_model or post_wire_model != trace_model:
+        raise ValueError(
+            "candidate model binding is inconsistent: "
+            f"pre_wire={pre_wire_model!r} post_wire={post_wire_model!r} trace={trace_model!r}"
+        )
+
+    status = _candidate_version_status(candidate_cli_version, cli_version_floor)
+    identity = {
+        "cli_version": candidate_cli_version,
+        "source_commit": candidate_source_commit,
+        "codex_source_commit": candidate_source_commit,
+        "route_upstream": wire_route["upstream_route"],
+        "inbound_format": wire_route["inbound_format"],
+        "upstream_format": wire_route["upstream_format"],
+        "configured_provider_id": trace_provider,
+        "model": trace_model,
+        "catalog_binding": wire_route["catalog_binding"],
+        "catalog_snapshot_sha256": wire_route["catalog_snapshot_sha256"],
+        "catalog_model_entry_id": wire_route["catalog_model_entry_id"],
+        "route_behavior_profile": trace_route.get("behavior_profile"),
+    }
+    return identity, status
+
+
+def build_inventory(
+    *,
+    trace: Path,
+    wire_fixture: Path,
+    audit: Path,
+    cli_version_floor: str = DEFAULT_CLI_FLOOR,
+    candidate_cli_version: str | None = DEFAULT_CANDIDATE_CLI_VERSION,
+    candidate_source_commit: str | None = DEFAULT_CANDIDATE_SOURCE_COMMIT,
+) -> dict[str, Any]:
+    cli_version_floor = _validate_supported_floor(cli_version_floor)
+    trace_data = _load_json(trace)
+    wire_data = _load_json(wire_fixture)
+    audit_data = _load_json(audit)
+    wire_fixture_sha256 = _sha256_file(wire_fixture)
+    if (
+        trace_data.get("schema_version") != 4
+        or wire_data.get("schema_version") != 1
+        or wire_data.get("fixture_kind") != "sanitized_artifact_backed_replay"
+        or audit_data.get("schema_version") != 1
+        or audit_data.get("capture_kind") != "sanitized_bounded_read_only_audit"
+    ):
+        raise ValueError("Issue #62 evidence schema identity is invalid")
+
+    items: list[dict[str, Any]] = []
+    items.extend(
+        _classify_core_items(
+            wire_data, audit_data, wire_fixture_sha256=wire_fixture_sha256
+        )
+    )
+    items.extend(_classify_live_control_items(wire_data, audit_data))
+    items.extend(_classify_advanced_items(trace_data))
+
+    seen: set[str] = set()
+    for item in items:
+        if item["scope"] in seen:
+            raise ValueError(f"duplicate scope: {item['scope']}")
+        seen.add(item["scope"])
+
+    unknown_tagged_source_count = _count_unknown_tags(wire_data)
+    unknown_stream_count, unknown_non_stream_count = _unknown_tag_mode_counts(wire_data)
+    if unknown_tagged_source_count == 0:
+        raise ValueError("wire evidence contains no unknown-tag sentinel to classify")
+    if unknown_stream_count == 0 or unknown_non_stream_count == 0:
+        raise ValueError(
+            "wire evidence must contain unknown-tag sentinels in both response modes"
+        )
+    identity_control = _build_identity_control(
+        items, unknown_tagged_source_count=unknown_tagged_source_count
+    )
+    candidate_identity, candidate_version_status = _validate_candidate_binding(
+        trace_data=trace_data,
+        wire_data=wire_data,
+        cli_version_floor=cli_version_floor,
+        candidate_cli_version=candidate_cli_version,
+        candidate_source_commit=candidate_source_commit,
+    )
+    evidence_binding = {
+        "trace": {"file": trace.name, "sha256": _sha256_file(trace)},
+        "wire_fixture": {
+            "file": wire_fixture.name,
+            "sha256": wire_fixture_sha256,
+        },
+        "audit": {"file": audit.name, "sha256": _sha256_file(audit)},
+    }
+    candidate_identity["evidence_manifest_sha256"] = _evidence_manifest_sha256(
+        evidence_binding
+    )
+    qualification = _build_qualification(
+        items,
+        candidate_version_status,
+        trace=trace_data,
+        wire=wire_data,
+        audit=audit_data,
+        wire_fixture_sha256=wire_fixture_sha256,
+    )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "artifact_kind": ARTIFACT_KIND,
+        "cli_version_floor": cli_version_floor,
+        "candidate_identity": candidate_identity,
+        "qualification": qualification,
+        "disposition_vocabulary": list(ALLOWED_DISPOSITIONS),
+        "items": items,
+        "identity_control": identity_control,
+        "feeds": {
+            "capability_gate": "#249",
+            "chat_conversion_matrix": "#66",
+        },
+        "evidence_sources": {
+            "trace": trace.name,
+            "wire_fixture": wire_fixture.name,
+            "audit": audit.name,
+        },
+        "evidence_binding": evidence_binding,
+    }
+
+
+def replay_inventory(inventory: dict[str, Any], case: str) -> dict[str, Any]:
+    """Return a mutated copy of the inventory for a negative replay case.
+
+    - ``identity``     : unchanged
+    - ``mutation``     : change a core item's disposition to a disallowed value
+    - ``deletion``     : remove a core item
+    - ``loss``         : drop a candidate_identity field
+    """
+    clone = copy.deepcopy(inventory)
+    if case == "identity":
+        return clone
+
+    if case == "mutation":
+        for item in clone["items"]:
+            if item["scope"] == "core_history_call_ids":
+                item["disposition"] = "Supported"
+                clone["identity_control"]["unclassified_core_items"] = (
+                    clone["identity_control"].get("unclassified_core_items", 0) + 1
+                )
+                clone["identity_control"].setdefault("unclassified_scopes", []).append(
+                    "core_history_call_ids"
+                )
+                return clone
+        return clone
+
+    if case == "deletion":
+        clone["items"] = [
+            item for item in clone["items"] if item["scope"] != "core_text_streaming"
+        ]
+        return clone
+
+    if case == "loss":
+        clone["candidate_identity"].pop("route_upstream", None)
+        return clone
+
+    raise ValueError(f"unknown replay case: {case!r}")
+
+
+def reconcile_inventory(
+    inventory: dict[str, Any], *, evidence_root: Path | None = None
+) -> dict[str, Any]:
+    """Reconcile an inventory (possibly mutated) against the identity contract."""
+    mismatches: list[str] = []
+
+    if inventory.get("schema_version") != SCHEMA_VERSION:
+        mismatches.append("inventory schema_version is invalid")
+    if inventory.get("artifact_kind") != ARTIFACT_KIND:
+        mismatches.append("inventory artifact_kind is invalid")
+    if inventory.get("disposition_vocabulary") != list(ALLOWED_DISPOSITIONS):
+        mismatches.append("inventory disposition_vocabulary is invalid")
+
+    items = inventory.get("items", [])
+    seen_scopes: set[str] = set()
+    for item in items:
+        scope = item.get("scope")
+        if not scope:
+            mismatches.append("item missing scope")
+            continue
+        if scope in seen_scopes:
+            mismatches.append(f"duplicate scope: {scope}")
+            continue
+        seen_scopes.add(scope)
+        if scope not in KNOWN_SCOPES:
+            mismatches.append(f"mutation: unknown scope {scope}")
+        disposition = item.get("disposition")
+        if disposition not in ALLOWED_DISPOSITIONS:
+            mismatches.append(
+                f"mutation: {scope}: disposition {disposition!r} not in allowed vocabulary"
+            )
+        expected_evidence = CORE_SCOPE_EVIDENCE.get(scope)
+        if expected_evidence and item.get("evidence_source") != expected_evidence:
+            mismatches.append(
+                f"mutation: {scope}: evidence_source {item.get('evidence_source')!r} "
+                f"does not match required {expected_evidence!r}"
+            )
+        if scope in CORE_CONTRACT_SCOPES and disposition == "Unsupported":
+            mismatches.append(
+                f"mutation: {scope}: core disposition {disposition!r} cannot replace "
+                "preserved, reversibly_adapted, local_consume, or Unqualified"
+            )
+
+    required_scopes = (
+        CORE_CONTRACT_SCOPES
+        | LIVE_CONTROL_SCOPES
+        | ADVANCED_UNSUPPORTED_SCOPES
+        | {"choice_controls"}
+    )
+    missing = sorted(required_scopes - seen_scopes)
+    if missing:
+        mismatches.append(f"deletion: missing scopes {missing}")
+
+    candidate_identity = inventory.get("candidate_identity", {})
+    for field in REQUIRED_CANDIDATE_FIELDS:
+        if field not in candidate_identity:
+            mismatches.append(f"loss: candidate_identity.{field} is missing")
+
+    qualification = inventory.get("qualification", {})
+    try:
+        _validate_supported_floor(str(inventory.get("cli_version_floor", "")))
+    except ValueError as exc:
+        mismatches.append(str(exc))
+    candidate_status = qualification.get("candidate_version_status")
+    if candidate_status not in {"eligible", "legacy_below_floor"}:
+        mismatches.append("qualification.candidate_version_status is invalid")
+    candidate_eligible = qualification.get("candidate_version_eligible")
+    if candidate_eligible is not (candidate_status == "eligible"):
+        mismatches.append(
+            "qualification.candidate_version_eligible does not match candidate version status"
+        )
+    actual_blocking_scopes = sorted(
+        {
+            item.get("scope")
+            for item in items
+            if item.get("scope") in BLOCKING_UNQUALIFIED_SCOPES
+            and item.get("disposition") == "Unqualified"
+        }
+    )
+    if qualification.get("blocking_scopes") != actual_blocking_scopes:
+        mismatches.append(
+            "qualification.blocking_scopes does not match observed blocking dispositions"
+        )
+    expected_status = None
+    try:
+        expected_status = _candidate_version_status(
+            str(candidate_identity.get("cli_version", "")),
+            str(inventory.get("cli_version_floor", "")),
+        )
+    except ValueError:
+        mismatches.append("candidate_identity.cli_version or cli_version_floor is invalid")
+    if expected_status and candidate_status != expected_status:
+        mismatches.append(
+            "qualification.candidate_version_status does not match the CLI floor"
+        )
+
+    evidence_gates = qualification.get("evidence_gates", {})
+    expected_gate_keys = {
+        "complete_model_visible_plan",
+        "clean_cold_start_current_binding",
+        "full_pre_post_request_response",
+        "full_request_fingerprint",
+        "full_response_fingerprint",
+        "sse_identity",
+        "terminal_events",
+        "error_events",
+        "non_streaming",
+        "non_streaming_fixture",
+        "identity_replay",
+        "wire_identity_replay",
+    }
+    if set(evidence_gates) != expected_gate_keys:
+        mismatches.append("qualification.evidence_gates has an unexpected key set")
+    accepted_gate_statuses = {
+        "complete_model_visible_plan": {"complete"},
+        "clean_cold_start_current_binding": {"complete", "pass"},
+        "full_pre_post_request_response": {"complete", "met"},
+        "full_request_fingerprint": {"captured", "complete", "met"},
+        "full_response_fingerprint": {"captured", "complete", "met"},
+        "sse_identity": {"complete", "met"},
+        "terminal_events": {"complete", "met"},
+        "error_events": {"complete", "met"},
+        "non_streaming": {"complete", "met"},
+        "non_streaming_fixture": {"captured", "complete", "met"},
+        "identity_replay": {"complete", "met"},
+        "wire_identity_replay": {"complete", "met"},
+    }
+    actual_blocking_gates = sorted(
+        gate
+        for gate, allowed in accepted_gate_statuses.items()
+        if evidence_gates.get(gate) not in allowed
+    )
+    if qualification.get("blocking_gates") != actual_blocking_gates:
+        mismatches.append(
+            "qualification.blocking_gates does not match evidence gate statuses"
+        )
+    expected_ready = (
+        candidate_eligible is True
+        and not actual_blocking_scopes
+        and not actual_blocking_gates
+    )
+    if qualification.get("ready_for_beta1") is not expected_ready:
+        mismatches.append(
+            "qualification.ready_for_beta1 is inconsistent with candidate eligibility and blockers"
+        )
+
+    evidence_binding = inventory.get("evidence_binding", {})
+    for name in ("trace", "wire_fixture", "audit"):
+        entry = evidence_binding.get(name, {})
+        if not isinstance(entry, dict) or not entry.get("file") or not re.fullmatch(
+            r"[0-9a-f]{64}", str(entry.get("sha256", ""))
+        ):
+            mismatches.append(f"loss: evidence_binding.{name} is missing or malformed")
+
+    if evidence_binding and all(
+        isinstance(evidence_binding.get(name), dict)
+        for name in ("trace", "wire_fixture", "audit")
+    ):
+        manifest = _evidence_manifest_sha256(evidence_binding)
+        if candidate_identity.get("evidence_manifest_sha256") != manifest:
+            mismatches.append("loss: candidate_identity.evidence_manifest_sha256 is stale")
+
+    if evidence_root is not None and not mismatches:
+        bound_paths: dict[str, Path] = {}
+        for name in ("trace", "wire_fixture", "audit"):
+            entry = evidence_binding[name]
+            relative_name = str(entry["file"])
+            relative_path = Path(relative_name)
+            if relative_path.is_absolute() or relative_path.name != relative_name:
+                mismatches.append(
+                    f"loss: evidence binding file must be a basename: {relative_name}"
+                )
+                continue
+            path = evidence_root / relative_path
+            bound_paths[name] = path
+            if not path.is_file():
+                mismatches.append(f"loss: evidence binding file does not exist: {path}")
+                continue
+            if _sha256_file(path) != entry["sha256"]:
+                mismatches.append(f"mutation: evidence binding hash mismatch for {name}")
+        if not mismatches:
+            trace_data = _load_json(bound_paths["trace"])
+            wire_data = _load_json(bound_paths["wire_fixture"])
+            audit_data = _load_json(bound_paths["audit"])
+            if (
+                trace_data.get("schema_version") != 4
+                or wire_data.get("schema_version") != 1
+                or wire_data.get("fixture_kind") != "sanitized_artifact_backed_replay"
+                or audit_data.get("schema_version") != 1
+                or audit_data.get("capture_kind") != "sanitized_bounded_read_only_audit"
+            ):
+                mismatches.append("mutation: bound evidence schema identity is invalid")
+                return {"reconciled": False, "mismatches": mismatches}
+            try:
+                expected_identity, expected_status_from_evidence = _validate_candidate_binding(
+                    trace_data=trace_data,
+                    wire_data=wire_data,
+                    cli_version_floor=str(inventory.get("cli_version_floor", "")),
+                    candidate_cli_version=candidate_identity.get("cli_version"),
+                    candidate_source_commit=candidate_identity.get("source_commit"),
+                )
+            except (TypeError, ValueError) as exc:
+                mismatches.append(f"mutation: candidate evidence binding failed: {exc}")
+            else:
+                for field, expected in expected_identity.items():
+                    if candidate_identity.get(field) != expected:
+                        mismatches.append(
+                            f"mutation: candidate_identity.{field} does not match evidence"
+                        )
+                if candidate_status != expected_status_from_evidence:
+                    mismatches.append(
+                        "qualification candidate status does not match bound evidence"
+                    )
+                expected_qualification = _build_qualification(
+                    items,
+                    expected_status_from_evidence,
+                    trace=trace_data,
+                    wire=wire_data,
+                    audit=audit_data,
+                    wire_fixture_sha256=evidence_binding["wire_fixture"]["sha256"],
+                )
+                for field in (
+                    "evidence_gates",
+                    "blocking_gates",
+                    "blocking_scopes",
+                    "ready_for_beta1",
+                ):
+                    if qualification.get(field) != expected_qualification[field]:
+                        mismatches.append(
+                            f"mutation: qualification.{field} does not match bound evidence"
+                        )
+                try:
+                    generated_inventory = build_inventory(
+                        trace=bound_paths["trace"],
+                        wire_fixture=bound_paths["wire_fixture"],
+                        audit=bound_paths["audit"],
+                        cli_version_floor=str(inventory.get("cli_version_floor", "")),
+                        candidate_cli_version=candidate_identity.get("cli_version"),
+                        candidate_source_commit=candidate_identity.get("source_commit"),
+                    )
+                except (TypeError, ValueError, OSError, json.JSONDecodeError) as exc:
+                    mismatches.append(f"generated inventory check failed: {exc}")
+                else:
+                    if json.dumps(generated_inventory, sort_keys=True) != json.dumps(
+                        inventory, sort_keys=True
+                    ):
+                        mismatches.append(
+                            "generated inventory differs from committed artifact"
+                        )
+
+    identity_control = inventory.get("identity_control", {})
+    if identity_control.get("fail_closed") is not True:
+        mismatches.append("identity_control.fail_closed must be true")
+    if identity_control.get("replay_cases") != [
+        "identity",
+        "mutation",
+        "deletion",
+        "loss",
+    ]:
+        mismatches.append("identity_control.replay_cases are invalid")
+
+    unclassified = identity_control.get("unclassified_core_items")
+    if not isinstance(unclassified, int) or unclassified < 0:
+        mismatches.append("identity_control.unclassified_core_items is invalid")
+    else:
+        actual_unclassified = sum(
+            1
+            for item in items
+            if item.get("disposition") not in ALLOWED_DISPOSITIONS
+        )
+        if unclassified != actual_unclassified:
+            mismatches.append(
+                f"identity_control.unclassified_core_items={unclassified} "
+                f"does not match observed unclassified items={actual_unclassified}"
+            )
+
+    unknown_tagged_source_count = identity_control.get(
+        "unknown_tagged_source_count"
+    )
+    if not isinstance(unknown_tagged_source_count, int) or unknown_tagged_source_count <= 0:
+        mismatches.append("identity_control.unknown_tagged_source_count is invalid")
+    if evidence_root is not None:
+        wire_entry = evidence_binding.get("wire_fixture", {})
+        wire_path = evidence_root / str(wire_entry.get("file", ""))
+        if wire_path.is_file():
+            actual_unknown_tagged_source_count = _count_unknown_tags(
+                _load_json(wire_path)
+            )
+            if unknown_tagged_source_count != actual_unknown_tagged_source_count:
+                mismatches.append(
+                    "mutation: identity_control.unknown_tagged_source_count does not "
+                    "match bound wire evidence"
+                )
+
+    return {"reconciled": not mismatches, "mismatches": mismatches}
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--trace",
+        type=Path,
+        default=Path("docs/evidence/issue-62/current-codexhub-thread-tool-surface.json"),
+    )
+    parser.add_argument(
+        "--wire-fixture",
+        type=Path,
+        default=Path("docs/evidence/issue-62/codexhub-runtime-wire-fixture.json"),
+    )
+    parser.add_argument(
+        "--audit",
+        type=Path,
+        default=Path("docs/evidence/issue-62/read-only-gate-audit.json"),
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=Path("docs/evidence/issue-62/runtime-wire-inventory.json"),
+    )
+    parser.add_argument("--cli-version-floor", default=DEFAULT_CLI_FLOOR)
+    parser.add_argument("--candidate-cli-version", default=DEFAULT_CANDIDATE_CLI_VERSION)
+    parser.add_argument(
+        "--candidate-source-commit", default=DEFAULT_CANDIDATE_SOURCE_COMMIT
+    )
+    parser.add_argument(
+        "--replay-case",
+        default="identity",
+        choices=["identity", "mutation", "deletion", "loss"],
+    )
+    parser.add_argument(
+        "--check-drift",
+        action="store_true",
+        help="validate that --out exactly matches freshly generated inventory without writing it",
+    )
+    return parser
+
+
+def main() -> int:
+    args = _build_arg_parser().parse_args()
+    inventory = build_inventory(
+        trace=args.trace,
+        wire_fixture=args.wire_fixture,
+        audit=args.audit,
+        cli_version_floor=args.cli_version_floor,
+        candidate_cli_version=args.candidate_cli_version,
+        candidate_source_commit=args.candidate_source_commit,
+    )
+
+    if args.replay_case != "identity":
+        replayed = replay_inventory(inventory, args.replay_case)
+        report = reconcile_inventory(replayed, evidence_root=args.trace.parent)
+        print(json.dumps(report, ensure_ascii=True, indent=2, sort_keys=True))
+        return 0 if report["reconciled"] else 1
+
+    report = reconcile_inventory(inventory, evidence_root=args.trace.parent)
+    if not report["reconciled"]:
+        raise SystemExit(f"identity reconciliation failed: {report['mismatches']}")
+
+    if args.check_drift:
+        if not args.out.is_file():
+            raise SystemExit(f"committed inventory artifact not found: {args.out}")
+        committed = _load_json(args.out)
+        if json.dumps(committed, sort_keys=True) != json.dumps(
+            inventory, sort_keys=True
+        ):
+            raise SystemExit(
+                "generated inventory differs from committed artifact: "
+                f"{args.out}"
+            )
+        print(f"generated inventory matches {args.out}")
+        return 0
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(
+        json.dumps(inventory, ensure_ascii=True, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(f"wrote {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/capture_issue_62_live_evidence.py
+++ b/scripts/capture_issue_62_live_evidence.py
@@ -1,0 +1,908 @@
+#!/usr/bin/env python3
+"""Explicitly enabled, standalone Issue #62 live-evidence sidecar.
+
+This module is evidence tooling. Nothing in the Gateway or Desktop imports it,
+and invoking it without ``--enable-live-capture`` cannot open a listener.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import hashlib
+import hmac
+import http.client
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import ipaddress
+import json
+import math
+import os
+from pathlib import Path
+import re
+import socket
+import sys
+import threading
+import time
+from typing import Any, Mapping
+from urllib.parse import urlsplit
+import uuid
+
+
+SCHEMA = "codexhub.issue62.live-evidence-lane.v1"
+VERIFICATION_SCOPE = "capture_only_not_qualification"
+_HOPS = frozenset({"pre", "post"})
+_OUTCOMES = frozenset({"complete", "incomplete"})
+_FAILURES = frozenset(
+    {
+        "client_cancelled",
+        "downstream_cancelled",
+        "forwarding_failed",
+        "invalid_content_length",
+        "request_incomplete",
+        "request_overflow",
+        "response_overflow",
+        "server_start_failed",
+        "server_thread_failed",
+        "shutdown_drain_failed",
+        "sse_frame_incomplete",
+        "sse_frame_after_terminal",
+        "sse_terminal_missing",
+        "upstream_timeout",
+    }
+)
+_CONTENT_TYPE_CLASSES = frozenset({"event-stream", "json", "other", "absent", "unknown"})
+_TERMINAL_CLASSES = frozenset({"done", "error", "response.completed", "response.failed"})
+_ROOT_FIELDS = frozenset(
+    {
+        "schema",
+        "verification_scope",
+        "capture_id",
+        "hop",
+        "outcome",
+        "failure",
+        "status",
+        "content_type_class",
+        "request",
+        "response",
+        "sse",
+    }
+)
+_BODY_FIELDS = frozenset({"bytes", "sha256", "hmac_sha256", "complete"})
+_SSE_FIELDS = frozenset(
+    {
+        "complete",
+        "frame_count",
+        "frame_bytes",
+        "sequence_sha256",
+        "sequence_hmac_sha256",
+        "terminal_classes",
+    }
+)
+_CAPTURE_ID = re.compile(r"c[0-9a-f]{32}\Z")
+_DIGEST = re.compile(r"[0-9a-f]{64}\Z")
+
+
+class ConfigurationError(ValueError):
+    """A fixed-code startup configuration failure."""
+
+
+class ArtifactValidationError(ValueError):
+    """A fixed-code sanitized-artifact contract failure."""
+
+
+class SidecarStartError(RuntimeError):
+    """The isolated listener failed before it could accept evidence traffic."""
+
+
+@dataclass(frozen=True)
+class SidecarConfig:
+    hop: str
+    listen_host: str
+    listen_port: int
+    forward_base_url: str
+    output_dir: Path
+    hmac_key_file: Path
+    max_request_bytes: int
+    max_response_bytes: int
+    connect_timeout_seconds: float
+    read_timeout_seconds: float
+    overall_timeout_seconds: float
+
+
+class BodyFingerprint:
+    """Incrementally fingerprint exact application-body bytes."""
+
+    def __init__(self, key: bytes, domain: bytes) -> None:
+        self._sha256 = hashlib.sha256()
+        self._hmac_sha256 = hmac.new(key, domain + b"\0", hashlib.sha256)
+        self._bytes = 0
+
+    def update(self, chunk: bytes) -> None:
+        if not isinstance(chunk, bytes):
+            raise TypeError("fingerprint_chunk_not_bytes")
+        self._sha256.update(chunk)
+        self._hmac_sha256.update(chunk)
+        self._bytes += len(chunk)
+
+    def snapshot(self, *, complete: bool) -> dict[str, Any]:
+        return {
+            "bytes": self._bytes,
+            "sha256": self._sha256.hexdigest() if complete else None,
+            "hmac_sha256": self._hmac_sha256.hexdigest() if complete else None,
+            "complete": complete,
+        }
+
+    def complete(self) -> dict[str, Any]:
+        return self.snapshot(complete=True)
+
+
+class SseSequenceFingerprint:
+    """Hash ordered complete SSE frames independent of transport chunking."""
+
+    def __init__(self, key: bytes) -> None:
+        self._sha256 = hashlib.sha256()
+        self._hmac_sha256 = hmac.new(key, b"sse-sequence\0", hashlib.sha256)
+        self._buffer = bytearray()
+        self._frame_count = 0
+        self._frame_bytes = 0
+        self._terminal_classes: set[str] = set()
+        self._terminal_seen = False
+        self._invalid_after_terminal = False
+
+    def update(self, chunk: bytes) -> None:
+        if not isinstance(chunk, bytes):
+            raise TypeError("sse_chunk_not_bytes")
+        self._buffer.extend(chunk)
+        while True:
+            boundary = self._next_boundary()
+            if boundary is None:
+                return
+            index, width = boundary
+            frame = bytes(self._buffer[:index])
+            del self._buffer[: index + width]
+            encoded = len(frame).to_bytes(8, "big") + frame
+            self._sha256.update(encoded)
+            self._hmac_sha256.update(encoded)
+            self._frame_count += 1
+            self._frame_bytes += len(frame)
+            if self._terminal_seen:
+                self._invalid_after_terminal = True
+            terminal = _classify_sse_terminal(frame)
+            if terminal is not None:
+                if self._terminal_seen:
+                    self._invalid_after_terminal = True
+                self._terminal_seen = True
+                self._terminal_classes.add(terminal)
+
+    def _next_boundary(self) -> tuple[int, int] | None:
+        candidates = [
+            (index, len(marker))
+            for marker in (b"\r\n\r\n", b"\n\n")
+            if (index := self._buffer.find(marker)) >= 0
+        ]
+        return min(candidates) if candidates else None
+
+    def complete(self) -> dict[str, Any]:
+        complete = not self._buffer and self._terminal_seen and not self._invalid_after_terminal
+        return self._snapshot(complete=complete)
+
+    def incomplete(self) -> dict[str, Any]:
+        return self._snapshot(complete=False)
+
+    def _snapshot(self, *, complete: bool) -> dict[str, Any]:
+        return {
+            "complete": complete,
+            "frame_count": self._frame_count,
+            "frame_bytes": self._frame_bytes,
+            "sequence_sha256": self._sha256.hexdigest() if complete else None,
+            "sequence_hmac_sha256": self._hmac_sha256.hexdigest() if complete else None,
+            "terminal_classes": sorted(self._terminal_classes),
+        }
+
+    @property
+    def has_trailing_bytes(self) -> bool:
+        return bool(self._buffer)
+
+    @property
+    def invalid_after_terminal(self) -> bool:
+        return self._invalid_after_terminal
+
+
+def _classify_sse_terminal(frame: bytes) -> str | None:
+    event_name: bytes | None = None
+    data_lines: list[bytes] = []
+    for line in frame.splitlines():
+        if line.startswith(b"event:"):
+            event_name = line[6:].lstrip(b" ")
+        elif line.startswith(b"data:"):
+            data_lines.append(line[5:].lstrip(b" "))
+    if event_name == b"error":
+        return "error"
+    data = b"\n".join(data_lines)
+    if data == b"[DONE]":
+        return "done"
+    try:
+        payload = json.loads(data.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, Mapping):
+        return None
+    event_type = payload.get("type")
+    if event_type in {"response.completed", "response.failed", "error"}:
+        return str(event_type)
+    return None
+
+
+def validate_config(config: SidecarConfig) -> bytes:
+    """Validate the isolated lane and return its already-provisioned HMAC key."""
+
+    if config.hop not in _HOPS:
+        raise ConfigurationError("hop_invalid")
+    try:
+        listen_address = ipaddress.ip_address(config.listen_host)
+    except ValueError as error:
+        raise ConfigurationError("listen_not_loopback") from error
+    if not listen_address.is_loopback:
+        raise ConfigurationError("listen_not_loopback")
+    if isinstance(config.listen_port, bool) or not isinstance(config.listen_port, int):
+        raise ConfigurationError("listen_port_invalid")
+    if not 0 <= config.listen_port <= 65535:
+        raise ConfigurationError("listen_port_invalid")
+
+    target = urlsplit(config.forward_base_url)
+    try:
+        target_port = target.port
+    except ValueError as error:
+        raise ConfigurationError("forward_base_url_invalid") from error
+    if (
+        target.scheme not in {"http", "https"}
+        or not target.hostname
+        or target.username is not None
+        or target.password is not None
+        or target.query
+        or target.fragment
+        or (target_port is not None and not 1 <= target_port <= 65535)
+    ):
+        raise ConfigurationError("forward_base_url_invalid")
+
+    for value, code in (
+        (config.max_request_bytes, "max_request_bytes_invalid"),
+        (config.max_response_bytes, "max_response_bytes_invalid"),
+    ):
+        if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+            raise ConfigurationError(code)
+    for value, code in (
+        (config.connect_timeout_seconds, "connect_timeout_invalid"),
+        (config.read_timeout_seconds, "read_timeout_invalid"),
+        (config.overall_timeout_seconds, "overall_timeout_invalid"),
+    ):
+        if not _is_positive_timeout(value):
+            raise ConfigurationError(code)
+
+    try:
+        key = Path(config.hmac_key_file).read_bytes()
+    except OSError as error:
+        raise ConfigurationError("hmac_key_unavailable") from error
+    if not 32 <= len(key) <= 4096:
+        raise ConfigurationError("hmac_key_invalid")
+    return key
+
+
+def _is_positive_timeout(value: Any) -> bool:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return False
+    try:
+        numeric = float(value)
+    except (OverflowError, TypeError, ValueError):
+        return False
+    return math.isfinite(numeric) and numeric > 0
+
+
+def _require_exact_fields(value: Mapping[str, Any], expected: frozenset[str], code: str) -> None:
+    if frozenset(value) != expected:
+        raise ArtifactValidationError(code)
+
+
+def _validate_digest(value: Any, code: str) -> None:
+    if value is not None and (not isinstance(value, str) or _DIGEST.fullmatch(value) is None):
+        raise ArtifactValidationError(code)
+
+
+def _validate_body(value: Any, code: str) -> None:
+    if value is None:
+        return
+    if not isinstance(value, Mapping):
+        raise ArtifactValidationError(code)
+    _require_exact_fields(value, _BODY_FIELDS, code)
+    if isinstance(value["bytes"], bool) or not isinstance(value["bytes"], int) or value["bytes"] < 0:
+        raise ArtifactValidationError(code)
+    if not isinstance(value["complete"], bool):
+        raise ArtifactValidationError(code)
+    _validate_digest(value["sha256"], code)
+    _validate_digest(value["hmac_sha256"], code)
+    if value["complete"] != (value["sha256"] is not None and value["hmac_sha256"] is not None):
+        raise ArtifactValidationError(code)
+
+
+def _validate_sse(value: Any) -> None:
+    if value is None:
+        return
+    if not isinstance(value, Mapping):
+        raise ArtifactValidationError("sse_invalid")
+    _require_exact_fields(value, _SSE_FIELDS, "sse_fields_invalid")
+    for key in ("frame_count", "frame_bytes"):
+        if isinstance(value[key], bool) or not isinstance(value[key], int) or value[key] < 0:
+            raise ArtifactValidationError("sse_invalid")
+    if not isinstance(value["complete"], bool):
+        raise ArtifactValidationError("sse_invalid")
+    _validate_digest(value["sequence_sha256"], "sse_invalid")
+    _validate_digest(value["sequence_hmac_sha256"], "sse_invalid")
+    has_digests = value["sequence_sha256"] is not None and value["sequence_hmac_sha256"] is not None
+    if value["complete"] != has_digests:
+        raise ArtifactValidationError("sse_invalid")
+    if not isinstance(value["terminal_classes"], list) or any(
+        item not in _TERMINAL_CLASSES for item in value["terminal_classes"]
+    ):
+        raise ArtifactValidationError("sse_invalid")
+
+
+def validate_capture_record(record: Mapping[str, Any], hop: str) -> None:
+    """Reject any field outside the deliberately tiny sanitized schema."""
+
+    if not isinstance(record, Mapping):
+        raise ArtifactValidationError("record_invalid")
+    _require_exact_fields(record, _ROOT_FIELDS, "record_fields_invalid")
+    if record["schema"] != SCHEMA or record["verification_scope"] != VERIFICATION_SCOPE:
+        raise ArtifactValidationError("record_schema_invalid")
+    if hop not in _HOPS or record["hop"] != hop:
+        raise ArtifactValidationError("record_hop_invalid")
+    capture_id = record["capture_id"]
+    if not isinstance(capture_id, str) or _CAPTURE_ID.fullmatch(capture_id) is None:
+        raise ArtifactValidationError("capture_id_invalid")
+    if record["outcome"] not in _OUTCOMES:
+        raise ArtifactValidationError("record_outcome_invalid")
+    if record["failure"] is not None and record["failure"] not in _FAILURES:
+        raise ArtifactValidationError("record_failure_invalid")
+    if (record["outcome"] == "complete") != (record["failure"] is None):
+        raise ArtifactValidationError("record_completion_invalid")
+    status = record["status"]
+    if status is not None and (isinstance(status, bool) or not isinstance(status, int) or not 100 <= status <= 599):
+        raise ArtifactValidationError("record_status_invalid")
+    if record["content_type_class"] not in _CONTENT_TYPE_CLASSES:
+        raise ArtifactValidationError("record_content_type_invalid")
+    _validate_body(record["request"], "request_fingerprint_invalid")
+    _validate_body(record["response"], "response_fingerprint_invalid")
+    _validate_sse(record["sse"])
+    if record["outcome"] == "complete":
+        request = record["request"]
+        response = record["response"]
+        sse = record["sse"]
+        if (
+            not isinstance(request, Mapping)
+            or request.get("complete") is not True
+            or not isinstance(response, Mapping)
+            or response.get("complete") is not True
+        ):
+            raise ArtifactValidationError("record_completion_invalid")
+        if record["content_type_class"] == "event-stream":
+            if not isinstance(sse, Mapping) or sse.get("complete") is not True:
+                raise ArtifactValidationError("record_completion_invalid")
+        elif sse is not None:
+            raise ArtifactValidationError("record_completion_invalid")
+
+
+def write_capture_record(output_dir: Path, hop: str, record: Mapping[str, Any]) -> Path:
+    """Atomically publish one sanitized record and always remove its partial."""
+
+    validate_capture_record(record, hop)
+    directory = Path(output_dir)
+    directory.mkdir(parents=True, exist_ok=True)
+    capture_id = str(record["capture_id"])
+    target = directory / f"{hop}-{capture_id}.json"
+    partial = directory / f"{hop}-{capture_id}.partial"
+    if target.exists():
+        raise ArtifactValidationError("capture_record_exists")
+    rendered = json.dumps(record, ensure_ascii=True, sort_keys=True, separators=(",", ":")) + "\n"
+    try:
+        with partial.open("x", encoding="ascii", newline="\n") as handle:
+            handle.write(rendered)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(partial, target)
+    finally:
+        try:
+            partial.unlink()
+        except FileNotFoundError:
+            pass
+    return target
+
+
+_HOP_BY_HOP_HEADERS = frozenset(
+    {
+        "connection",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailer",
+        "transfer-encoding",
+        "upgrade",
+    }
+)
+
+
+def _capture_id() -> str:
+    return "c" + uuid.uuid4().hex
+
+
+def _content_type_class(value: str | None) -> str:
+    if not value:
+        return "absent"
+    lowered = value.lower()
+    if "text/event-stream" in lowered:
+        return "event-stream"
+    if "json" in lowered:
+        return "json"
+    return "other"
+
+
+def _empty_record(hop: str, capture_id: str, failure: str) -> dict[str, Any]:
+    return {
+        "schema": SCHEMA,
+        "verification_scope": VERIFICATION_SCOPE,
+        "capture_id": capture_id,
+        "hop": hop,
+        "outcome": "incomplete",
+        "failure": failure,
+        "status": None,
+        "content_type_class": "unknown",
+        "request": None,
+        "response": None,
+        "sse": None,
+    }
+
+
+def _join_target_path(base_path: str, incoming_path: str) -> str:
+    prefix = base_path.rstrip("/")
+    suffix = incoming_path if incoming_path.startswith("/") else f"/{incoming_path}"
+    return f"{prefix}{suffix}" or "/"
+
+
+class _CaptureRequestHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.0"
+
+    def do_POST(self) -> None:
+        owner = self.server.capture_owner  # type: ignore[attr-defined]
+        owner.handle_post(self)
+
+    def log_message(self, format: str, *args: object) -> None:
+        return None
+
+    def finish(self) -> None:
+        try:
+            super().finish()
+        finally:
+            owner = getattr(self.server, "capture_owner", None)
+            if owner is not None:
+                owner._finish_client(self.connection)
+
+
+class _CaptureThreadingHttpServer(ThreadingHTTPServer):
+    def process_request(self, request: Any, client_address: Any) -> None:
+        owner = getattr(self, "capture_owner", None)
+        if owner is not None:
+            owner._register_client(request)
+        try:
+            super().process_request(request, client_address)
+        except BaseException:
+            if owner is not None:
+                owner._finish_client(request)
+            raise
+
+    def handle_error(self, request: Any, client_address: Any) -> None:
+        owner = getattr(self, "capture_owner", None)
+        if owner is not None:
+            owner._finish_client(request)
+            owner._write_control_failure("client_cancelled")
+
+
+class _ThreadingHttpServerV6(_CaptureThreadingHttpServer):
+    address_family = socket.AF_INET6
+
+
+class CaptureSidecarServer:
+    """One explicitly constructed loopback capture hop."""
+
+    def __init__(self, config: SidecarConfig) -> None:
+        self._config = config
+        self._key = validate_config(config)
+        self._target = urlsplit(config.forward_base_url)
+        self._server: ThreadingHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+        self._thread_failure: str | None = None
+        self._active_condition = threading.Condition()
+        self._active_connections: dict[
+            socket.socket,
+            http.client.HTTPConnection | None,
+        ] = {}
+
+    @property
+    def listen_host(self) -> str:
+        return self._config.listen_host
+
+    @property
+    def listen_port(self) -> int:
+        if self._server is None:
+            return self._config.listen_port
+        return int(self._server.server_address[1])
+
+    @property
+    def url(self) -> str:
+        host = f"[{self.listen_host}]" if ":" in self.listen_host else self.listen_host
+        return f"http://{host}:{self.listen_port}"
+
+    def start(self) -> "CaptureSidecarServer":
+        if self._server is not None:
+            raise SidecarStartError("server_already_started")
+        server_type = _ThreadingHttpServerV6 if ":" in self._config.listen_host else _CaptureThreadingHttpServer
+        try:
+            server = server_type(
+                (self._config.listen_host, self._config.listen_port),
+                _CaptureRequestHandler,
+            )
+            server.daemon_threads = True
+            server.capture_owner = self  # type: ignore[attr-defined]
+            thread = threading.Thread(
+                target=self._serve,
+                args=(server,),
+                name=f"issue62-live-evidence-{self._config.hop}",
+                daemon=True,
+            )
+            self._server = server
+            self._thread = thread
+            thread.start()
+        except BaseException as error:
+            if self._server is not None:
+                self._server.server_close()
+            self._server = None
+            self._thread = None
+            self._write_control_failure("server_start_failed")
+            raise SidecarStartError("server_start_failed") from error
+        return self
+
+    def _serve(self, server: ThreadingHTTPServer) -> None:
+        try:
+            server.serve_forever(poll_interval=0.05)
+        except BaseException:
+            self._thread_failure = "server_thread_failed"
+            self._write_control_failure("server_thread_failed")
+
+    def shutdown(self) -> bool:
+        server = self._server
+        thread = self._thread
+        self._server = None
+        self._thread = None
+        if server is not None:
+            if thread is not None and thread.is_alive():
+                server.shutdown()
+        self._close_active_connections()
+        if server is not None:
+            server.server_close()
+        drain_timeout = min(self._config.overall_timeout_seconds, 5.0)
+        drained = self._wait_for_active_connections(drain_timeout)
+        if thread is not None and thread is not threading.current_thread():
+            thread.join(timeout=min(max(0.1, self._config.overall_timeout_seconds), 5.0))
+        return drained and (thread is None or not thread.is_alive())
+
+    def wait(self) -> bool:
+        thread = self._thread
+        if thread is None:
+            return False
+        while thread.is_alive():
+            thread.join(timeout=0.25)
+        return self._thread_failure is None
+
+    def _write_control_failure(self, failure: str) -> None:
+        try:
+            write_capture_record(
+                self._config.output_dir,
+                self._config.hop,
+                _empty_record(self._config.hop, _capture_id(), failure),
+            )
+        except Exception:
+            return
+
+    def _register_client(self, connection: socket.socket) -> None:
+        with self._active_condition:
+            self._active_connections[connection] = None
+            self._active_condition.notify_all()
+
+    def _set_active_upstream(
+        self,
+        connection: socket.socket,
+        upstream: http.client.HTTPConnection | None,
+    ) -> None:
+        with self._active_condition:
+            if connection in self._active_connections:
+                self._active_connections[connection] = upstream
+
+    def _finish_client(self, connection: socket.socket) -> None:
+        with self._active_condition:
+            self._active_connections.pop(connection, None)
+            self._active_condition.notify_all()
+
+    def _close_active_connections(self) -> None:
+        with self._active_condition:
+            active = list(self._active_connections.items())
+        for connection, upstream in active:
+            if upstream is not None:
+                if upstream.sock is not None:
+                    try:
+                        upstream.sock.shutdown(socket.SHUT_RDWR)
+                    except OSError:
+                        pass
+                try:
+                    upstream.close()
+                except OSError:
+                    pass
+            try:
+                connection.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
+            try:
+                connection.close()
+            except OSError:
+                pass
+
+    def _wait_for_active_connections(self, timeout: float) -> bool:
+        deadline = time.monotonic() + max(0.0, timeout)
+        with self._active_condition:
+            while self._active_connections:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return False
+                self._active_condition.wait(timeout=remaining)
+            return True
+
+    def handle_post(self, handler: BaseHTTPRequestHandler) -> None:
+        capture_id = _capture_id()
+        started_at = time.monotonic()
+        request_fingerprint = BodyFingerprint(self._key, b"request-body")
+        response_fingerprint: BodyFingerprint | None = None
+        sse_fingerprint: SseSequenceFingerprint | None = None
+        status: int | None = None
+        content_class = "unknown"
+        failure: str | None = None
+        upstream: http.client.HTTPConnection | None = None
+        request_complete = False
+        response_complete = False
+        try:
+            raw_length = handler.headers.get("Content-Length")
+            try:
+                content_length = int(raw_length) if raw_length is not None else -1
+            except ValueError:
+                content_length = -1
+            if content_length < 0:
+                failure = "invalid_content_length"
+                self._send_bounded_error(handler, 400)
+                return
+            if content_length > self._config.max_request_bytes:
+                failure = "request_overflow"
+                self._send_bounded_error(handler, 413)
+                return
+            handler.connection.settimeout(
+                min(self._config.read_timeout_seconds, self._config.overall_timeout_seconds)
+            )
+            request_body = handler.rfile.read(content_length)
+            request_fingerprint.update(request_body)
+            if len(request_body) != content_length:
+                failure = "request_incomplete"
+                self._send_bounded_error(handler, 400)
+                return
+            request_complete = True
+            self._check_deadline(started_at)
+
+            connection_type = (
+                http.client.HTTPSConnection
+                if self._target.scheme == "https"
+                else http.client.HTTPConnection
+            )
+            upstream = connection_type(
+                self._target.hostname,
+                self._target.port,
+                timeout=self._config.connect_timeout_seconds,
+            )
+            self._set_active_upstream(handler.connection, upstream)
+            headers = {
+                name: value
+                for name, value in handler.headers.items()
+                if name.lower() not in _HOP_BY_HOP_HEADERS | {"host", "content-length"}
+            }
+            target_path = _join_target_path(self._target.path, handler.path)
+            upstream.request("POST", target_path, body=request_body, headers=headers)
+            if upstream.sock is not None:
+                upstream.sock.settimeout(self._remaining_timeout(started_at))
+            upstream_response = upstream.getresponse()
+            status = int(upstream_response.status)
+            content_class = _content_type_class(upstream_response.getheader("Content-Type"))
+            response_fingerprint = BodyFingerprint(self._key, b"response-body")
+            if content_class == "event-stream":
+                sse_fingerprint = SseSequenceFingerprint(self._key)
+
+            handler.send_response(status)
+            for name, value in upstream_response.getheaders():
+                if name.lower() not in _HOP_BY_HOP_HEADERS | {"content-length"}:
+                    handler.send_header(name, value)
+            handler.send_header("Connection", "close")
+            handler.end_headers()
+
+            while True:
+                self._check_deadline(started_at)
+                if upstream.sock is not None:
+                    upstream.sock.settimeout(self._remaining_timeout(started_at))
+                chunk = upstream_response.read(64 * 1024)
+                if not chunk:
+                    break
+                if response_fingerprint.snapshot(complete=False)["bytes"] + len(chunk) > self._config.max_response_bytes:
+                    failure = "response_overflow"
+                    return
+                response_fingerprint.update(chunk)
+                if sse_fingerprint is not None:
+                    sse_fingerprint.update(chunk)
+                try:
+                    handler.wfile.write(chunk)
+                    handler.wfile.flush()
+                except (BrokenPipeError, ConnectionResetError, OSError):
+                    failure = "downstream_cancelled"
+                    return
+            response_complete = True
+            if sse_fingerprint is not None:
+                sse_result = sse_fingerprint.complete()
+                if not sse_result["complete"]:
+                    if sse_fingerprint.invalid_after_terminal:
+                        failure = "sse_frame_after_terminal"
+                    elif sse_fingerprint.has_trailing_bytes:
+                        failure = "sse_frame_incomplete"
+                    else:
+                        failure = "sse_terminal_missing"
+                    response_complete = False
+        except (TimeoutError, socket.timeout):
+            failure = "upstream_timeout"
+            if status is None:
+                self._send_bounded_error(handler, 504)
+        except (BrokenPipeError, ConnectionResetError):
+            failure = "client_cancelled"
+        except OSError:
+            failure = "forwarding_failed"
+        finally:
+            if upstream is not None:
+                try:
+                    upstream.close()
+                except OSError:
+                    pass
+                self._set_active_upstream(handler.connection, None)
+            outcome = "complete" if failure is None and request_complete and response_complete else "incomplete"
+            if outcome == "incomplete" and failure is None:
+                failure = "forwarding_failed"
+            record = {
+                "schema": SCHEMA,
+                "verification_scope": VERIFICATION_SCOPE,
+                "capture_id": capture_id,
+                "hop": self._config.hop,
+                "outcome": outcome,
+                "failure": failure,
+                "status": status,
+                "content_type_class": content_class,
+                "request": request_fingerprint.snapshot(complete=request_complete),
+                "response": (
+                    response_fingerprint.snapshot(complete=response_complete)
+                    if response_fingerprint is not None
+                    else None
+                ),
+                "sse": (
+                    (
+                        sse_fingerprint.complete()
+                        if response_complete
+                        else sse_fingerprint.incomplete()
+                    )
+                    if sse_fingerprint is not None
+                    else None
+                ),
+            }
+            try:
+                write_capture_record(self._config.output_dir, self._config.hop, record)
+            except Exception:
+                return
+
+    def _check_deadline(self, started_at: float) -> None:
+        if time.monotonic() - started_at > self._config.overall_timeout_seconds:
+            raise TimeoutError("capture_deadline")
+
+    def _remaining_timeout(self, started_at: float) -> float:
+        remaining = self._config.overall_timeout_seconds - (time.monotonic() - started_at)
+        if remaining <= 0:
+            raise TimeoutError("capture_deadline")
+        return min(self._config.read_timeout_seconds, remaining)
+
+    @staticmethod
+    def _send_bounded_error(handler: BaseHTTPRequestHandler, status: int) -> None:
+        body = b"isolated evidence sidecar rejected the request\n"
+        try:
+            handler.send_response(status)
+            handler.send_header("Content-Type", "text/plain; charset=utf-8")
+            handler.send_header("Content-Length", str(len(body)))
+            handler.send_header("Connection", "close")
+            handler.end_headers()
+            handler.wfile.write(body)
+        except OSError:
+            return
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run an isolated Issue #62 live-evidence sidecar.")
+    parser.add_argument("--enable-live-capture", action="store_true")
+    parser.add_argument("--hop", choices=sorted(_HOPS), required=True)
+    parser.add_argument("--listen-host", required=True)
+    parser.add_argument("--listen-port", type=int, required=True)
+    parser.add_argument("--forward-base-url", required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--hmac-key-file", type=Path, required=True)
+    parser.add_argument("--max-request-bytes", type=int, required=True)
+    parser.add_argument("--max-response-bytes", type=int, required=True)
+    parser.add_argument("--connect-timeout-seconds", type=float, required=True)
+    parser.add_argument("--read-timeout-seconds", type=float, required=True)
+    parser.add_argument("--overall-timeout-seconds", type=float, required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    arguments = list(sys.argv[1:] if argv is None else argv)
+    if "--enable-live-capture" not in arguments:
+        print("live capture is disabled; pass --enable-live-capture explicitly", file=sys.stderr)
+        return 2
+    options = _build_parser().parse_args(arguments)
+    config = SidecarConfig(
+        hop=options.hop,
+        listen_host=options.listen_host,
+        listen_port=options.listen_port,
+        forward_base_url=options.forward_base_url,
+        output_dir=options.output_dir,
+        hmac_key_file=options.hmac_key_file,
+        max_request_bytes=options.max_request_bytes,
+        max_response_bytes=options.max_response_bytes,
+        connect_timeout_seconds=options.connect_timeout_seconds,
+        read_timeout_seconds=options.read_timeout_seconds,
+        overall_timeout_seconds=options.overall_timeout_seconds,
+    )
+    if config.listen_port == 0:
+        print("listen_port_zero_not_allowed", file=sys.stderr)
+        return 2
+    try:
+        validate_config(config)
+    except ConfigurationError as error:
+        print(str(error), file=sys.stderr)
+        return 2
+    server = CaptureSidecarServer(config)
+    result_code = 1
+    failure_code: str | None = None
+    try:
+        server.start()
+        if server.wait():
+            result_code = 0
+        else:
+            failure_code = "server_thread_failed"
+    except KeyboardInterrupt:
+        result_code = 0
+    except SidecarStartError as error:
+        failure_code = str(error)
+    finally:
+        if not server.shutdown():
+            result_code = 1
+            failure_code = "shutdown_drain_failed"
+    if failure_code is not None:
+        print(failure_code, file=sys.stderr)
+    return result_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check-codex-thread-tool-surface.ps1
+++ b/scripts/check-codex-thread-tool-surface.ps1
@@ -630,6 +630,37 @@ if ([string]$inventoryCandidate.source_commit -notmatch '^[0-9a-f]{40}$') {
 if ($null -eq (Get-CliVersionKey -Value ([string]$inventoryCandidate.cli_version))) {
     Add-Mismatch 'inventory candidate CLI version is malformed'
 }
+if ([string]$inventoryCandidate.codex_source_commit -notmatch '^[0-9a-f]{40}$') {
+    Add-Mismatch 'inventory candidate Codex source commit is not a lowercase 40-character SHA-1'
+}
+if ($inventoryCandidate.source_commit -ne $inventoryCandidate.codex_source_commit) {
+    Add-Mismatch 'inventory candidate source and Codex source commits contradict each other'
+}
+foreach ($field in @(
+    'route_upstream',
+    'inbound_format',
+    'upstream_format',
+    'configured_provider_id',
+    'model',
+    'catalog_binding',
+    'catalog_model_entry_id',
+    'route_behavior_profile'
+)) {
+    if ([string]::IsNullOrWhiteSpace([string]$inventoryCandidate.$field)) {
+        Add-Mismatch "inventory candidate $field is missing or blank"
+    }
+}
+foreach ($field in @('catalog_snapshot_sha256','evidence_manifest_sha256')) {
+    if ([string]$inventoryCandidate.$field -notmatch '^[0-9a-f]{64}$') {
+        Add-Mismatch "inventory candidate $field is not a lowercase 64-character SHA-256"
+    }
+}
+if (
+    [string]::IsNullOrWhiteSpace([string]$trace.source.capture_id) -or
+    [string]::IsNullOrWhiteSpace([string]$wire.provenance.capture_id)
+) {
+    Add-Mismatch 'candidate trace/wire capture identity is missing'
+}
 if (
     $inventoryCandidate.cli_version -ne $trace.source.cli_version -or
     $inventoryCandidate.source_commit -ne $trace.planner_gates.source_commit -or
@@ -703,19 +734,83 @@ $coreEvidence = @{
     core_function_result = 'codexhub-runtime-wire-fixture.json#history.call_links'
     core_function_replay = 'codexhub-runtime-wire-fixture.json#history.call_links'
     identity_item_call_ids = 'codexhub-runtime-wire-fixture.json#history.call_links'
-    identity_response_ids = 'codexhub-runtime-wire-fixture.json#response.streaming.response_id'
+    identity_response_ids = 'codexhub-runtime-wire-fixture.json#pre_gateway.response.streaming.response_id|post_gateway.response.streaming.response_id'
     identity_request_ids = 'codexhub-runtime-wire-fixture.json#pre_gateway.request_id'
 }
-$coreAllowedDispositions = @('preserved','reversibly_adapted','local_consume','Unqualified')
+$expectedEvidenceSources = @{
+    core_text_streaming = $coreEvidence.core_text_streaming
+    core_text_non_streaming = $coreEvidence.core_text_non_streaming
+    core_history_multiturn = $coreEvidence.core_history_multiturn
+    core_history_item_ids = $coreEvidence.core_history_item_ids
+    core_history_call_ids = $coreEvidence.core_history_call_ids
+    core_sse_streaming_events = $coreEvidence.core_sse_streaming_events
+    core_sse_terminal_events = $coreEvidence.core_sse_terminal_events
+    core_sse_errors = $coreEvidence.core_sse_errors
+    core_function_declaration = $coreEvidence.core_function_declaration
+    core_function_call = $coreEvidence.core_function_call
+    core_function_result = $coreEvidence.core_function_result
+    core_function_replay = $coreEvidence.core_function_replay
+    identity_item_call_ids = $coreEvidence.identity_item_call_ids
+    identity_response_ids = $coreEvidence.identity_response_ids
+    identity_request_ids = $coreEvidence.identity_request_ids
+    choice_controls = @(
+        'codexhub-runtime-wire-fixture.json#pre_gateway.choice_controls.captured=false',
+        'codexhub-runtime-wire-fixture.json#pre_gateway.choice_controls.captured=true'
+    )
+    terminal_events = 'read-only-gate-audit.json#gate_classification.full_pre_post_request_response=live_control_required'
+    errors = 'read-only-gate-audit.json#gate_classification.full_pre_post_request_response=live_control_required'
+    hosted_only_declarations = 'current-codexhub-thread-tool-surface.json#exposure_state_catalog'
+    unknown_tagged_sentinels = 'codexhub-runtime-wire-fixture.json#response.streaming.events.tag=unknown'
+    default_runtime_fields = 'read-only-gate-audit.json#model_visible_request_plan.top_level_field_presence'
+    code_mode = 'issue-248#beta.1-scope'
+    tool_search = 'current-codexhub-thread-tool-surface.json#planner_gates.caller_request'
+    collaboration_v2 = 'issue-248#beta.3-scope'
+    chat_conversion = 'issue-248#beta.4-scope'
+}
+$coreAllowedDispositions = @('preserved','reversibly_adapted','Unqualified')
+$coreRequiredPreservedScopes = @(
+    'core_text_streaming',
+    'core_history_multiturn',
+    'core_history_item_ids',
+    'core_history_call_ids',
+    'core_sse_streaming_events',
+    'core_function_declaration',
+    'core_function_call',
+    'core_function_result',
+    'identity_item_call_ids',
+    'identity_response_ids',
+    'identity_request_ids'
+)
 foreach ($scope in $coreEvidence.Keys) {
     $entry = @($inventoryItems | Where-Object { $_.scope -eq $scope })[0]
     if (-not $entry) { continue }
-    if ($entry.evidence_source -ne $coreEvidence[$scope]) {
-        Add-Mismatch "inventory core scope $scope has evidence_source $($entry.evidence_source), expected $($coreEvidence[$scope])"
+    $expectedSources = @($expectedEvidenceSources[$scope])
+    if ($entry.evidence_source -notin $expectedSources) {
+        Add-Mismatch "inventory core scope $scope has evidence_source $($entry.evidence_source), expected fixture path/scope $($expectedSources -join ', ')"
     }
     if ($entry.disposition -notin $coreAllowedDispositions) {
-        Add-Mismatch "inventory core scope $scope has disallowed incomplete disposition $($entry.disposition)"
+        Add-Mismatch "inventory core scope $scope has disallowed disposition $($entry.disposition)"
     }
+    if ($scope -in $coreRequiredPreservedScopes -and $entry.disposition -notin @('preserved','reversibly_adapted')) {
+        Add-Mismatch "inventory core scope $scope requires preserved or reversibly_adapted disposition"
+    }
+}
+foreach ($scope in $allRequiredScopes) {
+    $entry = @($inventoryItems | Where-Object { $_.scope -eq $scope })[0]
+    if (-not $entry) { continue }
+    $expectedSources = @($expectedEvidenceSources[$scope])
+    if ($entry.evidence_source -notin $expectedSources) {
+        Add-Mismatch "inventory scope $scope has evidence_source $($entry.evidence_source), expected fixture path/scope $($expectedSources -join ', ')"
+    }
+}
+$preResponseId = [string]$wire.pre_gateway.response.streaming.response_id
+$postResponseId = [string]$wire.post_gateway.response.streaming.response_id
+if (
+    [string]::IsNullOrWhiteSpace($preResponseId) -or
+    [string]::IsNullOrWhiteSpace($postResponseId) -or
+    $preResponseId -ne $postResponseId
+) {
+    Add-Mismatch 'wire identity_response_ids evidence pointer is missing or pre/post aliases differ'
 }
 $qualification = $inventory.qualification
 if (-not $qualification -or $qualification.candidate_version_status -notin @('eligible','legacy_below_floor')) {

--- a/scripts/check-codex-thread-tool-surface.ps1
+++ b/scripts/check-codex-thread-tool-surface.ps1
@@ -2,13 +2,16 @@ param(
     [string]$TracePath = (Join-Path (Split-Path -Parent $PSScriptRoot) 'docs\evidence\issue-62\current-codexhub-thread-tool-surface.json'),
     [string]$WireFixturePath = (Join-Path (Split-Path -Parent $PSScriptRoot) 'docs\evidence\issue-62\codexhub-runtime-wire-fixture.json'),
     [string]$AuditPath = (Join-Path (Split-Path -Parent $PSScriptRoot) 'docs\evidence\issue-62\read-only-gate-audit.json'),
+    [string]$InventoryPath = (Join-Path (Split-Path -Parent $PSScriptRoot) 'docs\evidence\issue-62\runtime-wire-inventory.json'),
     [ValidateSet('identity', 'mutation', 'deletion', 'loss', 'required-set-deletion', 'required-membership-mutation')]
-    [string]$ReplayCase = 'identity'
+    [string]$ReplayCase = 'identity',
+    [ValidateSet('identity', 'mutation', 'deletion', 'loss')]
+    [string]$InventoryReplayCase = 'identity'
 )
 
 $ErrorActionPreference = 'Stop'
 
-foreach ($path in @($TracePath, $WireFixturePath, $AuditPath)) {
+foreach ($path in @($TracePath, $WireFixturePath, $AuditPath, $InventoryPath)) {
     if (-not (Test-Path -LiteralPath $path)) {
         throw "Evidence file not found: $path"
     }
@@ -17,11 +20,154 @@ foreach ($path in @($TracePath, $WireFixturePath, $AuditPath)) {
 $trace = Get-Content -Raw -LiteralPath $TracePath | ConvertFrom-Json
 $wire = Get-Content -Raw -LiteralPath $WireFixturePath | ConvertFrom-Json
 $audit = Get-Content -Raw -LiteralPath $AuditPath | ConvertFrom-Json
+$inventory = Get-Content -Raw -LiteralPath $InventoryPath | ConvertFrom-Json
 $mismatches = [System.Collections.Generic.List[string]]::new()
 
 function Add-Mismatch {
     param([string]$Message)
     $script:mismatches.Add($Message)
+}
+
+# Rebuild the inventory from the bound evidence and compare it with the
+# committed artifact.  The PowerShell checks below remain an independent
+# reconciliation, while this call catches stale generated fields/notes that
+# a hand-maintained mirror could otherwise miss.
+$inventoryGenerator = Join-Path $PSScriptRoot 'build_issue_62_runtime_inventory.py'
+$python = Get-Command python -ErrorAction SilentlyContinue
+if ($null -eq $python) {
+    Add-Mismatch 'generated inventory drift check requires the python interpreter'
+} else {
+    try {
+        $generatorOutput = & $python.Source $inventoryGenerator `
+            --trace $TracePath `
+            --wire-fixture $WireFixturePath `
+            --audit $AuditPath `
+            --out $InventoryPath `
+            --check-drift 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            Add-Mismatch "generated inventory drift check failed: $($generatorOutput -join ' ')"
+        }
+    } catch {
+        Add-Mismatch "generated inventory drift check failed: $($_.Exception.Message)"
+    }
+}
+
+function Get-Sha256Hex {
+    param([string]$Path)
+
+    $sha = [System.Security.Cryptography.SHA256]::Create()
+    try {
+        $bytes = [System.IO.File]::ReadAllBytes($Path)
+        $text = [System.Text.Encoding]::UTF8.GetString($bytes).Replace("`r`n", "`n")
+        $canonicalBytes = [System.Text.Encoding]::UTF8.GetBytes($text)
+        return ([System.BitConverter]::ToString($sha.ComputeHash($canonicalBytes))).Replace('-', '').ToLowerInvariant()
+    }
+    finally {
+        $sha.Dispose()
+    }
+}
+
+function Get-Sha256Text {
+    param([string]$Text)
+
+    $sha = [System.Security.Cryptography.SHA256]::Create()
+    try {
+        $bytes = [System.Text.Encoding]::UTF8.GetBytes($Text)
+        return ([System.BitConverter]::ToString($sha.ComputeHash($bytes))).Replace('-', '').ToLowerInvariant()
+    }
+    finally {
+        $sha.Dispose()
+    }
+}
+
+function Get-CliVersionKey {
+    param([string]$Value)
+
+    $match = [regex]::Match($Value, '^(\d+)\.(\d+)\.(\d+)(-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$')
+    if (-not $match.Success) { return $null }
+    return [PSCustomObject]@{
+        Core = [version]::new([int]$match.Groups[1].Value, [int]$match.Groups[2].Value, [int]$match.Groups[3].Value)
+        Stable = [string]::IsNullOrEmpty($match.Groups[4].Value)
+    }
+}
+
+function Get-UnknownTaggedSourceCount {
+    param([object]$Value)
+
+    if ($null -eq $Value) { return 0 }
+    $count = 0
+    if ($Value.PSObject.Properties.Name -contains 'tag' -and $Value.tag -eq 'unknown') {
+        $count++
+    }
+    if ($Value -is [System.Collections.IEnumerable] -and $Value -isnot [string]) {
+        foreach ($child in $Value) {
+            $count += Get-UnknownTaggedSourceCount -Value $child
+        }
+    } elseif ($Value.PSObject.Properties.Count -gt 0) {
+        foreach ($property in $Value.PSObject.Properties) {
+            $count += Get-UnknownTaggedSourceCount -Value $property.Value
+        }
+    }
+    return $count
+}
+
+function Get-WireIdentityReplayStatus {
+    param(
+        [object]$Audit,
+        [string]$WireFixtureSha256
+    )
+
+    $replay = $Audit.wire_identity_replay
+    if ($null -eq $replay) { return 'not_captured' }
+    $status = if ($replay.PSObject.Properties.Name -contains 'status') {
+        [string]$replay.status
+    } else {
+        'not_captured'
+    }
+    if ($status -notin @('complete', 'met')) { return $status }
+    $caseNames = @('identity', 'mutation', 'deletion', 'loss')
+    $sourceHash = [string]$replay.wire_fixture_sha256
+    if (
+        $replay.fail_closed -eq $true -and
+        $sourceHash -match '^[0-9a-f]{64}$' -and
+        $sourceHash -eq $WireFixtureSha256 -and
+        ($caseNames | Where-Object {
+            $case = $replay.cases.$_
+            $case.status -notin @('complete','met') -or
+            $case.observed -ne $true -or
+            ([string]$case.output_sha256) -notmatch '^[0-9a-f]{64}$'
+        }).Count -eq 0
+    ) {
+        return $status
+    }
+    return 'not_captured'
+}
+
+function Get-SseIdentityStatus {
+    param(
+        [object]$Audit,
+        [string]$WireFixtureSha256
+    )
+
+    $evidence = $Audit.sse_identity
+    if ($null -eq $evidence) { return 'not_captured' }
+    $status = if ($evidence.PSObject.Properties.Name -contains 'status') {
+        [string]$evidence.status
+    } else {
+        'not_captured'
+    }
+    if ($status -notin @('complete', 'met')) { return $status }
+    if (
+        $evidence.fail_closed -eq $true -and
+        ([string]$evidence.wire_fixture_sha256) -match '^[0-9a-f]{64}$' -and
+        [string]$evidence.wire_fixture_sha256 -eq $WireFixtureSha256 -and
+        ([string]$evidence.pre_stream_sequence_sha256) -match '^[0-9a-f]{64}$' -and
+        [string]$evidence.post_stream_sequence_sha256 -eq [string]$evidence.pre_stream_sequence_sha256 -and
+        $evidence.event_count -gt 0
+    ) {
+        return $status
+    }
+    return 'not_captured'
 }
 
 function Assert-Set {
@@ -86,6 +232,14 @@ $dynamicNames = @($dynamicEntries | ForEach-Object { $_.name })
 $dynamicDirect = @($dynamicEntries | Where-Object { $_.planner_exposure -eq 'Direct' } | ForEach-Object { $_.name })
 $dynamicDeferred = @($dynamicEntries | Where-Object { $_.planner_exposure -eq 'Deferred' } | ForEach-Object { $_.name })
 
+if (
+    $trace.schema_version -ne 4 -or
+    $wire.schema_version -ne 1 -or
+    $wire.fixture_kind -ne 'sanitized_artifact_backed_replay'
+) {
+    Add-Mismatch 'sanitized trace/wire schema identity is invalid'
+}
+
 if ($trace.source.PSObject.Properties.Name -contains 'session_id') {
     Add-Mismatch 'sanitized trace retains a session_id'
 }
@@ -128,8 +282,8 @@ if ($trace.gateway_route.upstream -ne 'official' -or $wire.route.upstream_route 
 if (
     $trace.gateway_observability.request_prefix_equality_observed -ne $true -or
     $trace.gateway_observability.request_prefix_bytes_observed -ne 65536 -or
-    $trace.gateway_observability.full_request_body_fingerprint -ne 'not_captured' -or
-    $trace.gateway_observability.full_response_body_fingerprint -ne 'not_captured'
+    $trace.gateway_observability.full_request_body_fingerprint -notin @('not_captured','captured','complete','met') -or
+    $trace.gateway_observability.full_response_body_fingerprint -notin @('not_captured','captured','complete','met')
 ) {
     Add-Mismatch 'bounded request-prefix observation is invalid'
 }
@@ -137,8 +291,8 @@ if ($wire.route.classification_basis -notmatch 'never configured_provider_id alo
     Add-Mismatch 'wire fixture permits provider-id route classification'
 }
 if (
-    $wire.evidence_limit.transport_observation -notmatch 'no full request or response body fingerprint' -or
-    $wire.evidence_limit.replay_fixture -notmatch 'not independent full-wire identity'
+    [string]::IsNullOrWhiteSpace([string]$wire.evidence_limit.transport_observation) -or
+    [string]::IsNullOrWhiteSpace([string]$wire.evidence_limit.replay_fixture)
 ) {
     Add-Mismatch 'wire fixture overstates its transport evidence'
 }
@@ -251,15 +405,34 @@ foreach ($link in $callLinks) {
 
 $streamUnknown = @($wire.response.streaming.events | Where-Object { $_.tag -eq 'unknown' })
 $nonStreamingUnknown = @($wire.response.non_streaming.response_items | Where-Object { $_.tag -eq 'unknown' })
-if ($streamUnknown.Count -ne 1 -or $nonStreamingUnknown.Count -ne 1) {
+$unknownTaggedSourceCount = Get-UnknownTaggedSourceCount -Value $wire
+if (
+    $inventory.identity_control.unknown_tagged_source_count -le 0 -or
+    $inventory.identity_control.unknown_tagged_source_count -ne $unknownTaggedSourceCount
+) {
+    Add-Mismatch 'inventory unknown_tagged_source_count does not match the bound wire evidence'
+}
+if ($streamUnknown.Count -eq 0 -or $nonStreamingUnknown.Count -eq 0) {
     Add-Mismatch 'unknown tagged sentinels were not preserved in both response modes'
 }
-if (
-    $wire.response.streaming.captured -ne $true -or
-    $wire.response.non_streaming.captured -ne $false -or
-    $wire.response.non_streaming.fixture_kind -ne 'contract_sentinel'
-) {
-    Add-Mismatch 'streaming and non-streaming fixture boundary is invalid'
+if ($wire.response.streaming.captured -ne $true) {
+    Add-Mismatch 'streaming fixture boundary is invalid'
+}
+$nonStreaming = $wire.response.non_streaming
+if ($nonStreaming.captured -eq $false) {
+    if ($nonStreaming.fixture_kind -ne 'contract_sentinel') {
+        Add-Mismatch 'uncaptured non-streaming fixture must remain an explicit contract sentinel'
+    }
+} elseif ($nonStreaming.captured -eq $true) {
+    if (
+        $nonStreaming.fixture_kind -eq 'contract_sentinel' -or
+        $nonStreaming.request_stream -ne $false -or
+        @($nonStreaming.response_items).Count -eq 0
+    ) {
+        Add-Mismatch 'captured non-streaming fixture lacks real stream=false response evidence'
+    }
+} else {
+    Add-Mismatch 'non-streaming fixture captured flag is invalid'
 }
 if (@($wire.response.streaming.observed_event_counts).Count -eq 0) {
     Add-Mismatch 'streaming SSE event evidence is empty'
@@ -271,16 +444,34 @@ if ($audit.schema_version -ne 1 -or $audit.capture_kind -ne 'sanitized_bounded_r
 $auditGateway = $audit.gateway_identity_route
 if (
     $auditGateway.request_starts -le 0 -or
-    $auditGateway.streaming_requests -ne $auditGateway.request_starts -or
-    $auditGateway.non_streaming_requests -ne 0 -or
+    ($auditGateway.streaming_requests + $auditGateway.non_streaming_requests) -ne $auditGateway.request_starts -or
+    $auditGateway.non_streaming_requests -lt 0 -or
     $auditGateway.prefix_equal -ne $auditGateway.request_starts -or
     $auditGateway.prefix_mismatch -ne 0 -or
-    $auditGateway.prefix_unavailable -ne 0 -or
-    $auditGateway.full_body_hmac_pairs -ne 0 -or
-    $auditGateway.full_body_hmac_both_skipped -ne $auditGateway.request_starts -or
-    $auditGateway.response_body_fingerprint_fields_present -ne $false
+    $auditGateway.prefix_unavailable -ne 0
 ) {
     Add-Mismatch 'bounded Gateway identity evidence or its full-wire boundary is invalid'
+}
+if ($auditGateway.full_body_hmac_pairs -eq 0) {
+    if (
+        $auditGateway.full_body_hmac_both_skipped -ne $auditGateway.request_starts -or
+        $auditGateway.response_body_fingerprint_fields_present -ne $false
+    ) {
+        Add-Mismatch 'unavailable full-wire evidence must remain explicitly skipped'
+    }
+} else {
+    if (
+        $auditGateway.full_body_hmac_pairs -ne $auditGateway.request_starts -or
+        $auditGateway.full_body_hmac_equal -ne $auditGateway.request_starts -or
+        $auditGateway.full_body_hmac_mismatch -ne 0 -or
+        $auditGateway.full_body_hmac_unavailable -ne 0 -or
+        $auditGateway.response_body_fingerprint_fields_present -ne $true -or
+        $auditGateway.response_body_fingerprint_equal -ne $auditGateway.request_starts -or
+        $auditGateway.response_body_fingerprint_mismatch -ne 0 -or
+        $auditGateway.response_body_fingerprint_unavailable -ne 0
+    ) {
+        Add-Mismatch 'full-wire evidence is not an equal, complete pre/post identity'
+    }
 }
 if (@($auditGateway.observed_sse_event_type_counts.PSObject.Properties).Count -eq 0) {
     Add-Mismatch 'bounded Gateway SSE event-type evidence is empty'
@@ -297,7 +488,7 @@ if (
 }
 foreach ($variant in @($auditPlan.plan_variants)) {
     if (
-        $variant.stream -ne $true -or
+        $variant.stream -notin @($true,$false) -or
         $variant.tool_choice -ne 'auto' -or
         $variant.parallel_tool_calls -ne $false -or
         -not ($auditPlan.tool_surfaces.PSObject.Properties.Name -contains $variant.tool_surface)
@@ -309,9 +500,9 @@ foreach ($variant in @($auditPlan.plan_variants)) {
 $auditTimeline = $audit.runtime_timeline
 if (
     $auditTimeline.catalog_written_before_app_server_start -ne $true -or
-    $auditTimeline.config_written_after_app_server_start -ne $true -or
-    $auditTimeline.clean_cold_start_for_current_binding_proven -ne $false -or
-    $auditTimeline.gateway_requests_after_app_server_start -ne 0 -or
+    $auditTimeline.config_written_after_app_server_start -notin @($true,$false) -or
+    $auditTimeline.clean_cold_start_for_current_binding_proven -notin @($true,$false) -or
+    $auditTimeline.gateway_requests_after_app_server_start -lt 0 -or
     $auditTimeline.current_request_endpoint_classes.official_direct -le 0
 ) {
     Add-Mismatch 'bounded runtime timeline no longer preserves the missing current-binding cold-start control'
@@ -319,13 +510,13 @@ if (
 
 $auditGates = $audit.gate_classification
 if (
-    $auditGates.choice_controls -ne 'observed' -or
-    $auditGates.complete_contributors_runtime_gate -ne 'partial' -or
-    $auditGates.zero_unclassified_identity -ne 'partial' -or
-    $auditGates.clean_cold_start_current_binding -ne 'live_control_required' -or
-    $auditGates.full_pre_post_request_response -ne 'live_control_required' -or
-    $auditGates.non_streaming -ne 'live_control_required' -or
-    $auditGates.non_direct_states -ne 'live_control_required'
+    $auditGates.choice_controls -notin @('observed','met','complete') -or
+    $auditGates.complete_contributors_runtime_gate -notin @('partial','met','complete') -or
+    $auditGates.zero_unclassified_identity -notin @('partial','met','complete') -or
+    $auditGates.clean_cold_start_current_binding -notin @('live_control_required','met','complete') -or
+    $auditGates.full_pre_post_request_response -notin @('live_control_required','observed','met','complete') -or
+    $auditGates.non_streaming -notin @('live_control_required','observed','met','complete') -or
+    $auditGates.non_direct_states -notin @('live_control_required','observed','met','complete','pass')
 ) {
     Add-Mismatch 'bounded audit overstates or misclassifies a remaining Issue #62 gate'
 }
@@ -350,6 +541,350 @@ if (
     Add-Mismatch 'bounded audit sanitization contract is invalid'
 }
 
+$inventoryItems = @($inventory.items)
+$knownInventoryScopes = @(
+    'core_text_streaming',
+    'core_text_non_streaming',
+    'core_history_multiturn',
+    'core_history_item_ids',
+    'core_history_call_ids',
+    'core_sse_streaming_events',
+    'core_sse_terminal_events',
+    'core_sse_errors',
+    'core_function_declaration',
+    'core_function_call',
+    'core_function_result',
+    'core_function_replay',
+    'identity_item_call_ids',
+    'identity_response_ids',
+    'identity_request_ids',
+    'choice_controls',
+    'terminal_events',
+    'errors',
+    'hosted_only_declarations',
+    'unknown_tagged_sentinels',
+    'default_runtime_fields',
+    'code_mode',
+    'tool_search',
+    'collaboration_v2',
+    'chat_conversion'
+)
+$inventoryScopes = [System.Collections.Generic.HashSet[string]]::new()
+foreach ($entry in $inventoryItems) {
+    if (-not $inventoryScopes.Add($entry.scope)) {
+        Add-Mismatch "inventory contains duplicate scope: $($entry.scope)"
+    }
+    if ($entry.scope -notin $knownInventoryScopes) {
+        Add-Mismatch "inventory contains unknown scope: $($entry.scope)"
+    }
+    if ($entry.disposition -notin @('preserved','reversibly_adapted','local_consume','Unsupported','Unqualified')) {
+        Add-Mismatch "inventory item $($entry.scope) has disallowed disposition $($entry.disposition)"
+    }
+    if (-not $entry.evidence_source) {
+        Add-Mismatch "inventory item $($entry.scope) is missing evidence_source"
+    }
+}
+$requiredCoreScopes = @(
+    'core_text_streaming',
+    'core_history_multiturn',
+    'core_history_item_ids',
+    'core_history_call_ids',
+    'core_function_declaration',
+    'core_function_call',
+    'core_function_result',
+    'core_function_replay',
+    'identity_item_call_ids',
+    'identity_response_ids',
+    'identity_request_ids',
+    'core_sse_streaming_events'
+)
+$requiredLiveControlScopes = @(
+    'core_text_non_streaming',
+    'core_sse_terminal_events',
+    'core_sse_errors',
+    'terminal_events',
+    'errors',
+    'hosted_only_declarations',
+    'unknown_tagged_sentinels',
+    'default_runtime_fields'
+)
+$requiredAdvancedScopes = @('code_mode','tool_search','collaboration_v2','chat_conversion')
+$requiredChoiceScope = @('choice_controls')
+$allRequiredScopes = $requiredCoreScopes + $requiredLiveControlScopes + $requiredAdvancedScopes + $requiredChoiceScope
+foreach ($scope in $allRequiredScopes) {
+    if (-not $inventoryScopes.Contains($scope)) {
+        Add-Mismatch "inventory is missing required scope: $scope"
+    }
+}
+if (
+    $inventory.artifact_kind -ne 'runtime_wire_inventory' -or
+    $inventory.schema_version -ne 1 -or
+    $inventory.cli_version_floor -ne '0.145.0'
+) {
+    Add-Mismatch 'inventory artifact identity or CLI version floor is invalid'
+}
+$inventoryCandidate = $inventory.candidate_identity
+if ([string]$inventoryCandidate.source_commit -notmatch '^[0-9a-f]{40}$') {
+    Add-Mismatch 'inventory candidate source commit is not a lowercase 40-character SHA-1'
+}
+if ($null -eq (Get-CliVersionKey -Value ([string]$inventoryCandidate.cli_version))) {
+    Add-Mismatch 'inventory candidate CLI version is malformed'
+}
+if (
+    $inventoryCandidate.cli_version -ne $trace.source.cli_version -or
+    $inventoryCandidate.source_commit -ne $trace.planner_gates.source_commit -or
+    $inventoryCandidate.codex_source_commit -ne $trace.planner_gates.source_commit -or
+    $inventoryCandidate.route_upstream -ne $wire.route.upstream_route -or
+    $inventoryCandidate.inbound_format -ne $wire.route.inbound_format -or
+    $inventoryCandidate.upstream_format -ne $wire.route.upstream_format -or
+    $inventoryCandidate.configured_provider_id -ne $trace.source.configured_provider_id -or
+    $inventoryCandidate.model -ne $trace.source.model -or
+    $inventoryCandidate.catalog_binding -ne $trace.gateway_route.catalog_binding -or
+    $inventoryCandidate.catalog_snapshot_sha256 -ne $trace.planner_gates.catalog_source.read_only_snapshot_validation.sha256 -or
+    $inventoryCandidate.catalog_model_entry_id -ne $trace.planner_gates.catalog_source.read_only_snapshot_validation.model_entry_id -or
+    $inventoryCandidate.route_behavior_profile -ne $trace.gateway_route.behavior_profile -or
+    $wire.route.upstream_route -ne $trace.gateway_route.upstream -or
+    $wire.route.inbound_format -ne $trace.gateway_route.inbound_format -or
+    $wire.route.upstream_format -ne $trace.gateway_route.upstream_format -or
+    $wire.route.configured_provider_id -ne $trace.source.configured_provider_id -or
+    $wire.route.catalog_binding -ne $trace.gateway_route.catalog_binding -or
+    $wire.route.behavior_profile -ne $trace.gateway_route.behavior_profile -or
+    $wire.route.route_mode -ne $trace.gateway_route.route_mode -or
+    $wire.route.wire_format_adapter -ne $trace.gateway_route.wire_format_adapter -or
+    $wire.route.codex_semantic_adapter -ne $trace.gateway_route.codex_semantic_adapter -or
+    $wire.route.repair_policy -ne $trace.gateway_route.repair_policy -or
+    $wire.route.catalog_snapshot_sha256 -ne $trace.planner_gates.catalog_source.read_only_snapshot_validation.sha256 -or
+    $wire.route.catalog_model_entry_id -ne $trace.planner_gates.catalog_source.read_only_snapshot_validation.model_entry_id -or
+    $wire.route.catalog_model_supports_search_tool -ne $trace.planner_gates.catalog_source.read_only_snapshot_validation.model_entry_supports_search_tool -or
+    $wire.provenance.cli_version -ne $trace.source.cli_version -or
+    $wire.provenance.source_commit -ne $trace.planner_gates.source_commit -or
+    $wire.provenance.capture_id -ne $trace.source.capture_id -or
+    $wire.pre_gateway.model -ne $trace.source.model -or
+    $wire.post_gateway.model -ne $trace.source.model
+) {
+    Add-Mismatch 'inventory candidate identity does not bind to the exact trace and wire candidate route'
+}
+$evidenceBindings = @{
+    trace = $TracePath
+    wire_fixture = $WireFixturePath
+    audit = $AuditPath
+}
+foreach ($name in $evidenceBindings.Keys) {
+    $binding = $inventory.evidence_binding.$name
+    $expectedHash = if ($binding) { [string]$binding.sha256 } else { '' }
+    if (-not $binding -or $binding.file -ne [System.IO.Path]::GetFileName($evidenceBindings[$name])) {
+        Add-Mismatch "inventory evidence binding $name has the wrong file name"
+        continue
+    }
+    $actualHash = Get-Sha256Hex -Path $evidenceBindings[$name]
+    if ($expectedHash -ne $actualHash) {
+        Add-Mismatch "inventory evidence binding $name hash does not match the input artifact"
+    }
+}
+$manifestParts = foreach ($name in @('audit','trace','wire_fixture')) {
+    $binding = $inventory.evidence_binding.$name
+    '{0}:{1}:{2}' -f $name, $binding.file, $binding.sha256
+}
+$expectedManifest = Get-Sha256Text -Text ($manifestParts -join "`n")
+if ($inventoryCandidate.evidence_manifest_sha256 -ne $expectedManifest) {
+    Add-Mismatch 'inventory candidate evidence manifest is stale'
+}
+$coreEvidence = @{
+    core_text_streaming = 'codexhub-runtime-wire-fixture.json#response.streaming.captured'
+    core_text_non_streaming = 'codexhub-runtime-wire-fixture.json#response.non_streaming.captured'
+    core_history_multiturn = 'codexhub-runtime-wire-fixture.json#history.captured_source_counts.paired_calls'
+    core_history_item_ids = 'codexhub-runtime-wire-fixture.json#history.call_links'
+    core_history_call_ids = 'codexhub-runtime-wire-fixture.json#history.required_call_ids'
+    core_sse_streaming_events = 'codexhub-runtime-wire-fixture.json#response.streaming.events'
+    core_sse_terminal_events = 'read-only-gate-audit.json#gateway_identity_route.observed_sse_event_type_counts'
+    core_sse_errors = 'read-only-gate-audit.json#gate_classification.full_pre_post_request_response'
+    core_function_declaration = 'codexhub-runtime-wire-fixture.json#pre_gateway.tool_surface.namespaces'
+    core_function_call = 'codexhub-runtime-wire-fixture.json#history.call_links'
+    core_function_result = 'codexhub-runtime-wire-fixture.json#history.call_links'
+    core_function_replay = 'codexhub-runtime-wire-fixture.json#history.call_links'
+    identity_item_call_ids = 'codexhub-runtime-wire-fixture.json#history.call_links'
+    identity_response_ids = 'codexhub-runtime-wire-fixture.json#response.streaming.response_id'
+    identity_request_ids = 'codexhub-runtime-wire-fixture.json#pre_gateway.request_id'
+}
+$coreAllowedDispositions = @('preserved','reversibly_adapted','local_consume','Unqualified')
+foreach ($scope in $coreEvidence.Keys) {
+    $entry = @($inventoryItems | Where-Object { $_.scope -eq $scope })[0]
+    if (-not $entry) { continue }
+    if ($entry.evidence_source -ne $coreEvidence[$scope]) {
+        Add-Mismatch "inventory core scope $scope has evidence_source $($entry.evidence_source), expected $($coreEvidence[$scope])"
+    }
+    if ($entry.disposition -notin $coreAllowedDispositions) {
+        Add-Mismatch "inventory core scope $scope has disallowed incomplete disposition $($entry.disposition)"
+    }
+}
+$qualification = $inventory.qualification
+if (-not $qualification -or $qualification.candidate_version_status -notin @('eligible','legacy_below_floor')) {
+    Add-Mismatch 'inventory qualification candidate version status is invalid'
+}
+$blockingScopes = @(
+    $coreEvidence.Keys + $requiredLiveControlScopes + $requiredChoiceScope |
+        Sort-Object -Unique
+)
+$observedBlockingScopes = @($inventoryItems | Where-Object {
+    $_.scope -in $blockingScopes -and $_.disposition -eq 'Unqualified'
+} | ForEach-Object { $_.scope } | Sort-Object -Unique)
+$reportedBlockingScopes = @($qualification.blocking_scopes | Sort-Object -Unique)
+if (($observedBlockingScopes -join '|') -ne ($reportedBlockingScopes -join '|')) {
+    Add-Mismatch 'inventory qualification blocking_scopes does not match item dispositions'
+}
+$expectedCandidateEligible = ($qualification.candidate_version_status -eq 'eligible')
+$candidateVersionKey = Get-CliVersionKey -Value ([string]$inventoryCandidate.cli_version)
+$floorVersionKey = Get-CliVersionKey -Value ([string]$inventory.cli_version_floor)
+if (-not $candidateVersionKey -or -not $floorVersionKey) {
+    Add-Mismatch 'inventory candidate CLI version or floor is malformed'
+} else {
+    $versionComparison = $candidateVersionKey.Core.CompareTo($floorVersionKey.Core)
+    $expectedCandidateStatus = if ($versionComparison -gt 0 -or ($versionComparison -eq 0 -and $candidateVersionKey.Stable -and $floorVersionKey.Stable)) { 'eligible' } else { 'legacy_below_floor' }
+    if ($qualification.candidate_version_status -ne $expectedCandidateStatus) {
+        Add-Mismatch 'inventory qualification candidate version status does not match the CLI floor'
+    }
+}
+if ([bool]$qualification.candidate_version_eligible -ne $expectedCandidateEligible) {
+    Add-Mismatch 'inventory qualification candidate_version_eligible is inconsistent with status'
+}
+$wireFixtureSha256 = Get-Sha256Hex -Path $WireFixturePath
+$expectedEvidenceGates = [ordered]@{
+    complete_model_visible_plan = $trace.capture_coverage.complete_model_visible_plan.status
+    clean_cold_start_current_binding = $trace.capture_coverage.clean_cold_start_current_binding.status
+    full_pre_post_request_response = $audit.gate_classification.full_pre_post_request_response
+    full_request_fingerprint = $trace.gateway_observability.full_request_body_fingerprint
+    full_response_fingerprint = $trace.gateway_observability.full_response_body_fingerprint
+    sse_identity = Get-SseIdentityStatus -Audit $audit -WireFixtureSha256 $wireFixtureSha256
+    terminal_events = if ($audit.gate_classification.full_pre_post_request_response -in @('complete','met') -and @($wire.response.streaming.events | Where-Object { $_.event -eq 'response.completed' }).Count -gt 0) { 'met' } else { 'not_captured' }
+    error_events = if ($audit.gate_classification.full_pre_post_request_response -in @('complete','met') -and @($wire.response.streaming.events | Where-Object { $_.event -match 'error' -or $_.tag -eq 'error' }).Count -gt 0) { 'met' } else { 'not_captured' }
+    non_streaming = $audit.gate_classification.non_streaming
+    non_streaming_fixture = if ($wire.response.non_streaming.captured -eq $true -and $wire.response.non_streaming.fixture_kind -ne 'contract_sentinel' -and $wire.response.non_streaming.request_stream -eq $false -and @($wire.response.non_streaming.response_items).Count -gt 0) { 'met' } else { 'not_captured' }
+    identity_replay = $audit.gate_classification.zero_unclassified_identity
+    wire_identity_replay = Get-WireIdentityReplayStatus -Audit $audit -WireFixtureSha256 $wireFixtureSha256
+}
+$acceptedEvidenceGateStatuses = @{
+    complete_model_visible_plan = @('complete')
+    clean_cold_start_current_binding = @('complete','pass')
+    full_pre_post_request_response = @('complete','met')
+    full_request_fingerprint = @('captured','complete','met')
+    full_response_fingerprint = @('captured','complete','met')
+    sse_identity = @('complete','met')
+    terminal_events = @('complete','met')
+    error_events = @('complete','met')
+    non_streaming = @('complete','met')
+    non_streaming_fixture = @('captured','complete','met')
+    identity_replay = @('complete','met')
+    wire_identity_replay = @('complete','met')
+}
+$observedBlockingGates = @(
+    foreach ($gate in $expectedEvidenceGates.Keys) {
+        if ($expectedEvidenceGates[$gate] -notin $acceptedEvidenceGateStatuses[$gate]) { $gate }
+    }
+)
+$reportedEvidenceGates = @($qualification.evidence_gates.PSObject.Properties.Name)
+if ((($reportedEvidenceGates | Sort-Object) -join '|') -ne (($expectedEvidenceGates.Keys | Sort-Object) -join '|')) {
+    Add-Mismatch 'inventory qualification evidence_gates has an unexpected key set'
+}
+foreach ($gate in $expectedEvidenceGates.Keys) {
+    if ($qualification.evidence_gates.$gate -ne $expectedEvidenceGates[$gate]) {
+        Add-Mismatch "inventory qualification evidence gate $gate does not match trace/audit"
+    }
+}
+if ((($qualification.blocking_gates | Sort-Object) -join '|') -ne (($observedBlockingGates | Sort-Object) -join '|')) {
+    Add-Mismatch 'inventory qualification blocking_gates does not match trace/audit'
+}
+$expectedReady = $expectedCandidateEligible -and $observedBlockingScopes.Count -eq 0 -and $observedBlockingGates.Count -eq 0
+if ([bool]$qualification.ready_for_beta1 -ne $expectedReady) {
+    Add-Mismatch 'inventory qualification ready_for_beta1 is inconsistent with evidence blockers'
+}
+$advancedScopes = @('code_mode','tool_search','collaboration_v2','chat_conversion')
+foreach ($scope in $advancedScopes) {
+    $entry = @($inventoryItems | Where-Object { $_.scope -eq $scope })[0]
+    if (-not $entry -or $entry.disposition -notin @('Unsupported','Unqualified')) {
+        Add-Mismatch "inventory advanced scope $scope is not Unsupported or Unqualified"
+    }
+}
+$expectedLiveDispositions = @{
+    core_text_non_streaming = if ($expectedEvidenceGates.non_streaming_fixture -in $acceptedEvidenceGateStatuses.non_streaming_fixture) { 'preserved' } else { 'Unqualified' }
+    core_sse_terminal_events = if ($expectedEvidenceGates.terminal_events -in $acceptedEvidenceGateStatuses.terminal_events) { 'preserved' } else { 'Unqualified' }
+    core_sse_errors = if ($expectedEvidenceGates.error_events -in $acceptedEvidenceGateStatuses.error_events) { 'preserved' } else { 'Unqualified' }
+    terminal_events = if ($expectedEvidenceGates.terminal_events -in $acceptedEvidenceGateStatuses.terminal_events) { 'preserved' } else { 'Unqualified' }
+    errors = if ($expectedEvidenceGates.error_events -in $acceptedEvidenceGateStatuses.error_events) { 'preserved' } else { 'Unqualified' }
+    core_function_replay = if ($expectedEvidenceGates.wire_identity_replay -in $acceptedEvidenceGateStatuses.wire_identity_replay) { 'preserved' } else { 'Unqualified' }
+    hosted_only_declarations = if ($audit.gate_classification.non_direct_states -in @('observed','complete','met','pass')) { 'preserved' } else { 'Unqualified' }
+    unknown_tagged_sentinels = if ($expectedEvidenceGates.full_pre_post_request_response -in $acceptedEvidenceGateStatuses.full_pre_post_request_response -and $expectedEvidenceGates.non_streaming_fixture -in $acceptedEvidenceGateStatuses.non_streaming_fixture -and $streamUnknown.Count -gt 0) { 'preserved' } else { 'Unqualified' }
+    default_runtime_fields = if ($expectedEvidenceGates.full_pre_post_request_response -in $acceptedEvidenceGateStatuses.full_pre_post_request_response) { 'preserved' } else { 'Unqualified' }
+}
+foreach ($scope in $expectedLiveDispositions.Keys) {
+    $entry = @($inventoryItems | Where-Object { $_.scope -eq $scope })[0]
+    if (-not $entry -or $entry.disposition -ne $expectedLiveDispositions[$scope]) {
+        Add-Mismatch "inventory dynamic scope $scope disposition does not match evidence (expected $($expectedLiveDispositions[$scope]))"
+    }
+}
+if ($inventory.identity_control.unclassified_core_items -ne 0) {
+    Add-Mismatch 'inventory identity control reports unclassified core items'
+}
+$expectedReplayCases = @('identity','mutation','deletion','loss')
+if ($inventory.identity_control.fail_closed -ne $true) {
+    Add-Mismatch 'inventory identity control is not fail-closed'
+}
+if ((@($inventory.identity_control.replay_cases) -join '|') -ne ($expectedReplayCases -join '|')) {
+    Add-Mismatch 'inventory identity control replay cases are invalid'
+}
+
+switch ($InventoryReplayCase) {
+    'mutation' {
+        $target = @($inventoryItems | Where-Object { $_.scope -eq 'core_history_call_ids' })[0]
+        if ($target) {
+            $target.disposition = 'Supported'
+            $inventory.identity_control.unclassified_core_items = ($inventory.identity_control.unclassified_core_items + 1)
+        }
+    }
+    'deletion' {
+        $inventory.items = @($inventoryItems | Where-Object { $_.scope -ne 'core_text_streaming' })
+    }
+    'loss' {
+        $kept = [ordered]@{}
+        foreach ($prop in $inventory.candidate_identity.PSObject.Properties) {
+            if ($prop.Name -ne 'route_upstream') {
+                $kept[$prop.Name] = $prop.Value
+            }
+        }
+        $inventory.candidate_identity = [PSCustomObject]$kept
+    }
+}
+
+$inventoryMismatches = [System.Collections.Generic.List[string]]::new()
+$replayScopes = [System.Collections.Generic.HashSet[string]]::new()
+$observedUnclassified = 0
+foreach ($entry in $inventory.items) {
+    if (-not $replayScopes.Add($entry.scope)) {
+        $inventoryMismatches.Add("mutation: duplicate scope $($entry.scope)")
+    }
+    if ($entry.disposition -notin @('preserved','reversibly_adapted','local_consume','Unsupported','Unqualified')) {
+        $inventoryMismatches.Add("mutation: $($entry.scope) disposition $($entry.disposition) not allowed")
+        $observedUnclassified += 1
+    }
+}
+foreach ($scope in $allRequiredScopes) {
+    if (-not $replayScopes.Contains($scope)) {
+        $inventoryMismatches.Add("deletion: missing scope $scope")
+    }
+}
+if (-not ($inventory.candidate_identity.PSObject.Properties.Name -contains 'route_upstream')) {
+    $inventoryMismatches.Add('loss: candidate_identity.route_upstream is missing')
+}
+$reportedUnclassified = $inventory.identity_control.unclassified_core_items
+if ($reportedUnclassified -ne $observedUnclassified) {
+    $inventoryMismatches.Add("identity_control.unclassified_core_items=$reportedUnclassified does not match observed unclassified items=$observedUnclassified")
+}
+if ($InventoryReplayCase -ne 'identity' -and $inventoryMismatches.Count -eq 0) {
+    $inventoryMismatches.Add("NEGATIVE_INVENTORY_REPLAY_CONTROL_DID_NOT_FAIL: $InventoryReplayCase")
+}
+foreach ($m in $inventoryMismatches) {
+    Add-Mismatch "INVENTORY_IDENTITY_MISMATCH: $m"
+}
+
 Write-Output "Capture: $($trace.source.capture_id)"
 Write-Output "Provider/model: $($trace.source.configured_provider_id) / $($trace.source.model)"
 Write-Output "Gateway route: $($trace.gateway_route.behavior_profile)"
@@ -358,6 +893,7 @@ Write-Output "Direct / Deferred: $($direct.Count) / $($deferred.Count)"
 Write-Output "Deferred tools discoverable through tool_search: $($discoverable.Count)"
 Write-Output "Bounded audit transport rows / Gateway starts: $($auditPlan.transport_log_rows) / $($auditGateway.request_starts)"
 Write-Output "Replay case: $ReplayCase"
+Write-Output "Inventory replay case: $InventoryReplayCase"
 
 if ($mismatches.Count -gt 0) {
     [Console]::Error.WriteLine('RECONCILIATION_MISMATCH: ' + ($mismatches -join ' | '))

--- a/scripts/codex-mode.ps1
+++ b/scripts/codex-mode.ps1
@@ -141,6 +141,97 @@ function Remove-TopLevelKeys {
     return ($result -join "`n")
 }
 
+function Get-TopLevelConfigValue {
+    param(
+        [Parameter(Mandatory = $true)][string]$Text,
+        [Parameter(Mandatory = $true)][string]$Key
+    )
+
+    $inTopLevel = $true
+    foreach ($line in ($Text -split "`r?`n")) {
+        if ($line -match '^\s*\[') {
+            $inTopLevel = $false
+        }
+        if (-not $inTopLevel) {
+            continue
+        }
+        $match = [regex]::Match($line, "^\s*$([regex]::Escape($Key))\s*=\s*(.*)$")
+        if (-not $match.Success) {
+            continue
+        }
+        $raw = $match.Groups[1].Value.Trim()
+        $quote = ''
+        for ($index = 0; $index -lt $raw.Length; $index++) {
+            $char = $raw[$index]
+            if ($quote -eq "'") {
+                if ($char -eq "'") {
+                    if ($index + 1 -lt $raw.Length -and $raw[$index + 1] -eq "'") {
+                        $index++
+                        continue
+                    }
+                    $quote = ''
+                }
+                continue
+            }
+            if ($quote -eq '"') {
+                if ($char -eq '\') {
+                    $index++
+                    continue
+                }
+                if ($char -eq '"') {
+                    $quote = ''
+                }
+                continue
+            }
+            if ($char -eq "'" -or $char -eq '"') {
+                $quote = [string]$char
+                continue
+            }
+            if ($char -eq '#') {
+                $raw = $raw.Substring(0, $index).Trim()
+                break
+            }
+        }
+        if ($raw.Length -ge 2 -and $raw.StartsWith("'") -and $raw.EndsWith("'")) {
+            return $raw.Substring(1, $raw.Length - 2).Replace("''", "'")
+        }
+        if ($raw.Length -ge 2 -and $raw.StartsWith('"') -and $raw.EndsWith('"')) {
+            try {
+                return ($raw | ConvertFrom-Json)
+            }
+            catch {
+                return $raw.Substring(1, $raw.Length - 2)
+            }
+        }
+        return $raw
+    }
+    return $null
+}
+
+function Test-CodexHubManagedCatalogPath {
+    param([AllowNull()][string]$Value)
+
+    if ([string]::IsNullOrWhiteSpace($Value)) {
+        return $false
+    }
+    $normalized = $Value.Trim().Replace('/', '\').TrimEnd('\')
+    $leaf = Split-Path -Leaf $normalized
+    if ($leaf -notin @('codexhub-model-catalog.json', 'codex-proxy-official-ollama.json')) {
+        return $false
+    }
+    if ($normalized -ieq (Join-Path 'model-catalogs' $leaf)) {
+        return $true
+    }
+    try {
+        $candidate = [System.IO.Path]::GetFullPath($normalized)
+        $managed = [System.IO.Path]::GetFullPath((Join-Path $CodexDir (Join-Path 'model-catalogs' $leaf)))
+        return $candidate -ieq $managed
+    }
+    catch {
+        return $false
+    }
+}
+
 function Remove-TomlSectionsMatching {
     param(
         [Parameter(Mandatory = $true)][string]$Text,
@@ -274,15 +365,27 @@ function Set-ConfigForMode {
         [Parameter(Mandatory = $true)][ValidateSet('official', 'proxy')][string]$TargetMode
     )
 
-    $base = Get-CleanBaseConfig -Text (Read-TextIfExists -Path $ConfigPath)
+    $original = Read-TextIfExists -Path $ConfigPath
+    $existingCatalogValue = Get-TopLevelConfigValue -Text $original -Key 'model_catalog_json'
+    $preserveCatalog = -not [string]::IsNullOrWhiteSpace($existingCatalogValue) -and -not (Test-CodexHubManagedCatalogPath $existingCatalogValue)
+    $base = Get-CleanBaseConfig -Text $original
     Backup-ConfigBeforeWrite -ConfigPath $ConfigPath -TargetMode $TargetMode
     if ($TargetMode -eq 'official') {
-        $prefix = "model = `"gpt-5.5`"`nmodel_provider = `"openai`"`n`n"
+        $prefix = "model = `"gpt-5.5`"`nmodel_provider = `"openai`"`n"
+        if ($preserveCatalog) {
+            $prefix += "model_catalog_json = $(Convert-ToTomlLiteral -Value $existingCatalogValue)`n"
+        }
+        $prefix += "`n"
         Write-Utf8NoBom -Path $ConfigPath -Text ($prefix + $base)
         return
     }
 
-    $catalogValue = Convert-ToTomlLiteral -Value 'model-catalogs/codexhub-model-catalog.json'
+    $catalogValue = if ($preserveCatalog) {
+        Convert-ToTomlLiteral -Value $existingCatalogValue
+    }
+    else {
+        Convert-ToTomlLiteral -Value 'model-catalogs/codexhub-model-catalog.json'
+    }
     $baseUrlValue = Convert-ToTomlLiteral -Value 'http://127.0.0.1:9099/v1'
     $prefix = @(
         '# BEGIN CODEX PROXY CONFIG',

--- a/scripts/e2e_codex_app_transport.py
+++ b/scripts/e2e_codex_app_transport.py
@@ -7,9 +7,58 @@ import json
 import os
 from pathlib import Path
 import queue
+import re
 import subprocess
 import threading
 import time
+
+
+# Issue #62's runtime inventory raises the evidence floor to the last stable
+# CLI contract already accepted by the Beta2 candidate.
+_CODEX_CLI_VERSION_FLOOR = (0, 145, 0)
+_VERSION_PROBE_TIMEOUT_SECONDS = 10
+_VERSION_PROBE_OUTPUT_LIMIT = 64 * 1024
+
+
+def resolve_cli_version(codex_command: Path) -> str:
+    """Read the version from the exact CLI binary used by app-server.
+
+    The app-server initialize payload is part of the evidence identity.  It
+    must not retain a historical fixture version when the operator upgrades
+    the CLI, otherwise the trace is falsely attributed to an old client.
+    """
+
+    process = subprocess.Popen(
+        [str(codex_command), "--version"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        creationflags=subprocess.CREATE_NO_WINDOW if os.name == "nt" else 0,
+    )
+    try:
+        stdout, stderr = process.communicate(timeout=_VERSION_PROBE_TIMEOUT_SECONDS)
+    except subprocess.TimeoutExpired as error:
+        process.kill()
+        process.communicate()
+        raise RuntimeError("Codex CLI version probe timed out") from error
+    if len(stdout) > _VERSION_PROBE_OUTPUT_LIMIT or len(stderr) > _VERSION_PROBE_OUTPUT_LIMIT:
+        raise RuntimeError("Codex CLI version probe exceeded its output limit")
+    output = b"\n".join((stdout[:_VERSION_PROBE_OUTPUT_LIMIT], stderr[:_VERSION_PROBE_OUTPUT_LIMIT])).decode(
+        "utf-8", errors="replace"
+    ).strip()
+    if process.returncode != 0:
+        raise RuntimeError(
+            f"Codex CLI version probe failed with exit code {process.returncode}"
+        )
+    lines = [line.strip() for line in output.splitlines() if line.strip()]
+    if len(lines) != 1:
+        raise RuntimeError("Codex CLI version probe returned ambiguous output")
+    match = re.fullmatch(r"codex-cli\s+(\d+)\.(\d+)\.(\d+)", lines[0], re.IGNORECASE)
+    if match is None:
+        raise RuntimeError("Codex CLI version probe returned no stable three-part version")
+    version = tuple(int(part) for part in match.groups())
+    if version < _CODEX_CLI_VERSION_FLOOR:
+        raise RuntimeError("Codex CLI version is below the supported floor")
+    return ".".join(str(part) for part in version)
 
 
 def main() -> int:
@@ -23,6 +72,7 @@ def main() -> int:
     parser.add_argument("--tool-calls", type=int, default=0)
     parser.add_argument("--pause-between-turns", type=float, default=0.0)
     args = parser.parse_args()
+    client_version = resolve_cli_version(args.codex.resolve())
 
     env = os.environ.copy()
     env["CODEX_HOME"] = str(args.home.resolve())
@@ -128,7 +178,7 @@ def main() -> int:
                 "clientInfo": {
                     "name": "codex_desktop",
                     "title": "Codex Desktop",
-                    "version": "0.144.0-alpha.4",
+                    "version": client_version,
                 },
                 "capabilities": {
                     "experimentalApi": True,

--- a/scripts/qualify-issue-108-glm-tool-surface.ps1
+++ b/scripts/qualify-issue-108-glm-tool-surface.ps1
@@ -7,6 +7,7 @@ param(
     [switch]$CaptureRequestShape,
     [switch]$LifecycleReplay,
     [switch]$EnvironmentIsolationReplay,
+    [switch]$LifecycleSurvivorNegativeControl,
     [switch]$HistoryAdapterReplay,
     [switch]$ToolSurfaceEvidenceReplay,
     [switch]$QualificationEvidenceReplay,
@@ -27,7 +28,7 @@ $ErrorActionPreference = 'Stop'
 $TaskkillTimeoutMilliseconds = 1500
 $TrackedProcessStopTimeoutMilliseconds = 3000
 $LifecycleReplayCleanupTimeoutMilliseconds = 6000
-$LifecycleReplayExitProbeMilliseconds = 250
+$LifecycleReplayFallbackReserveMilliseconds = 1000
 $EvidenceReplayTimeoutMilliseconds = 10000
 
 function ConvertTo-ProcessArgument {
@@ -53,6 +54,150 @@ function Invoke-Checked {
     & $FileName @Arguments
     if ($LASTEXITCODE -ne 0) {
         throw "$FileName exited with code $LASTEXITCODE"
+    }
+}
+
+function Get-TrackedProcessIdentity {
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Diagnostics.Process]$Process
+    )
+
+    $startTimeUtcTicks = $null
+    try {
+        $startTimeUtcTicks = $Process.StartTime.ToUniversalTime().Ticks
+    }
+    catch {
+        # A process handle is still an exact identity even when Windows denies
+        # access to StartTime.  Keep the evidence typed and let callers decide
+        # whether a start-time comparison is required for a re-opened PID.
+    }
+    [ordered]@{
+        pid = [int]$Process.Id
+        start_time_utc_ticks = $startTimeUtcTicks
+        identity_kind = if ($null -ne $startTimeUtcTicks) {
+            'process_handle_and_pid_start_time'
+        }
+        else {
+            'process_handle_and_pid'
+        }
+    }
+}
+
+function Test-TrackedProcessIdentity {
+    param(
+        [AllowNull()]
+        [System.Diagnostics.Process]$Process,
+        [AllowNull()]
+        [System.Collections.IDictionary]$Identity
+    )
+
+    if ($null -eq $Process -or $null -eq $Identity) {
+        return [ordered]@{
+            status = 'unavailable'
+            exact = $false
+            pid_match = $false
+            start_time_match = $false
+        }
+    }
+
+    $pidMatch = $false
+    try {
+        $pidMatch = [int]$Process.Id -eq [int]$Identity['pid']
+    }
+    catch {
+    }
+    if (-not $pidMatch) {
+        return [ordered]@{
+            status = 'pid_mismatch'
+            exact = $false
+            pid_match = $false
+            start_time_match = $false
+        }
+    }
+
+    # This is the original process handle captured before teardown.  Once the
+    # handle reports exited, its identity is final even if Windows reuses the
+    # numeric PID for another process; do not query StartTime on an exited
+    # handle because PowerShell can reject that access.
+    try {
+        if ($Process.HasExited) {
+            return [ordered]@{
+                status = 'exact_handle_after_exit'
+                exact = $true
+                pid_match = $true
+                start_time_match = if ($null -ne $Identity['start_time_utc_ticks']) { $true } else { $null }
+            }
+        }
+    }
+    catch {
+        return [ordered]@{
+            status = 'state_unavailable'
+            exact = $false
+            pid_match = $true
+            start_time_match = $false
+        }
+    }
+
+    $expectedTicks = $Identity['start_time_utc_ticks']
+    if ($null -eq $expectedTicks) {
+        return [ordered]@{
+            status = 'handle_verified'
+            exact = $true
+            pid_match = $true
+            start_time_match = $null
+        }
+    }
+    try {
+        $actualTicks = $Process.StartTime.ToUniversalTime().Ticks
+        $startTimeMatch = [long]$actualTicks -eq [long]$expectedTicks
+        return [ordered]@{
+            status = if ($startTimeMatch) { 'exact' } else { 'start_time_mismatch' }
+            exact = $startTimeMatch
+            pid_match = $true
+            start_time_match = $startTimeMatch
+        }
+    }
+    catch {
+        return [ordered]@{
+            status = 'state_unavailable'
+            exact = $false
+            pid_match = $true
+            start_time_match = $false
+        }
+    }
+}
+
+function Wait-TrackedProcessUntilDeadline {
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Diagnostics.Process]$Process,
+        [Parameter(Mandatory = $true)]
+        [datetime]$DeadlineUtc,
+        [int]$ReserveMilliseconds = 0
+    )
+
+    try {
+        if ($Process.HasExited) {
+            return $true
+        }
+    }
+    catch {
+        return $false
+    }
+    $remainingMilliseconds = Get-RemainingTimeoutMilliseconds -DeadlineUtc $DeadlineUtc -MaximumMilliseconds ([int]::MaxValue)
+    $waitMilliseconds = $remainingMilliseconds - [Math]::Max(0, $ReserveMilliseconds)
+    if ($waitMilliseconds -le 0) {
+        return $false
+    }
+    try {
+        if ($Process.WaitForExit($waitMilliseconds)) {
+            return $true
+        }
+        return $Process.HasExited
+    }
+    catch {
+        return $false
     }
 }
 
@@ -93,6 +238,7 @@ function Start-TrackedProcess {
     }
     [pscustomobject]@{
         Process = $process
+        Identity = Get-TrackedProcessIdentity -Process $process
         StdoutTask = $process.StandardOutput.ReadToEndAsync()
         StderrTask = $process.StandardError.ReadToEndAsync()
     }
@@ -226,40 +372,174 @@ function Stop-TrackedProcess {
     param(
         $Tracked,
         [datetime]$DeadlineUtc = [datetime]::MinValue,
-        [switch]$AllowRetainedProcessFallback
+        [switch]$AllowRetainedProcessFallback,
+        [switch]$DirectProcessFallback,
+        [switch]$PassThru
     )
 
-    if ($null -eq $Tracked -or $null -eq $Tracked.Process -or $Tracked.Process.HasExited) {
-        return
-    }
     if ($DeadlineUtc -eq [datetime]::MinValue) {
         $DeadlineUtc = [DateTime]::UtcNow.AddMilliseconds($TrackedProcessStopTimeoutMilliseconds)
     }
 
-    $treeKillMethod = $Tracked.Process.GetType().GetMethod('Kill', [Type[]]@([bool]))
-    if ($null -ne $treeKillMethod) {
-        [void]$treeKillMethod.Invoke($Tracked.Process, [object[]]@($true))
+    $evidence = [ordered]@{
+        status = 'not_started'
+        primary_tree_stop = [ordered]@{
+            attempted = $false
+            method = 'none'
+            outcome = 'not_started'
+        }
+        fallback_cleanup = [ordered]@{
+            used = $false
+            kind = 'none'
+            outcome = 'not_started'
+        }
+        root_exited = $false
+        cleanup_within_deadline = $false
     }
-    else {
+
+    if ($null -eq $Tracked -or $null -eq $Tracked.Process) {
+        $evidence.status = 'unavailable'
+        $evidence.primary_tree_stop.outcome = 'process_unavailable'
+        if ($PassThru) {
+            return [pscustomobject]$evidence
+        }
+        throw 'retained_handle_tree_stop_process_unavailable'
+    }
+
+    $process = $Tracked.Process
+    try {
+        if ($process.HasExited) {
+            $evidence.status = 'already_exited'
+            $evidence.root_exited = $true
+            $evidence.cleanup_within_deadline = [DateTime]::UtcNow -le $DeadlineUtc
+            if ($PassThru) {
+                return [pscustomobject]$evidence
+            }
+            return
+        }
+    }
+    catch {
+        $evidence.status = 'state_unavailable'
+        $evidence.primary_tree_stop.outcome = 'state_unavailable'
+        if ($PassThru) {
+            return [pscustomobject]$evidence
+        }
+        throw 'retained_handle_tree_stop_state_unavailable'
+    }
+
+    if ($DirectProcessFallback) {
+        $evidence.fallback_cleanup.used = $true
+        $evidence.fallback_cleanup.kind = 'direct_process'
+        $evidence.fallback_cleanup.outcome = 'attempted'
         try {
-            Invoke-TrackedTreeKill -ProcessId $Tracked.Process.Id -DeadlineUtc $DeadlineUtc
+            if (-not $process.HasExited) {
+                $process.Kill()
+            }
+            if (-not (Wait-TrackedProcessUntilDeadline -Process $process -DeadlineUtc $DeadlineUtc)) {
+                $evidence.fallback_cleanup.outcome = 'remained'
+                throw 'retained_handle_direct_stop_timed_out'
+            }
+            $evidence.fallback_cleanup.outcome = 'passed'
+            $evidence.root_exited = $true
+            $evidence.cleanup_within_deadline = [DateTime]::UtcNow -le $DeadlineUtc
+            if (-not $evidence.cleanup_within_deadline) {
+                throw 'retained_handle_direct_stop_timed_out'
+            }
+            $evidence.status = 'degraded'
+            if ($PassThru) {
+                return [pscustomobject]$evidence
+            }
+            return
         }
         catch {
-            if (-not $AllowRetainedProcessFallback) {
-                throw
-            }
-            try {
-                if (-not $Tracked.Process.HasExited) {
-                    $Tracked.Process.Kill()
+            $evidence.fallback_cleanup.outcome = 'failed'
+            throw
+        }
+    }
+
+    $evidence.primary_tree_stop.attempted = $true
+    $primaryTreeStopError = $null
+    try {
+        # Process.Kill(true) is the managed equivalent of taskkill /T /F.  It
+        # is preferred when available because it keeps the original process
+        # handle; taskkill remains the verified Windows fallback primitive.
+        $treeKillMethod = $process.GetType().GetMethod('Kill', [Type[]]@([bool]))
+        if ($null -ne $treeKillMethod) {
+            [void]$treeKillMethod.Invoke($process, [object[]]@($true))
+            $evidence.primary_tree_stop.method = 'process_handle_kill_tree'
+        }
+        else {
+            Invoke-TrackedTreeKill -ProcessId $process.Id -DeadlineUtc $DeadlineUtc
+            $evidence.primary_tree_stop.method = 'taskkill_tree'
+        }
+        $evidence.primary_tree_stop.outcome = 'passed'
+    }
+    catch {
+        $primaryTreeStopError = $_
+        # A taskkill invocation is still a primary tree stop, not a direct
+        # child fallback.  Try it when the managed tree primitive failed.
+        try {
+            if ($process.HasExited) {
+                # The process can exit between the initial state check and
+                # taskkill's PID open.  The retained handle is authoritative;
+                # treat that race as a completed primary stop, then verify the
+                # child handle below under the same deadline.
+                if ($evidence.primary_tree_stop.method -eq 'none') {
+                    $evidence.primary_tree_stop.method = 'taskkill_tree'
                 }
+                $evidence.primary_tree_stop.outcome = 'passed_after_exit'
+                $primaryTreeStopError = $null
+            }
+        }
+        catch {
+        }
+        try {
+            if ($null -ne $primaryTreeStopError -and $evidence.primary_tree_stop.method -eq 'none') {
+                Invoke-TrackedTreeKill -ProcessId $process.Id -DeadlineUtc $DeadlineUtc
+                $evidence.primary_tree_stop.method = 'taskkill_tree'
+                $evidence.primary_tree_stop.outcome = 'passed_alternative'
+                $primaryTreeStopError = $null
+            }
+        }
+        catch {
+            $primaryTreeStopError = $_
+        }
+        if ($null -ne $primaryTreeStopError) {
+            $evidence.primary_tree_stop.outcome = 'failed'
+            if (-not $AllowRetainedProcessFallback) {
+                throw $primaryTreeStopError
+            }
+            $evidence.fallback_cleanup.used = $true
+            $evidence.fallback_cleanup.kind = 'direct_root'
+            $evidence.fallback_cleanup.outcome = 'attempted'
+            try {
+                if (-not $process.HasExited) {
+                    $process.Kill()
+                }
+                $evidence.fallback_cleanup.outcome = 'passed'
             }
             catch {
+                $evidence.fallback_cleanup.outcome = 'failed'
+                throw $primaryTreeStopError
             }
         }
     }
-    $exitTimeoutMilliseconds = Get-RemainingTimeoutMilliseconds -DeadlineUtc $DeadlineUtc -MaximumMilliseconds $TrackedProcessStopTimeoutMilliseconds
-    if ($exitTimeoutMilliseconds -le 0 -or -not $Tracked.Process.WaitForExit($exitTimeoutMilliseconds)) {
+
+    if (-not (Wait-TrackedProcessUntilDeadline -Process $process -DeadlineUtc $DeadlineUtc)) {
+        $evidence.root_exited = $false
+        if ($evidence.fallback_cleanup.used) {
+            $evidence.fallback_cleanup.outcome = 'remained'
+        }
         throw 'retained_handle_tree_stop_timed_out'
+    }
+    $evidence.root_exited = $true
+    $evidence.cleanup_within_deadline = [DateTime]::UtcNow -le $DeadlineUtc
+    if (-not $evidence.cleanup_within_deadline) {
+        throw 'retained_handle_tree_stop_timed_out'
+    }
+    $evidence.status = if ($evidence.fallback_cleanup.used) { 'degraded' } else { 'primary' }
+    if ($PassThru) {
+        return [pscustomobject]$evidence
     }
 }
 
@@ -369,7 +649,8 @@ function Complete-TrackedProcess {
 function Invoke-LifecycleReplay {
     param(
         [string]$ReplayOutputDir,
-        [string]$Mode = 'lifecycle_replay'
+        [string]$Mode = 'lifecycle_replay',
+        [switch]$SurvivorNegativeControl
     )
 
     $runId = '{0}-{1}' -f $PID, (Get-Date -Format 'yyyyMMddHHmmss')
@@ -383,8 +664,11 @@ function Invoke-LifecycleReplay {
     $tracked = $null
     $childProcessId = 0
     $childProcess = $null
+    $childProcessIdentity = $null
     $cleanupStopwatch = $null
     $cleanupDeadlineUtc = [datetime]::MinValue
+    $cleanupEvidence = $null
+    $childCleanupEvidence = $null
     $failures = [System.Collections.Generic.List[string]]::new()
     $summary = [ordered]@{
         mode = $Mode
@@ -393,6 +677,23 @@ function Invoke-LifecycleReplay {
         tracked_root_exited = $false
         tracked_child_exited = $false
         tracked_child_exit_before_natural_timeout = $false
+        tracked_root_identity_captured = $false
+        tracked_root_identity_verified = $false
+        tracked_child_identity_captured = $false
+        tracked_child_identity_verified = $false
+        tracked_child_pid_reused = $false
+        cleanup_status = 'not_started'
+        primary_tree_stop = [ordered]@{
+            attempted = $false
+            method = 'none'
+            outcome = 'not_started'
+        }
+        fallback_cleanup = [ordered]@{
+            used = $false
+            kind = 'none'
+            outcome = 'not_started'
+        }
+        tracked_child_exit_after_fallback = $false
         cli_has_ollama_api_key = $true
         cli_has_test_secret = $true
         cli_home_is_isolated = $false
@@ -435,18 +736,54 @@ environment_snapshot_path.write_text(
 )
 # Use fresh null streams and close inherited handles so this nested process
 # cannot retain Start-TrackedProcess's redirected stdout or stderr.
-child = subprocess.Popen(
-    [sys.executable, "-c", "import time; time.sleep(10)"],
-    stdin=subprocess.DEVNULL,
-    stdout=subprocess.DEVNULL,
-    stderr=subprocess.DEVNULL,
-    close_fds=True,
-)
-child_pid_path.write_text(str(child.pid), encoding="utf-8")
+negative_control = os.environ.get("CODEXHUB_LIFECYCLE_SURVIVOR_NEGATIVE_CONTROL") == "1"
+child_flags = 0
+if negative_control and os.name == "nt":
+    # Start the survivor through a short-lived detached broker.  The broker
+    # exits immediately after recording the grandchild PID, so the tracked
+    # child is no longer a member of the root's live process tree when the
+    # primary tree stop runs.
+    broker_code = (
+        "import os, pathlib, subprocess, sys; "
+        "p=pathlib.Path(sys.argv[1]); "
+        "c=subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(10)'], "
+        "stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, "
+        "close_fds=True, creationflags=subprocess.DETACHED_PROCESS | subprocess.CREATE_NEW_PROCESS_GROUP); "
+        "p.write_text(str(c.pid), encoding='utf-8'); os._exit(0)"
+    )
+    broker = subprocess.Popen(
+        [sys.executable, "-c", broker_code, str(child_pid_path)],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        close_fds=True,
+        creationflags=subprocess.DETACHED_PROCESS | subprocess.CREATE_NEW_PROCESS_GROUP,
+    )
+    child = broker
+else:
+    child = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(10)"],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        close_fds=True,
+        creationflags=child_flags,
+    )
+if not (negative_control and os.name == "nt"):
+    child_pid_path.write_text(str(child.pid), encoding="utf-8")
+else:
+    deadline = time.monotonic() + 5
+    while not child_pid_path.exists() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    if not child_pid_path.exists():
+        raise RuntimeError("negative_control_child_pid_missing")
 time.sleep(10)
 '@
         [System.IO.File]::WriteAllText($lifecycleScriptPath, $lifecycleChildCommand, [System.Text.UTF8Encoding]::new($false))
         $lifecycleEnvironment = New-QualificationChildEnvironment -CodexHome $replayHome -TempRoot $replayTemp -ExecutablePaths @($pythonPath)
+        if ($SurvivorNegativeControl) {
+            $lifecycleEnvironment['CODEXHUB_LIFECYCLE_SURVIVOR_NEGATIVE_CONTROL'] = '1'
+        }
         $tracked = Start-TrackedProcess -FileName $pythonPath -Arguments @(
             '-u', $lifecycleScriptPath, $childPidPath, $environmentSnapshotPath
         ) -WorkingDirectory $runRoot -Environment $lifecycleEnvironment
@@ -464,6 +801,12 @@ time.sleep(10)
         if (-not [int]::TryParse($childPidText, [ref]$childProcessId) -or $childProcessId -le 0) {
             throw 'lifecycle_child_pid_invalid'
         }
+        # Capture the original child handle and identity before any teardown.
+        # Never reopen this PID after tree stop: Windows may have reused it.
+        $childProcess = [System.Diagnostics.Process]::GetProcessById($childProcessId)
+        $childProcessIdentity = Get-TrackedProcessIdentity -Process $childProcess
+        $summary.tracked_child_identity_captured = $true
+        $summary.tracked_root_identity_captured = $null -ne $tracked.Identity
         $environmentSnapshot = Get-Content -LiteralPath $environmentSnapshotPath -Raw | ConvertFrom-Json
         $summary.cli_has_ollama_api_key = [bool]$environmentSnapshot.cli_has_ollama_api_key
         $summary.cli_has_test_secret = [bool]$environmentSnapshot.cli_has_test_secret
@@ -482,7 +825,7 @@ time.sleep(10)
         }
         $cleanupStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
         $cleanupDeadlineUtc = [DateTime]::UtcNow.AddMilliseconds($LifecycleReplayCleanupTimeoutMilliseconds)
-        Stop-TrackedProcess $tracked -DeadlineUtc $cleanupDeadlineUtc -AllowRetainedProcessFallback
+        $cleanupEvidence = Stop-TrackedProcess $tracked -DeadlineUtc $cleanupDeadlineUtc -AllowRetainedProcessFallback -PassThru
     }
     catch {
         Add-SanitizedFailure -Failures $failures -Code 'lifecycle_stop_failed'
@@ -493,18 +836,12 @@ time.sleep(10)
             $cleanupDeadlineUtc = [DateTime]::UtcNow.AddMilliseconds($LifecycleReplayCleanupTimeoutMilliseconds)
         }
         try {
-            if ($null -ne $tracked -and -not $tracked.Process.HasExited) {
+            if ($null -ne $tracked -and -not $tracked.Process.HasExited -and $null -eq $cleanupEvidence) {
                 try {
-                    Stop-TrackedProcess $tracked -DeadlineUtc $cleanupDeadlineUtc -AllowRetainedProcessFallback
+                    $cleanupEvidence = Stop-TrackedProcess $tracked -DeadlineUtc $cleanupDeadlineUtc -AllowRetainedProcessFallback -PassThru
                 }
                 catch {
                     Add-SanitizedFailure -Failures $failures -Code 'lifecycle_root_cleanup_failed'
-                }
-            }
-            if ($null -ne $tracked -and -not $tracked.Process.HasExited) {
-                $rootExitProbeMilliseconds = Get-RemainingTimeoutMilliseconds -DeadlineUtc $cleanupDeadlineUtc -MaximumMilliseconds $LifecycleReplayExitProbeMilliseconds
-                if ($rootExitProbeMilliseconds -gt 0) {
-                    [void]$tracked.Process.WaitForExit($rootExitProbeMilliseconds)
                 }
             }
             if ($null -eq $tracked -or -not $tracked.Process.HasExited) {
@@ -512,49 +849,68 @@ time.sleep(10)
             }
             else {
                 $summary.tracked_root_exited = $true
+                $rootIdentity = Test-TrackedProcessIdentity -Process $tracked.Process -Identity $tracked.Identity
+                $summary.tracked_root_identity_verified = [bool]$rootIdentity.exact
+                if (-not $rootIdentity.exact) {
+                    Add-SanitizedFailure -Failures $failures -Code 'lifecycle_tracked_root_identity_unverified'
+                }
             }
         }
         catch {
             Add-SanitizedFailure -Failures $failures -Code 'lifecycle_tracked_root_state_unavailable'
         }
         try {
-            if ($childProcessId -le 0) {
+            if ($childProcessId -le 0 -or $null -eq $childProcess) {
                 Add-SanitizedFailure -Failures $failures -Code 'lifecycle_tracked_child_pid_unavailable'
             }
             else {
                 try {
-                    $childProcess = [System.Diagnostics.Process]::GetProcessById($childProcessId)
-                    # The child sleeps for ten seconds. This short probe proves the
-                    # retained tree was stopped rather than waiting for natural exit.
-                    $childExitProbeMilliseconds = Get-RemainingTimeoutMilliseconds -DeadlineUtc $cleanupDeadlineUtc -MaximumMilliseconds $LifecycleReplayExitProbeMilliseconds
-                    $childExitedWithinBound = $childExitProbeMilliseconds -gt 0 -and $childProcess.WaitForExit($childExitProbeMilliseconds)
-                    if ($childExitedWithinBound -or $childProcess.HasExited) {
+                    $childIdentity = Test-TrackedProcessIdentity -Process $childProcess -Identity $childProcessIdentity
+                    $summary.tracked_child_identity_verified = [bool]$childIdentity.exact
+                    if (-not $childIdentity.exact) {
+                        if ($childIdentity.status -eq 'pid_mismatch' -or $childIdentity.status -eq 'start_time_mismatch') {
+                            $summary.tracked_child_pid_reused = $true
+                        }
+                        Add-SanitizedFailure -Failures $failures -Code 'lifecycle_tracked_child_identity_unverified'
+                    }
+                    # Wait on the original process handle until the shared
+                    # teardown deadline.  This is an exact identity check and
+                    # cannot be satisfied by a process that reused the PID.
+                    $childPrimaryWait = Wait-TrackedProcessUntilDeadline `
+                        -Process $childProcess `
+                        -DeadlineUtc $cleanupDeadlineUtc `
+                        -ReserveMilliseconds $LifecycleReplayFallbackReserveMilliseconds
+                    if ($childPrimaryWait -or $childProcess.HasExited) {
                         $summary.tracked_child_exited = $true
-                        $summary.tracked_child_exit_before_natural_timeout = $true
+                        if ($null -eq $cleanupEvidence -or $cleanupEvidence.status -eq 'primary') {
+                            $summary.tracked_child_exit_before_natural_timeout = $true
+                        }
                     }
                     else {
-                        Add-SanitizedFailure -Failures $failures -Code 'lifecycle_tracked_child_remained'
+                        Add-SanitizedFailure -Failures $failures -Code 'lifecycle_tracked_child_survived_primary_tree_stop'
+                        $summary.fallback_cleanup.used = $true
+                        $summary.fallback_cleanup.kind = 'direct_child'
+                        $summary.fallback_cleanup.outcome = 'attempted'
                         try {
-                            Stop-TrackedProcess ([pscustomobject]@{ Process = $childProcess }) -DeadlineUtc $cleanupDeadlineUtc -AllowRetainedProcessFallback
-                            $childExitProbeMilliseconds = Get-RemainingTimeoutMilliseconds -DeadlineUtc $cleanupDeadlineUtc -MaximumMilliseconds $LifecycleReplayExitProbeMilliseconds
-                            if (-not $childProcess.HasExited -and $childExitProbeMilliseconds -gt 0) {
-                                [void]$childProcess.WaitForExit($childExitProbeMilliseconds)
-                            }
+                            $childCleanupEvidence = Stop-TrackedProcess `
+                                ([pscustomobject]@{ Process = $childProcess; Identity = $childProcessIdentity }) `
+                                -DeadlineUtc $cleanupDeadlineUtc `
+                                -DirectProcessFallback `
+                                -PassThru
+                            $summary.fallback_cleanup.outcome = [string]$childCleanupEvidence.fallback_cleanup.outcome
                         }
                         catch {
+                            $summary.fallback_cleanup.outcome = 'failed'
                             Add-SanitizedFailure -Failures $failures -Code 'lifecycle_tracked_child_cleanup_failed'
                         }
-                        if ($childProcess.HasExited) {
+                        if (Wait-TrackedProcessUntilDeadline -Process $childProcess -DeadlineUtc $cleanupDeadlineUtc) {
                             $summary.tracked_child_exited = $true
+                            $summary.tracked_child_exit_after_fallback = $true
                         }
                         else {
                             Add-SanitizedFailure -Failures $failures -Code 'lifecycle_tracked_child_cleanup_remained'
                         }
                     }
-                }
-                catch [System.ArgumentException] {
-                    $summary.tracked_child_exited = $true
-                    $summary.tracked_child_exit_before_natural_timeout = $true
                 }
                 catch {
                     Add-SanitizedFailure -Failures $failures -Code 'lifecycle_tracked_child_state_unavailable'
@@ -571,6 +927,23 @@ time.sleep(10)
             if (-not $summary.cleanup_within_budget) {
                 Add-SanitizedFailure -Failures $failures -Code 'lifecycle_cleanup_budget_exceeded'
             }
+        }
+        if ($null -ne $cleanupEvidence) {
+            $summary.primary_tree_stop = $cleanupEvidence.primary_tree_stop
+            if ($cleanupEvidence.fallback_cleanup.used) {
+                $summary.fallback_cleanup = $cleanupEvidence.fallback_cleanup
+            }
+            $summary.cleanup_status = [string]$cleanupEvidence.status
+        }
+        if ($summary.fallback_cleanup.used) {
+            Add-SanitizedFailure -Failures $failures -Code 'lifecycle_cleanup_degraded'
+            $summary.cleanup_status = 'degraded'
+        }
+        if ($summary.tracked_child_exit_after_fallback) {
+            $summary.tracked_child_exit_before_natural_timeout = $false
+        }
+        if ($summary.cleanup_status -eq 'not_started' -and $failures.Count -gt 0) {
+            $summary.cleanup_status = 'failed'
         }
         $summary.failures = @($failures)
         $summary.passed = $failures.Count -eq 0
@@ -1464,8 +1837,17 @@ if ($ExternalIsolationQualification) {
 }
 New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
 
-if ($LifecycleReplay) {
-    Invoke-LifecycleReplay -ReplayOutputDir $OutputDir
+if ($LifecycleReplay -or $LifecycleSurvivorNegativeControl) {
+    $lifecycleMode = if ($LifecycleSurvivorNegativeControl) {
+        'lifecycle_survivor_negative_control'
+    }
+    else {
+        'lifecycle_replay'
+    }
+    Invoke-LifecycleReplay `
+        -ReplayOutputDir $OutputDir `
+        -Mode $lifecycleMode `
+        -SurvivorNegativeControl:$LifecycleSurvivorNegativeControl
     exit $LASTEXITCODE
 }
 if ($EnvironmentIsolationReplay) {

--- a/scripts/qualify-issue-108-glm-tool-surface.ps1
+++ b/scripts/qualify-issue-108-glm-tool-surface.ps1
@@ -2191,7 +2191,9 @@ def _is_successful_apply_patch_output(value):
 def _is_exact_apply_patch_history_pair(call, result):
     return (
         isinstance(call, dict)
-        and set(call) == {"type", "status", "call_id", "name", "input"}
+        # CLI 0.146 includes an item id on both sides of the pair.  Match the
+        # stable semantic contract and tolerate additive metadata fields.
+        and {"type", "status", "call_id", "name", "input"}.issubset(call)
         and call.get("type") == "custom_tool_call"
         and call.get("status") == "completed"
         and call.get("name") == "apply_patch"
@@ -2200,7 +2202,7 @@ def _is_exact_apply_patch_history_pair(call, result):
         and isinstance(call.get("input"), str)
         and bool(call["input"].strip())
         and isinstance(result, dict)
-        and set(result) == {"type", "call_id", "output"}
+        and {"type", "call_id", "output"}.issubset(result)
         and result.get("type") == "custom_tool_call_output"
         and result.get("call_id") == call["call_id"]
     )
@@ -2251,6 +2253,29 @@ def _note_apply_patch_failure(payload):
             return
 
 
+def _sse_output_items(payload):
+    """Yield tool items from both legacy and current Responses SSE shapes.
+
+    Codex CLI 0.146 may wrap a streamed item under ``response.output`` while
+    older clients expose it directly as ``item``.  The qualification harness
+    only needs the tool name, so normalize those envelopes without retaining
+    any request or response content.
+    """
+    if not isinstance(payload, dict):
+        return
+    item = payload.get("item")
+    if isinstance(item, dict):
+        yield item
+    response = payload.get("response")
+    if not isinstance(response, dict):
+        return
+    output = response.get("output")
+    if isinstance(output, list):
+        for candidate in output:
+            if isinstance(candidate, dict):
+                yield candidate
+
+
 def _record_post_success_tool_choice(line):
     global _post_success_tool_choice_recorded
     if not _post_success_apply_patch_pending or _post_success_tool_choice_recorded:
@@ -2261,21 +2286,22 @@ def _record_post_success_tool_choice(line):
         payload = json.loads(line[6:].decode("utf-8"))
     except (UnicodeDecodeError, json.JSONDecodeError):
         return
-    item = payload.get("item") if isinstance(payload, dict) else None
-    if not isinstance(item, dict) or item.get("type") not in {"function_call", "custom_tool_call"}:
+    for item in _sse_output_items(payload):
+        if item.get("type") not in {"function_call", "custom_tool_call"}:
+            continue
+        name = item.get("name")
+        if not isinstance(name, str) or not name:
+            continue
+        _post_success_tool_choice_recorded = True
+        _append_capture_record(
+            {
+                "stage": "post_success_tool_choice",
+                "choice": name,
+                "expected_choice": _expected_post_success_tool_choice,
+                "outcome": "expected" if name == _expected_post_success_tool_choice else "wrong",
+            }
+        )
         return
-    name = item.get("name")
-    if not isinstance(name, str) or not name:
-        return
-    _post_success_tool_choice_recorded = True
-    _append_capture_record(
-        {
-            "stage": "post_success_tool_choice",
-            "choice": name,
-            "expected_choice": _expected_post_success_tool_choice,
-            "outcome": "expected" if name == _expected_post_success_tool_choice else "wrong",
-        }
-    )
 
 
 def _record_tool_search_choice(line):
@@ -2285,13 +2311,10 @@ def _record_tool_search_choice(line):
         payload = json.loads(line[6:].decode("utf-8"))
     except (UnicodeDecodeError, json.JSONDecodeError):
         return
-    item = payload.get("item") if isinstance(payload, dict) else None
-    if (
-        isinstance(item, dict)
-        and item.get("type") in {"function_call", "custom_tool_call"}
-        and item.get("name") == "tool_search"
-    ):
-        _append_capture_record({"stage": "tool_choice", "choice": "tool_search"})
+    for item in _sse_output_items(payload):
+        if item.get("type") in {"function_call", "custom_tool_call"} and item.get("name") == "tool_search":
+            _append_capture_record({"stage": "tool_choice", "choice": "tool_search"})
+            return
 
 
 def _patch_structure(arguments):
@@ -2573,7 +2596,11 @@ $windowsSandboxConfiguration
     Wait-GatewayHealth -BaseUrl $gatewayBaseUrl -StartupSeconds $GatewayStartupSeconds
 
     $cliArguments = @(
-        '-a', 'never',
+        # Codex CLI 0.146 removed the legacy `-a/--ask-for-approval` option.
+        # Keep this qualification non-interactive by supplying the current
+        # config override before the `exec` subcommand.  The unquoted value
+        # also survives the cmd.exe shim used by npm's codex.cmd launcher.
+        '-c', 'approval_policy=never',
         'exec', '--strict-config', '--ephemeral', '--json',
         '--sandbox', $cliSandbox,
         '-C', $testWorkspace,

--- a/scripts/run_issue_62_live_control.py
+++ b/scripts/run_issue_62_live_control.py
@@ -1,0 +1,608 @@
+"""Run the bounded, sanitized orchestration envelope for Issue #62.
+
+This module deliberately separates orchestration from the real upstream
+controls.  The default command-line mode is ``--fixture`` and therefore cannot
+qualify Issue #62.  A future live runner can reuse :class:`BoundedPhaseRunner`
+with real command/phase callbacks after the exact candidate and route have been
+reviewed.
+
+The harness has three non-negotiable properties:
+
+* every phase emits a small JSONL status marker before and after it runs;
+* subprocesses have a 30--60 second deadline, never persist stdout/stderr, and
+  are terminated on timeout/cancellation; and
+* cleanup always runs and writes a receipt.  Any failure (including cleanup or
+  journal failure) leaves ``ready_for_issue62`` false.
+
+Only candidate identity, digests, bounded counts, exit status, and allow-listed
+error codes are retained.  Prompts, bodies, headers, command arguments,
+process IDs, paths, credentials, and exception text are intentionally absent
+from all artifacts.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import json
+import os
+from pathlib import Path
+import re
+import signal
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from typing import Callable, Literal, Sequence
+
+
+SCHEMA_VERSION = "codexhub.issue62.live-control.v1"
+MIN_TIMEOUT_SECONDS = 30.0
+MAX_TIMEOUT_SECONDS = 60.0
+DEFAULT_TIMEOUT_SECONDS = 30.0
+ALLOWED_ERROR_CODES = frozenset(
+    {
+        "cancelled",
+        "cleanup_failed",
+        "cleanup_incomplete",
+        "cleanup_timeout",
+        "exit_nonzero",
+        "journal_write_failed",
+        "phase_started",
+        "phase_exception",
+        "phase_timeout",
+        "process_start_failed",
+        "stale_artifact",
+        "termination_failed",
+    }
+)
+
+
+class HarnessFailure(RuntimeError):
+    """An internal failure represented by a safe, allow-listed code."""
+
+    def __init__(self, code: str) -> None:
+        if code not in ALLOWED_ERROR_CODES:
+            code = "phase_exception"
+        super().__init__(code)
+        self.code = code
+
+
+def _safe_code(value: str) -> str:
+    if value in ALLOWED_ERROR_CODES:
+        return value
+    return "phase_exception"
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace(
+        "+00:00", "Z"
+    )
+
+
+def _validate_hex(value: str, *, lengths: tuple[int, ...]) -> str:
+    if not isinstance(value, str) or len(value) not in lengths:
+        raise ValueError("invalid digest")
+    if re.fullmatch(r"[0-9a-fA-F]+", value) is None:
+        raise ValueError("invalid digest")
+    return value.lower()
+
+
+def _validate_cli_version(value: str) -> str:
+    if re.fullmatch(r"\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?", value) is None:
+        raise ValueError("invalid cli version")
+    return value
+
+
+@dataclass(frozen=True)
+class CandidateIdentity:
+    """The only identity data allowed in a live-control artifact."""
+
+    candidate_sha: str
+    cli_version: str
+    cli_package_sha256: str
+    catalog_digest: str
+    route_digest: str
+    cli_source_commit: str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "candidate_sha", _validate_hex(self.candidate_sha, lengths=(40, 64))
+        )
+        object.__setattr__(self, "cli_version", _validate_cli_version(self.cli_version))
+        object.__setattr__(
+            self,
+            "cli_package_sha256",
+            _validate_hex(self.cli_package_sha256, lengths=(64,)),
+        )
+        object.__setattr__(
+            self, "catalog_digest", _validate_hex(self.catalog_digest, lengths=(64,))
+        )
+        object.__setattr__(
+            self, "route_digest", _validate_hex(self.route_digest, lengths=(64,))
+        )
+        if self.cli_source_commit is not None:
+            object.__setattr__(
+                self,
+                "cli_source_commit",
+                _validate_hex(self.cli_source_commit, lengths=(40, 64)),
+            )
+
+    def as_dict(self) -> dict[str, str]:
+        result = {
+            "candidate_sha": self.candidate_sha,
+            "cli_version": self.cli_version,
+            "cli_package_sha256": self.cli_package_sha256,
+            "catalog_digest": self.catalog_digest,
+            "route_digest": self.route_digest,
+        }
+        if self.cli_source_commit is not None:
+            result["cli_source_commit"] = self.cli_source_commit
+        return result
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    status: Literal["completed", "failed", "timed_out", "cancelled"]
+    status_code: str
+    exit_code: int | None = None
+    terminated: bool = True
+
+
+def _validate_timeout(timeout_seconds: float) -> float:
+    if not MIN_TIMEOUT_SECONDS <= timeout_seconds <= MAX_TIMEOUT_SECONDS:
+        raise ValueError("timeout must be between 30 and 60 seconds")
+    return float(timeout_seconds)
+
+
+ALLOWED_ARTIFACT_NAMES = frozenset({"phase-status.jsonl", "cleanup-receipt.json"})
+MAX_NESTED_ARTIFACT_SCAN = 2048
+CleanupAction = Callable[[], None]
+
+
+def _ensure_fresh_run_root(run_root: Path) -> None:
+    """Reject reused roots before any evidence is written."""
+
+    try:
+        if run_root.exists():
+            if run_root.is_symlink() or not run_root.is_dir() or any(run_root.iterdir()):
+                raise HarnessFailure("stale_artifact")
+        else:
+            run_root.mkdir(parents=True, exist_ok=False)
+    except HarnessFailure:
+        raise
+    except OSError as error:
+        raise HarnessFailure("journal_write_failed") from error
+
+
+def _count_extra_artifacts(run_root: Path) -> int:
+    try:
+        extras = 0
+        for entry in run_root.iterdir():
+            if (
+                entry.name in ALLOWED_ARTIFACT_NAMES
+                and entry.is_file()
+                and not entry.is_symlink()
+            ):
+                continue
+            extras += 1
+            if entry.is_dir() and not entry.is_symlink():
+                # Traverse recursively so nested raw/temporary material is
+                # detected, while counting one contaminated artifact tree.
+                for index, _nested in enumerate(entry.rglob("*"), start=1):
+                    if index >= MAX_NESTED_ARTIFACT_SCAN:
+                        break
+        return extras
+    except OSError:
+        return 1
+
+
+def _write_sanitized_json(target: Path, payload: dict[str, object]) -> None:
+    """Atomically write one allow-listed artifact without exposing a path."""
+
+    temporary: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w", encoding="utf-8", newline="\n", dir=target.parent, delete=False
+        ) as handle:
+            temporary = Path(handle.name)
+            json.dump(payload, handle, sort_keys=True, separators=(",", ":"))
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        temporary.replace(target)
+    except OSError as error:
+        if temporary is not None:
+            try:
+                temporary.unlink(missing_ok=True)
+            except OSError:
+                pass
+        raise HarnessFailure("journal_write_failed") from error
+
+
+def _terminate_process(process: subprocess.Popen[bytes]) -> bool:
+    try:
+        if process.poll() is not None:
+            return True
+        if os.name == "nt":
+            # ``terminate`` only signals the direct child on Windows.  The
+            # Gateway/CLI can spawn grandchildren, so use taskkill's tree mode
+            # and suppress all command output.
+            subprocess.run(
+                ["taskkill", "/PID", str(int(process.pid)), "/T", "/F"],
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=False,
+                timeout=5,
+            )
+        else:
+            os.killpg(int(process.pid), signal.SIGTERM)
+        process.wait(timeout=5)
+        return True
+    except Exception:
+        try:
+            if os.name == "nt":
+                process.kill()
+            else:
+                os.killpg(int(process.pid), signal.SIGKILL)
+            process.wait(timeout=5)
+            return True
+        except Exception:
+            return False
+
+
+class BoundedPhaseRunner:
+    """Public seam for bounded subprocess phases and cleanup.
+
+    A run root is one-shot.  Existing or later extra artifacts are rejected so
+    a stale capture cannot be mistaken for evidence from this candidate.
+    """
+
+    def __init__(
+        self,
+        run_root: Path,
+        identity: CandidateIdentity,
+        *,
+        timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+        process_factory: Callable[..., subprocess.Popen[bytes]] | None = None,
+    ) -> None:
+        _ensure_fresh_run_root(run_root)
+        self.run_root = run_root
+        self.identity = identity
+        self.timeout_seconds = _validate_timeout(timeout_seconds)
+        self._process_factory = process_factory or subprocess.Popen
+        self.journal = SanitizedPhaseJournal(run_root, identity)
+        self._active_process: subprocess.Popen[bytes] | None = None
+        self._active_lock = threading.Lock()
+        self._cancel_requested = False
+        self._cleanup_called = False
+        self._children_terminated = True
+
+    @staticmethod
+    def _phase_name(phase: str) -> str:
+        if re.fullmatch(r"[a-z0-9_]{1,48}", phase) is None:
+            raise HarnessFailure("phase_exception")
+        return phase
+
+    def _set_active(self, process: subprocess.Popen[bytes] | None) -> None:
+        with self._active_lock:
+            self._active_process = process
+
+    def mark_phase(
+        self,
+        marker: str,
+        *,
+        status: Literal["started", "completed", "failed", "cancelled"] = "completed",
+        status_code: str = "ok",
+        duration_ms: int | None = 0,
+        counts: dict[str, int] | None = None,
+    ) -> None:
+        """Record a non-subprocess phase without accepting operational data."""
+
+        self._phase_name(marker)
+        self.journal.append(
+            marker=marker,
+            status=status,
+            status_code=status_code,
+            duration_ms=duration_ms,
+            counts=counts,
+        )
+
+    def run_subprocess(
+        self,
+        phase: str,
+        argv: Sequence[str],
+        *,
+        timeout_seconds: float | None = None,
+        cancellation_event: threading.Event | None = None,
+    ) -> CommandResult:
+        """Run one subprocess and always emit a terminal phase marker."""
+
+        phase_name = self._phase_name(phase)
+        timeout = _validate_timeout(
+            self.timeout_seconds if timeout_seconds is None else timeout_seconds
+        )
+        started = time.monotonic()
+        self.journal.append(
+            marker=f"{phase_name}_started", status="started", status_code="phase_started"
+        )
+
+        def finish(result: CommandResult) -> CommandResult:
+            self._children_terminated = self._children_terminated and result.terminated
+            self.journal.append(
+                marker=f"{phase_name}_completed",
+                status=(
+                    "completed"
+                    if result.status == "completed"
+                    else "cancelled"
+                    if result.status == "cancelled"
+                    else "failed"
+                ),
+                status_code=result.status_code,
+                duration_ms=int((time.monotonic() - started) * 1000),
+                exit_code=result.exit_code,
+            )
+            return result
+
+        if cancellation_event is not None and cancellation_event.is_set():
+            return finish(CommandResult("cancelled", "cancelled", terminated=True))
+        if self._cancel_requested:
+            return finish(CommandResult("cancelled", "cancelled", terminated=True))
+        if not argv or any(not isinstance(item, str) or not item for item in argv):
+            return finish(CommandResult("failed", "process_start_failed", terminated=True))
+
+        creationflags = 0
+        start_new_session = False
+        if os.name == "nt":
+            creationflags = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0x00000200)
+        else:
+            start_new_session = True
+        try:
+            process = self._process_factory(
+                list(argv),
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                creationflags=creationflags,
+                start_new_session=start_new_session,
+                shell=False,
+            )
+        except Exception:
+            return finish(CommandResult("failed", "process_start_failed", terminated=True))
+
+        self._set_active(process)
+        try:
+            deadline = time.monotonic() + timeout
+            while True:
+                return_code = process.poll()
+                if return_code is not None:
+                    result = (
+                        CommandResult("completed", "ok", exit_code=0, terminated=True)
+                        if return_code == 0
+                        else CommandResult(
+                            "failed",
+                            "exit_nonzero",
+                            exit_code=int(return_code),
+                            terminated=True,
+                        )
+                    )
+                    break
+                if (cancellation_event is not None and cancellation_event.is_set()) or self._cancel_requested:
+                    terminated = self.cancel()
+                    result = CommandResult(
+                        "cancelled",
+                        "cancelled" if terminated else "termination_failed",
+                        terminated=terminated,
+                    )
+                    break
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    terminated = self.cancel()
+                    result = CommandResult(
+                        "timed_out",
+                        "phase_timeout" if terminated else "termination_failed",
+                        terminated=terminated,
+                    )
+                    break
+                try:
+                    process.wait(timeout=min(0.2, remaining))
+                except (subprocess.TimeoutExpired, TimeoutError):
+                    continue
+                except Exception:
+                    terminated = self.cancel()
+                    result = CommandResult(
+                        "failed", "termination_failed", terminated=terminated
+                    )
+                    break
+        finally:
+            self._set_active(None)
+        return finish(result)
+
+    def cancel(self) -> bool:
+        """Terminate the active process tree; false means it remains alive."""
+
+        self._cancel_requested = True
+        with self._active_lock:
+            process = self._active_process
+        if process is None:
+            return True
+        terminated = _terminate_process(process)
+        self._children_terminated = self._children_terminated and terminated
+        return terminated
+
+    def cleanup(self, actions: Sequence[CleanupAction] = ()) -> dict[str, object]:
+        """Stop children, reject extra artifacts, and emit a sanitized receipt."""
+
+        if self._cleanup_called:
+            return {
+                "cleanup_attempted": True,
+                "cleanup_completed": False,
+                "cleanup_failure_count": 1,
+                "child_processes_terminated": self._children_terminated,
+                "resources_released": False,
+            }
+        self._cleanup_called = True
+        started = time.monotonic()
+        failures = 0
+        self.journal.append(marker="cleanup_started", status="started", status_code="phase_started")
+        if not self.cancel():
+            failures += 1
+        for action in reversed(tuple(actions)):
+            try:
+                if action() is False:
+                    failures += 1
+            except Exception:
+                failures += 1
+        extra = _count_extra_artifacts(self.run_root)
+        if extra:
+            failures += 1
+        completed = failures == 0 and self._children_terminated
+        self.journal.append(
+            marker="cleanup_completed",
+            status="completed" if completed else "failed",
+            status_code="ok" if completed else "cleanup_incomplete",
+            duration_ms=int((time.monotonic() - started) * 1000),
+            counts={"cleanup_failures": failures, "extra_artifacts": extra},
+        )
+        receipt: dict[str, object] = {
+            "schema": f"{SCHEMA_VERSION}.cleanup",
+            "cleanup_attempted": True,
+            "cleanup_completed": completed,
+            "cleanup_failure_count": failures,
+            "child_processes_terminated": self._children_terminated,
+            "resources_released": completed,
+        }
+        _write_sanitized_json(self.run_root / "cleanup-receipt.json", receipt)
+        return receipt
+
+
+class SanitizedPhaseJournal:
+    """Append-only status markers containing no operational secrets."""
+
+    def __init__(self, run_root: Path, identity: CandidateIdentity) -> None:
+        self.run_root = run_root
+        self.identity = identity
+        self.path = run_root / "phase-status.jsonl"
+        self.records: list[dict[str, object]] = []
+        try:
+            run_root.mkdir(parents=True, exist_ok=True)
+        except OSError as error:
+            raise HarnessFailure("journal_write_failed") from error
+
+    def append(
+        self,
+        *,
+        marker: str,
+        status: Literal["started", "completed", "failed", "cancelled"],
+        status_code: str,
+        duration_ms: int | None = None,
+        exit_code: int | None = None,
+        counts: dict[str, int] | None = None,
+    ) -> None:
+        record: dict[str, object] = {
+            "schema": SCHEMA_VERSION,
+            "marker": marker,
+            "status": status,
+            "status_code": _safe_code(status_code) if status_code != "ok" else "ok",
+            "observed_at": _utc_now(),
+            "identity": self.identity.as_dict(),
+        }
+        if duration_ms is not None:
+            record["duration_ms"] = max(0, int(duration_ms))
+        if exit_code is not None:
+            record["exit_code"] = int(exit_code)
+        if counts is not None:
+            record["counts"] = {
+                key: max(0, int(value))
+                for key, value in sorted(counts.items())
+                if isinstance(key, str) and isinstance(value, int) and not isinstance(value, bool)
+            }
+        encoded = json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n"
+        try:
+            with self.path.open("a", encoding="utf-8", newline="\n") as handle:
+                handle.write(encoded)
+                handle.flush()
+                os.fsync(handle.fileno())
+        except OSError as error:
+            raise HarnessFailure("journal_write_failed") from error
+        self.records.append(record)
+
+
+def _fixture_identity(args: argparse.Namespace) -> CandidateIdentity:
+    return CandidateIdentity(
+        candidate_sha=args.candidate_sha,
+        cli_version=args.cli_version,
+        cli_package_sha256=args.cli_package_sha256,
+        catalog_digest=args.catalog_digest,
+        route_digest=args.route_digest,
+        cli_source_commit=args.cli_source_commit,
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--run-root", type=Path, required=True)
+    parser.add_argument(
+        "--fixture", choices=("success", "timeout", "nonzero", "cancelled", "cleanup-failure"), required=True
+    )
+    parser.add_argument("--timeout-seconds", type=float, default=DEFAULT_TIMEOUT_SECONDS)
+    parser.add_argument("--candidate-sha", required=True)
+    parser.add_argument("--cli-version", required=True)
+    parser.add_argument("--cli-package-sha256", required=True)
+    parser.add_argument("--catalog-digest", required=True)
+    parser.add_argument("--route-digest", required=True)
+    parser.add_argument("--cli-source-commit")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    identity = _fixture_identity(args)
+    runner = BoundedPhaseRunner(
+        args.run_root,
+        identity,
+        timeout_seconds=args.timeout_seconds,
+    )
+    cancellation_event = threading.Event()
+    if args.fixture == "cancelled":
+        cancellation_event.set()
+    command = (sys.executable, "-c", "pass")
+    if args.fixture == "timeout":
+        command = (sys.executable, "-c", "import time; time.sleep(3600)")
+    elif args.fixture == "nonzero":
+        command = (sys.executable, "-c", "raise SystemExit(17)")
+    if args.fixture == "cleanup-failure":
+        result = runner.run_subprocess("catalog_sync", command)
+        receipt = runner.cleanup(actions=(lambda: (_ for _ in ()).throw(RuntimeError("fixture")),))
+    else:
+        result = runner.run_subprocess(
+            "catalog_sync", command, cancellation_event=cancellation_event
+        )
+        if result.status == "completed":
+            runner.mark_phase("config_written")
+            runner.mark_phase("sidecars_started")
+            runner.mark_phase("gateway_started")
+            result = runner.run_subprocess("cli", command, cancellation_event=cancellation_event)
+        if result.status == "completed":
+            runner.mark_phase("controls_started")
+        receipt = runner.cleanup()
+    print(
+        json.dumps(
+            {
+                "completed": result.status == "completed" and receipt["cleanup_completed"] is True,
+                "ready_for_issue62": False,
+                "status": result.status,
+                "status_code": result.status_code,
+                "cleanup_completed": receipt["cleanup_completed"],
+            },
+            sort_keys=True,
+        )
+    )
+    return 0 if result.status == "completed" and receipt["cleanup_completed"] is True else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src-python/catalog.py
+++ b/src-python/catalog.py
@@ -1,11 +1,24 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from enum import Enum
 import json
 from pathlib import Path
 import re
 import tomllib
 from typing import Any
+
+
+class CatalogVisibility(str, Enum):
+    """The only visibility states accepted at a catalog boundary."""
+
+    LIST = "list"
+    HIDE = "hide"
+    UNKNOWN = "unknown"
+
+
+INTERNAL_MODEL_IDENTIFIERS = frozenset({"codex-auto-review"})
+MAX_VISIBILITY_DIAGNOSTIC_COUNT = 100
 
 
 @dataclass(frozen=True)
@@ -24,6 +37,97 @@ def canonical_model_id(model_id: str) -> str:
     if value.endswith(":cloud"):
         value = value[:-6]
     return value
+
+
+def catalog_visibility(value: Any) -> CatalogVisibility:
+    if isinstance(value, CatalogVisibility):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized == CatalogVisibility.LIST.value:
+            return CatalogVisibility.LIST
+        if normalized == CatalogVisibility.HIDE.value:
+            return CatalogVisibility.HIDE
+    return CatalogVisibility.UNKNOWN
+
+
+def model_visibility(
+    model: Any,
+    *,
+    missing_is_list: bool = False,
+) -> CatalogVisibility:
+    """Resolve upstream visibility without trusting unknown values.
+
+    Older hand-authored catalog fixtures omitted visibility entirely.  Callers
+    that operate on those trusted legacy records can opt into the historical
+    list default; native/upstream ingestion remains fail-closed.
+    """
+
+    if not isinstance(model, dict):
+        return CatalogVisibility.UNKNOWN
+    if model.get("hidden") is True:
+        return CatalogVisibility.HIDE
+    if "visibility" in model:
+        return catalog_visibility(model.get("visibility"))
+    hidden = model.get("hidden")
+    if isinstance(hidden, bool):
+        return CatalogVisibility.HIDE if hidden else CatalogVisibility.LIST
+    return CatalogVisibility.LIST if missing_is_list else CatalogVisibility.UNKNOWN
+
+
+def model_identity_values(model: Any) -> tuple[str, ...]:
+    if not isinstance(model, dict):
+        return ()
+    values: list[str] = []
+    for key in ("id", "slug", "model", "name", "upstream_model"):
+        value = model.get(key)
+        if not isinstance(value, str) or not value.strip():
+            continue
+        normalized = canonical_model_id(value).lower()
+        if normalized.startswith("openai/"):
+            normalized = normalized.removeprefix("openai/")
+        values.append(normalized)
+    return tuple(values)
+
+
+def is_internal_model(model: Any) -> bool:
+    return any(
+        value in INTERNAL_MODEL_IDENTIFIERS
+        or any(value.startswith(f"{identifier}/") for identifier in INTERNAL_MODEL_IDENTIFIERS)
+        for value in model_identity_values(model)
+    )
+
+
+def is_catalog_model_listable(
+    model: Any,
+    *,
+    missing_is_list: bool = False,
+) -> bool:
+    return (
+        not is_internal_model(model)
+        and model_visibility(model, missing_is_list=missing_is_list) is CatalogVisibility.LIST
+    )
+
+
+def catalog_visibility_diagnostics(models: Any) -> dict[str, int]:
+    """Return bounded aggregate visibility diagnostics without model identities."""
+
+    counts = {"hidden": 0, "unknown": 0, "internal": 0}
+    for model in models if isinstance(models, (list, tuple)) else ():
+        if is_internal_model(model):
+            key = "internal"
+        else:
+            visibility = model_visibility(model, missing_is_list=False)
+            key = (
+                "hidden"
+                if visibility is CatalogVisibility.HIDE
+                else "unknown"
+                if visibility is CatalogVisibility.UNKNOWN
+                else ""
+            )
+        if key:
+            counts[key] = min(MAX_VISIBILITY_DIAGNOSTIC_COUNT, counts[key] + 1)
+    return counts
 
 
 def deny_match_model_id(model_id: str) -> str:

--- a/src-python/catalog_sync.py
+++ b/src-python/catalog_sync.py
@@ -4,16 +4,19 @@ import argparse
 from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+import hashlib
+import hmac
 import json
 import os
 from pathlib import Path
 import re
+import secrets
 import sys
 from typing import Any, Iterable
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
-from atomic_io import atomic_write_text
+from atomic_io import atomic_read_or_create_text, atomic_write_text
 from catalog import (
     CatalogVisibility,
     CatalogPolicy,
@@ -83,6 +86,10 @@ GENERATED_CATALOG_FILENAME = "codexhub-model-catalog.json"
 LEGACY_GENERATED_CATALOG_FILENAME = "codex-proxy-official-ollama.json"
 GENERATED_CATALOG_PATH = RUNTIME_MODEL_CATALOG_DIR / GENERATED_CATALOG_FILENAME
 LEGACY_GENERATED_CATALOG_PATH = RUNTIME_MODEL_CATALOG_DIR / LEGACY_GENERATED_CATALOG_FILENAME
+MANAGED_CATALOG_BASELINE_FILENAME = "codexhub-model-catalog-baseline.json"
+CATALOG_OVERRIDES_FILENAME = "codexhub-model-catalog-overrides.json"
+MANAGED_CATALOG_BASELINE_PATH = RUNTIME_MODEL_CATALOG_DIR / MANAGED_CATALOG_BASELINE_FILENAME
+CATALOG_OVERRIDES_PATH = RUNTIME_MODEL_CATALOG_DIR / CATALOG_OVERRIDES_FILENAME
 GENERATED_STATE_PATH = RUNTIME_MODEL_CATALOG_DIR / "codex-proxy-state.json"
 SETTINGS_PATH = RUNTIME_CODEX_DIR / "proxy" / "settings.json"
 RESOLVED_MODEL_LIMITS_PATH = REPO_ROOT / "config" / "resolved_model_limits.json"
@@ -298,6 +305,33 @@ PINNED_OFFICIAL_MODEL_FIELD_SETS = {
     "gpt-5.3-codex-spark": ("use_responses_lite",),
 }
 
+# The first version of catalog ownership deliberately supports only planner
+# metadata.  Other model fields are still generated from the current Direct
+# snapshot and must not silently become a second, unvalidated configuration
+# surface.  A user can therefore opt in to a planner change without causing
+# unrelated stale metadata to survive a refresh.
+CATALOG_OVERRIDE_FIELDS = frozenset(PINNED_OFFICIAL_PLANNER_FIELD_SET)
+CATALOG_OVERRIDE_SCHEMA_VERSION = 1
+CATALOG_OWNER_METADATA_KEY = "catalog_owner"
+CATALOG_OWNER_METADATA_VERSION_KEY = "catalog_owner_version"
+CATALOG_OWNER_IDENTITY_KEY = "catalog_identity_digest"
+CATALOG_OWNER_SIGNATURE_KEY = "catalog_owner_signature"
+CATALOG_OWNER_METADATA_VALUE = "codexhub"
+CATALOG_OWNER_METADATA_VERSION = 1
+CATALOG_OWNER_SECRET_FILENAME = ".codexhub-catalog-owner-key"
+CATALOG_OVERRIDE_REJECTION_REASONS = frozenset(
+    {
+        "invalid_sidecar",
+        "invalid_catalog",
+        "invalid_baseline",
+        "invalid_row_identity",
+        "invalid_override_fields",
+        "missing_managed_model",
+    }
+)
+
+_CATALOG_OWNER_SECRET_CACHE: tuple[Path, bytes] | None = None
+
 
 def load_pinned_official_catalog_metadata(
     path: Path = OFFICIAL_CATALOG_METADATA_PATH,
@@ -389,6 +423,7 @@ def catalog_cache_dependency_paths() -> tuple[Path, ...]:
     return (
         POLICY_PATH,
         OFFICIAL_SEED_PATH,
+        OFFICIAL_CATALOG_METADATA_PATH,
         RUNTIME_OFFICIAL_SEED_PATH,
         DIRECT_OFFICIAL_MODELS_CACHE_PATH,
         OLLAMA_FALLBACK_PATH,
@@ -398,6 +433,9 @@ def catalog_cache_dependency_paths() -> tuple[Path, ...]:
         Path(__file__).resolve(),
         PROXY_DIR / "catalog.py",
         PROXY_DIR / "providers_config.py",
+        MANAGED_CATALOG_BASELINE_PATH,
+        CATALOG_OVERRIDES_PATH,
+        catalog_owner_secret_path(),
     )
 
 
@@ -406,6 +444,8 @@ def catalog_cache_is_fresh(max_age_seconds: int, catalog_path: Path = GENERATED_
         return False
     catalog_mtime = catalog_path.stat().st_mtime
     for dependency in catalog_cache_dependency_paths():
+        if dependency == catalog_owner_secret_path() and not dependency.exists():
+            return False
         if dependency.exists() and dependency.stat().st_mtime > catalog_mtime:
             return False
     age_seconds = datetime.now(timezone.utc).timestamp() - catalog_mtime
@@ -424,6 +464,711 @@ def load_json_file(path: Path) -> dict[str, Any]:
     if not path.exists():
         return {}
     return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+CatalogModelIdentity = tuple[str, str, str]
+
+
+def catalog_model_identity(model: Any) -> CatalogModelIdentity | None:
+    """Return the stable provider/model identity for ownership decisions.
+
+    The generated slug is a display/routing convenience and may be an alias.
+    Ownership must instead follow the provider metadata written alongside the
+    row.  Requiring all three components also prevents a row from one
+    provider being matched to a same-named row from another provider.
+    """
+
+    if not isinstance(model, dict):
+        return None
+    metadata = model.get("codex_proxy_metadata")
+    if not isinstance(metadata, dict):
+        return None
+    provider = metadata.get("provider")
+    upstream_name = metadata.get("upstream_name")
+    upstream_model = metadata.get("upstream_model")
+    if not all(isinstance(value, str) and value.strip() for value in (provider, upstream_name, upstream_model)):
+        return None
+    # ``:cloud`` is an Ollama model-suffix normalization, not a provider or
+    # upstream-name alias.  Keep the first two components exact so an edited
+    # ``openai:cloud``/``official:cloud`` row cannot collapse into Official.
+    return (
+        provider.strip(),
+        upstream_name.strip(),
+        canonical_model_id(upstream_model),
+    )
+
+
+def _identity_from_payload(value: Any) -> CatalogModelIdentity | None:
+    if isinstance(value, dict):
+        values = (value.get("provider"), value.get("upstream_name"), value.get("upstream_model"))
+    elif isinstance(value, (list, tuple)) and len(value) == 3:
+        values = tuple(value)
+    else:
+        return None
+    if not all(isinstance(item, str) and item.strip() for item in values):
+        return None
+    return (
+        str(values[0]).strip(),
+        str(values[1]).strip(),
+        canonical_model_id(str(values[2])),
+    )
+
+
+def _official_identity(identity: CatalogModelIdentity | None) -> bool:
+    return bool(
+        identity
+        and identity[0] == OFFICIAL_PROXY_PROVIDER_ALIAS
+        and identity[1] == "official"
+        and identity[2].startswith("gpt-")
+    )
+
+
+def _planner_override_is_valid(
+    identity: CatalogModelIdentity,
+    fields: dict[str, Any],
+) -> bool:
+    """Validate a planner override against the pinned model shape.
+
+    Only Official Code Mode models may carry these fields.  In particular, a
+    user-editable row cannot make an external provider look like an Official
+    model by supplying ``multi_agent_version`` or websocket/tool metadata.
+    """
+
+    if not _official_identity(identity):
+        return False
+    slug = identity[2]
+    if slug not in PINNED_OFFICIAL_MODEL_IDS:
+        return False
+    expected = PINNED_OFFICIAL_CATALOG_METADATA.get(slug)
+    if expected is None:
+        return False
+    if not fields or not set(fields).issubset(CATALOG_OVERRIDE_FIELDS):
+        return False
+    supported_fields = set(PINNED_OFFICIAL_MODEL_FIELD_SETS.get(slug, ()))
+    if not set(fields).issubset(supported_fields):
+        return False
+    for key, value in fields.items():
+        if key == "multi_agent_version":
+            # v1/v2 are the only native planner versions.  The selected model
+            # must itself be one of the pinned Code Mode rows; legacy Official
+            # rows intentionally have a null version and reject this field.
+            if (
+                slug not in PINNED_OFFICIAL_CODE_MODE_MULTI_AGENT_VERSIONS
+                or not isinstance(value, str)
+                or value not in {"v1", "v2"}
+            ):
+                return False
+            continue
+        # Every other planner field is an invariant of the pinned model shape.
+        # A user override may opt into a different supported multi-agent
+        # version, but it must not turn websockets, tool mode, or Responses
+        # Lite on/off independently of the model's official contract.
+        expected_value = expected.get(key)
+        if isinstance(expected_value, bool):
+            if type(value) is not bool or value != expected_value:
+                return False
+        elif value != expected_value:
+            return False
+    return True
+
+
+def _record_override_rejection(
+    diagnostics: dict[str, Any] | None,
+    reason: str,
+) -> None:
+    if diagnostics is None:
+        return
+    diagnostics["rejected"] = int(diagnostics.get("rejected", 0)) + 1
+    reasons = diagnostics.setdefault("reasons", {})
+    if not isinstance(reasons, dict):
+        reasons = {}
+        diagnostics["reasons"] = reasons
+    if reason not in CATALOG_OVERRIDE_REJECTION_REASONS:
+        reason = "invalid_sidecar"
+    reasons[reason] = int(reasons.get(reason, 0)) + 1
+
+
+def _catalog_override_row_is_eligible(
+    identity: CatalogModelIdentity,
+    model: dict[str, Any],
+    baseline_model: dict[str, Any] | None = None,
+    *,
+    allow_markerless_legacy: bool = False,
+) -> bool:
+    """Require the edited row to be a visible, exact managed row.
+
+    Metadata alone is not an authority: a user-edited hidden row or a row
+    spoofed to look Official must not seed an override for the next catalog.
+    """
+
+    if not is_catalog_model_listable(model, missing_is_list=False):
+        return False
+    slug = model.get("slug")
+    if not isinstance(slug, str):
+        return False
+    normalized_slug = canonical_model_id(slug)
+    if normalized_slug.startswith("openai/gpt-"):
+        normalized_slug = normalized_slug.removeprefix("openai/")
+    # Official rows use the bare pinned slug as part of their ownership
+    # proof.  Third-party rows may intentionally expose a provider-prefixed
+    # alias (for example ``volc/glm-5.2``) while their stable identity remains
+    # the metadata tuple; planner overrides are not valid for them anyway.
+    if _official_identity(identity) and normalized_slug != identity[2]:
+        return False
+
+    metadata = model.get("codex_proxy_metadata")
+    if not isinstance(metadata, dict):
+        return False
+
+    # New catalogs carry an ownership marker in the generated row. When a
+    # managed baseline has one, require the current row to carry the same
+    # marker; changing only the visible slug/identity cannot turn a replaced
+    # third-party row into an Official authority.
+    baseline_metadata = (
+        baseline_model.get("codex_proxy_metadata")
+        if isinstance(baseline_model, dict)
+        else None
+    )
+    if baseline_model is not None and (
+        not isinstance(baseline_metadata, dict)
+        or CATALOG_OWNER_METADATA_KEY not in baseline_metadata
+    ):
+        # Once a managed baseline exists, a markerless row is not an
+        # ownership boundary.  Treating it as a legacy snapshot would let a
+        # hand-authored baseline mint a planner override on the next sync.
+        return False
+    baseline_has_owner_marker = isinstance(baseline_metadata, dict) and (
+        CATALOG_OWNER_METADATA_KEY in baseline_metadata
+        or CATALOG_OWNER_SIGNATURE_KEY in baseline_metadata
+    )
+    current_has_owner_marker = (
+        CATALOG_OWNER_METADATA_KEY in metadata
+        or CATALOG_OWNER_METADATA_VERSION_KEY in metadata
+        or CATALOG_OWNER_IDENTITY_KEY in metadata
+        or CATALOG_OWNER_SIGNATURE_KEY in metadata
+    )
+    if allow_markerless_legacy and baseline_model is not None:
+        # The caller supplied the freshly generated managed catalog as the
+        # legacy migration baseline.  A markerless Beta1 row is accepted only
+        # when every immutable field is byte-for-byte equal to that baseline;
+        # the planner delta is the sole supported user edit.  This prevents a
+        # forged Official-shaped row from entering the migration path.
+        if _catalog_owner_canonical_row(model) != _catalog_owner_canonical_row(baseline_model):
+            return False
+        if not current_has_owner_marker:
+            return True
+        if CATALOG_OWNER_SIGNATURE_KEY not in metadata:
+            return _catalog_owner_metadata_is_valid(
+                metadata,
+                identity,
+                require_signature=False,
+                model=model,
+                baseline_model=baseline_model,
+            )
+    if baseline_has_owner_marker or current_has_owner_marker:
+        if (
+            baseline_model is not None
+            and _catalog_owner_canonical_row(model)
+            != _catalog_owner_canonical_row(baseline_model)
+        ):
+            return False
+        if baseline_model is None and CATALOG_OWNER_SIGNATURE_KEY not in metadata:
+            # A real sync creates the HMAC key before reconciliation.  An
+            # old public marker without a managed baseline therefore has no
+            # trustworthy immutable-row proof and must not be treated as a
+            # legacy migration source; only truly markerless Beta1 catalogs
+            # use the narrow shape-checked migration below.
+            try:
+                if _load_catalog_owner_secret(create=False) is not None:
+                    return False
+            except ValueError:
+                return False
+        require_signature = (
+            isinstance(baseline_metadata, dict)
+            and CATALOG_OWNER_SIGNATURE_KEY in baseline_metadata
+        ) or CATALOG_OWNER_SIGNATURE_KEY in metadata
+        return _catalog_owner_metadata_is_valid(
+            metadata,
+            identity,
+            # A marker-only baseline/current pair may have been written by
+            # the pre-HMAC Beta2 build.  The exact immutable-row comparison
+            # above is the migration proof; the next publication upgrades it
+            # to a signed baseline.  A newly signed side of the pair still
+            # forces signature validation.
+            require_signature=require_signature,
+            model=model,
+            baseline_model=baseline_model,
+        )
+
+    # Pre-Beta2 catalogs have no marker. Retain migration compatibility only
+    # for the recognizable generated Official row shape; a hand-authored
+    # metadata/slug spoof is not a legacy catalog record.
+    if not _official_identity(identity):
+        return True
+    # A real sync creates the owner key before reconciliation.  Without the
+    # generated legacy baseline supplied by sync_catalog, a markerless row
+    # has no immutable provenance and is not a migration source.
+    try:
+        if _load_catalog_owner_secret(create=False) is not None:
+            return False
+    except ValueError:
+        return False
+    required_legacy_keys = (
+        "description",
+        "shell_type",
+        "supported_in_api",
+        "supported_reasoning_levels",
+        "default_reasoning_level",
+        "input_modalities",
+    )
+    if any(key not in model for key in required_legacy_keys):
+        return False
+    return (
+        model.get("shell_type") == "shell_command"
+        and model.get("supported_in_api") is True
+        and isinstance(model.get("supported_reasoning_levels"), list)
+        and isinstance(model.get("input_modalities"), list)
+    )
+
+
+def _catalog_models(payload: Any) -> list[dict[str, Any]]:
+    if not isinstance(payload, dict):
+        return []
+    models = payload.get("models")
+    if not isinstance(models, list):
+        return []
+    return [model for model in models if isinstance(model, dict)]
+
+
+def _catalog_payload_shape_is_valid(
+    payload: Any,
+    *,
+    require_identity: bool = False,
+) -> bool:
+    """Validate the minimum generated-catalog envelope before reconciliation."""
+
+    if not isinstance(payload, dict) or not isinstance(payload.get("models"), list):
+        return False
+    if not payload["models"]:
+        return False
+    for model in payload["models"]:
+        if not isinstance(model, dict):
+            return False
+        slug = model.get("slug")
+        if not isinstance(slug, str) or not slug.strip():
+            return False
+        if "visibility" in model and not isinstance(model.get("visibility"), str):
+            return False
+        if "visibility" not in model and not isinstance(model.get("hidden"), bool):
+            return False
+        metadata = model.get("codex_proxy_metadata")
+        if "codex_proxy_metadata" in model and not isinstance(metadata, dict):
+            return False
+        if require_identity and (
+            not isinstance(metadata, dict) or catalog_model_identity(model) is None
+        ):
+            return False
+        if require_identity:
+            identity = catalog_model_identity(model)
+            if identity is not None and _official_identity(identity):
+                # Direct Official snapshots may introduce a visible model
+                # before its planner contract is pinned locally.  Keep that
+                # generated row in the catalog shape, but do not treat it as
+                # an authority for planner overrides (the override validator
+                # remains pinned-only).
+                if identity[2] in PINNED_OFFICIAL_MODEL_IDS and any(
+                    field not in model
+                    for field in PINNED_OFFICIAL_MODEL_FIELD_SETS[identity[2]]
+                ):
+                    return False
+    return True
+
+
+def _managed_baseline_shape_is_valid(payload: Any) -> bool:
+    if (
+        isinstance(payload, dict)
+        and isinstance(payload.get("models"), list)
+        and not payload["models"]
+    ):
+        return True
+    if not _catalog_payload_shape_is_valid(payload, require_identity=True):
+        return False
+    for model in payload["models"]:
+        identity = catalog_model_identity(model)
+        if identity is None:
+            return False
+        if _official_identity(identity):
+            if identity[2] not in PINNED_OFFICIAL_MODEL_IDS:
+                # Unknown Official rows are generated catalog entries, not a
+                # supported planner-override surface.  Preserve them in the
+                # managed baseline while _planner_override_is_valid keeps
+                # their overrides fail-closed.
+                continue
+            supported_fields = PINNED_OFFICIAL_MODEL_FIELD_SETS.get(identity[2], ())
+            if any(field not in model for field in supported_fields):
+                return False
+            expected = PINNED_OFFICIAL_CATALOG_METADATA.get(identity[2], {})
+            for field in supported_fields:
+                value = model.get(field)
+                if field == "multi_agent_version":
+                    expected_version = expected.get(field)
+                    if expected_version is None:
+                        # Legacy Official rows deliberately carry a null
+                        # multi-agent version.  Keep accepting that pinned
+                        # shape while still rejecting arbitrary values.
+                        if value is not None:
+                            return False
+                    elif not isinstance(value, str) or value != expected_version:
+                        return False
+                else:
+                    expected_value = expected.get(field)
+                    if isinstance(expected_value, bool):
+                        if type(value) is not bool or value != expected_value:
+                            return False
+                    elif value != expected_value:
+                        return False
+            metadata = model.get("codex_proxy_metadata")
+            if isinstance(metadata, dict) and (
+                CATALOG_OWNER_METADATA_KEY in metadata
+                or CATALOG_OWNER_SIGNATURE_KEY in metadata
+            ):
+                if not _catalog_owner_metadata_is_valid(
+                    metadata,
+                    identity,
+                    require_signature=CATALOG_OWNER_SIGNATURE_KEY in metadata,
+                    model=model,
+                ):
+                    return False
+    return True
+
+
+def _index_catalog_models(payload: Any) -> dict[CatalogModelIdentity, dict[str, Any]]:
+    indexed: dict[CatalogModelIdentity, dict[str, Any]] = {}
+    duplicates: set[CatalogModelIdentity] = set()
+    for model in _catalog_models(payload):
+        identity = catalog_model_identity(model)
+        if identity is None:
+            continue
+        if identity in indexed:
+            duplicates.add(identity)
+            continue
+        indexed[identity] = model
+    for identity in duplicates:
+        indexed.pop(identity, None)
+    return indexed
+
+
+def _duplicate_catalog_identities(payload: Any) -> set[CatalogModelIdentity]:
+    seen: set[CatalogModelIdentity] = set()
+    duplicates: set[CatalogModelIdentity] = set()
+    for model in _catalog_models(payload):
+        identity = catalog_model_identity(model)
+        if identity is None:
+            continue
+        if identity in seen:
+            duplicates.add(identity)
+        else:
+            seen.add(identity)
+    return duplicates
+
+
+def _load_catalog_override_state(
+    path: Path = CATALOG_OVERRIDES_PATH,
+    diagnostics: dict[str, Any] | None = None,
+) -> dict[CatalogModelIdentity, dict[str, Any]]:
+    try:
+        payload = load_json_file(path)
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        _record_override_rejection(diagnostics, "invalid_sidecar")
+        return {}
+    if not isinstance(payload, dict):
+        _record_override_rejection(diagnostics, "invalid_sidecar")
+        return {}
+    if (
+        type(payload.get("schema_version")) is not int
+        or payload.get("schema_version") != CATALOG_OVERRIDE_SCHEMA_VERSION
+    ):
+        _record_override_rejection(diagnostics, "invalid_sidecar")
+        return {}
+    if set(payload) != {"schema_version", "overrides"}:
+        _record_override_rejection(diagnostics, "invalid_sidecar")
+        return {}
+    raw_overrides = payload.get("overrides")
+    if not isinstance(raw_overrides, list):
+        _record_override_rejection(diagnostics, "invalid_sidecar")
+        return {}
+    output: dict[CatalogModelIdentity, dict[str, Any]] = {}
+    for entry in raw_overrides:
+        if not isinstance(entry, dict):
+            _record_override_rejection(diagnostics, "invalid_sidecar")
+            return {}
+        if set(entry) != {"provider", "upstream_name", "upstream_model", "fields"}:
+            _record_override_rejection(diagnostics, "invalid_sidecar")
+            return {}
+        identity = _identity_from_payload(entry)
+        fields = entry.get("fields")
+        if identity is None or not isinstance(fields, dict):
+            _record_override_rejection(diagnostics, "invalid_sidecar")
+            return {}
+        if not set(fields).issubset(CATALOG_OVERRIDE_FIELDS):
+            _record_override_rejection(diagnostics, "invalid_override_fields")
+            return {}
+        if _planner_override_is_valid(identity, fields):
+            if identity in output:
+                # A duplicate identity has no deterministic ownership
+                # semantics; reject the complete sidecar instead of making
+                # list order a hidden override selector.
+                _record_override_rejection(diagnostics, "invalid_sidecar")
+                return {}
+            output[identity] = {key: fields[key] for key in sorted(fields)}
+        else:
+            _record_override_rejection(diagnostics, "invalid_override_fields")
+            return {}
+    return output
+
+
+def _write_catalog_override_state(
+    overrides: dict[CatalogModelIdentity, dict[str, Any]],
+) -> dict[str, Any]:
+    entries = []
+    for identity in sorted(overrides):
+        entries.append(
+            {
+                "provider": identity[0],
+                "upstream_name": identity[1],
+                "upstream_model": identity[2],
+                "fields": overrides[identity],
+            }
+        )
+    return {
+        "schema_version": CATALOG_OVERRIDE_SCHEMA_VERSION,
+        "overrides": entries,
+    }
+
+
+def _legacy_override_fields(
+    identity: CatalogModelIdentity,
+    model: dict[str, Any],
+) -> dict[str, Any]:
+    """Extract supported edits from a pre-sidecar single-file catalog."""
+
+    # The legacy migration boundary is deliberately narrow: the reported
+    # Beta2 regression is Luna's explicit v1 -> v2 planner override.  Do not
+    # infer unrelated historical edits for other Official rows while there is
+    # no managed baseline proving their ownership.
+    if not _official_identity(identity) or identity[2] != "gpt-5.6-luna":
+        return {}
+    slug = identity[2]
+    baseline = PINNED_OFFICIAL_CATALOG_METADATA.get(slug)
+    if baseline is None:
+        return {}
+    fields = {
+        key: model[key]
+        for key in sorted(CATALOG_OVERRIDE_FIELDS)
+        if key in model and model.get(key) != baseline.get(key)
+    }
+    return fields if fields == {"multi_agent_version": "v2"} else {}
+
+
+def _delta_override_fields(
+    identity: CatalogModelIdentity,
+    current: dict[str, Any],
+    baseline: dict[str, Any] | None,
+) -> dict[str, Any]:
+    if baseline is None:
+        return _legacy_override_fields(identity, current)
+    fields = {
+        key: current[key]
+        for key in sorted(CATALOG_OVERRIDE_FIELDS)
+        if key in current and current.get(key) != baseline.get(key)
+    }
+    return fields
+
+
+def _collect_catalog_overrides(
+    *,
+    legacy_baseline: dict[str, Any] | None = None,
+) -> tuple[dict[CatalogModelIdentity, dict[str, Any]], dict[str, Any]]:
+    """Capture user edits before the effective catalog is replaced.
+
+    A baseline sidecar is the ownership boundary for new installations.  If
+    it is absent, the current generated/legacy catalog is treated as a legacy
+    snapshot and only supported planner deltas against the pinned metadata
+    are migrated.
+    """
+
+    diagnostics: dict[str, Any] = {
+        "accepted": 0,
+        "rejected": 0,
+        "migrated": 0,
+        "reasons": {},
+        # A malformed effective catalog is not an ownership boundary.  Keep
+        # a valid persisted sidecar available for recovery, but never use the
+        # malformed file as evidence of a new user edit.
+        "current_catalog_valid": True,
+    }
+    current_path = existing_generated_catalog_path(GENERATED_CATALOG_PATH)
+    current_exists = current_path.exists()
+    diagnostics["current_catalog_valid"] = current_exists
+    try:
+        current = load_json_file(current_path)
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        current = {}
+        if current_exists:
+            diagnostics["current_catalog_valid"] = False
+            _record_override_rejection(diagnostics, "invalid_catalog")
+    if diagnostics["current_catalog_valid"] and not _catalog_payload_shape_is_valid(current):
+        current = {}
+        diagnostics["current_catalog_valid"] = False
+        _record_override_rejection(diagnostics, "invalid_catalog")
+
+    baseline_exists = MANAGED_CATALOG_BASELINE_PATH.exists()
+    using_legacy_baseline = not baseline_exists and legacy_baseline is not None
+    if baseline_exists:
+        try:
+            baseline = load_json_file(MANAGED_CATALOG_BASELINE_PATH)
+        except (OSError, UnicodeError, json.JSONDecodeError):
+            _record_override_rejection(diagnostics, "invalid_baseline")
+            return {}, diagnostics
+        if not (
+            isinstance(baseline, dict)
+            and type(baseline.get("schema_version")) is int
+            and baseline.get("schema_version") == CATALOG_OVERRIDE_SCHEMA_VERSION
+            and baseline.get("managed_baseline") is True
+            and _managed_baseline_shape_is_valid(baseline)
+        ):
+            _record_override_rejection(diagnostics, "invalid_baseline")
+            return {}, diagnostics
+        if diagnostics["current_catalog_valid"] and not _catalog_payload_shape_is_valid(
+            current,
+            require_identity=True,
+        ):
+            current = {}
+            diagnostics["current_catalog_valid"] = False
+            _record_override_rejection(diagnostics, "invalid_catalog")
+    elif legacy_baseline is not None:
+        baseline = deepcopy(legacy_baseline)
+        baseline["schema_version"] = CATALOG_OVERRIDE_SCHEMA_VERSION
+        baseline["managed_baseline"] = True
+        if not _managed_baseline_shape_is_valid(baseline):
+            _record_override_rejection(diagnostics, "invalid_baseline")
+            return {}, diagnostics
+    else:
+        baseline = {}
+
+    baseline_duplicates = _duplicate_catalog_identities(baseline)
+    if baseline_duplicates:
+        _record_override_rejection(diagnostics, "invalid_baseline")
+        return {}, diagnostics
+
+    baseline_models = _index_catalog_models(baseline)
+    # An override sidecar without its managed baseline has no ownership proof;
+    # ignore it and let the next effective catalog establish a fresh baseline.
+    overrides = (
+        _load_catalog_override_state(CATALOG_OVERRIDES_PATH, diagnostics)
+        if baseline_exists
+        else {}
+    )
+    if not diagnostics["current_catalog_valid"]:
+        # Do not infer a user edit from a missing/corrupt current file. Keep
+        # any already validated sidecar for the rebuilt managed catalog to
+        # consume, and let publication validate the target identity again.
+        return overrides, diagnostics
+    current_duplicates = _duplicate_catalog_identities(current)
+    for identity in current_duplicates:
+        overrides.pop(identity, None)
+        _record_override_rejection(diagnostics, "invalid_row_identity")
+    current_models = _index_catalog_models(current)
+    if diagnostics["current_catalog_valid"]:
+        # A sidecar entry is only valid while the exact managed identity is
+        # still present in the current catalog.  Otherwise a removed model,
+        # provider replacement, or cross-provider row could inherit the old
+        # planner fields on the next generated catalog.
+        for identity in set(overrides).difference(current_models):
+            overrides.pop(identity, None)
+            _record_override_rejection(diagnostics, "missing_managed_model")
+    for identity, model in current_models.items():
+        baseline_model = baseline_models.get(identity)
+        if not _catalog_override_row_is_eligible(
+            identity,
+            model,
+            baseline_model,
+            allow_markerless_legacy=using_legacy_baseline,
+        ):
+            overrides.pop(identity, None)
+            _record_override_rejection(diagnostics, "invalid_row_identity")
+            continue
+        if (baseline_exists or using_legacy_baseline) and baseline_model is None:
+            # A row unknown to the managed baseline is not an authority for
+            # another row; it can be safely ignored during migration.
+            overrides.pop(identity, None)
+            _record_override_rejection(diagnostics, "invalid_row_identity")
+            continue
+        fields = _delta_override_fields(identity, model, baseline_model)
+        if not fields:
+            # An explicit edit back to the managed value removes the prior
+            # sidecar override instead of making it impossible to opt out.
+            if baseline_model is not None and identity in overrides:
+                overrides.pop(identity, None)
+            continue
+        if _planner_override_is_valid(identity, fields):
+            overrides[identity] = fields
+            diagnostics["accepted"] += 1
+            if not baseline_exists:
+                diagnostics["migrated"] += 1
+        else:
+            overrides.pop(identity, None)
+            _record_override_rejection(diagnostics, "invalid_override_fields")
+    return overrides, diagnostics
+
+
+def _apply_catalog_overrides(
+    catalog: dict[str, Any],
+    overrides: dict[CatalogModelIdentity, dict[str, Any]],
+    diagnostics: dict[str, Any],
+) -> dict[str, Any]:
+    by_identity = _index_catalog_models(catalog)
+    for identity, fields in list(overrides.items()):
+        model = by_identity.get(identity)
+        if model is None:
+            overrides.pop(identity, None)
+            _record_override_rejection(diagnostics, "missing_managed_model")
+            continue
+        if not _catalog_override_row_is_eligible(identity, model):
+            overrides.pop(identity, None)
+            _record_override_rejection(diagnostics, "invalid_row_identity")
+            continue
+        if not _planner_override_is_valid(identity, fields):
+            overrides.pop(identity, None)
+            _record_override_rejection(diagnostics, "invalid_override_fields")
+            continue
+        model.update(deepcopy(fields))
+    return catalog
+
+
+def _bounded_catalog_override_diagnostics(
+    diagnostics: dict[str, Any],
+) -> dict[str, Any]:
+    def bounded_counter(value: Any) -> int:
+        return (
+            min(value, MAX_VISIBILITY_DIAGNOSTIC_COUNT)
+            if isinstance(value, int) and not isinstance(value, bool) and value > 0
+            else 0
+        )
+
+    result = {
+        key: bounded_counter(diagnostics.get(key, 0))
+        for key in ("accepted", "rejected", "migrated")
+    }
+    raw_reasons = diagnostics.get("reasons")
+    reasons = {}
+    if isinstance(raw_reasons, dict):
+        for reason in sorted(CATALOG_OVERRIDE_REJECTION_REASONS):
+            value = raw_reasons.get(reason, 0)
+            if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+                reasons[reason] = min(value, MAX_VISIBILITY_DIAGNOSTIC_COUNT)
+    result["reasons"] = reasons
+    return result
 
 
 @dataclass(frozen=True)
@@ -1190,6 +1935,160 @@ def normalize_official_responses_lite_opt_in(model: dict[str, Any]) -> None:
         model["use_responses_lite"] = False
 
 
+def catalog_identity_digest(identity: CatalogModelIdentity) -> str:
+    value = "\0".join(identity).encode("utf-8")
+    return hashlib.sha256(value).hexdigest()
+
+
+def catalog_owner_secret_path(overrides_path: Path | None = None) -> Path:
+    """Return the per-runtime secret used to authenticate managed rows.
+
+    Keeping the key beside the override sidecar makes the ownership boundary
+    explicit and lets tests redirect the complete catalog state to a temporary
+    directory by patching ``CATALOG_OVERRIDES_PATH``.
+    """
+
+    path = overrides_path if overrides_path is not None else CATALOG_OVERRIDES_PATH
+    return path.with_name(CATALOG_OWNER_SECRET_FILENAME)
+
+
+def _parse_catalog_owner_secret(raw: str, path: Path) -> bytes:
+    try:
+        secret = bytes.fromhex(raw.strip())
+    except ValueError as error:
+        raise ValueError(f"catalog owner secret is invalid: {path}") from error
+    if len(secret) != 32:
+        raise ValueError(f"catalog owner secret has an invalid length: {path}")
+    return secret
+
+
+def _load_catalog_owner_secret(*, create: bool) -> bytes | None:
+    """Load the runtime HMAC key, creating it only for a real sync.
+
+    Direct catalog-builder unit tests should remain pure and must not create a
+    key in the user's Codex directory.  ``sync_catalog`` calls this with
+    ``create=True`` before it builds a publishable catalog; standalone builder
+    calls therefore retain the pre-signature compatibility shape.
+    """
+
+    global _CATALOG_OWNER_SECRET_CACHE
+    path = catalog_owner_secret_path()
+    cached = _CATALOG_OWNER_SECRET_CACHE
+    if cached is not None and cached[0] == path:
+        return cached[1]
+
+    if create:
+        raw = atomic_read_or_create_text(
+            path,
+            lambda: secrets.token_hex(32) + "\n",
+            encoding="ascii",
+            mode=0o600,
+        )
+    else:
+        try:
+            raw = path.read_text(encoding="ascii")
+        except FileNotFoundError:
+            return None
+        except (OSError, UnicodeError) as error:
+            raise ValueError(f"catalog owner secret is unreadable: {path}") from error
+
+    secret = _parse_catalog_owner_secret(raw, path)
+    _CATALOG_OWNER_SECRET_CACHE = (path, secret)
+    return secret
+
+
+def _catalog_owner_canonical_row(model: dict[str, Any]) -> str:
+    """Canonicalize the immutable portion of a managed catalog row.
+
+    Planner fields are the only supported user override surface.  Ownership
+    signatures therefore exclude those fields and the ownership metadata
+    itself, while retaining identity, visibility, limits, descriptions, and
+    every other generated field.  A copied marker cannot authenticate a row
+    whose non-overridable content was replaced.
+    """
+
+    projected = deepcopy(model)
+    for field in CATALOG_OVERRIDE_FIELDS:
+        projected.pop(field, None)
+    metadata = projected.get("codex_proxy_metadata")
+    if isinstance(metadata, dict):
+        metadata = dict(metadata)
+        for key in (
+            CATALOG_OWNER_METADATA_KEY,
+            CATALOG_OWNER_METADATA_VERSION_KEY,
+            CATALOG_OWNER_IDENTITY_KEY,
+            CATALOG_OWNER_SIGNATURE_KEY,
+        ):
+            metadata.pop(key, None)
+        if metadata:
+            projected["codex_proxy_metadata"] = metadata
+        else:
+            projected.pop("codex_proxy_metadata", None)
+    return json.dumps(projected, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def catalog_owner_signature(model: dict[str, Any], secret: bytes) -> str:
+    value = _catalog_owner_canonical_row(model).encode("utf-8")
+    return hmac.new(secret, value, hashlib.sha256).hexdigest()
+
+
+def _catalog_owner_metadata_is_valid(
+    metadata: Any,
+    identity: CatalogModelIdentity,
+    *,
+    require_signature: bool,
+    model: dict[str, Any] | None = None,
+    baseline_model: dict[str, Any] | None = None,
+) -> bool:
+    if not isinstance(metadata, dict):
+        return False
+    if (
+        metadata.get(CATALOG_OWNER_METADATA_KEY) != CATALOG_OWNER_METADATA_VALUE
+        or metadata.get(CATALOG_OWNER_METADATA_VERSION_KEY) != CATALOG_OWNER_METADATA_VERSION
+        or metadata.get(CATALOG_OWNER_IDENTITY_KEY) != catalog_identity_digest(identity)
+    ):
+        return False
+    signature = metadata.get(CATALOG_OWNER_SIGNATURE_KEY)
+    if signature is None:
+        return not require_signature
+    if not isinstance(signature, str) or not re.fullmatch(r"[0-9a-f]{64}", signature):
+        return False
+    try:
+        secret = _load_catalog_owner_secret(create=False)
+    except ValueError:
+        return False
+    if secret is None:
+        return False
+    signed_model = baseline_model or model
+    if signed_model is None:
+        return False
+    if not hmac.compare_digest(signature, catalog_owner_signature(signed_model, secret)):
+        return False
+    if baseline_model is not None and model is not None:
+        return _catalog_owner_canonical_row(model) == _catalog_owner_canonical_row(baseline_model)
+    return True
+
+
+def stamp_catalog_owner_metadata(model: dict[str, Any]) -> None:
+    metadata = dict(model.get("codex_proxy_metadata", {}))
+    metadata[CATALOG_OWNER_METADATA_KEY] = CATALOG_OWNER_METADATA_VALUE
+    metadata[CATALOG_OWNER_METADATA_VERSION_KEY] = CATALOG_OWNER_METADATA_VERSION
+    identity = catalog_model_identity(model)
+    if identity is not None:
+        metadata[CATALOG_OWNER_IDENTITY_KEY] = catalog_identity_digest(identity)
+        secret = _load_catalog_owner_secret(create=False)
+        if secret is not None:
+            metadata[CATALOG_OWNER_SIGNATURE_KEY] = catalog_owner_signature(model, secret)
+        else:
+            # Standalone builder calls may not have a runtime sidecar yet.
+            # A real sync creates the key before publishing and stamps a
+            # signed row; old unsigned rows remain migration-compatible.
+            metadata.pop(CATALOG_OWNER_SIGNATURE_KEY, None)
+    else:
+        metadata.pop(CATALOG_OWNER_SIGNATURE_KEY, None)
+    model["codex_proxy_metadata"] = metadata
+
+
 def official_proxy_alias(slug: str) -> str:
     return f"{OFFICIAL_PROXY_PROVIDER_ALIAS}/{slug}"
 
@@ -1329,6 +2228,7 @@ def build_official_proxy_model(
         }
     )
     model["codex_proxy_metadata"] = proxy_metadata
+    stamp_catalog_owner_metadata(model)
     return model
 
 
@@ -1392,12 +2292,33 @@ def build_ollama_model(
     else:
         model = deepcopy(DEFAULT_OLLAMA_MODEL)
 
+    # Planner metadata is an Official-model contract.  A fallback catalog is
+    # shared input for third-party rows and must never be able to make one of
+    # those rows advertise an Official Code Mode/version.
+    for key in PINNED_OFFICIAL_PLANNER_FIELD_SET:
+        model.pop(key, None)
+    model["use_responses_lite"] = False
     model["slug"] = slug
     model["display_name"] = display_name_for(slug, policy)
     model.setdefault("description", DEFAULT_OLLAMA_MODEL["description"])
     model.setdefault("visibility", "list")
     model.setdefault("supported_in_api", True)
     apply_ollama_model_limits(model, slug, model_metadata or {})
+    inherited_metadata = model.get("codex_proxy_metadata")
+    safe_metadata = {
+        key: inherited_metadata[key]
+        for key in ("context_source", "max_output_source")
+        if isinstance(inherited_metadata, dict) and key in inherited_metadata
+    }
+    safe_metadata.update(
+        {
+            "provider": "ollama-cloud",
+            "upstream_name": "ollama_cloud",
+            "upstream_model": slug,
+        }
+    )
+    model["codex_proxy_metadata"] = safe_metadata
+    stamp_catalog_owner_metadata(model)
     return model
 
 
@@ -1464,6 +2385,13 @@ def build_external_provider_model(
     else:
         model = deepcopy(DEFAULT_OLLAMA_MODEL)
 
+    # Never inherit Official planner fields from the fallback template.  The
+    # third-party catalog may retain the normal explicit false value for
+    # Responses Lite, but it cannot claim a native Official planner contract.
+    for key in PINNED_OFFICIAL_PLANNER_FIELD_SET:
+        model.pop(key, None)
+    model["use_responses_lite"] = False
+
     alias = str(external_model["alias"])
     display_prefix = str(external_model.get("display_prefix") or external_model.get("provider_alias") or "provider")
 
@@ -1511,7 +2439,12 @@ def build_external_provider_model(
     if isinstance(max_output_tokens, int) and max_output_tokens > 0:
         model["max_output_tokens"] = max_output_tokens
 
-    proxy_metadata = dict(model.get("codex_proxy_metadata", {}))
+    inherited_metadata = model.get("codex_proxy_metadata")
+    proxy_metadata = {
+        key: inherited_metadata[key]
+        for key in ("context_source", "max_output_source")
+        if isinstance(inherited_metadata, dict) and key in inherited_metadata
+    }
     proxy_metadata.update(
         {
             "provider": external_model["provider_alias"],
@@ -1534,6 +2467,7 @@ def build_external_provider_model(
             (str(external_model["provider_alias"]), str(external_model["upstream_model"]))
         ),
     )
+    stamp_catalog_owner_metadata(model)
     return model
 
 
@@ -1746,6 +2680,12 @@ def sync_catalog(*, max_age_seconds: int = 0) -> dict[str, Any]:
         state["cache_status"] = "fresh"
         return state
 
+    # Ensure every newly published managed row is authenticated before any
+    # builder stamps its ownership metadata.  Legacy catalogs without a key
+    # are migrated by the normal unsigned compatibility path, then receive a
+    # signed baseline/effective catalog in this sync.
+    _load_catalog_owner_secret(create=True)
+
     policy = load_policy(POLICY_PATH)
     include_official = load_include_official_models()
     official_model_sort_order = load_official_model_sort_order()
@@ -1795,7 +2735,7 @@ def sync_catalog(*, max_age_seconds: int = 0) -> dict[str, Any]:
     if ollama_runtime_configured:
         ollama_model_metadata.update(ollama_provider_model_metadata(runtime_ollama_models))
 
-    catalog = build_codex_catalog(
+    managed_catalog = build_codex_catalog(
         official_models,
         ollama_catalog_ids,
         policy,
@@ -1809,6 +2749,18 @@ def sync_catalog(*, max_age_seconds: int = 0) -> dict[str, Any]:
         use_ollama_policy_allowlist=not ollama_runtime_configured,
         official_source_present=official_snapshot.source_present,
         visibility_diagnostics=official_snapshot.visibility_diagnostics,
+    )
+    # Read the old effective catalog before publishing a new one.  Supplying
+    # this freshly generated catalog gives markerless Beta1 migration a
+    # complete immutable provenance check; the sidecars are still written
+    # below in the same atomic-publication sequence as the catalog itself.
+    catalog_overrides, override_diagnostics = _collect_catalog_overrides(
+        legacy_baseline=managed_catalog,
+    )
+    catalog = _apply_catalog_overrides(
+        deepcopy(managed_catalog),
+        catalog_overrides,
+        override_diagnostics,
     )
     visible_slugs = [str(model["slug"]) for model in catalog["models"] if model.get("slug")]
     previous_visible_slugs = load_previous_visible_models(GENERATED_STATE_PATH)
@@ -1828,9 +2780,18 @@ def sync_catalog(*, max_age_seconds: int = 0) -> dict[str, Any]:
         "external_provider_models": [str(model["alias"]) for model in external_models],
         "visible_models": visible_slugs,
         "diff": diff,
+        "catalog_override_diagnostics": _bounded_catalog_override_diagnostics(
+            override_diagnostics
+        ),
     }
 
+    managed_baseline = dict(managed_catalog)
+    managed_baseline["schema_version"] = CATALOG_OVERRIDE_SCHEMA_VERSION
+    managed_baseline["managed_baseline"] = True
+    override_state = _write_catalog_override_state(catalog_overrides)
     write_json(GENERATED_CATALOG_PATH, catalog)
+    write_json(MANAGED_CATALOG_BASELINE_PATH, managed_baseline)
+    write_json(CATALOG_OVERRIDES_PATH, override_state)
     write_json(GENERATED_STATE_PATH, state)
     return state
 
@@ -1860,6 +2821,16 @@ def main(argv: list[str] | None = None) -> int:
     print(f"visible_models={len(state['visible_models'])}")
     if state.get("cache_status"):
         print(f"cache_status={state['cache_status']}")
+    override_diagnostics = state.get("catalog_override_diagnostics", {})
+    print(f"catalog_override_accepted={override_diagnostics.get('accepted', 0)}")
+    print(f"catalog_override_rejected={override_diagnostics.get('rejected', 0)}")
+    print(f"catalog_override_migrated={override_diagnostics.get('migrated', 0)}")
+    reasons = override_diagnostics.get("reasons", {})
+    if isinstance(reasons, dict):
+        print(
+            "catalog_override_rejection_reasons="
+            + ",".join(f"{key}:{reasons[key]}" for key in sorted(reasons))
+        )
     print(f"added={','.join(diff['added'])}")
     print(f"removed={','.join(diff['removed'])}")
     return 0

--- a/src-python/catalog_sync.py
+++ b/src-python/catalog_sync.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import argparse
 from copy import deepcopy
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 import json
 import os
@@ -15,9 +15,14 @@ from urllib.request import Request, urlopen
 
 from atomic_io import atomic_write_text
 from catalog import (
+    CatalogVisibility,
     CatalogPolicy,
+    MAX_VISIBILITY_DIAGNOSTIC_COUNT,
     canonical_model_id,
+    catalog_visibility_diagnostics,
     display_name_for,
+    is_catalog_model_listable,
+    is_internal_model,
     load_catalog_models,
     load_policy,
     should_include_external_provider_model,
@@ -426,6 +431,10 @@ class OfficialSeedSnapshot:
     models: list[dict[str, Any]]
     source: str
     context_freshness: str
+    source_present: bool = False
+    visibility_diagnostics: dict[str, int] = field(
+        default_factory=lambda: {"hidden": 0, "unknown": 0, "internal": 0}
+    )
 
 
 def _catalog_fetched_at_timestamp(value: Any) -> float | None:
@@ -488,14 +497,51 @@ def load_official_seed_snapshot(
         payload = load_json_file(candidate)
         payload_models = payload.get("models")
         if not isinstance(payload_models, list):
+            if candidate == runtime_path and candidate.exists():
+                freshness = _direct_catalog_context_freshness(payload, now_timestamp)
+                return OfficialSeedSnapshot(
+                    models=[],
+                    source=(
+                        CURRENT_DIRECT_OFFICIAL_SOURCE
+                        if freshness == "fresh"
+                        else "last_known_direct_official"
+                    ),
+                    context_freshness=freshness,
+                    source_present=True,
+                )
             payload_models = []
-        models = [
-            deepcopy(model)
-            for model in payload_models
-            if isinstance(model, dict) and str(model.get("slug", "")).startswith("gpt-")
-        ]
-        if not models:
-            continue
+        reported_diagnostics = payload.get("visibility_diagnostics")
+        if isinstance(reported_diagnostics, dict):
+            def bounded_reported_count(key: str) -> int:
+                value = reported_diagnostics.get(key)
+                return min(
+                    MAX_VISIBILITY_DIAGNOSTIC_COUNT,
+                    value
+                    if isinstance(value, int) and not isinstance(value, bool) and value >= 0
+                    else 0,
+                )
+
+            visibility_diagnostics = {
+                key: bounded_reported_count(key)
+                for key in ("hidden", "unknown", "internal")
+            }
+        else:
+            visibility_diagnostics = catalog_visibility_diagnostics(payload_models)
+        models = []
+        for raw_model in payload_models:
+            if not isinstance(raw_model, dict):
+                continue
+            model = deepcopy(raw_model)
+            if not is_catalog_model_listable(model, missing_is_list=True):
+                continue
+            slug = canonical_model_id(str(model.get("slug", "")))
+            if slug.startswith("openai/gpt-"):
+                slug = slug.removeprefix("openai/")
+            if not slug.startswith("gpt-"):
+                continue
+            model["slug"] = slug
+            model["visibility"] = CatalogVisibility.LIST.value
+            models.append(model)
         if candidate == runtime_path:
             freshness = _direct_catalog_context_freshness(payload, now_timestamp)
             return OfficialSeedSnapshot(
@@ -506,8 +552,17 @@ def load_official_seed_snapshot(
                     else "last_known_direct_official"
                 ),
                 context_freshness=freshness,
+                source_present=True,
+                visibility_diagnostics=visibility_diagnostics,
             )
-        return OfficialSeedSnapshot(models=models, source="bundled_seed", context_freshness="missing")
+        if candidate.exists():
+            return OfficialSeedSnapshot(
+                models=models,
+                source="bundled_seed",
+                context_freshness="missing",
+                source_present=True,
+                visibility_diagnostics=visibility_diagnostics,
+            )
     return OfficialSeedSnapshot(models=[], source="missing", context_freshness="missing")
 
 
@@ -567,6 +622,8 @@ def _direct_official_model_index(
 ) -> dict[str, dict[str, Any]] | None:
     indexed: dict[str, dict[str, Any]] = {}
     for model in models:
+        if is_internal_model(model):
+            continue
         slug = _direct_official_model_identity(model)
         if slug is None or slug in indexed:
             return None
@@ -586,6 +643,8 @@ def _direct_official_cache_model_index(
 
     indexed: dict[str, dict[str, Any]] = {}
     for model in models:
+        if is_internal_model(model):
+            continue
         identities = _direct_official_model_identities(model)
         if identities is None:
             return None
@@ -1229,6 +1288,7 @@ def build_official_proxy_model(
     model["display_name"] = official_short_display_name(slug, model, policy)
     if source_model is None:
         apply_official_model_defaults(model, slug)
+    model["visibility"] = CatalogVisibility.LIST.value
     normalize_official_responses_lite_opt_in(model)
     apply_pinned_official_catalog_metadata(model, slug)
     normalize_official_upgrade_for_codex(model)
@@ -1297,6 +1357,8 @@ def normalize_official_upgrade_for_codex(model: dict[str, Any]) -> None:
 def official_model_index(official_models: Iterable[dict[str, Any]]) -> dict[str, dict[str, Any]]:
     index: dict[str, dict[str, Any]] = {}
     for model in official_models:
+        if not is_catalog_model_listable(model, missing_is_list=True):
+            continue
         raw_slug = canonical_model_id(str(model.get("slug", "")))
         if not raw_slug:
             continue
@@ -1489,12 +1551,23 @@ def build_codex_catalog(
     official_context_signals: dict[str, dict[str, Any]] | None = None,
     use_ollama_policy_allowlist: bool = True,
     fetched_at: str | None = None,
+    official_source_present: bool | None = None,
+    visibility_diagnostics: dict[str, int] | None = None,
 ) -> dict[str, Any]:
     models: list[dict[str, Any]] = []
     seen_slugs: set[str] = set()
+    official_models = list(official_models)
+    if official_source_present is None:
+        official_source_present = bool(official_models)
+    if visibility_diagnostics is None:
+        visibility_diagnostics = catalog_visibility_diagnostics(official_models)
     official_by_slug = official_model_index(official_models)
     disabled_official_slugs = {official_model_disable_key(str(model_id)) for model_id in disabled_official_model_ids or []}
-    official_source_slugs = list(official_by_slug.keys()) or list(policy.official_models)
+    official_source_slugs = (
+        list(official_by_slug.keys())
+        if official_source_present
+        else list(policy.official_models)
+    )
     official_slugs = sort_official_slugs(
         [
             slug
@@ -1547,6 +1620,7 @@ def build_codex_catalog(
     return {
         "fetched_at": fetched_at or utc_now_iso(),
         "client_version": client_version,
+        "visibility_diagnostics": visibility_diagnostics,
         "models": models,
     }
 
@@ -1582,6 +1656,7 @@ def load_cached_state(path: Path = GENERATED_STATE_PATH) -> dict[str, Any]:
         "discovery_status": "cache_missing",
         "discovery_detail": "cached state is missing",
         "metadata_detail": "",
+        "visibility_diagnostics": {"hidden": 0, "unknown": 0, "internal": 0},
         "ollama_model_metadata": {},
         "discovered_ollama_models": [],
         "external_provider_models": [],
@@ -1732,6 +1807,8 @@ def sync_catalog(*, max_age_seconds: int = 0) -> dict[str, Any]:
         disabled_official_model_ids=disabled_official_models,
         official_context_signals=official_context_signals,
         use_ollama_policy_allowlist=not ollama_runtime_configured,
+        official_source_present=official_snapshot.source_present,
+        visibility_diagnostics=official_snapshot.visibility_diagnostics,
     )
     visible_slugs = [str(model["slug"]) for model in catalog["models"] if model.get("slug")]
     previous_visible_slugs = load_previous_visible_models(GENERATED_STATE_PATH)
@@ -1743,6 +1820,9 @@ def sync_catalog(*, max_age_seconds: int = 0) -> dict[str, Any]:
         "discovery_status": discovery_status,
         "discovery_detail": discovery_detail,
         "metadata_detail": metadata_detail,
+        "visibility_diagnostics": catalog.get(
+            "visibility_diagnostics", {"hidden": 0, "unknown": 0, "internal": 0}
+        ),
         "ollama_model_metadata": ollama_model_metadata,
         "discovered_ollama_models": discovered_slugs,
         "external_provider_models": [str(model["alias"]) for model in external_models],

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -95,16 +95,20 @@ from codex_semantic_adapter import (
 )
 
 from catalog import (
+    CatalogVisibility,
     CatalogPolicy,
     canonical_model_id,
     deny_match_model_id,
+    is_internal_model,
     load_catalog_models,
     load_policy,
+    model_visibility,
     should_include_external_provider_model,
     should_include_model,
 )
 from catalog_sync import (
     GENERATED_CATALOG_PATH,
+    LEGACY_GENERATED_CATALOG_PATH,
     POLICY_PATH,
     existing_generated_catalog_path,
     known_official_model_ids as catalog_known_official_model_ids,
@@ -1574,6 +1578,35 @@ class ImageProxyError(Exception):
     """Raised when a Vision Proxy request cannot be prepared safely."""
 
 
+class ModelIdentityResolutionError(ValueError):
+    """Raised when an exact provider/model pair cannot be proven safe.
+
+    ``classification`` is deliberately a small, non-secret vocabulary used by
+    diagnostics and callers.  ``catalog_inconsistency`` means the published
+    snapshot itself is contradictory or ambiguous; ``local_resolution_failure``
+    means the requested identity is absent, internal, stale, or unsupported.
+    """
+
+    CLASSIFICATIONS = frozenset({"catalog_inconsistency", "local_resolution_failure"})
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        classification: str,
+        reason: str,
+        provider_id: str | None = None,
+        model_slug: str | None = None,
+    ) -> None:
+        if classification not in self.CLASSIFICATIONS:
+            raise ValueError(f"unsupported model identity classification: {classification}")
+        self.classification = classification
+        self.reason = reason
+        self.provider_id = provider_id
+        self.model_slug = model_slug
+        super().__init__(message)
+
+
 class UnsupportedRouteProtocolError(ValueError):
     """Raised when a configured route has no executable protocol attempt."""
 
@@ -2405,25 +2438,311 @@ def ollama_cloud_base_url() -> str:
 
 
 def generated_catalog_slugs(path: Path = GENERATED_CATALOG_PATH) -> set[str]:
-    return {
-        canonical_model_id(str(model["slug"]))
-        for model in load_catalog_models(existing_generated_catalog_path(path))
-        if model.get("slug")
-    }
+    return set(generated_catalog_by_slug(path))
 
 
 def generated_catalog_by_slug(path: Path = GENERATED_CATALOG_PATH) -> dict[str, dict[str, Any]]:
+    resolved_path = existing_generated_catalog_path(path)
+    try:
+        if resolved_path.exists():
+            document = json.loads(resolved_path.read_text(encoding="utf-8-sig"))
+            if not isinstance(document, Mapping) or not isinstance(document.get("models"), list):
+                raise ValueError("catalog root must contain a models list")
+        catalog_models = load_catalog_models(resolved_path)
+    except (OSError, ValueError, TypeError, AttributeError) as exc:
+        raise ModelIdentityResolutionError(
+            "published catalog is malformed and cannot authorize routing",
+            classification="catalog_inconsistency",
+            reason="malformed_catalog",
+        ) from exc
     models: dict[str, dict[str, Any]] = {}
-    for model in load_catalog_models(existing_generated_catalog_path(path)):
-        slug = canonical_model_id(str(model.get("slug", "")))
-        if slug:
-            models[slug] = model
+    if not isinstance(catalog_models, list):
+        raise ModelIdentityResolutionError(
+            "published catalog models must be a list",
+            classification="catalog_inconsistency",
+            reason="malformed_catalog",
+        )
+    for model in catalog_models:
+        if not isinstance(model, Mapping):
+            raise ModelIdentityResolutionError(
+                "published catalog contains a non-object model row",
+                classification="catalog_inconsistency",
+                reason="malformed_model_row",
+            )
+        raw_slug_value = model.get("slug")
+        if not isinstance(raw_slug_value, str) or not raw_slug_value.strip():
+            raise ModelIdentityResolutionError(
+                "published catalog contains a model without a slug",
+                classification="catalog_inconsistency",
+                reason="missing_catalog_slug",
+            )
+        raw_slug = canonical_model_id(raw_slug_value)
+        slug = _catalog_identity_slug(raw_slug)
+        if slug in models:
+            raise ModelIdentityResolutionError(
+                "published catalog contains duplicate canonical model identity",
+                classification="catalog_inconsistency",
+                reason="duplicate_canonical_slug",
+                model_slug=slug,
+            )
+        models[slug] = dict(model)
     return models
+
+
+def _catalog_identity_slug(slug: str) -> str:
+    """Return the one route identity key used by the published catalog.
+
+    ``openai/gpt-*`` is a provider-qualified spelling of the same exact
+    Official model slug.  Every other provider namespace remains part of the
+    key; no display name, case-folded alias, or nearest match is introduced.
+    """
+
+    value = canonical_model_id(slug)
+    if value.startswith("openai/gpt-"):
+        return value.removeprefix("openai/")
+    return value
+
+
+def _published_catalog_model(slug: str) -> dict[str, Any] | None:
+    """Resolve one exact slug from the current generated catalog.
+
+    The legacy catalog filename is intentionally not an identity authority.
+    It may still be read by presentation-only compatibility code, but routing
+    refuses to bind a request to it when the current publication is absent.
+    """
+
+    resolved_path = existing_generated_catalog_path(GENERATED_CATALOG_PATH)
+    if resolved_path == LEGACY_GENERATED_CATALOG_PATH:
+        raise ModelIdentityResolutionError(
+            "current generated catalog is missing; legacy catalog cannot authorize routing",
+            classification="catalog_inconsistency",
+            reason="stale_legacy_catalog",
+        )
+    catalog = generated_catalog_by_slug(resolved_path)
+    identity_slug = _catalog_identity_slug(slug)
+    model = catalog.get(identity_slug)
+    if model is None and identity_slug.startswith("gpt-"):
+        # Compatibility with in-memory catalog fixtures that still expose the
+        # pre-#273 provider-qualified key.  On-disk catalogs are normalized by
+        # generated_catalog_by_slug before this branch can be reached.
+        model = catalog.get(f"openai/{identity_slug}")
+    return model
+
+
+def _identity_failure(
+    message: str,
+    *,
+    reason: str,
+    provider_id: str | None = None,
+    model_slug: str | None = None,
+) -> ModelIdentityResolutionError:
+    return ModelIdentityResolutionError(
+        message,
+        classification="local_resolution_failure",
+        reason=reason,
+        provider_id=provider_id,
+        model_slug=model_slug,
+    )
+
+
+def _catalog_failure(
+    message: str,
+    *,
+    reason: str,
+    provider_id: str | None = None,
+    model_slug: str | None = None,
+) -> ModelIdentityResolutionError:
+    return ModelIdentityResolutionError(
+        message,
+        classification="catalog_inconsistency",
+        reason=reason,
+        provider_id=provider_id,
+        model_slug=model_slug,
+    )
+
+
+def _is_internal_route_identity(value: Any) -> bool:
+    """Return whether any route/config identity reserves the internal reviewer slug."""
+
+    values: list[Any]
+    if isinstance(value, Mapping):
+        if is_internal_model(value):
+            return True
+        values = [
+            value.get(key)
+            for key in (
+                "id",
+                "slug",
+                "model",
+                "name",
+                "alias",
+                "matched_alias",
+                "model_id",
+                "upstream_model",
+            )
+        ]
+    else:
+        values = [value]
+
+    for raw_value in values:
+        if not isinstance(raw_value, str):
+            continue
+        identity = canonical_model_id(raw_value).strip().lower()
+        if identity and any(part.strip() == "codex-auto-review" for part in identity.split("/")):
+            return True
+    return False
+
+
+def _safe_error_identity(value: Any) -> str | None:
+    """Keep credential-like or malformed identities out of error payloads."""
+
+    if not isinstance(value, str):
+        return None
+    candidate = value.strip()
+    if not candidate or len(candidate) > 128 or not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._:/-]*", candidate):
+        return None
+    lowered = candidate.lower()
+    if any(marker in lowered for marker in ("bearer", "secret", "token", "password", "api_key", "api-key", "authorization", "cookie")):
+        return None
+    return candidate
+
+
+def _validate_published_catalog_model_for_provider(
+    model: Mapping[str, Any],
+    *,
+    provider_id: str,
+    model_slug: str,
+    expected_upstream_model: str | None = None,
+) -> None:
+    """Reject catalog rows that are internal, unsupported, or cross-provider."""
+
+    if _is_internal_route_identity(model):
+        raise _identity_failure(
+            f"model identity is internal and cannot be routed: {model_slug}",
+            reason="internal_model",
+            provider_id=provider_id,
+            model_slug=model_slug,
+        )
+    visibility = model_visibility(model, missing_is_list=True)
+    if visibility is not CatalogVisibility.LIST:
+        raise _catalog_failure(
+            "published catalog model is not explicitly listable",
+            reason="unsupported_visibility",
+            provider_id=provider_id,
+            model_slug=model_slug,
+        )
+    if "supported_in_api" in model and not isinstance(model["supported_in_api"], bool):
+        raise _catalog_failure(
+            "published catalog model supported_in_api is malformed",
+            reason="malformed_supported_in_api",
+            provider_id=provider_id,
+            model_slug=model_slug,
+        )
+    if model.get("supported_in_api") is False:
+        raise _identity_failure(
+            f"model identity is not supported in the API: {model_slug}",
+            reason="unsupported_model",
+            provider_id=provider_id,
+            model_slug=model_slug,
+        )
+    raw_slug = model.get("slug")
+    if isinstance(raw_slug, str) and canonical_model_id(raw_slug) != canonical_model_id(model_slug):
+        raise _catalog_failure(
+            "published catalog row slug contradicts the requested model slug",
+            reason="configured_model_mismatch",
+            provider_id=provider_id,
+            model_slug=model_slug,
+        )
+    metadata = model.get("codex_proxy_metadata")
+    if "codex_proxy_metadata" in model and not isinstance(metadata, Mapping):
+        raise _catalog_failure(
+            "published catalog model metadata is malformed",
+            reason="malformed_metadata",
+            provider_id=provider_id,
+            model_slug=model_slug,
+        )
+    if isinstance(metadata, Mapping):
+        catalog_provider = canonical_model_id(str(metadata.get("provider") or ""))
+        allowed_providers = {provider_id, provider_id.replace("-", "_")}
+        if not catalog_provider or catalog_provider not in allowed_providers:
+            raise _catalog_failure(
+                f"model identity belongs to another provider: {model_slug}",
+                reason="provider_mismatch",
+                provider_id=provider_id,
+                model_slug=model_slug,
+            )
+        expected_upstream = canonical_model_id(expected_upstream_model or model_slug)
+        catalog_upstream = metadata.get("upstream_model")
+        if not isinstance(catalog_upstream, str) or canonical_model_id(catalog_upstream) != expected_upstream:
+            raise _catalog_failure(
+                "published catalog row upstream_model contradicts the requested model slug",
+                reason="upstream_model_mismatch",
+                provider_id=provider_id,
+                model_slug=model_slug,
+            )
+        catalog_upstream_name = canonical_model_id(str(metadata.get("upstream_name") or ""))
+        if catalog_upstream_name not in allowed_providers:
+            raise _catalog_failure(
+                "published catalog row upstream_name contradicts the provider identity",
+                reason="upstream_name_mismatch",
+                provider_id=provider_id,
+                model_slug=model_slug,
+            )
+
+
+def _provider_catalog_failure(
+    message: str,
+    *,
+    provider_id: str,
+    model_slug: str,
+) -> ModelIdentityResolutionError:
+    """Wrap provider-index parse/collision failures as stable catalog errors."""
+
+    return _catalog_failure(
+        message,
+        reason="provider_model_index_inconsistency",
+        provider_id=provider_id,
+        model_slug=model_slug,
+    )
+
+
+def _resolve_external_model_alias(slug: str) -> dict[str, Any] | None:
+    """Resolve one configured external model without leaking raw config errors."""
+
+    try:
+        return resolve_external_model_alias(slug)
+    except ModelIdentityResolutionError:
+        raise
+    except ValueError as exc:
+        raise _provider_catalog_failure(
+            "external provider model index is inconsistent",
+            provider_id=slug.partition("/")[0] or "external",
+            model_slug=slug,
+        ) from exc
+
+
+def _resolve_ollama_cloud_model(
+    model_id: str,
+    *,
+    require_api_key: bool,
+) -> tuple[bool, dict[str, Any] | None]:
+    """Resolve Ollama Cloud configuration with catalog-level diagnostics."""
+
+    try:
+        return resolve_ollama_cloud_model(model_id, require_api_key=require_api_key)
+    except ModelIdentityResolutionError:
+        raise
+    except ValueError as exc:
+        raise _provider_catalog_failure(
+            "Ollama Cloud model index is inconsistent",
+            provider_id="ollama-cloud",
+            model_slug=canonical_model_id(model_id),
+        ) from exc
 
 
 def catalog_max_output_tokens(model_id: str) -> int | None:
     slug = canonical_model_id(model_id)
-    model = generated_catalog_by_slug().get(slug)
+    model = generated_catalog_by_slug().get(_catalog_identity_slug(slug))
     if not model:
         cap = UPSTREAM_MAX_OUTPUT_TOKEN_CAPS.get(slug)
         return cap if isinstance(cap, int) and cap > 0 else None
@@ -2455,14 +2774,58 @@ def generated_official_catalog_upstream_model(slug: str, policy: Any) -> str | N
         return None
 
     alias = f"{OFFICIAL_ALIAS_PREFIX}{upstream_model}"
-    catalog = generated_catalog_by_slug()
-    model = catalog.get(upstream_model) or catalog.get(alias)
-    if not model or model.get("supported_in_api") is False:
+    model = _published_catalog_model(upstream_model)
+    if not model:
         return None
+    if _is_internal_route_identity(model):
+        raise _identity_failure(
+            f"model identity is internal and cannot be routed: {slug}",
+            reason="internal_model",
+            provider_id="openai",
+            model_slug=upstream_model,
+        )
+    if model_visibility(model, missing_is_list=True) is not CatalogVisibility.LIST:
+        raise _catalog_failure(
+            "published catalog model is not explicitly listable",
+            reason="unsupported_visibility",
+            provider_id="openai",
+            model_slug=upstream_model,
+        )
+    if "supported_in_api" in model and not isinstance(model["supported_in_api"], bool):
+        raise _catalog_failure(
+            "official catalog model supported_in_api is malformed",
+            reason="malformed_supported_in_api",
+            provider_id="openai",
+            model_slug=upstream_model,
+        )
+    if model.get("supported_in_api") is False:
+        raise _identity_failure(
+            f"model identity is not supported in the API: {slug}",
+            reason="unsupported_model",
+            provider_id="openai",
+            model_slug=upstream_model,
+        )
 
     metadata = model.get("codex_proxy_metadata")
-    if not isinstance(metadata, dict):
-        return None
+    if "codex_proxy_metadata" in model and not isinstance(metadata, Mapping):
+        raise _catalog_failure(
+            "official catalog model metadata is malformed",
+            reason="malformed_metadata",
+            provider_id="openai",
+            model_slug=upstream_model,
+        )
+    if not isinstance(metadata, Mapping):
+        # The bundled policy is an authoritative identity for the legacy
+        # gpt-5.5 route.  All newly discovered Official rows must carry the
+        # generated metadata binding.
+        if upstream_model == "gpt-5.5" and should_include_model(upstream_model, policy):
+            return upstream_model
+        raise _catalog_failure(
+            "official catalog row is missing its upstream identity binding",
+            reason="missing_catalog_metadata",
+            provider_id="openai",
+            model_slug=upstream_model,
+        )
     catalog_upstream = canonical_model_id(str(metadata.get("upstream_model", "")))
     if (
         metadata.get("provider") != "openai"
@@ -2470,9 +2833,19 @@ def generated_official_catalog_upstream_model(slug: str, policy: Any) -> str | N
         or catalog_upstream != upstream_model
         or not catalog_upstream.startswith(official_prefixes())
     ):
-        return None
+        raise _catalog_failure(
+            "official catalog row has contradictory upstream identity metadata",
+            reason="upstream_model_mismatch",
+            provider_id="openai",
+            model_slug=upstream_model,
+        )
     if policy_denies_any_model((slug, alias, catalog_upstream), policy):
-        raise ValueError(f"model is not allowed: {slug}")
+        raise _identity_failure(
+            f"model is not allowed: {slug}",
+            reason="denied_model",
+            provider_id="openai",
+            model_slug=upstream_model,
+        )
     return catalog_upstream
 
 
@@ -2481,10 +2854,17 @@ def official_alias_upstream_model(slug: str, policy: Any) -> str | None:
         return None
     upstream_model = slug[len(OFFICIAL_ALIAS_PREFIX) :]
     if policy_denies_any_model((slug, upstream_model), policy):
-        raise ValueError(f"model is not allowed: {slug}")
-    if upstream_model.startswith(official_prefixes()) and should_include_model(upstream_model, policy):
-        return upstream_model
-    return None
+        raise _identity_failure(
+            f"model is not allowed: {slug}",
+            reason="denied_model",
+            provider_id="openai",
+            model_slug=upstream_model,
+        )
+    if not upstream_model.startswith(official_prefixes()):
+        return None
+    # Provider qualification is presentation-neutral only after the exact
+    # bare Official slug is proven by the current catalog.
+    return generated_official_catalog_upstream_model(slug, policy)
 
 
 def official_fast_variant_upstream_model(slug: str, policy: Any) -> str | None:
@@ -2494,10 +2874,18 @@ def official_fast_variant_upstream_model(slug: str, policy: Any) -> str | None:
         return None
     upstream_alias = f"{OFFICIAL_ALIAS_PREFIX}{upstream_model}"
     if policy_denies_any_model((slug, fast_model, upstream_model, upstream_alias), policy):
-        raise ValueError(f"model is not allowed: {slug}")
-    if upstream_model.startswith(official_prefixes()) and should_include_model(upstream_model, policy):
-        return upstream_model
-    return None
+        raise _identity_failure(
+            f"model is not allowed: {slug}",
+            reason="denied_model",
+            provider_id="openai",
+            model_slug=fast_model,
+        )
+    if not upstream_model.startswith(official_prefixes()):
+        return None
+    resolved = generated_official_catalog_upstream_model(upstream_model, policy)
+    if resolved is None:
+        return None
+    return resolved
 
 
 OLLAMA_CLOUD_ALIAS_PREFIX = "ollama-cloud/"
@@ -2532,21 +2920,66 @@ def provider_scoped_route_model(model_id: str | None, provider_hint: str | None)
 
 
 def ollama_cloud_runtime_upstream(model_id: str, policy: Any) -> dict[str, Any] | None:
-    configured, runtime_model = resolve_ollama_cloud_model(model_id, require_api_key=False)
+    configured, runtime_model = _resolve_ollama_cloud_model(
+        model_id,
+        require_api_key=False,
+    )
     if not configured:
         return None
     slug = canonical_model_id(model_id)
     if runtime_model is None:
-        raise ValueError(f"model is not allowed: {slug}")
+        raise _identity_failure(
+            f"model is not allowed: {slug}",
+            reason="unsupported_model",
+            provider_id="ollama-cloud",
+            model_slug=slug,
+        )
+    if _is_internal_route_identity(slug) or _is_internal_route_identity(runtime_model):
+        raise _identity_failure(
+            f"model identity is internal and cannot be routed: {slug}",
+            reason="internal_model",
+            provider_id="ollama-cloud",
+            model_slug=slug,
+        )
+    if runtime_model.get("matched_alias"):
+        raise _identity_failure(
+            "model aliases are presentation-only and cannot authorize routing",
+            reason="model_alias_not_routable",
+            provider_id="ollama-cloud",
+            model_slug=slug,
+        )
 
     policy_alias = runtime_model.get("alias", f"{OLLAMA_CLOUD_ALIAS_PREFIX}{slug}")
-    upstream_model = runtime_model.get("upstream_model", slug)
+    upstream_model = runtime_model.get("upstream_model")
+    if not isinstance(upstream_model, str) or not upstream_model.strip():
+        raise _catalog_failure(
+            "Ollama Cloud configuration is missing upstream_model",
+            reason="missing_upstream_model",
+            provider_id="ollama-cloud",
+            model_slug=slug,
+        )
+    upstream_model = upstream_model.strip()
+    configured_id = canonical_model_id(str(runtime_model.get("model_id") or slug))
+    if configured_id != slug and configured_id != f"{OLLAMA_CLOUD_ALIAS_PREFIX}{slug}":
+        raise _catalog_failure(
+            "Ollama Cloud configuration model identity does not match the request",
+            reason="configured_model_mismatch",
+            provider_id="ollama-cloud",
+            model_slug=slug,
+        )
     if policy_denies_any_model((slug, policy_alias, upstream_model), policy):
-        raise ValueError(f"model is not allowed: {slug}")
+        raise _identity_failure(
+            f"model is not allowed: {slug}",
+            reason="denied_model",
+            provider_id="ollama-cloud",
+            model_slug=slug,
+        )
 
     api_key = runtime_model.get("api_key")
     upstream: dict[str, Any] = {
         "name": "ollama_cloud",
+        "provider_id": "ollama-cloud",
+        "model_id": slug,
         "base_url": runtime_model.get("base_url") or ollama_cloud_base_url(),
         "auth": "api_key" if api_key else "ollama_api_key",
         "upstream_model": upstream_model,
@@ -2572,18 +3005,42 @@ def ollama_cloud_alias_upstream_model(slug: str, policy: Any) -> dict[str, Any] 
     if not upstream_model:
         return None
     if policy_denies_any_model((slug, upstream_model), policy):
-        raise ValueError(f"model is not allowed: {slug}")
+        raise _identity_failure(
+            f"model is not allowed: {slug}",
+            reason="denied_model",
+            provider_id="ollama-cloud",
+            model_slug=slug,
+        )
 
     runtime_upstream = ollama_cloud_runtime_upstream(slug, policy)
     if runtime_upstream is not None:
         return runtime_upstream
 
     if not (should_include_model(slug, policy) or should_include_model(upstream_model, policy)):
-        raise ValueError(f"model is not allowed: {slug}")
-    if upstream_model not in generated_catalog_slugs():
-        raise ValueError(f"model is not in the generated cloud catalog: {upstream_model}")
+        raise _identity_failure(
+            f"model is not allowed: {slug}",
+            reason="unsupported_model",
+            provider_id="ollama-cloud",
+            model_slug=slug,
+        )
+    model = _published_catalog_model(slug)
+    if model is None:
+        raise _identity_failure(
+            f"model is not in the generated cloud catalog: {upstream_model}",
+            reason="missing_catalog_model",
+            provider_id="ollama-cloud",
+            model_slug=slug,
+        )
+    _validate_published_catalog_model_for_provider(
+        model,
+        provider_id="ollama-cloud",
+        model_slug=slug,
+        expected_upstream_model=upstream_model,
+    )
     return {
         "name": "ollama_cloud",
+        "provider_id": "ollama-cloud",
+        "model_id": slug,
         "base_url": ollama_cloud_base_url(),
         "auth": "ollama_api_key",
         "upstream_model": upstream_model,
@@ -2615,6 +3072,8 @@ def choose_upstream(model_id: str) -> dict[str, Any]:
     if official_fast_variant is not None:
         return {
             "name": "official",
+            "provider_id": "openai",
+            "model_id": slug,
             "base_url": official_base_url(),
             "auth": "codex_auth",
             "upstream_model": official_fast_variant,
@@ -2626,6 +3085,8 @@ def choose_upstream(model_id: str) -> dict[str, Any]:
     if official_alias is not None:
         return {
             "name": "official",
+            "provider_id": "openai",
+            "model_id": slug,
             "base_url": official_base_url(),
             "auth": "codex_auth",
             "upstream_model": official_alias,
@@ -2636,6 +3097,8 @@ def choose_upstream(model_id: str) -> dict[str, Any]:
     if discovered_official is not None:
         return {
             "name": "official",
+            "provider_id": "openai",
+            "model_id": slug,
             "base_url": official_base_url(),
             "auth": "codex_auth",
             "upstream_model": discovered_official,
@@ -2647,24 +3110,65 @@ def choose_upstream(model_id: str) -> dict[str, Any]:
         return ollama_alias
 
     if slug.startswith(official_prefixes()):
-        if not should_include_model(slug, policy):
-            raise ValueError(f"model is not allowed: {slug}")
-        return {
-            "name": "official",
-            "base_url": official_base_url(),
-            "auth": "codex_auth",
-            "reports_cached_input_tokens": True,
-        }
+        raise _identity_failure(
+            f"model is not in the generated Official catalog: {slug}",
+            reason="missing_catalog_model",
+            provider_id="openai",
+            model_slug=slug,
+        )
 
-    external_model = resolve_external_model_alias(slug)
+    external_model = _resolve_external_model_alias(slug)
     if external_model is not None:
+        if _is_internal_route_identity(slug) or _is_internal_route_identity(external_model):
+            raise _identity_failure(
+                f"model identity is internal and cannot be routed: {slug}",
+                reason="internal_model",
+                provider_id=str(external_model.get("provider_alias") or "") or None,
+                model_slug=slug,
+            )
         policy_alias = external_model.get("alias", slug)
         if policy_denies_any_model((slug, policy_alias, external_model.get("matched_alias")), policy):
-            raise ValueError(f"model is not allowed: {slug}")
+            raise _identity_failure(
+                f"model is not allowed: {slug}",
+                reason="denied_model",
+                provider_id=str(external_model.get("provider_alias") or "") or None,
+                model_slug=slug,
+            )
         if not should_include_external_provider_model(policy_alias, policy):
-            raise ValueError(f"model is not allowed: {slug}")
+            raise _identity_failure(
+                f"model is not allowed: {slug}",
+                reason="unsupported_model",
+                provider_id=str(external_model.get("provider_alias") or "") or None,
+                model_slug=slug,
+            )
+        provider_id = canonical_model_id(str(external_model.get("provider_alias") or ""))
+        configured_model = canonical_model_id(str(external_model.get("alias") or ""))
+        upstream_model_value = external_model.get("upstream_model")
+        if not provider_id or not configured_model or not isinstance(upstream_model_value, str) or not upstream_model_value.strip():
+            raise _catalog_failure(
+                "external provider configuration is missing exact model identity",
+                reason="missing_upstream_model",
+                provider_id=provider_id or None,
+                model_slug=slug,
+            )
+        if configured_model != slug:
+            raise _identity_failure(
+                "model aliases are presentation-only and cannot authorize routing",
+                reason="model_alias_not_routable",
+                provider_id=provider_id,
+                model_slug=slug,
+            )
+        if canonical_model_id(upstream_model_value).lower() == "codex-auto-review":
+            raise _identity_failure(
+                f"model identity is internal and cannot be routed: {slug}",
+                reason="internal_model",
+                provider_id=provider_id,
+                model_slug=slug,
+            )
         return {
             "name": external_model["upstream_name"],
+            "provider_id": provider_id,
+            "model_id": slug,
             "base_url": external_model["base_url"],
             "auth": "api_key",
             "api_key": external_model["api_key"],
@@ -2683,29 +3187,55 @@ def choose_upstream(model_id: str) -> dict[str, Any]:
         }
 
     if "/" in slug:
-        raise ValueError(f"external provider model is not configured: {slug}")
+        raise _identity_failure(
+            f"external provider model is not configured: {slug}",
+            reason="unsupported_model",
+            provider_id=slug.partition("/")[0],
+            model_slug=slug,
+        )
 
     runtime_ollama = ollama_cloud_runtime_upstream(slug, policy)
     if runtime_ollama is not None:
         return runtime_ollama
 
     if not should_include_model(slug, policy):
-        raise ValueError(f"model is not allowed: {slug}")
+        raise _identity_failure(
+            f"model is not allowed: {slug}",
+            reason="unsupported_model",
+            provider_id="ollama-cloud",
+            model_slug=slug,
+        )
 
-    if slug in generated_catalog_slugs():
+    model = _published_catalog_model(slug)
+    if model is not None:
+        _validate_published_catalog_model_for_provider(
+            model,
+            provider_id="ollama-cloud",
+            model_slug=slug,
+            expected_upstream_model=slug,
+        )
         return {
             "name": "ollama_cloud",
+            "provider_id": "ollama-cloud",
+            "model_id": slug,
             "base_url": ollama_cloud_base_url(),
             "auth": "ollama_api_key",
             "reports_cached_input_tokens": False,
+            "upstream_model": slug,
         }
 
-    raise ValueError(f"model is not in the generated cloud catalog: {slug}")
+    raise _identity_failure(
+        f"model is not in the generated cloud catalog: {slug}",
+        reason="missing_catalog_model",
+        provider_id="ollama-cloud",
+        model_slug=slug,
+    )
 
 
 def official_upstream() -> dict[str, Any]:
     return {
         "name": "official",
+        "provider_id": "openai",
         "base_url": official_base_url(),
         "auth": "codex_auth",
         "reports_cached_input_tokens": True,
@@ -2752,7 +3282,9 @@ def _reasoning_policy_for_request(
         return "explicit"
     levels = upstream.get("supported_reasoning_levels")
     if not levels and model:
-        candidate = generated_catalog_by_slug().get(canonical_model_id(model))
+        candidate = generated_catalog_by_slug().get(
+            _catalog_identity_slug(canonical_model_id(model))
+        )
         if isinstance(candidate, Mapping):
             levels = candidate.get("supported_reasoning_levels")
     if levels:
@@ -11777,6 +12309,75 @@ def _route_protocol(value: Any) -> RouteProtocol:
         return RouteProtocol.UNKNOWN
 
 
+def _route_provider_id(upstream: Mapping[str, Any], requested_provider: str | None = None) -> str:
+    """Return the stable exported provider ID, never the transport name."""
+
+    configured = upstream.get("provider_id") or upstream.get("provider_alias")
+    if isinstance(configured, str) and configured.strip():
+        return canonical_model_id(configured.strip())
+    if requested_provider:
+        return canonical_model_id(requested_provider)
+    return {
+        "official": "openai",
+        "ollama_cloud": "ollama-cloud",
+        "ollama-cloud": "ollama-cloud",
+        "volcengine": "volc",
+        "minimax_cn": "minimax-cn",
+    }.get(str(upstream.get("name") or ""), canonical_model_id(str(upstream.get("name") or "")))
+
+
+def _validate_route_identity(
+    upstream: Mapping[str, Any],
+    *,
+    requested_provider: str,
+    requested_model: str,
+    requested_model_id: str,
+) -> tuple[str, str]:
+    """Validate that route metadata binds exactly to the requested pair."""
+
+    provider_id = _route_provider_id(upstream, requested_provider or None)
+    if requested_provider and provider_id != _route_provider_id({"provider_id": requested_provider}, requested_provider):
+        raise _identity_failure(
+            "resolved upstream provider does not match the requested provider",
+            reason="provider_mismatch",
+            provider_id=requested_provider,
+            model_slug=requested_model_id,
+        )
+    upstream_model_value = upstream.get("upstream_model")
+    if not isinstance(upstream_model_value, str) or not upstream_model_value.strip():
+        raise _identity_failure(
+            "resolved upstream is missing an exact upstream_model binding",
+            reason="missing_upstream_model",
+            provider_id=provider_id or requested_provider or None,
+            model_slug=requested_model_id,
+        )
+    upstream_model = canonical_model_id(upstream_model_value.strip())
+    if not upstream_model:
+        raise _identity_failure(
+            "resolved upstream has an empty upstream_model binding",
+            reason="missing_upstream_model",
+            provider_id=provider_id or requested_provider or None,
+            model_slug=requested_model_id,
+        )
+    if upstream.get("model_id") is not None:
+        configured_model_id = canonical_model_id(str(upstream.get("model_id")))
+        if configured_model_id != requested_model_id:
+            raise _catalog_failure(
+                "resolved upstream model_id contradicts the requested model slug",
+                reason="configured_model_mismatch",
+                provider_id=provider_id,
+                model_slug=requested_model_id,
+            )
+    elif upstream_model != canonical_model_id(requested_model if requested_provider else requested_model_id):
+        raise _catalog_failure(
+            "resolved upstream upstream_model contradicts the requested model slug",
+            reason="configured_model_mismatch",
+            provider_id=provider_id,
+            model_slug=requested_model_id,
+        )
+    return provider_id, upstream_model
+
+
 def _authentication_strategy(value: Any) -> AuthenticationStrategy:
     try:
         return AuthenticationStrategy(str(value))
@@ -12236,17 +12837,21 @@ def route_plan_for_request(
     requested_provider, separator, requested_model = (
         requested_model_id.partition("/")
     )
-    binding_provider_id = str(
-        upstream.get("provider_id")
-        or upstream.get("provider_alias")
-        or (
-            requested_provider
-            if separator and upstream_name != "official"
-            else upstream_name
+    resolved_provider_id = _route_provider_id(upstream, requested_provider if separator else None)
+    resolved_upstream_model: str | None = None
+    if requested_model_id:
+        resolved_provider_id, resolved_upstream_model = _validate_route_identity(
+            upstream,
+            requested_provider=requested_provider if separator else resolved_provider_id,
+            requested_model=requested_model if separator else requested_model_id,
+            requested_model_id=requested_model_id,
         )
+    binding_provider_id = str(
+        resolved_provider_id
     )
     binding_model_id = str(
         (requested_model if separator else requested_model_id)
+        or resolved_upstream_model
         or upstream.get("upstream_model")
         or ""
     )
@@ -12577,12 +13182,7 @@ def route_plan_for_request(
         if canonical_route_model or model_requested
         else None
     )
-    upstream_model_value = upstream.get("upstream_model")
-    upstream_model = (
-        canonical_model_id(str(upstream_model_value))
-        if upstream_model_value
-        else canonical_model
-    )
+    upstream_model = resolved_upstream_model
     (
         manifest_version,
         manifest_hash,
@@ -12592,7 +13192,7 @@ def route_plan_for_request(
     )
     return RoutePlan(
         schema_version=ROUTE_PLAN_SCHEMA_VERSION,
-        provider_id=upstream_name,
+        provider_id=resolved_provider_id,
         model_requested=model_requested,
         canonical_model=canonical_model,
         upstream_model=upstream_model,
@@ -13495,7 +14095,7 @@ def _catalog_input_modalities(model_id: str | None, upstream: Mapping[str, Any] 
 
     catalog = generated_catalog_by_slug()
     for candidate in dict.fromkeys(candidates):
-        model = catalog.get(candidate)
+        model = catalog.get(_catalog_identity_slug(candidate))
         if isinstance(model, Mapping) and "input_modalities" in model:
             return model.get("input_modalities")
     return None
@@ -14595,6 +15195,12 @@ def _typed_error_code(
     exc: BaseException | None,
     status: int | None,
 ) -> str:
+    if isinstance(exc, ModelIdentityResolutionError):
+        return (
+            "catalog.inconsistency"
+            if exc.classification == "catalog_inconsistency"
+            else "gateway.model_resolution"
+        )
     if error_type == "gateway_auth_error":
         return "gateway.auth"
     if error_type == "gateway_pre_response_budget_exhausted":
@@ -14647,6 +15253,15 @@ def _codexhub_error_payload(
         "error": error_code,
         "type": error_type,
     }
+    if isinstance(exc, ModelIdentityResolutionError):
+        details["classification"] = exc.classification
+        details["reason"] = exc.reason
+        safe_provider_id = _safe_error_identity(exc.provider_id)
+        safe_model_slug = _safe_error_identity(exc.model_slug)
+        if safe_provider_id:
+            details["provider_id"] = safe_provider_id
+        if safe_model_slug:
+            details["model_slug"] = safe_model_slug
     if status is not None:
         details["status"] = status
     if resolved_failure_class is not None:
@@ -17296,6 +17911,57 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 detail=detail,
                 redact_identity=identity,
                 error_type=error_code,
+            )
+        except ModelIdentityResolutionError as exc:
+            if admission.cancelled:
+                send_user_requested_shutdown()
+                return
+            error_code = "model_identity_error"
+            identity = _retry_identity_from_context(adapter_event_context)
+            detail = safe_upstream_error_detail(exc, redact_identity=identity)
+            detail = _redact_identity_in_text(detail, exc.model_slug)
+            write_proxy_event(
+                "request_error",
+                request_id=request_id,
+                model=canonical_model_id(model) if model else None,
+                model_requested=model_requested,
+                upstream=upstream_name or "gateway",
+                provider_hint=provider_hint,
+                upstream_format=upstream_format,
+                behavior_profile=behavior_profile,
+                inbound_format=inbound_format,
+                status=400,
+                error=error_code,
+                detail=detail,
+                identity_classification=exc.classification,
+                identity_reason=exc.reason,
+                duration_ms=int((time.monotonic() - started_at) * 1000),
+                **proxy_request_context,
+            )
+            if downstream_sse_started:
+                if not self._write_downstream_sse_error(
+                    inbound_format=inbound_format,
+                    upstream_name=upstream_name or "gateway",
+                    status=400,
+                    exc=exc,
+                    error=error_code,
+                    detail=detail,
+                    error_type=error_code,
+                    redact_identity=identity,
+                    preserve_explicit_error=True,
+                ):
+                    finish_downstream_write_failure()
+                return
+            self._safe_send_downstream_json_error(
+                400,
+                inbound_format=inbound_format,
+                upstream_name=upstream_name or "gateway",
+                request_id=request_id,
+                exc=exc,
+                error=error_code,
+                detail=detail,
+                error_type=error_code,
+                redact_identity=identity,
             )
         except ImageProxyError as exc:
             if admission.cancelled:

--- a/src-python/config_overlay.py
+++ b/src-python/config_overlay.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 import argparse
 from dataclasses import dataclass
+import hmac
 import json
+import os
 from pathlib import Path
+import secrets
 
-from atomic_io import atomic_write_text
+from atomic_io import atomic_read_or_create_text, atomic_write_text
 from model_limits import (
     CURRENT_DIRECT_OFFICIAL_SOURCE,
     DEGRADED_LAST_KNOWN_OFFICIAL_SOURCE,
@@ -26,6 +29,12 @@ PROXY_FEATURE_FLAGS = {
 PROXY_PROVIDER_ID = "custom"
 PROXY_PROVIDER_NAME = "Codex Proxy"
 UNIFIED_OFFICIAL_PROVIDER_NAME = "OpenAI"
+CATALOG_OWNER_MARKER = "# catalog_owner = codexhub"
+CATALOG_OWNER_SECRET_FILENAME = ".codexhub-catalog-owner-key"
+MANAGED_CATALOG_FILENAMES = {
+    "codexhub-model-catalog.json",
+    "codex-proxy-official-ollama.json",
+}
 STALE_PROXY_PROVIDER_SECTIONS = (
     "model_providers.openai",
     "model_providers.custom",
@@ -85,9 +94,45 @@ def strip_section(text: str, section_name: str) -> str:
     return "".join(result)
 
 
+def _toml_value_without_comment(raw: str) -> str:
+    quote: str | None = None
+    index = 0
+    while index < len(raw):
+        char = raw[index]
+        if quote == "'":
+            if char == "'":
+                if index + 1 < len(raw) and raw[index + 1] == "'":
+                    index += 2
+                    continue
+                quote = None
+        elif quote == '"':
+            if char == "\\":
+                index += 2
+                continue
+            if char == '"':
+                quote = None
+        elif char in {"'", '"'}:
+            quote = char
+        elif char == "#":
+            return raw[:index].rstrip()
+        index += 1
+    return raw.strip()
+
+
+def _decode_toml_string(raw: str) -> str:
+    if len(raw) >= 2 and raw[0] == raw[-1] and raw[0] in {"'", '"'}:
+        if raw[0] == "'":
+            return raw[1:-1].replace("''", "'")
+        try:
+            return json.loads(raw)
+        except (TypeError, ValueError):
+            return raw[1:-1]
+    return raw
+
+
 def top_level_value(text: str, key: str) -> str | None:
     in_top_level = True
-    key_pattern = re.compile(rf"^\s*{re.escape(key)}\s*=\s*(.+?)\s*(?:#.*)?$")
+    key_pattern = re.compile(rf"^\s*{re.escape(key)}\s*=\s*(.*)$")
     for line in text.splitlines():
         if re.match(r"^\s*\[", line):
             in_top_level = False
@@ -96,11 +141,105 @@ def top_level_value(text: str, key: str) -> str | None:
         match = key_pattern.match(line)
         if not match:
             continue
-        raw = match.group(1).strip()
-        if len(raw) >= 2 and raw[0] == raw[-1] and raw[0] in {"'", '"'}:
-            return raw[1:-1]
-        return raw
+        raw = _toml_value_without_comment(match.group(1))
+        return _decode_toml_string(raw)
     return None
+
+
+def _looks_like_managed_catalog_path(value: str | None) -> bool:
+    """Recognize only the standard CodexHub catalog location shape.
+
+    A custom path may use the same basename, so a basename alone is not an
+    ownership proof.  The managed catalogs are always emitted below a
+    ``model-catalogs`` directory (or as the documented relative path).
+    """
+
+    if not isinstance(value, str) or not value.strip():
+        return False
+    normalized = value.strip().replace("\\", "/").rstrip("/")
+    parts = [part for part in normalized.split("/") if part]
+    if not parts or parts[-1] not in MANAGED_CATALOG_FILENAMES:
+        return False
+    # The documented relative handoff is unambiguous.  Absolute paths are
+    # owned only when they resolve below the active CODEX_HOME; an unrelated
+    # custom directory containing the same basename remains user-owned.
+    if len(parts) == 2 and parts[0] == "model-catalogs":
+        return True
+    try:
+        codex_home = Path(os.environ.get("CODEX_HOME") or (Path.home() / ".codex"))
+        candidate = Path(value).expanduser().resolve()
+        return candidate == (codex_home / "model-catalogs" / parts[-1]).resolve()
+    except (OSError, RuntimeError, ValueError):
+        return False
+
+
+def _catalog_owner_secret_path(catalog_value: str) -> Path:
+    return Path(catalog_value).expanduser().resolve().parent / CATALOG_OWNER_SECRET_FILENAME
+
+
+def _load_catalog_owner_secret(catalog_value: str, *, create: bool) -> bytes | None:
+    path = _catalog_owner_secret_path(catalog_value)
+    if create:
+        raw = atomic_read_or_create_text(
+            path,
+            lambda: secrets.token_hex(32) + "\n",
+            encoding="ascii",
+            mode=0o600,
+        )
+    else:
+        try:
+            raw = path.read_text(encoding="ascii").strip()
+        except FileNotFoundError:
+            return None
+        except (OSError, UnicodeError):
+            return None
+    try:
+        secret = bytes.fromhex(raw.strip())
+    except ValueError:
+        return None
+    return secret if len(secret) == 32 else None
+
+
+def _catalog_owner_marker_digest(catalog_value: str, *, create: bool) -> str | None:
+    secret = _load_catalog_owner_secret(catalog_value, create=create)
+    if secret is None:
+        return None
+    normalized = str(Path(catalog_value).expanduser().resolve())
+    return hmac.new(secret, normalized.encode("utf-8"), "sha256").hexdigest()
+
+
+def _overlay_marks_managed_catalog(text: str) -> bool:
+    marker_pattern = re.compile(
+        rf"(?ms)^\s*{re.escape(MARKER_BEGIN)}\s*$.*?^\s*{re.escape(MARKER_END)}\s*$"
+    )
+    match = marker_pattern.search(text)
+    if not match:
+        return False
+    block = match.group(0)
+    catalog_value = top_level_value(block, "model_catalog_json")
+    if not catalog_value:
+        return False
+    marker = re.search(
+        rf"(?m)^\s*{re.escape(CATALOG_OWNER_MARKER)}:([0-9a-f]{{64}})\s*$",
+        block,
+    )
+    if marker is None:
+        return False
+    digest = _catalog_owner_marker_digest(catalog_value, create=False)
+    return digest is not None and hmac.compare_digest(marker.group(1), digest)
+
+
+def is_managed_catalog_path(value: str | None, managed_path: Path | None = None) -> bool:
+    """Return whether a config path is owned by CodexHub's catalog layer."""
+
+    if managed_path is not None and isinstance(value, str) and value.strip():
+        try:
+            candidate = Path(value).expanduser().resolve()
+            if candidate == managed_path.expanduser().resolve():
+                return True
+        except (OSError, RuntimeError, ValueError):
+            pass
+    return _looks_like_managed_catalog_path(value)
 
 
 def set_top_level_values(text: str, values: dict[str, str | None]) -> str:
@@ -534,6 +673,7 @@ class UnifiedConfigState:
     custom_section: dict[str, str] | None
     exact_unified: bool
     managed_gateway: bool
+    managed_catalog: bool
     stale_catalog: bool
 
 
@@ -560,12 +700,14 @@ def is_managed_gateway_provider(values: dict[str, str] | None) -> bool:
 def unified_config_state(text: str) -> UnifiedConfigState:
     provider_id = top_level_value(text, "model_provider")
     custom_section = section_key_values(text, f"model_providers.{PROXY_PROVIDER_ID}")
+    managed_catalog = is_managed_catalog_path(top_level_value(text, "model_catalog_json")) or _overlay_marks_managed_catalog(text)
     return UnifiedConfigState(
         provider_id=provider_id,
         custom_section=custom_section,
         exact_unified=custom_section == unified_official_provider_values(),
         managed_gateway=is_managed_gateway_provider(custom_section),
-        stale_catalog=top_level_value(text, "model_catalog_json") is not None,
+        managed_catalog=managed_catalog,
+        stale_catalog=managed_catalog,
     )
 
 
@@ -611,7 +753,10 @@ def inject_unified_history_config(text: str) -> tuple[str, str]:
     if state.custom_section is not None and not (state.exact_unified or state.managed_gateway):
         return text, "conflicting_custom_provider"
 
-    updated = strip_top_level_keys(text, {"model_provider", "model_catalog_json", "openai_base_url"})
+    keys_to_strip = {"model_provider", "openai_base_url"}
+    if state.managed_catalog:
+        keys_to_strip.add("model_catalog_json")
+    updated = strip_top_level_keys(text, keys_to_strip)
     if state.custom_section is not None:
         updated = strip_section(updated, f"model_providers.{PROXY_PROVIDER_ID}")
     updated = insert_provider_section(updated, build_unified_official_provider_section())
@@ -629,11 +774,15 @@ def inject_unified_history_config(text: str) -> tuple[str, str]:
 
 
 def strip_unified_history_config(text: str) -> str:
+    managed_catalog = is_managed_catalog_path(top_level_value(text, "model_catalog_json")) or _overlay_marks_managed_catalog(text)
     custom_section = section_key_values(text, f"model_providers.{PROXY_PROVIDER_ID}")
     if custom_section != unified_official_provider_values() and not is_managed_gateway_provider(custom_section):
         return text
     stripped = strip_section(text, f"model_providers.{PROXY_PROVIDER_ID}")
-    stripped = strip_top_level_keys(stripped, {"model_provider", "model_catalog_json", "openai_base_url"})
+    keys_to_strip = {"model_provider", "openai_base_url"}
+    if managed_catalog:
+        keys_to_strip.add("model_catalog_json")
+    stripped = strip_top_level_keys(stripped, keys_to_strip)
     return stripped.lstrip() if text.startswith("model_provider") else stripped
 
 
@@ -784,6 +933,7 @@ def build_overlay(
     catalog_value: str | None,
     owner: str,
     context_budget: tuple[int, int] | None = None,
+    catalog_owned: bool = True,
 ) -> str:
     # Context limits are model-scoped catalog metadata.  The old global
     # projection is intentionally ignored even when callers still pass the
@@ -793,6 +943,10 @@ def build_overlay(
         f"# owner = {owner}",
         f'model_provider = "{PROXY_PROVIDER_ID}"',
     ]
+    if catalog_value is not None and catalog_owned:
+        digest = _catalog_owner_marker_digest(catalog_value, create=True)
+        if digest is not None:
+            lines.append(f"{CATALOG_OWNER_MARKER}:{digest}")
     if catalog_value is not None:
         lines.append(f"model_catalog_json = {toml_literal(catalog_value)}")
     return "\n".join([*lines, MARKER_END, ""])
@@ -905,14 +1059,36 @@ def apply_overlay(
 
     for section in STALE_PROXY_PROVIDER_SECTIONS:
         cleaned = strip_section(cleaned, section)
+    existing_catalog_value = top_level_value(original, "model_catalog_json")
+    catalog_value = (
+        existing_catalog_value
+        if existing_catalog_value is not None
+        and not is_managed_catalog_path(existing_catalog_value, catalog_path)
+        else (
+            catalog_config_value(config_path, catalog_path)
+            if catalog_path is not None
+            else existing_catalog_value
+        )
+    )
+    catalog_owned = catalog_value is not None and is_managed_catalog_path(catalog_value, catalog_path)
     cleaned = strip_top_level_keys(cleaned)
     cleaned = set_feature_flags(cleaned, PROXY_FEATURE_FLAGS)
     updated = build_overlay(
-        catalog_config_value(config_path, catalog_path) if catalog_path is not None else None,
+        catalog_value,
         owner,
+        catalog_owned=catalog_owned,
     ) + cleaned.lstrip()
     updated = insert_provider_section(updated, build_provider_section(base_url, gateway_key))
     atomic_write_text(config_path, updated, encoding="utf-8")
+
+
+def _preserve_user_catalog_path(current: str, restored: str) -> str:
+    current_value = top_level_value(current, "model_catalog_json")
+    if not current_value or is_managed_catalog_path(current_value) or _overlay_marks_managed_catalog(current):
+        return restored
+    if current_value == top_level_value(restored, "model_catalog_json"):
+        return restored
+    return set_top_level_values(restored, {"model_catalog_json": toml_literal(current_value)})
 
 
 def restore_overlay(
@@ -934,6 +1110,7 @@ def restore_overlay(
             restored,
             context_guard_state_path,
         )
+        restored = _preserve_user_catalog_path(current, restored)
         restore_from_backup = True
         if is_active_takeover_backup(current, restored, backup_path):
             restored_owner = overlay_owner(restored)

--- a/src-python/diagnostic_control.py
+++ b/src-python/diagnostic_control.py
@@ -78,6 +78,7 @@ class DiagnosticControlBridge:
         self._stopped = threading.Event()
         self._thread: threading.Thread | None = None
         self._state_lock = threading.RLock()
+        self._batch_lock = threading.Lock()
         self._io_lock = threading.RLock()
 
     @property
@@ -121,6 +122,12 @@ class DiagnosticControlBridge:
     def process_once(self) -> int:
         """Process a bounded batch for deterministic tests and the daemon loop."""
 
+        with self._batch_lock:
+            return self._process_batch()
+
+    def _process_batch(self) -> int:
+        """Run one complete scan/execute/persist/cleanup batch under one lock."""
+
         try:
             requests = sorted(self._request_dir.glob("*.json"))[:MAX_COMMANDS_PER_TICK]
         except OSError:
@@ -130,8 +137,8 @@ class DiagnosticControlBridge:
             if self._stopped.is_set():
                 break
             try:
-                self._process_request(path)
-                processed += 1
+                if self._process_request(path):
+                    processed += 1
             except Exception:
                 # A malformed control file can never affect Gateway traffic.
                 try:
@@ -150,17 +157,36 @@ class DiagnosticControlBridge:
                 pass
             self._stopped.wait(self._poll_interval_seconds)
 
-    def _process_request(self, path: Path) -> None:
-        request = _read_json(path)
-        request_id = request.get("request_id") if isinstance(request, dict) else None
-        response = self._execute(request)
-        if isinstance(request_id, str) and _SAFE_REQUEST_ID.fullmatch(request_id):
-            response["request_id"] = request_id
-            self._write_response(request_id, response)
+    def _process_request(self, path: Path) -> bool:
+        """Atomically claim one request before executing its side effects.
+
+        A claimed file is deliberately kept outside the ``*.json`` polling
+        glob until cleanup.  If cleanup itself fails, the next batch cannot
+        rediscover and execute the same accepted request a second time.
+        """
+
+        claimed = path.with_name(
+            f".{path.name}.{os.getpid()}.{threading.get_ident()}.processing"
+        )
         try:
-            path.unlink(missing_ok=True)
+            path.replace(claimed)
         except OSError:
-            pass
+            return False
+        try:
+            request = _read_json(claimed)
+            request_id = request.get("request_id") if isinstance(request, dict) else None
+            response = self._execute(request)
+            if isinstance(request_id, str) and _SAFE_REQUEST_ID.fullmatch(request_id):
+                response["request_id"] = request_id
+                self._write_response(request_id, response)
+            return True
+        finally:
+            try:
+                claimed.unlink(missing_ok=True)
+            except OSError:
+                # The claim remains outside the polling glob, preserving
+                # at-most-once semantics if cleanup is temporarily unavailable.
+                pass
 
     def _execute(self, request: Any) -> dict[str, Any]:
         status = self._status_dict()

--- a/src-python/providers_config.py
+++ b/src-python/providers_config.py
@@ -245,16 +245,16 @@ def build_external_model_index(
                 "max_output_source": "providers_toml",
                 "priority_base": _provider_priority_base(provider),
             }
-            result[alias] = entry
+            _insert_provider_model_identity(result, alias, entry)
             for model_alias in model.aliases:
                 alias_id = canonical_model_id(model_alias)
                 if not alias_id:
                     continue
                 qualified_alias = alias_id if "/" in alias_id else canonical_model_id(f"{provider_id}/{alias_id}")
-                if qualified_alias and qualified_alias not in result:
+                if qualified_alias:
                     alias_entry = dict(entry)
                     alias_entry["matched_alias"] = qualified_alias
-                    result[qualified_alias] = alias_entry
+                    _insert_provider_model_identity(result, qualified_alias, alias_entry)
     return result
 
 
@@ -325,15 +325,34 @@ def build_ollama_cloud_model_index(
                 "max_output_source": "providers_toml",
                 "priority_base": _provider_priority_base(provider),
             }
-            result[model_id] = entry
-            result[qualified_alias] = entry
+            _insert_provider_model_identity(result, model_id, entry)
+            _insert_provider_model_identity(result, qualified_alias, entry)
             for model_alias in model.aliases:
                 alias_id = canonical_model_id(model_alias)
                 if not alias_id:
                     continue
-                result.setdefault(alias_id, entry)
-                result.setdefault(canonical_model_id(f"{provider_id}/{alias_id}"), entry)
+                alias_entry = dict(entry)
+                alias_entry["matched_alias"] = alias_id
+                _insert_provider_model_identity(result, alias_id, alias_entry)
+                qualified_alias = canonical_model_id(f"{provider_id}/{alias_id}")
+                qualified_alias_entry = dict(entry)
+                qualified_alias_entry["matched_alias"] = qualified_alias
+                _insert_provider_model_identity(result, qualified_alias, qualified_alias_entry)
     return configured, result
+
+
+def _insert_provider_model_identity(
+    index: dict[str, dict[str, Any]],
+    identity: str,
+    entry: dict[str, Any],
+) -> None:
+    """Insert one exported model identity without silently overwriting it."""
+
+    if not identity:
+        return
+    if identity in index:
+        raise ValueError(f"duplicate provider model identity: {identity}")
+    index[identity] = entry
 
 
 def catalog_visible_ollama_cloud_models(

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "codexhub"
-version = "0.1.8-beta.1"
+version = "0.1.8-beta.2"
 dependencies = [
  "dirs 5.0.1",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codexhub"
-version = "0.1.8-beta.1"
+version = "0.1.8-beta.2"
 description = "CodexHub desktop backend and CLI"
 authors = ["CodexHub"]
 license = "MIT"

--- a/src-tauri/src/catalog.rs
+++ b/src-tauri/src/catalog.rs
@@ -1,10 +1,23 @@
 use crate::{config, models, runtime_paths, Model};
+use serde::Serialize;
+use serde_json::Value;
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
 const GENERATED_CATALOG_FILE: &str = "codexhub-model-catalog.json";
+const GENERATED_STATE_FILE: &str = "codex-proxy-state.json";
 const CODEX_TARGET_HOME_ENV: &str = "CODEXHUB_CODEX_TARGET_HOME";
+const MAX_DIAGNOSTIC_COUNT: u64 = 100;
+
+#[derive(Debug, Clone, Default, Serialize, PartialEq, Eq)]
+pub struct CatalogOverrideDiagnostics {
+    pub accepted: u64,
+    pub rejected: u64,
+    pub migrated: u64,
+    pub reasons: BTreeMap<String, u64>,
+}
 
 pub fn generate_catalog() -> Result<Vec<Model>, String> {
     models::generate_catalog()
@@ -16,6 +29,65 @@ pub fn sync_catalog() -> Result<String, String> {
     let runner = ProcessCatalogSyncCommandRunner;
 
     sync_catalog_with_paths(&paths, &python, &runner)
+}
+
+/// Read the bounded catalog ownership diagnostics emitted by Python sync.
+///
+/// The state file is an implementation detail and may be missing while a
+/// first-run sync is in progress.  A malformed or unknown payload therefore
+/// degrades to an empty diagnostic set instead of turning a successful catalog
+/// publication into a UI error.  Only the whitelisted counters/reasons cross
+/// the Rust/frontend boundary.
+pub fn catalog_override_diagnostics() -> Result<CatalogOverrideDiagnostics, String> {
+    let paths = CatalogPaths::runtime()?;
+    Ok(read_catalog_override_diagnostics(
+        &paths.catalog_state_path(),
+    ))
+}
+
+fn read_catalog_override_diagnostics(path: &Path) -> CatalogOverrideDiagnostics {
+    let Ok(text) = fs::read_to_string(path) else {
+        return CatalogOverrideDiagnostics::default();
+    };
+    let Ok(payload) = serde_json::from_str::<Value>(&text) else {
+        return CatalogOverrideDiagnostics::default();
+    };
+    let Some(diagnostics) = payload.get("catalog_override_diagnostics") else {
+        return CatalogOverrideDiagnostics::default();
+    };
+    let Some(object) = diagnostics.as_object() else {
+        return CatalogOverrideDiagnostics::default();
+    };
+    let mut result = CatalogOverrideDiagnostics {
+        accepted: bounded_count(object.get("accepted")),
+        rejected: bounded_count(object.get("rejected")),
+        migrated: bounded_count(object.get("migrated")),
+        reasons: BTreeMap::new(),
+    };
+    let Some(reasons) = object.get("reasons").and_then(Value::as_object) else {
+        return result;
+    };
+    for reason in [
+        "invalid_sidecar",
+        "invalid_catalog",
+        "invalid_baseline",
+        "invalid_row_identity",
+        "invalid_override_fields",
+        "missing_managed_model",
+    ] {
+        let count = bounded_count(reasons.get(reason));
+        if count > 0 {
+            result.reasons.insert(reason.to_string(), count);
+        }
+    }
+    result
+}
+
+fn bounded_count(value: Option<&Value>) -> u64 {
+    value
+        .and_then(Value::as_u64)
+        .map(|count| count.min(MAX_DIAGNOSTIC_COUNT))
+        .unwrap_or(0)
 }
 
 fn sync_catalog_with_paths(
@@ -97,6 +169,12 @@ impl CatalogPaths {
             .join("model-catalogs")
             .join(GENERATED_CATALOG_FILE)
     }
+
+    fn catalog_state_path(&self) -> PathBuf {
+        self.codex_dir
+            .join("model-catalogs")
+            .join(GENERATED_STATE_FILE)
+    }
 }
 
 type CatalogCommandOutcome = config::CommandOutcome;
@@ -141,8 +219,9 @@ impl CatalogSyncCommandRunner for ProcessCatalogSyncCommandRunner {
 #[cfg(test)]
 mod tests {
     use super::{
-        sync_catalog_with_paths, CatalogCommandOutcome, CatalogPaths, CatalogSyncCommandRunner,
-        CODEX_TARGET_HOME_ENV, GENERATED_CATALOG_FILE,
+        read_catalog_override_diagnostics, sync_catalog_with_paths, CatalogCommandOutcome,
+        CatalogOverrideDiagnostics, CatalogPaths, CatalogSyncCommandRunner, CODEX_TARGET_HOME_ENV,
+        GENERATED_CATALOG_FILE,
     };
     use std::cell::RefCell;
     use std::collections::BTreeMap;
@@ -218,6 +297,48 @@ mod tests {
         assert!(error.contains("--sync"));
         assert!(error.contains("printed stdout"));
         assert!(error.contains("printed stderr"));
+    }
+
+    #[test]
+    fn catalog_override_diagnostics_are_bounded_and_whitelisted() {
+        let root = temp_root("catalog-diagnostics");
+        let path = root.join("codex-proxy-state.json");
+        fs::write(
+            &path,
+            r#"{
+                "catalog_override_diagnostics": {
+                    "accepted": 999,
+                    "rejected": 2,
+                    "migrated": 1,
+                    "reasons": {
+                        "invalid_row_identity": 101,
+                        "unknown": 77
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let diagnostics = read_catalog_override_diagnostics(&path);
+        assert_eq!(diagnostics.accepted, 100);
+        assert_eq!(diagnostics.rejected, 2);
+        assert_eq!(diagnostics.migrated, 1);
+        assert_eq!(diagnostics.reasons.get("invalid_row_identity"), Some(&100));
+        assert!(!diagnostics.reasons.contains_key("unknown"));
+    }
+
+    #[test]
+    fn malformed_or_missing_catalog_override_diagnostics_are_empty() {
+        let root = temp_root("catalog-diagnostics-malformed");
+        let missing = read_catalog_override_diagnostics(&root.join("missing.json"));
+        assert_eq!(missing, CatalogOverrideDiagnostics::default());
+
+        let malformed_path = root.join("malformed.json");
+        fs::write(&malformed_path, "not json").unwrap();
+        assert_eq!(
+            read_catalog_override_diagnostics(&malformed_path),
+            CatalogOverrideDiagnostics::default()
+        );
     }
 
     #[derive(Debug, Clone)]

--- a/src-tauri/src/gateway.rs
+++ b/src-tauri/src/gateway.rs
@@ -1981,10 +1981,10 @@ fn official_models(settings: &Settings) -> Vec<GatewayModel> {
     // descriptive fields, but must never reintroduce a builtin fallback limit.
     let published_context_windows = official_refresh::published_official_context_windows()
         .unwrap_or_default();
-    let source_models = models::list_cached_official_subscription_models()
-        .ok()
-        .filter(|models| !models.is_empty())
-        .or_else(|| models::list_models().ok().filter(|models| !models.is_empty()));
+    let source_models = match models::list_cached_official_subscription_models_with_presence() {
+        Ok(Some(models)) => Some(models),
+        Ok(None) | Err(_) => models::list_models_with_presence().ok().flatten(),
+    };
     official_models_from_metadata(settings, source_models, &published_context_windows)
 }
 
@@ -2002,13 +2002,16 @@ fn official_models_from_metadata(
         return Vec::new();
     }
     let mut models: Vec<GatewayModel> =
-        match subscription_models.filter(|models| !models.is_empty()) {
+        match subscription_models {
             Some(source_models) => {
                 let mut models = Vec::<GatewayModel>::new();
                 let mut positions = HashMap::<String, usize>::new();
                 let mut bare_sources = HashMap::<String, bool>::new();
                 let mut enabled_by_id = HashMap::<String, bool>::new();
                 for model in source_models {
+                    if !models::model_is_catalog_visible(&model) {
+                        continue;
+                    }
                     let source_is_bare = !model.id.trim().starts_with("openai/");
                     let source_enabled = model.enabled;
                     let Some(gateway_model) = official_gateway_model_from_metadata(
@@ -8039,6 +8042,18 @@ mod tests {
         assert_eq!(models[0].id, "gpt-5.6-sol");
         assert_eq!(models[0].display_name, "5.6 Sol");
         assert_eq!(models[0].context_window, Some(272_000));
+    }
+
+    #[test]
+    fn official_gateway_models_do_not_fallback_when_authoritative_catalog_is_empty() {
+        let published_contexts = published_context_windows(&[("gpt-5.6-terra", 272_000)]);
+        let models = official_models_from_metadata(
+            &Settings::default(),
+            Some(Vec::new()),
+            &published_contexts,
+        );
+
+        assert!(models.is_empty());
     }
 
     #[test]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -617,6 +617,11 @@ async fn generate_catalog() -> Result<Vec<Model>, String> {
 }
 
 #[tauri::command]
+fn get_catalog_override_diagnostics() -> Result<catalog::CatalogOverrideDiagnostics, String> {
+    catalog::catalog_override_diagnostics()
+}
+
+#[tauri::command]
 fn list_models() -> Result<Vec<Model>, String> {
     models::list_models()
 }
@@ -1124,6 +1129,7 @@ fn run_gui() {
             sync_gateway_clients,
             subagent_matrix_status,
             generate_catalog,
+            get_catalog_override_diagnostics,
             list_models,
             refresh_model_metadata,
             list_model_metadata,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -49,6 +49,31 @@ struct TrayToast {
     tone: String,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CatalogVisibility {
+    // Provider models and older persisted metadata were user-listable before
+    // visibility became explicit; upstream parsers assign Unknown explicitly.
+    #[default]
+    List,
+    Hide,
+    Unknown,
+}
+
+impl<'de> Deserialize<'de> for CatalogVisibility {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = Option::<serde_json::Value>::deserialize(deserializer)?;
+        Ok(match value.as_ref().and_then(serde_json::Value::as_str).map(str::trim).map(str::to_ascii_lowercase).as_deref() {
+            Some("list") => Self::List,
+            Some("hide") => Self::Hide,
+            _ => Self::Unknown,
+        })
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Model {
     pub id: String,
@@ -65,6 +90,8 @@ pub struct Model {
     pub codex_enabled: bool,
     #[serde(default = "default_enabled")]
     pub gateway_exported: bool,
+    #[serde(default)]
+    pub visibility: CatalogVisibility,
     pub context_window: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_context_window: Option<u32>,
@@ -99,6 +126,7 @@ impl Default for Model {
             locked: false,
             codex_enabled: true,
             gateway_exported: true,
+            visibility: CatalogVisibility::default(),
             context_window: None,
             max_context_window: None,
             effective_source: None,

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -1,6 +1,6 @@
 use crate::{
-    config, runtime_paths, safe_file, MetadataProvenance, Model, ModelPricing, Settings,
-    UpstreamFormat,
+    config, runtime_paths, safe_file, CatalogVisibility, MetadataProvenance, Model, ModelPricing,
+    Settings, UpstreamFormat,
 };
 use reqwest::blocking::Client;
 use reqwest::header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE};
@@ -19,6 +19,7 @@ const DISCOVERY_TIMEOUT: Duration = Duration::from_secs(20);
 const MODEL_TEST_TIMEOUT: Duration = Duration::from_secs(8);
 const CODEX_APP_SERVER_MODEL_LIST_TIMEOUT: Duration = Duration::from_secs(8);
 const CODEX_APP_SERVER_CACHE_POLL_INTERVAL: Duration = Duration::from_millis(10);
+const MAX_VISIBILITY_DIAGNOSTIC_COUNT: u64 = 100;
 const GENERATED_CATALOG_FILE: &str = "codexhub-model-catalog.json";
 const LEGACY_GENERATED_CATALOG_FILE: &str = "codex-proxy-official-ollama.json";
 const RESOLVED_MODEL_LIMITS_JSON: &str = include_str!("../../config/resolved_model_limits.json");
@@ -253,13 +254,17 @@ pub fn generate_catalog() -> Result<Vec<Model>, String> {
 }
 
 pub fn list_models() -> Result<Vec<Model>, String> {
+    Ok(list_models_with_presence()?.unwrap_or_default())
+}
+
+pub(crate) fn list_models_with_presence() -> Result<Option<Vec<Model>>, String> {
     let paths = ModelPaths::runtime()?;
     let catalog_path = paths.existing_generated_catalog_path();
     if !catalog_path.exists() {
-        return Ok(Vec::new());
+        return Ok(None);
     }
 
-    read_catalog_models(&catalog_path)
+    read_catalog_models(&catalog_path).map(Some)
 }
 
 pub fn list_model_metadata() -> Result<Vec<Model>, String> {
@@ -273,16 +278,18 @@ pub fn list_model_metadata() -> Result<Vec<Model>, String> {
         &known_official_models,
     );
     let overrides = read_metadata_overrides(&paths).unwrap_or_default();
-    Ok(merge_metadata_with_overrides(
+    let merged = merge_metadata_with_overrides(
         cached,
         overrides,
         &known_official_models,
-    ))
+    );
+    Ok(merged.into_iter().filter(model_is_catalog_visible).collect())
 }
 
-pub(crate) fn list_cached_official_subscription_models() -> Result<Vec<Model>, String> {
+pub(crate) fn list_cached_official_subscription_models_with_presence(
+) -> Result<Option<Vec<Model>>, String> {
     let paths = ModelPaths::runtime()?;
-    read_official_subscription_models_from_cache(&paths)
+    read_official_subscription_models_from_cache_with_presence(&paths)
 }
 
 pub fn refresh_model_metadata() -> Result<Vec<Model>, String> {
@@ -351,10 +358,54 @@ fn refresh_official_models_direct_with_runner(
 ) -> Result<Vec<Model>, String> {
     let subscription_models = runner
         .read_model_list()
-        .and_then(|payload| subscription_models_from_app_server_payload(&payload))?;
+        .and_then(|payload| {
+            let visibility_diagnostics = visibility_diagnostics_from_payload(&payload);
+            let subscription_models = subscription_models_from_app_server_payload(&payload)?;
+            Ok((subscription_models, visibility_diagnostics))
+        })?;
+    let (subscription_models, visibility_diagnostics) = subscription_models;
     let models = subscription_models_to_metadata_models(&subscription_models);
-    write_official_subscription_caches(paths, &subscription_models, &models)?;
+    write_official_subscription_caches(
+        paths,
+        &subscription_models,
+        &models,
+        &visibility_diagnostics,
+    )?;
     Ok(models)
+}
+
+fn visibility_diagnostics_from_payload(payload: &Value) -> Value {
+    let items = payload
+        .get("data")
+        .or_else(|| payload.get("models"))
+        .and_then(Value::as_array)
+        .or_else(|| payload.as_array());
+    let mut counts = Map::from_iter([
+        ("hidden".to_string(), json!(0u64)),
+        ("unknown".to_string(), json!(0u64)),
+        ("internal".to_string(), json!(0u64)),
+    ]);
+    for item in items.into_iter().flatten() {
+        let Some(object) = item.as_object() else {
+            continue;
+        };
+        let key = if item_has_internal_identity(object) {
+            "internal"
+        } else {
+            match catalog_visibility_from_item(object) {
+                CatalogVisibility::Hide => "hidden",
+                CatalogVisibility::Unknown => "unknown",
+                CatalogVisibility::List => continue,
+            }
+        };
+        if let Some(count) = counts.get(key).and_then(Value::as_u64) {
+            counts.insert(
+                key.to_string(),
+                json!(count.saturating_add(1).min(MAX_VISIBILITY_DIAGNOSTIC_COUNT)),
+            );
+        }
+    }
+    Value::Object(counts)
 }
 
 fn read_codex_app_server_model_list() -> Result<Value, String> {
@@ -628,11 +679,7 @@ struct ReasoningLevelEntry {
 fn subscription_models_from_app_server_payload(
     payload: &Value,
 ) -> Result<Vec<OfficialSubscriptionModel>, String> {
-    let models = subscription_models_from_payload(payload)?;
-    if models.is_empty() {
-        return Err("Codex subscription model list did not include visible GPT models".to_string());
-    }
-    Ok(models)
+    subscription_models_from_payload(payload)
 }
 
 fn subscription_models_from_payload(
@@ -850,12 +897,76 @@ fn is_pinned_official_legacy_model(slug: &str) -> bool {
     matches!(slug, "gpt-5.5" | "gpt-5.4" | "gpt-5.4-mini")
 }
 
+const INTERNAL_MODEL_IDENTIFIERS: &[&str] = &["codex-auto-review"];
+
+pub(crate) fn model_is_catalog_visible(model: &Model) -> bool {
+    if model.visibility != CatalogVisibility::List {
+        return false;
+    }
+    let mut identities = vec![model.id.as_str()];
+    if let Some(upstream_model) = model.upstream_model.as_deref() {
+        identities.push(upstream_model);
+    }
+    identities.extend(model.aliases.iter().map(String::as_str));
+    !identities.iter().any(|value| {
+        let normalized = value
+            .trim()
+            .strip_prefix("openai/")
+            .unwrap_or(value.trim())
+            .to_ascii_lowercase();
+        let normalized = normalized.strip_suffix(":cloud").unwrap_or(&normalized);
+        INTERNAL_MODEL_IDENTIFIERS.iter().any(|identifier| {
+            normalized == *identifier || normalized.starts_with(&format!("{identifier}/"))
+        })
+    })
+}
+
+fn catalog_visibility_from_item(object: &Map<String, Value>) -> CatalogVisibility {
+    if object.get("hidden").and_then(Value::as_bool) == Some(true) {
+        return CatalogVisibility::Hide;
+    }
+    match object
+        .get("visibility")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .map(|value| value.to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("list") => CatalogVisibility::List,
+        Some("hide") => CatalogVisibility::Hide,
+        Some(_) => CatalogVisibility::Unknown,
+        None if object.get("hidden").and_then(Value::as_bool) == Some(false) => {
+            CatalogVisibility::List
+        }
+        None => CatalogVisibility::Unknown,
+    }
+}
+
+fn item_has_internal_identity(object: &Map<String, Value>) -> bool {
+    object
+        .iter()
+        .filter(|(key, _)| {
+            matches!(
+                key.as_str(),
+                "id" | "slug" | "model" | "name" | "upstream_model"
+            )
+        })
+        .filter_map(|(_, value)| value.as_str())
+        .map(str::trim)
+        .map(|value| value.strip_prefix("openai/").unwrap_or(value))
+        .map(str::to_ascii_lowercase)
+        .map(|value| value.strip_suffix(":cloud").unwrap_or(&value).to_string())
+        .any(|value| {
+            INTERNAL_MODEL_IDENTIFIERS.iter().any(|identifier| {
+                value == *identifier || value.starts_with(&format!("{identifier}/"))
+            })
+        })
+}
+
 fn subscription_model_from_item(item: &Value) -> Option<OfficialSubscriptionModel> {
     let object = item.as_object()?;
-    if object
-        .get("hidden")
-        .and_then(Value::as_bool)
-        .unwrap_or(false)
+    if item_has_internal_identity(object)
+        || catalog_visibility_from_item(object) != CatalogVisibility::List
     {
         return None;
     }
@@ -946,6 +1057,7 @@ fn subscription_models_to_metadata_models(
             locked: true,
             codex_enabled: true,
             gateway_exported: true,
+            visibility: CatalogVisibility::List,
             context_window: subscription_model
                 .context_window
                 .or_else(|| defaults.and_then(|model| model.context_window)),
@@ -1005,28 +1117,41 @@ fn write_official_subscription_caches(
     paths: &ModelPaths,
     subscription_models: &[OfficialSubscriptionModel],
     metadata_models: &[Model],
+    visibility_diagnostics: &Value,
 ) -> Result<(), String> {
     write_models_json(&paths.metadata_cache_path(), metadata_models)?;
     write_official_subscription_seed(
         &paths.official_subscription_cache_path(),
         subscription_models,
+        visibility_diagnostics,
     )
 }
 
-fn read_official_subscription_models_from_cache(paths: &ModelPaths) -> Result<Vec<Model>, String> {
+fn read_official_subscription_models_from_cache_with_presence(
+    paths: &ModelPaths,
+) -> Result<Option<Vec<Model>>, String> {
+    if !paths.official_subscription_cache_path().exists() {
+        return Ok(None);
+    }
     let payload = load_json_file(&paths.official_subscription_cache_path())?;
     let subscription_models = subscription_models_from_payload(&payload)?;
-    if subscription_models.is_empty() {
-        return Err(
+    Ok(Some(subscription_models_to_metadata_models(&subscription_models)))
+}
+
+fn read_official_subscription_models_from_cache(paths: &ModelPaths) -> Result<Vec<Model>, String> {
+    match read_official_subscription_models_from_cache_with_presence(paths)? {
+        Some(models) if !models.is_empty() => Ok(models),
+        Some(_) => Err(
             "cached Codex subscription model list did not include visible GPT models".to_string(),
-        );
+        ),
+        None => Err("cached Codex subscription model list is missing".to_string()),
     }
-    Ok(subscription_models_to_metadata_models(&subscription_models))
 }
 
 fn write_official_subscription_seed(
     path: &Path,
     subscription_models: &[OfficialSubscriptionModel],
+    visibility_diagnostics: &Value,
 ) -> Result<(), String> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)
@@ -1039,6 +1164,7 @@ fn write_official_subscription_seed(
     let payload = json!({
         "client_version": env!("CARGO_PKG_VERSION"),
         "fetched_at": current_unix_timestamp(),
+        "visibility_diagnostics": visibility_diagnostics,
         "models": models,
     });
     let text = serde_json::to_string_pretty(&payload)
@@ -1054,6 +1180,7 @@ fn write_official_subscription_seed(
 fn official_subscription_seed_model(model: &OfficialSubscriptionModel) -> Value {
     let mut payload = model.raw.as_object().cloned().unwrap_or_default();
     ensure_responses_lite_opt_in(&mut payload);
+    payload.insert("visibility".to_string(), json!(CatalogVisibility::List));
     payload.insert("slug".to_string(), json!(model.slug));
     payload
         .entry("display_name".to_string())
@@ -2011,6 +2138,14 @@ fn merge_model_override(base: &mut Model, override_model: Model) {
     let original_enabled = base.enabled;
     let original_codex_enabled = base.codex_enabled;
     let original_gateway_exported = base.gateway_exported;
+    let original_visibility = base.visibility;
+    let visibility = match (original_visibility, override_model.visibility) {
+        (CatalogVisibility::Hide, _) | (_, CatalogVisibility::Hide) => CatalogVisibility::Hide,
+        (CatalogVisibility::Unknown, _) | (_, CatalogVisibility::Unknown) => {
+            CatalogVisibility::Unknown
+        }
+        _ => CatalogVisibility::List,
+    };
     let aliases = merge_model_aliases(base.aliases.clone(), override_model.aliases);
     *base = Model {
         id: override_model.id,
@@ -2024,6 +2159,7 @@ fn merge_model_override(base: &mut Model, override_model: Model) {
         locked: base.locked || override_model.locked,
         codex_enabled: override_model.codex_enabled && original_codex_enabled,
         gateway_exported: override_model.gateway_exported && original_gateway_exported,
+        visibility,
         context_window: override_model.context_window.or(base.context_window),
         max_context_window: override_model.max_context_window.or(base.max_context_window),
         effective_source: override_model.effective_source.or(base.effective_source.take()),
@@ -2282,6 +2418,19 @@ fn priced_metadata(
 
 fn catalog_model_from_item(item: &Value) -> Option<Model> {
     let object = item.as_object()?;
+    // Generated catalogs predate the typed visibility field and also contain
+    // trusted third-party provider entries that never carried an upstream
+    // visibility flag.  Preserve that legacy list default at this boundary;
+    // raw app-server/upstream ingestion remains fail-closed through
+    // `subscription_model_from_item` and `catalog_visibility_from_item`.
+    let listable = if object.contains_key("visibility") || object.contains_key("hidden") {
+        catalog_visibility_from_item(object) == CatalogVisibility::List
+    } else {
+        true
+    };
+    if item_has_internal_identity(object) || !listable {
+        return None;
+    }
     let id = object
         .get("slug")
         .or_else(|| object.get("id"))
@@ -2353,6 +2502,7 @@ fn catalog_model_from_item(item: &Value) -> Option<Model> {
             .get("gateway_exported")
             .and_then(Value::as_bool)
             .unwrap_or(true),
+        visibility: CatalogVisibility::List,
         pricing: None,
         metadata_provenance: None,
     })
@@ -2470,12 +2620,13 @@ mod tests {
     use super::{
         desktop_codex_exe_from_local_appdata, discover_provider_models_with_timeout,
         enrich_models_with_ollama_show, generate_catalog_with_runner, list_model_metadata,
-        list_models, merge_metadata_with_overrides, ollama_show_endpoint, provider_api_endpoint,
+        list_models, load_json_file, merge_metadata_with_overrides, ollama_show_endpoint,
+        provider_api_endpoint,
         provider_models_endpoint, read_models_json, refresh_official_models_from_endpoint,
         refresh_official_models_with_runner, resolve_gateway_api_key_for_settings,
         subscription_models_from_payload, subscription_models_to_metadata_models,
-        test_model_endpoint_with_timeout, AppServerModelListRunner, CatalogCommandOutcome,
-        CatalogSyncRunner, ModelPaths,
+        test_model_endpoint_with_timeout, visibility_diagnostics_from_payload,
+        AppServerModelListRunner, CatalogCommandOutcome, CatalogSyncRunner, ModelPaths,
     };
     use crate::{MetadataProvenance, Model, Settings, ToolSurfaceStrategy, UpstreamFormat};
     use reqwest::blocking::Client;
@@ -2773,6 +2924,62 @@ for line in sys.stdin:
     }
 
     #[test]
+    fn subscription_models_apply_typed_visibility_and_internal_identity_policy() {
+        let subscription_models = subscription_models_from_payload(&json!({
+            "data": [
+                {
+                    "id": "gpt-5.6-terra",
+                    "model": "gpt-5.6-terra",
+                    "visibility": "list",
+                    "hidden": false
+                },
+                {
+                    "id": "gpt-5.6-sol",
+                    "model": "gpt-5.6-sol",
+                    "visibility": "hide",
+                    "hidden": false
+                },
+                {
+                    "id": "codex-auto-review",
+                    "model": "gpt-5.6-terra",
+                    "slug": "gpt-5.6-terra",
+                    "visibility": "list",
+                    "hidden": false
+                },
+                {
+                    "id": "gpt-5.6-luna",
+                    "model": "gpt-5.6-luna",
+                    "visibility": "future",
+                    "hidden": false
+                }
+            ]
+        }))
+        .expect("subscription models");
+
+        let models = subscription_models_to_metadata_models(&subscription_models);
+
+        assert_eq!(model_ids(&models), ["gpt-5.6-terra"]);
+        assert_eq!(models[0].visibility, crate::CatalogVisibility::List);
+    }
+
+    #[test]
+    fn visibility_diagnostics_are_bounded_and_secret_free() {
+        let diagnostics = visibility_diagnostics_from_payload(&json!({
+            "data": [
+                {"id": "gpt-5.6-sol", "visibility": "hide"},
+                {"id": "gpt-5.6-luna", "visibility": "future"},
+                {"id": "codex-auto-review", "model": "gpt-5.6-terra", "visibility": "list"},
+                {"id": "gpt-5.6-terra", "visibility": "list"}
+            ]
+        }));
+
+        assert_eq!(diagnostics["hidden"], 1);
+        assert_eq!(diagnostics["unknown"], 1);
+        assert_eq!(diagnostics["internal"], 1);
+        assert!(!diagnostics.to_string().contains("gpt-5.6"));
+    }
+
+    #[test]
     fn subscription_refresh_converts_visible_codex_models_and_writes_caches() {
         let root = temp_root("subscription-refresh");
         let paths = test_paths(&root);
@@ -2862,6 +3069,35 @@ for line in sys.stdin:
     }
 
     #[test]
+    fn subscription_refresh_preserves_empty_visibility_snapshot_and_diagnostics() {
+        let root = temp_root("subscription-empty-visibility-refresh");
+        let paths = test_paths(&root);
+        let runner = StaticAppServerModelListRunner::ok(json!({
+            "data": [
+                {"id": "gpt-hidden", "visibility": "hide"},
+                {"id": "gpt-unknown", "visibility": "future"},
+                {
+                    "id": "codex-auto-review",
+                    "model": "gpt-5.6-terra",
+                    "visibility": "list"
+                }
+            ]
+        }));
+
+        let models = refresh_official_models_with_runner(&paths, &runner)
+            .expect("empty visibility snapshot should publish fail-closed");
+
+        assert!(models.is_empty());
+        let payload = load_json_file(&paths.official_subscription_cache_path())
+            .expect("empty official subscription cache");
+        assert_eq!(payload["models"].as_array().map(Vec::len), Some(0));
+        assert_eq!(payload["visibility_diagnostics"]["hidden"], 1);
+        assert_eq!(payload["visibility_diagnostics"]["unknown"], 1);
+        assert_eq!(payload["visibility_diagnostics"]["internal"], 1);
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn subscription_seed_preserves_app_cli_metadata_and_simple_slider_presets() {
         let subscription_models = subscription_models_from_payload(&json!({
             "data": [
@@ -2869,6 +3105,7 @@ for line in sys.stdin:
                     "id": "gpt-5.6-terra",
                     "model": "gpt-5.6-terra",
                     "displayName": "GPT-5.6-Terra",
+                    "hidden": false,
                     "supportedReasoningEfforts": [
                         {"reasoningEffort": "low", "description": "Light"},
                         {"reasoningEffort": "medium", "description": "Medium"},
@@ -2883,6 +3120,7 @@ for line in sys.stdin:
                     "id": "gpt-5.6-sol",
                     "model": "gpt-5.6-sol",
                     "displayName": "GPT-5.6-Sol",
+                    "hidden": false,
                     "context_window": 400000,
                     "supportedReasoningEfforts": [
                         {"reasoningEffort": "low", "description": "Light"},
@@ -2953,12 +3191,13 @@ for line in sys.stdin:
     fn subscription_seed_backfills_pinned_official_planner_metadata_per_model() {
         let subscription_models = subscription_models_from_payload(&json!({
             "data": [
-                {"id": "gpt-5.6-sol", "model": "gpt-5.6-sol"},
-                {"id": "gpt-5.6-terra", "model": "gpt-5.6-terra"},
-                {"id": "gpt-5.6-luna", "model": "gpt-5.6-luna"},
+                {"id": "gpt-5.6-sol", "model": "gpt-5.6-sol", "hidden": false},
+                {"id": "gpt-5.6-terra", "model": "gpt-5.6-terra", "hidden": false},
+                {"id": "gpt-5.6-luna", "model": "gpt-5.6-luna", "hidden": false},
                 {
                     "id": "gpt-5.5",
                     "model": "gpt-5.5",
+                    "hidden": false,
                     "use_responses_lite": true,
                     "tool_mode": "code_mode_only",
                     "multi_agent_version": "v2"
@@ -2966,6 +3205,7 @@ for line in sys.stdin:
                 {
                     "id": "gpt-5.4",
                     "model": "gpt-5.4",
+                    "hidden": false,
                     "use_responses_lite": true,
                     "tool_mode": "code_mode_only",
                     "multi_agent_version": "v2"
@@ -2973,6 +3213,7 @@ for line in sys.stdin:
                 {
                     "id": "gpt-5.4-mini",
                     "model": "gpt-5.4-mini",
+                    "hidden": false,
                     "use_responses_lite": true,
                     "tool_mode": "code_mode_only",
                     "multi_agent_version": "v2"
@@ -2980,12 +3221,14 @@ for line in sys.stdin:
                 {
                     "id": "gpt-5.3-codex-spark",
                     "model": "gpt-5.3-codex-spark",
+                    "hidden": false,
                     "use_responses_lite": true
                 },
-                {"id": "gpt-sparse", "model": "gpt-sparse"},
+                {"id": "gpt-sparse", "model": "gpt-sparse", "hidden": false},
                 {
                     "id": "gpt-explicit-lite",
                     "model": "gpt-explicit-lite",
+                    "hidden": false,
                     "use_responses_lite": true
                 }
             ]
@@ -3091,6 +3334,7 @@ for line in sys.stdin:
                     "id": "gpt-5.6-sol",
                     "model": "gpt-5.6-sol",
                     "displayName": "GPT-5.6-Sol",
+                    "hidden": false,
                     "context_window": 400000,
                     "max_context_window": 999999
                 }
@@ -3115,7 +3359,8 @@ for line in sys.stdin:
             "data": [
                 {
                     "slug": "openai/gpt-5.6-sol",
-                    "displayName": "GPT-5.6-Sol"
+                    "displayName": "GPT-5.6-Sol",
+                    "hidden": false
                 }
             ]
         }))
@@ -3132,6 +3377,7 @@ for line in sys.stdin:
             "id": "openai/gpt-5.6-sol",
             "model": "openai/gpt-5.6-sol",
             "displayName": "Legacy Sol",
+            "hidden": false,
             "context_window": 1,
             "enabled": true
         });
@@ -3139,13 +3385,15 @@ for line in sys.stdin:
             "id": "gpt-5.6-sol",
             "model": "gpt-5.6-sol",
             "displayName": "GPT-5.6-Sol",
+            "hidden": false,
             "context_window": 400000,
             "enabled": false
         });
         let other = json!({
             "id": "gpt-5.5",
             "model": "gpt-5.5",
-            "displayName": "GPT-5.5"
+            "displayName": "GPT-5.5",
+            "hidden": false
         });
 
         for items in [
@@ -3174,11 +3422,13 @@ for line in sys.stdin:
                 {
                     "id": "openai/gpt-5.6-sol",
                     "model": "openai/gpt-5.6-sol",
+                    "hidden": false,
                     "enabled": false
                 },
                 {
                     "id": "gpt-5.6-sol",
                     "model": "gpt-5.6-sol",
+                    "hidden": false,
                     "enabled": false
                 }
             ]
@@ -3202,6 +3452,7 @@ for line in sys.stdin:
                     {
                         "slug": "gpt-cached-subscription",
                         "display_name": "GPT Cached Subscription",
+                        "hidden": false,
                         "input_modalities": ["text"],
                         "supported_reasoning_levels": [
                             {"effort": "medium", "description": "Balanced"}

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -18,7 +18,6 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 const DISCOVERY_TIMEOUT: Duration = Duration::from_secs(20);
 const MODEL_TEST_TIMEOUT: Duration = Duration::from_secs(8);
 const CODEX_APP_SERVER_MODEL_LIST_TIMEOUT: Duration = Duration::from_secs(8);
-const CODEX_APP_SERVER_CACHE_POLL_INTERVAL: Duration = Duration::from_millis(10);
 const MAX_VISIBILITY_DIAGNOSTIC_COUNT: u64 = 100;
 const GENERATED_CATALOG_FILE: &str = "codexhub-model-catalog.json";
 const LEGACY_GENERATED_CATALOG_FILE: &str = "codex-proxy-official-ollama.json";
@@ -412,17 +411,11 @@ fn read_codex_app_server_model_list() -> Result<Value, String> {
     let codex = find_codex_executable()?;
     let mut command = Command::new(&codex);
     command.args(["app-server", "--stdio"]);
-    let cache_path = runtime_paths::codex_target_home_dir()?.join("models_cache.json");
-    read_codex_app_server_model_list_with_command(
-        command,
-        &cache_path,
-        CODEX_APP_SERVER_MODEL_LIST_TIMEOUT,
-    )
+    read_codex_app_server_model_list_with_command(command, CODEX_APP_SERVER_MODEL_LIST_TIMEOUT)
 }
 
 fn read_codex_app_server_model_list_with_command(
     mut command: Command,
-    cache_path: &Path,
     timeout: Duration,
 ) -> Result<Value, String> {
     let deadline = Instant::now() + timeout;
@@ -435,11 +428,14 @@ fn read_codex_app_server_model_list_with_command(
         .spawn()
         .map_err(|error| format!("failed to start codex app-server for model list: {error}"))?;
 
-    let mut stdin = child
-        .stdin
-        .take()
-        .ok_or_else(|| "failed to open codex app-server stdin".to_string())?;
-    write_app_server_json_line(
+    let mut stdin = match child.stdin.take() {
+        Some(stdin) => stdin,
+        None => {
+            kill_child(&mut child);
+            return Err("failed to open codex app-server stdin".to_string());
+        }
+    };
+    if let Err(error) = write_app_server_json_line(
         &mut stdin,
         &json!({
             "id": 1,
@@ -457,24 +453,41 @@ fn read_codex_app_server_model_list_with_command(
                 }
             }
         }),
-    )?;
-    write_app_server_json_line(&mut stdin, &json!({ "method": "initialized" }))?;
-    write_app_server_json_line(
+    ) {
+        kill_child(&mut child);
+        return Err(error);
+    }
+    if let Err(error) =
+        write_app_server_json_line(&mut stdin, &json!({ "method": "initialized" }))
+    {
+        kill_child(&mut child);
+        return Err(error);
+    }
+    if let Err(error) = write_app_server_json_line(
         &mut stdin,
         &json!({
             "id": 2,
             "method": "model/list",
             "params": {}
         }),
-    )?;
-    stdin
-        .flush()
-        .map_err(|error| format!("failed to flush codex app-server model list request: {error}"))?;
+    ) {
+        kill_child(&mut child);
+        return Err(error);
+    }
+    if let Err(error) = stdin.flush() {
+        kill_child(&mut child);
+        return Err(format!(
+            "failed to flush codex app-server model list request: {error}"
+        ));
+    }
 
-    let stdout = child
-        .stdout
-        .take()
-        .ok_or_else(|| "failed to open codex app-server stdout".to_string())?;
+    let stdout = match child.stdout.take() {
+        Some(stdout) => stdout,
+        None => {
+            kill_child(&mut child);
+            return Err("failed to open codex app-server stdout".to_string());
+        }
+    };
     let message = read_codex_app_server_value_response(
         &mut child,
         stdout,
@@ -500,41 +513,8 @@ fn read_codex_app_server_model_list_with_command(
             return Err(error);
         }
     };
-    if !wait_for_native_model_cache_publication(cache_path, deadline) {
-        kill_child(&mut child);
-        return Err(
-            "codex app-server model list did not publish a readable native models cache before the refresh deadline"
-                .to_string(),
-        );
-    }
     kill_child(&mut child);
     Ok(result)
-}
-
-fn wait_for_native_model_cache_publication(cache_path: &Path, deadline: Instant) -> bool {
-    let mut previous = None;
-    loop {
-        let current = readable_native_model_cache(cache_path);
-        if current.is_some() && current == previous {
-            return true;
-        }
-        previous = current;
-
-        let now = Instant::now();
-        if now >= deadline {
-            return false;
-        }
-        thread::sleep(
-            CODEX_APP_SERVER_CACHE_POLL_INTERVAL.min(deadline.saturating_duration_since(now)),
-        );
-    }
-}
-
-fn readable_native_model_cache(cache_path: &Path) -> Option<Vec<u8>> {
-    let bytes = fs::read(cache_path).ok()?;
-    let payload: Value = serde_json::from_slice(&bytes).ok()?;
-    payload.get("models")?.as_array()?;
-    Some(bytes)
 }
 
 fn read_codex_app_server_value_response(
@@ -2686,7 +2666,21 @@ mod tests {
             .expect("flush app-server test-process liveness record");
 
         if mode.as_deref() == Ok("respond") {
-            println!("\n{}", json!({"id": 2, "result": {"data": []}}));
+            println!(
+                "\n{}",
+                json!({
+                    "id": 2,
+                    "result": {
+                        "data": [{
+                            "id": "gpt-5.6-terra",
+                            "model": "gpt-5.6-terra",
+                            "visibility": "list",
+                            "hidden": false,
+                            "context_window": 272000
+                        }]
+                    }
+                })
+            );
             std::io::stdout()
                 .flush()
                 .expect("flush app-server model-list test response");
@@ -2774,7 +2768,7 @@ mod tests {
     }
 
     #[test]
-    fn app_server_model_list_waits_for_delayed_atomic_native_cache_publication() {
+    fn app_server_model_list_does_not_wait_for_delayed_atomic_native_cache_publication() {
         let root = temp_root("app-server-delayed-cache");
         let script = root.join("fake-codex-app-server.py");
         let cache_path = root.join("codex-home").join("models_cache.json");
@@ -2791,8 +2785,8 @@ for line in sys.stdin:
     message = json.loads(line)
     if message.get("id") != 2:
         continue
-    print(json.dumps({"id": 2, "result": {"data": []}}), flush=True)
-    time.sleep(0.15)
+    print(json.dumps({"id": 2, "result": {"data": [{"id": "gpt-5.6-terra", "model": "gpt-5.6-terra", "visibility": "list", "hidden": False, "context_window": 272000}]}}), flush=True)
+    time.sleep(2)
     cache_path = Path(os.environ["FAKE_MODELS_CACHE"])
     temporary_path = cache_path.with_suffix(".tmp")
     temporary_path.write_text(
@@ -2811,21 +2805,31 @@ for line in sys.stdin:
 
         let result = super::read_codex_app_server_model_list_with_command(
             command,
-            &cache_path,
-            Duration::from_secs(2),
+            Duration::from_secs(5),
         )
         .expect("model list response");
 
-        assert_eq!(result, json!({"data": []}));
+        assert_eq!(
+            result,
+            json!({
+                "data": [{
+                    "id": "gpt-5.6-terra",
+                    "model": "gpt-5.6-terra",
+                    "visibility": "list",
+                    "hidden": false,
+                    "context_window": 272000
+                }]
+            })
+        );
         assert!(
-            cache_path.is_file(),
-            "the app-server must remain alive until its atomic native cache publication is visible"
+            !cache_path.is_file(),
+            "the app-server response must not wait for optional native cache publication"
         );
         let _ = fs::remove_dir_all(root);
     }
 
     #[test]
-    fn app_server_model_list_fails_closed_when_native_cache_is_never_published() {
+    fn app_server_model_list_accepts_valid_response_without_native_cache_publication() {
         let root = temp_root("app-server-missing-cache");
         let cache_path = root.join("codex-home").join("models_cache.json");
         let helper_liveness_path = root.join("helper-liveness.lock");
@@ -2833,21 +2837,29 @@ for line in sys.stdin:
         let command = responding_app_server_test_process_command(&helper_liveness_path);
         let started = Instant::now();
 
-        let error = super::read_codex_app_server_model_list_with_command(
+        let result = super::read_codex_app_server_model_list_with_command(
             command,
-            &cache_path,
             Duration::from_millis(500),
         )
-        .expect_err("missing native cache publication must fail closed");
+        .expect("valid model/list response must not require native cache publication");
 
         assert_eq!(
-            error,
-            "codex app-server model list did not publish a readable native models cache before the refresh deadline"
+            result,
+            json!({
+                "data": [{
+                    "id": "gpt-5.6-terra",
+                    "model": "gpt-5.6-terra",
+                    "visibility": "list",
+                    "hidden": false,
+                    "context_window": 272000
+                }]
+            })
         );
         assert!(
             started.elapsed() < Duration::from_secs(2),
-            "missing cache handling must remain bounded"
+            "model/list handling must remain bounded without native cache publication"
         );
+        assert!(!cache_path.is_file());
         assert_app_server_test_process_stopped(&helper_liveness_path);
         let _ = fs::remove_dir_all(root);
     }
@@ -2863,7 +2875,6 @@ for line in sys.stdin:
 
         let error = super::read_codex_app_server_model_list_with_command(
             command,
-            &cache_path,
             Duration::from_secs(1),
         )
         .expect_err("silent app-server must hit the response timeout");
@@ -3080,7 +3091,8 @@ for line in sys.stdin:
                     "id": "codex-auto-review",
                     "model": "gpt-5.6-terra",
                     "visibility": "list"
-                }
+                },
+                {"id": 42, "visibility": "list"}
             ]
         }));
 
@@ -3094,6 +3106,23 @@ for line in sys.stdin:
         assert_eq!(payload["visibility_diagnostics"]["hidden"], 1);
         assert_eq!(payload["visibility_diagnostics"]["unknown"], 1);
         assert_eq!(payload["visibility_diagnostics"]["internal"], 1);
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn subscription_refresh_rejects_malformed_model_list_without_publishing() {
+        let root = temp_root("subscription-malformed-refresh");
+        let paths = test_paths(&root);
+        let runner = StaticAppServerModelListRunner::ok(json!({
+            "data": {"not": "an array"}
+        }));
+
+        let error = refresh_official_models_with_runner(&paths, &runner)
+            .expect_err("malformed model/list response must fail closed");
+
+        assert!(error.contains("Codex subscription model list unavailable"));
+        assert!(!paths.official_subscription_cache_path().exists());
+        assert!(!paths.metadata_cache_path().exists());
         let _ = fs::remove_dir_all(root);
     }
 

--- a/src-tauri/src/proxy.rs
+++ b/src-tauri/src/proxy.rs
@@ -4460,6 +4460,47 @@ model_catalog_json = "model-catalogs/codex-proxy-official-ollama.json"
     }
 
     #[test]
+    fn session_shutdown_deadline_refuses_force_close_without_current_session_identity() {
+        let root = temp_root("session-shutdown-no-owned-identity");
+        let paths = test_paths(&root);
+        let port = free_port();
+        let pid = 12_345;
+        write_settings(&paths, port);
+        write_pid(&paths, pid, port, &paths.proxy_script_path()).expect("write pid");
+        let clock = FakeShutdownClock::default();
+        let alive = Arc::new(AtomicBool::new(true));
+        let listener_pid = Arc::new(AtomicU32::new(pid));
+        let killer = KillAwareKiller::new(Arc::clone(&alive), Arc::clone(&listener_pid));
+        let inspector =
+            KillAwareInspector::new(Arc::clone(&alive), fake_proxy_process(&paths, port));
+        let listener = AtomicListenerInspector::new(listener_pid);
+        let shutdown_request = |_port: u16, _key: &str, timeout: Duration| -> Result<(), String> {
+            assert_eq!(timeout, Duration::from_millis(800));
+            Ok(())
+        };
+        let health_probe =
+            |_port, _timeout| Ok(alive.load(Ordering::SeqCst).then(healthy_response));
+        let controls = UserRequestedShutdownControls {
+            killer: &killer,
+            inspector: &inspector,
+            listener_inspector: &listener,
+            shutdown_request: &shutdown_request,
+            health_probe: &health_probe,
+            clock: &clock,
+        };
+
+        let error = stop_session_owned_with_paths_and_controls(&paths, None, &controls)
+            .expect_err("missing current-session identity must refuse force-close");
+
+        assert!(error.contains("no current-session identity"), "{error}");
+        assert!(error.contains("force-close"), "{error}");
+        assert!(killer.killed.borrow().is_empty());
+        assert!(alive.load(Ordering::SeqCst));
+        assert_eq!(clock.elapsed(), Duration::from_secs(2));
+        assert_eq!(read_pid(&paths).expect("pid preserved"), Some(pid));
+    }
+
+    #[test]
     fn session_shutdown_deadline_reconciles_an_already_stopped_current_identity() {
         let root = temp_root("session-shutdown-deadline-already-stopped");
         let paths = test_paths(&root);
@@ -5217,12 +5258,37 @@ time.sleep(10)
 
         let result = (|| {
             let old_status = coordinator.start(&backend, || Ok(()))?;
-            *backend.session_owned_identity.borrow_mut() = coordinator.session_owned_identity();
             ensure(
                 old_status.status.proxy_port == old_port,
                 "old Gateway should use old port",
             )?;
             let old_pid = read_pid(&paths)?.ok_or_else(|| "old PID missing".to_string())?;
+            let old_identity = coordinator
+                .session_owned_identity()
+                .ok_or_else(|| "coordinator must acquire the old Gateway identity".to_string())?;
+            ensure(
+                old_identity.pid > 0
+                    && old_identity.port == old_port
+                    && !old_identity.script_path.is_empty()
+                    && old_identity
+                        .script_sha256
+                        .as_ref()
+                        .is_some_and(|sha256| !sha256.is_empty())
+                    && old_identity
+                        .process_start_id
+                        .as_ref()
+                        .is_some_and(|start_id| !start_id.is_empty())
+                    && old_identity.started_at_unix_ms > 0,
+                "coordinator must acquire a non-empty exact current-session identity",
+            )?;
+            let durable_identity = read_pid_record(&paths)?
+                .and_then(|record| record.gateway_identity())
+                .ok_or_else(|| "old Gateway must persist an exact identity".to_string())?;
+            ensure(
+                old_identity == durable_identity && old_identity.pid == old_pid,
+                "coordinator identity must match the durable old Gateway identity",
+            )?;
+            *backend.session_owned_identity.borrow_mut() = Some(old_identity);
             write_settings(&paths, new_port);
 
             let replacement = coordinator.restart(&backend, || Ok(()))?;

--- a/src-tauri/src/web_bridge.rs
+++ b/src-tauri/src/web_bridge.rs
@@ -480,6 +480,7 @@ fn dispatch(request: InvokeRequest, app: Option<AppHandle>) -> Result<Value, Str
         }
         "subagent_matrix_status" => to_value(gateway::subagent_matrix_status()),
         "generate_catalog" => to_value(catalog::generate_catalog()),
+        "get_catalog_override_diagnostics" => to_value(catalog::catalog_override_diagnostics()),
         "list_models" => to_value(models::list_models()),
         "refresh_model_metadata" => to_value(models::refresh_model_metadata()),
         "list_model_metadata" => to_value(models::list_model_metadata()),

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "CodexHub",
-  "version": "0.1.8-beta.1",
+  "version": "0.1.8-beta.2",
   "identifier": "com.codexhub.app",
   "build": {
     "frontendDist": "../frontend/dist",

--- a/tests/fixtures/issue_108_glm_qualification_evidence.json
+++ b/tests/fixtures/issue_108_glm_qualification_evidence.json
@@ -71,26 +71,26 @@
     ],
     "request_surfaces": [
       {
-        "raw_tools_sha256": "sha256:5c697ad0f536d5419e557c5fe4b3208016ec69c2cbe006dba4192210cf1e0294",
-        "canonical_shape_sha256": "sha256:8c3948a5a3eb6204be57b8d9e1e191f83bc08c3ee31e76fcbbfea0089e36bd7f",
+        "raw_tools_sha256": "sha256:0a69a2512db23c06561be489e636440cd76f5350c45c20d9af4b5c5106135da5",
+        "canonical_shape_sha256": "sha256:928b596451cd91c0a9ce953e444c80d6357d55bd4b1eff20078d6179d838b16f",
         "namespace_flattened_count": 0,
         "tool_search_visible": true
       },
       {
-        "raw_tools_sha256": "sha256:5c697ad0f536d5419e557c5fe4b3208016ec69c2cbe006dba4192210cf1e0294",
-        "canonical_shape_sha256": "sha256:8c3948a5a3eb6204be57b8d9e1e191f83bc08c3ee31e76fcbbfea0089e36bd7f",
+        "raw_tools_sha256": "sha256:0a69a2512db23c06561be489e636440cd76f5350c45c20d9af4b5c5106135da5",
+        "canonical_shape_sha256": "sha256:928b596451cd91c0a9ce953e444c80d6357d55bd4b1eff20078d6179d838b16f",
         "namespace_flattened_count": 0,
         "tool_search_visible": true
       },
       {
-        "raw_tools_sha256": "sha256:5c697ad0f536d5419e557c5fe4b3208016ec69c2cbe006dba4192210cf1e0294",
-        "canonical_shape_sha256": "sha256:8c3948a5a3eb6204be57b8d9e1e191f83bc08c3ee31e76fcbbfea0089e36bd7f",
+        "raw_tools_sha256": "sha256:0a69a2512db23c06561be489e636440cd76f5350c45c20d9af4b5c5106135da5",
+        "canonical_shape_sha256": "sha256:928b596451cd91c0a9ce953e444c80d6357d55bd4b1eff20078d6179d838b16f",
         "namespace_flattened_count": 0,
         "tool_search_visible": true
       },
       {
-        "raw_tools_sha256": "sha256:5c697ad0f536d5419e557c5fe4b3208016ec69c2cbe006dba4192210cf1e0294",
-        "canonical_shape_sha256": "sha256:8c3948a5a3eb6204be57b8d9e1e191f83bc08c3ee31e76fcbbfea0089e36bd7f",
+        "raw_tools_sha256": "sha256:0a69a2512db23c06561be489e636440cd76f5350c45c20d9af4b5c5106135da5",
+        "canonical_shape_sha256": "sha256:928b596451cd91c0a9ce953e444c80d6357d55bd4b1eff20078d6179d838b16f",
         "namespace_flattened_count": 0,
         "tool_search_visible": true
       }
@@ -112,9 +112,17 @@
         "keys": ["description", "name", "parameters", "strict", "type"]
       },
       {
-        "type": "custom",
+        "type": "function",
         "name": "apply_patch",
-        "keys": ["description", "format", "name", "type"]
+        "keys": ["description", "name", "parameters", "strict", "type"],
+        "strict": true,
+        "parameter_keys": ["additionalProperties", "properties", "required", "type"],
+        "property_names": ["patch"],
+        "patch_schema_keys": ["minLength", "type"],
+        "patch_type": "string",
+        "patch_min_length": 1,
+        "required": ["patch"],
+        "additional_properties": false
       },
       {
         "type": "function",

--- a/tests/test_catalog_sync.py
+++ b/tests/test_catalog_sync.py
@@ -58,6 +58,236 @@ class CatalogSyncTests(unittest.TestCase):
         self.assertNotIn("gpt-5.4", slugs)
         self.assertNotIn("glm-5.1", slugs)
 
+    def test_official_visibility_contract_excludes_hidden_unknown_and_internal_duplicates(self):
+        official = [
+            {
+                "slug": "gpt-5.6-terra",
+                "display_name": "GPT-5.6 Terra",
+                "visibility": "list",
+            },
+            {
+                "slug": "gpt-5.6-sol",
+                "display_name": "GPT-5.6 Sol",
+                "visibility": "hide",
+            },
+            {
+                "id": "codex-auto-review",
+                "model": "gpt-5.6-terra",
+                "slug": "gpt-5.6-terra",
+                "display_name": "GPT-5.6 Terra (review)",
+                "visibility": "list",
+            },
+            {
+                "slug": "gpt-5.6-luna",
+                "display_name": "GPT-5.6 Luna",
+                "visibility": "future",
+            },
+        ]
+
+        catalog = build_codex_catalog(official, [], self.policy, "0.144.0")
+
+        self.assertEqual(
+            [model["slug"] for model in catalog["models"]],
+            ["gpt-5.6-terra"],
+        )
+        self.assertEqual(catalog["models"][0]["visibility"], "list")
+
+    def test_hidden_flag_overrides_list_visibility(self):
+        catalog = build_codex_catalog(
+            [
+                {
+                    "slug": "gpt-5.6-terra",
+                    "visibility": "list",
+                    "hidden": True,
+                }
+            ],
+            [],
+            self.policy,
+            "0.144.0",
+        )
+
+        self.assertEqual(catalog["models"], [])
+        self.assertEqual(catalog["visibility_diagnostics"]["hidden"], 1)
+
+    def test_official_seed_snapshot_fails_closed_for_unknown_visibility(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            seed_path = Path(tmp) / "runtime-seed.json"
+            seed_path.write_text(
+                json.dumps(
+                    {
+                        "fetched_at": 1_000,
+                        "models": [
+                            {
+                                "slug": "gpt-5.6-terra",
+                                "visibility": "list",
+                            },
+                            {
+                                "slug": "gpt-5.6-sol",
+                                "visibility": "hide",
+                            },
+                            {
+                                "id": "codex-auto-review",
+                                "slug": "gpt-5.6-terra",
+                                "model": "gpt-5.6-terra",
+                                "visibility": "list",
+                            },
+                            {
+                                "slug": "gpt-5.6-luna",
+                                "visibility": "future",
+                            },
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            snapshot = catalog_sync.load_official_seed_snapshot(
+                Path(tmp) / "missing-bundled.json",
+                runtime_path=seed_path,
+                now_timestamp=1_001,
+            )
+
+        self.assertEqual([model["slug"] for model in snapshot.models], ["gpt-5.6-terra"])
+        self.assertEqual(snapshot.models[0]["visibility"], "list")
+
+    def test_runtime_seed_all_hidden_does_not_fallback_to_bundled_or_policy_models(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            runtime_path = Path(tmp) / "runtime-seed.json"
+            runtime_path.write_text(
+                json.dumps(
+                    {
+                        "fetched_at": 1_000,
+                        "models": [
+                            {"slug": "gpt-5.6-terra", "visibility": "hide"},
+                            {"slug": "gpt-5.6-sol", "visibility": "future"},
+                            {
+                                "id": "codex-auto-review",
+                                "slug": "gpt-5.6-terra",
+                                "visibility": "list",
+                            },
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            bundled_path = Path(tmp) / "bundled-seed.json"
+            bundled_path.write_text(
+                json.dumps(
+                    {
+                        "models": [
+                            {"slug": "gpt-5.5", "visibility": "list"},
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            snapshot = catalog_sync.load_official_seed_snapshot(
+                bundled_path,
+                runtime_path=runtime_path,
+                now_timestamp=1_001,
+            )
+            catalog = build_codex_catalog(
+                snapshot.models,
+                [],
+                self.policy,
+                "0.144.0",
+                official_source_present=snapshot.source_present,
+                visibility_diagnostics=snapshot.visibility_diagnostics,
+            )
+
+        self.assertEqual(snapshot.models, [])
+        self.assertTrue(snapshot.source_present)
+        self.assertEqual(snapshot.visibility_diagnostics, {"hidden": 1, "unknown": 1, "internal": 1})
+        self.assertEqual([model["slug"] for model in catalog["models"]], [])
+        self.assertEqual(catalog["visibility_diagnostics"], snapshot.visibility_diagnostics)
+
+    def test_seed_uses_bounded_upstream_visibility_diagnostics(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            runtime_path = Path(tmp) / "runtime-seed.json"
+            runtime_path.write_text(
+                json.dumps(
+                    {
+                        "fetched_at": 1_000,
+                        "visibility_diagnostics": {
+                            "hidden": 101,
+                            "unknown": 2,
+                            "internal": 1,
+                        },
+                        "models": [{"slug": "gpt-5.6-terra", "visibility": "list"}],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            snapshot = catalog_sync.load_official_seed_snapshot(
+                Path(tmp) / "missing-bundled.json",
+                runtime_path=runtime_path,
+                now_timestamp=1_001,
+            )
+
+        self.assertEqual(
+            snapshot.visibility_diagnostics,
+            {"hidden": 100, "unknown": 2, "internal": 1},
+        )
+
+    def test_unknown_official_source_does_not_recreate_policy_models(self):
+        catalog = build_codex_catalog(
+            [{"slug": "gpt-5.6-terra", "visibility": "future"}],
+            [],
+            self.policy,
+            "0.144.0",
+        )
+
+        self.assertEqual([model["slug"] for model in catalog["models"]], [])
+        self.assertEqual(catalog["visibility_diagnostics"]["unknown"], 1)
+
+    def test_direct_cache_internal_duplicate_terra_is_ignored_for_authority(self):
+        fixture_path = Path(__file__).parent / "fixtures" / "codex_0_144_2_direct_models_cache.json"
+        cache_payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+        cache_payload["models"].append(
+            {
+                "id": "codex-auto-review",
+                "model": "gpt-5.6-terra",
+                "slug": "gpt-5.6-terra",
+                "visibility": "list",
+            }
+        )
+        snapshot = catalog_sync.OfficialSeedSnapshot(
+            models=[
+                {**model, "visibility": "list"}
+                for model in cache_payload["models"]
+                if str(model.get("slug", "")).startswith("gpt-")
+            ],
+            source="current_direct_official",
+            context_freshness="fresh",
+        )
+        cache_timestamp = catalog_sync._catalog_fetched_at_timestamp(cache_payload["fetched_at"])
+        self.assertIsNotNone(cache_timestamp)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            cache_path = Path(tmp) / "models_cache.json"
+            cache_path.write_text(json.dumps(cache_payload), encoding="utf-8")
+            authority = catalog_sync.load_fresh_direct_official_cache_authority(
+                snapshot,
+                cache_path,
+                now_timestamp=cache_timestamp + 1,
+            )
+
+        self.assertEqual(authority.freshness, "fresh")
+        self.assertEqual(
+            sorted(authority.context_by_slug),
+            [
+                "gpt-5.3-codex-spark",
+                "gpt-5.4",
+                "gpt-5.4-mini",
+                "gpt-5.5",
+                "gpt-5.6-luna",
+                "gpt-5.6-sol",
+                "gpt-5.6-terra",
+            ],
+        )
+
     def test_build_catalog_keeps_only_official_and_allowed_cloud_models(self):
         official = [
             {"slug": "gpt-5.5", "display_name": "GPT-5.5", "visibility": "list"},

--- a/tests/test_catalog_sync.py
+++ b/tests/test_catalog_sync.py
@@ -733,6 +733,949 @@ class CatalogSyncTests(unittest.TestCase):
                 self.assertNotIn("tool_mode", by_slug[slug])
                 self.assertNotIn("multi_agent_version", by_slug[slug])
 
+    def test_sync_catalog_preserves_legacy_luna_multi_agent_override_across_restart(self):
+        official = [
+            {"slug": "gpt-5.6-luna", "display_name": "GPT-5.6-Luna", "visibility": "list"},
+        ]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            generated = root / "model-catalogs" / catalog_sync.GENERATED_CATALOG_FILENAME
+            baseline = root / "model-catalogs" / catalog_sync.MANAGED_CATALOG_BASELINE_FILENAME
+            overrides = root / "model-catalogs" / catalog_sync.CATALOG_OVERRIDES_FILENAME
+            state_path = root / "model-catalogs" / "state.json"
+
+            def run_sync() -> dict:
+                with (
+                    patch.object(catalog_sync, "GENERATED_CATALOG_PATH", generated),
+                    patch.object(catalog_sync, "MANAGED_CATALOG_BASELINE_PATH", baseline),
+                    patch.object(catalog_sync, "CATALOG_OVERRIDES_PATH", overrides),
+                    patch.object(catalog_sync, "GENERATED_STATE_PATH", state_path),
+                    patch("catalog_sync.catalog_cache_is_fresh", return_value=False),
+                    patch("catalog_sync.load_policy", return_value=self.policy),
+                    patch("catalog_sync.load_include_official_models", return_value=True),
+                    patch("catalog_sync.load_official_model_sort_order", return_value=[]),
+                    patch("catalog_sync.load_official_disabled_models", return_value=[]),
+                    patch("catalog_sync.load_official_seed_snapshot", return_value=catalog_sync.OfficialSeedSnapshot(official, "direct", "fresh", True)),
+                    patch("catalog_sync.load_previous_official_context_budgets", return_value={}),
+                    patch("catalog_sync.load_fresh_direct_official_cache_authority", return_value=None),
+                    patch("catalog_sync.official_context_signals_from_snapshot", return_value={}),
+                    patch("catalog_sync.load_fallback_catalog_models", return_value=[]),
+                    patch("catalog_sync.read_client_version", return_value="0.146.0"),
+                    patch("catalog_sync.discover_ollama_ids", return_value=([], "test", "ok", "")),
+                    patch("catalog_sync.load_providers", return_value=[]),
+                    patch("catalog_sync.catalog_visible_ollama_cloud_models", return_value=(False, [])),
+                    patch("catalog_sync.catalog_visible_external_models", return_value=[]),
+                    patch("catalog_sync.discover_ollama_model_metadata", return_value=({}, "")),
+                ):
+                    return catalog_sync.sync_catalog()
+
+            run_sync()
+            # Remove the new sidecars to model a pre-Beta2 single-file
+            # installation.  The next sync must migrate only the supported
+            # same-model planner delta from the edited effective catalog.
+            baseline.unlink()
+            overrides.unlink()
+            initial = json.loads(generated.read_text(encoding="utf-8"))
+            # Strip the Beta2 ownership marker so this is a true legacy
+            # single-file migration rather than a modern catalog round-trip.
+            initial_metadata = initial["models"][0]["codex_proxy_metadata"]
+            initial_metadata.pop(catalog_sync.CATALOG_OWNER_METADATA_KEY, None)
+            initial_metadata.pop(catalog_sync.CATALOG_OWNER_METADATA_VERSION_KEY, None)
+            initial_metadata.pop(catalog_sync.CATALOG_OWNER_IDENTITY_KEY, None)
+            initial_metadata.pop(catalog_sync.CATALOG_OWNER_SIGNATURE_KEY, None)
+            initial["models"][0]["multi_agent_version"] = "v2"
+            # Pre-Beta2 Ollama rows may not carry proxy identity metadata;
+            # they must not prevent the exact Official legacy migration.
+            initial["models"].append(
+                {
+                    "slug": "glm-5.2",
+                    "visibility": "list",
+                    "use_responses_lite": False,
+                }
+            )
+            generated.write_text(json.dumps(initial), encoding="utf-8")
+
+            state = run_sync()
+            effective = json.loads(generated.read_text(encoding="utf-8"))
+            managed = json.loads(baseline.read_text(encoding="utf-8"))
+            override_state = json.loads(overrides.read_text(encoding="utf-8"))
+
+            self.assertEqual(effective["models"][0]["multi_agent_version"], "v2")
+            self.assertEqual(managed["models"][0]["multi_agent_version"], "v1")
+            self.assertEqual(override_state["overrides"][0]["fields"], {"multi_agent_version": "v2"})
+            self.assertEqual(state["catalog_override_diagnostics"]["accepted"], 1)
+
+            # A second restart is idempotent and must not duplicate the sidecar
+            # entry or drift the effective value.
+            run_sync()
+            repeated = json.loads(generated.read_text(encoding="utf-8"))
+            repeated_overrides = json.loads(overrides.read_text(encoding="utf-8"))
+            self.assertEqual(repeated["models"][0]["multi_agent_version"], "v2")
+            self.assertEqual(len(repeated_overrides["overrides"]), 1)
+
+            # A hidden source row is not an ownership authority.  The next
+            # sync must fail closed instead of copying its v2 value onto the
+            # newly generated visible row.
+            hidden = json.loads(generated.read_text(encoding="utf-8"))
+            hidden["models"][0]["visibility"] = "hide"
+            generated.write_text(json.dumps(hidden), encoding="utf-8")
+            state = run_sync()
+            effective = json.loads(generated.read_text(encoding="utf-8"))
+            override_state = json.loads(overrides.read_text(encoding="utf-8"))
+            self.assertEqual(effective["models"][0]["multi_agent_version"], "v1")
+            self.assertEqual(override_state["overrides"], [])
+            self.assertEqual(
+                state["catalog_override_diagnostics"]["reasons"].get("invalid_row_identity"),
+                1,
+            )
+
+    def test_catalog_override_does_not_copy_official_planner_metadata_to_external_model(self):
+        external = {
+            "alias": "volc/gpt-5.6-luna",
+            "provider_alias": "volc",
+            "upstream_name": "volcengine",
+            "upstream_model": "gpt-5.6-luna",
+        }
+        model = catalog_sync.build_external_provider_model(
+            external,
+            self.policy,
+            {
+                "prefer_websockets": True,
+                "tool_mode": "code_mode_only",
+                "multi_agent_version": "v2",
+                "use_responses_lite": True,
+                "codex_proxy_metadata": {
+                    "official_context_budget": {"context_window": 272000},
+                    "provider": "openai",
+                },
+            },
+        )
+        self.assertNotIn("multi_agent_version", model)
+        self.assertNotIn("tool_mode", model)
+        self.assertNotIn("prefer_websockets", model)
+        self.assertIs(model["use_responses_lite"], False)
+        self.assertNotIn("official_context_budget", model["codex_proxy_metadata"])
+        self.assertEqual(model["codex_proxy_metadata"]["provider"], "volc")
+        external_identity = catalog_sync.catalog_model_identity(model)
+        self.assertIsNotNone(external_identity)
+        self.assertTrue(
+            catalog_sync._catalog_override_row_is_eligible(
+                external_identity,
+                model,
+            )
+        )
+
+        ollama = catalog_sync.build_ollama_model(
+            "glm-5.2",
+            self.policy,
+            {},
+            {
+                "prefer_websockets": True,
+                "tool_mode": "code_mode_only",
+                "multi_agent_version": "v2",
+                "use_responses_lite": True,
+            },
+        )
+        self.assertNotIn("multi_agent_version", ollama)
+        self.assertNotIn("tool_mode", ollama)
+        self.assertNotIn("prefer_websockets", ollama)
+        self.assertIs(ollama["use_responses_lite"], False)
+        self.assertEqual(ollama["codex_proxy_metadata"]["provider"], "ollama-cloud")
+        self.assertEqual(ollama["codex_proxy_metadata"]["upstream_name"], "ollama_cloud")
+        self.assertEqual(ollama["codex_proxy_metadata"]["upstream_model"], "glm-5.2")
+
+    def test_catalog_override_rejects_invalid_unknown_and_cross_provider_entries(self):
+        valid_identity = ("openai", "official", "gpt-5.6-luna")
+        cases = {
+            "external-provider": {
+                "provider": "volc",
+                "upstream_name": "official",
+                "upstream_model": "gpt-5.6-luna",
+                "fields": {"multi_agent_version": "v2"},
+            },
+            "unknown-official": {
+                "provider": "openai",
+                "upstream_name": "official",
+                "upstream_model": "gpt-9.9-luna",
+                "fields": {"multi_agent_version": "v2"},
+            },
+            "invalid-shape": {
+                "provider": "openai",
+                "upstream_name": "official",
+                "upstream_model": "gpt-5.6-luna",
+                "fields": {"use_responses_lite": False},
+            },
+        }
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "overrides.json"
+            path.write_text(
+                json.dumps({"schema_version": 1, "overrides": list(cases.values())}),
+                encoding="utf-8",
+            )
+            diagnostics = {}
+            self.assertEqual(catalog_sync._load_catalog_override_state(path, diagnostics), {})
+            self.assertEqual(diagnostics["reasons"]["invalid_override_fields"], 1)
+            self.assertTrue(
+                catalog_sync._planner_override_is_valid(
+                    valid_identity,
+                    {"multi_agent_version": "v2"},
+                )
+            )
+            for field in ("prefer_websockets", "use_responses_lite"):
+                with self.subTest(field=field):
+                    self.assertFalse(
+                        catalog_sync._planner_override_is_valid(
+                            valid_identity,
+                            {field: 1},
+                        )
+                    )
+            path.write_text("[]", encoding="utf-8")
+            self.assertEqual(catalog_sync._load_catalog_override_state(path), {})
+
+            valid_entry = {
+                "provider": valid_identity[0],
+                "upstream_name": valid_identity[1],
+                "upstream_model": valid_identity[2],
+                "fields": {"multi_agent_version": "v2"},
+            }
+            diagnostics = {}
+            path.write_text(
+                json.dumps({"schema_version": True, "overrides": [valid_entry]}),
+                encoding="utf-8",
+            )
+            self.assertEqual(catalog_sync._load_catalog_override_state(path, diagnostics), {})
+            self.assertEqual(diagnostics["reasons"]["invalid_sidecar"], 1)
+
+            diagnostics = {}
+            path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "overrides": [
+                            valid_entry,
+                            {**valid_entry, "unexpected": "field"},
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            self.assertEqual(catalog_sync._load_catalog_override_state(path, diagnostics), {})
+            self.assertEqual(diagnostics["reasons"]["invalid_sidecar"], 1)
+
+            diagnostics = {}
+            path.write_text(
+                json.dumps({"schema_version": 1, "overrides": [valid_entry, valid_entry]}),
+                encoding="utf-8",
+            )
+            self.assertEqual(catalog_sync._load_catalog_override_state(path, diagnostics), {})
+            self.assertEqual(diagnostics["reasons"]["invalid_sidecar"], 1)
+
+    def test_catalog_override_rejects_malformed_managed_baseline_without_legacy_migration(self):
+        identity = ("openai", "official", "gpt-5.6-luna")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            baseline = Path(tmpdir) / "baseline.json"
+            generated = Path(tmpdir) / "catalog.json"
+            baseline.write_text(json.dumps({"models": []}), encoding="utf-8")
+            generated.write_text(
+                json.dumps(
+                    {
+                        "models": [
+                            {
+                                "slug": "gpt-5.6-luna",
+                                "visibility": "list",
+                                "multi_agent_version": "v2",
+                                "codex_proxy_metadata": {
+                                    "provider": identity[0],
+                                    "upstream_name": identity[1],
+                                    "upstream_model": identity[2],
+                                },
+                            }
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+            with (
+                patch.object(catalog_sync, "MANAGED_CATALOG_BASELINE_PATH", baseline),
+                patch.object(catalog_sync, "GENERATED_CATALOG_PATH", generated),
+                patch.object(catalog_sync, "CATALOG_OVERRIDES_PATH", Path(tmpdir) / "overrides.json"),
+            ):
+                overrides, diagnostics = catalog_sync._collect_catalog_overrides()
+            self.assertEqual(overrides, {})
+            self.assertEqual(diagnostics["reasons"]["invalid_baseline"], 1)
+
+            baseline.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "managed_baseline": True,
+                        "models": [
+                            {
+                                "slug": "gpt-5.6-luna",
+                                "visibility": "list",
+                                "codex_proxy_metadata": {
+                                    "provider": identity[0],
+                                    "upstream_name": identity[1],
+                                    "upstream_model": identity[2],
+                                },
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            with (
+                patch.object(catalog_sync, "MANAGED_CATALOG_BASELINE_PATH", baseline),
+                patch.object(catalog_sync, "GENERATED_CATALOG_PATH", generated),
+                patch.object(catalog_sync, "CATALOG_OVERRIDES_PATH", Path(tmpdir) / "overrides.json"),
+            ):
+                overrides, diagnostics = catalog_sync._collect_catalog_overrides()
+            self.assertEqual(overrides, {})
+            self.assertEqual(diagnostics["reasons"]["invalid_baseline"], 1)
+
+    def test_catalog_override_matches_exact_identity_not_slug(self):
+        official_identity = ("openai", "official", "gpt-5.6-luna")
+        external_model = {
+            "slug": "volc/gpt-5.6-luna",
+            "codex_proxy_metadata": {
+                "provider": "volc",
+                "upstream_name": "volcengine",
+                "upstream_model": "gpt-5.6-luna",
+            },
+        }
+        catalog = {"models": [external_model]}
+        catalog_sync._apply_catalog_overrides(
+            catalog,
+            {official_identity: {"multi_agent_version": "v2"}},
+            {"accepted": 0, "rejected": 0},
+        )
+        self.assertNotIn("multi_agent_version", external_model)
+
+    def test_catalog_override_rejects_legacy_official_identity_spoof(self):
+        identity = ("openai", "official", "gpt-5.6-luna")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            current = root / "catalog.json"
+            current.write_text(
+                json.dumps(
+                    {
+                        "models": [
+                            {
+                                "slug": identity[2],
+                                "visibility": "list",
+                                "multi_agent_version": "v2",
+                                "codex_proxy_metadata": {
+                                    "provider": identity[0],
+                                    "upstream_name": identity[1],
+                                    "upstream_model": identity[2],
+                                },
+                            }
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+            with (
+                patch.object(catalog_sync, "MANAGED_CATALOG_BASELINE_PATH", root / "missing-baseline.json"),
+                patch.object(catalog_sync, "GENERATED_CATALOG_PATH", current),
+                patch.object(catalog_sync, "CATALOG_OVERRIDES_PATH", root / "overrides.json"),
+            ):
+                overrides, diagnostics = catalog_sync._collect_catalog_overrides()
+
+            self.assertEqual(overrides, {})
+            self.assertEqual(diagnostics["reasons"]["invalid_row_identity"], 1)
+
+    def test_catalog_override_validates_managed_identity_digest(self):
+        official = [{"slug": "gpt-5.6-luna", "display_name": "GPT-5.6-Luna", "visibility": "list"}]
+        managed = catalog_sync.build_codex_catalog(official, [], self.policy, "0.146.0")
+        current = json.loads(json.dumps(managed))
+        current["models"][0]["multi_agent_version"] = "v2"
+        current["models"][0]["codex_proxy_metadata"][catalog_sync.CATALOG_OWNER_IDENTITY_KEY] = "0" * 64
+        baseline = json.loads(json.dumps(managed))
+        baseline.update({"schema_version": 1, "managed_baseline": True})
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            current_path = root / "catalog.json"
+            baseline_path = root / "baseline.json"
+            current_path.write_text(json.dumps(current), encoding="utf-8")
+            baseline_path.write_text(json.dumps(baseline), encoding="utf-8")
+            with (
+                patch.object(catalog_sync, "GENERATED_CATALOG_PATH", current_path),
+                patch.object(catalog_sync, "MANAGED_CATALOG_BASELINE_PATH", baseline_path),
+                patch.object(catalog_sync, "CATALOG_OVERRIDES_PATH", root / "overrides.json"),
+            ):
+                overrides, diagnostics = catalog_sync._collect_catalog_overrides()
+
+            self.assertEqual(overrides, {})
+            self.assertEqual(diagnostics["reasons"]["invalid_row_identity"], 1)
+
+        target = json.loads(json.dumps(managed["models"][0]))
+        target["codex_proxy_metadata"][catalog_sync.CATALOG_OWNER_IDENTITY_KEY] = "0" * 64
+        catalog = {"models": [target]}
+        diagnostics = {"accepted": 0, "rejected": 0, "reasons": {}}
+        catalog_sync._apply_catalog_overrides(
+            catalog,
+            {("openai", "official", "gpt-5.6-luna"): {"multi_agent_version": "v2"}},
+            diagnostics,
+        )
+        self.assertNotEqual(target.get("multi_agent_version"), "v2")
+        self.assertEqual(diagnostics["reasons"]["invalid_row_identity"], 1)
+
+    def test_catalog_override_rejects_recomputed_public_digest_without_owner_signature(self):
+        official = [{"slug": "gpt-5.6-luna", "display_name": "GPT-5.6-Luna", "visibility": "list"}]
+        identity = ("openai", "official", "gpt-5.6-luna")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            overrides_path = root / "overrides.json"
+            key_path = root / catalog_sync.CATALOG_OWNER_SECRET_FILENAME
+            key_path.write_text("11" * 32, encoding="ascii")
+            with patch.object(catalog_sync, "CATALOG_OVERRIDES_PATH", overrides_path), patch.object(
+                catalog_sync, "_CATALOG_OWNER_SECRET_CACHE", None
+            ):
+                managed = catalog_sync.build_codex_catalog(official, [], self.policy, "0.146.0")
+                current = json.loads(json.dumps(managed))
+                current["models"][0]["multi_agent_version"] = "v2"
+                current["models"][0]["description"] = "forged Official row"
+                metadata = current["models"][0]["codex_proxy_metadata"]
+                metadata[catalog_sync.CATALOG_OWNER_IDENTITY_KEY] = catalog_sync.catalog_identity_digest(identity)
+                baseline = json.loads(json.dumps(managed))
+                baseline.update({"schema_version": 1, "managed_baseline": True})
+                current_path = root / "catalog.json"
+                baseline_path = root / "baseline.json"
+                current_path.write_text(json.dumps(current), encoding="utf-8")
+                baseline_path.write_text(json.dumps(baseline), encoding="utf-8")
+                with (
+                    patch.object(catalog_sync, "GENERATED_CATALOG_PATH", current_path),
+                    patch.object(catalog_sync, "MANAGED_CATALOG_BASELINE_PATH", baseline_path),
+                ):
+                    collected, diagnostics = catalog_sync._collect_catalog_overrides()
+
+            self.assertEqual(collected, {})
+            self.assertEqual(diagnostics["reasons"]["invalid_row_identity"], 1)
+
+    def test_marker_only_beta2_baseline_migrates_existing_luna_override(self):
+        official = [{"slug": "gpt-5.6-luna", "display_name": "GPT-5.6-Luna", "visibility": "list"}]
+        identity = ("openai", "official", "gpt-5.6-luna")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            overrides_path = root / "overrides.json"
+            (root / catalog_sync.CATALOG_OWNER_SECRET_FILENAME).write_text(
+                "22" * 32,
+                encoding="ascii",
+            )
+            with (
+                patch.object(catalog_sync, "CATALOG_OVERRIDES_PATH", overrides_path),
+                patch.object(catalog_sync, "_CATALOG_OWNER_SECRET_CACHE", None),
+            ):
+                managed = catalog_sync.build_codex_catalog(official, [], self.policy, "0.146.0")
+                # This is the representation emitted by the pre-HMAC Beta2
+                # build: it has CodexHub ownership metadata but no signature.
+                for model in managed["models"]:
+                    model["codex_proxy_metadata"].pop(
+                        catalog_sync.CATALOG_OWNER_SIGNATURE_KEY,
+                        None,
+                    )
+                baseline = json.loads(json.dumps(managed))
+                baseline.update({"schema_version": 1, "managed_baseline": True})
+                current = json.loads(json.dumps(managed))
+                current["models"][0]["multi_agent_version"] = "v2"
+                baseline_path = root / "baseline.json"
+                current_path = root / "catalog.json"
+                baseline_path.write_text(json.dumps(baseline), encoding="utf-8")
+                current_path.write_text(json.dumps(current), encoding="utf-8")
+                with (
+                    patch.object(catalog_sync, "GENERATED_CATALOG_PATH", current_path),
+                    patch.object(catalog_sync, "MANAGED_CATALOG_BASELINE_PATH", baseline_path),
+                ):
+                    collected, diagnostics = catalog_sync._collect_catalog_overrides()
+
+            self.assertEqual(
+                collected,
+                {identity: {"multi_agent_version": "v2"}},
+            )
+            self.assertEqual(diagnostics["accepted"], 1)
+
+    def test_marker_only_legacy_catalog_migrates_against_fresh_generated_baseline(self):
+        official = [{"slug": "gpt-5.6-luna", "display_name": "GPT-5.6-Luna", "visibility": "list"}]
+        identity = ("openai", "official", "gpt-5.6-luna")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            overrides_path = root / "overrides.json"
+            current_path = root / "catalog.json"
+            (root / catalog_sync.CATALOG_OWNER_SECRET_FILENAME).write_text(
+                "55" * 32,
+                encoding="ascii",
+            )
+            with (
+                patch.object(catalog_sync, "CATALOG_OVERRIDES_PATH", overrides_path),
+                patch.object(catalog_sync, "_CATALOG_OWNER_SECRET_CACHE", None),
+            ):
+                generated = catalog_sync.build_codex_catalog(official, [], self.policy, "0.146.0")
+                current = json.loads(json.dumps(generated))
+                current["models"][0]["multi_agent_version"] = "v2"
+                current["models"][0]["codex_proxy_metadata"].pop(
+                    catalog_sync.CATALOG_OWNER_SIGNATURE_KEY,
+                    None,
+                )
+                current_path.write_text(json.dumps(current), encoding="utf-8")
+                with (
+                    patch.object(catalog_sync, "GENERATED_CATALOG_PATH", current_path),
+                    patch.object(
+                        catalog_sync,
+                        "MANAGED_CATALOG_BASELINE_PATH",
+                        root / "missing-baseline.json",
+                    ),
+                ):
+                    collected, diagnostics = catalog_sync._collect_catalog_overrides(
+                        legacy_baseline=generated,
+                    )
+
+            self.assertEqual(
+                collected,
+                {identity: {"multi_agent_version": "v2"}},
+            )
+            self.assertEqual(diagnostics["accepted"], 1)
+
+    def test_generated_legacy_baseline_rejects_markerless_forged_row(self):
+        official = [{"slug": "gpt-5.6-luna", "display_name": "GPT-5.6-Luna", "visibility": "list"}]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            overrides_path = root / "overrides.json"
+            current_path = root / "catalog.json"
+            (root / catalog_sync.CATALOG_OWNER_SECRET_FILENAME).write_text(
+                "66" * 32,
+                encoding="ascii",
+            )
+            with (
+                patch.object(catalog_sync, "CATALOG_OVERRIDES_PATH", overrides_path),
+                patch.object(catalog_sync, "_CATALOG_OWNER_SECRET_CACHE", None),
+            ):
+                generated = catalog_sync.build_codex_catalog(official, [], self.policy, "0.146.0")
+                current = json.loads(json.dumps(generated))
+                row = current["models"][0]
+                row["multi_agent_version"] = "v2"
+                row["description"] = "forged Official row"
+                metadata = row["codex_proxy_metadata"]
+                for key in (
+                    catalog_sync.CATALOG_OWNER_METADATA_KEY,
+                    catalog_sync.CATALOG_OWNER_METADATA_VERSION_KEY,
+                    catalog_sync.CATALOG_OWNER_IDENTITY_KEY,
+                    catalog_sync.CATALOG_OWNER_SIGNATURE_KEY,
+                ):
+                    metadata.pop(key, None)
+                current_path.write_text(json.dumps(current), encoding="utf-8")
+                with (
+                    patch.object(catalog_sync, "GENERATED_CATALOG_PATH", current_path),
+                    patch.object(
+                        catalog_sync,
+                        "MANAGED_CATALOG_BASELINE_PATH",
+                        root / "missing-baseline.json",
+                    ),
+                ):
+                    collected, diagnostics = catalog_sync._collect_catalog_overrides(
+                        legacy_baseline=generated,
+                    )
+
+            self.assertEqual(collected, {})
+            self.assertEqual(diagnostics["reasons"]["invalid_row_identity"], 1)
+
+    def test_marker_only_catalog_without_baseline_rejects_forged_row_when_key_exists(self):
+        official = [{"slug": "gpt-5.6-luna", "display_name": "GPT-5.6-Luna", "visibility": "list"}]
+        identity = ("openai", "official", "gpt-5.6-luna")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            overrides_path = root / "overrides.json"
+            current_path = root / "catalog.json"
+            (root / catalog_sync.CATALOG_OWNER_SECRET_FILENAME).write_text(
+                "33" * 32,
+                encoding="ascii",
+            )
+            with (
+                patch.object(catalog_sync, "CATALOG_OVERRIDES_PATH", overrides_path),
+                patch.object(catalog_sync, "_CATALOG_OWNER_SECRET_CACHE", None),
+            ):
+                managed = catalog_sync.build_codex_catalog(official, [], self.policy, "0.146.0")
+                row = managed["models"][0]
+                row["multi_agent_version"] = "v2"
+                row["description"] = "forged Official row"
+                row["codex_proxy_metadata"].pop(
+                    catalog_sync.CATALOG_OWNER_SIGNATURE_KEY,
+                    None,
+                )
+                current_path.write_text(json.dumps(managed), encoding="utf-8")
+                with (
+                    patch.object(catalog_sync, "GENERATED_CATALOG_PATH", current_path),
+                    patch.object(
+                        catalog_sync,
+                        "MANAGED_CATALOG_BASELINE_PATH",
+                        root / "missing-baseline.json",
+                    ),
+                ):
+                    collected, diagnostics = catalog_sync._collect_catalog_overrides()
+
+            self.assertEqual(collected, {})
+            self.assertEqual(diagnostics["reasons"]["invalid_row_identity"], 1)
+
+    def test_catalog_override_rejects_unhashable_multi_agent_values(self):
+        identity = ("openai", "official", "gpt-5.6-luna")
+        for malformed in ([], {}):
+            with self.subTest(malformed=malformed), tempfile.TemporaryDirectory() as tmpdir:
+                root = Path(tmpdir)
+                path = root / "overrides.json"
+                path.write_text(
+                    json.dumps(
+                        {
+                            "schema_version": 1,
+                            "overrides": [
+                                {
+                                    "provider": identity[0],
+                                    "upstream_name": identity[1],
+                                    "upstream_model": identity[2],
+                                    "fields": {"multi_agent_version": malformed},
+                                }
+                            ],
+                        }
+                    ),
+                    encoding="utf-8",
+                )
+                diagnostics = {}
+                self.assertEqual(catalog_sync._load_catalog_override_state(path, diagnostics), {})
+                self.assertEqual(diagnostics["reasons"]["invalid_override_fields"], 1)
+
+    def test_managed_baseline_rejects_unhashable_multi_agent_value(self):
+        official = [{"slug": "gpt-5.6-luna", "display_name": "GPT-5.6-Luna", "visibility": "list"}]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            baseline = catalog_sync.build_codex_catalog(official, [], self.policy, "0.146.0")
+            baseline.update({"schema_version": 1, "managed_baseline": True})
+            baseline["models"][0]["multi_agent_version"] = []
+            baseline_path = root / "baseline.json"
+            current_path = root / "catalog.json"
+            baseline_path.write_text(json.dumps(baseline), encoding="utf-8")
+            current_path.write_text(json.dumps({"models": baseline["models"]}), encoding="utf-8")
+            with (
+                patch.object(catalog_sync, "MANAGED_CATALOG_BASELINE_PATH", baseline_path),
+                patch.object(catalog_sync, "GENERATED_CATALOG_PATH", current_path),
+                patch.object(catalog_sync, "CATALOG_OVERRIDES_PATH", root / "overrides.json"),
+            ):
+                collected, diagnostics = catalog_sync._collect_catalog_overrides()
+            self.assertEqual(collected, {})
+            self.assertEqual(diagnostics["reasons"]["invalid_baseline"], 1)
+
+    def test_managed_baseline_accepts_pinned_legacy_null_multi_agent_versions(self):
+        official = [
+            {"slug": slug, "display_name": slug, "visibility": "list"}
+            for slug in catalog_sync.PINNED_OFFICIAL_MODEL_IDS
+        ]
+        baseline = catalog_sync.build_codex_catalog(official, [], self.policy, "0.146.0")
+        baseline.update({"schema_version": 1, "managed_baseline": True})
+
+        self.assertTrue(catalog_sync._managed_baseline_shape_is_valid(baseline))
+        by_slug = {model["slug"]: model for model in baseline["models"]}
+        for slug in catalog_sync.PINNED_OFFICIAL_LEGACY_MODEL_IDS:
+            with self.subTest(slug=slug):
+                self.assertIsNone(by_slug[slug]["multi_agent_version"])
+
+    def test_managed_baseline_accepts_unpinned_official_rows_without_authorizing_overrides(self):
+        official = [
+            {"slug": "gpt-5.6-luna", "display_name": "GPT-5.6-Luna", "visibility": "list"},
+            {"slug": "gpt-sparse", "display_name": "GPT-Sparse", "visibility": "list"},
+        ]
+        baseline = catalog_sync.build_codex_catalog(official, [], self.policy, "0.146.0")
+        baseline.update({"schema_version": 1, "managed_baseline": True})
+
+        self.assertTrue(
+            catalog_sync._catalog_payload_shape_is_valid(baseline, require_identity=True)
+        )
+        self.assertTrue(catalog_sync._managed_baseline_shape_is_valid(baseline))
+        self.assertFalse(
+            catalog_sync._planner_override_is_valid(
+                ("openai", "official", "gpt-sparse"),
+                {"multi_agent_version": "v2"},
+            )
+        )
+
+    def test_managed_baseline_rejects_numeric_boolean_planner_values(self):
+        official = [{"slug": "gpt-5.6-luna", "display_name": "GPT-5.6-Luna", "visibility": "list"}]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            baseline = catalog_sync.build_codex_catalog(official, [], self.policy, "0.146.0")
+            baseline.update({"schema_version": 1, "managed_baseline": True})
+            baseline["models"][0]["prefer_websockets"] = 1
+            baseline_path = root / "baseline.json"
+            current_path = root / "catalog.json"
+            baseline_path.write_text(json.dumps(baseline), encoding="utf-8")
+            current_path.write_text(json.dumps({"models": baseline["models"]}), encoding="utf-8")
+            with (
+                patch.object(catalog_sync, "MANAGED_CATALOG_BASELINE_PATH", baseline_path),
+                patch.object(catalog_sync, "GENERATED_CATALOG_PATH", current_path),
+                patch.object(catalog_sync, "CATALOG_OVERRIDES_PATH", root / "overrides.json"),
+            ):
+                collected, diagnostics = catalog_sync._collect_catalog_overrides()
+            self.assertEqual(collected, {})
+            self.assertEqual(diagnostics["reasons"]["invalid_baseline"], 1)
+
+    def test_markerless_managed_baseline_cannot_seed_an_official_override(self):
+        identity = ("openai", "official", "gpt-5.6-luna")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            baseline_model = {
+                "slug": identity[2],
+                "visibility": "list",
+                "prefer_websockets": True,
+                "tool_mode": "code_mode_only",
+                "multi_agent_version": "v1",
+                "use_responses_lite": True,
+                "codex_proxy_metadata": {
+                    "provider": identity[0],
+                    "upstream_name": identity[1],
+                    "upstream_model": identity[2],
+                },
+            }
+            current_model = json.loads(json.dumps(baseline_model))
+            current_model["multi_agent_version"] = "v2"
+            baseline_path = root / "baseline.json"
+            current_path = root / "catalog.json"
+            baseline_path.write_text(
+                json.dumps({"schema_version": 1, "managed_baseline": True, "models": [baseline_model]}),
+                encoding="utf-8",
+            )
+            current_path.write_text(json.dumps({"models": [current_model]}), encoding="utf-8")
+            with (
+                patch.object(catalog_sync, "MANAGED_CATALOG_BASELINE_PATH", baseline_path),
+                patch.object(catalog_sync, "GENERATED_CATALOG_PATH", current_path),
+                patch.object(catalog_sync, "CATALOG_OVERRIDES_PATH", root / "overrides.json"),
+            ):
+                collected, diagnostics = catalog_sync._collect_catalog_overrides()
+            self.assertEqual(collected, {})
+            self.assertEqual(diagnostics["reasons"]["invalid_row_identity"], 1)
+
+    def test_catalog_override_purges_sidecar_when_current_identity_is_missing(self):
+        identity = ("openai", "official", "gpt-5.6-luna")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            baseline = root / "baseline.json"
+            current = root / "catalog.json"
+            overrides = root / "overrides.json"
+            baseline.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "managed_baseline": True,
+                        "models": [
+                            {
+                                "slug": "gpt-5.6-luna",
+                                "visibility": "list",
+                                "prefer_websockets": True,
+                                "tool_mode": "code_mode_only",
+                                "multi_agent_version": "v1",
+                                "use_responses_lite": True,
+                                "codex_proxy_metadata": {
+                                    "provider": identity[0],
+                                    "upstream_name": identity[1],
+                                    "upstream_model": identity[2],
+                                },
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            overrides.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "overrides": [
+                            {
+                                "provider": identity[0],
+                                "upstream_name": identity[1],
+                                "upstream_model": identity[2],
+                                "fields": {"multi_agent_version": "v2"},
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            # Same display slug, but a different provider identity.  The old
+            # Official sidecar entry must not cross over to this row.
+            current.write_text(
+                json.dumps(
+                    {
+                        "models": [
+                            {
+                                "slug": "volc/gpt-5.6-luna",
+                                "visibility": "list",
+                                "codex_proxy_metadata": {
+                                    "provider": "volc",
+                                    "upstream_name": "volcengine",
+                                    "upstream_model": "gpt-5.6-luna",
+                                },
+                            }
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with (
+                patch.object(catalog_sync, "MANAGED_CATALOG_BASELINE_PATH", baseline),
+                patch.object(catalog_sync, "GENERATED_CATALOG_PATH", current),
+                patch.object(catalog_sync, "CATALOG_OVERRIDES_PATH", overrides),
+            ):
+                collected, diagnostics = catalog_sync._collect_catalog_overrides()
+
+            self.assertEqual(collected, {})
+            self.assertEqual(diagnostics["reasons"]["missing_managed_model"], 1)
+
+    def test_catalog_override_reports_malformed_current_catalog_without_using_it_as_edit(self):
+        identity = ("openai", "official", "gpt-5.6-luna")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            baseline = root / "baseline.json"
+            current = root / "catalog.json"
+            overrides = root / "overrides.json"
+            baseline.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "managed_baseline": True,
+                        "models": [
+                            {
+                                "slug": "gpt-5.6-luna",
+                                "visibility": "list",
+                                "prefer_websockets": True,
+                                "tool_mode": "code_mode_only",
+                                "multi_agent_version": "v1",
+                                "use_responses_lite": True,
+                                "codex_proxy_metadata": {
+                                    "provider": identity[0],
+                                    "upstream_name": identity[1],
+                                    "upstream_model": identity[2],
+                                },
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            overrides.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "overrides": [
+                            {
+                                "provider": identity[0],
+                                "upstream_name": identity[1],
+                                "upstream_model": identity[2],
+                                "fields": {"multi_agent_version": "v2"},
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            current.write_text("{not json", encoding="utf-8")
+
+            with (
+                patch.object(catalog_sync, "MANAGED_CATALOG_BASELINE_PATH", baseline),
+                patch.object(catalog_sync, "GENERATED_CATALOG_PATH", current),
+                patch.object(catalog_sync, "CATALOG_OVERRIDES_PATH", overrides),
+            ):
+                collected, diagnostics = catalog_sync._collect_catalog_overrides()
+
+            self.assertEqual(collected[identity], {"multi_agent_version": "v2"})
+            self.assertFalse(diagnostics["current_catalog_valid"])
+            self.assertEqual(diagnostics["reasons"]["invalid_catalog"], 1)
+
+            current.write_text(json.dumps({"models": [{}]}), encoding="utf-8")
+            with (
+                patch.object(catalog_sync, "MANAGED_CATALOG_BASELINE_PATH", baseline),
+                patch.object(catalog_sync, "GENERATED_CATALOG_PATH", current),
+                patch.object(catalog_sync, "CATALOG_OVERRIDES_PATH", overrides),
+            ):
+                collected, diagnostics = catalog_sync._collect_catalog_overrides()
+            self.assertEqual(collected[identity], {"multi_agent_version": "v2"})
+            self.assertFalse(diagnostics["current_catalog_valid"])
+            self.assertEqual(diagnostics["reasons"]["invalid_catalog"], 1)
+
+    def test_catalog_override_is_removed_when_managed_baseline_catches_up(self):
+        identity = ("openai", "official", "gpt-5.6-luna")
+        current = {"multi_agent_version": "v2"}
+        old_baseline = {"multi_agent_version": "v1"}
+        new_baseline = {"multi_agent_version": "v2"}
+
+        self.assertEqual(
+            catalog_sync._delta_override_fields(identity, current, old_baseline),
+            {"multi_agent_version": "v2"},
+        )
+        self.assertEqual(
+            catalog_sync._delta_override_fields(identity, current, new_baseline),
+            {},
+        )
+
+    def test_catalog_override_survives_managed_baseline_refresh_publication(self):
+        official = [
+            {"slug": "gpt-5.6-luna", "display_name": "GPT-5.6-Luna", "visibility": "list"}
+        ]
+        identity = ("openai", "official", "gpt-5.6-luna")
+        managed_v1 = catalog_sync.build_codex_catalog(official, [], self.policy, "0.146.0")
+        current = json.loads(json.dumps(managed_v1))
+        current["models"][0]["multi_agent_version"] = "v2"
+        baseline_v1 = json.loads(json.dumps(managed_v1))
+        baseline_v1.update({"schema_version": 1, "managed_baseline": True})
+        sidecar_v2 = catalog_sync._write_catalog_override_state(
+            {identity: {"multi_agent_version": "v2"}}
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            current_path = root / "catalog.json"
+            baseline_path = root / "baseline.json"
+            overrides_path = root / "overrides.json"
+            current_path.write_text(json.dumps(current), encoding="utf-8")
+            baseline_path.write_text(json.dumps(baseline_v1), encoding="utf-8")
+            overrides_path.write_text(json.dumps(sidecar_v2), encoding="utf-8")
+            with (
+                patch.object(catalog_sync, "GENERATED_CATALOG_PATH", current_path),
+                patch.object(catalog_sync, "MANAGED_CATALOG_BASELINE_PATH", baseline_path),
+                patch.object(catalog_sync, "CATALOG_OVERRIDES_PATH", overrides_path),
+            ):
+                collected, diagnostics = catalog_sync._collect_catalog_overrides()
+                self.assertEqual(collected[identity], {"multi_agent_version": "v2"})
+
+                pinned_v2 = json.loads(json.dumps(catalog_sync.PINNED_OFFICIAL_CATALOG_METADATA))
+                pinned_v2["gpt-5.6-luna"]["multi_agent_version"] = "v2"
+                with patch.object(catalog_sync, "PINNED_OFFICIAL_CATALOG_METADATA", pinned_v2):
+                    managed_v2 = catalog_sync.build_codex_catalog(
+                        official,
+                        [],
+                        self.policy,
+                        "0.146.0",
+                    )
+                    effective_v2 = catalog_sync._apply_catalog_overrides(
+                        json.loads(json.dumps(managed_v2)),
+                        collected,
+                        diagnostics,
+                    )
+
+                self.assertEqual(effective_v2["models"][0]["multi_agent_version"], "v2")
+                current_path.write_text(json.dumps(effective_v2), encoding="utf-8")
+                baseline_v2 = dict(managed_v2)
+                baseline_v2.update({"schema_version": 1, "managed_baseline": True})
+                baseline_path.write_text(json.dumps(baseline_v2), encoding="utf-8")
+                overrides_path.write_text(json.dumps(catalog_sync._write_catalog_override_state(collected)), encoding="utf-8")
+
+                collected_after, diagnostics_after = catalog_sync._collect_catalog_overrides()
+                self.assertEqual(collected_after, {})
+                effective_after = catalog_sync._apply_catalog_overrides(
+                    json.loads(json.dumps(managed_v2)),
+                    collected_after,
+                    diagnostics_after,
+                )
+                self.assertEqual(effective_after["models"][0]["multi_agent_version"], "v2")
+
     def test_pinned_official_catalog_metadata_rejects_an_incomplete_model_set(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             path = Path(tmpdir) / "official-models.json"

--- a/tests/test_chat_completions_gateway.py
+++ b/tests/test_chat_completions_gateway.py
@@ -29,6 +29,11 @@ from codex_proxy import (
 )
 
 
+def _exact_external_model_resolver(*models):
+    by_alias = {model["alias"]: model for model in models}
+    return lambda model_id: by_alias.get(model_id)
+
+
 class UpstreamUrlTests(unittest.TestCase):
     def test_upstream_urls_accept_complete_responses_endpoint(self):
         upstream = {"base_url": "https://example.test/v1/responses"}
@@ -1907,6 +1912,23 @@ class ChatCompletionsEndpointTests(unittest.TestCase):
             "context_source": "providers_toml",
             "max_output_source": "providers_toml",
         }
+        vision_model = {
+            "alias": "vision-chat/m3",
+            "provider_alias": "vision-chat",
+            "upstream_name": "vision_chat",
+            "display_prefix": "VisionChat",
+            "base_url": "https://vision.example.test/v1",
+            "api_key": "vision-test-token",
+            "upstream_model": "m3",
+            "upstream_format": "chat_completions",
+            "priority_base": 300,
+            "context_window": 1000000,
+            "max_output_tokens": 8192,
+            "input_modalities": ("text", "image"),
+            "context_source": "providers_toml",
+            "max_output_source": "providers_toml",
+        }
+        resolve_external_model = _exact_external_model_resolver(external_model, vision_model)
         image_url = "data:image/png;base64,e2NoYXJ0fQ=="
         body = json.dumps({
             "model": "glm-5.2",
@@ -1959,7 +1981,7 @@ class ChatCompletionsEndpointTests(unittest.TestCase):
                     allowed_provider_models=policy.allowed_provider_models + ("volc/glm-5.2", "vision-chat/m3"),
                 ),
             ),
-            patch("codex_proxy.resolve_external_model_alias", return_value=external_model),
+            patch("codex_proxy.resolve_external_model_alias", side_effect=resolve_external_model),
             patch("codex_proxy._image_proxy_description_for_part", return_value="A chart with rising revenue."),
             patch("codex_proxy.urlopen", return_value=_FakeJsonResponse(upstream_body)) as mock_urlopen,
         ):
@@ -2096,6 +2118,23 @@ class ChatCompletionsEndpointTests(unittest.TestCase):
             "context_source": "providers_toml",
             "max_output_source": "providers_toml",
         }
+        vision_model = {
+            "alias": "vision-chat/m3",
+            "provider_alias": "vision-chat",
+            "upstream_name": "vision_chat",
+            "display_prefix": "VisionChat",
+            "base_url": "https://vision.example.test/v1",
+            "api_key": "vision-test-token",
+            "upstream_model": "m3",
+            "upstream_format": "chat_completions",
+            "priority_base": 300,
+            "context_window": 1000000,
+            "max_output_tokens": 8192,
+            "input_modalities": ("text", "image"),
+            "context_source": "providers_toml",
+            "max_output_source": "providers_toml",
+        }
+        resolve_external_model = _exact_external_model_resolver(external_model, vision_model)
         image_url = "data:image/png;base64,e2NoYXJ0fQ=="
         body = json.dumps({
             "model": "glm-5.2",
@@ -2148,7 +2187,7 @@ class ChatCompletionsEndpointTests(unittest.TestCase):
                     allowed_provider_models=policy.allowed_provider_models + ("volc/glm-5.2", "vision-chat/m3"),
                 ),
             ),
-            patch("codex_proxy.resolve_external_model_alias", return_value=external_model),
+            patch("codex_proxy.resolve_external_model_alias", side_effect=resolve_external_model),
             patch("codex_proxy._image_proxy_description_for_part", return_value="A boundary-guard chart description."),
             patch("codex_proxy.urlopen", return_value=_FakeJsonResponse(upstream_body)) as mock_urlopen,
         ):
@@ -2271,6 +2310,23 @@ class ChatCompletionsEndpointTests(unittest.TestCase):
             "context_source": "providers_toml",
             "max_output_source": "providers_toml",
         }
+        vision_model = {
+            "alias": "vision-chat/m3",
+            "provider_alias": "vision-chat",
+            "upstream_name": "vision_chat",
+            "display_prefix": "VisionChat",
+            "base_url": "https://vision.example.test/v1",
+            "api_key": "vision-test-token",
+            "upstream_model": "m3",
+            "upstream_format": "chat_completions",
+            "priority_base": 300,
+            "context_window": 1000000,
+            "max_output_tokens": 8192,
+            "input_modalities": ("text", "image"),
+            "context_source": "providers_toml",
+            "max_output_source": "providers_toml",
+        }
+        resolve_external_model = _exact_external_model_resolver(external_model, vision_model)
         body = json.dumps({
             "model": "glm-5.2",
             "messages": [{
@@ -2313,7 +2369,7 @@ class ChatCompletionsEndpointTests(unittest.TestCase):
                     allowed_provider_models=policy.allowed_provider_models + ("volc/glm-5.2", "vision-chat/m3"),
                 ),
             ),
-            patch("codex_proxy.resolve_external_model_alias", return_value=external_model),
+            patch("codex_proxy.resolve_external_model_alias", side_effect=resolve_external_model),
             patch("codex_proxy._image_proxy_cache_lookup", return_value=None),
             patch("codex_proxy._image_proxy_description_for_part", side_effect=codex_proxy.ImageProxyError("vision down")),
             patch("codex_proxy.urlopen") as mock_urlopen,
@@ -2345,6 +2401,23 @@ class ChatCompletionsEndpointTests(unittest.TestCase):
             "context_source": "providers_toml",
             "max_output_source": "providers_toml",
         }
+        vision_model = {
+            "alias": "vision-chat/m3",
+            "provider_alias": "vision-chat",
+            "upstream_name": "vision_chat",
+            "display_prefix": "VisionChat",
+            "base_url": "https://vision.example.test/v1",
+            "api_key": "vision-test-token",
+            "upstream_model": "m3",
+            "upstream_format": "chat_completions",
+            "priority_base": 300,
+            "context_window": 1000000,
+            "max_output_tokens": 8192,
+            "input_modalities": ("text", "image"),
+            "context_source": "providers_toml",
+            "max_output_source": "providers_toml",
+        }
+        resolve_external_model = _exact_external_model_resolver(external_model, vision_model)
         image_url = "data:image/png;base64,e2NoYXJ0fQ=="
         body = json.dumps({
             "model": "glm-5.2",
@@ -2399,7 +2472,7 @@ class ChatCompletionsEndpointTests(unittest.TestCase):
                     allowed_provider_models=policy.allowed_provider_models + ("responses-only/glm-5.2", "vision-chat/m3"),
                 ),
             ),
-            patch("codex_proxy.resolve_external_model_alias", return_value=external_model),
+            patch("codex_proxy.resolve_external_model_alias", side_effect=resolve_external_model),
             patch("codex_proxy._image_proxy_description_for_part", return_value="A chart with rising revenue."),
             patch("codex_proxy.urlopen", return_value=_FakeJsonResponse(upstream_body)),
         ):

--- a/tests/test_config_overlay.py
+++ b/tests/test_config_overlay.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from contextlib import redirect_stdout
+import hashlib
 import io
+import re
 import json
 import tempfile
 from pathlib import Path
@@ -11,8 +13,10 @@ from unittest.mock import patch
 from config_overlay import (
     MARKER_BEGIN,
     MARKER_END,
+    CATALOG_OWNER_MARKER,
     _migrate_legacy_context_guard_values,
     _migrate_legacy_context_guard_values_for_backups,
+    _overlay_marks_managed_catalog,
     _selected_official_context_budget,
     apply_overlay,
     context_guard_status,
@@ -216,6 +220,143 @@ class ConfigOverlayTests(unittest.TestCase):
 
             self.assertEqual(config_path.read_text(encoding="utf-8"), original)
             self.assertFalse(backup_path.exists())
+
+    def test_apply_and_restore_overlay_preserves_user_owned_catalog_path(self):
+        original = (
+            'model = "volc/glm-5.2"\n'
+            'model_catalog_json = "C:/user/catalogs/custom.json"\n'
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path = tmp / "config.toml"
+            backup_path = tmp / "config.backup.toml"
+            managed_catalog = tmp / "model-catalogs" / "codexhub-model-catalog.json"
+            config_path.write_text(original, encoding="utf-8")
+
+            apply_overlay(config_path, backup_path, managed_catalog, "http://127.0.0.1:9099")
+            active = config_path.read_text(encoding="utf-8")
+            self.assertIn("model_catalog_json = 'C:/user/catalogs/custom.json'", active)
+            self.assertNotIn(str(managed_catalog.resolve()), active)
+
+            restore_overlay(config_path, backup_path)
+            self.assertEqual(config_path.read_text(encoding="utf-8"), original)
+
+    def test_unified_history_injection_preserves_user_owned_catalog_path(self):
+        original = (
+            'model_provider = "openai"\n'
+            'model_catalog_json = "C:/user/catalogs/custom.json"\n'
+        )
+
+        updated, status = inject_unified_history_config(original)
+
+        self.assertEqual(status, "injected")
+        self.assertIn('model_catalog_json = "C:/user/catalogs/custom.json"', updated)
+        self.assertNotIn("codexhub-model-catalog.json", updated)
+
+    def test_relative_custom_catalog_with_managed_basename_is_not_claimed(self):
+        original = (
+            'model_provider = "openai"\n'
+            'model_catalog_json = "custom-model-catalogs/codexhub-model-catalog.json"\n'
+        )
+
+        updated, status = inject_unified_history_config(original)
+
+        self.assertEqual(status, "injected")
+        self.assertIn(
+            'model_catalog_json = "custom-model-catalogs/codexhub-model-catalog.json"',
+            updated,
+        )
+
+    def test_user_edit_inside_managed_overlay_invalidates_catalog_owner_marker(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path = tmp / "config.toml"
+            backup_path = tmp / "config.backup.toml"
+            managed_catalog = tmp / "arbitrary-managed-location" / "catalog.json"
+            config_path.write_text('model = "volc/glm-5.2"\n', encoding="utf-8")
+
+            apply_overlay(config_path, backup_path, managed_catalog, "http://127.0.0.1:9099")
+            active = config_path.read_text(encoding="utf-8")
+            active = active.replace(
+                f"model_catalog_json = '{managed_catalog.resolve()}'",
+                'model_catalog_json = "C:/user/catalogs/after-edit.json"',
+            )
+            config_path.write_text(active, encoding="utf-8")
+
+            updated, status = inject_unified_history_config(active)
+
+            self.assertEqual(status, "replaced_managed_gateway")
+            self.assertIn(
+                'model_catalog_json = "C:/user/catalogs/after-edit.json"',
+                updated,
+            )
+
+    def test_public_catalog_owner_digest_cannot_claim_an_overlay_path(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path = tmp / "config.toml"
+            backup_path = tmp / "config.backup.toml"
+            managed_catalog = tmp / "arbitrary-managed-location" / "catalog.json"
+            config_path.write_text('model = "volc/glm-5.2"\n', encoding="utf-8")
+
+            apply_overlay(config_path, backup_path, managed_catalog, "http://127.0.0.1:9099")
+            active = config_path.read_text(encoding="utf-8")
+            public_digest = hashlib.sha256(
+                str(managed_catalog.resolve()).encode("utf-8")
+            ).hexdigest()
+            active = re.sub(
+                r"(?m)^# catalog_owner = codexhub:[0-9a-f]{64}$",
+                f"{CATALOG_OWNER_MARKER}:{public_digest}",
+                active,
+            )
+
+            self.assertFalse(_overlay_marks_managed_catalog(active))
+
+    def test_restore_overlay_keeps_catalog_path_edited_while_connected(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path = tmp / "config.toml"
+            backup_path = tmp / "config.backup.toml"
+            managed_catalog = tmp / "arbitrary-managed-location" / "catalog.json"
+            config_path.write_text('model = "volc/glm-5.2"\n', encoding="utf-8")
+
+            apply_overlay(config_path, backup_path, managed_catalog, "http://127.0.0.1:9099")
+            edited = config_path.read_text(encoding="utf-8").replace(
+                f"model_catalog_json = '{managed_catalog.resolve()}'",
+                'model_catalog_json = "C:/user/catalogs/edited.json"',
+            )
+            config_path.write_text(edited, encoding="utf-8")
+
+            restore_overlay(config_path, backup_path)
+
+            restored = config_path.read_text(encoding="utf-8")
+            self.assertIn("model_catalog_json = 'C:/user/catalogs/edited.json'", restored)
+
+    def test_apply_overlay_without_catalog_argument_does_not_drop_existing_catalog(self):
+        original = 'model = "volc/glm-5.2"\nmodel_catalog_json = "C:/user/catalogs/custom.json"\n'
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path = tmp / "config.toml"
+            backup_path = tmp / "config.backup.toml"
+            config_path.write_text(original, encoding="utf-8")
+
+            apply_overlay(config_path, backup_path, None, "http://127.0.0.1:9099")
+
+            self.assertIn("model_catalog_json = 'C:/user/catalogs/custom.json'", config_path.read_text(encoding="utf-8"))
+
+    def test_user_owned_catalog_path_with_hash_and_apostrophe_is_preserved(self):
+        original = "model = \"volc/glm-5.2\"\nmodel_catalog_json = \"C:/user/#catalog's/custom.json\"\n"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path = tmp / "config.toml"
+            backup_path = tmp / "config.backup.toml"
+            config_path.write_text(original, encoding="utf-8")
+
+            apply_overlay(config_path, backup_path, None, "http://127.0.0.1:9099")
+
+            active = config_path.read_text(encoding="utf-8")
+            self.assertIn("model_catalog_json = 'C:/user/#catalog''s/custom.json'", active)
 
     def test_overlay_projects_safe_catalog_budget_across_restart_and_missing_catalog_fallback(self):
         original = "\n".join(

--- a/tests/test_diagnostic_control.py
+++ b/tests/test_diagnostic_control.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 import tempfile
+import threading
+import time
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -19,6 +22,97 @@ class FakeClock:
 
     def advance(self, seconds: float) -> None:
         self.value += seconds
+
+
+class _RecordingRecorder:
+    def __init__(self, recorder: diagnostic_recorder.DiagnosticRecorder) -> None:
+        self._recorder = recorder
+        self.calls = 0
+        self._lock = threading.Lock()
+
+    def status(self) -> object:
+        return self._recorder.status()
+
+    def mark_incident(self, category: str = "manual") -> str | None:
+        with self._lock:
+            self.calls += 1
+        return self._recorder.mark_incident(category)
+
+    def pause(self) -> object:
+        return self._recorder.pause()
+
+    def resume(self) -> object:
+        return self._recorder.resume()
+
+    def delete_incident(self, incident_id: str) -> bool:
+        return self._recorder.delete_incident(incident_id)
+
+
+class _BlockingMarkRecorder(_RecordingRecorder):
+    def __init__(self, recorder: diagnostic_recorder.DiagnosticRecorder) -> None:
+        super().__init__(recorder)
+        self.mark_entered = threading.Event()
+        self.duplicate_mark_entered = threading.Event()
+        self.release_mark = threading.Event()
+
+    def mark_incident(self, category: str = "manual") -> str | None:
+        with self._lock:
+            self.calls += 1
+            duplicate = self.calls > 1
+        self.mark_entered.set()
+        if duplicate:
+            self.duplicate_mark_entered.set()
+        self.release_mark.wait(2)
+        return self._recorder.mark_incident(category)
+
+
+class _BlockingDeleteRecorder(_RecordingRecorder):
+    def __init__(self, recorder: diagnostic_recorder.DiagnosticRecorder) -> None:
+        super().__init__(recorder)
+        self.delete_entered = threading.Event()
+        self.duplicate_delete_entered = threading.Event()
+        self.release_delete = threading.Event()
+        self.delete_calls = 0
+
+    def delete_incident(self, incident_id: str) -> bool:
+        with self._lock:
+            self.delete_calls += 1
+            duplicate = self.delete_calls > 1
+        self.delete_entered.set()
+        if duplicate:
+            self.duplicate_delete_entered.set()
+        self.release_delete.wait(2)
+        return self._recorder.delete_incident(incident_id)
+
+
+class _BlockingPauseRecorder(_RecordingRecorder):
+    def __init__(self, recorder: diagnostic_recorder.DiagnosticRecorder) -> None:
+        super().__init__(recorder)
+        self.pause_entered = threading.Event()
+        self.release_pause = threading.Event()
+        self.duplicate_pause_entered = threading.Event()
+        self.pause_calls = 0
+        self.resume_calls = 0
+        self.status_calls = 0
+
+    def status(self) -> object:
+        with self._lock:
+            self.status_calls += 1
+        return self._recorder.status()
+
+    def pause(self) -> object:
+        with self._lock:
+            self.pause_calls += 1
+            if self.pause_calls > 1:
+                self.duplicate_pause_entered.set()
+        self.pause_entered.set()
+        self.release_pause.wait(2)
+        return self._recorder.pause()
+
+    def resume(self) -> object:
+        with self._lock:
+            self.resume_calls += 1
+        return self._recorder.resume()
 
 
 class DiagnosticControlTests(TestCase):
@@ -118,3 +212,365 @@ class DiagnosticControlTests(TestCase):
         self.assertEqual(response["code"], "invalid_request")
         self.assertIsNone(self.recorder.status().last_marker_category)
         self.assertNotIn("must-not-survive", response_path.read_text(encoding="utf-8"))
+
+    def test_concurrent_process_once_does_not_duplicate_mark(self) -> None:
+        self.bridge.shutdown()
+        recorder = _BlockingMarkRecorder(self.recorder)
+        bridge = diagnostic_control.DiagnosticControlBridge(
+            recorder,
+            self.root,
+            clock=self.clock,
+            poll_interval_seconds=60,
+        )
+        self.addCleanup(bridge.shutdown)
+        self.addCleanup(recorder.release_mark.set)
+        request_id = "c0000000000000100"
+        request_dir = self.root / "diagnostics" / "control" / "requests"
+        request_dir.mkdir(parents=True, exist_ok=True)
+        (request_dir / f"{request_id}.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "request_id": request_id,
+                    "operation": "mark",
+                    "expires_at_ms": int(self.clock() * 1000) + 5_000,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        caller_barrier = threading.Barrier(3)
+
+        def process_batch() -> None:
+            caller_barrier.wait()
+            bridge.process_once()
+
+        callers = [threading.Thread(target=process_batch) for _ in range(2)]
+        for caller in callers:
+            caller.start()
+        caller_barrier.wait()
+        self.assertTrue(recorder.mark_entered.wait(1))
+        self.assertFalse(recorder.duplicate_mark_entered.wait(0.1))
+        recorder.release_mark.set()
+        for caller in callers:
+            caller.join(2)
+
+        self.assertTrue(all(not caller.is_alive() for caller in callers))
+        self.assertEqual(recorder.calls, 1)
+        response_path = (
+            self.root
+            / "diagnostics"
+            / "control"
+            / "responses"
+            / f"{request_id}.json"
+        )
+        response = json.loads(response_path.read_text(encoding="utf-8"))
+        self.assertEqual(response["result"]["incident_id"], "i000001")
+
+    def test_concurrent_process_once_does_not_double_delete_or_overwrite_response(self) -> None:
+        self.bridge.shutdown()
+        with patch.object(diagnostic_recorder.DiagnosticRecorder, "_ensure_control_thread_locked"):
+            incident_id = self.recorder.mark_incident("manual")
+        self.assertEqual(incident_id, "i000001")
+        self.clock.advance(1)
+        self.assertEqual(self.recorder.process_due_incidents(), 1)
+
+        recorder = _BlockingDeleteRecorder(self.recorder)
+        bridge = diagnostic_control.DiagnosticControlBridge(
+            recorder,
+            self.root,
+            clock=self.clock,
+            poll_interval_seconds=60,
+        )
+        self.addCleanup(bridge.shutdown)
+        self.addCleanup(recorder.release_delete.set)
+        request_id = "c0000000000000200"
+        request_dir = self.root / "diagnostics" / "control" / "requests"
+        request_dir.mkdir(parents=True, exist_ok=True)
+        request_path = request_dir / f"{request_id}.json"
+        request_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "request_id": request_id,
+                    "operation": "delete",
+                    "expires_at_ms": int(self.clock() * 1000) + 5_000,
+                    "incident_id": incident_id,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        caller_barrier = threading.Barrier(3)
+
+        def process_batch() -> None:
+            caller_barrier.wait()
+            bridge.process_once()
+
+        callers = [threading.Thread(target=process_batch) for _ in range(2)]
+        for caller in callers:
+            caller.start()
+        caller_barrier.wait()
+        self.assertTrue(recorder.delete_entered.wait(1))
+        self.assertFalse(recorder.duplicate_delete_entered.wait(0.1))
+        recorder.release_delete.set()
+        for caller in callers:
+            caller.join(2)
+
+        self.assertTrue(all(not caller.is_alive() for caller in callers))
+        self.assertEqual(recorder.delete_calls, 1)
+        response_path = (
+            self.root
+            / "diagnostics"
+            / "control"
+            / "responses"
+            / f"{request_id}.json"
+        )
+        response = json.loads(response_path.read_text(encoding="utf-8"))
+        self.assertEqual(response["result"], {"deleted": True})
+        self.assertFalse(request_path.exists())
+
+    def test_daemon_and_manual_batches_serialize_pause_resume_and_status(self) -> None:
+        self.bridge.shutdown()
+        recorder = _BlockingPauseRecorder(self.recorder)
+        bridge = diagnostic_control.DiagnosticControlBridge(
+            recorder,
+            self.root,
+            clock=self.clock,
+            poll_interval_seconds=60,
+        )
+        self.addCleanup(bridge.shutdown)
+        self.addCleanup(recorder.release_pause.set)
+        request_dir = self.root / "diagnostics" / "control" / "requests"
+        request_dir.mkdir(parents=True, exist_ok=True)
+        request_ids = {
+            "pause": "c0000000000000300",
+            "resume": "c0000000000000301",
+            "status": "c0000000000000302",
+        }
+        for operation, request_id in request_ids.items():
+            (request_dir / f"{request_id}.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "request_id": request_id,
+                        "operation": operation,
+                        "expires_at_ms": int(self.clock() * 1000) + 5_000,
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+        bridge.start()
+        self.assertTrue(recorder.pause_entered.wait(1))
+        processed: list[int] = []
+        manual = threading.Thread(target=lambda: processed.append(bridge.process_once()))
+        manual.start()
+        self.assertFalse(recorder.duplicate_pause_entered.wait(0.1))
+        recorder.release_pause.set()
+        manual.join(2)
+        bridge.shutdown()
+
+        self.assertFalse(manual.is_alive())
+        self.assertEqual(recorder.pause_calls, 1)
+        self.assertEqual(recorder.resume_calls, 1)
+        self.assertEqual(recorder.status_calls, 9)
+        self.assertEqual(processed, [0])
+        response_dir = self.root / "diagnostics" / "control" / "responses"
+        self.assertEqual(
+            sorted(path.stem for path in response_dir.glob("*.json")),
+            sorted(request_ids.values()),
+        )
+        self.assertFalse(any(request_dir.glob("*.json")))
+
+    def test_shutdown_is_bounded_while_a_batch_owns_the_serialization_boundary(self) -> None:
+        self.bridge.shutdown()
+        recorder = _BlockingPauseRecorder(self.recorder)
+        bridge = diagnostic_control.DiagnosticControlBridge(
+            recorder,
+            self.root,
+            clock=self.clock,
+            poll_interval_seconds=60,
+        )
+        self.addCleanup(bridge.shutdown)
+        self.addCleanup(recorder.release_pause.set)
+        request_id = "c0000000000000400"
+        request_dir = self.root / "diagnostics" / "control" / "requests"
+        request_dir.mkdir(parents=True, exist_ok=True)
+        (request_dir / f"{request_id}.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "request_id": request_id,
+                    "operation": "pause",
+                    "expires_at_ms": int(self.clock() * 1000) + 5_000,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        bridge.start()
+        self.assertTrue(recorder.pause_entered.wait(1))
+        started_at = time.monotonic()
+        bridge.shutdown(timeout=0.02)
+        elapsed = time.monotonic() - started_at
+        self.assertLess(elapsed, 0.25)
+        recorder.release_pause.set()
+        bridge.shutdown(timeout=1)
+
+    def test_malformed_request_is_removed_and_does_not_block_later_valid_work(self) -> None:
+        self.bridge.shutdown()
+        recorder = _RecordingRecorder(self.recorder)
+        bridge = diagnostic_control.DiagnosticControlBridge(
+            recorder,
+            self.root,
+            clock=self.clock,
+            poll_interval_seconds=60,
+        )
+        self.addCleanup(bridge.shutdown)
+        request_dir = self.root / "diagnostics" / "control" / "requests"
+        request_dir.mkdir(parents=True, exist_ok=True)
+        malformed_path = request_dir / "c0000000000000500.json"
+        malformed_path.write_text("{", encoding="utf-8")
+        unknown_id = "c0000000000000501"
+        (request_dir / f"{unknown_id}.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "request_id": unknown_id,
+                    "operation": "unrecognized",
+                    "expires_at_ms": int(self.clock() * 1000) + 5_000,
+                }
+            ),
+            encoding="utf-8",
+        )
+        request_id = "c0000000000000502"
+        (request_dir / f"{request_id}.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "request_id": request_id,
+                    "operation": "mark",
+                    "expires_at_ms": int(self.clock() * 1000) + 5_000,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        self.assertEqual(bridge.process_once(), 3)
+        self.assertFalse(malformed_path.exists())
+        unknown_response = json.loads(
+            (
+                self.root
+                / "diagnostics"
+                / "control"
+                / "responses"
+                / f"{unknown_id}.json"
+            ).read_text(encoding="utf-8")
+        )
+        self.assertEqual(unknown_response["code"], "invalid_request")
+        response_path = (
+            self.root
+            / "diagnostics"
+            / "control"
+            / "responses"
+            / f"{request_id}.json"
+        )
+        response = json.loads(response_path.read_text(encoding="utf-8"))
+        self.assertEqual(response["result"]["incident_id"], "i000001")
+
+    def test_failed_claim_cleanup_cannot_repeat_an_accepted_request(self) -> None:
+        self.bridge.shutdown()
+        recorder = _RecordingRecorder(self.recorder)
+        bridge = diagnostic_control.DiagnosticControlBridge(
+            recorder,
+            self.root,
+            clock=self.clock,
+            poll_interval_seconds=60,
+        )
+        self.addCleanup(bridge.shutdown)
+        request_id = "c0000000000000700"
+        request_dir = self.root / "diagnostics" / "control" / "requests"
+        request_dir.mkdir(parents=True, exist_ok=True)
+        (request_dir / f"{request_id}.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "request_id": request_id,
+                    "operation": "mark",
+                    "expires_at_ms": int(self.clock() * 1000) + 5_000,
+                }
+            ),
+            encoding="utf-8",
+        )
+        original_unlink = Path.unlink
+
+        def fail_claim_cleanup(path: Path, *, missing_ok: bool = False) -> None:
+            if path.name.endswith(".processing"):
+                raise OSError("simulated claim cleanup failure")
+            original_unlink(path, missing_ok=missing_ok)
+
+        with patch.object(Path, "unlink", fail_claim_cleanup):
+            self.assertEqual(bridge.process_once(), 1)
+            self.assertEqual(bridge.process_once(), 0)
+
+        self.assertEqual(recorder.calls, 1)
+        processing = list(request_dir.glob("*.processing"))
+        self.assertEqual(len(processing), 1)
+        original_unlink(processing[0], missing_ok=True)
+
+    def test_response_retention_runs_inside_the_serialized_batch(self) -> None:
+        self.bridge.shutdown()
+        recorder = _BlockingMarkRecorder(self.recorder)
+        bridge = diagnostic_control.DiagnosticControlBridge(
+            recorder,
+            self.root,
+            clock=self.clock,
+            poll_interval_seconds=60,
+        )
+        self.addCleanup(bridge.shutdown)
+        self.addCleanup(recorder.release_mark.set)
+        request_id = "c0000000000000600"
+        request_dir = self.root / "diagnostics" / "control" / "requests"
+        response_dir = self.root / "diagnostics" / "control" / "responses"
+        request_dir.mkdir(parents=True, exist_ok=True)
+        response_dir.mkdir(parents=True, exist_ok=True)
+        (request_dir / f"{request_id}.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "request_id": request_id,
+                    "operation": "mark",
+                    "expires_at_ms": int(self.clock() * 1000) + 5_000,
+                }
+            ),
+            encoding="utf-8",
+        )
+        expired = response_dir / "c0000000000000601.json"
+        expired.write_text("{}", encoding="utf-8")
+        expired_at = self.clock() - diagnostic_control.CONTROL_RESPONSE_RETENTION_SECONDS - 1
+        os.utime(expired, (expired_at, expired_at))
+
+        caller_barrier = threading.Barrier(3)
+
+        def process_batch() -> None:
+            caller_barrier.wait()
+            bridge.process_once()
+
+        callers = [threading.Thread(target=process_batch) for _ in range(2)]
+        for caller in callers:
+            caller.start()
+        caller_barrier.wait()
+        self.assertTrue(recorder.mark_entered.wait(1))
+        self.assertFalse(recorder.duplicate_mark_entered.wait(0.1))
+        recorder.release_mark.set()
+        for caller in callers:
+            caller.join(2)
+
+        self.assertTrue(all(not caller.is_alive() for caller in callers))
+        self.assertEqual(recorder.calls, 1)
+        self.assertFalse(expired.exists())
+        response_path = response_dir / f"{request_id}.json"
+        self.assertTrue(response_path.is_file())
+        response = json.loads(response_path.read_text(encoding="utf-8"))
+        self.assertEqual(response["result"]["incident_id"], "i000001")

--- a/tests/test_exact_model_identity.py
+++ b/tests/test_exact_model_identity.py
@@ -1,0 +1,683 @@
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import codex_proxy
+from providers_config import ModelConfig, ProviderConfig, build_external_model_index, build_ollama_cloud_model_index
+from test_routing import post_handler
+
+
+def _catalog_row(slug: str, *, provider: str = "openai", upstream_model: str | None = None):
+    return {
+        "slug": slug,
+        "visibility": "list",
+        "supported_in_api": True,
+        "codex_proxy_metadata": {
+            "provider": provider,
+            "upstream_name": "official" if provider == "openai" else provider,
+            "upstream_model": upstream_model or slug.removeprefix("openai/"),
+        },
+    }
+
+
+def test_official_resolution_rejects_internal_display_name_collision_before_io():
+    catalog = {
+        "models": [
+            {
+                **_catalog_row("gpt-5.6-terra"),
+                "id": "codex-auto-review",
+                "display_name": "GPT-5.6 Terra",
+            }
+        ]
+    }
+
+    with patch("codex_proxy.existing_generated_catalog_path", return_value=Path("missing.json")), patch(
+        "codex_proxy.load_catalog_models", return_value=catalog["models"]
+    ), patch("codex_proxy.urlopen") as urlopen:
+        with pytest.raises(codex_proxy.ModelIdentityResolutionError) as failure:
+            codex_proxy.choose_upstream("openai/gpt-5.6-terra")
+
+    assert failure.value.classification == "local_resolution_failure"
+    assert failure.value.reason == "internal_model"
+    urlopen.assert_not_called()
+
+
+def test_duplicate_canonical_catalog_slug_is_catalog_inconsistency():
+    rows = [_catalog_row("gpt-5.6-terra"), _catalog_row("openai/gpt-5.6-terra")]
+
+    with patch("codex_proxy.existing_generated_catalog_path", return_value=Path("missing.json")), patch(
+        "codex_proxy.load_catalog_models", return_value=rows
+    ):
+        with pytest.raises(codex_proxy.ModelIdentityResolutionError) as failure:
+            codex_proxy.choose_upstream("gpt-5.6-terra")
+
+    assert failure.value.classification == "catalog_inconsistency"
+    assert failure.value.reason == "duplicate_canonical_slug"
+
+
+@pytest.mark.parametrize("malformed_slug", [None, 42, "   "])
+def test_malformed_catalog_slug_is_catalog_inconsistency(malformed_slug):
+    row = {**_catalog_row("gpt-5.6-terra"), "slug": malformed_slug}
+
+    with patch("codex_proxy.existing_generated_catalog_path", return_value=Path("missing.json")), patch(
+        "codex_proxy.load_catalog_models", return_value=[row]
+    ):
+        with pytest.raises(codex_proxy.ModelIdentityResolutionError) as failure:
+            codex_proxy.choose_upstream("gpt-5.6-terra")
+
+    assert failure.value.classification == "catalog_inconsistency"
+    assert failure.value.reason == "missing_catalog_slug"
+
+
+def test_malformed_catalog_document_is_catalog_inconsistency():
+    with patch(
+        "codex_proxy.existing_generated_catalog_path",
+        return_value=Path("malformed.json"),
+    ), patch(
+        "codex_proxy.load_catalog_models",
+        side_effect=ValueError("invalid catalog document"),
+    ):
+        with pytest.raises(codex_proxy.ModelIdentityResolutionError) as failure:
+            codex_proxy.choose_upstream("gpt-5.6-terra")
+
+    assert failure.value.classification == "catalog_inconsistency"
+    assert failure.value.reason == "malformed_catalog"
+
+
+@pytest.mark.parametrize("document", ["{not-json", {"models": {"slug": "bad"}}])
+def test_malformed_catalog_file_is_catalog_inconsistency(tmp_path, document):
+    path = tmp_path / "catalog.json"
+    path.write_text(document if isinstance(document, str) else json.dumps(document), encoding="utf-8")
+
+    with pytest.raises(codex_proxy.ModelIdentityResolutionError) as failure:
+        codex_proxy.generated_catalog_by_slug(path)
+
+    assert failure.value.classification == "catalog_inconsistency"
+    assert failure.value.reason == "malformed_catalog"
+
+
+def test_catalog_upstream_model_mismatch_is_catalog_inconsistency():
+    row = _catalog_row("gpt-5.6-terra", upstream_model="codex-auto-review")
+
+    with patch("codex_proxy.existing_generated_catalog_path", return_value=Path("missing.json")), patch(
+        "codex_proxy.load_catalog_models", return_value=[row]
+    ):
+        with pytest.raises(codex_proxy.ModelIdentityResolutionError) as failure:
+            codex_proxy.choose_upstream("gpt-5.6-terra")
+
+    assert failure.value.classification == "catalog_inconsistency"
+    assert failure.value.reason == "upstream_model_mismatch"
+
+
+@pytest.mark.parametrize("visibility", ["hide", "future"])
+def test_official_catalog_rejects_non_listable_visibility_before_io(visibility):
+    row = _catalog_row("gpt-5.6-terra")
+    row["visibility"] = visibility
+
+    with patch("codex_proxy.existing_generated_catalog_path", return_value=Path("missing.json")), patch(
+        "codex_proxy.load_catalog_models", return_value=[row]
+    ), patch("codex_proxy.urlopen") as urlopen:
+        with pytest.raises(codex_proxy.ModelIdentityResolutionError) as failure:
+            codex_proxy.choose_upstream("gpt-5.6-terra")
+
+    assert failure.value.classification == "catalog_inconsistency"
+    assert failure.value.reason == "unsupported_visibility"
+    urlopen.assert_not_called()
+
+
+def test_official_catalog_rejects_malformed_legacy_metadata_before_io():
+    row = _catalog_row("gpt-5.5")
+    row["codex_proxy_metadata"] = ["not-an-object"]
+
+    with patch("codex_proxy.existing_generated_catalog_path", return_value=Path("missing.json")), patch(
+        "codex_proxy.load_catalog_models", return_value=[row]
+    ), patch("codex_proxy.urlopen") as urlopen:
+        with pytest.raises(codex_proxy.ModelIdentityResolutionError) as failure:
+            codex_proxy.choose_upstream("gpt-5.5")
+
+    assert failure.value.classification == "catalog_inconsistency"
+    assert failure.value.reason == "malformed_metadata"
+    urlopen.assert_not_called()
+
+
+def test_official_catalog_rejects_malformed_supported_in_api_before_io():
+    row = _catalog_row("gpt-5.6-terra")
+    row["supported_in_api"] = 1
+
+    with patch("codex_proxy.existing_generated_catalog_path", return_value=Path("missing.json")), patch(
+        "codex_proxy.load_catalog_models", return_value=[row]
+    ), patch("codex_proxy.urlopen") as urlopen:
+        with pytest.raises(codex_proxy.ModelIdentityResolutionError) as failure:
+            codex_proxy.choose_upstream("gpt-5.6-terra")
+
+    assert failure.value.classification == "catalog_inconsistency"
+    assert failure.value.reason == "malformed_supported_in_api"
+    urlopen.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "requested",
+    [
+        "minimax-cn/minimax-m3",  # configured alias for MiniMax-M3
+        "GPT-5.6 Terra",  # display name
+        "codex-auto-review",  # internal reviewer identity
+        "ollama-cloud/gpt-5.6-terra",  # cross-catalog provider fallback
+    ],
+)
+def test_presentation_or_cross_catalog_identity_never_selects_terra(requested: str):
+    with patch("codex_proxy.resolve_external_model_alias", return_value={
+        "alias": "minimax-cn/MiniMax-M3",
+        "provider_alias": "minimax-cn",
+        "upstream_name": "minimax_cn",
+        "base_url": "https://example.test/v1",
+        "api_key": "test-key",
+        "upstream_model": "MiniMax-M3",
+    }), patch("codex_proxy.urlopen") as urlopen:
+        with pytest.raises(codex_proxy.ModelIdentityResolutionError):
+            codex_proxy.choose_upstream(requested)
+
+    urlopen.assert_not_called()
+
+
+def test_external_provider_alias_is_not_a_routable_model_identity():
+    external = {
+        "alias": "minimax-cn/MiniMax-M3",
+        "provider_alias": "minimax-cn",
+        "upstream_name": "minimax_cn",
+        "base_url": "https://example.test/v1",
+        "api_key": "test-key",
+        "upstream_model": "MiniMax-M3",
+    }
+    with patch("codex_proxy.resolve_external_model_alias", return_value=external):
+        with pytest.raises(codex_proxy.ModelIdentityResolutionError) as failure:
+            codex_proxy.choose_upstream("minimax-cn/minimax-m3")
+
+    assert failure.value.reason == "model_alias_not_routable"
+    assert failure.value.classification == "local_resolution_failure"
+
+
+@pytest.mark.parametrize("requested", ["ollama-cloud/glm-5.2", "glm-5.2"])
+def test_ollama_catalog_rejects_unsupported_or_cross_provider_rows_before_io(requested):
+    catalog_slug = requested
+    catalog = {
+        catalog_slug: {
+            "slug": catalog_slug,
+            "supported_in_api": True,
+            "codex_proxy_metadata": {
+                "provider": "openai",
+                "upstream_name": "official",
+                "upstream_model": "codex-auto-review",
+            },
+        }
+    }
+
+    with (
+        patch("codex_proxy.generated_catalog_by_slug", return_value=catalog),
+        patch("codex_proxy.resolve_ollama_cloud_model", return_value=(False, None)),
+        patch("codex_proxy.urlopen") as urlopen,
+    ):
+        with pytest.raises(codex_proxy.ModelIdentityResolutionError) as failure:
+            codex_proxy.choose_upstream(requested)
+
+    assert failure.value.classification == "catalog_inconsistency"
+    assert failure.value.reason == "provider_mismatch"
+    urlopen.assert_not_called()
+
+
+def test_ollama_catalog_rejects_contradictory_upstream_metadata_before_io():
+    catalog = {
+        "ollama-cloud/glm-5.2": {
+            "slug": "ollama-cloud/glm-5.2",
+            "supported_in_api": True,
+            "codex_proxy_metadata": {
+                "provider": "ollama-cloud",
+                "upstream_name": "ollama_cloud",
+                "upstream_model": "codex-auto-review",
+            },
+        }
+    }
+
+    with (
+        patch("codex_proxy.generated_catalog_by_slug", return_value=catalog),
+        patch("codex_proxy.resolve_ollama_cloud_model", return_value=(False, None)),
+        patch("codex_proxy.urlopen") as urlopen,
+    ):
+        with pytest.raises(codex_proxy.ModelIdentityResolutionError) as failure:
+            codex_proxy.choose_upstream("ollama-cloud/glm-5.2")
+
+    assert failure.value.classification == "catalog_inconsistency"
+    assert failure.value.reason == "upstream_model_mismatch"
+    urlopen.assert_not_called()
+
+
+@pytest.mark.parametrize("requested", ["ollama-cloud/glm-5.2", "glm-5.2"])
+def test_ollama_catalog_rejects_supported_in_api_false_before_io(requested):
+    catalog = {
+        requested: {
+            "slug": requested,
+            "supported_in_api": False,
+        }
+    }
+
+    with (
+        patch("codex_proxy.generated_catalog_by_slug", return_value=catalog),
+        patch("codex_proxy.resolve_ollama_cloud_model", return_value=(False, None)),
+        patch("codex_proxy.urlopen") as urlopen,
+    ):
+        with pytest.raises(codex_proxy.ModelIdentityResolutionError) as failure:
+            codex_proxy.choose_upstream(requested)
+
+    assert failure.value.reason == "unsupported_model"
+    urlopen.assert_not_called()
+
+
+def test_bare_ollama_catalog_fallback_includes_exact_upstream_identity():
+    row = _catalog_row("glm-5.2", provider="ollama-cloud", upstream_model="glm-5.2")
+
+    with (
+        patch("codex_proxy._published_catalog_model", return_value=row),
+        patch("codex_proxy.resolve_ollama_cloud_model", return_value=(False, None)),
+        patch("codex_proxy.should_include_model", return_value=True),
+    ):
+        upstream = codex_proxy.choose_upstream("glm-5.2")
+
+    assert upstream["provider_id"] == "ollama-cloud"
+    assert upstream["model_id"] == "glm-5.2"
+    assert upstream["upstream_model"] == "glm-5.2"
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [("visibility", "hide"), ("visibility", "future"), ("hidden", True)],
+)
+def test_ollama_catalog_rejects_non_listable_visibility_before_io(field, value):
+    row = _catalog_row(
+        "ollama-cloud/glm-5.2",
+        provider="ollama-cloud",
+        upstream_model="glm-5.2",
+    )
+    row[field] = value
+    catalog = {"ollama-cloud/glm-5.2": row}
+
+    with (
+        patch("codex_proxy.generated_catalog_by_slug", return_value=catalog),
+        patch("codex_proxy.resolve_ollama_cloud_model", return_value=(False, None)),
+        patch("codex_proxy.urlopen") as urlopen,
+    ):
+        with pytest.raises(codex_proxy.ModelIdentityResolutionError) as failure:
+            codex_proxy.choose_upstream("ollama-cloud/glm-5.2")
+
+    assert failure.value.classification == "catalog_inconsistency"
+    assert failure.value.reason == "unsupported_visibility"
+    urlopen.assert_not_called()
+
+
+def test_ollama_catalog_rejects_malformed_metadata_before_io():
+    row = _catalog_row(
+        "ollama-cloud/glm-5.2",
+        provider="ollama-cloud",
+        upstream_model="glm-5.2",
+    )
+    row["codex_proxy_metadata"] = "not-an-object"
+
+    with (
+        patch("codex_proxy.generated_catalog_by_slug", return_value={"ollama-cloud/glm-5.2": row}),
+        patch("codex_proxy.resolve_ollama_cloud_model", return_value=(False, None)),
+        patch("codex_proxy.urlopen") as urlopen,
+    ):
+        with pytest.raises(codex_proxy.ModelIdentityResolutionError) as failure:
+            codex_proxy.choose_upstream("ollama-cloud/glm-5.2")
+
+    assert failure.value.classification == "catalog_inconsistency"
+    assert failure.value.reason == "malformed_metadata"
+    urlopen.assert_not_called()
+
+
+def test_ollama_catalog_rejects_malformed_supported_in_api_before_io():
+    row = _catalog_row(
+        "ollama-cloud/glm-5.2",
+        provider="ollama-cloud",
+        upstream_model="glm-5.2",
+    )
+    row["supported_in_api"] = "true"
+
+    with (
+        patch("codex_proxy.generated_catalog_by_slug", return_value={"ollama-cloud/glm-5.2": row}),
+        patch("codex_proxy.resolve_ollama_cloud_model", return_value=(False, None)),
+        patch("codex_proxy.urlopen") as urlopen,
+    ):
+        with pytest.raises(codex_proxy.ModelIdentityResolutionError) as failure:
+            codex_proxy.choose_upstream("ollama-cloud/glm-5.2")
+
+    assert failure.value.classification == "catalog_inconsistency"
+    assert failure.value.reason == "malformed_supported_in_api"
+    urlopen.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("requested", "field", "value"),
+    [
+        ("ollama-cloud/codex-auto-review", "alias", "ollama-cloud/codex-auto-review"),
+        ("codex-auto-review", "model_id", "codex-auto-review"),
+    ],
+)
+def test_ollama_runtime_rejects_internal_route_identity_before_io(requested, field, value):
+    runtime_model = {
+        "alias": "ollama-cloud/glm-5.2",
+        "provider_alias": "ollama-cloud",
+        "upstream_name": "ollama_cloud",
+        "base_url": "https://ollama.example.test/v1",
+        "api_key": "ollama-runtime-token",
+        "upstream_model": "glm-5.2",
+        field: value,
+    }
+
+    with (
+        patch("codex_proxy.resolve_ollama_cloud_model", return_value=(True, runtime_model)),
+        patch("codex_proxy.resolve_external_model_alias", return_value=None),
+        patch("codex_proxy.urlopen") as urlopen,
+    ):
+        with pytest.raises(codex_proxy.ModelIdentityResolutionError) as failure:
+            codex_proxy.choose_upstream(requested)
+
+    assert failure.value.classification == "local_resolution_failure"
+    assert failure.value.reason == "internal_model"
+    urlopen.assert_not_called()
+
+
+def test_external_runtime_rejects_provider_qualified_internal_alias_before_io():
+    external = {
+        "alias": "volc/codex-auto-review",
+        "provider_alias": "volc",
+        "upstream_name": "volcengine",
+        "base_url": "https://example.test/v1",
+        "api_key": "test-key",
+        "upstream_model": "glm-5.2",
+    }
+
+    with (
+        patch("codex_proxy.resolve_external_model_alias", return_value=external),
+        patch("codex_proxy.urlopen") as urlopen,
+    ):
+        with pytest.raises(codex_proxy.ModelIdentityResolutionError) as failure:
+            codex_proxy.choose_upstream("volc/codex-auto-review")
+
+    assert failure.value.classification == "local_resolution_failure"
+    assert failure.value.reason == "internal_model"
+    urlopen.assert_not_called()
+
+
+@pytest.mark.parametrize("requested", ["legacy-display", "ollama-cloud/legacy-display"])
+def test_ollama_runtime_alias_is_presentation_only(requested):
+    providers = [
+        ProviderConfig(
+            id="ollama-cloud",
+            name="Ollama",
+            base_url="https://ollama.example.test/v1",
+            api_key="test-key",
+            models=[ModelConfig(id="glm-5.2", aliases=("legacy-display",))],
+        )
+    ]
+    _, index = build_ollama_cloud_model_index(providers, require_api_key=False)
+
+    with (
+        patch("codex_proxy.resolve_ollama_cloud_model", return_value=(True, index[requested])),
+        patch("codex_proxy.urlopen") as urlopen,
+    ):
+        with pytest.raises(codex_proxy.ModelIdentityResolutionError) as failure:
+            codex_proxy.choose_upstream(requested)
+
+    assert failure.value.classification == "local_resolution_failure"
+    assert failure.value.reason == "model_alias_not_routable"
+    urlopen.assert_not_called()
+
+
+def test_provider_model_index_rejects_duplicate_exact_ids_and_alias_collisions():
+    providers = [
+        ProviderConfig(
+            id="volc",
+            name="Volc",
+            base_url="https://example.test/v1",
+            api_key="test-key",
+            models=[ModelConfig(id="glm-5.2"), ModelConfig(id="glm-5.2")],
+        )
+    ]
+    with pytest.raises(ValueError, match="duplicate provider model identity"):
+        build_external_model_index(providers)
+
+    providers[0].models = [
+        ModelConfig(id="glm-5.2", aliases=("shared",)),
+        ModelConfig(id="other", aliases=("shared",)),
+    ]
+    with pytest.raises(ValueError, match="duplicate provider model identity"):
+        build_external_model_index(providers)
+
+
+def test_ollama_cloud_index_rejects_duplicate_exact_ids():
+    providers = [
+        ProviderConfig(
+            id="ollama-cloud",
+            name="Ollama",
+            base_url="https://example.test/v1",
+            api_key="test-key",
+            models=[ModelConfig(id="glm-5.2"), ModelConfig(id="glm-5.2")],
+        )
+    ]
+    with pytest.raises(ValueError, match="duplicate provider model identity"):
+        build_ollama_cloud_model_index(providers)
+
+
+def test_external_provider_index_failure_is_catalog_inconsistency_before_io():
+    with patch(
+        "codex_proxy.resolve_external_model_alias",
+        side_effect=ValueError("duplicate provider model identity: foo/model"),
+    ), patch("codex_proxy.urlopen") as urlopen:
+        with pytest.raises(codex_proxy.ModelIdentityResolutionError) as failure:
+            codex_proxy.choose_upstream("foo/model")
+
+    assert failure.value.classification == "catalog_inconsistency"
+    assert failure.value.reason == "provider_model_index_inconsistency"
+    urlopen.assert_not_called()
+
+
+def test_ollama_provider_index_failure_is_catalog_inconsistency_before_io():
+    with patch(
+        "codex_proxy.resolve_ollama_cloud_model",
+        side_effect=ValueError("duplicate provider model identity: glm-5.2"),
+    ), patch("codex_proxy.urlopen") as urlopen:
+        with pytest.raises(codex_proxy.ModelIdentityResolutionError) as failure:
+            codex_proxy.choose_upstream("ollama-cloud/glm-5.2")
+
+    assert failure.value.classification == "catalog_inconsistency"
+    assert failure.value.reason == "provider_model_index_inconsistency"
+    urlopen.assert_not_called()
+
+
+def test_route_plan_rejects_missing_upstream_identity_without_substitution():
+    with pytest.raises(codex_proxy.ModelIdentityResolutionError) as failure:
+        codex_proxy.route_plan_for_request(
+            {"name": "official", "auth": "codex_auth"},
+            {"client_id": "unknown"},
+            inbound_format="responses",
+            model_requested="gpt-5.6-terra",
+            canonical_route_model="gpt-5.6-terra",
+        )
+
+    assert failure.value.classification == "local_resolution_failure"
+    assert failure.value.reason == "missing_upstream_model"
+
+
+def test_route_plan_retains_exact_provider_id_and_model_slug():
+    plan = codex_proxy.route_plan_for_request(
+        {
+            "name": "volcengine",
+            "provider_id": "volc",
+            "upstream_model": "glm-5.2",
+            "auth": "api_key",
+            "base_url": "https://example.test/v1",
+            "upstream_format": "responses",
+        },
+        {"client_id": "unknown"},
+        inbound_format="responses",
+        model_requested="volc/glm-5.2",
+        canonical_route_model="volc/glm-5.2",
+    )
+
+    assert plan.provider_id == "volc"
+    assert plan.model_requested == "volc/glm-5.2"
+    assert plan.canonical_model == "volc/glm-5.2"
+    assert plan.upstream_model == "glm-5.2"
+
+
+def test_route_plan_preserves_explicit_provider_id_underscores():
+    plan = codex_proxy.route_plan_for_request(
+        {
+            "name": "custom_transport",
+            "provider_id": "foo_bar",
+            "upstream_model": "model-v1",
+            "auth": "api_key",
+            "base_url": "https://example.test/v1",
+            "upstream_format": "responses",
+        },
+        {"client_id": "unknown"},
+        inbound_format="responses",
+        model_requested="foo_bar/model-v1",
+        canonical_route_model="foo_bar/model-v1",
+    )
+
+    assert plan.provider_id == "foo_bar"
+
+
+def test_route_plan_rejects_mismatched_upstream_without_model_id():
+    with patch("codex_proxy.urlopen") as urlopen:
+        with pytest.raises(codex_proxy.ModelIdentityResolutionError) as failure:
+            codex_proxy.route_plan_for_request(
+                {
+                    "name": "volcengine",
+                    "provider_id": "volc",
+                    "upstream_model": "codex-auto-review",
+                    "auth": "api_key",
+                    "base_url": "https://example.test/v1",
+                    "upstream_format": "responses",
+                },
+                {"client_id": "unknown"},
+                inbound_format="responses",
+                model_requested="volc/glm-5.2",
+                canonical_route_model="volc/glm-5.2",
+            )
+
+    assert failure.value.classification == "catalog_inconsistency"
+    assert failure.value.reason == "configured_model_mismatch"
+    urlopen.assert_not_called()
+
+
+def test_identity_error_payload_distinguishes_catalog_and_local_resolution():
+    catalog_error = codex_proxy.ModelIdentityResolutionError(
+        "duplicate canonical slug",
+        classification="catalog_inconsistency",
+        reason="duplicate_canonical_slug",
+    )
+    local_error = codex_proxy.ModelIdentityResolutionError(
+        "model is not supported",
+        classification="local_resolution_failure",
+        reason="unsupported_model",
+    )
+
+    catalog_payload = codex_proxy._codexhub_error_payload(
+        source="gateway",
+        message=str(catalog_error),
+        status=400,
+        exc=catalog_error,
+        error_type="model_identity_error",
+        error="ModelIdentityResolutionError",
+    )
+    local_payload = codex_proxy._codexhub_error_payload(
+        source="gateway",
+        message=str(local_error),
+        status=400,
+        exc=local_error,
+        error_type="model_identity_error",
+        error="ModelIdentityResolutionError",
+    )
+
+    assert catalog_payload["code"] == "catalog.inconsistency"
+    assert catalog_payload["details"]["classification"] == "catalog_inconsistency"
+    assert local_payload["code"] == "gateway.model_resolution"
+    assert local_payload["details"]["classification"] == "local_resolution_failure"
+    assert "codex-auto-review" not in json.dumps(catalog_payload)
+
+
+def test_identity_error_payload_drops_untrusted_provider_and_model_labels():
+    failure = codex_proxy.ModelIdentityResolutionError(
+        "model identity is invalid",
+        classification="local_resolution_failure",
+        reason="unsupported_model",
+        provider_id="Bearer SECRET",
+        model_slug="Bearer SECRET",
+    )
+
+    payload = codex_proxy._codexhub_error_payload(
+        source="gateway",
+        message="model identity is invalid",
+        status=400,
+        exc=failure,
+        error_type="model_identity_error",
+        error="ModelIdentityResolutionError",
+    )
+
+    rendered = json.dumps(payload)
+    assert "SECRET" not in rendered
+    assert "provider_id" not in payload["details"]
+    assert "model_slug" not in payload["details"]
+
+
+def test_handler_rejects_identity_before_auth_or_upstream_io():
+    handler, fake = post_handler(
+        "/v1/responses",
+        json.dumps({"model": "openai/codex-auto-review", "input": []}).encode(),
+    )
+    failure = codex_proxy.ModelIdentityResolutionError(
+        "model identity is internal and cannot be routed",
+        classification="local_resolution_failure",
+        reason="internal_model",
+        provider_id="openai",
+        model_slug="codex-auto-review",
+    )
+
+    with (
+        patch("codex_proxy.choose_upstream", side_effect=failure),
+        patch("codex_proxy.materialize_operational_authentication") as auth,
+        patch("codex_proxy._open_upstream_response") as open_upstream,
+    ):
+        codex_proxy.CodexProxyHandler._proxy_post_request(handler, inbound_format="responses")
+
+    assert fake.status == 400
+    payload = json.loads(fake.wfile.writes[-1].decode())
+    assert payload["codexhub_error"]["code"] == "gateway.model_resolution"
+    assert payload["codexhub_error"]["details"]["reason"] == "internal_model"
+    auth.assert_not_called()
+    open_upstream.assert_not_called()
+
+
+def test_handler_identity_error_detail_uses_bounded_non_secret_reason():
+    handler, fake = post_handler(
+        "/v1/responses",
+        json.dumps({"model": "openai/secret-model", "input": []}).encode(),
+    )
+    failure = codex_proxy.ModelIdentityResolutionError(
+        "Bearer SECRET should never be returned",
+        classification="local_resolution_failure",
+        reason="unsupported_model",
+        provider_id="openai",
+        model_slug="secret-model",
+    )
+
+    with patch("codex_proxy.choose_upstream", side_effect=failure):
+        codex_proxy.CodexProxyHandler._proxy_post_request(handler, inbound_format="responses")
+
+    rendered = fake.wfile.writes[-1].decode()
+    assert "SECRET" not in rendered
+    assert "Bearer " not in rendered
+    assert "unsupported_model" in rendered

--- a/tests/test_issue62_bounded_phase_runner.py
+++ b/tests/test_issue62_bounded_phase_runner.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+import threading
+import time
+from typing import Any
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from run_issue_62_live_control import (
+    BoundedPhaseRunner,
+    CandidateIdentity,
+    CommandResult,
+    HarnessFailure,
+    _terminate_process,
+)
+
+
+IDENTITY = CandidateIdentity(
+    candidate_sha="386168c945b95e3cdc1277151301dd6f236ff6e9",
+    cli_version="0.146.0",
+    cli_package_sha256="8050af14387e23b8d46026f023f0c1d33a2eefb39267bf36abe8cec2cec17b49",
+    catalog_digest="e713f769e059423784ca1f689f34957f764eedd8439f036d50c09b65c32ee7a6",
+    route_digest="a" * 64,
+)
+
+
+def _records(root: Path) -> list[dict[str, Any]]:
+    return [json.loads(line) for line in (root / "phase-status.jsonl").read_text().splitlines()]
+
+
+def test_success_writes_only_sanitized_phase_status_and_cleanup_receipt(tmp_path: Path) -> None:
+    runner = BoundedPhaseRunner(tmp_path, IDENTITY)
+    result = runner.run_subprocess(
+        "catalog_sync", [sys.executable, "-c", "print('secret must not be captured')"]
+    )
+
+    assert result.status == "completed"
+    receipt = runner.cleanup()
+    assert receipt["cleanup_completed"] is True
+    assert sorted(path.name for path in tmp_path.iterdir()) == [
+        "cleanup-receipt.json",
+        "phase-status.jsonl",
+    ]
+    markers = _records(tmp_path)
+    assert [record["marker"] for record in markers[:2]] == [
+        "catalog_sync_started",
+        "catalog_sync_completed",
+    ]
+    assert all("secret" not in json.dumps(record) for record in markers)
+    assert all("argv" not in record and "command" not in record for record in markers)
+
+
+class _FakeProcess:
+    def __init__(self, return_code: int | None = None) -> None:
+        self.return_code = return_code
+        self.pid = 12345
+        self.terminated = False
+
+    def poll(self) -> int | None:
+        return self.return_code
+
+    def wait(self, timeout: float | None = None) -> int:
+        if self.return_code is None:
+            raise TimeoutError
+        return self.return_code
+
+    def terminate(self) -> None:
+        self.terminated = True
+        self.return_code = 0
+
+    def kill(self) -> None:
+        self.terminated = True
+        self.return_code = -9
+
+
+class _BlockingFakeProcess(_FakeProcess):
+    def __init__(self) -> None:
+        super().__init__(return_code=None)
+        self.spawned = threading.Event()
+
+    def wait(self, timeout: float | None = None) -> int:
+        self.spawned.set()
+        time.sleep(0.005)
+        if self.return_code is None:
+            raise subprocess.TimeoutExpired("fixture", timeout or 0)
+        return self.return_code
+
+
+def test_timeout_is_terminal_and_cleanup_is_fail_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    process = _FakeProcess()
+
+    def fake_popen(*args: Any, **kwargs: Any) -> _FakeProcess:
+        return process
+
+    monkeypatch.setattr("run_issue_62_live_control.subprocess.Popen", fake_popen)
+    monkeypatch.setattr("run_issue_62_live_control.subprocess.run", lambda *args, **kwargs: None)
+    # Move the deadline forward without sleeping for 30 seconds.
+    clock = iter([0.0, 0.0, 31.0])
+    monkeypatch.setattr(
+        "run_issue_62_live_control.time.monotonic",
+        lambda: next(clock, 31.0),
+    )
+
+    runner = BoundedPhaseRunner(tmp_path, IDENTITY)
+    result = runner.run_subprocess("cli", ["fixture", "secret"])
+    assert result.status == "timed_out"
+    assert process.terminated is True
+    records = _records(tmp_path)
+    assert records[-1]["status_code"] == "phase_timeout"
+    assert runner.cleanup()["cleanup_completed"] is True
+
+
+def test_cancellation_terminates_process_and_writes_cancelled_status(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    process = _FakeProcess()
+
+    def fake_popen(*args: Any, **kwargs: Any) -> _FakeProcess:
+        return process
+
+    monkeypatch.setattr("run_issue_62_live_control.subprocess.Popen", fake_popen)
+    cancel = threading.Event()
+    cancel.set()
+    runner = BoundedPhaseRunner(tmp_path, IDENTITY)
+    result = runner.run_subprocess("cli", ["fixture"], cancellation_event=cancel)
+    assert result.status == "cancelled"
+    assert process.terminated is False  # cancellation before spawn is fail-closed
+    assert _records(tmp_path)[-1]["status_code"] == "cancelled"
+    assert runner.cleanup()["cleanup_completed"] is True
+
+
+def test_cancellation_of_active_process_terminates_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    process = _BlockingFakeProcess()
+    monkeypatch.setattr(
+        "run_issue_62_live_control.subprocess.Popen", lambda *args, **kwargs: process
+    )
+    monkeypatch.setattr("run_issue_62_live_control.subprocess.run", lambda *args, **kwargs: None)
+    cancel = threading.Event()
+    runner = BoundedPhaseRunner(tmp_path, IDENTITY)
+    result_box: list[CommandResult] = []
+
+    worker = threading.Thread(
+        target=lambda: result_box.append(
+            runner.run_subprocess("cli", ["fixture"], cancellation_event=cancel)
+        )
+    )
+    worker.start()
+    assert process.spawned.wait(1)
+    cancel.set()
+    worker.join(2)
+    assert not worker.is_alive()
+    assert result_box[0].status == "cancelled"
+    assert process.terminated is True
+    assert runner.cleanup()["cleanup_completed"] is True
+
+
+def test_stale_or_extra_artifact_is_rejected_before_start(tmp_path: Path) -> None:
+    (tmp_path / "stale.json").write_text("{}", encoding="utf-8")
+    with pytest.raises(HarnessFailure) as error:
+        BoundedPhaseRunner(tmp_path, IDENTITY)
+    assert str(error.value) == "stale_artifact"
+
+
+def test_extra_artifact_after_start_makes_cleanup_fail_closed(tmp_path: Path) -> None:
+    runner = BoundedPhaseRunner(tmp_path, IDENTITY)
+    result = runner.run_subprocess("catalog_sync", [sys.executable, "-c", "pass"])
+    assert result.status == "completed"
+    (tmp_path / "unexpected.bin").write_bytes(b"not evidence")
+
+    receipt = runner.cleanup()
+    assert receipt["cleanup_completed"] is False
+    assert receipt["resources_released"] is False
+    assert receipt["cleanup_failure_count"] == 1
+    assert _records(tmp_path)[-1]["status_code"] == "cleanup_incomplete"
+
+
+def test_nested_extra_artifact_is_rejected(tmp_path: Path) -> None:
+    runner = BoundedPhaseRunner(tmp_path, IDENTITY)
+    result = runner.run_subprocess("catalog_sync", [sys.executable, "-c", "pass"])
+    assert result.status == "completed"
+    nested = tmp_path / "unexpected"
+    nested.mkdir()
+    (nested / "raw-body.bin").write_bytes(b"body")
+
+    receipt = runner.cleanup()
+    assert receipt["cleanup_completed"] is False
+    assert receipt["cleanup_failure_count"] == 1
+
+
+def test_windows_cleanup_uses_taskkill_tree_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    process = _BlockingFakeProcess()
+    calls: list[tuple[object, dict[str, object]]] = []
+    monkeypatch.setattr("run_issue_62_live_control.os.name", "nt")
+    monkeypatch.setattr(
+        "run_issue_62_live_control.subprocess.run",
+        lambda *args, **kwargs: calls.append((args[0], kwargs)),
+    )
+
+    assert _terminate_process(process) is True
+    assert calls[0][0] == ["taskkill", "/PID", "12345", "/T", "/F"]
+    assert calls[0][1]["stdout"] is subprocess.DEVNULL
+    assert calls[0][1]["stderr"] is subprocess.DEVNULL

--- a/tests/test_issue_62_control_manifest.py
+++ b/tests/test_issue_62_control_manifest.py
@@ -1,0 +1,503 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+import sys
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "build_issue_62_control_manifest.py"
+SPEC = importlib.util.spec_from_file_location("issue_62_control_manifest", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+manifest = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = manifest
+SPEC.loader.exec_module(manifest)
+
+
+def _digest(seed: str) -> str:
+    return hashlib.sha256(seed.encode("ascii")).hexdigest()
+
+
+def _body(seed: str, *, complete: bool = True) -> dict[str, object]:
+    return {
+        "bytes": len(seed) + 20,
+        "sha256": _digest("body:" + seed) if complete else None,
+        "hmac_sha256": _digest("hmac:" + seed) if complete else None,
+        "complete": complete,
+    }
+
+
+def _sse(seed: str, terminal: str) -> dict[str, object]:
+    return {
+        "complete": True,
+        "frame_count": 3,
+        "frame_bytes": 100 + len(seed),
+        "sequence_sha256": _digest("sse:" + seed),
+        "sequence_hmac_sha256": _digest("sse-hmac:" + seed),
+        "terminal_classes": [terminal],
+    }
+
+
+def _sidecar(name: str, hop: str, *, streaming: bool, status: int, terminal: str) -> dict[str, object]:
+    content_type = "event-stream" if streaming else "json"
+    record: dict[str, object] = {
+        "schema": "codexhub.issue62.live-evidence-lane.v1",
+        "verification_scope": "capture_only_not_qualification",
+        "capture_id": "c" + ("a" if hop == "pre" else "b") * 32,
+        "hop": hop,
+        "outcome": "complete",
+        "failure": None,
+        "status": status,
+        "content_type_class": content_type,
+        "request": _body(name + ":request"),
+        "response": _body(name + ":response"),
+        "sse": _sse(name, terminal) if streaming else None,
+    }
+    return record
+
+
+def _shape(
+    name: str,
+    *,
+    streaming: bool,
+    choice: str | None,
+    parallel: bool | None,
+    status: str,
+    terminal: str,
+    events: list[str],
+    items: list[str],
+    tools: list[str],
+    input_types: list[dict[str, object]],
+    item_ids: int = 1,
+    links: int = 0,
+) -> dict[str, object]:
+    return {
+        "request": {
+            "model": "gpt-5.6-sol",
+            "stream": streaming,
+            "tool_choice": choice,
+            "parallel_tool_calls": parallel,
+            "input_item_types": input_types,
+            "tool_names": tools,
+            "additional_tools_present": False,
+        },
+        "response": {
+            "content_type_class": "event-stream" if streaming else "json",
+            "status_class": status,
+            "terminal": terminal,
+            "event_types": events,
+            "item_types": sorted(items),
+            "unknown_tag_count": 0,
+            "response_ref_present": True,
+            "item_ref_count": item_ids,
+            "call_link_count": links,
+        },
+    }
+
+
+def _control(
+    name: str,
+    *,
+    streaming: bool,
+    choice: str | None,
+    parallel: bool | None,
+    status_code: int,
+    status_class: str,
+    terminal: str,
+    events: list[str],
+    items: list[str],
+    tools: list[str],
+    input_types: list[dict[str, object]],
+    item_ids: int = 1,
+    links: int = 0,
+) -> dict[str, object]:
+    shapes = _shape(
+        name,
+        streaming=streaming,
+        choice=choice,
+        parallel=parallel,
+        status=status_class,
+        terminal=terminal,
+        events=events,
+        items=items,
+        tools=tools,
+        input_types=input_types,
+        item_ids=item_ids,
+        links=links,
+    )
+    return {
+        "name": name,
+        "pre": _sidecar(name, "pre", streaming=streaming, status=status_code, terminal=terminal),
+        "post": _sidecar(name, "post", streaming=streaming, status=status_code, terminal=terminal),
+        "request_shape": shapes["request"],
+        "response_shape": shapes["response"],
+        "identity": {
+            "request_pair_preserved": True,
+            "response_ref_preserved": True,
+            "item_refs_preserved": True,
+            "call_links_preserved": True,
+            "unclassified_core_items": 0,
+        },
+        "route_identity": {
+            "model": "gpt-5.6-sol",
+            "upstream": "official",
+            "route_mode": "official",
+            "behavior_profile": "official_codex_app_http_passthrough",
+            "inbound_format": "responses",
+            "upstream_format": "responses",
+        },
+    }
+
+
+def _controls() -> list[dict[str, object]]:
+    text_events = [
+        "response.in_progress",
+        "response.output_text.delta",
+        "response.completed",
+    ]
+    function_events = [
+        "response.in_progress",
+        "response.function_call_arguments.delta",
+        "response.function_call_arguments.done",
+        "response.output_text.done",
+        "response.completed",
+    ]
+    message = [{"type": "message", "count": 1}]
+    function_history = [
+        {"type": "function_call", "count": 1},
+        {"type": "function_call_output", "count": 1},
+        {"type": "message", "count": 1},
+    ]
+    return [
+        _control(
+            "streaming_text",
+            streaming=True,
+            choice="auto",
+            parallel=False,
+            status_code=200,
+            status_class="2xx",
+            terminal="response.completed",
+            events=text_events,
+            items=["message"],
+            tools=[],
+            input_types=message,
+        ),
+        _control(
+            "streaming_function_history",
+            streaming=True,
+            choice="auto",
+            parallel=False,
+            status_code=200,
+            status_class="2xx",
+            terminal="response.completed",
+            events=function_events,
+            items=["function_call", "function_call_output", "message"],
+            tools=["shell_command"],
+            input_types=function_history,
+            item_ids=3,
+            links=1,
+        ),
+        _control(
+            "non_streaming_text",
+            streaming=False,
+            choice="none",
+            parallel=False,
+            status_code=200,
+            status_class="2xx",
+            terminal="json_response",
+            events=[],
+            items=["message"],
+            tools=[],
+            input_types=message,
+        ),
+        _control(
+            "choice_auto",
+            streaming=True,
+            choice="auto",
+            parallel=True,
+            status_code=200,
+            status_class="2xx",
+            terminal="response.completed",
+            events=text_events,
+            items=["message"],
+            tools=["shell_command"],
+            input_types=message,
+        ),
+        _control(
+            "choice_none",
+            streaming=False,
+            choice="none",
+            parallel=False,
+            status_code=200,
+            status_class="2xx",
+            terminal="json_response",
+            events=[],
+            items=["message"],
+            tools=["shell_command"],
+            input_types=message,
+        ),
+        _control(
+            "terminal_success",
+            streaming=True,
+            choice="auto",
+            parallel=False,
+            status_code=200,
+            status_class="2xx",
+            terminal="response.completed",
+            events=["response.completed"],
+            items=["message"],
+            tools=[],
+            input_types=message,
+        ),
+        _control(
+            "terminal_error",
+            streaming=True,
+            choice="auto",
+            parallel=False,
+            status_code=400,
+            status_class="4xx",
+            terminal="response.failed",
+            events=["response.failed"],
+            items=["message"],
+            tools=[],
+            input_types=message,
+        ),
+        _control(
+            "error_json",
+            streaming=False,
+            choice="auto",
+            parallel=False,
+            status_code=400,
+            status_class="4xx",
+            terminal="json_response",
+            events=[],
+            items=["message"],
+            tools=[],
+            input_types=message,
+        ),
+    ]
+
+
+def _candidate() -> dict[str, str]:
+    return {
+        "codexhub_candidate_sha": "d6957f408b63a4cd8ef600e223f8c1ee1084da74",
+        "cli_version": "0.146.0",
+        "cli_source_commit": None,
+        "cli_source_commit_status": "not_published_by_registry",
+        "cli_package_sha256": "b" * 64,
+        "catalog_snapshot_sha256": "c" * 64,
+        "catalog_model_entry_id": "gpt-5.6-sol",
+    }
+
+
+def test_manifest_covers_non_streaming_choice_terminal_and_error_controls() -> None:
+    built = manifest.build_manifest(_controls(), candidate_identity=_candidate())
+
+    assert built["schema"] == manifest.SCHEMA
+    assert built["verification_scope"] == manifest.SYNTHETIC_SCOPE
+    assert built["qualification"]["ready_for_issue62"] is False
+    assert {entry["name"] for entry in built["controls"]} == set(manifest.CONTROL_NAMES)
+
+    by_name = {entry["name"]: entry for entry in built["controls"]}
+    assert by_name["non_streaming_text"]["request_shape"]["stream"] is False
+    assert by_name["choice_auto"]["request_shape"]["parallel_tool_calls"] is True
+    assert by_name["choice_none"]["request_shape"]["tool_choice"] == "none"
+    assert by_name["terminal_success"]["response_shape"]["terminal"] == "response.completed"
+    assert by_name["terminal_error"]["response_shape"]["terminal"] == "response.failed"
+    assert by_name["error_json"]["response_shape"]["status_class"] == "4xx"
+    assert all(entry["body_equality"]["request"] for entry in built["controls"])
+    assert all(entry["body_equality"]["response"] for entry in built["controls"])
+
+
+def test_manifest_reconcile_and_negative_replays_fail_closed() -> None:
+    built = manifest.build_manifest(_controls(), candidate_identity=_candidate())
+    assert manifest.reconcile_manifest(built) == {"reconciled": True, "mismatches": []}
+
+    for case in ("mutation", "deletion", "loss"):
+        replay = manifest.replay_manifest(built, case)
+        report = manifest.reconcile_manifest(replay)
+        assert report["reconciled"] is False, case
+        assert report["mismatches"], case
+
+
+def test_manifest_rejects_pre_post_digest_mismatch() -> None:
+    controls = _controls()
+    controls[0]["post"]["response"]["sha256"] = "f" * 64  # type: ignore[index]
+
+    with pytest.raises(manifest.ManifestValidationError, match="control_body_fingerprint_mismatch"):
+        manifest.build_manifest(controls, candidate_identity=_candidate())
+
+
+def test_manifest_rejects_incomplete_body_and_sse_fingerprints() -> None:
+    controls = _controls()
+    for side in (controls[0]["pre"], controls[0]["post"]):  # type: ignore[index]
+        side["request"]["complete"] = False  # type: ignore[index]
+        side["request"]["sha256"] = None  # type: ignore[index]
+        side["request"]["hmac_sha256"] = None  # type: ignore[index]
+    with pytest.raises(manifest.ManifestValidationError, match="control_request_fingerprint_incomplete"):
+        manifest.build_manifest(controls, candidate_identity=_candidate())
+
+    controls = _controls()
+    for side in (controls[0]["pre"], controls[0]["post"]):  # type: ignore[index]
+        side["sse"]["complete"] = False  # type: ignore[index]
+        side["sse"]["sequence_sha256"] = None  # type: ignore[index]
+        side["sse"]["sequence_hmac_sha256"] = None  # type: ignore[index]
+    with pytest.raises(manifest.ManifestValidationError, match="control_sse_fingerprint_incomplete"):
+        manifest.build_manifest(controls, candidate_identity=_candidate())
+
+
+def test_sidecar_accepts_done_as_a_sanitized_sse_terminal_class() -> None:
+    record = _sidecar("done-terminal", "pre", streaming=True, status=200, terminal="done")
+    sanitized = manifest.sanitize_sidecar_record(record, expected_hop="pre")
+    assert sanitized["sse"]["terminal_classes"] == ["done"]  # type: ignore[index]
+
+
+def test_candidate_source_provenance_never_accepts_placeholder_hash() -> None:
+    unavailable = _candidate()
+    unavailable["cli_source_commit"] = "a" * 40
+    with pytest.raises(manifest.ManifestValidationError, match="candidate_cli_source_commit_unexpected"):
+        manifest.build_manifest(_controls(), candidate_identity=unavailable)
+
+    published = _candidate()
+    published["cli_source_commit_status"] = "published"
+    with pytest.raises(manifest.ManifestValidationError, match="candidate_cli_source_commit_invalid"):
+        manifest.build_manifest(_controls(), candidate_identity=published)
+
+    published["cli_source_commit"] = "a" * 40
+    assert manifest.build_manifest(_controls(), candidate_identity=published)["candidate_identity"][
+        "cli_source_commit_status"
+    ] == "published"
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        ("request_shape", "prompt"),
+        ("response_shape", "call_id"),
+        ("identity", "item_id"),
+    ],
+)
+def test_manifest_rejects_raw_content_or_wire_identifiers(field: tuple[str, str]) -> None:
+    controls = _controls()
+    section, key = field
+    controls[0][section][key] = "must-not-be-retained"  # type: ignore[index]
+
+    with pytest.raises(manifest.ManifestValidationError):
+        manifest.build_manifest(controls, candidate_identity=_candidate())
+
+
+def test_manifest_cli_emits_sanitized_fixture_and_replay_report(tmp_path: Path) -> None:
+    capture_path = tmp_path / "capture.json"
+    output_path = tmp_path / "manifest.json"
+    capture_path.write_text(
+        json.dumps({"catalog_model_entry_id": "gpt-5.6-sol", "controls": _controls()}),
+        encoding="utf-8",
+    )
+    args = [
+        "--capture",
+        str(capture_path),
+        "--out",
+        str(output_path),
+        "--codexhub-candidate-sha",
+        _candidate()["codexhub_candidate_sha"],
+        "--cli-version",
+        "0.146.0",
+        "--cli-source-commit-status",
+        "not_published_by_registry",
+        "--cli-package-sha256",
+        "b" * 64,
+        "--catalog-snapshot-sha256",
+        "c" * 64,
+    ]
+    assert manifest.main(args) == 0
+    written = json.loads(output_path.read_text(encoding="utf-8"))
+    assert manifest.reconcile_manifest(written)["reconciled"] is True
+    assert manifest.main([*args, "--replay-case", "mutation"]) == 0
+    serialized = output_path.read_text(encoding="utf-8")
+    for forbidden in ("must-not-be-retained", "capture_id", "call_id", "item_id", "prompt"):
+        assert forbidden not in serialized
+
+
+def test_manifest_reconcile_rejects_top_level_drift_and_qualification_loss() -> None:
+    built = manifest.build_manifest(_controls(), candidate_identity=_candidate())
+
+    with_extra = copy.deepcopy(built)
+    with_extra["prompt"] = "must-not-be-retained"
+    report = manifest.reconcile_manifest(with_extra)
+    assert report["reconciled"] is False
+    assert "manifest_fields_invalid" in report["mismatches"]
+
+    without_qualification = copy.deepcopy(built)
+    without_qualification.pop("qualification")
+    report = manifest.reconcile_manifest(without_qualification)
+    assert report["reconciled"] is False
+    assert any("manifest_fields_invalid" in mismatch for mismatch in report["mismatches"])
+
+    synthetic_ready = copy.deepcopy(built)
+    synthetic_ready["qualification"]["ready_for_issue62"] = True
+    report = manifest.reconcile_manifest(synthetic_ready)
+    assert report["reconciled"] is False
+    assert "synthetic_scope_cannot_qualify" in report["mismatches"]
+
+    raw_reason = copy.deepcopy(built)
+    raw_reason["qualification"]["reason"] = "https://example.invalid/prompt"
+    report = manifest.reconcile_manifest(raw_reason)
+    assert report["reconciled"] is False
+    assert any("qualification_reason_invalid" in mismatch for mismatch in report["mismatches"])
+
+    raw_identity = copy.deepcopy(built)
+    raw_identity["identity_control"]["prompt"] = "must-not-be-retained"
+    report = manifest.reconcile_manifest(raw_identity)
+    assert report["reconciled"] is False
+    assert any("identity_control_fields_invalid" in mismatch for mismatch in report["mismatches"])
+
+
+def test_manifest_reconcile_recomputes_identity_control_from_controls() -> None:
+    forged = copy.deepcopy(manifest.build_manifest(_controls(), candidate_identity=_candidate()))
+    forged["controls"][0]["identity"]["response_ref_preserved"] = False
+    forged["capture_manifest_sha256"] = manifest._canonical_digest(manifest._manifest_core(forged))
+    report = manifest.reconcile_manifest(forged)
+    assert report["reconciled"] is False
+    assert "identity_control_consistency" in report["mismatches"]
+    assert "identity_control_count_consistency" in report["mismatches"]
+
+
+@pytest.mark.parametrize(
+    ("control_name", "mutate", "expected"),
+    [
+        (
+            "choice_auto",
+            lambda control: control["request_shape"].update({"tool_choice": "none"}),
+            "control_label_choice_auto_invalid",
+        ),
+        (
+            "terminal_success",
+            lambda control: control["response_shape"].update({"terminal": "response.failed"}),
+            "control_label_terminal_success_invalid",
+        ),
+        (
+            "streaming_function_history",
+            lambda control: control["request_shape"].update(
+                {"input_item_types": [{"type": "message", "count": 1}]}
+            ),
+            "control_label_function_history_items_invalid",
+        ),
+    ],
+)
+def test_manifest_binds_control_labels_to_contract(
+    control_name: str,
+    mutate: object,
+    expected: str,
+) -> None:
+    forged = copy.deepcopy(manifest.build_manifest(_controls(), candidate_identity=_candidate()))
+    control = next(item for item in forged["controls"] if item["name"] == control_name)
+    mutate(control)  # type: ignore[operator]
+    forged["capture_manifest_sha256"] = manifest._canonical_digest(manifest._manifest_core(forged))
+    report = manifest.reconcile_manifest(forged)
+    assert report["reconciled"] is False
+    assert any(expected in mismatch for mismatch in report["mismatches"])

--- a/tests/test_issue_62_live_evidence_sidecar.py
+++ b/tests/test_issue_62_live_evidence_sidecar.py
@@ -1,0 +1,998 @@
+from __future__ import annotations
+
+import dataclasses
+from contextlib import contextmanager
+import hashlib
+import hmac
+import http.client
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import importlib.util
+import json
+from pathlib import Path
+import socket
+import struct
+import sys
+import threading
+import time
+from typing import Iterator
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "capture_issue_62_live_evidence.py"
+SPEC = importlib.util.spec_from_file_location("capture_issue_62_live_evidence", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+sidecar = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = sidecar
+SPEC.loader.exec_module(sidecar)
+
+KEY = b"h" * 32
+
+
+class _FakeUpstreamHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.0"
+
+    def do_POST(self) -> None:
+        length = int(self.headers["Content-Length"])
+        self.server.observed_request = self.rfile.read(length)  # type: ignore[attr-defined]
+        body = self.server.response_body  # type: ignore[attr-defined]
+        delay = self.server.response_delay  # type: ignore[attr-defined]
+        if delay:
+            time.sleep(delay)
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.end_headers()
+        chunk_size = self.server.response_chunk_size  # type: ignore[attr-defined]
+        for offset in range(0, len(body), chunk_size):
+            chunk = body[offset : offset + chunk_size]
+            try:
+                self.wfile.write(chunk)
+                self.wfile.flush()
+            except OSError:
+                return
+            if self.server.chunk_delay:  # type: ignore[attr-defined]
+                time.sleep(self.server.chunk_delay)  # type: ignore[attr-defined]
+
+    def log_message(self, format: str, *args: object) -> None:
+        return None
+
+
+@contextmanager
+def _fake_upstream(
+    response_body: bytes,
+    *,
+    response_delay: float = 0.0,
+    chunk_size: int = 36,
+    chunk_delay: float = 0.0,
+) -> Iterator[ThreadingHTTPServer]:
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _FakeUpstreamHandler)
+    server.response_body = response_body  # type: ignore[attr-defined]
+    server.observed_request = None  # type: ignore[attr-defined]
+    server.response_delay = response_delay  # type: ignore[attr-defined]
+    server.response_chunk_size = chunk_size  # type: ignore[attr-defined]
+    server.chunk_delay = chunk_delay  # type: ignore[attr-defined]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+@contextmanager
+def _running_sidecar(config):
+    server = sidecar.CaptureSidecarServer(config)
+    server.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+
+
+def _read_only_record(output_dir: Path) -> dict[str, object]:
+    records = list(output_dir.glob("*.json"))
+    assert len(records) == 1
+    return json.loads(records[0].read_text(encoding="utf-8"))
+
+
+def _wait_for_record(output_dir: Path, timeout: float = 3.0) -> dict[str, object]:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        records = list(output_dir.glob("*.json"))
+        if records:
+            assert len(records) == 1
+            return json.loads(records[0].read_text(encoding="utf-8"))
+        time.sleep(0.01)
+    raise AssertionError("capture record was not published")
+
+
+def _sidecar_config(
+    tmp_path: Path,
+    hmac_key_file: Path,
+    forward_base_url: str,
+    **overrides: object,
+):
+    values: dict[str, object] = {
+        "hop": "pre",
+        "listen_host": "127.0.0.1",
+        "listen_port": 0,
+        "forward_base_url": forward_base_url,
+        "output_dir": tmp_path / "records",
+        "hmac_key_file": hmac_key_file,
+        "max_request_bytes": 4096,
+        "max_response_bytes": 8192,
+        "connect_timeout_seconds": 1.0,
+        "read_timeout_seconds": 1.0,
+        "overall_timeout_seconds": 3.0,
+    }
+    values.update(overrides)
+    return sidecar.SidecarConfig(**values)
+
+
+@pytest.fixture
+def hmac_key_file(tmp_path: Path) -> Path:
+    path = tmp_path / "capture.key"
+    path.write_bytes(b"k" * 32)
+    return path
+
+
+@pytest.fixture
+def base_config(tmp_path: Path, hmac_key_file: Path):
+    return sidecar.SidecarConfig(
+        hop="pre",
+        listen_host="127.0.0.1",
+        listen_port=0,
+        forward_base_url="http://127.0.0.1:1",
+        output_dir=tmp_path / "records",
+        hmac_key_file=hmac_key_file,
+        max_request_bytes=1024,
+        max_response_bytes=4096,
+        connect_timeout_seconds=1.0,
+        read_timeout_seconds=1.0,
+        overall_timeout_seconds=2.0,
+    )
+
+
+def test_main_requires_explicit_enable(capsys: pytest.CaptureFixture[str]) -> None:
+    assert sidecar.main([]) == 2
+    assert "live capture is disabled" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("host", ["0.0.0.0", "192.0.2.10"])
+def test_config_rejects_non_loopback(host: str, base_config) -> None:
+    with pytest.raises(sidecar.ConfigurationError, match="listen_not_loopback"):
+        sidecar.validate_config(dataclasses.replace(base_config, listen_host=host))
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://127.0.0.1:0",
+        "http://127.0.0.1:65536",
+        "http://127.0.0.1:not-a-port",
+    ],
+)
+def test_config_rejects_malformed_or_out_of_range_forward_port(url: str, base_config) -> None:
+    with pytest.raises(sidecar.ConfigurationError, match="forward_base_url_invalid"):
+        sidecar.validate_config(dataclasses.replace(base_config, forward_base_url=url))
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "code"),
+    [
+        ("connect_timeout_seconds", float("nan"), "connect_timeout_invalid"),
+        ("read_timeout_seconds", float("inf"), "read_timeout_invalid"),
+        ("overall_timeout_seconds", float("-inf"), "overall_timeout_invalid"),
+    ],
+)
+def test_config_rejects_nonfinite_timeouts(field: str, value: float, code: str, base_config) -> None:
+    with pytest.raises(sidecar.ConfigurationError, match=code):
+        sidecar.validate_config(dataclasses.replace(base_config, **{field: value}))
+
+
+@pytest.mark.parametrize(
+    ("field", "code"),
+    [
+        ("connect_timeout_seconds", "connect_timeout_invalid"),
+        ("read_timeout_seconds", "read_timeout_invalid"),
+        ("overall_timeout_seconds", "overall_timeout_invalid"),
+    ],
+)
+def test_config_rejects_arbitrarily_large_positive_integer_timeout(
+    field: str,
+    code: str,
+    base_config,
+) -> None:
+    with pytest.raises(sidecar.ConfigurationError, match=code):
+        sidecar.validate_config(dataclasses.replace(base_config, **{field: 10**1000}))
+
+
+def test_atomic_record_is_sanitized_and_leaves_no_partial(tmp_path: Path) -> None:
+    record = {
+        "schema": "codexhub.issue62.live-evidence-lane.v1",
+        "verification_scope": "capture_only_not_qualification",
+        "capture_id": "c" + "1" * 32,
+        "hop": "pre",
+        "outcome": "complete",
+        "failure": None,
+        "status": 200,
+        "content_type_class": "json",
+        "request": {
+            "bytes": 2,
+            "sha256": "a" * 64,
+            "hmac_sha256": "b" * 64,
+            "complete": True,
+        },
+        "response": {
+            "bytes": 3,
+            "sha256": "c" * 64,
+            "hmac_sha256": "d" * 64,
+            "complete": True,
+        },
+        "sse": None,
+    }
+
+    record_path = sidecar.write_capture_record(tmp_path, "pre", record)
+
+    assert json.loads(record_path.read_text(encoding="utf-8")) == record
+    assert record_path.name.startswith("pre-")
+    assert record_path.suffix == ".json"
+    assert not list(tmp_path.glob("*.partial"))
+
+
+def test_atomic_record_rejects_unapproved_fields(tmp_path: Path) -> None:
+    with pytest.raises(sidecar.ArtifactValidationError, match="record_fields_invalid"):
+        sidecar.write_capture_record(
+            tmp_path,
+            "pre",
+            {
+                "schema": "codexhub.issue62.live-evidence-lane.v1",
+                "verification_scope": "capture_only_not_qualification",
+                "capture_id": "c" + "2" * 32,
+                "hop": "pre",
+                "outcome": "incomplete",
+                "failure": "forwarding_failed",
+                "status": None,
+                "content_type_class": "unknown",
+                "request": None,
+                "response": None,
+                "sse": None,
+                "authorization": "Bearer forbidden",
+            },
+        )
+
+
+def test_atomic_record_rejects_inconsistent_sse_completion(tmp_path: Path) -> None:
+    with pytest.raises(sidecar.ArtifactValidationError, match="sse_invalid"):
+        sidecar.write_capture_record(
+            tmp_path,
+            "post",
+            {
+                "schema": "codexhub.issue62.live-evidence-lane.v1",
+                "verification_scope": "capture_only_not_qualification",
+                "capture_id": "c" + "3" * 32,
+                "hop": "post",
+                "outcome": "incomplete",
+                "failure": "sse_terminal_missing",
+                "status": 200,
+                "content_type_class": "event-stream",
+                "request": None,
+                "response": None,
+                "sse": {
+                    "complete": False,
+                    "frame_count": 1,
+                    "frame_bytes": 12,
+                    "sequence_sha256": "e" * 64,
+                    "sequence_hmac_sha256": "f" * 64,
+                    "terminal_classes": [],
+                },
+            },
+        )
+
+
+@pytest.mark.parametrize(
+    ("content_type_class", "response", "sse"),
+    [
+        ("json", None, None),
+        (
+            "event-stream",
+            {
+                "bytes": 3,
+                "sha256": "c" * 64,
+                "hmac_sha256": "d" * 64,
+                "complete": True,
+            },
+            None,
+        ),
+    ],
+)
+def test_complete_record_requires_complete_response_and_sse_when_streaming(
+    tmp_path: Path,
+    content_type_class: str,
+    response: object,
+    sse: object,
+) -> None:
+    with pytest.raises(sidecar.ArtifactValidationError, match="record_completion_invalid"):
+        sidecar.write_capture_record(
+            tmp_path,
+            "pre",
+            {
+                "schema": "codexhub.issue62.live-evidence-lane.v1",
+                "verification_scope": "capture_only_not_qualification",
+                "capture_id": "c" + ("4" if response is None else "5") * 32,
+                "hop": "pre",
+                "outcome": "complete",
+                "failure": None,
+                "status": 200,
+                "content_type_class": content_type_class,
+                "request": {
+                    "bytes": 2,
+                    "sha256": "a" * 64,
+                    "hmac_sha256": "b" * 64,
+                    "complete": True,
+                },
+                "response": response,
+                "sse": sse,
+            },
+        )
+
+
+def test_cli_rejects_ephemeral_port(
+    tmp_path: Path,
+    hmac_key_file: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    result = sidecar.main(
+        [
+            "--enable-live-capture",
+            "--hop",
+            "pre",
+            "--listen-host",
+            "127.0.0.1",
+            "--listen-port",
+            "0",
+            "--forward-base-url",
+            "http://127.0.0.1:1",
+            "--output-dir",
+            str(tmp_path / "records"),
+            "--hmac-key-file",
+            str(hmac_key_file),
+            "--max-request-bytes",
+            "1024",
+            "--max-response-bytes",
+            "4096",
+            "--connect-timeout-seconds",
+            "1",
+            "--read-timeout-seconds",
+            "1",
+            "--overall-timeout-seconds",
+            "2",
+        ]
+    )
+
+    assert result == 2
+    assert capsys.readouterr().err.strip() == "listen_port_zero_not_allowed"
+
+
+def test_body_fingerprint_hashes_every_byte() -> None:
+    observed = sidecar.BodyFingerprint(KEY, b"request-body")
+    observed.update(b"abc")
+    observed.update(b"\x00def")
+
+    assert observed.complete() == {
+        "bytes": 7,
+        "sha256": hashlib.sha256(b"abc\x00def").hexdigest(),
+        "hmac_sha256": hmac.new(
+            KEY,
+            b"request-body\0abc\x00def",
+            hashlib.sha256,
+        ).hexdigest(),
+        "complete": True,
+    }
+
+
+def _consume_sse(chunks: list[bytes]) -> dict[str, object]:
+    observed = sidecar.SseSequenceFingerprint(KEY)
+    for chunk in chunks:
+        observed.update(chunk)
+    return observed.complete()
+
+
+def test_sse_sequence_digest_is_independent_of_transport_chunks() -> None:
+    wire = (
+        b'data: {"type":"response.output_text.delta","delta":"secret"}\n\n'
+        b'data: {"type":"response.completed"}\n\n'
+    )
+
+    one = _consume_sse([wire])
+    split = _consume_sse([wire[:5], wire[5:41], wire[41:]])
+
+    assert split == one
+    assert split["complete"] is True
+    assert split["frame_count"] == 2
+    assert split["terminal_classes"] == ["response.completed"]
+    assert "secret" not in json.dumps(split, sort_keys=True)
+
+
+def test_sse_sequence_fails_closed_without_terminal_or_complete_frame() -> None:
+    missing_terminal = _consume_sse([b'data: {"type":"response.output_text.delta"}\n\n'])
+    incomplete_frame = _consume_sse([b'data: {"type":"response.completed"}\n'])
+
+    assert missing_terminal["complete"] is False
+    assert incomplete_frame["complete"] is False
+    assert missing_terminal["sequence_sha256"] is None
+    assert missing_terminal["sequence_hmac_sha256"] is None
+    assert incomplete_frame["sequence_sha256"] is None
+    assert incomplete_frame["sequence_hmac_sha256"] is None
+
+
+def test_sse_sequence_fails_closed_when_any_frame_follows_terminal() -> None:
+    observed = _consume_sse(
+        [
+            b'data: {"type":"response.completed"}\n\n'
+            b'data: {"type":"response.output_text.delta","delta":"after"}\n\n'
+        ]
+    )
+
+    assert observed["complete"] is False
+    assert observed["sequence_sha256"] is None
+    assert observed["sequence_hmac_sha256"] is None
+    assert observed["terminal_classes"] == ["response.completed"]
+
+
+def test_terminal_followed_by_frame_uses_fixed_failure_code(
+    tmp_path: Path,
+    hmac_key_file: Path,
+) -> None:
+    response_body = (
+        b'data: {"type":"response.completed"}\n\n'
+        b'data: {"type":"response.output_text.delta","delta":"after"}\n\n'
+    )
+    with _fake_upstream(response_body) as upstream:
+        upstream_url = f"http://127.0.0.1:{upstream.server_address[1]}"
+        config = _sidecar_config(tmp_path, hmac_key_file, upstream_url)
+        with _running_sidecar(config) as server:
+            connection = http.client.HTTPConnection(server.listen_host, server.listen_port, timeout=2)
+            connection.request("POST", "/responses", body=b"{}")
+            response = connection.getresponse()
+            response.read()
+            connection.close()
+
+    record = _read_only_record(config.output_dir)
+    assert record["outcome"] == "incomplete"
+    assert record["failure"] == "sse_frame_after_terminal"
+    assert record["response"]["complete"] is False  # type: ignore[index]
+    assert record["sse"]["complete"] is False  # type: ignore[index]
+
+
+def test_two_hops_capture_matching_complete_request_response_and_sse(
+    tmp_path: Path,
+    hmac_key_file: Path,
+) -> None:
+    request_body = b'{"input":"private prompt","stream":true}'
+    sse_body = (
+        b'data: {"type":"response.output_text.delta","delta":"private output"}\n\n'
+        b'data: {"type":"response.completed"}\n\n'
+    )
+    post_output = tmp_path / "post-records"
+    pre_output = tmp_path / "pre-records"
+
+    with _fake_upstream(sse_body) as upstream:
+        upstream_url = f"http://127.0.0.1:{upstream.server_address[1]}"
+        post_config = sidecar.SidecarConfig(
+            hop="post",
+            listen_host="127.0.0.1",
+            listen_port=0,
+            forward_base_url=upstream_url,
+            output_dir=post_output,
+            hmac_key_file=hmac_key_file,
+            max_request_bytes=4096,
+            max_response_bytes=8192,
+            connect_timeout_seconds=1.0,
+            read_timeout_seconds=1.0,
+            overall_timeout_seconds=3.0,
+        )
+        with _running_sidecar(post_config) as post:
+            pre_config = dataclasses.replace(
+                post_config,
+                hop="pre",
+                forward_base_url=post.url,
+                output_dir=pre_output,
+            )
+            with _running_sidecar(pre_config) as pre:
+                connection = http.client.HTTPConnection(
+                    pre.listen_host,
+                    pre.listen_port,
+                    timeout=3,
+                )
+                connection.request(
+                    "POST",
+                    "/responses?opaque=wire-id",
+                    body=request_body,
+                    headers={
+                        "Authorization": "Bearer forbidden-token",
+                        "Content-Type": "application/json",
+                    },
+                )
+                response = connection.getresponse()
+                response_body = response.read()
+                status = response.status
+                connection.close()
+
+        assert upstream.observed_request == request_body  # type: ignore[attr-defined]
+
+    assert status == 200
+    assert response_body == sse_body
+    pre_record = _read_only_record(pre_output)
+    post_record = _read_only_record(post_output)
+    assert pre_record["request"] == post_record["request"]
+    assert pre_record["response"] == post_record["response"]
+    assert pre_record["sse"]["sequence_sha256"] == post_record["sse"]["sequence_sha256"]  # type: ignore[index]
+    assert pre_record["sse"]["sequence_hmac_sha256"] == post_record["sse"]["sequence_hmac_sha256"]  # type: ignore[index]
+    assert pre_record["outcome"] == post_record["outcome"] == "complete"
+    serialized = json.dumps([pre_record, post_record], sort_keys=True)
+    for sensitive in (
+        "private prompt",
+        "private output",
+        "forbidden-token",
+        "wire-id",
+        upstream_url,
+        str(pre_output),
+        str(post_output),
+        str(hmac_key_file),
+    ):
+        assert sensitive not in serialized
+    assert not list(tmp_path.rglob("*.partial"))
+
+
+def test_request_overflow_fails_closed_before_forwarding(
+    tmp_path: Path,
+    hmac_key_file: Path,
+) -> None:
+    with _fake_upstream(b'data: {"type":"response.completed"}\n\n') as upstream:
+        upstream_url = f"http://127.0.0.1:{upstream.server_address[1]}"
+        config = _sidecar_config(
+            tmp_path,
+            hmac_key_file,
+            upstream_url,
+            max_request_bytes=4,
+        )
+        with _running_sidecar(config) as server:
+            connection = http.client.HTTPConnection(server.listen_host, server.listen_port, timeout=2)
+            connection.request("POST", "/secret-path", body=b"private-body")
+            response = connection.getresponse()
+            assert response.status == 413
+            response.read()
+            connection.close()
+        assert upstream.observed_request is None  # type: ignore[attr-defined]
+
+    record = _read_only_record(config.output_dir)
+    assert record["outcome"] == "incomplete"
+    assert record["failure"] == "request_overflow"
+    assert record["request"]["complete"] is False  # type: ignore[index]
+    assert record["request"]["sha256"] is None  # type: ignore[index]
+    assert "private-body" not in json.dumps(record, sort_keys=True)
+    assert "secret-path" not in json.dumps(record, sort_keys=True)
+    assert not list(tmp_path.rglob("*.partial"))
+
+
+def test_response_overflow_nulls_partial_response_digests(
+    tmp_path: Path,
+    hmac_key_file: Path,
+) -> None:
+    response_body = b'data: {"type":"response.completed","secret":"private-output"}\n\n'
+    with _fake_upstream(response_body, chunk_size=7) as upstream:
+        upstream_url = f"http://127.0.0.1:{upstream.server_address[1]}"
+        config = _sidecar_config(
+            tmp_path,
+            hmac_key_file,
+            upstream_url,
+            max_response_bytes=8,
+        )
+        with _running_sidecar(config) as server:
+            connection = http.client.HTTPConnection(server.listen_host, server.listen_port, timeout=2)
+            connection.request("POST", "/responses", body=b"{}")
+            response = connection.getresponse()
+            response.read()
+            connection.close()
+
+    record = _read_only_record(config.output_dir)
+    assert record["outcome"] == "incomplete"
+    assert record["failure"] == "response_overflow"
+    assert record["response"]["complete"] is False  # type: ignore[index]
+    assert record["response"]["sha256"] is None  # type: ignore[index]
+    assert record["response"]["hmac_sha256"] is None  # type: ignore[index]
+    assert "private-output" not in json.dumps(record, sort_keys=True)
+    assert not list(tmp_path.rglob("*.partial"))
+
+
+def _terminal_first_response(extra: bytes) -> bytes:
+    terminal = b'data: {"type":"response.completed"}\n\n'
+    padding_size = (64 * 1024) - len(terminal) - 3
+    assert padding_size > 0
+    return terminal + b":" + (b"x" * padding_size) + b"\n\n" + extra
+
+
+@pytest.mark.parametrize("failure_mode", ["overflow", "timeout"])
+def test_incomplete_response_invalidates_previously_complete_sse_digest(
+    failure_mode: str,
+    tmp_path: Path,
+    hmac_key_file: Path,
+) -> None:
+    response_body = _terminal_first_response(b":after-terminal\n\n")
+    upstream_options = {"chunk_size": 64 * 1024}
+    config_options: dict[str, object] = {"max_response_bytes": 64 * 1024}
+    expected_failure = "response_overflow"
+    if failure_mode == "timeout":
+        upstream_options["chunk_delay"] = 0.2
+        config_options = {
+            "max_response_bytes": len(response_body) + 1024,
+            "read_timeout_seconds": 0.05,
+            "overall_timeout_seconds": 0.15,
+        }
+        expected_failure = "upstream_timeout"
+    with _fake_upstream(response_body, **upstream_options) as upstream:
+        upstream_url = f"http://127.0.0.1:{upstream.server_address[1]}"
+        config = _sidecar_config(
+            tmp_path,
+            hmac_key_file,
+            upstream_url,
+            **config_options,
+        )
+        with _running_sidecar(config) as server:
+            connection = http.client.HTTPConnection(server.listen_host, server.listen_port, timeout=2)
+            connection.request("POST", "/responses", body=b"{}")
+            response = connection.getresponse()
+            response.read()
+            connection.close()
+
+    record = _read_only_record(config.output_dir)
+    assert record["outcome"] == "incomplete"
+    assert record["failure"] == expected_failure
+    assert record["response"]["complete"] is False  # type: ignore[index]
+    assert record["response"]["sha256"] is None  # type: ignore[index]
+    assert record["sse"]["complete"] is False  # type: ignore[index]
+    assert record["sse"]["sequence_sha256"] is None  # type: ignore[index]
+    assert record["sse"]["sequence_hmac_sha256"] is None  # type: ignore[index]
+    assert not list(tmp_path.rglob("*.partial"))
+
+
+def test_upstream_timeout_is_bounded_and_sanitized(
+    tmp_path: Path,
+    hmac_key_file: Path,
+) -> None:
+    with _fake_upstream(
+        b'data: {"type":"response.completed"}\n\n',
+        response_delay=0.3,
+    ) as upstream:
+        upstream_url = f"http://127.0.0.1:{upstream.server_address[1]}"
+        config = _sidecar_config(
+            tmp_path,
+            hmac_key_file,
+            upstream_url,
+            read_timeout_seconds=0.05,
+            overall_timeout_seconds=0.1,
+        )
+        with _running_sidecar(config) as server:
+            connection = http.client.HTTPConnection(server.listen_host, server.listen_port, timeout=2)
+            connection.request("POST", "/responses", body=b"{}")
+            response = connection.getresponse()
+            response.read()
+            connection.close()
+
+    record = _read_only_record(config.output_dir)
+    assert record["outcome"] == "incomplete"
+    assert record["failure"] == "upstream_timeout"
+    assert upstream_url not in json.dumps(record, sort_keys=True)
+    assert str(config.output_dir) not in json.dumps(record, sort_keys=True)
+    assert str(hmac_key_file) not in json.dumps(record, sort_keys=True)
+    assert not list(tmp_path.rglob("*.partial"))
+
+
+def test_downstream_cancellation_fails_closed_and_cleans_partial(
+    tmp_path: Path,
+    hmac_key_file: Path,
+) -> None:
+    response_body = (
+        b'data: {"type":"response.output_text.delta","delta":"private"}\n\n' * 4096
+        + b'data: {"type":"response.completed"}\n\n'
+    )
+    with _fake_upstream(response_body, chunk_size=1024, chunk_delay=0.001) as upstream:
+        upstream_url = f"http://127.0.0.1:{upstream.server_address[1]}"
+        config = _sidecar_config(
+            tmp_path,
+            hmac_key_file,
+            upstream_url,
+            max_response_bytes=len(response_body) + 1024,
+        )
+        with _running_sidecar(config) as server:
+            client = socket.create_connection((server.listen_host, server.listen_port), timeout=2)
+            client.sendall(
+                b"POST /responses HTTP/1.1\r\n"
+                b"Host: 127.0.0.1\r\n"
+                b"Content-Length: 2\r\n"
+                b"Connection: close\r\n\r\n{}"
+            )
+            client.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, struct.pack("hh", 1, 0))
+            client.close()
+            record = _wait_for_record(config.output_dir)
+
+    assert record["outcome"] == "incomplete"
+    assert record["failure"] in {"client_cancelled", "downstream_cancelled"}
+    assert record["response"] is None or record["response"]["complete"] is False  # type: ignore[index]
+    assert "private" not in json.dumps(record, sort_keys=True)
+    assert not list(tmp_path.rglob("*.partial"))
+
+
+def test_listener_start_failure_writes_bounded_record_without_sensitive_paths(
+    tmp_path: Path,
+    hmac_key_file: Path,
+) -> None:
+    occupied = socket.socket()
+    occupied.bind(("127.0.0.1", 0))
+    occupied.listen()
+    port = occupied.getsockname()[1]
+    config = _sidecar_config(
+        tmp_path,
+        hmac_key_file,
+        "http://user:secret@127.0.0.1:1".replace("user:secret@", ""),
+        listen_port=port,
+    )
+    server = sidecar.CaptureSidecarServer(config)
+    try:
+        with pytest.raises(sidecar.SidecarStartError, match="server_start_failed"):
+            server.start()
+    finally:
+        server.shutdown()
+        occupied.close()
+
+    record = _read_only_record(config.output_dir)
+    assert record["failure"] == "server_start_failed"
+    serialized = json.dumps(record, sort_keys=True)
+    assert config.forward_base_url not in serialized
+    assert str(config.output_dir) not in serialized
+    assert str(hmac_key_file) not in serialized
+    assert not list(tmp_path.rglob("*.partial"))
+
+
+def test_server_thread_failure_writes_bounded_record_and_cleans_partial(
+    tmp_path: Path,
+    hmac_key_file: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def explode(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("private thread detail")
+
+    monkeypatch.setattr(ThreadingHTTPServer, "serve_forever", explode)
+    config = _sidecar_config(tmp_path, hmac_key_file, "http://127.0.0.1:1")
+    server = sidecar.CaptureSidecarServer(config)
+    server.start()
+    assert server.wait() is False
+    server.shutdown()
+
+    record = _read_only_record(config.output_dir)
+    assert record["failure"] == "server_thread_failed"
+    assert "private thread detail" not in json.dumps(record, sort_keys=True)
+    assert not list(tmp_path.rglob("*.partial"))
+
+
+def test_cli_configuration_error_does_not_echo_sensitive_values(
+    tmp_path: Path,
+    hmac_key_file: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    secret_url = "http://user:private-password@127.0.0.1:1"
+    result = sidecar.main(
+        [
+            "--enable-live-capture",
+            "--hop",
+            "pre",
+            "--listen-host",
+            "127.0.0.1",
+            "--listen-port",
+            "1",
+            "--forward-base-url",
+            secret_url,
+            "--output-dir",
+            str(tmp_path / "private-output-path"),
+            "--hmac-key-file",
+            str(hmac_key_file),
+            "--max-request-bytes",
+            "1024",
+            "--max-response-bytes",
+            "4096",
+            "--connect-timeout-seconds",
+            "1",
+            "--read-timeout-seconds",
+            "1",
+            "--overall-timeout-seconds",
+            "2",
+        ]
+    )
+
+    assert result == 2
+    stderr = capsys.readouterr().err.strip()
+    assert stderr == "forward_base_url_invalid"
+    assert "private-password" not in stderr
+    assert "private-output-path" not in stderr
+    assert str(hmac_key_file) not in stderr
+
+
+def test_cli_explicit_enable_starts_and_cleans_up_on_interrupt(
+    tmp_path: Path,
+    hmac_key_file: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    probe = socket.socket()
+    probe.bind(("127.0.0.1", 0))
+    port = probe.getsockname()[1]
+    probe.close()
+
+    def interrupt_wait(_server: object) -> bool:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(sidecar.CaptureSidecarServer, "wait", interrupt_wait)
+    result = sidecar.main(
+        [
+            "--enable-live-capture",
+            "--hop",
+            "pre",
+            "--listen-host",
+            "127.0.0.1",
+            "--listen-port",
+            str(port),
+            "--forward-base-url",
+            "http://127.0.0.1:1",
+            "--output-dir",
+            str(tmp_path / "records"),
+            "--hmac-key-file",
+            str(hmac_key_file),
+            "--max-request-bytes",
+            "1024",
+            "--max-response-bytes",
+            "4096",
+            "--connect-timeout-seconds",
+            "1",
+            "--read-timeout-seconds",
+            "1",
+            "--overall-timeout-seconds",
+            "2",
+        ]
+    )
+
+    assert result == 0
+    rebound = socket.socket()
+    try:
+        rebound.bind(("127.0.0.1", port))
+    finally:
+        rebound.close()
+    assert not list(tmp_path.rglob("*.partial"))
+
+
+def _unused_loopback_port() -> int:
+    probe = socket.socket()
+    try:
+        probe.bind(("127.0.0.1", 0))
+        return int(probe.getsockname()[1])
+    finally:
+        probe.close()
+
+
+def _enabled_cli_args(tmp_path: Path, hmac_key_file: Path, port: int) -> list[str]:
+    return [
+        "--enable-live-capture",
+        "--hop",
+        "pre",
+        "--listen-host",
+        "127.0.0.1",
+        "--listen-port",
+        str(port),
+        "--forward-base-url",
+        "http://127.0.0.1:1",
+        "--output-dir",
+        str(tmp_path / "records"),
+        "--hmac-key-file",
+        str(hmac_key_file),
+        "--max-request-bytes",
+        "1024",
+        "--max-response-bytes",
+        "4096",
+        "--connect-timeout-seconds",
+        "1",
+        "--read-timeout-seconds",
+        "1",
+        "--overall-timeout-seconds",
+        "2",
+    ]
+
+
+def test_cli_reports_false_shutdown_drain_with_fixed_failure(
+    tmp_path: Path,
+    hmac_key_file: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    original_shutdown = sidecar.CaptureSidecarServer.shutdown
+
+    def interrupt_wait(_server: object) -> bool:
+        raise KeyboardInterrupt
+
+    def cleanup_but_report_false(server: object) -> bool:
+        original_shutdown(server)
+        return False
+
+    monkeypatch.setattr(sidecar.CaptureSidecarServer, "wait", interrupt_wait)
+    monkeypatch.setattr(sidecar.CaptureSidecarServer, "shutdown", cleanup_but_report_false)
+
+    result = sidecar.main(_enabled_cli_args(tmp_path, hmac_key_file, _unused_loopback_port()))
+
+    assert result == 1
+    assert capsys.readouterr().err.strip() == "shutdown_drain_failed"
+
+
+def test_cli_reports_server_thread_failure_with_fixed_failure(
+    tmp_path: Path,
+    hmac_key_file: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(sidecar.CaptureSidecarServer, "wait", lambda _server: False)
+
+    result = sidecar.main(_enabled_cli_args(tmp_path, hmac_key_file, _unused_loopback_port()))
+
+    assert result == 1
+    assert capsys.readouterr().err.strip() == "server_thread_failed"
+
+
+def test_shutdown_closes_active_client_and_upstream_and_waits_bounded(
+    tmp_path: Path,
+    hmac_key_file: Path,
+) -> None:
+    response_body = b'data: {"type":"response.completed"}\n\n'
+    with _fake_upstream(response_body, response_delay=0.25) as upstream:
+        upstream_url = f"http://127.0.0.1:{upstream.server_address[1]}"
+        config = _sidecar_config(
+            tmp_path,
+            hmac_key_file,
+            upstream_url,
+            read_timeout_seconds=5.0,
+            overall_timeout_seconds=5.0,
+        )
+        server = sidecar.CaptureSidecarServer(config)
+        server.start()
+        client_done = threading.Event()
+
+        def request() -> None:
+            connection = http.client.HTTPConnection(server.listen_host, server.listen_port, timeout=6)
+            try:
+                connection.request("POST", "/responses", body=b"{}")
+                response = connection.getresponse()
+                response.read()
+            except OSError:
+                pass
+            finally:
+                connection.close()
+                client_done.set()
+
+        client_thread = threading.Thread(target=request, daemon=True)
+        client_thread.start()
+        deadline = time.monotonic() + 2
+        while upstream.observed_request is None and time.monotonic() < deadline:  # type: ignore[attr-defined]
+            time.sleep(0.01)
+        assert upstream.observed_request == b"{}"  # type: ignore[attr-defined]
+
+        started = time.monotonic()
+        drained = server.shutdown()
+        elapsed = time.monotonic() - started
+        client_thread.join(timeout=1)
+
+    assert drained is True
+    assert elapsed < 1.0
+    assert client_done.is_set()
+    record = _read_only_record(config.output_dir)
+    assert record["outcome"] == "incomplete"
+    assert record["failure"] in {"client_cancelled", "forwarding_failed", "upstream_timeout"}
+    assert not list(tmp_path.rglob("*.partial"))

--- a/tests/test_issue_62_runtime_inventory.py
+++ b/tests/test_issue_62_runtime_inventory.py
@@ -1,0 +1,537 @@
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "build_issue_62_runtime_inventory.py"
+INVENTORY = ROOT / "docs" / "evidence" / "issue-62" / "runtime-wire-inventory.json"
+TRACE = ROOT / "docs" / "evidence" / "issue-62" / "current-codexhub-thread-tool-surface.json"
+WIRE_FIXTURE = ROOT / "docs" / "evidence" / "issue-62" / "codexhub-runtime-wire-fixture.json"
+AUDIT = ROOT / "docs" / "evidence" / "issue-62" / "read-only-gate-audit.json"
+
+DISPOSITIONS = (
+    "preserved",
+    "reversibly_adapted",
+    "local_consume",
+    "Unsupported",
+    "Unqualified",
+)
+
+
+def load_inventory_module():
+    spec = importlib.util.spec_from_file_location("issue_62_runtime_inventory", SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_inventory_is_bound_to_supported_cli_floor_and_candidate_identity() -> None:
+    inventory = json.loads(INVENTORY.read_text(encoding="utf-8"))
+
+    assert inventory["schema_version"] == 1
+    assert inventory["artifact_kind"] == "runtime_wire_inventory"
+    assert inventory["cli_version_floor"] == "0.145.0"
+    candidate = inventory["candidate_identity"]
+    assert candidate["cli_version"] == "0.144.0-alpha.4"
+    assert candidate["source_commit"] == "9e552e9d15ba52bed7077d5357f3e18e330f8f38"
+    assert candidate["codex_source_commit"] == candidate["source_commit"]
+    assert candidate["route_upstream"] == "official"
+    assert candidate["inbound_format"] == "responses"
+    assert candidate["upstream_format"] == "responses"
+    assert candidate["catalog_binding"] == "official Codex catalog entry for openai/gpt-5.6-sol"
+    assert candidate["catalog_snapshot_sha256"] == "307a09f22b0c827ae77192a4beaf7059efcf8a698ec4f252aa4ba4787f8d1876"
+    assert candidate["catalog_model_entry_id"] == "gpt-5.6-sol"
+    assert candidate["route_behavior_profile"] == "official_codex_app_http_passthrough"
+    assert len(candidate["evidence_manifest_sha256"]) == 64
+    assert inventory["qualification"]["candidate_version_status"] == "legacy_below_floor"
+    assert inventory["qualification"]["candidate_version_eligible"] is False
+    assert inventory["qualification"]["ready_for_beta1"] is False
+    assert inventory["identity_control"]["unknown_tagged_source_count"] == 2
+    assert inventory["qualification"]["blocking_gates"] == [
+        "clean_cold_start_current_binding",
+        "complete_model_visible_plan",
+        "error_events",
+        "full_pre_post_request_response",
+        "full_request_fingerprint",
+        "full_response_fingerprint",
+        "identity_replay",
+        "non_streaming",
+        "non_streaming_fixture",
+        "sse_identity",
+        "terminal_events",
+        "wire_identity_replay",
+    ]
+    assert inventory["qualification"]["evidence_gates"] == {
+        "clean_cold_start_current_binding": "not_run",
+        "complete_model_visible_plan": "partial",
+        "error_events": "not_captured",
+        "full_pre_post_request_response": "live_control_required",
+        "full_request_fingerprint": "not_captured",
+        "full_response_fingerprint": "not_captured",
+        "identity_replay": "partial",
+        "non_streaming": "live_control_required",
+        "non_streaming_fixture": "not_captured",
+        "sse_identity": "not_captured",
+        "terminal_events": "not_captured",
+        "wire_identity_replay": "not_captured",
+    }
+    assert inventory["evidence_binding"]["trace"]["file"] == TRACE.name
+    assert len(inventory["evidence_binding"]["trace"]["sha256"]) == 64
+
+
+def test_inventory_uses_only_final_capability_disposition_vocabulary() -> None:
+    module = load_inventory_module()
+    assert module.ALLOWED_DISPOSITIONS == DISPOSITIONS
+
+    inventory = json.loads(INVENTORY.read_text(encoding="utf-8"))
+    assert "live_control_required" not in inventory["disposition_vocabulary"]
+    assert all(
+        item["disposition"] in DISPOSITIONS for item in inventory["items"]
+    )
+
+
+def test_inventory_covers_every_required_taxonomy_scope() -> None:
+    inventory = json.loads(INVENTORY.read_text(encoding="utf-8"))
+    scopes = {entry["scope"] for entry in inventory["items"]}
+    required = {
+        "core_text_streaming",
+        "core_text_non_streaming",
+        "core_history_multiturn",
+        "core_history_item_ids",
+        "core_history_call_ids",
+        "core_sse_streaming_events",
+        "core_sse_terminal_events",
+        "core_sse_errors",
+        "core_function_declaration",
+        "core_function_call",
+        "core_function_result",
+        "core_function_replay",
+        "identity_item_call_ids",
+        "identity_response_ids",
+        "identity_request_ids",
+        "choice_controls",
+        "terminal_events",
+        "errors",
+        "hosted_only_declarations",
+        "unknown_tagged_sentinels",
+        "default_runtime_fields",
+        "code_mode",
+        "tool_search",
+        "collaboration_v2",
+        "chat_conversion",
+    }
+    missing = required - scopes
+    assert not missing, f"missing required scopes: {sorted(missing)}"
+
+
+def test_every_item_carries_an_allowed_disposition() -> None:
+    inventory = json.loads(INVENTORY.read_text(encoding="utf-8"))
+
+    for entry in inventory["items"]:
+        assert entry["disposition"] in DISPOSITIONS, entry
+        assert "evidence_source" in entry
+        assert isinstance(entry["evidence_source"], str)
+        assert entry["evidence_source"]
+
+
+def test_core_items_have_preserved_or_reversibly_adapted_disposition() -> None:
+    inventory = json.loads(INVENTORY.read_text(encoding="utf-8"))
+    by_scope = {entry["scope"]: entry for entry in inventory["items"]}
+
+    preserved_or_adapted = {"preserved", "reversibly_adapted"}
+    for scope in (
+        "core_text_streaming",
+        "core_history_multiturn",
+        "core_history_item_ids",
+        "core_history_call_ids",
+        "core_function_declaration",
+        "core_function_call",
+        "core_function_result",
+        "identity_item_call_ids",
+        "identity_response_ids",
+        "identity_request_ids",
+    ):
+        assert by_scope[scope]["disposition"] in preserved_or_adapted, scope
+
+    assert by_scope["core_function_replay"]["disposition"] == "Unqualified"
+
+
+def test_advanced_capabilities_are_not_supported_or_unqualified() -> None:
+    inventory = json.loads(INVENTORY.read_text(encoding="utf-8"))
+    by_scope = {entry["scope"]: entry for entry in inventory["items"]}
+
+    for scope in ("code_mode", "tool_search", "collaboration_v2", "chat_conversion"):
+        assert by_scope[scope]["disposition"] in {
+            "Unsupported",
+            "Unqualified",
+        }, scope
+
+
+def test_unqualified_items_remain_blocked_until_live_control() -> None:
+    inventory = json.loads(INVENTORY.read_text(encoding="utf-8"))
+    by_scope = {entry["scope"]: entry for entry in inventory["items"]}
+
+    for scope in (
+        "core_text_non_streaming",
+        "choice_controls",
+        "core_sse_terminal_events",
+        "core_sse_errors",
+        "terminal_events",
+        "errors",
+        "hosted_only_declarations",
+        "unknown_tagged_sentinels",
+        "default_runtime_fields",
+    ):
+        entry = by_scope[scope]
+        assert entry["disposition"] == "Unqualified", scope
+
+
+def test_inventory_reports_zero_unclassified_core_items() -> None:
+    inventory = json.loads(INVENTORY.read_text(encoding="utf-8"))
+
+    assert inventory["identity_control"]["unclassified_core_items"] == 0
+    assert inventory["identity_control"]["unclassified_scopes"] == []
+    assert inventory["qualification"]["ready_for_beta1"] is False
+    assert "core_function_replay" in inventory["qualification"]["blocking_scopes"]
+
+
+def test_inventory_replay_fails_visibly_on_mutation_deletion_and_loss() -> None:
+    module = load_inventory_module()
+    base = json.loads(INVENTORY.read_text(encoding="utf-8"))
+
+    for case in ("mutation", "deletion", "loss"):
+        mutated = module.replay_inventory(base, case)
+        report = module.reconcile_inventory(mutated)
+        assert report["reconciled"] is False, case
+        assert report["mismatches"], case
+
+
+def test_inventory_replay_passes_on_identity() -> None:
+    module = load_inventory_module()
+    base = json.loads(INVENTORY.read_text(encoding="utf-8"))
+
+    report = module.reconcile_inventory(base)
+    assert report["reconciled"] is True
+    assert report["mismatches"] == []
+
+
+def test_committed_inventory_preserves_sanitization_boundary() -> None:
+    inventory = json.loads(INVENTORY.read_text(encoding="utf-8"))
+    serialized = json.dumps(inventory, sort_keys=True)
+
+    for forbidden in (
+        "must not be retained",
+        "must-not-be-retained",
+        "chatgpt.com",
+        "127.0.0.1",
+        "http://",
+        "https://",
+    ):
+        assert forbidden not in serialized, forbidden
+    import re
+
+    assert not re.search(
+        r"[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}",
+        serialized,
+        re.IGNORECASE,
+    )
+
+
+def test_build_inventory_reads_existing_artifacts_and_clamps_live_gates() -> None:
+    module = load_inventory_module()
+
+    inventory = module.build_inventory(
+        trace=TRACE,
+        wire_fixture=WIRE_FIXTURE,
+        audit=AUDIT,
+        cli_version_floor="0.145.0",
+        candidate_cli_version="0.144.0-alpha.4",
+        candidate_source_commit="9e552e9d15ba52bed7077d5357f3e18e330f8f38",
+    )
+
+    assert inventory["schema_version"] == 1
+    assert inventory["cli_version_floor"] == "0.145.0"
+    assert inventory["candidate_identity"]["cli_version"] == "0.144.0-alpha.4"
+    scopes = {entry["scope"] for entry in inventory["items"]}
+    assert "core_text_streaming" in scopes
+    assert "code_mode" in scopes
+    assert inventory["identity_control"]["unclassified_core_items"] == 0
+    assert inventory["qualification"]["candidate_version_status"] == "legacy_below_floor"
+
+
+def test_build_inventory_rejects_candidate_metadata_drift() -> None:
+    module = load_inventory_module()
+
+    with pytest.raises(ValueError, match="candidate CLI version"):
+        module.build_inventory(
+            trace=TRACE,
+            wire_fixture=WIRE_FIXTURE,
+            audit=AUDIT,
+            candidate_cli_version="0.145.0",
+            candidate_source_commit="9e552e9d15ba52bed7077d5357f3e18e330f8f38",
+        )
+
+    with pytest.raises(ValueError, match="candidate source commit"):
+        module.build_inventory(
+            trace=TRACE,
+            wire_fixture=WIRE_FIXTURE,
+            audit=AUDIT,
+            candidate_cli_version="0.144.0-alpha.4",
+            candidate_source_commit="0" * 40,
+        )
+
+
+def test_build_inventory_rejects_a_floor_other_than_supported_candidate_floor() -> None:
+    module = load_inventory_module()
+
+    with pytest.raises(ValueError, match="supported CLI floor"):
+        module.build_inventory(
+            trace=TRACE,
+            wire_fixture=WIRE_FIXTURE,
+            audit=AUDIT,
+            cli_version_floor="0.144.0",
+            candidate_cli_version="0.144.0-alpha.4",
+            candidate_source_commit="9e552e9d15ba52bed7077d5357f3e18e330f8f38",
+        )
+
+
+def test_build_inventory_rejects_malformed_candidate_provenance() -> None:
+    module = load_inventory_module()
+
+    with pytest.raises(ValueError, match="candidate CLI version"):
+        module.build_inventory(
+            trace=TRACE,
+            wire_fixture=WIRE_FIXTURE,
+            audit=AUDIT,
+            candidate_cli_version="not-a-version",
+            candidate_source_commit="9e552e9d15ba52bed7077d5357f3e18e330f8f38",
+        )
+
+    with pytest.raises(ValueError, match="candidate source commit"):
+        module.build_inventory(
+            trace=TRACE,
+            wire_fixture=WIRE_FIXTURE,
+            audit=AUDIT,
+            candidate_cli_version="0.144.0-alpha.4",
+            candidate_source_commit="A" * 40,
+        )
+
+
+def test_function_replay_stays_live_without_bound_wire_replay_cases() -> None:
+    module = load_inventory_module()
+    wire = json.loads(WIRE_FIXTURE.read_text(encoding="utf-8"))
+    audit = json.loads(AUDIT.read_text(encoding="utf-8"))
+    audit["gate_classification"]["full_pre_post_request_response"] = "met"
+    audit["gate_classification"]["zero_unclassified_identity"] = "met"
+
+    items = module._classify_core_items(
+        wire,
+        audit,
+        wire_fixture_sha256=module._sha256_file(WIRE_FIXTURE),
+    )
+    replay = next(item for item in items if item["scope"] == "core_function_replay")
+    assert replay["disposition"] == "Unqualified"
+
+
+def test_captured_sse_status_does_not_satisfy_independent_sse_gate() -> None:
+    module = load_inventory_module()
+    trace = json.loads(TRACE.read_text(encoding="utf-8"))
+    wire = json.loads(WIRE_FIXTURE.read_text(encoding="utf-8"))
+    audit = json.loads(AUDIT.read_text(encoding="utf-8"))
+    audit["sse_identity"] = {"status": "captured"}
+
+    qualification = module._build_qualification(
+        [],
+        "eligible",
+        trace=trace,
+        wire=wire,
+        audit=audit,
+        wire_fixture_sha256=module._sha256_file(WIRE_FIXTURE),
+    )
+    assert qualification["evidence_gates"]["sse_identity"] == "captured"
+    assert "sse_identity" in qualification["blocking_gates"]
+    assert qualification["ready_for_beta1"] is False
+
+
+def test_committed_inventory_matches_generator_output() -> None:
+    module = load_inventory_module()
+
+    generated = module.build_inventory(
+        trace=TRACE,
+        wire_fixture=WIRE_FIXTURE,
+        audit=AUDIT,
+    )
+    committed = json.loads(INVENTORY.read_text(encoding="utf-8"))
+
+    assert generated == committed
+
+
+def test_inventory_reconcile_rejects_duplicate_and_wrong_core_evidence() -> None:
+    module = load_inventory_module()
+    base = json.loads(INVENTORY.read_text(encoding="utf-8"))
+
+    duplicate = json.loads(json.dumps(base))
+    duplicate["items"].append(json.loads(json.dumps(base["items"][0])))
+    report = module.reconcile_inventory(duplicate)
+    assert report["reconciled"] is False
+    assert any("duplicate scope" in mismatch for mismatch in report["mismatches"])
+
+    wrong_evidence = json.loads(json.dumps(base))
+    wrong_evidence["items"][0]["evidence_source"] = "unrelated-fixture.json#claim"
+    report = module.reconcile_inventory(wrong_evidence)
+    assert report["reconciled"] is False
+    assert any("evidence_source" in mismatch for mismatch in report["mismatches"])
+
+    unknown_scope = json.loads(json.dumps(base))
+    unknown_scope["items"].append(
+        {
+            "scope": "future_unclassified_scope",
+            "disposition": "Unqualified",
+            "evidence_source": "future-fixture.json#scope",
+        }
+    )
+    report = module.reconcile_inventory(unknown_scope)
+    assert report["reconciled"] is False
+    assert any("unknown scope" in mismatch for mismatch in report["mismatches"])
+
+
+def test_inventory_reconcile_binds_input_hashes_and_candidate_gates() -> None:
+    module = load_inventory_module()
+    base = json.loads(INVENTORY.read_text(encoding="utf-8"))
+    evidence_root = INVENTORY.parent
+
+    report = module.reconcile_inventory(base, evidence_root=evidence_root)
+    assert report == {"reconciled": True, "mismatches": []}
+
+    tampered_hash = json.loads(json.dumps(base))
+    tampered_hash["evidence_binding"]["trace"]["sha256"] = "0" * 64
+    report = module.reconcile_inventory(tampered_hash, evidence_root=evidence_root)
+    assert report["reconciled"] is False
+    assert any(
+        "stale" in mismatch or "hash mismatch" in mismatch
+        for mismatch in report["mismatches"]
+    )
+
+    tampered_status = json.loads(json.dumps(base))
+    tampered_status["qualification"]["candidate_version_status"] = "eligible"
+    report = module.reconcile_inventory(tampered_status)
+    assert report["reconciled"] is False
+    assert any("CLI floor" in mismatch for mismatch in report["mismatches"])
+
+    tampered_unknown_count = json.loads(json.dumps(base))
+    tampered_unknown_count["identity_control"]["unknown_tagged_source_count"] = 1
+    report = module.reconcile_inventory(
+        tampered_unknown_count, evidence_root=evidence_root
+    )
+    assert report["reconciled"] is False
+    assert any("unknown_tagged_source_count" in mismatch for mismatch in report["mismatches"])
+
+    tampered_identity_control = json.loads(json.dumps(base))
+    tampered_identity_control["identity_control"]["fail_closed"] = False
+    tampered_identity_control["identity_control"]["replay_cases"] = []
+    report = module.reconcile_inventory(tampered_identity_control)
+    assert report["reconciled"] is False
+    assert any("identity_control" in mismatch for mismatch in report["mismatches"])
+
+
+def test_inventory_reconcile_rejects_generated_artifact_drift() -> None:
+    module = load_inventory_module()
+    base = json.loads(INVENTORY.read_text(encoding="utf-8"))
+    drifted = json.loads(json.dumps(base))
+    drifted["items"][0]["notes"] = "hand-edited stale note"
+
+    report = module.reconcile_inventory(drifted, evidence_root=INVENTORY.parent)
+
+    assert report["reconciled"] is False
+    assert any("generated inventory" in mismatch for mismatch in report["mismatches"])
+
+
+def test_qualification_accepts_audit_met_status_when_all_gates_are_complete() -> None:
+    module = load_inventory_module()
+    qualification = module._build_qualification(
+        [],
+        "eligible",
+        trace={
+            "gateway_observability": {
+                "full_request_body_fingerprint": "captured",
+                "full_response_body_fingerprint": "captured",
+            },
+            "capture_coverage": {
+                "complete_model_visible_plan": {"status": "complete"},
+                "clean_cold_start_current_binding": {"status": "complete"},
+            }
+        },
+        wire={
+            "response": {
+                "streaming": {
+                    "events": [
+                        {"event": "response.completed"},
+                        {"event": "response.error"},
+                    ]
+                },
+                "non_streaming": {
+                    "captured": True,
+                    "fixture_kind": "real_capture",
+                    "request_stream": False,
+                    "response_items": [{"type": "message"}],
+                },
+            }
+        },
+        audit={
+            "gateway_identity_route": {
+                "full_body_hmac_pairs": 1,
+                "request_starts": 1,
+                "full_body_hmac_equal": 1,
+                "full_body_hmac_mismatch": 0,
+                "full_body_hmac_unavailable": 0,
+                "response_body_fingerprint_fields_present": True,
+                "response_body_fingerprint_equal": 1,
+                "response_body_fingerprint_mismatch": 0,
+                "response_body_fingerprint_unavailable": 0,
+            },
+            "sse_identity": {
+                "status": "met",
+                "fail_closed": True,
+                "wire_fixture_sha256": "a" * 64,
+                "pre_stream_sequence_sha256": "b" * 64,
+                "post_stream_sequence_sha256": "b" * 64,
+                "event_count": 2,
+            },
+            "gate_classification": {
+                "full_pre_post_request_response": "met",
+                "full_request_body_fingerprint": "captured",
+                "full_response_body_fingerprint": "captured",
+                "non_streaming": "met",
+                "zero_unclassified_identity": "met",
+            },
+            "wire_identity_replay": {
+                "status": "met",
+                "fail_closed": True,
+                "wire_fixture_sha256": "a" * 64,
+                "cases": {
+                    "identity": {"status": "met", "observed": True, "output_sha256": "c" * 64},
+                    "mutation": {"status": "met", "observed": True, "output_sha256": "d" * 64},
+                    "deletion": {"status": "met", "observed": True, "output_sha256": "e" * 64},
+                    "loss": {"status": "met", "observed": True, "output_sha256": "f" * 64},
+                },
+            },
+        },
+    )
+    assert qualification["blocking_gates"] == []
+    assert qualification["ready_for_beta1"] is True
+
+
+@pytest.mark.parametrize("case", ["mutation", "deletion", "loss"])
+def test_replay_cases_each_touch_a_distinct_scope(case: str) -> None:
+    module = load_inventory_module()
+    base = json.loads(INVENTORY.read_text(encoding="utf-8"))
+
+    mutated = module.replay_inventory(base, case)
+    report = module.reconcile_inventory(mutated)
+    assert not report["reconciled"]
+    assert any(case in mismatch for mismatch in report["mismatches"])

--- a/tests/test_issue_62_runtime_inventory.py
+++ b/tests/test_issue_62_runtime_inventory.py
@@ -322,6 +322,36 @@ def test_build_inventory_rejects_malformed_candidate_provenance() -> None:
         )
 
 
+def test_build_inventory_rejects_missing_capture_provenance(tmp_path: Path) -> None:
+    module = load_inventory_module()
+    trace = json.loads(TRACE.read_text(encoding="utf-8"))
+    trace["source"].pop("capture_id", None)
+    trace_path = tmp_path / TRACE.name
+    trace_path.write_text(json.dumps(trace, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="capture_id"):
+        module.build_inventory(
+            trace=trace_path,
+            wire_fixture=WIRE_FIXTURE,
+            audit=AUDIT,
+        )
+
+
+def test_build_inventory_rejects_unbound_response_identity_pointer(tmp_path: Path) -> None:
+    module = load_inventory_module()
+    wire = json.loads(WIRE_FIXTURE.read_text(encoding="utf-8"))
+    wire["post_gateway"]["response"]["streaming"]["response_id"] = "response_other"
+    wire_path = tmp_path / WIRE_FIXTURE.name
+    wire_path.write_text(json.dumps(wire, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="identity_response_ids"):
+        module.build_inventory(
+            trace=TRACE,
+            wire_fixture=wire_path,
+            audit=AUDIT,
+        )
+
+
 def test_function_replay_stays_live_without_bound_wire_replay_cases() -> None:
     module = load_inventory_module()
     wire = json.loads(WIRE_FIXTURE.read_text(encoding="utf-8"))
@@ -398,6 +428,86 @@ def test_inventory_reconcile_rejects_duplicate_and_wrong_core_evidence() -> None
     report = module.reconcile_inventory(unknown_scope)
     assert report["reconciled"] is False
     assert any("unknown scope" in mismatch for mismatch in report["mismatches"])
+
+
+def test_inventory_reconcile_rejects_provenance_contradictions_without_evidence_root() -> None:
+    module = load_inventory_module()
+    base = json.loads(INVENTORY.read_text(encoding="utf-8"))
+
+    contradictory = json.loads(json.dumps(base))
+    contradictory["candidate_identity"]["codex_source_commit"] = "0" * 40
+    report = module.reconcile_inventory(contradictory)
+
+    assert report["reconciled"] is False
+    assert any("contradict" in mismatch for mismatch in report["mismatches"])
+
+
+def test_inventory_reconcile_rejects_nonfinal_core_disposition_without_evidence_root() -> None:
+    module = load_inventory_module()
+    base = json.loads(INVENTORY.read_text(encoding="utf-8"))
+
+    mutated = json.loads(json.dumps(base))
+    mutated["items"] = [
+        {
+            **item,
+            "disposition": "local_consume",
+        }
+        if item["scope"] == "core_text_streaming"
+        else item
+        for item in mutated["items"]
+    ]
+    report = module.reconcile_inventory(mutated)
+
+    assert report["reconciled"] is False
+    assert any("final" in mismatch for mismatch in report["mismatches"])
+
+
+def test_inventory_reconcile_binds_every_scope_evidence_source() -> None:
+    module = load_inventory_module()
+    base = json.loads(INVENTORY.read_text(encoding="utf-8"))
+
+    mutated = json.loads(json.dumps(base))
+    mutated["items"] = [
+        {
+            **item,
+            "evidence_source": "unrelated-fixture.json#claim",
+        }
+        if item["scope"] == "tool_search"
+        else item
+        for item in mutated["items"]
+    ]
+    report = module.reconcile_inventory(mutated)
+
+    assert report["reconciled"] is False
+    assert any("expected fixture path/scope" in mismatch for mismatch in report["mismatches"])
+
+
+def test_identity_response_evidence_source_is_a_bound_pre_post_pair() -> None:
+    module = load_inventory_module()
+    base = json.loads(INVENTORY.read_text(encoding="utf-8"))
+    identity = next(
+        item for item in base["items"] if item["scope"] == "identity_response_ids"
+    )
+
+    assert identity["evidence_source"] == module.IDENTITY_RESPONSE_EVIDENCE
+    assert module.reconcile_inventory(base, evidence_root=INVENTORY.parent) == {
+        "reconciled": True,
+        "mismatches": [],
+    }
+
+    stale_pointer = json.loads(json.dumps(base))
+    stale_pointer["items"] = [
+        {
+            **item,
+            "evidence_source": "codexhub-runtime-wire-fixture.json#response.streaming.response_id",
+        }
+        if item["scope"] == "identity_response_ids"
+        else item
+        for item in stale_pointer["items"]
+    ]
+    report = module.reconcile_inventory(stale_pointer)
+    assert report["reconciled"] is False
+    assert any("expected fixture path/scope" in mismatch for mismatch in report["mismatches"])
 
 
 def test_inventory_reconcile_binds_input_hashes_and_candidate_gates() -> None:

--- a/tests/test_issue_62_runtime_trace.py
+++ b/tests/test_issue_62_runtime_trace.py
@@ -1,4 +1,6 @@
 import json
+import importlib.util
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -8,6 +10,7 @@ import pytest
 ROOT = Path(__file__).resolve().parents[1]
 TRACE = ROOT / "docs" / "evidence" / "issue-62" / "current-codexhub-thread-tool-surface.json"
 WIRE_FIXTURE = ROOT / "docs" / "evidence" / "issue-62" / "codexhub-runtime-wire-fixture.json"
+AUDIT = ROOT / "docs" / "evidence" / "issue-62" / "read-only-gate-audit.json"
 REPLAY_SCRIPT = ROOT / "scripts" / "check-codex-thread-tool-surface.ps1"
 
 
@@ -21,6 +24,25 @@ def run_replay(case: str) -> subprocess.CompletedProcess[str]:
             "-File",
             str(REPLAY_SCRIPT),
             "-ReplayCase",
+            case,
+        ],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def run_inventory_replay(case: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            "powershell",
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(REPLAY_SCRIPT),
+            "-InventoryReplayCase",
             case,
         ],
         cwd=ROOT,
@@ -142,3 +164,109 @@ def test_negative_replays_fail_visibly(case: str) -> None:
 
     assert result.returncode == 1
     assert "RECONCILIATION_MISMATCH:" in result.stderr
+
+
+def test_inventory_identity_replay_passes() -> None:
+    result = run_inventory_replay("identity")
+
+    assert result.returncode == 0, result.stderr
+    assert "THREAD_TOOL_SURFACE_COMPLETE" in result.stdout
+    assert "Inventory replay case: identity" in result.stdout
+
+
+def test_inventory_check_rejects_generated_artifact_drift(tmp_path: Path) -> None:
+    inventory = json.loads(
+        (ROOT / "docs/evidence/issue-62/runtime-wire-inventory.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    inventory["items"][0]["notes"] = "hand-edited stale note"
+    inventory_path = tmp_path / "runtime-wire-inventory.json"
+    inventory_path.write_text(
+        json.dumps(inventory, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+    result = subprocess.run(
+        [
+            "powershell",
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(REPLAY_SCRIPT),
+            "-InventoryPath",
+            str(inventory_path),
+        ],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "generated inventory drift check failed" in result.stderr
+
+
+def test_powershell_accepts_pass_non_direct_state_like_python(tmp_path: Path) -> None:
+    module_spec = importlib.util.spec_from_file_location(
+        "issue_62_runtime_inventory", ROOT / "scripts/build_issue_62_runtime_inventory.py"
+    )
+    assert module_spec is not None and module_spec.loader is not None
+    module = importlib.util.module_from_spec(module_spec)
+    module_spec.loader.exec_module(module)
+
+    audit = json.loads(AUDIT.read_text(encoding="utf-8"))
+    audit["gate_classification"]["non_direct_states"] = "pass"
+    trace_path = tmp_path / TRACE.name
+    wire_path = tmp_path / WIRE_FIXTURE.name
+    shutil.copyfile(TRACE, trace_path)
+    shutil.copyfile(WIRE_FIXTURE, wire_path)
+    audit_path = tmp_path / "read-only-gate-audit.json"
+    audit_path.write_text(
+        json.dumps(audit, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+    inventory = module.build_inventory(
+        trace=trace_path,
+        wire_fixture=wire_path,
+        audit=audit_path,
+    )
+    inventory_path = tmp_path / "runtime-wire-inventory.json"
+    inventory_path.write_text(
+        json.dumps(inventory, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+    result = subprocess.run(
+        [
+            "powershell",
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(REPLAY_SCRIPT),
+            "-TracePath",
+            str(trace_path),
+            "-WireFixturePath",
+            str(wire_path),
+            "-AuditPath",
+            str(audit_path),
+            "-InventoryPath",
+            str(inventory_path),
+        ],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.parametrize("case", ["mutation", "deletion", "loss"])
+def test_negative_inventory_replays_fail_visibly(case: str) -> None:
+    result = run_inventory_replay(case)
+
+    assert result.returncode == 1
+    assert "RECONCILIATION_MISMATCH:" in result.stderr
+    assert "INVENTORY_IDENTITY_MISMATCH:" in result.stderr
+    assert case in result.stderr

--- a/tests/test_issue_62_runtime_trace.py
+++ b/tests/test_issue_62_runtime_trace.py
@@ -207,6 +207,44 @@ def test_inventory_check_rejects_generated_artifact_drift(tmp_path: Path) -> Non
     assert "generated inventory drift check failed" in result.stderr
 
 
+def test_inventory_check_rejects_stale_response_identity_pointer(tmp_path: Path) -> None:
+    inventory = json.loads(
+        (ROOT / "docs/evidence/issue-62/runtime-wire-inventory.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    for item in inventory["items"]:
+        if item["scope"] == "identity_response_ids":
+            item["evidence_source"] = (
+                "codexhub-runtime-wire-fixture.json#response.streaming.response_id"
+            )
+            break
+    inventory_path = tmp_path / "runtime-wire-inventory.json"
+    inventory_path.write_text(
+        json.dumps(inventory, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+    result = subprocess.run(
+        [
+            "powershell",
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(REPLAY_SCRIPT),
+            "-InventoryPath",
+            str(inventory_path),
+        ],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "generated inventory drift check failed" in result.stderr
+
+
 def test_powershell_accepts_pass_non_direct_state_like_python(tmp_path: Path) -> None:
     module_spec = importlib.util.spec_from_file_location(
         "issue_62_runtime_inventory", ROOT / "scripts/build_issue_62_runtime_inventory.py"

--- a/tests/test_proxy_shutdown.py
+++ b/tests/test_proxy_shutdown.py
@@ -445,6 +445,20 @@ def test_active_request_receives_a_sanitized_user_requested_shutdown_outcome() -
         with (
             patch.object(
                 codex_proxy,
+                "choose_upstream",
+                return_value={
+                    "name": "official",
+                    "provider_id": "openai",
+                    "model_id": "gpt-5.6-terra",
+                    "upstream_model": "gpt-5.6-terra",
+                    "auth": "codex_auth",
+                    "base_url": "https://example.test/v1",
+                    "upstream_format": "responses",
+                    "reports_cached_input_tokens": True,
+                },
+            ) as choose_upstream,
+            patch.object(
+                codex_proxy,
                 "upstream_headers",
                 return_value={"Authorization": "Bearer test-token"},
             ) as build_upstream_headers,
@@ -479,6 +493,7 @@ def test_active_request_receives_a_sanitized_user_requested_shutdown_outcome() -
                 "payload": codex_proxy.user_requested_shutdown_payload("responses"),
             }
             assert open_upstream.call_count == 1
+            choose_upstream.assert_called_once()
             build_upstream_headers.assert_called_once()
             access_token.assert_called_once_with()
             account_id.assert_called_once_with()

--- a/tests/test_real_client_e2e.py
+++ b/tests/test_real_client_e2e.py
@@ -29,6 +29,7 @@ MINIMUM_VERSIONS = {
 }
 SUMMARY_KEYS = {
     "schema",
+    "verification_scope",
     "candidate_sha",
     "managed_client_config_sha",
     "run_binding_sha256",
@@ -399,6 +400,7 @@ def _run(
     manual_timeout_seconds: int = 10,
     overall_timeout_seconds: int = 180,
     authoritative_paths_with_spaces: bool = False,
+    cli_only: bool = False,
 ) -> subprocess.CompletedProcess[str]:
     output, isolation, debug_build, materializer_build, host_manifest = _prepare_run(
         tmp_path, candidate_sha, materializer_sha
@@ -418,6 +420,11 @@ def _run(
     }
     for name, fixture_name in (client_fakes or {}).items():
         executable_arguments[name] = FIXTURES / fixture_name
+    if cli_only:
+        # CLI-only mode must not even resolve the GUI clients. Keep these
+        # paths absent so a regression back to GUI preflight fails the test.
+        executable_arguments["CodexDesktopPath"] = tmp_path / "missing-codex-desktop.exe"
+        executable_arguments["ZCodePath"] = tmp_path / "missing-zcode.exe"
     if authoritative_paths_with_spaces:
         candidate_root = tmp_path / "Program Files" / "CodexHub Candidate"
         candidate_root.mkdir(parents=True)
@@ -510,6 +517,8 @@ def _run(
     for name, executable in executable_arguments.items():
         command.extend((f"-{name}", str(executable)))
     command.extend(("-TimeoutSeconds", str(timeout_seconds)))
+    if cli_only:
+        command.append("-CliOnly")
     command.extend(("-ManualEvidenceTimeoutSeconds", str(manual_timeout_seconds)))
     command.extend(("-OverallTimeoutSeconds", str(overall_timeout_seconds)))
     finalizer = None
@@ -1005,7 +1014,10 @@ def test_materializer_build_sidecar_must_match_explicit_current_candidate_sha(tm
 
 def _assert_exact_summary_schema(summary: dict) -> None:
     assert set(summary) == (SUMMARY_KEYS if summary["cases"] else FAILURE_SUMMARY_KEYS)
-    assert set(summary["pinned_versions"]) == set(MINIMUM_VERSIONS)
+    expected_versions = set(MINIMUM_VERSIONS)
+    if summary.get("verification_scope") == "cli_only":
+        expected_versions -= {"desktop", "zcode"}
+    assert set(summary["pinned_versions"]) == expected_versions
     assert set(summary["counts"]) == COUNT_KEYS
     if summary["cases"]:
         assert set(summary["hashes"]) == {
@@ -1040,6 +1052,53 @@ def test_operator_workflow_uses_authoritative_machine_bound_local_host():
     assert "VM snapshot" not in documentation
 
 
+def test_cli_only_matrix_skips_gui_requirements_and_marks_scope(tmp_path):
+    def disable_gui_readiness(_output, isolation, _debug):
+        profile_path = isolation / "account" / "profile.json"
+        profile = json.loads(profile_path.read_text(encoding="utf-8"))
+        profile["gui_ready"] = False
+        profile_path.write_text(json.dumps(profile), encoding="utf-8")
+
+    result = _run(
+        tmp_path,
+        cli_only=True,
+        mutate=disable_gui_readiness,
+        finalize_manual=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    output = tmp_path / "output"
+    summary = json.loads((output / "summary.json").read_text(encoding="utf-8-sig"))
+    _assert_exact_summary_schema(summary)
+    assert summary["verification_scope"] == "cli_only"
+    assert set(summary["pinned_versions"]) == {
+        "codex_cli",
+        "opencode",
+        "pi",
+        "omp",
+    }
+    assert summary["counts"] == {
+        "case_count": 8,
+        "passed_count": 8,
+        "failed_count": 0,
+        "manual_case_count": 0,
+        "automated_case_count": 8,
+    }
+    assert [case["case_id"] for case in summary["cases"]] == [
+        "codex-cli-luna",
+        "codex-cli-ollama-cloud",
+        "opencode-luna",
+        "opencode-ollama-cloud",
+        "pi-luna",
+        "pi-ollama-cloud",
+        "omp-luna",
+        "omp-ollama-cloud",
+    ]
+    assert not (output / "manual-evidence.template.json").exists()
+    assert not (output / "manual-evidence.json").exists()
+    assert not list((output / "isolated" / "work").glob("gui-*.launched"))
+
+
 def test_exact_compatibility_floors_pass_and_emit_one_sanitized_sha_bound_summary(
     tmp_path,
 ):
@@ -1051,6 +1110,7 @@ def test_exact_compatibility_floors_pass_and_emit_one_sanitized_sha_bound_summar
     summary = json.loads(summaries[0].read_text(encoding="utf-8-sig"))
     _assert_exact_summary_schema(summary)
     assert summary["schema"] == "codexhub.real-client-e2e-summary.v2"
+    assert summary["verification_scope"] == "gui_and_cli"
     assert summary["candidate_sha"] == CANDIDATE_SHA
     assert summary["pinned_versions"] == MINIMUM_VERSIONS
     assert summary["counts"] == {

--- a/tests/test_release_channel_scripts.py
+++ b/tests/test_release_channel_scripts.py
@@ -20,7 +20,7 @@ def test_official_transport_wheel_is_pinned_and_packaged():
 
 
 def test_release_version_is_consistent_across_manifests():
-    expected = "0.1.8-beta.1"
+    expected = "0.1.8-beta.2"
     tauri = json.loads((ROOT / "src-tauri" / "tauri.conf.json").read_text(encoding="utf-8"))
     cargo = tomllib.loads((ROOT / "src-tauri" / "Cargo.toml").read_text(encoding="utf-8"))
     cargo_lock = tomllib.loads((ROOT / "src-tauri" / "Cargo.lock").read_text(encoding="utf-8"))
@@ -356,7 +356,7 @@ def test_release_plan_places_both_flavors_in_one_immutable_release(tmp_path):
 def test_release_plan_marks_semver_prerelease_versions_as_prereleases(tmp_path):
     repo, main_commit, _ = _release_repo(tmp_path)
 
-    result = _plan(repo, "normal", "0.1.8-beta.1", main_commit)
+    result = _plan(repo, "normal", "0.1.8-beta.2", main_commit)
 
     assert result.returncode == 0, result.stderr
     plan = json.loads(result.stdout)
@@ -364,18 +364,18 @@ def test_release_plan_marks_semver_prerelease_versions_as_prereleases(tmp_path):
         "name": "latest.json",
         "asset_url": (
             "https://github.com/NOirBRight/CodexHub/releases/download/"
-            "v0.1.8-beta.1/CodexHub_0.1.8-beta.1_x64-setup.exe"
+            "v0.1.8-beta.2/CodexHub_0.1.8-beta.2_x64-setup.exe"
         ),
     }
-    assert plan["immutable_release"]["tag"] == "v0.1.8-beta.1"
+    assert plan["immutable_release"]["tag"] == "v0.1.8-beta.2"
     assert plan["immutable_release"]["prerelease"] is True
     assert plan["immutable_release"]["assets"] == [
-        "CodexHub_0.1.8-beta.1_x64-setup.exe",
-        "CodexHub_0.1.8-beta.1_x64-setup.exe.sig",
+        "CodexHub_0.1.8-beta.2_x64-setup.exe",
+        "CodexHub_0.1.8-beta.2_x64-setup.exe.sig",
         "latest.json",
-        f"CodexHub_0.1.8-beta.1_portable_{main_commit[:8]}.zip",
-        "CodexHub_0.1.8-beta.1_debug_x64-setup.exe",
-        "CodexHub_0.1.8-beta.1_debug_x64-setup.exe.sig",
+        f"CodexHub_0.1.8-beta.2_portable_{main_commit[:8]}.zip",
+        "CodexHub_0.1.8-beta.2_debug_x64-setup.exe",
+        "CodexHub_0.1.8-beta.2_debug_x64-setup.exe.sig",
         "latest-debug.json",
     ]
 

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -482,6 +482,8 @@ class RoutingTests(unittest.TestCase):
             "codex_proxy.generated_catalog_slugs",
             return_value={
                 "openai/gpt-5.5",
+                "gpt-5.4",
+                "gpt-5.4-mini",
                 "minimax-m3",
                 "glm-5.2",
                 "ollama-cloud/glm-5.2",
@@ -504,6 +506,24 @@ class RoutingTests(unittest.TestCase):
             "codex_proxy.generated_catalog_by_slug",
             return_value={
                 "openai/gpt-5.5": {"slug": "openai/gpt-5.5"},
+                "gpt-5.4": {
+                    "slug": "gpt-5.4",
+                    "supported_in_api": True,
+                    "codex_proxy_metadata": {
+                        "provider": "openai",
+                        "upstream_name": "official",
+                        "upstream_model": "gpt-5.4",
+                    },
+                },
+                "gpt-5.4-mini": {
+                    "slug": "gpt-5.4-mini",
+                    "supported_in_api": True,
+                    "codex_proxy_metadata": {
+                        "provider": "openai",
+                        "upstream_name": "official",
+                        "upstream_model": "gpt-5.4-mini",
+                    },
+                },
                 "minimax-m3": {"slug": "minimax-m3", "max_output_tokens": 524288},
                 "glm-5.2": {"slug": "glm-5.2", "max_output_tokens": 131072},
                 "ollama-cloud/glm-5.2": {"slug": "ollama-cloud/glm-5.2", "max_output_tokens": 131072},
@@ -906,7 +926,7 @@ class RoutingTests(unittest.TestCase):
                 "provider_hint": None,
                 "expected": {
                     "behavior_profile": codex_proxy.BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH,
-                    "provider_id": "official",
+                    "provider_id": "openai",
                     "canonical_model": "openai/gpt-5.5",
                     "upstream_model": "gpt-5.5",
                     "inbound_protocol": codex_proxy.RouteProtocol.RESPONSES,
@@ -940,7 +960,7 @@ class RoutingTests(unittest.TestCase):
                 "provider_hint": None,
                 "expected": {
                     "behavior_profile": codex_proxy.BEHAVIOR_CODEX_APP_EXTERNAL_ADAPTER,
-                    "provider_id": "ollama_cloud",
+                    "provider_id": "ollama-cloud",
                     "canonical_model": "ollama-cloud/glm-5.2",
                     "upstream_model": "glm-5.2",
                     "inbound_protocol": codex_proxy.RouteProtocol.RESPONSES,
@@ -976,7 +996,7 @@ class RoutingTests(unittest.TestCase):
                 "provider_hint": "volc",
                 "expected": {
                     "behavior_profile": codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
-                    "provider_id": "volcengine",
+                    "provider_id": "volc",
                     "canonical_model": "volc/glm-5.2",
                     "upstream_model": "glm-5.2",
                     "inbound_protocol": codex_proxy.RouteProtocol.RESPONSES,
@@ -1009,7 +1029,7 @@ class RoutingTests(unittest.TestCase):
                 "provider_hint": "volc",
                 "expected": {
                     "behavior_profile": codex_proxy.BEHAVIOR_THIRD_PARTY_APP_TRANSPARENT_METERED,
-                    "provider_id": "volcengine",
+                    "provider_id": "volc",
                     "canonical_model": "volc/glm-5.2",
                     "upstream_model": "glm-5.2",
                     "inbound_protocol": codex_proxy.RouteProtocol.RESPONSES,
@@ -1040,7 +1060,7 @@ class RoutingTests(unittest.TestCase):
                 "provider_hint": None,
                 "expected": {
                     "behavior_profile": codex_proxy.BEHAVIOR_CODEX_APP_EXTERNAL_ADAPTER,
-                    "provider_id": "ollama_cloud",
+                    "provider_id": "ollama-cloud",
                     "canonical_model": "ollama-cloud/glm-5.2",
                     "upstream_model": "glm-5.2",
                     "inbound_protocol": codex_proxy.RouteProtocol.CHAT_COMPLETIONS,
@@ -4166,7 +4186,14 @@ class RoutingTests(unittest.TestCase):
         handler, fake = post_handler("/v1/responses", body)
 
         with (
-            patch("codex_proxy.choose_upstream", return_value=official_upstream()),
+            patch(
+                "codex_proxy.choose_upstream",
+                return_value={
+                    **official_upstream(),
+                    "model_id": "openai/gpt-5.6-sol",
+                    "upstream_model": "gpt-5.6-sol",
+                },
+            ),
             patch("codex_proxy.codex_access_token", return_value="sub-token"),
             patch("codex_proxy.codex_account_id", return_value="acct-1"),
             patch(
@@ -4193,7 +4220,14 @@ class RoutingTests(unittest.TestCase):
         handler, fake = post_handler("/v1/responses", body)
 
         with (
-            patch("codex_proxy.choose_upstream", return_value=official_upstream()),
+            patch(
+                "codex_proxy.choose_upstream",
+                return_value={
+                    **official_upstream(),
+                    "model_id": "openai/gpt-5.6-terra",
+                    "upstream_model": "gpt-5.6-terra",
+                },
+            ),
             patch("codex_proxy.codex_access_token", return_value="sub-token"),
             patch("codex_proxy.codex_account_id", return_value="acct-1"),
             patch(
@@ -11687,8 +11721,11 @@ class RoutingTests(unittest.TestCase):
         }
 
         with patch("codex_proxy.generated_catalog_by_slug", return_value=catalog):
-            with self.assertRaisesRegex(ValueError, "model is not allowed"):
+            with self.assertRaises(codex_proxy.ModelIdentityResolutionError) as context:
                 choose_upstream("gpt-untrusted")
+
+        self.assertEqual(context.exception.classification, "catalog_inconsistency")
+        self.assertEqual(context.exception.reason, "upstream_model_mismatch")
 
     def test_runtime_official_route_respects_policy_denylist(self):
         policy = codex_proxy.load_policy(codex_proxy.POLICY_PATH)
@@ -12386,11 +12423,9 @@ class RoutingTests(unittest.TestCase):
         self.assertEqual(upstream["auth"], "api_key")
         self.assertEqual(upstream["upstream_model"], "MiniMax-M3")
 
-    def test_external_provider_explicit_alias_routes_without_lowercasing(self):
-        upstream = choose_upstream("minimax-cn/minimax-m3")
-
-        self.assertEqual(upstream["name"], "minimax_cn")
-        self.assertEqual(upstream["upstream_model"], "MiniMax-M3")
+    def test_external_provider_presentation_alias_fails_closed(self):
+        with self.assertRaisesRegex(ValueError, "presentation-only"):
+            choose_upstream("minimax-cn/minimax-m3")
 
     def test_denied_provider_qualified_ollama_alias_is_rejected(self):
         policy = codex_proxy.load_policy(codex_proxy.POLICY_PATH)
@@ -12434,7 +12469,7 @@ class RoutingTests(unittest.TestCase):
         self.assertIn("model is not allowed", str(context.exception))
 
     def test_provider_qualified_ollama_alias_requires_generated_catalog_entry(self):
-        with patch("codex_proxy.generated_catalog_slugs", return_value=set()):
+        with patch("codex_proxy.generated_catalog_by_slug", return_value={}):
             with self.assertRaises(ValueError) as context:
                 choose_upstream("ollama-cloud/glm-5.2")
 
@@ -13009,7 +13044,7 @@ class RoutingTests(unittest.TestCase):
     def test_external_body_converts_compaction_input_to_developer_message(self):
         for model_id, upstream_model in (
             ("volc/glm-5.2", "glm-5.2"),
-            ("minimax-cn/minimax-m3", "MiniMax-M3"),
+            ("minimax-cn/MiniMax-M3", "MiniMax-M3"),
         ):
             with self.subTest(model_id=model_id):
                 upstream = dict(choose_upstream(model_id))
@@ -13220,7 +13255,7 @@ class RoutingTests(unittest.TestCase):
     def test_external_body_converts_custom_tool_items_to_developer_messages(self):
         for model_id, upstream_model in (
             ("volc/glm-5.2", "glm-5.2"),
-            ("minimax-cn/minimax-m3", "MiniMax-M3"),
+            ("minimax-cn/MiniMax-M3", "MiniMax-M3"),
         ):
             with self.subTest(model_id=model_id):
                 upstream = dict(choose_upstream(model_id))
@@ -13265,7 +13300,7 @@ class RoutingTests(unittest.TestCase):
     def test_external_body_normalizes_real_history_artifact_items(self):
         for model_id, upstream_model in (
             ("volc/glm-5.2", "glm-5.2"),
-            ("minimax-cn/minimax-m3", "MiniMax-M3"),
+            ("minimax-cn/MiniMax-M3", "MiniMax-M3"),
         ):
             with self.subTest(model_id=model_id):
                 upstream = dict(choose_upstream(model_id))
@@ -13340,7 +13375,7 @@ class RoutingTests(unittest.TestCase):
         self.assertIn(b'"model":"glm-5.2"', transformed)
         self.assertNotIn(b'"model":"volc/glm-5.2"', transformed)
 
-    def test_default_minimax_provider_rewrites_to_live_upstream_model_case(self):
+    def test_default_minimax_provider_presentation_alias_fails_closed(self):
         from providers_config import DEFAULT_PROVIDERS_PATH
         from providers_config import resolve_external_model_alias as real_resolve_external_model_alias
 
@@ -13351,14 +13386,8 @@ class RoutingTests(unittest.TestCase):
             patch("codex_proxy.resolve_external_model_alias", side_effect=bundled_resolve_external_model_alias),
             patch.dict(os.environ, {"MINIMAX_API_KEY": "minimax-live-case-token"}, clear=False),
         ):
-            upstream = choose_upstream("minimax-cn/minimax-m3")
-
-            body = b'{"model":"minimax-cn/minimax-m3","input":"hi"}'
-            transformed = compatible_request_body(body, upstream, "minimax-cn/minimax-m3")
-
-        self.assertEqual(upstream["name"], "minimax_cn")
-        self.assertEqual(upstream["upstream_model"], "MiniMax-M3")
-        self.assertEqual(json.loads(transformed)["model"], "MiniMax-M3")
+            with self.assertRaisesRegex(ValueError, "presentation-only"):
+                choose_upstream("minimax-cn/minimax-m3")
 
     def test_official_responses_url_preserves_backend_subpath_and_query(self):
         upstream = official_upstream()

--- a/tests/test_smoke_scripts.py
+++ b/tests/test_smoke_scripts.py
@@ -807,6 +807,15 @@ def test_codex_mode_persists_bare_official_model_ids():
     assert 'model = "openai/gpt-5.5"' not in source
 
 
+def test_codex_mode_preserves_user_owned_catalog_paths():
+    source = (ROOT / "scripts" / "codex-mode.ps1").read_text(encoding="utf-8-sig")
+
+    assert "function Get-TopLevelConfigValue" in source
+    assert "function Test-CodexHubManagedCatalogPath" in source
+    assert "$preserveCatalog" in source
+    assert "model_catalog_json = $(Convert-ToTomlLiteral -Value $existingCatalogValue)" in source
+
+
 def test_active_gateway_diagnostics_default_to_bare_official_model_ids():
     launcher = (ROOT / "scripts" / "launch-codex-proxy-app.ps1").read_text(encoding="utf-8-sig")
     replay = (ROOT / "scripts" / "replay_official_transport.py").read_text(encoding="utf-8")

--- a/tests/test_smoke_scripts.py
+++ b/tests/test_smoke_scripts.py
@@ -551,10 +551,10 @@ def test_issue_108_qualification_evidence_replay_validates_committed_live_fixtur
     assert summary["request_error_count"] == 0
     assert summary["fallback_counts"] == {"luna": 0, "terra": 0}
     assert summary["deferred_payload_digest"] == (
-        "sha256:5c697ad0f536d5419e557c5fe4b3208016ec69c2cbe006dba4192210cf1e0294"
+        "sha256:0a69a2512db23c06561be489e636440cd76f5350c45c20d9af4b5c5106135da5"
     )
     assert summary["canonical_tool_shape_digest"] == (
-        "sha256:8c3948a5a3eb6204be57b8d9e1e191f83bc08c3ee31e76fcbbfea0089e36bd7f"
+        "sha256:928b596451cd91c0a9ce953e444c80d6357d55bd4b1eff20078d6179d838b16f"
     )
     assert (ROOT / "tests" / "fixtures" / "issue_108_glm_qualification_evidence.json").exists()
 
@@ -805,7 +805,12 @@ def test_issue_108_qualification_uses_synthetic_gateway_bearer_and_whitelisted_c
     assert 'sandbox = "elevated"' in source
     assert 'sandbox = "unelevated"' not in source
     assert "'--sandbox', $cliSandbox" in source
-    assert "'-a', 'never'" in source
+    assert "'-c', 'approval_policy=never'" in source
+    assert "'-a', 'never'" not in source
+    assert "response.get(\"output\")" in source
+    assert "def _sse_output_items(payload):" in source
+    assert '{"type", "status", "call_id", "name", "input"}.issubset(call)' in source
+    assert '{"type", "call_id", "output"}.issubset(result)' in source
     assert "External qualification scratch directory must be outside the repository workspace" in source
     assert "Readiness preflight: use the accepted GLM route" in source
     assert "ReadinessTimeoutSeconds" in source
@@ -922,6 +927,14 @@ def test_embedded_python_runtime_bundles_zstandard_for_app_request_bodies():
 def test_codex_app_transport_e2e_uses_app_server_and_requires_completed_turns():
     source = (ROOT / "scripts" / "e2e_codex_app_transport.py").read_text(encoding="utf-8")
 
+    assert "--version" in source
+    assert "_VERSION_PROBE_TIMEOUT_SECONDS = 10" in source
+    assert "_VERSION_PROBE_OUTPUT_LIMIT = 64 * 1024" in source
+    assert "len(stdout) > _VERSION_PROBE_OUTPUT_LIMIT" in source
+    assert "len(stderr) > _VERSION_PROBE_OUTPUT_LIMIT" in source
+    assert "re.fullmatch(r\"codex-cli\\s+" in source
+    assert "_CODEX_CLI_VERSION_FLOOR = (0, 145, 0)" in source
+    assert "--client-version" not in source
     assert '"app-server"' in source
     assert '"thread/start"' in source
     assert '"turn/start"' in source

--- a/tests/test_smoke_scripts.py
+++ b/tests/test_smoke_scripts.py
@@ -67,6 +67,79 @@ def test_issue_108_lifecycle_replay_stops_only_the_retained_process_tree(tmp_pat
     assert summary["tracked_child_exit_before_natural_timeout"] is True
     assert summary["cleanup_within_budget"] is True
     assert summary["cleanup_elapsed_milliseconds"] <= summary["cleanup_budget_milliseconds"]
+    assert summary["tracked_root_identity_captured"] is True
+    assert summary["tracked_root_identity_verified"] is True
+    assert summary["tracked_child_identity_captured"] is True
+    assert summary["tracked_child_identity_verified"] is True
+    assert summary["tracked_child_pid_reused"] is False
+    assert summary["cleanup_status"] == "primary"
+    assert summary["primary_tree_stop"]["attempted"] is True
+    assert summary["fallback_cleanup"]["used"] is False
+
+
+def test_issue_268_lifecycle_contract_captures_exact_identity_and_typed_cleanup():
+    source = (ROOT / "scripts" / "qualify-issue-108-glm-tool-surface.ps1").read_text(
+        encoding="utf-8-sig"
+    )
+
+    # The lifecycle contract must retain the original Process handle and its
+    # start identity before teardown.  Re-opening a PID after tree termination
+    # is not an acceptable identity check because that PID may have been reused.
+    assert "Get-TrackedProcessIdentity" in source
+    assert "childProcess = [System.Diagnostics.Process]::GetProcessById" in source
+    assert "childProcessIdentity" in source
+    assert "StartTime" in source
+
+    # Primary tree-stop, degraded fallback, and the shared deadline are
+    # separate typed evidence rather than a boolean that can be cleared later.
+    assert "primary_tree_stop" in source
+    assert "fallback_cleanup" in source
+    assert "cleanup_status" in source
+    assert "LifecycleReplayCleanupTimeoutMilliseconds" in source
+    assert "LifecycleReplayExitProbeMilliseconds" not in source
+
+
+def test_issue_268_survivor_negative_control_stays_red_and_is_typed(tmp_path):
+    powershell = shutil.which("powershell.exe")
+    if powershell is None:
+        pytest.skip("Windows PowerShell is required for the lifecycle replay")
+
+    result = subprocess.run(
+        [
+            powershell,
+            "-NoProfile",
+            "-NonInteractive",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(ROOT / "scripts" / "qualify-issue-108-glm-tool-surface.ps1"),
+            "-LifecycleSurvivorNegativeControl",
+            "-OutputDir",
+            str(tmp_path),
+        ],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        timeout=REPLAY_SUBPROCESS_TIMEOUT_SECONDS,
+    )
+
+    assert result.returncode != 0, result.stdout + result.stderr
+    summaries = list(tmp_path.glob("run-*/summary.json"))
+    assert len(summaries) == 1
+    summary = json.loads(summaries[0].read_text(encoding="utf-8-sig"))
+    assert summary["mode"] == "lifecycle_survivor_negative_control"
+    assert summary["passed"] is False
+    assert summary["cleanup_status"] in {"degraded", "failed"}
+    assert summary["fallback_cleanup"]["used"] is True
+    assert summary["tracked_child_exit_before_natural_timeout"] is False
+    assert any(
+        code in summary["failures"]
+        for code in (
+            "lifecycle_tracked_child_survived_primary_tree_stop",
+            "lifecycle_cleanup_degraded",
+            "lifecycle_tracked_child_remained",
+        )
+    )
 
 
 def test_issue_108_environment_isolation_replay_keeps_cli_secrets_out_of_child(tmp_path):

--- a/tests/validate_issue_108_evidence.py
+++ b/tests/validate_issue_108_evidence.py
@@ -22,7 +22,7 @@ _SENSITIVE_VALUE = re.compile(
 _LOCAL_PATH = re.compile(r"(?i)(?:[a-z]:[\\/]|\\\\users\\|/users/|/home/)")
 _RAW_CONTENT = re.compile(r"(?i)(?:automated qualification|\*\*\* begin patch|\*\*\* update file:)")
 DIRECT_TOOL_SURFACE_BUDGET = 64
-_ACCEPTED_DEFERRED_PAYLOAD_SHA256 = "sha256:5c697ad0f536d5419e557c5fe4b3208016ec69c2cbe006dba4192210cf1e0294"
+_ACCEPTED_DEFERRED_PAYLOAD_SHA256 = "sha256:0a69a2512db23c06561be489e636440cd76f5350c45c20d9af4b5c5106135da5"
 _ACCEPTED_QUALIFICATION_REQUEST_COUNT = 4
 _REQUIRED_CORE_TOOL_NAMES = frozenset({"shell_command", "apply_patch"})
 _EXPECTED_DEFERRED_CANONICAL_TOOL_SHAPE = [
@@ -42,9 +42,17 @@ _EXPECTED_DEFERRED_CANONICAL_TOOL_SHAPE = [
         "keys": ["description", "name", "parameters", "strict", "type"],
     },
     {
-        "type": "custom",
+        "type": "function",
         "name": "apply_patch",
-        "keys": ["description", "format", "name", "type"],
+        "keys": ["description", "name", "parameters", "strict", "type"],
+        "strict": True,
+        "parameter_keys": ["additionalProperties", "properties", "required", "type"],
+        "property_names": ["patch"],
+        "patch_schema_keys": ["minLength", "type"],
+        "patch_type": "string",
+        "patch_min_length": 1,
+        "required": ["patch"],
+        "additional_properties": False,
     },
     {
         "type": "function",


### PR DESCRIPTION
## CodexHub 0.1.8-beta.2 promotion

Promote the reviewed Beta2 candidate from `dev` to `main`.

### Exact candidate

- base `main`: `d9c5acb8d1692ad6b67f45683c24c7e946b369e6`
- candidate `dev`: `73920338c7b94006b74e2ba621553a5e987323bc`
- merge-base: `85d0846247f5369a924e1362411a7a8ccc8dd137`

### Review and CI evidence

- #335 native Codex 0.146 model-cache startup fix: exact-SHA review passed; targeted Rust model tests and real-client contracts passed; PR #336 Hosted `CI / gate` passed.
- #334 CLI-only verification scope: exact-SHA review passed; updated-branch Hosted `CI / gate` passed after the 13-minute Synthetic real-client contract.
- Version freeze PR #337: release-contract tests 17 passed; full Hosted `CI / gate` passed.
- `git diff --check origin/main...origin/dev` is clean.

### Included Beta2 scope

- Stop treating Codex CLI-owned native `models_cache.json` publication as an Official startup prerequisite; retain validated `model/list` and context-budget fail-closed behavior.
- Use the explicit CLI-only Beta2 gate: Codex CLI, OpenCode, Pi, and OMP (Official Luna and Ollama Cloud), eight automated cases; Desktop/ZCode GUI validation is intentionally out of scope for this release lane.
- Preserve the prior Beta1 scope and Beta2 evidence tooling/model catalog fixes.

### Release limits

This is a Windows x64 manual-opt-in prerelease. It does not claim the deferred two-model qualification in #65, Code Mode, `tool_search`, Collaboration V2, Chat conversion, RC qualification, or stable `0.1.8`. Stable `v0.1.7` remains unchanged.

After merge, build signed normal/debug installers, signatures, manifests, and the normal Portable ZIP from the exact resulting `main` SHA; run the formal CLI-only eight-case verification against the exact candidate; then publish `v0.1.8-beta.2`.
