### PR TITLE
fix: isolate Collaboration V1 repair from V2

### DIFF
--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -2407,6 +2407,29 @@ def _write_adapter_event(event_context: Mapping[str, Any] | None, event: str, **
     write_proxy_event(event, **payload)
 
 
+def _raise_collaboration_boundary_error(
+    event_context: Mapping[str, Any] | None,
+    *,
+    classification: str,
+    message: str,
+    cause: BaseException | None = None,
+) -> NoReturn:
+    _write_adapter_event(
+        event_context,
+        "collaboration_boundary_rejected",
+        classification=classification,
+    )
+    error = UpstreamProtocolTranslationError(
+        UnsupportedProtocolTranslationError(
+            COLLABORATION_BOUNDARY_ERROR_CODE,
+            message,
+        )
+    )
+    if cause is not None:
+        raise error from cause
+    raise error
+
+
 def _resolve_collaboration_boundary(
     payload: Any,
     event_context: Mapping[str, Any] | None,
@@ -2414,80 +2437,84 @@ def _resolve_collaboration_boundary(
     try:
         payload_protocol = _classify_collaboration_payload(payload)
         metadata_protocol = None
-        if isinstance(event_context, Mapping) and "multi_agent_version" in event_context:
+        if isinstance(event_context, Mapping):
+            metadata = {
+                key: event_context[key]
+                for key in (
+                    "collaboration_protocol",
+                    "multi_agent_version",
+                    "metadata",
+                    "model_metadata",
+                    "capabilities",
+                    "features",
+                )
+                if key in event_context
+            }
+        else:
+            metadata = {}
+        if metadata:
             metadata_protocol = _classify_collaboration_payload(
-                {"metadata": {"multi_agent_version": event_context.get("multi_agent_version")}}
+                {"metadata": metadata}
             )
     except _CollaborationBoundaryError as exc:
-        _write_adapter_event(
+        _raise_collaboration_boundary_error(
             event_context,
-            "collaboration_boundary_rejected",
             classification=exc.classification,
+            message="Collaboration protocol boundary is malformed or ambiguous.",
+            cause=exc,
         )
-        raise UpstreamProtocolTranslationError(
-            UnsupportedProtocolTranslationError(
-                COLLABORATION_BOUNDARY_ERROR_CODE,
-                "Collaboration protocol boundary is malformed or ambiguous.",
-            )
-        ) from exc
     selected_protocol = None
     metadata_conflict = False
     if isinstance(event_context, Mapping):
         selected_protocol = event_context.get("collaboration_protocol")
-        if selected_protocol in {None, "", "unclassified"}:
-            selected_protocol = None
-        elif selected_protocol not in {_COLLABORATION_V1, _COLLABORATION_V2}:
-            _write_adapter_event(
+        if (
+            selected_protocol is not None
+            and selected_protocol not in {_COLLABORATION_V1, _COLLABORATION_V2}
+        ):
+            _raise_collaboration_boundary_error(
                 event_context,
-                "collaboration_boundary_rejected",
                 classification="unknown_state",
-            )
-            raise UpstreamProtocolTranslationError(
-                UnsupportedProtocolTranslationError(
-                    COLLABORATION_BOUNDARY_ERROR_CODE,
-                    "Collaboration protocol selection is unknown.",
-                )
+                message="Collaboration protocol selection is unknown.",
             )
         if selected_protocol is None:
             selected_protocol = metadata_protocol
         elif metadata_protocol is not None and selected_protocol != metadata_protocol:
             metadata_conflict = True
     if metadata_conflict:
-        _write_adapter_event(
+        _raise_collaboration_boundary_error(
             event_context,
-            "collaboration_boundary_rejected",
             classification="conflicting_selection",
-        )
-        raise UpstreamProtocolTranslationError(
-            UnsupportedProtocolTranslationError(
-                COLLABORATION_BOUNDARY_ERROR_CODE,
-                "Collaboration protocol metadata conflicts with the selected protocol.",
-            )
+            message="Collaboration protocol metadata conflicts with the selected protocol.",
         )
     if (
         selected_protocol is not None
         and payload_protocol is not None
         and selected_protocol != payload_protocol
     ):
-        _write_adapter_event(
+        _raise_collaboration_boundary_error(
             event_context,
-            "collaboration_boundary_rejected",
             classification="conflicting_selection",
-        )
-        raise UpstreamProtocolTranslationError(
-            UnsupportedProtocolTranslationError(
-                COLLABORATION_BOUNDARY_ERROR_CODE,
-                "Collaboration protocol selection conflicts with the request.",
-            )
+            message="Collaboration protocol selection conflicts with the request.",
         )
     protocol = payload_protocol or selected_protocol
-    if isinstance(event_context, dict):
-        event_context["collaboration_protocol"] = protocol or "unclassified"
+    if isinstance(event_context, dict) and protocol is not None:
+        event_context["collaboration_protocol"] = protocol
     return protocol
 
 
 def _is_collaboration_v2_context(event_context: Mapping[str, Any] | None) -> bool:
     return (event_context or {}).get("collaboration_protocol") == _COLLABORATION_V2
+
+
+def _collaboration_context_with_protocol(
+    event_context: Mapping[str, Any] | None,
+    protocol: str | None,
+) -> Mapping[str, Any] | None:
+    if protocol is None or isinstance(event_context, dict):
+        return event_context
+    context = dict(event_context or {})
+    context["collaboration_protocol"] = protocol
+    return context
 
 
 def _event_context_with_request_kind(context: Mapping[str, Any], request_kind: str) -> dict[str, Any]:
@@ -11337,6 +11364,8 @@ def compatible_response_body(
     except (UnicodeDecodeError, json.JSONDecodeError):
         return body
 
+    collaboration_protocol = _resolve_collaboration_boundary(payload, event_context)
+    event_context = _collaboration_context_with_protocol(event_context, collaboration_protocol)
     changed = _hide_reasoning_text(payload)
     payload, apply_patch_changed = _adapt_third_party_apply_patch_response_body(payload, event_context)
     changed = changed or apply_patch_changed
@@ -11409,6 +11438,9 @@ def compatible_sse_line(
         payload = json.loads(payload_bytes.decode("utf-8-sig"))
     except (UnicodeDecodeError, json.JSONDecodeError):
         return line
+
+    collaboration_protocol = _resolve_collaboration_boundary(payload, event_context)
+    event_context = _collaboration_context_with_protocol(event_context, collaboration_protocol)
 
     if _is_reasoning_text_stream_event(payload):
         return b""

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -82,6 +82,10 @@ from protocol_translation import (
 
 from codex_semantic_adapter import (
     BINDING_ACCEPTED as _BINDING_ACCEPTED,
+    COLLABORATION_V1 as _COLLABORATION_V1,
+    COLLABORATION_V2 as _COLLABORATION_V2,
+    CollaborationBoundaryError as _CollaborationBoundaryError,
+    classify_collaboration_payload as _classify_collaboration_payload,
     coerce_number as _semantic_coerce_number,
     coerce_target as _semantic_coerce_target,
     coerce_targets as _semantic_coerce_targets,
@@ -648,6 +652,7 @@ TOOL_SURFACE_STRATEGY_ERROR_CODE = "invalid_external_tool_surface_strategy"
 NATIVE_RESPONSES_TOOL_CODECS = {"none", "strict_apply_patch"}
 NATIVE_RESPONSES_TOOL_CODEC_ERROR_CODE = "invalid_native_responses_tool_codec"
 NATIVE_RESPONSES_TOOL_CONTRACT_ERROR_CODE = "invalid_native_responses_tool_contract"
+COLLABORATION_BOUNDARY_ERROR_CODE = "invalid_collaboration_boundary"
 TOOL_SEARCH_EXPLICIT_FUNCTION_TOOL = {
     "type": "function",
     "name": "tool_search",
@@ -2400,6 +2405,89 @@ def _write_adapter_event(event_context: Mapping[str, Any] | None, event: str, **
     payload = _public_event_context(event_context)
     payload.update(fields)
     write_proxy_event(event, **payload)
+
+
+def _resolve_collaboration_boundary(
+    payload: Any,
+    event_context: Mapping[str, Any] | None,
+) -> str | None:
+    try:
+        payload_protocol = _classify_collaboration_payload(payload)
+        metadata_protocol = None
+        if isinstance(event_context, Mapping) and "multi_agent_version" in event_context:
+            metadata_protocol = _classify_collaboration_payload(
+                {"metadata": {"multi_agent_version": event_context.get("multi_agent_version")}}
+            )
+    except _CollaborationBoundaryError as exc:
+        _write_adapter_event(
+            event_context,
+            "collaboration_boundary_rejected",
+            classification=exc.classification,
+        )
+        raise UpstreamProtocolTranslationError(
+            UnsupportedProtocolTranslationError(
+                COLLABORATION_BOUNDARY_ERROR_CODE,
+                "Collaboration protocol boundary is malformed or ambiguous.",
+            )
+        ) from exc
+    selected_protocol = None
+    metadata_conflict = False
+    if isinstance(event_context, Mapping):
+        selected_protocol = event_context.get("collaboration_protocol")
+        if selected_protocol in {None, "", "unclassified"}:
+            selected_protocol = None
+        elif selected_protocol not in {_COLLABORATION_V1, _COLLABORATION_V2}:
+            _write_adapter_event(
+                event_context,
+                "collaboration_boundary_rejected",
+                classification="unknown_state",
+            )
+            raise UpstreamProtocolTranslationError(
+                UnsupportedProtocolTranslationError(
+                    COLLABORATION_BOUNDARY_ERROR_CODE,
+                    "Collaboration protocol selection is unknown.",
+                )
+            )
+        if selected_protocol is None:
+            selected_protocol = metadata_protocol
+        elif metadata_protocol is not None and selected_protocol != metadata_protocol:
+            metadata_conflict = True
+    if metadata_conflict:
+        _write_adapter_event(
+            event_context,
+            "collaboration_boundary_rejected",
+            classification="conflicting_selection",
+        )
+        raise UpstreamProtocolTranslationError(
+            UnsupportedProtocolTranslationError(
+                COLLABORATION_BOUNDARY_ERROR_CODE,
+                "Collaboration protocol metadata conflicts with the selected protocol.",
+            )
+        )
+    if (
+        selected_protocol is not None
+        and payload_protocol is not None
+        and selected_protocol != payload_protocol
+    ):
+        _write_adapter_event(
+            event_context,
+            "collaboration_boundary_rejected",
+            classification="conflicting_selection",
+        )
+        raise UpstreamProtocolTranslationError(
+            UnsupportedProtocolTranslationError(
+                COLLABORATION_BOUNDARY_ERROR_CODE,
+                "Collaboration protocol selection conflicts with the request.",
+            )
+        )
+    protocol = payload_protocol or selected_protocol
+    if isinstance(event_context, dict):
+        event_context["collaboration_protocol"] = protocol or "unclassified"
+    return protocol
+
+
+def _is_collaboration_v2_context(event_context: Mapping[str, Any] | None) -> bool:
+    return (event_context or {}).get("collaboration_protocol") == _COLLABORATION_V2
 
 
 def _event_context_with_request_kind(context: Mapping[str, Any], request_kind: str) -> dict[str, Any]:
@@ -7020,6 +7108,8 @@ def _apply_external_worker_response_contract(
     validate_selectors: bool = True,
     attach_sidecars: bool = True,
 ) -> tuple[Any, bool]:
+    if _is_collaboration_v2_context(event_context):
+        return value, False
     if validate_selectors:
         _validate_external_worker_selectors(value, event_context, surface=surface)
     if attach_sidecars:
@@ -7126,12 +7216,17 @@ def _validate_worker_binding_history(
         )
 
 
-def _normalize_third_party_tool_call(value: Any) -> tuple[Any, bool]:
+def _normalize_third_party_tool_call(
+    value: Any,
+    event_context: Mapping[str, Any] | None = None,
+) -> tuple[Any, bool]:
+    if _is_collaboration_v2_context(event_context):
+        return value, False
     if isinstance(value, list):
         changed = False
         rewritten = []
         for item in value:
-            replacement, item_changed = _normalize_third_party_tool_call(item)
+            replacement, item_changed = _normalize_third_party_tool_call(item, event_context)
             rewritten.append(replacement)
             changed = changed or item_changed
         return (rewritten if changed else value), changed
@@ -7217,7 +7312,7 @@ def _normalize_third_party_tool_call(value: Any) -> tuple[Any, bool]:
             changed = True
 
     for key, item in list(rewritten.items()):
-        replacement, item_changed = _normalize_third_party_tool_call(item)
+        replacement, item_changed = _normalize_third_party_tool_call(item, event_context)
         if item_changed:
             rewritten[key] = replacement
             changed = True
@@ -8431,7 +8526,7 @@ def _suppress_multi_agent_calls_after_lifecycle_final(
     event_context: Mapping[str, Any] | None,
 ) -> tuple[Any, bool]:
     context = event_context or {}
-    if _is_raw_provider_probe_context(context):
+    if _is_raw_provider_probe_context(context) or _is_collaboration_v2_context(context):
         return value, False
     tool_protocol = str(context.get("tool_protocol") or "")
     if tool_protocol not in {"text_compat", "chat_tools", "responses_structured"}:
@@ -8560,7 +8655,11 @@ def _suppress_coordinator_forbidden_tool_calls(
     event_context: Mapping[str, Any] | None,
 ) -> tuple[Any, bool]:
     context = event_context or {}
-    if bool(context.get("subagent_worker_context")) or _is_raw_provider_probe_context(context):
+    if (
+        bool(context.get("subagent_worker_context"))
+        or _is_raw_provider_probe_context(context)
+        or _is_collaboration_v2_context(context)
+    ):
         return value, False
     tool_protocol = str(context.get("tool_protocol") or "")
     if tool_protocol not in {"text_compat", "chat_tools", "responses_structured"}:
@@ -8684,7 +8783,7 @@ def _suppress_worker_multi_agent_tool_calls(
     value: Any,
     event_context: Mapping[str, Any] | None,
 ) -> tuple[Any, bool]:
-    if not bool((event_context or {}).get("subagent_worker_context")):
+    if _is_collaboration_v2_context(event_context) or not bool((event_context or {}).get("subagent_worker_context")):
         return value, False
     if isinstance(event_context, dict):
         suppressed = event_context.setdefault("_worker_suppressed_multi_agent_item_ids", set())
@@ -9928,6 +10027,8 @@ def compatible_request_body(
     if official_passthrough:
         return official_passthrough_request_body(body, payload, upstream, model_id=model_id)
 
+    collaboration_protocol = _resolve_collaboration_boundary(payload, event_context)
+
     changed = _normalize_responses_message_input_items(payload)
     if upstream_name == "official":
         if _sanitize_official_reasoning_items(payload):
@@ -9977,11 +10078,12 @@ def compatible_request_body(
         if validated_tool_surface_strategy is not None
         else _external_tool_surface_strategy(upstream)
     )
+    collaboration_v2 = collaboration_protocol == _COLLABORATION_V2
     guidance_enabled = subagent_guidance_enabled(event_context)
     semantic_repair_enabled = subagent_semantic_repair_enabled(event_context)
     if isinstance(event_context, dict):
         event_context["tool_protocol"] = tool_protocol
-    if not raw_provider_probe:
+    if not raw_provider_probe and not collaboration_v2:
         _validate_worker_binding_history(payload)
     bounded_tool_search_terminal_calls = (
         {}
@@ -10007,7 +10109,7 @@ def compatible_request_body(
                 status=TOOL_SEARCH_UNAVAILABLE_STATUS,
             )
         changed = True
-    if raw_provider_probe:
+    if raw_provider_probe or collaboration_v2:
         pass
     else:
         # ``additional_tools`` is a legacy Codex input carrier. Preserve it
@@ -10033,6 +10135,7 @@ def compatible_request_body(
     input_items = payload.get("input")
     subagent_worker_context = (
         not raw_provider_probe
+        and not collaboration_v2
         and tool_protocol in {"text_compat", "chat_tools", "responses_structured"}
         and is_worker_subagent_request(input_items)
     )
@@ -10042,12 +10145,14 @@ def compatible_request_body(
     # Worker subagents retain their established restricted surface.
     include_tool_search = (
         tool_surface_strategy == "deferred_core"
+        and not collaboration_v2
         and not subagent_worker_context
     )
     subagent_state = (
         build_subagent_state(input_items)
         if (
             not raw_provider_probe
+            and not collaboration_v2
             and not subagent_worker_context
             and tool_protocol in {"text_compat", "chat_tools", "responses_structured"}
         )
@@ -10059,7 +10164,9 @@ def compatible_request_body(
         or subagent_state.next_action == "send_input"
     )
     node_repl_single_step_complete = (
-        not raw_provider_probe and _has_completed_single_step_node_repl_context(input_items)
+        not raw_provider_probe
+        and not collaboration_v2
+        and _has_completed_single_step_node_repl_context(input_items)
     )
     subagent_workflow_plan_read_complete = (
         not raw_provider_probe
@@ -10092,6 +10199,18 @@ def compatible_request_body(
         include_send_input = False
         state_hint = None
     elif subagent_worker_context:
+        open_agent_ids = []
+        wait_agent_ids = []
+        close_agent_ids = []
+        closed_agent_ids = []
+        lifecycle_complete = False
+        include_spawn_agent = False
+        include_wait_agent = False
+        include_close_agent = False
+        include_resume_agent = False
+        include_send_input = False
+        state_hint = None
+    elif collaboration_v2:
         open_agent_ids = []
         wait_agent_ids = []
         close_agent_ids = []
@@ -10317,7 +10436,7 @@ def compatible_request_body(
     ):
         changed = True
     allow_codex_tools = tool_protocol != "none"
-    if inject_codex_tools and allow_codex_tools and not raw_provider_probe:
+    if inject_codex_tools and allow_codex_tools and not raw_provider_probe and not collaboration_v2:
         if lifecycle_complete:
             if _hide_tools_for_completed_subagent_lifecycle(payload):
                 _write_adapter_event(
@@ -11227,7 +11346,7 @@ def compatible_response_body(
         surface="body",
         attach_sidecars=False,
     )
-    payload, alias_changed = _normalize_third_party_tool_call(payload)
+    payload, alias_changed = _normalize_third_party_tool_call(payload, event_context)
     if alias_changed:
         _write_adapter_event(
             event_context,
@@ -11301,7 +11420,7 @@ def compatible_sse_line(
         surface="sse",
         attach_sidecars=False,
     )
-    payload, alias_changed = _normalize_third_party_tool_call(payload)
+    payload, alias_changed = _normalize_third_party_tool_call(payload, event_context)
     if alias_changed:
         _write_adapter_event(
             event_context,
@@ -20412,7 +20531,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                             sse_mutation_policy
                             != MutationPolicy.TRANSPARENT
                         ):
-                            event, _ = _normalize_third_party_tool_call(event)
+                            event, _ = _normalize_third_party_tool_call(event, compatibility_event_context)
                             event, _ = _suppress_bounded_tool_search_calls(
                                 event,
                                 compatibility_event_context,
@@ -20420,7 +20539,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                             if event is None:
                                 continue
                             event, _ = _downgrade_invalid_third_party_tool_calls(event)
-                            event, _ = _guard_duplicate_multi_agent_spawn_calls(event, event_context)
+                            event, _ = _guard_duplicate_multi_agent_spawn_calls(event, compatibility_event_context)
                         event_type = event.get("type")
                         if isinstance(event_type, str) and event_type:
                             if not self._write_sse_event(event_type, event):
@@ -21203,7 +21322,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         events,
                         event_context=compatibility_event_context,
                     )
-                    events, _ = _normalize_third_party_tool_call(events)
+                    events, _ = _normalize_third_party_tool_call(events, compatibility_event_context)
                     events, _ = _suppress_bounded_tool_search_calls(
                         events,
                         compatibility_event_context,

--- a/src-python/codex_semantic_adapter.py
+++ b/src-python/codex_semantic_adapter.py
@@ -22,6 +22,188 @@ MULTI_AGENT_TOOL_NAMES = {
     "resume_agent",
 }
 
+COLLABORATION_V1 = "collaboration_v1"
+COLLABORATION_V2 = "collaboration_v2"
+COLLABORATION_V1_NAMESPACE = "multi_agent_v1"
+COLLABORATION_V2_NAMESPACE = "collaboration"
+COLLABORATION_V1_TOOL_NAMES = frozenset(
+    {"spawn_agent", "send_input", "wait_agent", "close_agent", "resume_agent"}
+)
+COLLABORATION_V2_TOOL_NAMES = frozenset(
+    {"spawn_agent", "send_message", "followup_task", "wait_agent", "interrupt_agent", "list_agents"}
+)
+COLLABORATION_V1_ONLY_FIELDS = frozenset({"agent_id", "fork_context"})
+COLLABORATION_V2_ONLY_FIELDS = frozenset({"task_name", "task_path", "fork_turns", "continuation_id"})
+COLLABORATION_PROTOCOL_METADATA_KEYS = frozenset(
+    {"collaboration_protocol", "multi_agent_version"}
+)
+
+
+class CollaborationBoundaryError(ValueError):
+    """A malformed or ambiguous Collaboration boundary that must fail closed."""
+
+    def __init__(self, classification: str):
+        self.classification = classification
+        super().__init__(classification)
+
+
+def _collaboration_alias_protocol(name: Any) -> str | None:
+    if not isinstance(name, str):
+        return None
+    for prefix in (
+        "multi_agent_v1__",
+        "multi_agent_v1.",
+        "multi_agent_v1",
+        "mcp__multi_agent_v1__",
+        "mcp__multi_agent_v1.",
+    ):
+        if not name.startswith(prefix):
+            continue
+        suffix = name[len(prefix) :]
+        if suffix in COLLABORATION_V1_TOOL_NAMES:
+            return COLLABORATION_V1
+    return None
+
+
+def _classify_collaboration_item(value: Mapping[str, Any], inherited_namespace: str | None) -> str | None:
+    namespace = value.get("namespace")
+    name = value.get("name")
+    tool_name = value.get("tool_name")
+    item_type = value.get("type")
+    if "name" in value and "tool_name" in value and name != tool_name:
+        raise CollaborationBoundaryError("discriminator_conflict")
+    if name is None:
+        name = tool_name
+
+    declaration = item_type == "namespace" and name in {
+        COLLABORATION_V1_NAMESPACE,
+        COLLABORATION_V2_NAMESPACE,
+    }
+    if namespace is None and declaration:
+        namespace = name
+        name = None
+    elif namespace is None:
+        namespace = inherited_namespace
+
+    if namespace is None:
+        alias_protocol = _collaboration_alias_protocol(name)
+        if alias_protocol is not None:
+            return alias_protocol
+        if name in (COLLABORATION_V1_TOOL_NAMES | COLLABORATION_V2_TOOL_NAMES):
+            raise CollaborationBoundaryError("missing_namespace")
+        return None
+
+    if namespace == COLLABORATION_V1_NAMESPACE:
+        if declaration and name is None:
+            return COLLABORATION_V1
+        if name is None:
+            raise CollaborationBoundaryError("missing_namespace")
+        if "tools" in value and item_type != "namespace":
+            raise CollaborationBoundaryError("mixed_v1_v2")
+        if name in COLLABORATION_V2_TOOL_NAMES and name not in COLLABORATION_V1_TOOL_NAMES:
+            raise CollaborationBoundaryError("mixed_v1_v2")
+        if name in COLLABORATION_V1_TOOL_NAMES or _collaboration_alias_protocol(name) == COLLABORATION_V1:
+            return COLLABORATION_V1
+        raise CollaborationBoundaryError("unknown_v1_tool")
+
+    if namespace == COLLABORATION_V2_NAMESPACE:
+        if declaration and name is None:
+            return COLLABORATION_V2
+        if name is None:
+            raise CollaborationBoundaryError("missing_namespace")
+        if "parameters" in value and item_type != "namespace":
+            raise CollaborationBoundaryError("mixed_v1_v2")
+        if name in COLLABORATION_V1_TOOL_NAMES and name not in COLLABORATION_V2_TOOL_NAMES:
+            raise CollaborationBoundaryError("mixed_v1_v2")
+        if name in COLLABORATION_V2_TOOL_NAMES:
+            return COLLABORATION_V2
+        if _collaboration_alias_protocol(name) == COLLABORATION_V1:
+            raise CollaborationBoundaryError("mixed_v1_v2")
+        raise CollaborationBoundaryError("unknown_v2_tool")
+
+    if name in (COLLABORATION_V1_TOOL_NAMES | COLLABORATION_V2_TOOL_NAMES) or _collaboration_alias_protocol(name):
+        raise CollaborationBoundaryError("unknown_namespace")
+    return None
+
+
+def _metadata_protocol(value: Mapping[str, Any]) -> str | None:
+    """Resolve an explicit model/feature selection marker when present."""
+
+    candidates: list[Any] = [value]
+    for key in ("metadata", "model_metadata", "capabilities", "features"):
+        nested = value.get(key)
+        if isinstance(nested, Mapping):
+            candidates.append(nested)
+    protocols: set[str] = set()
+    for candidate in candidates:
+        for key in COLLABORATION_PROTOCOL_METADATA_KEYS:
+            if key not in candidate:
+                continue
+            marker = candidate.get(key)
+            if marker is None:
+                continue
+            if key == "multi_agent_version":
+                marker = {
+                    "v1": COLLABORATION_V1,
+                    "v2": COLLABORATION_V2,
+                }.get(marker)
+            elif marker in {"v1", "v2"}:
+                marker = f"collaboration_{marker}"
+            if marker not in {COLLABORATION_V1, COLLABORATION_V2}:
+                raise CollaborationBoundaryError("unknown_state")
+            protocols.add(marker)
+    if len(protocols) > 1:
+        raise CollaborationBoundaryError("mixed_v1_v2")
+    return next(iter(protocols), None)
+
+
+def classify_collaboration_payload(value: Any) -> str | None:
+    """Resolve the V1/V2 boundary before semantic repair or tool injection.
+
+    Unrelated tools are ignored.  Any known Collaboration marker with a
+    missing, conflicting, or unknown protocol fails closed.  The return value
+    is one protocol family or ``None`` when the payload contains no marker.
+    """
+
+    protocols: set[str] = set()
+
+    def visit(item: Any, inherited_namespace: str | None = None) -> None:
+        if isinstance(item, Mapping):
+            metadata_protocol = _metadata_protocol(item)
+            if metadata_protocol is not None:
+                protocols.add(metadata_protocol)
+            protocol = _classify_collaboration_item(item, inherited_namespace)
+            if protocol is not None:
+                protocols.add(protocol)
+                arguments = item.get("arguments")
+                fields = set(arguments) if isinstance(arguments, Mapping) else set()
+                fields.update(key for key in item if key in (COLLABORATION_V1_ONLY_FIELDS | COLLABORATION_V2_ONLY_FIELDS))
+                if protocol == COLLABORATION_V1 and fields & COLLABORATION_V2_ONLY_FIELDS:
+                    raise CollaborationBoundaryError("mixed_v1_v2")
+                if protocol == COLLABORATION_V2 and fields & COLLABORATION_V1_ONLY_FIELDS:
+                    raise CollaborationBoundaryError("mixed_v1_v2")
+
+            child_namespace = None
+            if item.get("type") == "namespace" and item.get("name") in {
+                COLLABORATION_V1_NAMESPACE,
+                COLLABORATION_V2_NAMESPACE,
+            }:
+                child_namespace = item["name"]
+            for key, child in item.items():
+                if key == "tools" and child_namespace is not None:
+                    visit(child, child_namespace)
+                elif key not in {"arguments", "parameters", "properties"}:
+                    visit(child)
+            return
+        if isinstance(item, list):
+            for child in item:
+                visit(child, inherited_namespace)
+
+    visit(value)
+    if len(protocols) > 1:
+        raise CollaborationBoundaryError("mixed_v1_v2")
+    return next(iter(protocols), None)
+
 MULTI_AGENT_DISCOVERY_QUERY = "spawn_agent multi_agent subagent native Codex"
 WORKER_AGENT_TYPE = "worker"
 BINDING_ACCEPTED = "accepted"

--- a/src-python/subagent_policy.py
+++ b/src-python/subagent_policy.py
@@ -4,6 +4,7 @@ import os
 from collections.abc import Mapping, Sequence
 from typing import Any
 
+from codex_semantic_adapter import COLLABORATION_V2
 
 ASSIST_MODES = {"strict", "guided", "assisted"}
 REPAIR_CODEX_SUBAGENT = "codex_subagent_repair"
@@ -53,7 +54,7 @@ def _raw_provider_probe(context: Mapping[str, Any] | None) -> bool:
 
 
 def _collaboration_v2(context: Mapping[str, Any] | None) -> bool:
-    return bool(context and context.get("collaboration_protocol") == "collaboration_v2")
+    return bool(context and context.get("collaboration_protocol") == COLLABORATION_V2)
 
 
 def _subagent_repair_policy_enabled(context: Mapping[str, Any] | None) -> bool:

--- a/src-python/subagent_policy.py
+++ b/src-python/subagent_policy.py
@@ -16,6 +16,8 @@ def subagent_assist_mode() -> str:
 
 
 def guidance_enabled(context: Mapping[str, Any] | None) -> bool:
+    if _collaboration_v2(context):
+        return False
     if not _subagent_repair_policy_enabled(context):
         return False
     if _raw_provider_probe(context):
@@ -24,6 +26,8 @@ def guidance_enabled(context: Mapping[str, Any] | None) -> bool:
 
 
 def semantic_repair_enabled(context: Mapping[str, Any] | None) -> bool:
+    if _collaboration_v2(context):
+        return False
     if not _subagent_repair_policy_enabled(context):
         return False
     if _raw_provider_probe(context):
@@ -46,6 +50,10 @@ def _has_known_tool_and_arguments(action: Mapping[str, Any]) -> bool:
 
 def _raw_provider_probe(context: Mapping[str, Any] | None) -> bool:
     return bool(context and context.get("raw_provider_probe"))
+
+
+def _collaboration_v2(context: Mapping[str, Any] | None) -> bool:
+    return bool(context and context.get("collaboration_protocol") == "collaboration_v2")
 
 
 def _subagent_repair_policy_enabled(context: Mapping[str, Any] | None) -> bool:

--- a/tests/test_issue_198_v1_v2_isolation.py
+++ b/tests/test_issue_198_v1_v2_isolation.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import codex_proxy
+from codex_semantic_adapter import (
+    COLLABORATION_V1,
+    COLLABORATION_V2,
+    CollaborationBoundaryError,
+    classify_collaboration_payload,
+)
+from subagent_policy import REPAIR_CODEX_SUBAGENT, guidance_enabled, semantic_repair_enabled
+
+
+def _upstream() -> dict[str, object]:
+    return {
+        "name": "ollama_cloud",
+        "upstream_model": "glm-5.2",
+        "upstream_format": "responses",
+        "tool_protocol": "responses_structured",
+        "tool_surface_strategy": "eager",
+    }
+
+
+def _v2_spawn_call() -> dict[str, object]:
+    return {
+        "type": "function_call",
+        "namespace": "collaboration",
+        "name": "spawn_agent",
+        "call_id": "call_v2_spawn",
+        "arguments": {
+            "task_name": "worker-task",
+            "message": "return the bounded result",
+            "fork_turns": "all",
+        },
+    }
+
+
+def _v1_spawn_call() -> dict[str, object]:
+    return {
+        "type": "function_call",
+        "namespace": "multi_agent_v1",
+        "name": "spawn_agent",
+        "call_id": "call_v1_spawn",
+        "arguments": {"agent_type": "general", "message": "return the bounded result"},
+    }
+
+
+def test_collaboration_boundary_classifies_explicit_protocols_and_rejects_mixed_inputs() -> None:
+    assert classify_collaboration_payload({"input": [_v1_spawn_call()]}) == COLLABORATION_V1
+    assert classify_collaboration_payload({"input": [_v2_spawn_call()]}) == COLLABORATION_V2
+    assert classify_collaboration_payload(
+        {
+            "tools": [
+                {
+                    "type": "namespace",
+                    "name": "collaboration",
+                    "tools": [{"type": "function", "name": "spawn_agent"}],
+                }
+            ]
+        }
+    ) == COLLABORATION_V2
+
+    with pytest.raises(CollaborationBoundaryError, match="mixed_v1_v2"):
+        classify_collaboration_payload({"input": [_v1_spawn_call(), _v2_spawn_call()]})
+    with pytest.raises(CollaborationBoundaryError, match="missing_namespace"):
+        classify_collaboration_payload({"input": [{"type": "function_call", "name": "spawn_agent"}]})
+    with pytest.raises(CollaborationBoundaryError, match="mixed_v1_v2"):
+        classify_collaboration_payload(
+            {
+                "input": [
+                    {
+                        **_v2_spawn_call(),
+                        "arguments": {"task_name": "worker-task", "fork_context": False},
+                    }
+                ]
+            }
+        )
+    assert classify_collaboration_payload({"metadata": {"multi_agent_version": "v2"}}) == COLLABORATION_V2
+    with pytest.raises(CollaborationBoundaryError, match="unknown_state"):
+        classify_collaboration_payload({"metadata": {"multi_agent_version": "v3"}})
+    with pytest.raises(CollaborationBoundaryError, match="missing_namespace"):
+        classify_collaboration_payload({"namespace": "collaboration", "type": "function_call"})
+
+
+def test_v2_disables_v1_guidance_and_semantic_repair() -> None:
+    context = {"repair_policy": REPAIR_CODEX_SUBAGENT, "collaboration_protocol": COLLABORATION_V2}
+    assert guidance_enabled(context) is False
+    assert semantic_repair_enabled(context) is False
+
+
+def test_v2_request_preserves_native_namespace_and_does_not_inject_v1_tools() -> None:
+    context = {"repair_policy": REPAIR_CODEX_SUBAGENT, "request_id": "issue198-v2"}
+    body = {
+        "model": "glm-5.2",
+        "input": [_v2_spawn_call()],
+        "tools": [
+            {
+                "type": "namespace",
+                "name": "collaboration",
+                "tools": [{"type": "function", "name": "spawn_agent"}],
+            }
+        ],
+    }
+
+    transformed = codex_proxy.compatible_request_body(
+        json.dumps(body).encode(),
+        _upstream(),
+        event_context=context,
+    )
+    payload = json.loads(transformed)
+
+    assert context["collaboration_protocol"] == COLLABORATION_V2
+    assert context["subagent_spawn_allowed"] is False
+    assert payload["input"] == body["input"]
+    assert payload["tools"] == body["tools"]
+    assert "multi_agent_v1__spawn_agent" not in {
+        tool.get("name") for tool in payload["tools"] if isinstance(tool, dict)
+    }
+
+
+def test_v2_response_does_not_apply_v1_alias_repair() -> None:
+    context = {"repair_policy": REPAIR_CODEX_SUBAGENT, "collaboration_protocol": COLLABORATION_V2}
+    body = {
+        "id": "resp_v2",
+        "output": [
+            {
+                "type": "function_call",
+                "namespace": "collaboration",
+                "name": "multi_agent_v1__spawn_agent",
+                "call_id": "call_v2_alias",
+                "arguments": "{\"task_name\":\"worker-task\"}",
+            }
+        ],
+    }
+
+    transformed = codex_proxy.compatible_response_body(
+        json.dumps(body).encode(),
+        "ollama_cloud",
+        event_context=context,
+    )
+
+    assert json.loads(transformed) == body
+
+
+def test_selected_v2_metadata_skips_v1_injection_without_a_call_marker() -> None:
+    context = {
+        "repair_policy": REPAIR_CODEX_SUBAGENT,
+        "collaboration_protocol": COLLABORATION_V2,
+        "request_id": "issue198-selected-v2",
+    }
+    body = {
+        "model": "glm-5.2",
+        "input": [{"type": "message", "role": "user", "content": "continue"}],
+    }
+
+    transformed = codex_proxy.compatible_request_body(
+        json.dumps(body).encode(),
+        _upstream(),
+        event_context=context,
+    )
+    payload = json.loads(transformed)
+
+    assert context["collaboration_protocol"] == COLLABORATION_V2
+    assert payload["input"] == body["input"]
+    assert "multi_agent_v1__spawn_agent" not in {
+        tool.get("name") for tool in payload.get("tools", []) if isinstance(tool, dict)
+    }
+
+
+def test_selected_v2_model_metadata_in_context_skips_v1_injection() -> None:
+    context = {
+        "repair_policy": REPAIR_CODEX_SUBAGENT,
+        "multi_agent_version": "v2",
+        "request_id": "issue198-context-v2",
+    }
+    transformed = codex_proxy.compatible_request_body(
+        json.dumps({"model": "glm-5.2", "input": "continue"}).encode(),
+        _upstream(),
+        event_context=context,
+    )
+    payload = json.loads(transformed)
+
+    assert context["collaboration_protocol"] == COLLABORATION_V2
+    assert "multi_agent_v1__spawn_agent" not in {
+        tool.get("name") for tool in payload.get("tools", []) if isinstance(tool, dict)
+    }
+
+
+def test_payload_and_selected_v2_metadata_conflict_fails_closed() -> None:
+    context = {
+        "repair_policy": REPAIR_CODEX_SUBAGENT,
+        "collaboration_protocol": COLLABORATION_V2,
+        "request_id": "issue198-conflict",
+    }
+
+    with pytest.raises(codex_proxy.UpstreamProtocolTranslationError) as exc_info:
+        codex_proxy.compatible_request_body(
+            json.dumps({"model": "glm-5.2", "input": [_v1_spawn_call()]}).encode(),
+            _upstream(),
+            event_context=context,
+        )
+
+    assert exc_info.value.cause.code == codex_proxy.COLLABORATION_BOUNDARY_ERROR_CODE
+
+
+def test_official_passthrough_does_not_interpret_collaboration_metadata() -> None:
+    body_payload = {
+        "model": "gpt-5.5",
+        "input": [{"type": "function_call", "namespace": "unknown", "name": "spawn_agent"}],
+        "stream": True,
+    }
+    body = json.dumps(body_payload).encode()
+
+    transformed = codex_proxy.compatible_request_body(
+        body,
+        {"name": "official", "auth": "codex_auth"},
+        event_context={"request_id": "issue198-official"},
+        behavior_profile=codex_proxy.BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH,
+    )
+
+    payload = json.loads(transformed)
+    assert payload["input"] == body_payload["input"]
+
+
+def test_v1_request_keeps_existing_repair_path_and_boundary_is_fail_closed() -> None:
+    context = {"repair_policy": REPAIR_CODEX_SUBAGENT, "request_id": "issue198-v1"}
+    transformed = codex_proxy.compatible_request_body(
+        json.dumps({"model": "glm-5.2", "input": [_v1_spawn_call()]}).encode(),
+        _upstream(),
+        event_context=context,
+    )
+    payload = json.loads(transformed)
+    assert context["collaboration_protocol"] == COLLABORATION_V1
+    assert any(
+        isinstance(item, dict)
+        and item.get("name") in {"multi_agent_v1__spawn_agent", "spawn_agent"}
+        for item in payload.get("tools", [])
+    )
+
+    with pytest.raises(codex_proxy.UpstreamProtocolTranslationError) as exc_info:
+        codex_proxy.compatible_request_body(
+            json.dumps({"model": "glm-5.2", "input": [_v1_spawn_call(), _v2_spawn_call()]}).encode(),
+            _upstream(),
+            event_context={"request_id": "issue198-mixed"},
+        )
+    assert exc_info.value.cause.code == codex_proxy.COLLABORATION_BOUNDARY_ERROR_CODE

--- a/tests/test_issue_198_v1_v2_isolation.py
+++ b/tests/test_issue_198_v1_v2_isolation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from unittest.mock import patch
 
 import pytest
 
@@ -129,7 +130,7 @@ def test_v2_response_does_not_apply_v1_alias_repair() -> None:
             {
                 "type": "function_call",
                 "namespace": "collaboration",
-                "name": "multi_agent_v1__spawn_agent",
+                "name": "spawn_agent",
                 "call_id": "call_v2_alias",
                 "arguments": "{\"task_name\":\"worker-task\"}",
             }
@@ -143,6 +144,45 @@ def test_v2_response_does_not_apply_v1_alias_repair() -> None:
     )
 
     assert json.loads(transformed) == body
+
+
+def test_v2_response_with_a_v1_alias_fails_closed() -> None:
+    body = {
+        "id": "resp_v2_mixed",
+        "output": [
+            {
+                "type": "function_call",
+                "namespace": "collaboration",
+                "name": "multi_agent_v1__spawn_agent",
+                "call_id": "call_v2_mixed",
+                "arguments": "{\"task_name\":\"worker-task\"}",
+            }
+        ],
+    }
+
+    with pytest.raises(codex_proxy.UpstreamProtocolTranslationError) as exc_info:
+        codex_proxy.compatible_response_body(
+            json.dumps(body).encode(),
+            "ollama_cloud",
+            event_context={"collaboration_protocol": COLLABORATION_V2},
+        )
+
+    assert exc_info.value.cause.code == codex_proxy.COLLABORATION_BOUNDARY_ERROR_CODE
+
+
+def test_direct_v2_response_and_sse_resolve_boundary_before_repairs() -> None:
+    body = {
+        "id": "resp_v2_direct",
+        "output": [_v2_spawn_call()],
+    }
+    transformed = codex_proxy.compatible_response_body(
+        json.dumps(body).encode(),
+        "ollama_cloud",
+    )
+    assert json.loads(transformed) == body
+
+    line = b"data: " + json.dumps(_v2_spawn_call(), separators=(",", ":")).encode() + b"\n\n"
+    assert codex_proxy.compatible_sse_line(line, "ollama_cloud") == line
 
 
 def test_selected_v2_metadata_skips_v1_injection_without_a_call_marker() -> None:
@@ -187,6 +227,76 @@ def test_selected_v2_model_metadata_in_context_skips_v1_injection() -> None:
     assert "multi_agent_v1__spawn_agent" not in {
         tool.get("name") for tool in payload.get("tools", []) if isinstance(tool, dict)
     }
+
+
+@pytest.mark.parametrize(
+    ("selection", "expected"),
+    [
+        ({"collaboration_protocol": "collaboration_v1"}, COLLABORATION_V1),
+        ({"collaboration_protocol": "collaboration_v2"}, COLLABORATION_V2),
+        ({"metadata": {"multi_agent_version": "v2"}}, COLLABORATION_V2),
+        ({"features": {"multi_agent_version": "v2"}}, COLLABORATION_V2),
+    ],
+)
+def test_context_feature_selection_is_table_driven(
+    selection: dict[str, object],
+    expected: str,
+) -> None:
+    context = {"repair_policy": REPAIR_CODEX_SUBAGENT, **selection}
+    body = {"model": "glm-5.2", "input": "continue"}
+
+    transformed = codex_proxy.compatible_request_body(
+        json.dumps(body).encode(),
+        _upstream(),
+        event_context=context,
+    )
+
+    assert context["collaboration_protocol"] == expected
+    if expected == COLLABORATION_V2:
+        payload = json.loads(transformed)
+        assert "multi_agent_v1__spawn_agent" not in {
+            tool.get("name") for tool in payload.get("tools", []) if isinstance(tool, dict)
+        }
+
+
+def test_unknown_context_state_fails_closed() -> None:
+    with pytest.raises(codex_proxy.UpstreamProtocolTranslationError) as exc_info:
+        codex_proxy.compatible_request_body(
+            json.dumps({"model": "glm-5.2", "input": "continue"}).encode(),
+            _upstream(),
+            event_context={"collaboration_protocol": "unclassified"},
+        )
+
+    assert exc_info.value.cause.code == codex_proxy.COLLABORATION_BOUNDARY_ERROR_CODE
+
+
+def test_boundary_rejection_diagnostic_is_bounded_and_does_not_include_payload() -> None:
+    context = {"request_id": "safe-request", "repair_policy": REPAIR_CODEX_SUBAGENT}
+    body = {
+        "model": "glm-5.2",
+        "input": [
+            {
+                **_v1_spawn_call(),
+                "arguments": {"message": "SECRET_PROMPT", "task_path": "SECRET_TASK"},
+            },
+            _v2_spawn_call(),
+        ],
+    }
+
+    with patch.object(codex_proxy, "write_proxy_event") as write_event:
+        with pytest.raises(codex_proxy.UpstreamProtocolTranslationError):
+            codex_proxy.compatible_request_body(
+                json.dumps(body).encode(),
+                _upstream(),
+                event_context=context,
+            )
+
+    event = next(call for call in write_event.call_args_list if call.args[0] == "collaboration_boundary_rejected")
+    fields = event.kwargs
+    assert fields["classification"] == "mixed_v1_v2"
+    assert "SECRET_PROMPT" not in repr(fields)
+    assert "SECRET_TASK" not in repr(fields)
+    assert "call_v1_spawn" not in repr(fields)
 
 
 def test_payload_and_selected_v2_metadata_conflict_fails_closed() -> None:


### PR DESCRIPTION
## Summary

- Resolve the Collaboration V1/V2 boundary before third-party request and response compatibility transforms.
- Keep V1 repair/state/scheduler behavior unchanged for V1, while making V2 bypass those paths and preserve native namespace items.
- Fail closed for missing, conflicting, unknown, or malformed Collaboration metadata with a stable sanitized error classification.
- Add request, response, SSE, metadata-selection, conflict, and diagnostic redaction regressions.

## Why

The generic third-party compatibility layer could apply V1-only namespace repair and lifecycle logic to a V2 request. That could rewrite V2 calls, inject the wrong tools, or corrupt continuation state. Official passthrough remains transparent and no model/provider fallback or Gateway-owned agent execution is added.

## Validation

- Focused #198, policy, and #64 inventory tests: 34 passed.
- Routing suite: 599 passed, 223 subtests.
- Chat gateway suite: 101 passed, 10 subtests.
- Full Python core: 1898 passed, 1 skipped; 3 unrelated baseline failures reproduced on origin/dev (`test_ci_md_fallback_commands_use_watchdog_with_3600s_bound` and two Issue108 smoke replays).
- Python partition completeness, py_compile, and `git diff --check` passed.
- Report-only quality gates completed; findings are pre-existing/non-blocking.

Closes #198
