### PR TITLE
test(issue62): bind live capture correlation

### DIFF
--- a/docs/superpowers/plans/2026-08-02-issue-62-live-evidence-sidecar.md
+++ b/docs/superpowers/plans/2026-08-02-issue-62-live-evidence-sidecar.md
@@ -27,7 +27,7 @@
 - Create: `tests/test_issue_62_live_evidence_sidecar.py`
 
 **Interfaces:**
-- Produces: `SidecarConfig`, `validate_config(config)`, `write_capture_record(output_dir, hop, record)`, and `main(argv=None) -> int`.
+- Produces: `SidecarConfig`, `validate_config(config)`, `write_capture_record(output_dir, hop, record, capture_key=..., correlation_token=...)`, and `main(argv=None) -> int`.
 - Consumes: only Python standard-library modules and a pre-existing HMAC key file.
 
 - [x] **Step 1: Write failing activation and artifact tests**
@@ -43,7 +43,13 @@ def test_config_rejects_non_loopback(host, base_config):
         sidecar.validate_config(dataclasses.replace(base_config, listen_host=host))
 
 def test_atomic_record_is_sanitized_and_leaves_no_partial(tmp_path):
-    record_path = sidecar.write_capture_record(tmp_path, "pre", SAFE_RECORD)
+    record_path = sidecar.write_capture_record(
+        tmp_path,
+        "pre",
+        SAFE_RECORD,
+        capture_key=KEY,
+        correlation_token=CORRELATION_TOKEN,
+    )
     assert json.loads(record_path.read_text(encoding="utf-8"))["schema"] == (
         "codexhub.issue62.live-evidence-lane.v1"
     )

--- a/scripts/capture_issue_62_live_evidence.py
+++ b/scripts/capture_issue_62_live_evidence.py
@@ -35,6 +35,7 @@ _OUTCOMES = frozenset({"complete", "incomplete"})
 _FAILURES = frozenset(
     {
         "client_cancelled",
+        "correlation_binding_invalid",
         "downstream_cancelled",
         "forwarding_failed",
         "invalid_content_length",
@@ -80,6 +81,9 @@ _SSE_FIELDS = frozenset(
 )
 _CAPTURE_ID = re.compile(r"c[0-9a-f]{32}\Z")
 _DIGEST = re.compile(r"[0-9a-f]{64}\Z")
+_CORRELATION_TOKEN = re.compile(r"[0-9a-f]{32}\Z")
+_CORRELATION_BINDING = re.compile(r"([0-9a-f]{32})\.([0-9a-f]{64})\Z")
+_CORRELATION_HEADER = "X-CodexHub-Issue62-Capture"
 
 
 class ConfigurationError(ValueError):
@@ -391,10 +395,76 @@ def validate_capture_record(record: Mapping[str, Any], hop: str) -> None:
             raise ArtifactValidationError("record_completion_invalid")
 
 
-def write_capture_record(output_dir: Path, hop: str, record: Mapping[str, Any]) -> Path:
-    """Atomically publish one sanitized record and always remove its partial."""
+def _capture_id_for_token(key: bytes, correlation_token: str) -> str:
+    if not isinstance(key, bytes) or not 32 <= len(key) <= 4096:
+        raise ValueError("capture_key_invalid")
+    if (
+        not isinstance(correlation_token, str)
+        or _CORRELATION_TOKEN.fullmatch(correlation_token) is None
+    ):
+        raise ValueError("correlation_token_invalid")
+    digest = hmac.new(
+        key,
+        b"issue62-capture\0" + correlation_token.encode("ascii"),
+        hashlib.sha256,
+    ).hexdigest()
+    return "c" + digest[:32]
+
+
+def _new_correlation_token() -> str:
+    return uuid.uuid4().hex
+
+
+def _correlation_binding(key: bytes, correlation_token: str) -> str:
+    if (
+        not isinstance(correlation_token, str)
+        or _CORRELATION_TOKEN.fullmatch(correlation_token) is None
+    ):
+        raise ValueError("correlation_token_invalid")
+    signature = hmac.new(
+        key,
+        b"issue62-correlation\0" + correlation_token.encode("ascii"),
+        hashlib.sha256,
+    ).hexdigest()
+    return f"{correlation_token}.{signature}"
+
+
+def _correlation_token_from_header(key: bytes, value: str | None) -> str | None:
+    if not isinstance(value, str):
+        return None
+    match = _CORRELATION_BINDING.fullmatch(value)
+    if match is None:
+        return None
+    correlation_token, signature = match.groups()
+    expected = hmac.new(
+        key,
+        b"issue62-correlation\0" + correlation_token.encode("ascii"),
+        hashlib.sha256,
+    ).hexdigest()
+    if not hmac.compare_digest(signature, expected):
+        return None
+    return correlation_token
+
+
+def write_capture_record(
+    output_dir: Path,
+    hop: str,
+    record: Mapping[str, Any],
+    *,
+    capture_key: bytes | None = None,
+    correlation_token: str | None = None,
+) -> Path:
+    """Atomically publish one live-bound sanitized record and remove its partial."""
 
     validate_capture_record(record, hop)
+    if capture_key is None or correlation_token is None:
+        raise ArtifactValidationError("capture_binding_missing")
+    try:
+        expected_capture_id = _capture_id_for_token(capture_key, correlation_token)
+    except (TypeError, ValueError):
+        raise ArtifactValidationError("capture_binding_invalid") from None
+    if not hmac.compare_digest(str(record["capture_id"]), expected_capture_id):
+        raise ArtifactValidationError("capture_binding_invalid")
     directory = Path(output_dir)
     directory.mkdir(parents=True, exist_ok=True)
     capture_id = str(record["capture_id"])
@@ -429,10 +499,6 @@ _HOP_BY_HOP_HEADERS = frozenset(
         "upgrade",
     }
 )
-
-
-def _capture_id() -> str:
-    return "c" + uuid.uuid4().hex
 
 
 def _content_type_class(value: str | None) -> str:
@@ -603,11 +669,18 @@ class CaptureSidecarServer:
         return self._thread_failure is None
 
     def _write_control_failure(self, failure: str) -> None:
+        correlation_token = _new_correlation_token()
         try:
             write_capture_record(
                 self._config.output_dir,
                 self._config.hop,
-                _empty_record(self._config.hop, _capture_id(), failure),
+                _empty_record(
+                    self._config.hop,
+                    _capture_id_for_token(self._key, correlation_token),
+                    failure,
+                ),
+                capture_key=self._key,
+                correlation_token=correlation_token,
             )
         except Exception:
             return
@@ -665,7 +738,8 @@ class CaptureSidecarServer:
             return True
 
     def handle_post(self, handler: BaseHTTPRequestHandler) -> None:
-        capture_id = _capture_id()
+        correlation_token = _new_correlation_token()
+        capture_id = _capture_id_for_token(self._key, correlation_token)
         started_at = time.monotonic()
         request_fingerprint = BodyFingerprint(self._key, b"request-body")
         response_fingerprint: BodyFingerprint | None = None
@@ -677,6 +751,17 @@ class CaptureSidecarServer:
         request_complete = False
         response_complete = False
         try:
+            if self._config.hop == "post":
+                bound_token = _correlation_token_from_header(
+                    self._key,
+                    handler.headers.get(_CORRELATION_HEADER),
+                )
+                if bound_token is None:
+                    failure = "correlation_binding_invalid"
+                    self._send_bounded_error(handler, 400)
+                    return
+                correlation_token = bound_token
+                capture_id = _capture_id_for_token(self._key, correlation_token)
             raw_length = handler.headers.get("Content-Length")
             try:
                 content_length = int(raw_length) if raw_length is not None else -1
@@ -716,8 +801,11 @@ class CaptureSidecarServer:
             headers = {
                 name: value
                 for name, value in handler.headers.items()
-                if name.lower() not in _HOP_BY_HOP_HEADERS | {"host", "content-length"}
+                if name.lower()
+                not in _HOP_BY_HOP_HEADERS | {"host", "content-length", _CORRELATION_HEADER.lower()}
             }
+            if self._config.hop == "pre":
+                headers[_CORRELATION_HEADER] = _correlation_binding(self._key, correlation_token)
             target_path = _join_target_path(self._target.path, handler.path)
             upstream.request("POST", target_path, body=request_body, headers=headers)
             if upstream.sock is not None:
@@ -810,7 +898,13 @@ class CaptureSidecarServer:
                 ),
             }
             try:
-                write_capture_record(self._config.output_dir, self._config.hop, record)
+                write_capture_record(
+                    self._config.output_dir,
+                    self._config.hop,
+                    record,
+                    capture_key=self._key,
+                    correlation_token=correlation_token,
+                )
             except Exception:
                 return
 

--- a/tests/test_issue_62_live_evidence_sidecar.py
+++ b/tests/test_issue_62_live_evidence_sidecar.py
@@ -28,6 +28,11 @@ sys.modules[SPEC.name] = sidecar
 SPEC.loader.exec_module(sidecar)
 
 KEY = b"h" * 32
+CORRELATION_TOKEN = "1" * 32
+
+
+def _capture_id(correlation_token: str = CORRELATION_TOKEN) -> str:
+    return sidecar._capture_id_for_token(KEY, correlation_token)
 
 
 class _FakeUpstreamHandler(BaseHTTPRequestHandler):
@@ -36,6 +41,9 @@ class _FakeUpstreamHandler(BaseHTTPRequestHandler):
     def do_POST(self) -> None:
         length = int(self.headers["Content-Length"])
         self.server.observed_request = self.rfile.read(length)  # type: ignore[attr-defined]
+        self.server.observed_headers = {  # type: ignore[attr-defined]
+            name.lower(): value for name, value in self.headers.items()
+        }
         body = self.server.response_body  # type: ignore[attr-defined]
         delay = self.server.response_delay  # type: ignore[attr-defined]
         if delay:
@@ -69,6 +77,7 @@ def _fake_upstream(
     server = ThreadingHTTPServer(("127.0.0.1", 0), _FakeUpstreamHandler)
     server.response_body = response_body  # type: ignore[attr-defined]
     server.observed_request = None  # type: ignore[attr-defined]
+    server.observed_headers = {}  # type: ignore[attr-defined]
     server.response_delay = response_delay  # type: ignore[attr-defined]
     server.response_chunk_size = chunk_size  # type: ignore[attr-defined]
     server.chunk_delay = chunk_delay  # type: ignore[attr-defined]
@@ -214,7 +223,7 @@ def test_atomic_record_is_sanitized_and_leaves_no_partial(tmp_path: Path) -> Non
     record = {
         "schema": "codexhub.issue62.live-evidence-lane.v1",
         "verification_scope": "capture_only_not_qualification",
-        "capture_id": "c" + "1" * 32,
+        "capture_id": _capture_id(),
         "hop": "pre",
         "outcome": "complete",
         "failure": None,
@@ -235,12 +244,82 @@ def test_atomic_record_is_sanitized_and_leaves_no_partial(tmp_path: Path) -> Non
         "sse": None,
     }
 
-    record_path = sidecar.write_capture_record(tmp_path, "pre", record)
+    record_path = sidecar.write_capture_record(
+        tmp_path,
+        "pre",
+        record,
+        capture_key=KEY,
+        correlation_token=CORRELATION_TOKEN,
+    )
 
     assert json.loads(record_path.read_text(encoding="utf-8")) == record
     assert record_path.name.startswith("pre-")
     assert record_path.suffix == ".json"
     assert not list(tmp_path.glob("*.partial"))
+
+
+def test_atomic_record_rejects_prebuilt_record_without_live_capture_binding(tmp_path: Path) -> None:
+    record = {
+        "schema": "codexhub.issue62.live-evidence-lane.v1",
+        "verification_scope": "capture_only_not_qualification",
+        "capture_id": _capture_id("2" * 32),
+        "hop": "pre",
+        "outcome": "complete",
+        "failure": None,
+        "status": 200,
+        "content_type_class": "json",
+        "request": {
+            "bytes": 2,
+            "sha256": "a" * 64,
+            "hmac_sha256": "b" * 64,
+            "complete": True,
+        },
+        "response": {
+            "bytes": 3,
+            "sha256": "c" * 64,
+            "hmac_sha256": "d" * 64,
+            "complete": True,
+        },
+        "sse": None,
+    }
+
+    with pytest.raises(sidecar.ArtifactValidationError, match="capture_binding_missing"):
+        sidecar.write_capture_record(tmp_path, "pre", record)
+
+
+def test_atomic_record_rejects_capture_id_from_different_live_correlation(tmp_path: Path) -> None:
+    record = {
+        "schema": "codexhub.issue62.live-evidence-lane.v1",
+        "verification_scope": "capture_only_not_qualification",
+        "capture_id": _capture_id("2" * 32),
+        "hop": "pre",
+        "outcome": "complete",
+        "failure": None,
+        "status": 200,
+        "content_type_class": "json",
+        "request": {
+            "bytes": 2,
+            "sha256": "a" * 64,
+            "hmac_sha256": "b" * 64,
+            "complete": True,
+        },
+        "response": {
+            "bytes": 3,
+            "sha256": "c" * 64,
+            "hmac_sha256": "d" * 64,
+            "complete": True,
+        },
+        "sse": None,
+    }
+
+    with pytest.raises(sidecar.ArtifactValidationError, match="capture_binding_invalid"):
+        sidecar.write_capture_record(
+            tmp_path,
+            "pre",
+            record,
+            capture_key=KEY,
+            correlation_token=CORRELATION_TOKEN,
+        )
 
 
 def test_atomic_record_rejects_unapproved_fields(tmp_path: Path) -> None:
@@ -515,6 +594,7 @@ def test_two_hops_capture_matching_complete_request_response_and_sse(
                     headers={
                         "Authorization": "Bearer forbidden-token",
                         "Content-Type": "application/json",
+                        "X-CodexHub-Issue62-Capture": ("0" * 32) + "." + ("f" * 64),
                     },
                 )
                 response = connection.getresponse()
@@ -529,10 +609,12 @@ def test_two_hops_capture_matching_complete_request_response_and_sse(
     pre_record = _read_only_record(pre_output)
     post_record = _read_only_record(post_output)
     assert pre_record["request"] == post_record["request"]
+    assert pre_record["capture_id"] == post_record["capture_id"]
     assert pre_record["response"] == post_record["response"]
     assert pre_record["sse"]["sequence_sha256"] == post_record["sse"]["sequence_sha256"]  # type: ignore[index]
     assert pre_record["sse"]["sequence_hmac_sha256"] == post_record["sse"]["sequence_hmac_sha256"]  # type: ignore[index]
     assert pre_record["outcome"] == post_record["outcome"] == "complete"
+    assert "x-codexhub-issue62-capture" not in upstream.observed_headers  # type: ignore[attr-defined]
     serialized = json.dumps([pre_record, post_record], sort_keys=True)
     for sensitive in (
         "private prompt",
@@ -545,6 +627,42 @@ def test_two_hops_capture_matching_complete_request_response_and_sse(
         str(hmac_key_file),
     ):
         assert sensitive not in serialized
+    assert not list(tmp_path.rglob("*.partial"))
+
+
+@pytest.mark.parametrize(
+    "correlation_header",
+    [None, ("0" * 32) + "." + ("f" * 64)],
+)
+def test_post_rejects_missing_or_invalid_correlation_before_forwarding(
+    correlation_header: str | None,
+    tmp_path: Path,
+    hmac_key_file: Path,
+) -> None:
+    with _fake_upstream(b'data: {"type":"response.completed"}\n\n') as upstream:
+        upstream_url = f"http://127.0.0.1:{upstream.server_address[1]}"
+        config = _sidecar_config(
+            tmp_path,
+            hmac_key_file,
+            upstream_url,
+            hop="post",
+        )
+        with _running_sidecar(config) as server:
+            connection = http.client.HTTPConnection(server.listen_host, server.listen_port, timeout=2)
+            headers = {}
+            if correlation_header is not None:
+                headers["X-CodexHub-Issue62-Capture"] = correlation_header
+            connection.request("POST", "/responses", body=b"{}", headers=headers)
+            response = connection.getresponse()
+            assert response.status == 400
+            response.read()
+            connection.close()
+
+    assert upstream.observed_request is None  # type: ignore[attr-defined]
+    record = _read_only_record(config.output_dir)
+    assert record["outcome"] == "incomplete"
+    assert record["failure"] == "correlation_binding_invalid"
+    assert "X-CodexHub-Issue62-Capture" not in json.dumps(record, sort_keys=True)
     assert not list(tmp_path.rglob("*.partial"))
 
 

--- a/tests/test_issue_62_live_evidence_sidecar.py
+++ b/tests/test_issue_62_live_evidence_sidecar.py
@@ -35,6 +35,11 @@ def _capture_id(correlation_token: str = CORRELATION_TOKEN) -> str:
     return sidecar._capture_id_for_token(KEY, correlation_token)
 
 
+def test_capture_id_is_deterministically_bound_to_correlation_token() -> None:
+    assert _capture_id() == _capture_id(CORRELATION_TOKEN)
+    assert _capture_id() != _capture_id("2" * 32)
+
+
 class _FakeUpstreamHandler(BaseHTTPRequestHandler):
     protocol_version = "HTTP/1.0"
 


### PR DESCRIPTION
## Summary

Refs #62. Evidence-only sidecar hardening from exact base `9ec0b9b5413b6861595c21fe8e213441e03a0b0e`.

- Binds each pre/post sanitized capture record to an HMAC-derived correlation token propagated only across the isolated pre→post hop.
- Rejects prebuilt, missing, or mismatched capture bindings before forwarding and preserves bounded cleanup/error behavior.
- Updates the implementation plan to document the required live binding arguments.
- Does not change production routing, telemetry, configuration, or release metadata, and does not claim #62 qualification.

Known boundary: the companion manifest contract must consume and validate paired capture IDs; full planner, live wire controls, and qualification remain open under #62.

Exact head under review: `67b724096029be624238bca2ce571cf6ff9e0476`.

Verification: `py -3.13 -m pytest tests/test_issue_62_live_evidence_sidecar.py -q` — 41 passed; `git diff --check` — passed.

No Beta2 tag or Release is created by this PR.