### PR TITLE
docs(issue64): inventory Collaboration V1/V2 boundary

### DIFF
--- a/docs/evidence/issue-64/README.md
+++ b/docs/evidence/issue-64/README.md
@@ -16,7 +16,8 @@ The inventory is bound to the accepted Issue #62 source contract:
 - `capture_status=not_observed`
 - source-contract `qualification_status=unqualified`
 
-The source-contract file is retained by name and SHA-256 in the JSON artifact.
+The source-contract file is retained by name and canonical-LF SHA-256 in the
+JSON artifact (`6f38b8b07b98c6f28edd7418b63449242ee41d6396694392a70c0d7fb2b70f2c`).
 This is source/repository evidence only: no CLI request, credentials, raw
 capture, prompt, call ID, item ID, or token is retained here. A historical
 0.144 trace, if encountered elsewhere, must remain labeled 0.144 and must not
@@ -46,16 +47,18 @@ fields fail closed; they are not guessed or repaired.
 
 ## V1 shape (`multi_agent_v1`)
 
-V1 declarations are a `function` with `name` and `parameters`. Calls are
-`function_call` items carrying `namespace`, `name`, `item_id`, `call_id`, and
-`arguments`; results are `function_call_output` items linked by `call_id` and
-`item_id`.
+The V1 entry records the current CodexHub compatibility surface from
+`src-python/codex_proxy.py#MULTI_AGENT_DISCOVERY_TOOLS`: a `namespace` with
+child `function` tools. It is not an official raw CLI capture; the official
+CLI 0.146 V1 shape remains `not_observed`. Calls are `function_call` items
+carrying `namespace`, `name`, `item_id`, `call_id`, and `arguments`; results are
+`function_call_output` items linked by `call_id` and `item_id`.
 
-The V1 spawn call requires `message` and may carry `agent_type`, `model`,
-`reasoning`, `nickname`, or `fork_context`. `send_input` requires `target` and
-`message` (with optional `interrupt`); `wait_agent` requires `targets` (with
-optional `timeout_ms`); `close_agent` requires `target`; and `resume_agent`
-requires `target` and `message`.
+The compatibility-surface spawn call requires `agent_type` and may carry
+`fork_context` or `message`. `send_input` requires `target` and may carry
+`message` or `interrupt`; `wait_agent` requires `targets` (with optional
+`timeout_ms`); `close_agent` requires `target`; and `resume_agent` requires
+`id`.
 
 V1 results identify the child with `agent_id`. The result fields are
 tool-specific: spawn returns `agent_id`/`nickname`, wait returns
@@ -67,7 +70,9 @@ tool-specific: spawn returns `agent_id`/`nickname`, wait returns
 
 ## V2 shape (`collaboration`)
 
-V2 declarations are a `namespace` with child `function` tools. Calls use the
+V2 is an accepted structural contract, not a live capture; its official CLI
+capture status is `not_observed`. V2 declarations are a `namespace` with child
+`function` tools. Calls use the
 same Responses `function_call` envelope (`namespace`, child `name`,
 `item_id`, `call_id`, and `arguments`), and results use
 `function_call_output` linked by `call_id` and `item_id`.
@@ -105,10 +110,15 @@ The Codex client owns execution for both V1 and V2 (`owner=codex_client`,
 `executor=codex_client`). The Gateway is not an executor, scheduler, result
 forger, or V2-to-V1 downgrade path.
 
-The JSON records requirements only for follow-up issues #198 and #58:
+The JSON records requirements only for follow-up issues #198 and #58. The V2
+namespace may pass natively when the selected protocol supports namespaces;
+otherwise a generic namespace-to-function Adapter is optional for V2 and must
+remain reversible. The current V1 compatibility namespace similarly requires
+that Adapter only when the selected protocol lacks namespace support.
 
 - map a namespace child to an injective, request-scoped function alias;
-- preserve `task_path` and all call/result/history links;
+- preserve `task_path`, `continuation_id`, `task_name`, and `fork_turns`;
+- preserve inverse declaration/call/result/history mappings;
 - assemble streamed arguments before validation;
 - reject unknown or ambiguous boundaries; and
 - keep V1 and V2 repair paths isolated.

--- a/docs/evidence/issue-64/README.md
+++ b/docs/evidence/issue-64/README.md
@@ -1,0 +1,127 @@
+# Issue #64 Collaboration V1/V2 inventory
+
+This directory contains a bounded, structural inventory of the two native
+Collaboration protocol families that must be distinguished before any Gateway
+tool exposure or semantic repair. It is a schema boundary and adapter
+requirement record, not a live protocol capture and not a Collaboration
+lifecycle implementation.
+
+## Source contract and evidence boundary
+
+The inventory is bound to the accepted Issue #62 source contract:
+
+- Codex CLI `0.146.0`
+- source tag `rust-v0.146.0`
+- attested source commit `e363b08c9175ac1cbe5893615dd2cb9ddf95043b`
+- `capture_status=not_observed`
+- source-contract `qualification_status=unqualified`
+
+The source-contract file is retained by name and SHA-256 in the JSON artifact.
+This is source/repository evidence only: no CLI request, credentials, raw
+capture, prompt, call ID, item ID, or token is retained here. A historical
+0.144 trace, if encountered elsewhere, must remain labeled 0.144 and must not
+be promoted or relabeled as the 0.146 contract.
+
+Regenerate or check the canonical artifact with:
+
+```powershell
+python scripts/build_issue_64_collaboration_inventory.py
+python scripts/build_issue_64_collaboration_inventory.py --check
+```
+
+## Boundary discriminator
+
+Classification happens before exposure and before any semantic repair. Both
+`namespace` and child tool `name` are mandatory discriminators:
+
+| Family | Namespace | Tools |
+| --- | --- | --- |
+| Collaboration V1 | `multi_agent_v1` | `spawn_agent`, `send_input`, `wait_agent`, `close_agent`, `resume_agent` |
+| Collaboration V2 | `collaboration` | `spawn_agent`, `send_message`, `followup_task`, `wait_agent`, `interrupt_agent`, `list_agents` |
+
+A flattened alias such as `multi_agent_v1__spawn_agent` is not sufficient to
+choose a family without its namespace. Unknown namespaces/tools, missing
+discriminators, ambiguous flattened names, and payloads mixing V1 and V2
+fields fail closed; they are not guessed or repaired.
+
+## V1 shape (`multi_agent_v1`)
+
+V1 declarations are a `function` with `name` and `parameters`. Calls are
+`function_call` items carrying `namespace`, `name`, `item_id`, `call_id`, and
+`arguments`; results are `function_call_output` items linked by `call_id` and
+`item_id`.
+
+The V1 spawn call requires `message` and may carry `agent_type`, `model`,
+`reasoning`, `nickname`, or `fork_context`. `send_input` requires `target` and
+`message` (with optional `interrupt`); `wait_agent` requires `targets` (with
+optional `timeout_ms`); `close_agent` requires `target`; and `resume_agent`
+requires `target` and `message`.
+
+V1 results identify the child with `agent_id`. The result fields are
+tool-specific: spawn returns `agent_id`/`nickname`, wait returns
+`timed_out`/`status`, close returns `previous_status`, and send/resume return
+`status`. History links use `agent_id`, `call_id`, `call_item_id`, and
+`output_item_id`; the continuation identity is `agent_id`. `close_agent` and
+`resume_agent` are separate V1 operations. V1 has no V2 `task_path`,
+`continuation_id`, or `fork_turns` semantics.
+
+## V2 shape (`collaboration`)
+
+V2 declarations are a `namespace` with child `function` tools. Calls use the
+same Responses `function_call` envelope (`namespace`, child `name`,
+`item_id`, `call_id`, and `arguments`), and results use
+`function_call_output` linked by `call_id` and `item_id`.
+
+V2 spawn requires `task_name` and `message`; optional controls are
+`fork_turns`, `agent_type`, `model`, and `reasoning_effort`. `fork_turns` is
+preserved as one of `all`, `none`, or a positive decimal string. The other
+operations are `send_message(target, message)`,
+`followup_task(target, message)`, `wait_agent(timeout_ms?)`,
+`interrupt_agent(target)`, and `list_agents(path_prefix?)`.
+
+V2 continuation and history identity use `task_path` (with
+`continuation_id`, `task_name`, and `fork_turns` carried alongside it), plus
+the call/item links. V2 does not acquire V1's `agent_id`, `send_input`,
+`close_agent`, `resume_agent`, or `fork_context` semantics. Full pagination and
+continuation behavior remains a deferred qualification.
+
+## Common wire lifecycle shape
+
+For both families, the bounded function-call stream shape is:
+
+1. `response.output_item.added`
+2. `response.function_call_arguments.delta`
+3. `response.function_call_arguments.done`
+4. `response.output_item.done`
+
+The terminal set is `response.completed`, `response.incomplete`, and
+`response.failed`; the error event is `response.failed` with `id`, `status`,
+and `error` fields. These stream and terminal/error entries are structural
+markers with `qualification=not_observed`; they do not claim a live run.
+
+## Ownership and adapter boundary
+
+The Codex client owns execution for both V1 and V2 (`owner=codex_client`,
+`executor=codex_client`). The Gateway is not an executor, scheduler, result
+forger, or V2-to-V1 downgrade path.
+
+The JSON records requirements only for follow-up issues #198 and #58:
+
+- map a namespace child to an injective, request-scoped function alias;
+- preserve `task_path` and all call/result/history links;
+- assemble streamed arguments before validation;
+- reject unknown or ambiguous boundaries; and
+- keep V1 and V2 repair paths isolated.
+
+No adapter, route, catalog, model-selection, scheduling, or tool-execution
+implementation is included in this issue.
+
+## Deferred qualification
+
+The inventory deliberately does not qualify the complete
+`spawn → message/follow-up → wait → interrupt → list` lifecycle. Restart and
+cold-root resume, cross-Home topology/history, and full V2 pagination are also
+deferred to the Collaboration V2/Beta4 phase (`#284`, with topology/history
+work in `#197`). Those controls require separately authorized evidence; this
+artifact must not be read as a release, capability unlock, or issue-closure
+claim.

--- a/docs/evidence/issue-64/collaboration-v1-v2-inventory.json
+++ b/docs/evidence/issue-64/collaboration-v1-v2-inventory.json
@@ -1,0 +1,455 @@
+{
+  "adapter_requirements": {
+    "adaptation_owner": "codexhub_gateway",
+    "forbidden_gateway_actions": [
+      "execute_tools",
+      "schedule_agents",
+      "forge_results",
+      "downgrade_v2_to_v1"
+    ],
+    "owner": "codex_client",
+    "requirements": [
+      "namespace_to_function",
+      "injective_request_scoped_aliases",
+      "preserve_task_path_identity",
+      "preserve_call_result_history_links",
+      "assemble_stream_before_validation",
+      "reject_unknown_or_ambiguous_boundary",
+      "keep_v1_and_v2_isolated"
+    ],
+    "scope": "requirements_only_for_198_and_58"
+  },
+  "artifact_kind": "collaboration_v1_v2_inventory",
+  "boundary": {
+    "ambiguous_action": "fail_closed",
+    "discriminator_fields": [
+      "namespace",
+      "name"
+    ],
+    "flattened_name_policy": "not_decidable_without_namespace",
+    "mixed_v1_v2_action": "fail_closed",
+    "pre_exposure_stage": "before_tool_exposure_or_semantic_repair",
+    "protocol_markers": {
+      "collaboration_v1": {
+        "namespace": "multi_agent_v1",
+        "tool_names": [
+          "spawn_agent",
+          "send_input",
+          "wait_agent",
+          "close_agent",
+          "resume_agent"
+        ]
+      },
+      "collaboration_v2": {
+        "namespace": "collaboration",
+        "tool_names": [
+          "spawn_agent",
+          "send_message",
+          "followup_task",
+          "wait_agent",
+          "interrupt_agent",
+          "list_agents"
+        ]
+      }
+    },
+    "unknown_action": "fail_closed"
+  },
+  "candidate_identity": {
+    "cli_version": "0.146.0",
+    "source_capture_status": "not_observed",
+    "source_commit": "e363b08c9175ac1cbe5893615dd2cb9ddf95043b",
+    "source_commit_status": "published_attested",
+    "source_contract_file": "codex-0.146-source-contract.json",
+    "source_tag": "rust-v0.146.0"
+  },
+  "deferred_qualification": [
+    "full_spawn_message_followup_wait_interrupt_list_lifecycle",
+    "restart_and_cold_root_resume",
+    "cross_home_topology_and_history"
+  ],
+  "evidence_binding": {
+    "basis": "accepted_issue_62_source_contract_and_repository_evidence",
+    "source_contract": {
+      "file": "codex-0.146-source-contract.json",
+      "sha256": "a23365c255e5230604241800170ca1d0a283650f7a89c540f92f9ce68512727e"
+    }
+  },
+  "protocols": [
+    {
+      "call": {
+        "argument_fields": {
+          "close_agent": {
+            "optional": [],
+            "required": [
+              "target"
+            ]
+          },
+          "resume_agent": {
+            "optional": [],
+            "required": [
+              "target",
+              "message"
+            ]
+          },
+          "send_input": {
+            "optional": [
+              "interrupt"
+            ],
+            "required": [
+              "target",
+              "message"
+            ]
+          },
+          "spawn_agent": {
+            "optional": [
+              "agent_type",
+              "model",
+              "reasoning",
+              "nickname",
+              "fork_context"
+            ],
+            "required": [
+              "message"
+            ]
+          },
+          "wait_agent": {
+            "optional": [
+              "timeout_ms"
+            ],
+            "required": [
+              "targets"
+            ]
+          }
+        },
+        "fields": [
+          "type",
+          "namespace",
+          "name",
+          "item_id",
+          "call_id",
+          "arguments"
+        ],
+        "identity_fields": [
+          "call_id",
+          "item_id"
+        ],
+        "wire_type": "function_call"
+      },
+      "declaration": {
+        "discriminator": {
+          "namespace": "multi_agent_v1",
+          "tool_field": "name"
+        },
+        "fields": [
+          "type",
+          "name",
+          "parameters"
+        ],
+        "flattened_name_prefixes": [
+          "multi_agent_v1__",
+          "multi_agent_v1."
+        ],
+        "tool_names": [
+          "spawn_agent",
+          "send_input",
+          "wait_agent",
+          "close_agent",
+          "resume_agent"
+        ],
+        "wire_type": "function"
+      },
+      "executor": "codex_client",
+      "history": {
+        "continuation_identity": "agent_id",
+        "identity_fields": [
+          "agent_id",
+          "call_id",
+          "call_item_id",
+          "output_item_id"
+        ],
+        "items": [
+          "function_call",
+          "function_call_output"
+        ],
+        "transcript_markers": [
+          "Previous real Codex native multi_agent_v1.<tool> call transcript",
+          "Codex native multi_agent_v1.<tool> result"
+        ]
+      },
+      "id": "collaboration_v1",
+      "isolation": {
+        "forbidden_v2_fields": [
+          "continuation_id",
+          "fork_turns",
+          "task_name",
+          "task_path"
+        ],
+        "forbidden_v2_semantics": [
+          "task_path_continuation",
+          "fork_turns"
+        ],
+        "forbidden_v2_tools": [
+          "followup_task",
+          "interrupt_agent",
+          "list_agents",
+          "send_message"
+        ]
+      },
+      "namespace": "multi_agent_v1",
+      "owner": "codex_client",
+      "result": {
+        "fields": [
+          "type",
+          "call_id",
+          "item_id",
+          "output"
+        ],
+        "identity_fields": [
+          "call_id",
+          "item_id"
+        ],
+        "result_fields_by_tool": {
+          "close_agent": [
+            "previous_status"
+          ],
+          "resume_agent": [
+            "status"
+          ],
+          "send_input": [
+            "status"
+          ],
+          "spawn_agent": [
+            "agent_id",
+            "nickname"
+          ],
+          "wait_agent": [
+            "timed_out",
+            "status"
+          ]
+        },
+        "result_identity": "agent_id",
+        "wire_type": "function_call_output"
+      },
+      "status": "legacy_structural_contract",
+      "stream": {
+        "error_event": "response.failed",
+        "event_order": [
+          "response.output_item.added",
+          "response.function_call_arguments.delta",
+          "response.function_call_arguments.done",
+          "response.output_item.done"
+        ],
+        "qualification": "not_observed",
+        "terminal_events": [
+          "response.completed",
+          "response.incomplete",
+          "response.failed"
+        ]
+      },
+      "terminal_error": {
+        "error_event": "response.failed",
+        "error_fields": [
+          "id",
+          "status",
+          "error"
+        ],
+        "qualification": "not_observed",
+        "terminal_events": [
+          "response.completed",
+          "response.incomplete",
+          "response.failed"
+        ]
+      }
+    },
+    {
+      "call": {
+        "argument_fields": {
+          "followup_task": {
+            "optional": [],
+            "required": [
+              "target",
+              "message"
+            ]
+          },
+          "interrupt_agent": {
+            "optional": [],
+            "required": [
+              "target"
+            ]
+          },
+          "list_agents": {
+            "optional": [
+              "path_prefix"
+            ],
+            "required": []
+          },
+          "send_message": {
+            "optional": [],
+            "required": [
+              "target",
+              "message"
+            ]
+          },
+          "spawn_agent": {
+            "optional": [
+              "fork_turns",
+              "agent_type",
+              "model",
+              "reasoning_effort"
+            ],
+            "required": [
+              "task_name",
+              "message"
+            ]
+          },
+          "wait_agent": {
+            "optional": [
+              "timeout_ms"
+            ],
+            "required": []
+          }
+        },
+        "fields": [
+          "type",
+          "namespace",
+          "name",
+          "item_id",
+          "call_id",
+          "arguments"
+        ],
+        "fork_turns": {
+          "field": "fork_turns",
+          "values": [
+            "all",
+            "none",
+            "positive_decimal_string"
+          ]
+        },
+        "identity_fields": [
+          "call_id",
+          "item_id",
+          "task_path",
+          "continuation_id"
+        ],
+        "wire_type": "function_call"
+      },
+      "declaration": {
+        "child_wire_type": "function",
+        "discriminator": {
+          "namespace": "collaboration",
+          "tool_field": "name"
+        },
+        "fields": [
+          "type",
+          "name",
+          "tools"
+        ],
+        "tool_names": [
+          "spawn_agent",
+          "send_message",
+          "followup_task",
+          "wait_agent",
+          "interrupt_agent",
+          "list_agents"
+        ],
+        "wire_type": "namespace"
+      },
+      "executor": "codex_client",
+      "history": {
+        "continuation_fields": [
+          "task_path",
+          "continuation_id",
+          "task_name",
+          "fork_turns"
+        ],
+        "continuation_identity": "task_path",
+        "identity_fields": [
+          "task_path",
+          "continuation_id",
+          "call_id",
+          "call_item_id",
+          "output_item_id"
+        ],
+        "inherited_prefix": "deferred_qualification",
+        "items": [
+          "function_call",
+          "function_call_output"
+        ],
+        "pagination": "deferred_qualification"
+      },
+      "id": "collaboration_v2",
+      "isolation": {
+        "forbidden_v1_fields": [
+          "agent_id",
+          "fork_context"
+        ],
+        "forbidden_v1_semantics": [
+          "agent_id_close_resume",
+          "fork_context"
+        ],
+        "forbidden_v1_tools": [
+          "close_agent",
+          "resume_agent",
+          "send_input"
+        ]
+      },
+      "namespace": "collaboration",
+      "owner": "codex_client",
+      "result": {
+        "fields": [
+          "type",
+          "call_id",
+          "item_id",
+          "output"
+        ],
+        "identity_fields": [
+          "call_id",
+          "item_id",
+          "task_path",
+          "continuation_id"
+        ],
+        "result_fields": [
+          "task_path",
+          "continuation_id",
+          "status"
+        ],
+        "result_identity": "task_path",
+        "wire_type": "function_call_output"
+      },
+      "status": "stable_surface_not_lifecycle_qualified",
+      "stream": {
+        "call_semantics": "namespace_child_function_uses_function_call_lifecycle",
+        "error_event": "response.failed",
+        "event_order": [
+          "response.output_item.added",
+          "response.function_call_arguments.delta",
+          "response.function_call_arguments.done",
+          "response.output_item.done"
+        ],
+        "qualification": "not_observed",
+        "terminal_events": [
+          "response.completed",
+          "response.incomplete",
+          "response.failed"
+        ]
+      },
+      "terminal_error": {
+        "error_event": "response.failed",
+        "error_fields": [
+          "id",
+          "status",
+          "error"
+        ],
+        "qualification": "not_observed",
+        "terminal_events": [
+          "response.completed",
+          "response.incomplete",
+          "response.failed"
+        ]
+      }
+    }
+  ],
+  "qualification_status": "structural_boundary_only",
+  "schema": "codexhub.issue64.collaboration-v1-v2.v1",
+  "verification_scope": "structural_contract_only"
+}

--- a/docs/evidence/issue-64/collaboration-v1-v2-inventory.json
+++ b/docs/evidence/issue-64/collaboration-v1-v2-inventory.json
@@ -8,11 +8,34 @@
       "downgrade_v2_to_v1"
     ],
     "owner": "codex_client",
+    "protocol_shape_decisions": {
+      "collaboration_v1": {
+        "inverse_mapping": "request_scoped_and_lossless",
+        "namespace_to_function": "required_when_selected_protocol_lacks_namespace",
+        "official_cli_capture_status": "not_observed",
+        "shape_kind": "current_gateway_compatibility_surface"
+      },
+      "collaboration_v2": {
+        "inverse_mapping": "request_scoped_and_lossless",
+        "namespace_to_function": "optional_only_when_selected_protocol_lacks_namespace",
+        "native_namespace": "may_pass_when_selected_protocol_supports_namespace",
+        "official_cli_capture_status": "not_observed",
+        "preserved_fields": [
+          "task_path",
+          "continuation_id",
+          "task_name",
+          "fork_turns"
+        ],
+        "shape_kind": "accepted_structural_contract"
+      }
+    },
     "requirements": [
       "namespace_to_function",
       "injective_request_scoped_aliases",
       "preserve_task_path_identity",
+      "preserve_continuation_id_and_fork_turns",
       "preserve_call_result_history_links",
+      "preserve_inverse_declaration_call_result_history_mapping",
       "assemble_stream_before_validation",
       "reject_unknown_or_ambiguous_boundary",
       "keep_v1_and_v2_isolated"
@@ -71,7 +94,7 @@
     "basis": "accepted_issue_62_source_contract_and_repository_evidence",
     "source_contract": {
       "file": "codex-0.146-source-contract.json",
-      "sha256": "a23365c255e5230604241800170ca1d0a283650f7a89c540f92f9ce68512727e"
+      "sha256": "6f38b8b07b98c6f28edd7418b63449242ee41d6396694392a70c0d7fb2b70f2c"
     }
   },
   "protocols": [
@@ -87,29 +110,25 @@
           "resume_agent": {
             "optional": [],
             "required": [
-              "target",
-              "message"
+              "id"
             ]
           },
           "send_input": {
             "optional": [
-              "interrupt"
+              "interrupt",
+              "message"
             ],
             "required": [
-              "target",
-              "message"
+              "target"
             ]
           },
           "spawn_agent": {
             "optional": [
-              "agent_type",
-              "model",
-              "reasoning",
-              "nickname",
-              "fork_context"
+              "fork_context",
+              "message"
             ],
             "required": [
-              "message"
+              "agent_type"
             ]
           },
           "wait_agent": {
@@ -136,6 +155,7 @@
         "wire_type": "function_call"
       },
       "declaration": {
+        "child_wire_type": "function",
         "discriminator": {
           "namespace": "multi_agent_v1",
           "tool_field": "name"
@@ -143,7 +163,7 @@
         "fields": [
           "type",
           "name",
-          "parameters"
+          "tools"
         ],
         "flattened_name_prefixes": [
           "multi_agent_v1__",
@@ -156,7 +176,7 @@
           "close_agent",
           "resume_agent"
         ],
-        "wire_type": "function"
+        "wire_type": "namespace"
       },
       "executor": "codex_client",
       "history": {
@@ -229,6 +249,11 @@
         },
         "result_identity": "agent_id",
         "wire_type": "function_call_output"
+      },
+      "shape_provenance": {
+        "official_cli_capture_status": "not_observed",
+        "shape_kind": "current_gateway_compatibility_surface",
+        "source": "src-python/codex_proxy.py#MULTI_AGENT_DISCOVERY_TOOLS"
       },
       "status": "legacy_structural_contract",
       "stream": {
@@ -415,6 +440,11 @@
         ],
         "result_identity": "task_path",
         "wire_type": "function_call_output"
+      },
+      "shape_provenance": {
+        "official_cli_capture_status": "not_observed",
+        "shape_kind": "accepted_structural_contract",
+        "source": "accepted_issue_62_source_contract_and_repository_evidence"
       },
       "status": "stable_surface_not_lifecycle_qualified",
       "stream": {

--- a/scripts/build_issue_64_collaboration_inventory.py
+++ b/scripts/build_issue_64_collaboration_inventory.py
@@ -579,8 +579,13 @@ def validate_inventory(payload: Mapping[str, Any], source_contract_path: Path) -
         },
         "boundary_fields_invalid",
     )
+    _require(
+        boundary["pre_exposure_stage"] == "before_tool_exposure_or_semantic_repair",
+        "boundary_pre_exposure_stage_invalid",
+    )
     _require(boundary["discriminator_fields"] == ["namespace", "name"], "boundary_discriminator_fields_invalid")
     _require(boundary["unknown_action"] == "fail_closed" and boundary["ambiguous_action"] == "fail_closed", "boundary_fail_closed_invalid")
+    _require(boundary["mixed_v1_v2_action"] == "fail_closed", "boundary_mixed_action_invalid")
     markers = _exact(boundary["protocol_markers"], {V1_ID, V2_ID}, "boundary_markers_invalid")
     _require(markers[V1_ID] == {"namespace": V1_NAMESPACE, "tool_names": list(V1_TOOLS)}, "boundary_v1_marker_invalid")
     _require(markers[V2_ID] == {"namespace": V2_NAMESPACE, "tool_names": list(V2_TOOLS)}, "boundary_v2_marker_invalid")

--- a/scripts/build_issue_64_collaboration_inventory.py
+++ b/scripts/build_issue_64_collaboration_inventory.py
@@ -1,0 +1,515 @@
+#!/usr/bin/env python3
+"""Build and reconcile the bounded Issue #64 Collaboration V1/V2 contract.
+
+This is a structural inventory only.  It binds the accepted Codex CLI 0.146
+source contract, records the pre-exposure discriminator and the two small
+schema families, and states the namespace adapter requirements needed by #198
+and #58.  It does not inspect a live client, execute tools, schedule agents,
+or implement a protocol adapter.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+
+SCHEMA = "codexhub.issue64.collaboration-v1-v2.v1"
+ARTIFACT_KIND = "collaboration_v1_v2_inventory"
+DEFAULT_SOURCE_CONTRACT = Path("docs/evidence/issue-62/codex-0.146-source-contract.json")
+DEFAULT_OUTPUT = Path("docs/evidence/issue-64/collaboration-v1-v2-inventory.json")
+
+V1_ID = "collaboration_v1"
+V2_ID = "collaboration_v2"
+V1_NAMESPACE = "multi_agent_v1"
+V2_NAMESPACE = "collaboration"
+V1_TOOLS = ("spawn_agent", "send_input", "wait_agent", "close_agent", "resume_agent")
+V2_TOOLS = (
+    "spawn_agent",
+    "send_message",
+    "followup_task",
+    "wait_agent",
+    "interrupt_agent",
+    "list_agents",
+)
+V1_ONLY_FIELDS = frozenset({"agent_id", "fork_context"})
+V2_ONLY_FIELDS = frozenset({"task_name", "task_path", "fork_turns", "continuation_id"})
+V1_ONLY_TOOLS = frozenset({"send_input", "close_agent", "resume_agent"})
+V2_ONLY_TOOLS = frozenset({"send_message", "followup_task", "interrupt_agent", "list_agents"})
+DEFERRED_QUALIFICATION = [
+    "full_spawn_message_followup_wait_interrupt_list_lifecycle",
+    "restart_and_cold_root_resume",
+    "cross_home_topology_and_history",
+]
+
+
+class InventoryValidationError(ValueError):
+    """A deliberately bounded, non-sensitive contract failure."""
+
+
+def _require(condition: bool, code: str) -> None:
+    if not condition:
+        raise InventoryValidationError(code)
+
+
+def _exact(value: Any, fields: set[str], code: str) -> Mapping[str, Any]:
+    _require(isinstance(value, Mapping), code)
+    _require(set(value) == fields, code)
+    return value
+
+
+def _sha256_file(path: Path) -> str:
+    try:
+        digest = hashlib.sha256()
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+        return digest.hexdigest()
+    except OSError as error:
+        raise InventoryValidationError("source_contract_unavailable") from error
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise InventoryValidationError("source_contract_invalid") from error
+    _require(isinstance(value, dict), "source_contract_root_invalid")
+    return value
+
+
+def _validate_source_contract(source_contract: Mapping[str, Any]) -> None:
+    _require(source_contract.get("fixture_kind") == "codex_cli_source_contract", "source_contract_kind_invalid")
+    _require(source_contract.get("capture_status") == "not_observed", "source_contract_capture_status_invalid")
+    provenance = source_contract.get("provenance")
+    _require(isinstance(provenance, Mapping), "source_contract_provenance_invalid")
+    _require(provenance.get("cli_version") == "0.146.0", "source_contract_cli_version_invalid")
+    _require(provenance.get("source_commit") == "e363b08c9175ac1cbe5893615dd2cb9ddf95043b", "source_contract_commit_invalid")
+    _require(provenance.get("cli_source_tag") == "rust-v0.146.0", "source_contract_tag_invalid")
+    _require(provenance.get("cli_source_commit_status") == "published_attested", "source_contract_commit_status_invalid")
+    surface = source_contract.get("runtime_wire_surface")
+    _require(isinstance(surface, Mapping), "source_contract_surface_invalid")
+    families = surface.get("declaration_family_order")
+    _require(isinstance(families, list) and "namespace" in families, "source_contract_namespace_family_missing")
+
+
+def _boundary_arguments(value: Mapping[str, Any]) -> Mapping[str, Any]:
+    arguments = value.get("arguments")
+    return arguments if isinstance(arguments, Mapping) else {}
+
+
+def classify_boundary(value: Mapping[str, Any]) -> str:
+    """Classify a declaration/call before exposure or semantic repair.
+
+    The namespace and child tool name are both required.  A bare or flattened
+    name is intentionally not enough to choose a repair path.
+    """
+
+    _require(isinstance(value, Mapping), "boundary_input_invalid")
+    namespace = value.get("namespace")
+    name = value.get("name", value.get("tool_name"))
+    _require(isinstance(namespace, str) and namespace, "boundary_discriminator_missing")
+    _require(isinstance(name, str) and name, "boundary_discriminator_missing")
+    arguments = _boundary_arguments(value)
+    fields = set(arguments)
+    if namespace == V1_NAMESPACE:
+        if fields & V2_ONLY_FIELDS or name in V2_ONLY_TOOLS:
+            raise InventoryValidationError("boundary_v1_v2_field_mixed")
+        if name not in V1_TOOLS:
+            raise InventoryValidationError("boundary_tool_unknown")
+        return V1_ID
+    if namespace == V2_NAMESPACE:
+        if fields & V1_ONLY_FIELDS or name in V1_ONLY_TOOLS:
+            raise InventoryValidationError("boundary_v1_v2_field_mixed")
+        if name not in V2_TOOLS:
+            raise InventoryValidationError("boundary_tool_unknown")
+        return V2_ID
+    raise InventoryValidationError("boundary_namespace_unknown")
+
+
+def _stream_shape() -> dict[str, Any]:
+    return {
+        "event_order": [
+            "response.output_item.added",
+            "response.function_call_arguments.delta",
+            "response.function_call_arguments.done",
+            "response.output_item.done",
+        ],
+        "terminal_events": ["response.completed", "response.incomplete", "response.failed"],
+        "error_event": "response.failed",
+        "qualification": "not_observed",
+    }
+
+
+def _protocol_v1() -> dict[str, Any]:
+    return {
+        "id": V1_ID,
+        "namespace": V1_NAMESPACE,
+        "owner": "codex_client",
+        "executor": "codex_client",
+        "status": "legacy_structural_contract",
+        "declaration": {
+            "discriminator": {"namespace": V1_NAMESPACE, "tool_field": "name"},
+            "wire_type": "function",
+            "fields": ["type", "name", "parameters"],
+            "tool_names": list(V1_TOOLS),
+            "flattened_name_prefixes": ["multi_agent_v1__", "multi_agent_v1."],
+        },
+        "call": {
+            "wire_type": "function_call",
+            "fields": ["type", "namespace", "name", "item_id", "call_id", "arguments"],
+            "identity_fields": ["call_id", "item_id"],
+            "argument_fields": {
+                "spawn_agent": {"required": ["message"], "optional": ["agent_type", "model", "reasoning", "nickname", "fork_context"]},
+                "send_input": {"required": ["target", "message"], "optional": ["interrupt"]},
+                "wait_agent": {"required": ["targets"], "optional": ["timeout_ms"]},
+                "close_agent": {"required": ["target"], "optional": []},
+                "resume_agent": {"required": ["target", "message"], "optional": []},
+            },
+        },
+        "result": {
+            "wire_type": "function_call_output",
+            "fields": ["type", "call_id", "item_id", "output"],
+            "identity_fields": ["call_id", "item_id"],
+            "result_identity": "agent_id",
+            "result_fields_by_tool": {
+                "spawn_agent": ["agent_id", "nickname"],
+                "wait_agent": ["timed_out", "status"],
+                "close_agent": ["previous_status"],
+                "send_input": ["status"],
+                "resume_agent": ["status"],
+            },
+        },
+        "history": {
+            "items": ["function_call", "function_call_output"],
+            "identity_fields": ["agent_id", "call_id", "call_item_id", "output_item_id"],
+            "continuation_identity": "agent_id",
+            "transcript_markers": [
+                "Previous real Codex native multi_agent_v1.<tool> call transcript",
+                "Codex native multi_agent_v1.<tool> result",
+            ],
+        },
+        "stream": _stream_shape(),
+        "terminal_error": {
+            "terminal_events": ["response.completed", "response.incomplete", "response.failed"],
+            "error_event": "response.failed",
+            "error_fields": ["id", "status", "error"],
+            "qualification": "not_observed",
+        },
+        "isolation": {
+            "forbidden_v2_fields": sorted(V2_ONLY_FIELDS),
+            "forbidden_v2_tools": sorted(V2_ONLY_TOOLS),
+            "forbidden_v2_semantics": ["task_path_continuation", "fork_turns"],
+        },
+    }
+
+
+def _protocol_v2() -> dict[str, Any]:
+    return {
+        "id": V2_ID,
+        "namespace": V2_NAMESPACE,
+        "owner": "codex_client",
+        "executor": "codex_client",
+        "status": "stable_surface_not_lifecycle_qualified",
+        "declaration": {
+            "discriminator": {"namespace": V2_NAMESPACE, "tool_field": "name"},
+            "wire_type": "namespace",
+            "fields": ["type", "name", "tools"],
+            "child_wire_type": "function",
+            "tool_names": list(V2_TOOLS),
+        },
+        "call": {
+            "wire_type": "function_call",
+            "fields": ["type", "namespace", "name", "item_id", "call_id", "arguments"],
+            "identity_fields": ["call_id", "item_id", "task_path", "continuation_id"],
+            "argument_fields": {
+                "spawn_agent": {"required": ["task_name", "message"], "optional": ["fork_turns", "agent_type", "model", "reasoning_effort"]},
+                "send_message": {"required": ["target", "message"], "optional": []},
+                "followup_task": {"required": ["target", "message"], "optional": []},
+                "wait_agent": {"required": [], "optional": ["timeout_ms"]},
+                "interrupt_agent": {"required": ["target"], "optional": []},
+                "list_agents": {"required": [], "optional": ["path_prefix"]},
+            },
+            "fork_turns": {"field": "fork_turns", "values": ["all", "none", "positive_decimal_string"]},
+        },
+        "result": {
+            "wire_type": "function_call_output",
+            "fields": ["type", "call_id", "item_id", "output"],
+            "identity_fields": ["call_id", "item_id", "task_path", "continuation_id"],
+            "result_identity": "task_path",
+            "result_fields": ["task_path", "continuation_id", "status"],
+        },
+        "history": {
+            "items": ["function_call", "function_call_output"],
+            "identity_fields": ["task_path", "continuation_id", "call_id", "call_item_id", "output_item_id"],
+            "continuation_identity": "task_path",
+            "continuation_fields": ["task_path", "continuation_id", "task_name", "fork_turns"],
+            "pagination": "deferred_qualification",
+            "inherited_prefix": "deferred_qualification",
+        },
+        "stream": {
+            **_stream_shape(),
+            "call_semantics": "namespace_child_function_uses_function_call_lifecycle",
+        },
+        "terminal_error": {
+            "terminal_events": ["response.completed", "response.incomplete", "response.failed"],
+            "error_event": "response.failed",
+            "error_fields": ["id", "status", "error"],
+            "qualification": "not_observed",
+        },
+        "isolation": {
+            "forbidden_v1_fields": sorted(V1_ONLY_FIELDS),
+            "forbidden_v1_tools": sorted(V1_ONLY_TOOLS),
+            "forbidden_v1_semantics": ["agent_id_close_resume", "fork_context"],
+        },
+    }
+
+
+def _build_inventory(source_contract_path: Path) -> dict[str, Any]:
+    source_contract = _load_json(source_contract_path)
+    _validate_source_contract(source_contract)
+    return {
+        "schema": SCHEMA,
+        "artifact_kind": ARTIFACT_KIND,
+        "verification_scope": "structural_contract_only",
+        "qualification_status": "structural_boundary_only",
+        "candidate_identity": {
+            "cli_version": "0.146.0",
+            "source_commit": "e363b08c9175ac1cbe5893615dd2cb9ddf95043b",
+            "source_tag": "rust-v0.146.0",
+            "source_commit_status": "published_attested",
+            "source_capture_status": "not_observed",
+            "source_contract_file": source_contract_path.name,
+        },
+        "evidence_binding": {
+            "source_contract": {"file": source_contract_path.name, "sha256": _sha256_file(source_contract_path)},
+            "basis": "accepted_issue_62_source_contract_and_repository_evidence",
+        },
+        "boundary": {
+            "pre_exposure_stage": "before_tool_exposure_or_semantic_repair",
+            "discriminator_fields": ["namespace", "name"],
+            "protocol_markers": {
+                V1_ID: {"namespace": V1_NAMESPACE, "tool_names": list(V1_TOOLS)},
+                V2_ID: {"namespace": V2_NAMESPACE, "tool_names": list(V2_TOOLS)},
+            },
+            "flattened_name_policy": "not_decidable_without_namespace",
+            "unknown_action": "fail_closed",
+            "ambiguous_action": "fail_closed",
+            "mixed_v1_v2_action": "fail_closed",
+        },
+        "protocols": [_protocol_v1(), _protocol_v2()],
+        "adapter_requirements": {
+            "owner": "codex_client",
+            "adaptation_owner": "codexhub_gateway",
+            "requirements": [
+                "namespace_to_function",
+                "injective_request_scoped_aliases",
+                "preserve_task_path_identity",
+                "preserve_call_result_history_links",
+                "assemble_stream_before_validation",
+                "reject_unknown_or_ambiguous_boundary",
+                "keep_v1_and_v2_isolated",
+            ],
+            "forbidden_gateway_actions": ["execute_tools", "schedule_agents", "forge_results", "downgrade_v2_to_v1"],
+            "scope": "requirements_only_for_198_and_58",
+        },
+        "deferred_qualification": list(DEFERRED_QUALIFICATION),
+    }
+
+
+def _validate_protocol(protocol: Any, expected_id: str, expected_namespace: str) -> None:
+    expected_fields = {
+        "id",
+        "namespace",
+        "owner",
+        "executor",
+        "status",
+        "declaration",
+        "call",
+        "result",
+        "history",
+        "stream",
+        "terminal_error",
+        "isolation",
+    }
+    _exact(protocol, expected_fields, "protocol_fields_invalid")
+    _require(protocol["id"] == expected_id and protocol["namespace"] == expected_namespace, "protocol_identity_invalid")
+    _require(protocol["owner"] == "codex_client" and protocol["executor"] == "codex_client", "protocol_owner_invalid")
+    declaration = protocol["declaration"]
+    _require(isinstance(declaration, Mapping), "declaration_invalid")
+    _require(isinstance(declaration.get("fields"), list) and declaration["fields"], "declaration_fields_invalid")
+    tools = declaration.get("tool_names")
+    expected_tools = V1_TOOLS if expected_id == V1_ID else V2_TOOLS
+    _require(tools == list(expected_tools), "declaration_tool_names_invalid")
+    for key in ("call", "result", "history"):
+        section = protocol[key]
+        _require(isinstance(section, Mapping), f"{key}_invalid")
+        _require(isinstance(section.get("fields", section.get("identity_fields")), list), f"{key}_fields_invalid")
+    stream = protocol["stream"]
+    _require(isinstance(stream, Mapping) and stream.get("event_order") == _stream_shape()["event_order"], "stream_shape_invalid")
+    terminal_error = protocol["terminal_error"]
+    _require(isinstance(terminal_error, Mapping), "terminal_error_invalid")
+    _require(terminal_error.get("error_event") == "response.failed", "terminal_error_event_invalid")
+    _require(terminal_error.get("terminal_events") == ["response.completed", "response.incomplete", "response.failed"], "terminal_events_invalid")
+    isolation = protocol["isolation"]
+    _require(isinstance(isolation, Mapping), "isolation_invalid")
+    if expected_id == V1_ID:
+        _require(isolation.get("forbidden_v2_fields") == sorted(V2_ONLY_FIELDS), "v1_isolation_invalid")
+        _require(isolation.get("forbidden_v2_tools") == sorted(V2_ONLY_TOOLS), "v1_isolation_invalid")
+    else:
+        _require(isolation.get("forbidden_v1_fields") == sorted(V1_ONLY_FIELDS), "v2_isolation_invalid")
+        _require(isolation.get("forbidden_v1_tools") == sorted(V1_ONLY_TOOLS), "v2_isolation_invalid")
+
+
+def validate_inventory(payload: Mapping[str, Any], source_contract_path: Path) -> None:
+    _exact(
+        payload,
+        {
+            "schema",
+            "artifact_kind",
+            "verification_scope",
+            "qualification_status",
+            "candidate_identity",
+            "evidence_binding",
+            "boundary",
+            "protocols",
+            "adapter_requirements",
+            "deferred_qualification",
+        },
+        "inventory_fields_invalid",
+    )
+    _require(payload["schema"] == SCHEMA, "inventory_schema_invalid")
+    _require(payload["artifact_kind"] == ARTIFACT_KIND, "inventory_kind_invalid")
+    _require(payload["verification_scope"] == "structural_contract_only", "inventory_scope_invalid")
+    _require(payload["qualification_status"] == "structural_boundary_only", "inventory_qualification_invalid")
+    _validate_source_contract(_load_json(source_contract_path))
+
+    candidate = _exact(
+        payload["candidate_identity"],
+        {
+            "cli_version",
+            "source_commit",
+            "source_tag",
+            "source_commit_status",
+            "source_capture_status",
+            "source_contract_file",
+        },
+        "candidate_fields_invalid",
+    )
+    _require(
+        dict(candidate)
+        == {
+            "cli_version": "0.146.0",
+            "source_commit": "e363b08c9175ac1cbe5893615dd2cb9ddf95043b",
+            "source_tag": "rust-v0.146.0",
+            "source_commit_status": "published_attested",
+            "source_capture_status": "not_observed",
+            "source_contract_file": source_contract_path.name,
+        },
+        "candidate_identity_invalid",
+    )
+    binding = _exact(payload["evidence_binding"], {"source_contract", "basis"}, "evidence_binding_invalid")
+    source_binding = _exact(binding["source_contract"], {"file", "sha256"}, "evidence_binding_source_invalid")
+    _require(source_binding["file"] == source_contract_path.name, "evidence_binding_source_file_invalid")
+    _require(source_binding["sha256"] == _sha256_file(source_contract_path), "evidence_binding_source_digest_invalid")
+    _require(binding["basis"] == "accepted_issue_62_source_contract_and_repository_evidence", "evidence_binding_basis_invalid")
+
+    boundary = _exact(
+        payload["boundary"],
+        {
+            "pre_exposure_stage",
+            "discriminator_fields",
+            "protocol_markers",
+            "flattened_name_policy",
+            "unknown_action",
+            "ambiguous_action",
+            "mixed_v1_v2_action",
+        },
+        "boundary_fields_invalid",
+    )
+    _require(boundary["discriminator_fields"] == ["namespace", "name"], "boundary_discriminator_fields_invalid")
+    _require(boundary["unknown_action"] == "fail_closed" and boundary["ambiguous_action"] == "fail_closed", "boundary_fail_closed_invalid")
+    markers = _exact(boundary["protocol_markers"], {V1_ID, V2_ID}, "boundary_markers_invalid")
+    _require(markers[V1_ID] == {"namespace": V1_NAMESPACE, "tool_names": list(V1_TOOLS)}, "boundary_v1_marker_invalid")
+    _require(markers[V2_ID] == {"namespace": V2_NAMESPACE, "tool_names": list(V2_TOOLS)}, "boundary_v2_marker_invalid")
+    _require(boundary["flattened_name_policy"] == "not_decidable_without_namespace", "boundary_flattened_policy_invalid")
+
+    protocols = payload["protocols"]
+    _require(isinstance(protocols, list) and len(protocols) == 2, "protocols_invalid")
+    _validate_protocol(protocols[0], V1_ID, V1_NAMESPACE)
+    _validate_protocol(protocols[1], V2_ID, V2_NAMESPACE)
+    _require(classify_boundary({"namespace": V1_NAMESPACE, "name": "spawn_agent"}) == V1_ID, "boundary_v1_not_decidable")
+    _require(classify_boundary({"namespace": V2_NAMESPACE, "name": "spawn_agent"}) == V2_ID, "boundary_v2_not_decidable")
+
+    adapter = _exact(payload["adapter_requirements"], {"owner", "adaptation_owner", "requirements", "forbidden_gateway_actions", "scope"}, "adapter_requirements_invalid")
+    _require(adapter["owner"] == "codex_client" and adapter["adaptation_owner"] == "codexhub_gateway", "adapter_owner_invalid")
+    _require(adapter["scope"] == "requirements_only_for_198_and_58", "adapter_scope_invalid")
+    _require(isinstance(adapter["requirements"], list) and "namespace_to_function" in adapter["requirements"], "adapter_requirements_list_invalid")
+    _require(
+        adapter["forbidden_gateway_actions"] == ["execute_tools", "schedule_agents", "forge_results", "downgrade_v2_to_v1"],
+        "adapter_forbidden_actions_invalid",
+    )
+    _require(payload["deferred_qualification"] == DEFERRED_QUALIFICATION, "deferred_qualification_invalid")
+
+
+def reconcile_inventory(payload: Mapping[str, Any], *, source_contract_path: Path) -> dict[str, Any]:
+    mismatches: list[str] = []
+    try:
+        validate_inventory(payload, source_contract_path)
+    except InventoryValidationError as error:
+        mismatches.append(str(error))
+    return {"reconciled": not mismatches, "mismatches": mismatches}
+
+
+def replay_inventory(payload: Mapping[str, Any], case: str) -> dict[str, Any]:
+    _require(case in {"mutation", "deletion", "loss"}, "replay_case_invalid")
+    clone = copy.deepcopy(dict(payload))
+    if case == "mutation":
+        clone["protocols"][1]["namespace"] = V1_NAMESPACE
+    elif case == "deletion":
+        clone["protocols"] = clone["protocols"][:1]
+    else:
+        clone["candidate_identity"].pop("source_commit", None)
+    return clone
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source-contract", type=Path, default=DEFAULT_SOURCE_CONTRACT)
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument("--check", action="store_true")
+    parser.add_argument("--replay-case", choices=("identity", "mutation", "deletion", "loss"), default="identity")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        inventory = _build_inventory(args.source_contract)
+        validate_inventory(inventory, args.source_contract)
+        if args.replay_case != "identity":
+            report = reconcile_inventory(replay_inventory(inventory, args.replay_case), source_contract_path=args.source_contract)
+            print(json.dumps(report, sort_keys=True))
+            return 0 if not report["reconciled"] else 1
+        if args.check:
+            existing = _load_json(args.out)
+            report = reconcile_inventory(existing, source_contract_path=args.source_contract)
+            if not report["reconciled"]:
+                print(json.dumps(report, sort_keys=True))
+                return 1
+            return 0
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(json.dumps(inventory, ensure_ascii=True, indent=2, sort_keys=True) + "\n", encoding="utf-8", newline="\n")
+        print(json.dumps({"schema": SCHEMA, "reconciled": True}, sort_keys=True))
+        return 0
+    except InventoryValidationError as error:
+        print(f"INVENTORY_INVALID:{error}")
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_issue_64_collaboration_inventory.py
+++ b/scripts/build_issue_64_collaboration_inventory.py
@@ -22,6 +22,8 @@ SCHEMA = "codexhub.issue64.collaboration-v1-v2.v1"
 ARTIFACT_KIND = "collaboration_v1_v2_inventory"
 DEFAULT_SOURCE_CONTRACT = Path("docs/evidence/issue-62/codex-0.146-source-contract.json")
 DEFAULT_OUTPUT = Path("docs/evidence/issue-64/collaboration-v1-v2-inventory.json")
+EXPECTED_SOURCE_CONTRACT_SHA256 = "6f38b8b07b98c6f28edd7418b63449242ee41d6396694392a70c0d7fb2b70f2c"
+EXPECTED_SOURCE_RUNTIME_SURFACE_DIGEST = "53ad2ec352b7ad558fefdb265f01d3f28da0f410f022ffdf0cc231a488f5d318"
 
 V1_ID = "collaboration_v1"
 V2_ID = "collaboration_v2"
@@ -40,11 +42,129 @@ V1_ONLY_FIELDS = frozenset({"agent_id", "fork_context"})
 V2_ONLY_FIELDS = frozenset({"task_name", "task_path", "fork_turns", "continuation_id"})
 V1_ONLY_TOOLS = frozenset({"send_input", "close_agent", "resume_agent"})
 V2_ONLY_TOOLS = frozenset({"send_message", "followup_task", "interrupt_agent", "list_agents"})
+BOUNDARY_ARGUMENT_FIELDS = {
+    V1_NAMESPACE: {
+        "spawn_agent": frozenset({"agent_type", "fork_context", "message"}),
+        "send_input": frozenset({"target", "message", "interrupt"}),
+        "wait_agent": frozenset({"targets", "timeout_ms"}),
+        "close_agent": frozenset({"target"}),
+        "resume_agent": frozenset({"id"}),
+    },
+    V2_NAMESPACE: {
+        "spawn_agent": frozenset({"task_name", "message", "fork_turns", "agent_type", "model", "reasoning_effort"}),
+        "send_message": frozenset({"target", "message"}),
+        "followup_task": frozenset({"target", "message"}),
+        "wait_agent": frozenset({"timeout_ms"}),
+        "interrupt_agent": frozenset({"target"}),
+        "list_agents": frozenset({"path_prefix"}),
+    },
+}
+BOUNDARY_INPUT_FIELDS = frozenset({
+    "namespace",
+    "name",
+    "tool_name",
+    "arguments",
+    "type",
+    "item_id",
+    "call_id",
+    "parameters",
+    "tools",
+})
 DEFERRED_QUALIFICATION = [
     "full_spawn_message_followup_wait_interrupt_list_lifecycle",
     "restart_and_cold_root_resume",
     "cross_home_topology_and_history",
 ]
+
+SOURCE_CONTRACT_TOP_LEVEL_FIELDS = {
+    "schema_version",
+    "fixture_kind",
+    "capture_status",
+    "qualification_status",
+    "captured_at",
+    "provenance",
+    "runtime_wire_surface",
+}
+SOURCE_CONTRACT_PROVENANCE = {
+    "cli_version": "0.146.0",
+    "source_commit": "e363b08c9175ac1cbe5893615dd2cb9ddf95043b",
+    "cli_source_tag": "rust-v0.146.0",
+    "cli_source_commit_status": "published_attested",
+    "cli_binary_sha256": "bc343ba420dc2e2e9f59e6fc5e5bf0aae1cd8c771fc319665241fc9c0271fddb",
+    "candidate_revision": "accab8ff6eb4d6ebd93cda84585fb5f6cb89da82",
+}
+SOURCE_DECLARATION_FAMILY_ORDER = [
+    "plain_function",
+    "custom_freeform",
+    "namespace",
+    "client_executed_tool_discovery",
+    "selected_provider_hosted",
+    "unknown_future_kind",
+]
+SOURCE_DECLARATION_FAMILIES = [
+    {
+        "family": "plain_function",
+        "runtime_type": "function",
+        "wire_declaration_type": "function",
+        "observed": False,
+        "observation": "not_observed_source_contract_only",
+        "executor": "codex_client",
+        "loss_boundary": "preserve declaration and inverse call/result/history IDs",
+    },
+    {
+        "family": "custom_freeform",
+        "runtime_type": "custom",
+        "wire_declaration_type": "custom",
+        "observed": False,
+        "observation": "not_observed_source_contract_only",
+        "executor": "codex_client",
+        "loss_boundary": "preserve declaration and inverse call/result/history IDs",
+    },
+    {
+        "family": "namespace",
+        "runtime_type": "namespace",
+        "wire_declaration_type": "namespace",
+        "observed": False,
+        "observation": "not_observed_source_contract_only",
+        "executor": "codex_client",
+        "loss_boundary": "preserve declaration and inverse call/result/history IDs",
+    },
+    {
+        "family": "client_executed_tool_discovery",
+        "runtime_type": "tool_search",
+        "wire_declaration_type": "tool_search",
+        "observed": False,
+        "observation": "not_observed_source_contract_only",
+        "executor": "codex_client",
+        "loss_boundary": "discovery request/result stays client-executed",
+    },
+    {
+        "family": "selected_provider_hosted",
+        "runtime_type": "web_search",
+        "wire_declaration_type": "web_search",
+        "observed": False,
+        "observation": "not_observed_selected_provider_control_required",
+        "executor": "selected_provider",
+        "loss_boundary": "optional unsupported hosted capability is omitted; required capability fails visibly",
+    },
+    {
+        "family": "unknown_future_kind",
+        "runtime_type": "unknown",
+        "wire_declaration_type": "<unknown>",
+        "observed": False,
+        "observation": "opaque_sentinel_only",
+        "executor": "unknown",
+        "loss_boundary": "retain tag and opaque payload; do not normalize",
+    },
+]
+SOURCE_RUNTIME_SURFACE_FIELDS = {
+    "source",
+    "declaration_family_order",
+    "declaration_families",
+    "request_shape",
+    "response_shape",
+    "declaration_family_examples",
+}
 
 
 class InventoryValidationError(ValueError):
@@ -64,11 +184,10 @@ def _exact(value: Any, fields: set[str], code: str) -> Mapping[str, Any]:
 
 def _sha256_file(path: Path) -> str:
     try:
-        digest = hashlib.sha256()
-        with path.open("rb") as handle:
-            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
-                digest.update(chunk)
-        return digest.hexdigest()
+        # Evidence files are text.  Bind their canonical LF bytes so Windows
+        # CRLF and Linux LF checkouts reconcile to the same source digest.
+        canonical = path.read_bytes().replace(b"\r\n", b"\n")
+        return hashlib.sha256(canonical).hexdigest()
     except OSError as error:
         raise InventoryValidationError("source_contract_unavailable") from error
 
@@ -83,23 +202,33 @@ def _load_json(path: Path) -> dict[str, Any]:
 
 
 def _validate_source_contract(source_contract: Mapping[str, Any]) -> None:
+    _require(set(source_contract) == SOURCE_CONTRACT_TOP_LEVEL_FIELDS, "source_contract_fields_invalid")
+    _require(source_contract.get("schema_version") == 1, "source_contract_schema_invalid")
     _require(source_contract.get("fixture_kind") == "codex_cli_source_contract", "source_contract_kind_invalid")
     _require(source_contract.get("capture_status") == "not_observed", "source_contract_capture_status_invalid")
+    _require(source_contract.get("qualification_status") == "unqualified", "source_contract_qualification_invalid")
+    _require(source_contract.get("captured_at") is None, "source_contract_captured_at_invalid")
     provenance = source_contract.get("provenance")
     _require(isinstance(provenance, Mapping), "source_contract_provenance_invalid")
-    _require(provenance.get("cli_version") == "0.146.0", "source_contract_cli_version_invalid")
-    _require(provenance.get("source_commit") == "e363b08c9175ac1cbe5893615dd2cb9ddf95043b", "source_contract_commit_invalid")
-    _require(provenance.get("cli_source_tag") == "rust-v0.146.0", "source_contract_tag_invalid")
-    _require(provenance.get("cli_source_commit_status") == "published_attested", "source_contract_commit_status_invalid")
+    _require(dict(provenance) == SOURCE_CONTRACT_PROVENANCE, "source_contract_provenance_invalid")
     surface = source_contract.get("runtime_wire_surface")
     _require(isinstance(surface, Mapping), "source_contract_surface_invalid")
-    families = surface.get("declaration_family_order")
-    _require(isinstance(families, list) and "namespace" in families, "source_contract_namespace_family_missing")
+    _require(set(surface) == SOURCE_RUNTIME_SURFACE_FIELDS, "source_contract_surface_fields_invalid")
+    _require(surface.get("source") == "Codex CLI 0.146.0 ToolSpec and ResponseItem source contract", "source_contract_surface_source_invalid")
+    _require(surface.get("declaration_family_order") == SOURCE_DECLARATION_FAMILY_ORDER, "source_contract_family_order_invalid")
+    _require(surface.get("declaration_families") == SOURCE_DECLARATION_FAMILIES, "source_contract_families_invalid")
+    surface_digest = hashlib.sha256(
+        json.dumps(surface, ensure_ascii=True, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    _require(surface_digest == EXPECTED_SOURCE_RUNTIME_SURFACE_DIGEST, "source_contract_surface_digest_invalid")
 
 
 def _boundary_arguments(value: Mapping[str, Any]) -> Mapping[str, Any]:
+    if "arguments" not in value:
+        return {}
     arguments = value.get("arguments")
-    return arguments if isinstance(arguments, Mapping) else {}
+    _require(isinstance(arguments, Mapping), "boundary_arguments_invalid")
+    return arguments
 
 
 def classify_boundary(value: Mapping[str, Any]) -> str:
@@ -110,20 +239,30 @@ def classify_boundary(value: Mapping[str, Any]) -> str:
     """
 
     _require(isinstance(value, Mapping), "boundary_input_invalid")
+    _require(set(value).issubset(BOUNDARY_INPUT_FIELDS), "boundary_fields_unknown")
+    if "name" in value and "tool_name" in value:
+        _require(value["name"] == value["tool_name"], "boundary_discriminator_conflict")
     namespace = value.get("namespace")
     name = value.get("name", value.get("tool_name"))
     _require(isinstance(namespace, str) and namespace, "boundary_discriminator_missing")
     _require(isinstance(name, str) and name, "boundary_discriminator_missing")
     arguments = _boundary_arguments(value)
     fields = set(arguments)
+    if (namespace == V1_NAMESPACE and "tools" in value) or (namespace == V2_NAMESPACE and "parameters" in value):
+        raise InventoryValidationError("boundary_v1_v2_field_mixed")
+    if (namespace == V1_NAMESPACE and fields & V2_ONLY_FIELDS) or (namespace == V2_NAMESPACE and fields & V1_ONLY_FIELDS):
+        raise InventoryValidationError("boundary_v1_v2_field_mixed")
+    allowed_fields = BOUNDARY_ARGUMENT_FIELDS.get(namespace, {}).get(name)
+    if allowed_fields is not None:
+        _require(fields.issubset(allowed_fields), "boundary_arguments_unknown")
     if namespace == V1_NAMESPACE:
-        if fields & V2_ONLY_FIELDS or name in V2_ONLY_TOOLS:
+        if name in V2_ONLY_TOOLS:
             raise InventoryValidationError("boundary_v1_v2_field_mixed")
         if name not in V1_TOOLS:
             raise InventoryValidationError("boundary_tool_unknown")
         return V1_ID
     if namespace == V2_NAMESPACE:
-        if fields & V1_ONLY_FIELDS or name in V1_ONLY_TOOLS:
+        if name in V1_ONLY_TOOLS:
             raise InventoryValidationError("boundary_v1_v2_field_mixed")
         if name not in V2_TOOLS:
             raise InventoryValidationError("boundary_tool_unknown")
@@ -152,10 +291,16 @@ def _protocol_v1() -> dict[str, Any]:
         "owner": "codex_client",
         "executor": "codex_client",
         "status": "legacy_structural_contract",
+        "shape_provenance": {
+            "shape_kind": "current_gateway_compatibility_surface",
+            "source": "src-python/codex_proxy.py#MULTI_AGENT_DISCOVERY_TOOLS",
+            "official_cli_capture_status": "not_observed",
+        },
         "declaration": {
             "discriminator": {"namespace": V1_NAMESPACE, "tool_field": "name"},
-            "wire_type": "function",
-            "fields": ["type", "name", "parameters"],
+            "wire_type": "namespace",
+            "fields": ["type", "name", "tools"],
+            "child_wire_type": "function",
             "tool_names": list(V1_TOOLS),
             "flattened_name_prefixes": ["multi_agent_v1__", "multi_agent_v1."],
         },
@@ -164,11 +309,11 @@ def _protocol_v1() -> dict[str, Any]:
             "fields": ["type", "namespace", "name", "item_id", "call_id", "arguments"],
             "identity_fields": ["call_id", "item_id"],
             "argument_fields": {
-                "spawn_agent": {"required": ["message"], "optional": ["agent_type", "model", "reasoning", "nickname", "fork_context"]},
-                "send_input": {"required": ["target", "message"], "optional": ["interrupt"]},
+                "spawn_agent": {"required": ["agent_type"], "optional": ["fork_context", "message"]},
+                "send_input": {"required": ["target"], "optional": ["interrupt", "message"]},
                 "wait_agent": {"required": ["targets"], "optional": ["timeout_ms"]},
                 "close_agent": {"required": ["target"], "optional": []},
-                "resume_agent": {"required": ["target", "message"], "optional": []},
+                "resume_agent": {"required": ["id"], "optional": []},
             },
         },
         "result": {
@@ -215,6 +360,11 @@ def _protocol_v2() -> dict[str, Any]:
         "owner": "codex_client",
         "executor": "codex_client",
         "status": "stable_surface_not_lifecycle_qualified",
+        "shape_provenance": {
+            "shape_kind": "accepted_structural_contract",
+            "source": "accepted_issue_62_source_contract_and_repository_evidence",
+            "official_cli_capture_status": "not_observed",
+        },
         "declaration": {
             "discriminator": {"namespace": V2_NAMESPACE, "tool_field": "name"},
             "wire_type": "namespace",
@@ -272,6 +422,7 @@ def _protocol_v2() -> dict[str, Any]:
 def _build_inventory(source_contract_path: Path) -> dict[str, Any]:
     source_contract = _load_json(source_contract_path)
     _validate_source_contract(source_contract)
+    _require(_sha256_file(source_contract_path) == EXPECTED_SOURCE_CONTRACT_SHA256, "source_contract_digest_invalid")
     return {
         "schema": SCHEMA,
         "artifact_kind": ARTIFACT_KIND,
@@ -305,11 +456,29 @@ def _build_inventory(source_contract_path: Path) -> dict[str, Any]:
         "adapter_requirements": {
             "owner": "codex_client",
             "adaptation_owner": "codexhub_gateway",
+            "protocol_shape_decisions": {
+                V1_ID: {
+                    "shape_kind": "current_gateway_compatibility_surface",
+                    "namespace_to_function": "required_when_selected_protocol_lacks_namespace",
+                    "official_cli_capture_status": "not_observed",
+                    "inverse_mapping": "request_scoped_and_lossless",
+                },
+                V2_ID: {
+                    "shape_kind": "accepted_structural_contract",
+                    "namespace_to_function": "optional_only_when_selected_protocol_lacks_namespace",
+                    "native_namespace": "may_pass_when_selected_protocol_supports_namespace",
+                    "official_cli_capture_status": "not_observed",
+                    "inverse_mapping": "request_scoped_and_lossless",
+                    "preserved_fields": ["task_path", "continuation_id", "task_name", "fork_turns"],
+                },
+            },
             "requirements": [
                 "namespace_to_function",
                 "injective_request_scoped_aliases",
                 "preserve_task_path_identity",
+                "preserve_continuation_id_and_fork_turns",
                 "preserve_call_result_history_links",
+                "preserve_inverse_declaration_call_result_history_mapping",
                 "assemble_stream_before_validation",
                 "reject_unknown_or_ambiguous_boundary",
                 "keep_v1_and_v2_isolated",
@@ -328,6 +497,7 @@ def _validate_protocol(protocol: Any, expected_id: str, expected_namespace: str)
         "owner",
         "executor",
         "status",
+        "shape_provenance",
         "declaration",
         "call",
         "result",
@@ -337,32 +507,9 @@ def _validate_protocol(protocol: Any, expected_id: str, expected_namespace: str)
         "isolation",
     }
     _exact(protocol, expected_fields, "protocol_fields_invalid")
+    expected = _protocol_v1() if expected_id == V1_ID else _protocol_v2()
+    _require(protocol == expected, "protocol_schema_invalid")
     _require(protocol["id"] == expected_id and protocol["namespace"] == expected_namespace, "protocol_identity_invalid")
-    _require(protocol["owner"] == "codex_client" and protocol["executor"] == "codex_client", "protocol_owner_invalid")
-    declaration = protocol["declaration"]
-    _require(isinstance(declaration, Mapping), "declaration_invalid")
-    _require(isinstance(declaration.get("fields"), list) and declaration["fields"], "declaration_fields_invalid")
-    tools = declaration.get("tool_names")
-    expected_tools = V1_TOOLS if expected_id == V1_ID else V2_TOOLS
-    _require(tools == list(expected_tools), "declaration_tool_names_invalid")
-    for key in ("call", "result", "history"):
-        section = protocol[key]
-        _require(isinstance(section, Mapping), f"{key}_invalid")
-        _require(isinstance(section.get("fields", section.get("identity_fields")), list), f"{key}_fields_invalid")
-    stream = protocol["stream"]
-    _require(isinstance(stream, Mapping) and stream.get("event_order") == _stream_shape()["event_order"], "stream_shape_invalid")
-    terminal_error = protocol["terminal_error"]
-    _require(isinstance(terminal_error, Mapping), "terminal_error_invalid")
-    _require(terminal_error.get("error_event") == "response.failed", "terminal_error_event_invalid")
-    _require(terminal_error.get("terminal_events") == ["response.completed", "response.incomplete", "response.failed"], "terminal_events_invalid")
-    isolation = protocol["isolation"]
-    _require(isinstance(isolation, Mapping), "isolation_invalid")
-    if expected_id == V1_ID:
-        _require(isolation.get("forbidden_v2_fields") == sorted(V2_ONLY_FIELDS), "v1_isolation_invalid")
-        _require(isolation.get("forbidden_v2_tools") == sorted(V2_ONLY_TOOLS), "v1_isolation_invalid")
-    else:
-        _require(isolation.get("forbidden_v1_fields") == sorted(V1_ONLY_FIELDS), "v2_isolation_invalid")
-        _require(isolation.get("forbidden_v1_tools") == sorted(V1_ONLY_TOOLS), "v2_isolation_invalid")
 
 
 def validate_inventory(payload: Mapping[str, Any], source_contract_path: Path) -> None:
@@ -387,6 +534,7 @@ def validate_inventory(payload: Mapping[str, Any], source_contract_path: Path) -
     _require(payload["verification_scope"] == "structural_contract_only", "inventory_scope_invalid")
     _require(payload["qualification_status"] == "structural_boundary_only", "inventory_qualification_invalid")
     _validate_source_contract(_load_json(source_contract_path))
+    _require(_sha256_file(source_contract_path) == EXPECTED_SOURCE_CONTRACT_SHA256, "source_contract_digest_invalid")
 
     candidate = _exact(
         payload["candidate_identity"],
@@ -415,7 +563,7 @@ def validate_inventory(payload: Mapping[str, Any], source_contract_path: Path) -
     binding = _exact(payload["evidence_binding"], {"source_contract", "basis"}, "evidence_binding_invalid")
     source_binding = _exact(binding["source_contract"], {"file", "sha256"}, "evidence_binding_source_invalid")
     _require(source_binding["file"] == source_contract_path.name, "evidence_binding_source_file_invalid")
-    _require(source_binding["sha256"] == _sha256_file(source_contract_path), "evidence_binding_source_digest_invalid")
+    _require(source_binding["sha256"] == EXPECTED_SOURCE_CONTRACT_SHA256, "evidence_binding_source_digest_invalid")
     _require(binding["basis"] == "accepted_issue_62_source_contract_and_repository_evidence", "evidence_binding_basis_invalid")
 
     boundary = _exact(
@@ -445,10 +593,36 @@ def validate_inventory(payload: Mapping[str, Any], source_contract_path: Path) -
     _require(classify_boundary({"namespace": V1_NAMESPACE, "name": "spawn_agent"}) == V1_ID, "boundary_v1_not_decidable")
     _require(classify_boundary({"namespace": V2_NAMESPACE, "name": "spawn_agent"}) == V2_ID, "boundary_v2_not_decidable")
 
-    adapter = _exact(payload["adapter_requirements"], {"owner", "adaptation_owner", "requirements", "forbidden_gateway_actions", "scope"}, "adapter_requirements_invalid")
+    adapter = _exact(payload["adapter_requirements"], {"owner", "adaptation_owner", "protocol_shape_decisions", "requirements", "forbidden_gateway_actions", "scope"}, "adapter_requirements_invalid")
     _require(adapter["owner"] == "codex_client" and adapter["adaptation_owner"] == "codexhub_gateway", "adapter_owner_invalid")
     _require(adapter["scope"] == "requirements_only_for_198_and_58", "adapter_scope_invalid")
-    _require(isinstance(adapter["requirements"], list) and "namespace_to_function" in adapter["requirements"], "adapter_requirements_list_invalid")
+    _require(adapter["protocol_shape_decisions"] == {
+        V1_ID: {
+            "shape_kind": "current_gateway_compatibility_surface",
+            "namespace_to_function": "required_when_selected_protocol_lacks_namespace",
+            "official_cli_capture_status": "not_observed",
+            "inverse_mapping": "request_scoped_and_lossless",
+        },
+        V2_ID: {
+            "shape_kind": "accepted_structural_contract",
+            "namespace_to_function": "optional_only_when_selected_protocol_lacks_namespace",
+            "native_namespace": "may_pass_when_selected_protocol_supports_namespace",
+            "official_cli_capture_status": "not_observed",
+            "inverse_mapping": "request_scoped_and_lossless",
+            "preserved_fields": ["task_path", "continuation_id", "task_name", "fork_turns"],
+        },
+    }, "adapter_shape_decisions_invalid")
+    _require(adapter["requirements"] == [
+        "namespace_to_function",
+        "injective_request_scoped_aliases",
+        "preserve_task_path_identity",
+        "preserve_continuation_id_and_fork_turns",
+        "preserve_call_result_history_links",
+        "preserve_inverse_declaration_call_result_history_mapping",
+        "assemble_stream_before_validation",
+        "reject_unknown_or_ambiguous_boundary",
+        "keep_v1_and_v2_isolated",
+    ], "adapter_requirements_list_invalid")
     _require(
         adapter["forbidden_gateway_actions"] == ["execute_tools", "schedule_agents", "forge_results", "downgrade_v2_to_v1"],
         "adapter_forbidden_actions_invalid",

--- a/tests/test_issue_64_collaboration_inventory.py
+++ b/tests/test_issue_64_collaboration_inventory.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "build_issue_64_collaboration_inventory.py"
+INVENTORY = ROOT / "docs" / "evidence" / "issue-64" / "collaboration-v1-v2-inventory.json"
+SOURCE_CONTRACT = ROOT / "docs" / "evidence" / "issue-62" / "codex-0.146-source-contract.json"
+
+
+def load_inventory_module():
+    spec = importlib.util.spec_from_file_location("issue_64_collaboration_inventory", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_inventory_is_bound_to_the_accepted_0146_source_contract() -> None:
+    payload = json.loads(INVENTORY.read_text(encoding="utf-8"))
+
+    assert payload["schema"] == "codexhub.issue64.collaboration-v1-v2.v1"
+    assert payload["artifact_kind"] == "collaboration_v1_v2_inventory"
+    assert payload["qualification_status"] == "structural_boundary_only"
+    assert payload["candidate_identity"] == {
+        "cli_version": "0.146.0",
+        "source_commit": "e363b08c9175ac1cbe5893615dd2cb9ddf95043b",
+        "source_tag": "rust-v0.146.0",
+        "source_commit_status": "published_attested",
+        "source_capture_status": "not_observed",
+        "source_contract_file": "codex-0.146-source-contract.json",
+    }
+
+
+def test_inventory_covers_bounded_v1_and_v2_shapes() -> None:
+    payload = json.loads(INVENTORY.read_text(encoding="utf-8"))
+    protocols = {entry["id"]: entry for entry in payload["protocols"]}
+
+    assert set(protocols) == {"collaboration_v1", "collaboration_v2"}
+    for protocol in protocols.values():
+        assert set(protocol) == {
+            "id",
+            "namespace",
+            "owner",
+            "executor",
+            "status",
+            "declaration",
+            "call",
+            "result",
+            "history",
+            "stream",
+            "terminal_error",
+            "isolation",
+        }
+        assert protocol["owner"] == protocol["executor"] == "codex_client"
+        assert protocol["declaration"]["fields"]
+        assert protocol["call"]["fields"]
+        assert protocol["result"]["fields"]
+        assert protocol["history"]["identity_fields"]
+        assert protocol["stream"]["event_order"]
+        assert protocol["terminal_error"]["terminal_events"]
+
+    v1 = protocols["collaboration_v1"]
+    assert v1["namespace"] == "multi_agent_v1"
+    assert v1["declaration"]["tool_names"] == [
+        "spawn_agent",
+        "send_input",
+        "wait_agent",
+        "close_agent",
+        "resume_agent",
+    ]
+    assert v1["history"]["continuation_identity"] == "agent_id"
+    assert "task_path" in v1["isolation"]["forbidden_v2_fields"]
+    assert "fork_turns" in v1["isolation"]["forbidden_v2_fields"]
+
+    v2 = protocols["collaboration_v2"]
+    assert v2["namespace"] == "collaboration"
+    assert v2["declaration"]["tool_names"] == [
+        "spawn_agent",
+        "send_message",
+        "followup_task",
+        "wait_agent",
+        "interrupt_agent",
+        "list_agents",
+    ]
+    assert v2["history"]["continuation_identity"] == "task_path"
+    assert v2["call"]["argument_fields"]["spawn_agent"]["optional"] == [
+        "fork_turns",
+        "agent_type",
+        "model",
+        "reasoning_effort",
+    ]
+    assert "agent_id" in v2["isolation"]["forbidden_v1_fields"]
+    assert "close_agent" in v2["isolation"]["forbidden_v1_tools"]
+
+
+def test_boundary_requires_exact_namespace_and_tool_discriminator() -> None:
+    module = load_inventory_module()
+
+    assert module.classify_boundary({"namespace": "multi_agent_v1", "name": "spawn_agent"}) == "collaboration_v1"
+    assert module.classify_boundary({"namespace": "collaboration", "name": "followup_task"}) == "collaboration_v2"
+
+    for value, code in (
+        ({"name": "spawn_agent"}, "boundary_discriminator_missing"),
+        ({"namespace": "unknown", "name": "spawn_agent"}, "boundary_namespace_unknown"),
+        ({"namespace": "collaboration", "name": "unknown_tool"}, "boundary_tool_unknown"),
+    ):
+        with pytest.raises(module.InventoryValidationError, match=code):
+            module.classify_boundary(value)
+
+
+def test_boundary_rejects_v1_v2_mixed_fields_before_repair() -> None:
+    module = load_inventory_module()
+
+    mixed_v1 = {
+        "namespace": "multi_agent_v1",
+        "name": "spawn_agent",
+        "arguments": {"message": "<redacted>", "task_path": "<opaque>"},
+    }
+    mixed_v2 = {
+        "namespace": "collaboration",
+        "name": "spawn_agent",
+        "arguments": {"message": "<redacted>", "fork_context": False, "agent_id": "<opaque>"},
+    }
+
+    for value, code in ((mixed_v1, "boundary_v1_v2_field_mixed"), (mixed_v2, "boundary_v1_v2_field_mixed")):
+        with pytest.raises(module.InventoryValidationError, match=code):
+            module.classify_boundary(value)
+
+
+def test_inventory_declares_adapter_requirements_without_implementing_lifecycle() -> None:
+    payload = json.loads(INVENTORY.read_text(encoding="utf-8"))
+    requirements = payload["adapter_requirements"]
+
+    assert requirements["owner"] == "codex_client"
+    assert requirements["adaptation_owner"] == "codexhub_gateway"
+    assert "namespace_to_function" in requirements["requirements"]
+    assert "injective_request_scoped_aliases" in requirements["requirements"]
+    assert "preserve_task_path_identity" in requirements["requirements"]
+    assert "execute_tools" in requirements["forbidden_gateway_actions"]
+    assert "schedule_agents" in requirements["forbidden_gateway_actions"]
+    assert "forge_results" in requirements["forbidden_gateway_actions"]
+    assert payload["deferred_qualification"] == [
+        "full_spawn_message_followup_wait_interrupt_list_lifecycle",
+        "restart_and_cold_root_resume",
+        "cross_home_topology_and_history",
+    ]
+
+
+def test_inventory_reconciliation_fails_closed_on_unknown_or_mutated_shape() -> None:
+    module = load_inventory_module()
+    payload = json.loads(INVENTORY.read_text(encoding="utf-8"))
+
+    assert module.reconcile_inventory(payload, source_contract_path=SOURCE_CONTRACT) == {
+        "reconciled": True,
+        "mismatches": [],
+    }
+
+    unknown = copy.deepcopy(payload)
+    unknown["protocols"][0]["new_field"] = "must-fail"
+    report = module.reconcile_inventory(unknown, source_contract_path=SOURCE_CONTRACT)
+    assert report["reconciled"] is False
+    assert any("protocol_fields_invalid" in item for item in report["mismatches"])
+
+    ambiguous = copy.deepcopy(payload)
+    ambiguous["boundary"]["discriminator_fields"] = ["name"]
+    report = module.reconcile_inventory(ambiguous, source_contract_path=SOURCE_CONTRACT)
+    assert report["reconciled"] is False
+    assert any("boundary_discriminator_fields_invalid" in item for item in report["mismatches"])
+
+
+def test_inventory_replay_controls_are_negative() -> None:
+    module = load_inventory_module()
+    payload = json.loads(INVENTORY.read_text(encoding="utf-8"))
+
+    for case in ("mutation", "deletion", "loss"):
+        replay = module.replay_inventory(payload, case)
+        report = module.reconcile_inventory(replay, source_contract_path=SOURCE_CONTRACT)
+        assert report["reconciled"] is False, case
+        assert report["mismatches"], case

--- a/tests/test_issue_64_collaboration_inventory.py
+++ b/tests/test_issue_64_collaboration_inventory.py
@@ -222,6 +222,16 @@ def test_inventory_reconciliation_fails_closed_on_unknown_or_mutated_shape() -> 
     assert report["reconciled"] is False
     assert any("boundary_discriminator_fields_invalid" in item for item in report["mismatches"])
 
+    for field, value, code in (
+        ("pre_exposure_stage", "after_repair", "boundary_pre_exposure_stage_invalid"),
+        ("mixed_v1_v2_action", "guess", "boundary_mixed_action_invalid"),
+    ):
+        mutated = copy.deepcopy(payload)
+        mutated["boundary"][field] = value
+        report = module.reconcile_inventory(mutated, source_contract_path=SOURCE_CONTRACT)
+        assert report["reconciled"] is False
+        assert any(code in item for item in report["mismatches"])
+
 
 def test_inventory_replay_controls_are_negative() -> None:
     module = load_inventory_module()

--- a/tests/test_issue_64_collaboration_inventory.py
+++ b/tests/test_issue_64_collaboration_inventory.py
@@ -50,6 +50,7 @@ def test_inventory_covers_bounded_v1_and_v2_shapes() -> None:
             "owner",
             "executor",
             "status",
+            "shape_provenance",
             "declaration",
             "call",
             "result",
@@ -68,6 +69,13 @@ def test_inventory_covers_bounded_v1_and_v2_shapes() -> None:
 
     v1 = protocols["collaboration_v1"]
     assert v1["namespace"] == "multi_agent_v1"
+    assert v1["shape_provenance"] == {
+        "shape_kind": "current_gateway_compatibility_surface",
+        "source": "src-python/codex_proxy.py#MULTI_AGENT_DISCOVERY_TOOLS",
+        "official_cli_capture_status": "not_observed",
+    }
+    assert v1["declaration"]["wire_type"] == "namespace"
+    assert v1["declaration"]["child_wire_type"] == "function"
     assert v1["declaration"]["tool_names"] == [
         "spawn_agent",
         "send_input",
@@ -76,11 +84,24 @@ def test_inventory_covers_bounded_v1_and_v2_shapes() -> None:
         "resume_agent",
     ]
     assert v1["history"]["continuation_identity"] == "agent_id"
+    assert v1["call"]["argument_fields"]["spawn_agent"] == {
+        "required": ["agent_type"],
+        "optional": ["fork_context", "message"],
+    }
+    assert v1["call"]["argument_fields"]["resume_agent"] == {
+        "required": ["id"],
+        "optional": [],
+    }
     assert "task_path" in v1["isolation"]["forbidden_v2_fields"]
     assert "fork_turns" in v1["isolation"]["forbidden_v2_fields"]
 
     v2 = protocols["collaboration_v2"]
     assert v2["namespace"] == "collaboration"
+    assert v2["shape_provenance"] == {
+        "shape_kind": "accepted_structural_contract",
+        "source": "accepted_issue_62_source_contract_and_repository_evidence",
+        "official_cli_capture_status": "not_observed",
+    }
     assert v2["declaration"]["tool_names"] == [
         "spawn_agent",
         "send_message",
@@ -105,11 +126,28 @@ def test_boundary_requires_exact_namespace_and_tool_discriminator() -> None:
 
     assert module.classify_boundary({"namespace": "multi_agent_v1", "name": "spawn_agent"}) == "collaboration_v1"
     assert module.classify_boundary({"namespace": "collaboration", "name": "followup_task"}) == "collaboration_v2"
+    assert module.classify_boundary({
+        "type": "function_call",
+        "namespace": "collaboration",
+        "name": "spawn_agent",
+        "item_id": "<opaque>",
+        "call_id": "<opaque>",
+        "arguments": {"task_name": "<opaque>", "message": "<redacted>"},
+    }) == "collaboration_v2"
 
     for value, code in (
         ({"name": "spawn_agent"}, "boundary_discriminator_missing"),
         ({"namespace": "unknown", "name": "spawn_agent"}, "boundary_namespace_unknown"),
         ({"namespace": "collaboration", "name": "unknown_tool"}, "boundary_tool_unknown"),
+        ({"namespace": "multi_agent_v1", "name": "spawn_agent", "arguments": "{}"}, "boundary_arguments_invalid"),
+        ({"namespace": "multi_agent_v1", "name": "spawn_agent", "arguments": []}, "boundary_arguments_invalid"),
+        ({"namespace": "multi_agent_v1", "name": "spawn_agent", "arguments": None}, "boundary_arguments_invalid"),
+        ({"namespace": "multi_agent_v1", "name": "spawn_agent", "tool_name": "wait_agent"}, "boundary_discriminator_conflict"),
+        ({"namespace": "multi_agent_v1", "name": "spawn_agent", "unexpected": True}, "boundary_fields_unknown"),
+        ({"namespace": "multi_agent_v1", "name": "spawn_agent", "arguments": {"random": True}}, "boundary_arguments_unknown"),
+        ({"namespace": "collaboration", "name": "wait_agent", "arguments": {"random": True}}, "boundary_arguments_unknown"),
+        ({"namespace": "multi_agent_v1", "name": "spawn_agent", "tools": []}, "boundary_v1_v2_field_mixed"),
+        ({"namespace": "collaboration", "name": "spawn_agent", "parameters": {}}, "boundary_v1_v2_field_mixed"),
     ):
         with pytest.raises(module.InventoryValidationError, match=code):
             module.classify_boundary(value)
@@ -143,6 +181,16 @@ def test_inventory_declares_adapter_requirements_without_implementing_lifecycle(
     assert "namespace_to_function" in requirements["requirements"]
     assert "injective_request_scoped_aliases" in requirements["requirements"]
     assert "preserve_task_path_identity" in requirements["requirements"]
+    assert "preserve_continuation_id_and_fork_turns" in requirements["requirements"]
+    assert "preserve_inverse_declaration_call_result_history_mapping" in requirements["requirements"]
+    assert requirements["protocol_shape_decisions"]["collaboration_v2"] == {
+        "shape_kind": "accepted_structural_contract",
+        "namespace_to_function": "optional_only_when_selected_protocol_lacks_namespace",
+        "native_namespace": "may_pass_when_selected_protocol_supports_namespace",
+        "official_cli_capture_status": "not_observed",
+        "inverse_mapping": "request_scoped_and_lossless",
+        "preserved_fields": ["task_path", "continuation_id", "task_name", "fork_turns"],
+    }
     assert "execute_tools" in requirements["forbidden_gateway_actions"]
     assert "schedule_agents" in requirements["forbidden_gateway_actions"]
     assert "forge_results" in requirements["forbidden_gateway_actions"]
@@ -184,3 +232,74 @@ def test_inventory_replay_controls_are_negative() -> None:
         report = module.reconcile_inventory(replay, source_contract_path=SOURCE_CONTRACT)
         assert report["reconciled"] is False, case
         assert report["mismatches"], case
+
+
+def test_source_contract_validator_rejects_provenance_and_family_mutations() -> None:
+    module = load_inventory_module()
+    source = json.loads(SOURCE_CONTRACT.read_text(encoding="utf-8"))
+
+    for key, value, code in (
+        ("schema_version", 2, "source_contract_schema_invalid"),
+        ("qualification_status", "observed", "source_contract_qualification_invalid"),
+    ):
+        mutated = copy.deepcopy(source)
+        mutated[key] = value
+        with pytest.raises(module.InventoryValidationError, match=code):
+            module._validate_source_contract(mutated)
+
+    mutated = copy.deepcopy(source)
+    mutated["runtime_wire_surface"]["declaration_family_order"] = ["namespace"]
+    with pytest.raises(module.InventoryValidationError, match="source_contract_family_order_invalid"):
+        module._validate_source_contract(mutated)
+
+    mutated = copy.deepcopy(source)
+    mutated["runtime_wire_surface"]["declaration_families"][0]["observed"] = True
+    with pytest.raises(module.InventoryValidationError, match="source_contract_families_invalid"):
+        module._validate_source_contract(mutated)
+
+    mutated = copy.deepcopy(source)
+    mutated["runtime_wire_surface"]["response_shape"]["terminal_events"] = ["response.completed"]
+    with pytest.raises(module.InventoryValidationError, match="source_contract_surface_digest_invalid"):
+        module._validate_source_contract(mutated)
+
+
+def test_source_contract_digest_normalizes_lf_and_crlf(tmp_path: Path) -> None:
+    module = load_inventory_module()
+    canonical = SOURCE_CONTRACT.read_bytes().replace(b"\r\n", b"\n")
+    lf_path = tmp_path / "source-lf.json"
+    crlf_path = tmp_path / "source-crlf.json"
+    lf_path.write_bytes(canonical)
+    crlf_path.write_bytes(canonical.replace(b"\n", b"\r\n"))
+
+    assert module._sha256_file(lf_path) == module._sha256_file(crlf_path)
+    assert module._sha256_file(lf_path) == module.EXPECTED_SOURCE_CONTRACT_SHA256
+
+    mutated = copy.deepcopy(json.loads(SOURCE_CONTRACT.read_text(encoding="utf-8")))
+    mutated["qualification_status"] = "observed"
+    mutated_path = tmp_path / "codex-0.146-source-contract.json"
+    mutated_path.write_text(json.dumps(mutated), encoding="utf-8", newline="\n")
+    with pytest.raises(module.InventoryValidationError, match="source_contract_qualification_invalid"):
+        module._build_inventory(mutated_path)
+
+    reformatted_path = tmp_path / "reformatted-source-contract.json"
+    reformatted_path.write_text(json.dumps(json.loads(SOURCE_CONTRACT.read_text(encoding="utf-8"))), encoding="utf-8", newline="\n")
+    with pytest.raises(module.InventoryValidationError, match="source_contract_digest_invalid"):
+        module._build_inventory(reformatted_path)
+
+
+def test_nested_protocol_schema_mutations_fail_closed() -> None:
+    module = load_inventory_module()
+    payload = json.loads(INVENTORY.read_text(encoding="utf-8"))
+
+    mutations = (
+        ("stream_terminal_events", lambda value: value["protocols"][0]["stream"].__setitem__("terminal_events", [])),
+        ("call_wire_type", lambda value: value["protocols"][0]["call"].__setitem__("wire_type", "unknown")),
+        ("declaration_discriminator", lambda value: value["protocols"][0]["declaration"].__setitem__("discriminator", {"namespace": "wrong", "tool_field": "name"})),
+        ("history_identity_fields", lambda value: value["protocols"][1]["history"].__setitem__("identity_fields", ["task_path"])),
+    )
+    for case, mutate in mutations:
+        replay = copy.deepcopy(payload)
+        mutate(replay)
+        report = module.reconcile_inventory(replay, source_contract_path=SOURCE_CONTRACT)
+        assert report["reconciled"] is False, case
+        assert any("protocol_schema_invalid" in item for item in report["mismatches"]), case


### PR DESCRIPTION
## Summary

- Add a bounded machine-readable and human-readable Collaboration V1/V2 inventory bound to the accepted Issue #62 Codex CLI 0.146 source contract.
- Keep the pre-exposure namespace/name boundary fail-closed for unknown, ambiguous, mixed, malformed, and per-tool unknown fields.
- Record truthful shape provenance: V1 is the current Gateway compatibility surface from `MULTI_AGENT_DISCOVERY_TOOLS` with official CLI capture still unobserved; V2 remains an unobserved structural contract.
- Record Codex Client ownership and requirements-only V2 namespace/native-vs-Adapter decisions for #198/#58, including lossless task/continuation/fork/history mapping.

## Exact-SHA review fixes

HEAD `6a536ad97eb9f1df39478af197208ddca0634dd0` includes:

- canonical-LF source-contract hashing and digest binding to the accepted #62 contract;
- strict source top-level, provenance, runtime-family, and semantic surface validation;
- strict nested protocol reconciliation for declaration/call/result/history/stream/terminal/error/identity/discriminator fields;
- fail-closed argument type, argument-key, unknown-input, and name/tool_name conflict controls;
- corrected V1 Gateway compatibility fields and explicit unobserved official CLI provenance;
- regression coverage for newline normalization, source/schema mutation, nested schema mutation, boundary ambiguity, and per-tool unknown arguments.

This remains evidence and focused contract-test work only. It makes no production route, catalog, model-selection, scheduling, or tool-execution changes and runs no real CLI request.

## Validation

- `py -3.13 -m pytest tests/test_issue_64_collaboration_inventory.py -q` — 10 passed
- `python scripts/build_issue_64_collaboration_inventory.py --check` — passed
- `python scripts/build_issue_64_collaboration_inventory.py --replay-case mutation` — fail-closed (`reconciled=false`)
- `python scripts/report_quality_gates.py` — report-only findings, exit 0
- `git diff --check` — passed

Refs #64