### PR TITLE
docs: make local verification authoritative

### DIFF
--- a/docs/agents/ci.md
+++ b/docs/agents/ci.md
@@ -1,21 +1,22 @@
-# CI and manual verification
+# Local verification
 
-GitHub Actions runs the required PR validation for branches targeting `dev`
-and `main` on fresh GitHub-hosted runners. Actions owns the trigger, exact-SHA
-logs, artifacts, Check status, and readback. Local candidate checks are
-selected by `docs/agents/verification-policy.md`; they do not duplicate every
-CI job by default.
+GitHub Actions CI is disabled for this project. It is not a merge, release, or
+issue gate, and no candidate may wait for or claim a Hosted `CI / gate` result.
+Historical workflow runs and the matrix below are retained only as reference.
+All current candidates are verified locally on the exact candidate SHA using
+`docs/agents/verification-policy.md`.
 
-## CI jobs
+## Historical Hosted matrix (non-gating)
 
-Every workflow run creates one immutable **CI classifier** and one final
-**`CI / gate`** check.  The classifier in
+The former workflow created one immutable **CI classifier** and one final
+**`CI / gate`** check. The classifier in
 `scripts/ci/ci_change_plan.py` compares a pull request's merge-base to its
 head and emits the job-selection booleans.  Formal jobs keep their existing
 check names, but are skipped when their contract is unaffected.  A skipped
 formal job is acceptable only when the classifier selected it as out of scope;
-the gate fails on classifier failure, cancellation, or any selected job that
-does not pass.
+the historical gate failed on classifier failure, cancellation, or any
+selected job that did not pass. These jobs are not run by the current release
+process.
 
 - **Python core**: `python -m pytest -q --ignore=tests/test_real_client_e2e.py --junitxml=.pytest-results/junit-core.xml --durations=0` when the classifier selects Python core.
 - **Synthetic real-client contract**: when selected, it runs the synthetic module through `tests/fixtures/real_client_e2e/run-with-windows-watchdog.py` with an explicit 3600-second outer bound while retaining JUnit and per-test duration output. The unified classifier uses the existing synthetic dependency set; `python scripts/ci/check_python_test_partitions.py` still proves the core and synthetic partitions are disjoint and complete.
@@ -33,17 +34,12 @@ does not pass.
   `safe_file.rs` must stay free of crate dependencies so the standalone compile
   keeps working.
 
-### Triggers and path scheduling
+### Former triggers and path scheduling
 
-Same-repository and fork PRs to `dev` and `main` always run the classifier and
-gate.  The classifier selects Python, frontend, Rust, Linux `safe_file`, and
-release checks from changed paths; documentation-only changes run only the
-classifier and gate.  Unknown paths, planner/workflow changes, path-read
-failures, pushes, schedules, and manual dispatches fail closed to the full
-matrix.  Workflow triggers intentionally do not use `paths` filters, so the
-required `CI / gate` check is never left permanently pending by GitHub.
-Hosted runners are disposable and do not depend on the developer machine or a
-repository self-hosted registration.
+The former workflow ran the classifier and gate for pull requests, pushes,
+schedules, and manual dispatches. Its path planner and fail-closed behavior
+remain useful references for selecting the equivalent local suites, but no
+GitHub check is required or authoritative.
 
 Windows jobs pin `windows-2025`; the Linux-only `safe_file` job pins
 `ubuntu-24.04`, so its `cfg(unix)` code is compiled and exercised on Linux.
@@ -64,13 +60,13 @@ return a typed `not_applicable_unmanaged_checkout` result in CI. Missing Paseo
 state in an unmanaged checkout is not a product regression and must not be
 reported as one.
 
-### Hosted runner contract
+### Former Hosted runner contract (historical)
 
-Routine CI must remain runnable on a clean GitHub-hosted Windows or Linux
-virtual machine. Do not add requirements for a persistent service, desktop
-session, local credentials, or a developer/Paseo workspace. Cargo caches may
-contain only `~/.cargo/registry` and `~/.cargo/git`; never cache
-`src-tauri/target`.
+The former routine CI ran on clean GitHub-hosted Windows or Linux virtual
+machines. It is disabled and must not be restarted to unblock a candidate.
+The old contract remains documented for provenance only. Cargo caches in any
+local verification must contain only `~/.cargo/registry` and `~/.cargo/git`;
+never cache `src-tauri/target`.
 
 The former repository self-hosted runners are retired. Their historical
 registration and de-registration record is kept in
@@ -100,9 +96,9 @@ classifier failure instead of silently accepting a partial plan.
 
 The Rust jobs create a temporary `src-tauri/resources/python/.ci-placeholder` file during CI because Tauri's resource glob requires at least one runtime Python resource file. The placeholder is not committed.
 
-## Full manual fallback
+## Full local verification matrix
 
-Use all of these commands when GitHub Actions is unavailable and the change must be integrated. Before opening a normal PR, run only the local suites selected by the verification policy:
+For `standard` and `strict` candidates, run the affected suites selected by the verification policy. Use the following complete matrix when the changed boundary spans the whole product or when a release gate explicitly requires it:
 
 ```powershell
 python -m pytest -q --ignore=tests/test_real_client_e2e.py --junitxml=.pytest-results/junit-core.xml --durations=0

--- a/docs/agents/verification-policy.md
+++ b/docs/agents/verification-policy.md
@@ -35,9 +35,10 @@ language full suite. A `fast` isolated UI or pure-logic change still runs the
 narrow compile/test command that proves its acceptance, but does not duplicate
 the repository's complete language suite locally.
 
-After review fixes, run affected targeted checks and rely on CI. Repeat a local
-full suite only when the delta crosses a new row of this matrix. Do not rerun a
-full suite merely because a reviewer re-read the same candidate.
+After review fixes, rerun the affected targeted checks on the reviewed exact
+SHA. For `standard` and `strict` work, run the relevant local full suite once
+on that candidate. Do not rerun a full suite merely because a reviewer re-read
+the same candidate.
 
 ## Manual and runtime evidence
 
@@ -51,22 +52,22 @@ hypothesis or materially changed environment.
 changed Python, TypeScript/TSX, or Rust source is in its scan scope; findings do
 not block PR, merge, or release under the current policy.
 
-## CI authority
+## Local verification authority
 
-GitHub Actions always creates the classifier and `CI / gate` for every PR to
-`dev` or `main`. The immutable classifier selects the applicable formal jobs
-(Python core, synthetic real-client contract, frontend build and UI contract,
-Rust tests for both flavors, Rust clippy, release flavor contract, and the
-safe_file Linux compile/lint/tests). Unknown paths, planner/workflow changes,
-path-read failures, and non-PR events fail closed to the full matrix. Routine
-checks run on fresh GitHub-hosted Windows and Linux runners. Because the
-repository is public, fork PR code is allowed to run only on those disposable
-hosted VMs; it never receives access to a persistent developer or self-hosted
-machine. True real-client Desktop/CLI evidence remains a local release-
-operator procedure.
-Local risk selection reduces duplicate work; it does not weaken CI. When CI is
-unavailable and a merge must proceed, reproduce the full fallback in
-`docs/agents/ci.md`.
+GitHub Actions CI is disabled for CodexHub. There is no required status check
+and no Hosted runner result can approve a merge or release. The former
+classifier and Hosted matrix are retained as historical reference only.
+The authoritative sequence for every candidate is:
+
+1. implement on an isolated worker branch;
+2. review the exact candidate SHA (Spec/Quality as required by the Issue);
+3. run the local focused and affected full suites selected below;
+4. run any Issue-required CLI, Desktop, or provider manual check;
+5. record the local result before merge, tag, or release.
+
+Unknown paths, planner/workflow changes, and release candidates should fail
+closed to the complete local matrix. True real-client Desktop/CLI evidence
+remains a local release-operator procedure.
 
 ### Python checks
 
@@ -79,14 +80,12 @@ suite is only invoked when its contract surface actually changed:
 - **`Synthetic real-client contract`** is selected for the real-client E2E
   dependency surface and runs `tests/test_real_client_e2e.py` in full.
 
-Non-PR events (`push`, `workflow_dispatch`, the weekly full-validation
-`schedule`, release/full-validation, and unknown events) fail closed and run
-the full matrix. The unified planner lives at
+The unified planner lives at
 `scripts/ci/ci_change_plan.py`; the existing Python partition planner remains
 the source of the core/synthetic partition definitions used by local fallback
-and is tested by `tests/test_ci_python_plan.py`. The Hosted workflow keeps
-those same stable pytest arguments after the unified planner selects the job.
-Collection completeness is verified by
+and is tested by `tests/test_ci_python_plan.py`. Use the same stable pytest
+arguments locally when the corresponding boundary is selected. Collection
+completeness is verified by
 `python scripts/ci/check_python_test_partitions.py`.
 
 Existing active work migrates incrementally: retain already completed full


### PR DESCRIPTION
## Summary

- Make local verification the authoritative merge/release process after GitHub Actions CI was disabled.
- Keep the former Hosted matrix and planner documented as historical reference only.
- Record the exact implementation → SHA review → local suites/CLI/manual verification → result sequence.

## Verification

- `git diff --check`

No GitHub CI run is expected for this draft; the repository workflow is `disabled_manually` and `dev`/`main` have no required status check.