### PR TITLE
test: await previous Gateway exit before bundle upgrade

### DIFF
--- a/src-tauri/src/proxy.rs
+++ b/src-tauri/src/proxy.rs
@@ -5372,6 +5372,8 @@ time.sleep(10)
             let old_status =
                 start_with_controlled_inspector(&old_paths, &old_inspector, &listener_inspector)?;
             ensure(old_status.proxy_running, "old bundle should start")?;
+            let old_pid = read_pid(&old_paths)?
+                .ok_or_else(|| "old bundle should own the proxy PID".to_string())?;
 
             replace_managed_proxy_from_previous_bundle_with_controls(
                 &new_paths,
@@ -5380,6 +5382,11 @@ time.sleep(10)
                 &listener_inspector,
             )?;
             previous_bundle_replaced = true;
+            // The debug Gateway closes its health endpoint before its recorder
+            // drains and the Python process exits.  Keep the bundle-upgrade
+            // fixture from racing the next reconciliation through that
+            // transient health-unavailable/PID-still-live window.
+            wait_for_missing_process(old_pid);
             let new_status =
                 start_with_controlled_inspector(&new_paths, &new_inspector, &listener_inspector)?;
             ensure(new_status.proxy_running, "new bundle should start")?;


### PR DESCRIPTION
## Summary
- wait for the old Windows Gateway PID to disappear after the controlled previous-bundle replacement
- keep the upgrade fixture from racing the transient health-unavailable/PID-still-live window
- preserve production process inspection, timeouts, ownership checks, and non-Windows coverage

Closes #307

## Exact review and verification
- exact head: `ee25ffe0ce68558a3adbeea5607713ff150234d5`
- fixed point: `144fa5289ce75b1149f9005b4371477d685be165`
- Standards: PASS
- Spec: PASS
- `cargo test --locked --features debug-diagnostics proxy::tests::start_replaces_running_managed_proxy_from_previous_bundle -- --nocapture --test-threads=1`: PASS
- `cargo test --locked proxy::tests::start_replaces_running_managed_proxy_from_previous_bundle -- --nocapture --test-threads=1`: PASS
- `git diff --check`: PASS

This is a CI/test-fixture fix only. It is not a Beta2 release and must not create a tag or release.