### PR TITLE
feat(gateway): add runtime-derived tool compatibility

### DIFF
--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -79,6 +79,12 @@ from protocol_translation import (
     responses_tool_choice_to_chat_tool_choice,
     responses_tools_to_chat_tools,
 )
+from runtime_tool_compatibility import (
+    ProtocolCapabilities as RuntimeProtocolCapabilities,
+    ToolCompatibilityError as RuntimeToolCompatibilityError,
+    ToolCompatibilityPlan as RuntimeToolCompatibilityPlan,
+    build_tool_compatibility_plan,
+)
 
 from codex_semantic_adapter import (
     BINDING_ACCEPTED as _BINDING_ACCEPTED,
@@ -3780,6 +3786,23 @@ def _parse_sse_json_payload(line: bytes) -> dict[str, Any] | None:
     return payload if isinstance(payload, dict) else None
 
 
+def _parse_sse_json_payloads(blob: bytes) -> list[dict[str, Any]]:
+    """Parse every JSON data frame emitted for one upstream SSE line.
+
+    Runtime compatibility adapters can buffer one upstream function lifecycle
+    and emit several native Responses events as a single byte string.  Relay
+    bookkeeping must inspect each emitted frame rather than treating that
+    byte string as one JSON payload.
+    """
+
+    return [
+        payload
+        for line in blob.splitlines(keepends=True)
+        for payload in [_parse_sse_json_payload(line)]
+        if payload is not None
+    ]
+
+
 class UpstreamSseSemanticError(ValueError):
     """A complete converted SSE frame is not valid source-protocol JSON."""
 
@@ -5902,6 +5925,189 @@ def _external_native_responses_tool_codec(upstream: Mapping[str, Any]) -> str:
     )
 
 
+_RUNTIME_TOOL_COMPATIBILITY_PLAN_KEY = "_runtime_tool_compatibility_plan"
+_RUNTIME_TOOL_COMPATIBILITY_STREAM_KEY = "_runtime_tool_compatibility_stream"
+
+
+def _runtime_tool_protocol_capabilities(
+    tool_protocol: str,
+    upstream: Mapping[str, Any],
+) -> RuntimeProtocolCapabilities:
+    supplied = upstream.get("tool_protocol_capabilities")
+    if isinstance(supplied, Mapping):
+        # A capability manifest is authoritative only for predicates it
+        # explicitly states.  In particular, a Responses endpoint without
+        # lifecycle facts is not evidence of native namespace/custom/search
+        # support; retain the conservative plain-function + adapter baseline.
+        baseline_protocol = "chat_tools" if tool_protocol in {"responses_structured", "text_compat"} else tool_protocol
+        return RuntimeProtocolCapabilities.for_protocol(baseline_protocol, supplied)
+    if tool_protocol in {"responses_structured", "text_compat"}:
+        return RuntimeProtocolCapabilities.chat_tools()
+    if tool_protocol == "chat_tools":
+        return RuntimeProtocolCapabilities.chat_tools()
+    return RuntimeProtocolCapabilities()
+
+
+def _raise_runtime_tool_compatibility_error(error: RuntimeToolCompatibilityError) -> NoReturn:
+    raise UpstreamProtocolTranslationError(
+        UnsupportedProtocolTranslationError(error.code, str(error))
+    ) from error
+
+
+def _prepare_runtime_tool_compatibility(
+    payload: dict[str, Any],
+    upstream: Mapping[str, Any],
+    tool_protocol: str,
+    event_context: dict[str, Any],
+    native_responses_tool_codec: str | None = None,
+) -> bool:
+    tools = payload.get("tools")
+    declarations = tools if isinstance(tools, list) else []
+    codec = (
+        native_responses_tool_codec
+        if native_responses_tool_codec is not None
+        else _external_native_responses_tool_codec(upstream)
+    )
+    if tool_protocol == "responses_structured" and codec == "strict_apply_patch":
+        apply_patch_tools = [
+            tool
+            for tool in declarations
+            if isinstance(tool, Mapping) and tool.get("name") == APPLY_PATCH_FUNCTION_NAME
+        ]
+        if len(apply_patch_tools) > 1:
+            _raise_native_responses_tool_contract_error(
+                event_context,
+                codec=codec,
+                reason="duplicate_declaration",
+                count=len(apply_patch_tools),
+            )
+        if apply_patch_tools:
+            apply_patch_tool = apply_patch_tools[0]
+            if apply_patch_tool.get("type") != "custom":
+                _raise_native_responses_tool_contract_error(
+                    event_context,
+                    codec=codec,
+                    reason="declaration_not_custom",
+                )
+            _validate_strict_apply_patch_custom_tool(
+                apply_patch_tool,
+                event_context,
+                codec=codec,
+            )
+    planned_declarations = [
+        declaration
+        for declaration in declarations
+        if not (
+            isinstance(declaration, Mapping)
+            and declaration.get("name") == APPLY_PATCH_FUNCTION_NAME
+            and (
+                codec == "strict_apply_patch"
+                or not isinstance(declaration.get("format"), Mapping)
+            )
+        )
+    ]
+    try:
+        plan = build_tool_compatibility_plan(
+            planned_declarations,
+            selected_protocol=tool_protocol,
+            provider_hosted_capabilities=upstream.get("hosted_tool_capabilities"),
+            tool_choice=payload.get("tool_choice"),
+            protocol_capabilities=_runtime_tool_protocol_capabilities(tool_protocol, upstream),
+            request_token=uuid.uuid4().hex,
+        )
+    except RuntimeToolCompatibilityError as exc:
+        write_proxy_event(
+            "runtime_tool_compatibility_rejected",
+            classification=exc.classification,
+            surface=exc.surface,
+        )
+        _raise_runtime_tool_compatibility_error(exc)
+    event_context[_RUNTIME_TOOL_COMPATIBILITY_PLAN_KEY] = plan
+    event_context.pop(_RUNTIME_TOOL_COMPATIBILITY_STREAM_KEY, None)
+    write_proxy_event(
+        "runtime_tool_compatibility_planned",
+        counts=plan.diagnostics.as_dict()["counts"],
+    )
+    return False
+
+
+def _apply_runtime_tool_compatibility_plan(
+    payload: dict[str, Any],
+    plan: RuntimeToolCompatibilityPlan,
+) -> bool:
+    try:
+        encoded = plan.encode_payload(payload)
+    except RuntimeToolCompatibilityError as exc:
+        _raise_runtime_tool_compatibility_error(exc)
+    if encoded == payload:
+        return False
+    payload.clear()
+    payload.update(encoded)
+    return True
+
+
+def _runtime_tool_compatibility_plan(
+    event_context: Mapping[str, Any] | None,
+) -> RuntimeToolCompatibilityPlan | None:
+    value = (event_context or {}).get(_RUNTIME_TOOL_COMPATIBILITY_PLAN_KEY)
+    return value if isinstance(value, RuntimeToolCompatibilityPlan) else None
+
+
+def _runtime_alias_matches_namespace(
+    plan: RuntimeToolCompatibilityPlan | None,
+    tool: Any,
+    namespace: str,
+) -> bool:
+    if plan is None or not isinstance(tool, Mapping):
+        return False
+    record = plan.registry.record_for_alias(_tool_schema_name(tool))
+    return record is not None and record.namespace == namespace
+
+
+def _runtime_alias_for_namespace_child(
+    plan: RuntimeToolCompatibilityPlan | None,
+    namespace: str,
+    child_name: str,
+) -> str | None:
+    if plan is None:
+        return None
+    for alias in plan.aliases:
+        record = plan.registry.record_for_alias(alias)
+        if record is not None and record.namespace == namespace and record.child_name == child_name:
+            return alias
+    return None
+
+
+def _runtime_plan_has_native_plain_function(
+    plan: RuntimeToolCompatibilityPlan | None,
+    item: Mapping[str, Any],
+) -> bool:
+    name = item.get("name")
+    return bool(
+        plan is not None
+        and isinstance(name, str)
+        and any(
+            entry.family == "plain_function"
+            and entry.disposition == "native"
+            and entry.original_name == name
+            for entry in plan.entries
+        )
+    )
+
+
+def _rewrite_generated_guidance_tool_name(value: Any, original: str, alias: str) -> Any:
+    if isinstance(value, str):
+        return value.replace(original, alias)
+    if isinstance(value, list):
+        return [_rewrite_generated_guidance_tool_name(item, original, alias) for item in value]
+    if isinstance(value, Mapping):
+        return {
+            key: _rewrite_generated_guidance_tool_name(item, original, alias)
+            for key, item in value.items()
+        }
+    return value
+
+
 STRICT_APPLY_PATCH_EXAMPLE = """*** Begin Patch
 *** Update File: example.txt
 @@
@@ -6150,6 +6356,7 @@ def _rewrite_structured_tool_input_items(
     payload: dict[str, Any],
     event_context: Mapping[str, Any] | None = None,
     upstream_name: str | None = None,
+    compatibility_plan: RuntimeToolCompatibilityPlan | None = None,
 ) -> bool:
     input_items = payload.get("input")
     if not isinstance(input_items, list):
@@ -6166,6 +6373,16 @@ def _rewrite_structured_tool_input_items(
     available_function_names = _function_tool_names(payload.get("tools"))
     for item in input_items:
         if not isinstance(item, dict):
+            rewritten_items.append(item)
+            continue
+        if (
+            compatibility_plan is not None
+            and compatibility_plan.owns_wire_value(item)
+            and not _runtime_plan_has_native_plain_function(compatibility_plan, item)
+        ):
+            call_id = item.get("call_id")
+            if isinstance(call_id, str):
+                preserved_structured_call_ids.add(call_id)
             rewritten_items.append(item)
             continue
         if item.get("type") == "function_call":
@@ -6437,7 +6654,12 @@ def _inject_explicit_codex_tools(
     return changed
 
 
-def _filter_tools_for_subagent_coordinator(payload: dict[str, Any], *, include_node_repl_tools: bool) -> bool:
+def _filter_tools_for_subagent_coordinator(
+    payload: dict[str, Any],
+    *,
+    include_node_repl_tools: bool,
+    compatibility_plan: RuntimeToolCompatibilityPlan | None = None,
+) -> bool:
     tools = payload.get("tools")
     if not isinstance(tools, list):
         return False
@@ -6445,7 +6667,14 @@ def _filter_tools_for_subagent_coordinator(payload: dict[str, Any], *, include_n
         tool
         for tool in tools
         if _is_multi_agent_tool_schema(tool)
-        or (include_node_repl_tools and _is_node_repl_tool_schema(tool))
+        or _runtime_alias_matches_namespace(compatibility_plan, tool, "multi_agent_v1")
+        or (
+            include_node_repl_tools
+            and (
+                _is_node_repl_tool_schema(tool)
+                or _runtime_alias_matches_namespace(compatibility_plan, tool, NODE_REPL_NAMESPACE)
+            )
+        )
     ]
     if len(filtered_tools) == len(tools):
         return False
@@ -6453,7 +6682,11 @@ def _filter_tools_for_subagent_coordinator(payload: dict[str, Any], *, include_n
     return True
 
 
-def _filter_tools_for_subagent_worker(payload: dict[str, Any]) -> bool:
+def _filter_tools_for_subagent_worker(
+    payload: dict[str, Any],
+    *,
+    compatibility_plan: RuntimeToolCompatibilityPlan | None = None,
+) -> bool:
     tools = payload.get("tools")
     if not isinstance(tools, list):
         return False
@@ -6462,6 +6695,14 @@ def _filter_tools_for_subagent_worker(payload: dict[str, Any]) -> bool:
         for tool in tools
         if not _is_multi_agent_tool_schema(tool)
         and not _is_mcp_or_codex_app_tool_schema(tool)
+        and not any(
+            _runtime_alias_matches_namespace(compatibility_plan, tool, namespace)
+            for namespace in (
+                NODE_REPL_NAMESPACE,
+                "multi_agent_v1",
+                "mcp__multi_agent_v1",
+            )
+        )
         and _tool_schema_name(tool) != TOOL_SEARCH_EXPLICIT_FUNCTION_TOOL["name"]
     ]
     if len(filtered_tools) == len(tools):
@@ -10136,6 +10377,19 @@ def compatible_request_body(
                 status=TOOL_SEARCH_UNAVAILABLE_STATUS,
             )
         changed = True
+    runtime_tool_plan: RuntimeToolCompatibilityPlan | None = None
+    if isinstance(event_context, dict) and not raw_provider_probe:
+        if _hoist_additional_tools_input_items(payload):
+            changed = True
+        if _prepare_runtime_tool_compatibility(
+            payload,
+            upstream,
+            tool_protocol,
+            event_context,
+            native_responses_tool_codec=native_responses_tool_codec_override,
+        ):
+            changed = True
+        runtime_tool_plan = _runtime_tool_compatibility_plan(event_context)
     if raw_provider_probe or collaboration_v2:
         pass
     else:
@@ -10145,7 +10399,12 @@ def compatible_request_body(
         if tool_surface_strategy == "deferred_core" and _hoist_additional_tools_input_items(payload):
             changed = True
         if tool_protocol in STRUCTURED_TOOL_PROTOCOLS:
-            if _rewrite_structured_tool_input_items(payload, event_context=event_context, upstream_name=upstream_name):
+            if _rewrite_structured_tool_input_items(
+                payload,
+                event_context=event_context,
+                upstream_name=upstream_name,
+                compatibility_plan=runtime_tool_plan,
+            ):
                 changed = True
         elif tool_protocol == "none":
             tools = payload.get("tools")
@@ -10410,6 +10669,17 @@ def compatible_request_body(
         event_context["subagent_workflow_plan_read_complete"] = bool(subagent_workflow_plan_read_complete)
         event_context["subagent_workflow_plan_read_required"] = bool(subagent_workflow_plan_read_required)
     if guidance_enabled and state_hint is not None and isinstance(input_items, list):
+        node_repl_alias = _runtime_alias_for_namespace_child(
+            runtime_tool_plan,
+            NODE_REPL_NAMESPACE,
+            "js",
+        )
+        if node_repl_alias is not None:
+            state_hint = _rewrite_generated_guidance_tool_name(
+                state_hint,
+                "mcp__node_repl__js",
+                node_repl_alias,
+            )
         input_items.append(state_hint)
         _write_adapter_event(
             event_context,
@@ -10453,6 +10723,16 @@ def compatible_request_body(
             return body
         return json.dumps(payload, ensure_ascii=True, separators=(",", ":")).encode("utf-8")
     if (
+        (
+            runtime_tool_plan is None
+            or (
+                native_responses_tool_codec_override
+                if native_responses_tool_codec_override is not None
+                else _external_native_responses_tool_codec(upstream)
+            )
+            == "strict_apply_patch"
+        )
+        and
         tool_protocol == "responses_structured"
         and _adapt_native_responses_tool_declarations(
             payload,
@@ -10483,8 +10763,20 @@ def compatible_request_body(
             )
             # Coordinator and worker restrictions deliberately remain narrower
             # than the normal deferred-core surface.
+            runtime_plain_tool_search = bool(
+                runtime_tool_plan is not None
+                and any(
+                    entry.family == "plain_function"
+                    and entry.original_name == TOOL_SEARCH_EXPLICIT_FUNCTION_TOOL["name"]
+                    and entry.disposition != "omit"
+                    for entry in runtime_tool_plan.entries
+                )
+            )
             effective_include_tool_search = (
-                include_tool_search and not restrict_to_subagent_coordinator_tools
+                include_tool_search
+                and (runtime_tool_plan is None or runtime_plain_tool_search)
+                and not subagent_worker_context
+                and not restrict_to_subagent_coordinator_tools
             )
             include_node_repl_for_subagent_workflow = (
                 restrict_to_subagent_coordinator_tools
@@ -10493,7 +10785,10 @@ def compatible_request_body(
                 and not bool(getattr(subagent_state, "dynamic_dag_intent", False))
                 and not bool(subagent_state.agents if subagent_state is not None else {})
             )
-            if subagent_worker_context and _filter_tools_for_subagent_worker(payload):
+            if subagent_worker_context and _filter_tools_for_subagent_worker(
+                payload,
+                compatibility_plan=runtime_tool_plan,
+            ):
                 _write_adapter_event(
                     event_context,
                     "subagent_worker_tools_restricted",
@@ -10504,6 +10799,7 @@ def compatible_request_body(
             if restrict_to_subagent_coordinator_tools and _filter_tools_for_subagent_coordinator(
                 payload,
                 include_node_repl_tools=include_node_repl_for_subagent_workflow,
+                compatibility_plan=runtime_tool_plan,
             ):
                 _write_adapter_event(
                     event_context,
@@ -10546,8 +10842,13 @@ def compatible_request_body(
                     else not node_repl_single_step_complete
                 ),
                 include_local_tool_gateway_tools=not subagent_worker_context,
-                strip_all_namespace_tools=tool_surface_strategy == "deferred_core",
-                include_flattened_namespace_tools=tool_surface_strategy == "eager",
+                strip_namespace_tools=runtime_tool_plan is None,
+                strip_all_namespace_tools=(
+                    runtime_tool_plan is None and tool_surface_strategy == "deferred_core"
+                ),
+                include_flattened_namespace_tools=(
+                    runtime_tool_plan is None and tool_surface_strategy == "eager"
+                ),
                 tool_surface_counts=tool_surface_counts,
                 open_agent_ids=open_agent_ids,
                 wait_agent_ids=wait_agent_ids,
@@ -10578,12 +10879,21 @@ def compatible_request_body(
                 changed = True
             required_tool_choice_name = None
             if subagent_state_active:
+                runtime_node_repl_alias = _runtime_alias_for_namespace_child(
+                    runtime_tool_plan,
+                    NODE_REPL_NAMESPACE,
+                    "js",
+                )
+                required_node_repl_name = runtime_node_repl_alias or "mcp__node_repl__js"
                 if (
                     subagent_workflow_plan_read_required
                     and include_node_repl_for_subagent_workflow
-                    and "mcp__node_repl__js" in _function_tool_names(payload.get("tools"))
+                    and (
+                        runtime_node_repl_alias is not None
+                        or required_node_repl_name in _function_tool_names(payload.get("tools"))
+                    )
                 ):
-                    required_tool_choice_name = "mcp__node_repl__js"
+                    required_tool_choice_name = required_node_repl_name
                 else:
                     required_tool_choice_name = _required_subagent_tool_choice(
                         tool_protocol=tool_protocol,
@@ -10611,6 +10921,24 @@ def compatible_request_body(
                 upstream=upstream_name,
             ):
                 changed = True
+    if runtime_tool_plan is not None and isinstance(payload.get("tools"), list):
+        final_declarations = [
+            tool
+            for tool in payload["tools"]
+            if not (
+                isinstance(tool, Mapping)
+                and tool.get("name") == APPLY_PATCH_FUNCTION_NAME
+            )
+        ]
+        finalized_plan = runtime_tool_plan.with_final_declarations(final_declarations)
+        if finalized_plan is not runtime_tool_plan and isinstance(event_context, dict):
+            runtime_tool_plan = finalized_plan
+            event_context[_RUNTIME_TOOL_COMPATIBILITY_PLAN_KEY] = finalized_plan
+    if runtime_tool_plan is not None and _apply_runtime_tool_compatibility_plan(
+        payload,
+        runtime_tool_plan,
+    ):
+        changed = True
     model_id = payload.get("model")
     max_output_tokens = catalog_max_output_tokens(model_id) if isinstance(model_id, str) else None
     if max_output_tokens is not None:
@@ -11366,7 +11694,17 @@ def compatible_response_body(
 
     collaboration_protocol = _resolve_collaboration_boundary(payload, event_context)
     event_context = _collaboration_context_with_protocol(event_context, collaboration_protocol)
-    changed = _hide_reasoning_text(payload)
+    changed = False
+    runtime_tool_plan = _runtime_tool_compatibility_plan(event_context)
+    if runtime_tool_plan is not None:
+        try:
+            decoded_payload = runtime_tool_plan.decode_payload(payload)
+        except RuntimeToolCompatibilityError as exc:
+            _raise_runtime_tool_compatibility_error(exc)
+        if decoded_payload != payload:
+            payload = decoded_payload
+            changed = True
+    changed = _hide_reasoning_text(payload) or changed
     payload, apply_patch_changed = _adapt_third_party_apply_patch_response_body(payload, event_context)
     changed = changed or apply_patch_changed
     payload, _ = _apply_external_worker_response_contract(
@@ -11442,10 +11780,33 @@ def compatible_sse_line(
     collaboration_protocol = _resolve_collaboration_boundary(payload, event_context)
     event_context = _collaboration_context_with_protocol(event_context, collaboration_protocol)
 
+    runtime_tool_plan = _runtime_tool_compatibility_plan(event_context)
+    if runtime_tool_plan is not None and isinstance(event_context, dict):
+        stream_state = event_context.get(_RUNTIME_TOOL_COMPATIBILITY_STREAM_KEY)
+        if stream_state is None:
+            stream_state = runtime_tool_plan.new_stream()
+            event_context[_RUNTIME_TOOL_COMPATIBILITY_STREAM_KEY] = stream_state
+        try:
+            decoded_events = stream_state.decode_events_for_event(payload)
+        except RuntimeToolCompatibilityError as exc:
+            _raise_runtime_tool_compatibility_error(exc)
+        if not decoded_events:
+            return b""
+        if len(decoded_events) > 1:
+            return b"".join(
+                _sse_json_line(event, line_ending) + line_ending
+                for event in decoded_events
+            )
+        decoded_payload = decoded_events[0]
+        runtime_tool_changed = decoded_payload != payload
+        payload = decoded_payload
+    else:
+        runtime_tool_changed = False
+
     if _is_reasoning_text_stream_event(payload):
         return b""
 
-    changed = _hide_reasoning_text(payload)
+    changed = _hide_reasoning_text(payload) or runtime_tool_changed
     payload, _ = _apply_external_worker_response_contract(
         payload,
         event_context,
@@ -21340,6 +21701,25 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                             )
                 else:
                     events = _chat_stream_chunks_to_response_events(chunks)
+                    runtime_tool_plan = _runtime_tool_compatibility_plan(compatibility_event_context)
+                    if runtime_tool_plan is not None and isinstance(compatibility_event_context, dict):
+                        runtime_tool_stream = compatibility_event_context.get(
+                            _RUNTIME_TOOL_COMPATIBILITY_STREAM_KEY
+                        )
+                        if runtime_tool_stream is None:
+                            runtime_tool_stream = runtime_tool_plan.new_stream()
+                            compatibility_event_context[
+                                _RUNTIME_TOOL_COMPATIBILITY_STREAM_KEY
+                            ] = runtime_tool_stream
+                        decoded_events: list[Mapping[str, Any]] = []
+                        try:
+                            for event in events:
+                                decoded_events.extend(
+                                    runtime_tool_stream.decode_events_for_event(event)
+                                )
+                        except RuntimeToolCompatibilityError as exc:
+                            _raise_runtime_tool_compatibility_error(exc)
+                        events = decoded_events
                     _write_adapter_event(
                         event_context,
                         "chat_to_responses_event_summary",
@@ -21495,14 +21875,19 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                             upstream_name,
                             event_context=compatibility_event_context,
                         )
-                        rewritten_payload = _parse_sse_json_payload(rewritten_line) if upstream_name != "official" else usage_payload
-                        _count_sse_reasoning_event(reasoning_stats, original_payload, rewritten_payload)
-                        if isinstance(rewritten_payload, Mapping):
-                            rewritten_events.append(rewritten_payload)
-                        terminal = bool(
-                            isinstance(rewritten_payload, Mapping)
-                            and _responses_events_have_terminal([rewritten_payload])
+                        rewritten_payloads = (
+                            _parse_sse_json_payloads(rewritten_line)
+                            if upstream_name != "official"
+                            else ([usage_payload] if isinstance(usage_payload, Mapping) else [])
                         )
+                        if rewritten_payloads:
+                            _count_sse_reasoning_event(reasoning_stats, original_payload, rewritten_payloads[0])
+                            for emitted_payload in rewritten_payloads[1:]:
+                                _count_sse_reasoning_event(reasoning_stats, None, emitted_payload)
+                            rewritten_events.extend(rewritten_payloads)
+                        else:
+                            _count_sse_reasoning_event(reasoning_stats, original_payload, None)
+                        terminal = _responses_events_have_terminal(rewritten_payloads)
                         buffered_lines.append((rewritten_line, terminal))
                         if saw_terminal_event:
                             break
@@ -21890,12 +22275,22 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                             else:
                                 line = _sse_json_line(replacement_events[0], _sse_line_ending(line))
                     line = compatible_sse_line(line, upstream_name, event_context=compatibility_event_context)
-                    rewritten_payload = _parse_sse_json_payload(line) if upstream_name != "official" else None
-                    if isinstance(rewritten_payload, Mapping):
-                        remember_completed_tool_event(rewritten_payload)
+                    rewritten_payloads = (
+                        _parse_sse_json_payloads(line)
+                        if upstream_name != "official"
+                        else []
+                    )
+                    if rewritten_payloads:
+                        for emitted_payload in rewritten_payloads:
+                            remember_completed_tool_event(emitted_payload)
+                        _count_sse_reasoning_event(reasoning_stats, original_payload, rewritten_payloads[0])
+                        for emitted_payload in rewritten_payloads[1:]:
+                            _count_sse_reasoning_event(reasoning_stats, None, emitted_payload)
                     elif isinstance(usage_payload, Mapping):
                         remember_completed_tool_event(usage_payload)
-                    _count_sse_reasoning_event(reasoning_stats, original_payload, rewritten_payload)
+                        _count_sse_reasoning_event(reasoning_stats, original_payload, None)
+                    else:
+                        _count_sse_reasoning_event(reasoning_stats, original_payload, None)
 
                     if not line and upstream_name != "official":
                         pending_sse_event_metadata = []

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -5928,6 +5928,11 @@ def _external_native_responses_tool_codec(upstream: Mapping[str, Any]) -> str:
 
 _RUNTIME_TOOL_COMPATIBILITY_PLAN_KEY = "_runtime_tool_compatibility_plan"
 _RUNTIME_TOOL_COMPATIBILITY_STREAM_KEY = "_runtime_tool_compatibility_stream"
+_RUNTIME_TOOL_COMPATIBILITY_ATTEMPT_KEY = "_runtime_tool_compatibility_attempt_generation"
+_RUNTIME_TOOL_COMPATIBILITY_ATTEMPT_PLAN_KEY = "_runtime_tool_compatibility_attempt_plan"
+_RUNTIME_TOOL_COMPATIBILITY_ATTEMPT_PLAN_GENERATION_KEY = (
+    "_runtime_tool_compatibility_attempt_plan_generation"
+)
 _RUNTIME_TOOL_CAPABILITY_MANIFEST_ERROR_CODE = "tool_compatibility_capability_manifest"
 
 
@@ -6088,6 +6093,8 @@ def _prepare_runtime_tool_compatibility(
         _raise_runtime_tool_compatibility_error(exc)
     event_context[_RUNTIME_TOOL_COMPATIBILITY_PLAN_KEY] = plan
     event_context.pop(_RUNTIME_TOOL_COMPATIBILITY_STREAM_KEY, None)
+    event_context.pop(_RUNTIME_TOOL_COMPATIBILITY_ATTEMPT_PLAN_KEY, None)
+    event_context.pop(_RUNTIME_TOOL_COMPATIBILITY_ATTEMPT_PLAN_GENERATION_KEY, None)
     write_proxy_event(
         "runtime_tool_compatibility_planned",
         counts=plan.diagnostics.as_dict()["counts"],
@@ -6115,6 +6122,99 @@ def _runtime_tool_compatibility_plan(
 ) -> RuntimeToolCompatibilityPlan | None:
     value = (event_context or {}).get(_RUNTIME_TOOL_COMPATIBILITY_PLAN_KEY)
     return value if isinstance(value, RuntimeToolCompatibilityPlan) else None
+
+
+def _runtime_tool_compatibility_plan_for_attempt(
+    event_context: Mapping[str, Any] | None,
+) -> RuntimeToolCompatibilityPlan | None:
+    """Resolve the immutable request plan into the current relay attempt.
+
+    The request plan owns stable aliases and declaration classification.  Each
+    permitted upstream retry receives a shallow plan copy with a fresh call
+    ownership ledger; no route or provider selection is performed here.
+    """
+    request_plan = _runtime_tool_compatibility_plan(event_context)
+    if request_plan is None or not isinstance(event_context, dict):
+        return request_plan
+    generation = event_context.get(_RUNTIME_TOOL_COMPATIBILITY_ATTEMPT_KEY)
+    if generation is None:
+        return request_plan
+    attempt_plan = event_context.get(_RUNTIME_TOOL_COMPATIBILITY_ATTEMPT_PLAN_KEY)
+    planned_generation = event_context.get(
+        _RUNTIME_TOOL_COMPATIBILITY_ATTEMPT_PLAN_GENERATION_KEY
+    )
+    if (
+        not isinstance(attempt_plan, RuntimeToolCompatibilityPlan)
+        or planned_generation != generation
+        or attempt_plan is request_plan
+    ):
+        attempt_plan = request_plan.new_attempt()
+        event_context[_RUNTIME_TOOL_COMPATIBILITY_ATTEMPT_PLAN_KEY] = attempt_plan
+        event_context[_RUNTIME_TOOL_COMPATIBILITY_ATTEMPT_PLAN_GENERATION_KEY] = generation
+        event_context.pop(_RUNTIME_TOOL_COMPATIBILITY_STREAM_KEY, None)
+    return attempt_plan
+
+
+def _runtime_tool_compatibility_stream_for_attempt(
+    event_context: Mapping[str, Any] | None,
+) -> tuple[RuntimeToolCompatibilityPlan | None, Any | None]:
+    """Return the attempt-local stream ledger shared by both relay surfaces."""
+    plan = _runtime_tool_compatibility_plan_for_attempt(event_context)
+    if plan is None or not isinstance(event_context, dict):
+        return plan, None
+    stream = event_context.get(_RUNTIME_TOOL_COMPATIBILITY_STREAM_KEY)
+    if stream is None or getattr(stream, "plan", None) is not plan:
+        stream = plan.new_stream()
+        event_context[_RUNTIME_TOOL_COMPATIBILITY_STREAM_KEY] = stream
+    return plan, stream
+
+
+def _runtime_required_tool_diagnostics(
+    plan: RuntimeToolCompatibilityPlan | None,
+    tool_choice_name: Any,
+) -> tuple[str, str]:
+    """Return bounded family/disposition fields for required-tool telemetry."""
+    if plan is None or not isinstance(tool_choice_name, str):
+        return "unknown", "unknown"
+
+    record = plan.registry.record_for_alias(tool_choice_name)
+    if record is not None:
+        family = record.family
+        disposition = next(
+            (
+                entry.disposition
+                for entry in plan.entries
+                if entry.declaration_index == record.declaration_index
+            ),
+            "unknown",
+        )
+    else:
+        matches = [
+            entry for entry in plan.entries if entry.original_name == tool_choice_name
+        ]
+        if len(matches) != 1:
+            return "unknown", "unknown"
+        family = matches[0].family
+        disposition = matches[0].disposition
+
+    bounded_families = {
+        "plain_function",
+        "namespace",
+        "custom_freeform",
+        "tool_search",
+        "selected_provider_hosted",
+        "unknown_future_kind",
+    }
+    bounded_dispositions = {
+        "native",
+        "adapt",
+        "omit",
+        "required-but-unavailable",
+    }
+    return (
+        family if family in bounded_families else "unknown",
+        disposition if disposition in bounded_dispositions else "unknown",
+    )
 
 
 def _runtime_alias_matches_namespace(
@@ -10970,12 +11070,15 @@ def compatible_request_body(
                         include_node_repl_for_subagent_workflow=include_node_repl_for_subagent_workflow,
                     )
             if semantic_repair_enabled and _restrict_tools_to_required_tool(payload, required_tool_choice_name):
-                _write_adapter_event(
-                    event_context,
+                required_tool_family, required_tool_disposition = _runtime_required_tool_diagnostics(
+                    runtime_tool_plan,
+                    required_tool_choice_name,
+                )
+                write_proxy_event(
                     "required_tool_tools_restricted",
-                    upstream=upstream_name,
-                    model=payload.get("model") if isinstance(payload.get("model"), str) else None,
-                    tool_name=required_tool_choice_name,
+                    tool_choice_required=True,
+                    required_tool_family=required_tool_family,
+                    required_tool_disposition=required_tool_disposition,
                 )
                 changed = True
             if semantic_repair_enabled and _set_required_subagent_tool_choice(
@@ -11762,7 +11865,7 @@ def compatible_response_body(
     collaboration_protocol = _resolve_collaboration_boundary(payload, event_context)
     event_context = _collaboration_context_with_protocol(event_context, collaboration_protocol)
     changed = False
-    runtime_tool_plan = _runtime_tool_compatibility_plan(event_context)
+    runtime_tool_plan = _runtime_tool_compatibility_plan_for_attempt(event_context)
     if runtime_tool_plan is not None:
         try:
             decoded_payload = runtime_tool_plan.decode_payload(payload)
@@ -11847,12 +11950,10 @@ def compatible_sse_line(
     collaboration_protocol = _resolve_collaboration_boundary(payload, event_context)
     event_context = _collaboration_context_with_protocol(event_context, collaboration_protocol)
 
-    runtime_tool_plan = _runtime_tool_compatibility_plan(event_context)
-    if runtime_tool_plan is not None and isinstance(event_context, dict):
-        stream_state = event_context.get(_RUNTIME_TOOL_COMPATIBILITY_STREAM_KEY)
-        if stream_state is None:
-            stream_state = runtime_tool_plan.new_stream()
-            event_context[_RUNTIME_TOOL_COMPATIBILITY_STREAM_KEY] = stream_state
+    runtime_tool_plan, stream_state = _runtime_tool_compatibility_stream_for_attempt(
+        event_context
+    )
+    if runtime_tool_plan is not None and stream_state is not None:
         try:
             decoded_events = stream_state.decode_events_for_event(payload)
         except RuntimeToolCompatibilityError as exc:
@@ -17985,6 +18086,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
             open_attempt_budget = (
                 primary_route_attempt.retry.new_open_attempt_budget()
             )
+            runtime_tool_compatibility_attempt_generation = 0
             for route_attempt in route_plan.attempts:
                 active_route_attempt = route_attempt
                 upstream_format = route_attempt.selected_upstream_format
@@ -18012,6 +18114,11 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 lifecycle_final_retry_reason: str | None = None
                 try:
                     while relay_attempt <= max_relay_attempts:
+                        runtime_tool_compatibility_attempt_generation += 1
+                        if isinstance(adapter_event_context, dict):
+                            adapter_event_context[
+                                _RUNTIME_TOOL_COMPATIBILITY_ATTEMPT_KEY
+                            ] = runtime_tool_compatibility_attempt_generation
                         seam = _handler_downstream_stream_commit(self)
                         if seam is not None:
                             seam.set_upstream_format(upstream_format)
@@ -21768,16 +21875,12 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                             )
                 else:
                     events = _chat_stream_chunks_to_response_events(chunks)
-                    runtime_tool_plan = _runtime_tool_compatibility_plan(compatibility_event_context)
-                    if runtime_tool_plan is not None and isinstance(compatibility_event_context, dict):
-                        runtime_tool_stream = compatibility_event_context.get(
-                            _RUNTIME_TOOL_COMPATIBILITY_STREAM_KEY
+                    runtime_tool_plan, runtime_tool_stream = (
+                        _runtime_tool_compatibility_stream_for_attempt(
+                            compatibility_event_context
                         )
-                        if runtime_tool_stream is None:
-                            runtime_tool_stream = runtime_tool_plan.new_stream()
-                            compatibility_event_context[
-                                _RUNTIME_TOOL_COMPATIBILITY_STREAM_KEY
-                            ] = runtime_tool_stream
+                    )
+                    if runtime_tool_plan is not None and runtime_tool_stream is not None:
                         decoded_events: list[Mapping[str, Any]] = []
                         try:
                             for event in events:

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -10994,7 +10994,10 @@ def compatible_request_body(
                 and tool.get("name") == APPLY_PATCH_FUNCTION_NAME
             )
         ]
-        finalized_plan = runtime_tool_plan.with_final_declarations(final_declarations)
+        finalized_plan = runtime_tool_plan.with_final_declarations(
+            final_declarations,
+            tool_choice=payload.get("tool_choice"),
+        )
         if finalized_plan is not runtime_tool_plan and isinstance(event_context, dict):
             runtime_tool_plan = finalized_plan
             event_context[_RUNTIME_TOOL_COMPATIBILITY_PLAN_KEY] = finalized_plan

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 from copy import deepcopy
+from collections.abc import Iterable as IterableABC
 from dataclasses import dataclass, replace
 from datetime import timezone
 from email.utils import parsedate_to_datetime
@@ -5927,25 +5928,88 @@ def _external_native_responses_tool_codec(upstream: Mapping[str, Any]) -> str:
 
 _RUNTIME_TOOL_COMPATIBILITY_PLAN_KEY = "_runtime_tool_compatibility_plan"
 _RUNTIME_TOOL_COMPATIBILITY_STREAM_KEY = "_runtime_tool_compatibility_stream"
+_RUNTIME_TOOL_CAPABILITY_MANIFEST_ERROR_CODE = "tool_compatibility_capability_manifest"
+
+
+def _raise_malformed_runtime_tool_capability_manifest() -> NoReturn:
+    raise RuntimeToolCompatibilityError(
+        _RUNTIME_TOOL_CAPABILITY_MANIFEST_ERROR_CODE,
+        "malformed_capability_manifest",
+    )
+
+
+def _validate_runtime_tool_capability_facts(facts: Mapping[str, Any]) -> None:
+    boolean_keys = {
+        "function_lifecycle",
+        "supports_functions",
+        "namespace_lifecycle",
+        "supports_namespace",
+        "supports_namespaces",
+        "custom_lifecycle",
+        "supports_custom",
+        "supports_custom_tools",
+        "tool_search_lifecycle",
+        "supports_tool_search",
+        "accepts_namespace_adapter",
+        "namespace_adapter",
+        "accepts_custom_adapter",
+        "custom_adapter",
+    }
+    for key in boolean_keys:
+        if key in facts and type(facts[key]) is not bool:
+            _raise_malformed_runtime_tool_capability_manifest()
+
+    for key in ("hosted_lifecycles", "hosted_kinds", "unknown_lifecycles", "unknown_kinds"):
+        if key not in facts:
+            continue
+        value = facts[key]
+        if isinstance(value, str):
+            continue
+        if isinstance(value, Mapping):
+            if any(not isinstance(name, str) or type(enabled) is not bool for name, enabled in value.items()):
+                _raise_malformed_runtime_tool_capability_manifest()
+            continue
+        if isinstance(value, (bytes, bytearray)) or not isinstance(value, IterableABC):
+            _raise_malformed_runtime_tool_capability_manifest()
+        if any(not isinstance(name, str) for name in value):
+            _raise_malformed_runtime_tool_capability_manifest()
+
+    for key in ("max_tool_name_length", "max_alias_attempts"):
+        if key in facts and (type(facts[key]) is not int or facts[key] <= 0):
+            _raise_malformed_runtime_tool_capability_manifest()
 
 
 def _runtime_tool_protocol_capabilities(
     tool_protocol: str,
     upstream: Mapping[str, Any],
 ) -> RuntimeProtocolCapabilities:
-    supplied = upstream.get("tool_protocol_capabilities")
-    if isinstance(supplied, Mapping):
+    try:
+        supplied = upstream.get("tool_protocol_capabilities")
+        if supplied is not None and not isinstance(supplied, Mapping):
+            _raise_malformed_runtime_tool_capability_manifest()
+        if isinstance(supplied, Mapping):
+            _validate_runtime_tool_capability_facts(supplied)
+        facts = supplied if isinstance(supplied, Mapping) else None
         # A capability manifest is authoritative only for predicates it
-        # explicitly states.  In particular, a Responses endpoint without
-        # lifecycle facts is not evidence of native namespace/custom/search
-        # support; retain the conservative plain-function + adapter baseline.
-        baseline_protocol = "chat_tools" if tool_protocol in {"responses_structured", "text_compat"} else tool_protocol
-        return RuntimeProtocolCapabilities.for_protocol(baseline_protocol, supplied)
-    if tool_protocol in {"responses_structured", "text_compat"}:
-        return RuntimeProtocolCapabilities.chat_tools()
-    if tool_protocol == "chat_tools":
-        return RuntimeProtocolCapabilities.chat_tools()
-    return RuntimeProtocolCapabilities()
+        # explicitly states.  Responses and chat-completions retain the
+        # conservative plain-function + adapter baseline.  Text-compatible
+        # endpoints have no native lifecycle by default; every capability
+        # must be explicit.
+        if tool_protocol == "text_compat":
+            baseline_protocol = "none"
+        elif tool_protocol == "responses_structured":
+            baseline_protocol = "chat_tools"
+        else:
+            baseline_protocol = tool_protocol
+        if facts is not None:
+            return RuntimeProtocolCapabilities.for_protocol(baseline_protocol, facts)
+        if baseline_protocol in {"chat_tools", "chat", "chat_completions"}:
+            return RuntimeProtocolCapabilities.chat_tools()
+        return RuntimeProtocolCapabilities()
+    except RuntimeToolCompatibilityError:
+        raise
+    except (AttributeError, OverflowError, TypeError, ValueError):
+        _raise_malformed_runtime_tool_capability_manifest()
 
 
 def _raise_runtime_tool_compatibility_error(error: RuntimeToolCompatibilityError) -> NoReturn:

--- a/src-python/runtime_tool_compatibility.py
+++ b/src-python/runtime_tool_compatibility.py
@@ -490,6 +490,70 @@ def _declaration_key(declaration: Mapping[str, Any]) -> tuple[Any, ...]:
     )
 
 
+def _tool_choice_matches_declaration(
+    declaration: Mapping[str, Any],
+    tool_choice: Any,
+) -> bool:
+    """Return whether an explicit choice identifies this declaration exactly."""
+    family = classify_declaration(declaration)
+    name = _name_of(declaration)
+    namespace, children, _version, _valid = _namespace_details(declaration)
+
+    if isinstance(tool_choice, str):
+        if tool_choice in {"auto", "none", "required"}:
+            return False
+        if family == NAMESPACE:
+            return tool_choice == namespace or any(
+                tool_choice == f"{namespace}__{child.get('name')}" for child in children
+            )
+        if family == TOOL_SEARCH and tool_choice == "tool_search":
+            return True
+        return tool_choice == name
+
+    if not isinstance(tool_choice, Mapping):
+        return False
+    choice_type = tool_choice.get("type")
+    choice_name = tool_choice.get("name")
+    if choice_type in (None, "function"):
+        if not isinstance(choice_name, str):
+            return False
+        if family == PLAIN_FUNCTION:
+            return choice_name == name
+        if family == NAMESPACE:
+            choice_namespace = tool_choice.get("namespace")
+            return (
+                choice_namespace == namespace and choice_name in {child.get("name") for child in children}
+            ) or (
+                choice_namespace is None
+                and any(choice_name == f"{namespace}__{child.get('name')}" for child in children)
+            )
+        return False
+    if choice_type == "namespace":
+        return family == NAMESPACE and choice_name in {None, namespace}
+    if choice_type == "custom":
+        return family == CUSTOM_FREEFORM and choice_name == name
+    if choice_type == "tool_search":
+        return family == TOOL_SEARCH
+    if isinstance(choice_type, str) and choice_type == declaration.get("type"):
+        return choice_name in {None, name}
+    return False
+
+
+def _has_explicit_named_tool_choice(tool_choice: Any) -> bool:
+    if isinstance(tool_choice, str):
+        return tool_choice not in {"auto", "none", "required"}
+    if not isinstance(tool_choice, Mapping):
+        return False
+    if isinstance(tool_choice.get("name"), str):
+        return True
+    return tool_choice.get("type") in {
+        "namespace",
+        "custom",
+        "tool_search",
+        *_KNOWN_HOSTED_TYPES,
+    }
+
+
 def _required_by_rule(
     declaration: Mapping[str, Any],
     index: int,
@@ -524,19 +588,9 @@ def _required_by_rule(
         return result
     if not isinstance(tool_choice, Mapping):
         if isinstance(tool_choice, str) and tool_choice not in {"auto", "none"}:
-            return result or tool_choice in names
+            return result or _tool_choice_matches_declaration(declaration, tool_choice)
         return result
-    choice_type = tool_choice.get("type")
-    choice_name = tool_choice.get("name")
-    if choice_type == "function" and isinstance(choice_name, str):
-        return result or choice_name in names
-    if choice_type in {"namespace", "custom", "tool_search"} and (
-        choice_name is None or choice_name in names
-    ):
-        return True
-    if isinstance(choice_type, str) and choice_type in names:
-        return True
-    return result
+    return result or _tool_choice_matches_declaration(declaration, tool_choice)
 
 
 def _protocol_capabilities(
@@ -558,7 +612,11 @@ def _declaration_valid_for_family(declaration: Mapping[str, Any], family: str) -
     if family == NAMESPACE:
         return _namespace_details(declaration)[3]
     if family == CUSTOM_FREEFORM:
-        return declaration.get("type") == "custom" and bool(_name_of(declaration)) and "format" in declaration
+        return (
+            declaration.get("type") == "custom"
+            and bool(_name_of(declaration))
+            and isinstance(declaration.get("format"), Mapping)
+        )
     if family == TOOL_SEARCH:
         return declaration.get("type") == "tool_search" and declaration.get("execution") == "client"
     if family == SELECTED_PROVIDER_HOSTED:
@@ -705,6 +763,11 @@ def build_tool_compatibility_plan(
             )
         )
 
+    if _has_explicit_named_tool_choice(tool_choice) and not any(
+        _tool_choice_matches_declaration(declaration, tool_choice)
+        for declaration in declarations
+    ):
+        raise RequiredToolUnavailableError()
     if tool_choice in ("required", True) and not any(
         entry.disposition in {NATIVE, ADAPT} for entry in preliminary
     ):
@@ -812,20 +875,7 @@ class ToolCompatibilityPlan:
     def with_final_declarations(self, declarations: Iterable[Mapping[str, Any]]) -> "ToolCompatibilityPlan":
         """Add model-visible native declarations while preserving request aliases."""
         final = list(declarations)
-        occurrence: dict[tuple[Any, ...], int] = {}
-        matched_keys: set[tuple[Any, ...]] = set()
-        for declaration in final:
-            if isinstance(declaration, Mapping):
-                key = _declaration_key(declaration)
-                existing = self._entry_for_declaration(declaration, occurrence)
-                if existing is not None:
-                    matched_keys.add((key, existing.declaration_index))
         entries = list(self.entries)
-        existing_occurrence: dict[tuple[Any, ...], int] = {}
-        for entry in self.entries:
-            existing_occurrence[_declaration_key(entry.declaration)] = existing_occurrence.get(
-                _declaration_key(entry.declaration), 0
-            ) + 1
         native_names: set[str] = set()
         for declaration in final:
             if not isinstance(declaration, Mapping):
@@ -899,24 +949,34 @@ class ToolCompatibilityPlan:
     def _entry_for_name(self, name: Any, namespace: Any = None) -> ToolCompatibilityEntry | None:
         if not isinstance(name, str):
             return None
-        for entry in self.entries:
-            if (
-                entry.family == NAMESPACE
-                and (
-                    (
-                        (namespace is None or namespace == entry.namespace)
-                        and name in entry.child_names
-                    )
-                    or (
-                        namespace is None
-                        and any(name == f"{entry.namespace}__{child}" for child in entry.child_names)
-                    )
-                )
-            ):
-                return entry
-            if entry.family != NAMESPACE and entry.original_name == name:
-                return entry
-        return None
+        matches: list[ToolCompatibilityEntry] = []
+        if namespace is not None:
+            matches = [
+                entry
+                for entry in self.entries
+                if entry.family == NAMESPACE
+                and entry.namespace == namespace
+                and name in entry.child_names
+            ]
+        else:
+            # An unqualified child name is not enough to identify an adapted
+            # namespace call.  Prefer an exact non-namespace declaration (in
+            # particular a native plain function) and only accept the
+            # explicit flattened ``namespace__child`` spelling for an
+            # adapted namespace call.
+            matches = [
+                entry
+                for entry in self.entries
+                if entry.family != NAMESPACE and entry.original_name == name
+            ]
+            if not matches:
+                matches = [
+                    entry
+                    for entry in self.entries
+                    if entry.family == NAMESPACE
+                    and any(name == f"{entry.namespace}__{child}" for child in entry.child_names)
+                ]
+        return matches[0] if len(matches) == 1 else None
 
     def _entries_for_name(self, name: Any, namespace: Any = None) -> list[ToolCompatibilityEntry]:
         if not isinstance(name, str):
@@ -926,14 +986,24 @@ class ToolCompatibilityPlan:
             if entry.family == NAMESPACE:
                 if namespace is not None and namespace != entry.namespace:
                     continue
-                if name in entry.child_names or (
-                    namespace is None
-                    and any(name == f"{entry.namespace}__{child}" for child in entry.child_names)
+                if namespace is not None and name in entry.child_names:
+                    matches.append(entry)
+                elif namespace is None and any(
+                    name == f"{entry.namespace}__{child}" for child in entry.child_names
                 ):
                     matches.append(entry)
             elif entry.original_name == name:
-                matches.append(entry)
+                if namespace is None:
+                    matches.append(entry)
         return matches
+
+    def _has_unqualified_adapted_child(self, name: Any) -> bool:
+        return isinstance(name, str) and any(
+            entry.family == NAMESPACE
+            and entry.disposition == ADAPT
+            and name in entry.child_names
+            for entry in self.entries
+        )
 
     def _alias_for(self, entry: ToolCompatibilityEntry, *, child_name: str | None = None) -> str | None:
         if entry.family == NAMESPACE:
@@ -1044,9 +1114,13 @@ class ToolCompatibilityPlan:
                 result["type"] = "function"
                 result["name"] = aliases[0]
                 return result, True
-        entry = self._entry_for_name(name)
+        entry = self._entry_for_name(name, result.get("namespace"))
         if choice_type == "function" and isinstance(name, str):
-            candidates = [candidate for candidate in self._entries_for_name(name) if candidate.disposition == ADAPT]
+            candidates = [
+                candidate
+                for candidate in self._entries_for_name(name, result.get("namespace"))
+                if candidate.disposition == ADAPT
+            ]
             if len(candidates) > 1:
                 raise ToolCompatibilityError("tool_compatibility_boundary", "ambiguous_tool_choice")
         alias = (
@@ -1057,6 +1131,7 @@ class ToolCompatibilityPlan:
         if alias:
             result["name"] = alias
             result["type"] = "function"
+            result.pop("namespace", None)
             return result, True
         return result, False
 
@@ -1351,7 +1426,13 @@ class ToolCompatibilityPlan:
                         decoded, item_changed = item, False
                     elif self.registry.looks_like_alias(item.get("name")):
                         raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_alias", surface="history")
-                    elif self.has_adaptations and self._entry_for_name(item.get("name"), item.get("namespace")) is not None:
+                    elif self.has_adaptations and (
+                        self._entry_for_name(item.get("name"), item.get("namespace")) is not None
+                        or (
+                            item.get("namespace") is None
+                            and self._has_unqualified_adapted_child(item.get("name"))
+                        )
+                    ):
                         raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_alias", surface="history")
                     else:
                         decoded, item_changed = item, False
@@ -1360,7 +1441,13 @@ class ToolCompatibilityPlan:
                 if native_entry is not None:
                     self._validate_native_item(item, native_entry)
                     decoded, item_changed = item, False
-                elif self.has_adaptations and self._entry_for_name(item.get("name"), item.get("namespace")) is not None:
+                elif self.has_adaptations and (
+                    self._entry_for_name(item.get("name"), item.get("namespace")) is not None
+                    or (
+                        item.get("namespace") is None
+                        and self._has_unqualified_adapted_child(item.get("name"))
+                    )
+                ):
                     raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_alias", surface="history")
                 else:
                     decoded, item_changed = item, False
@@ -1566,6 +1653,14 @@ class CompatibilityStreamState:
         if event_type in {"response.function_call_arguments.delta", "response.custom_tool_call_input.delta"}:
             item_id = self._item_id(result)
             if item_id in self._native_pending:
+                expected_call_id, _family = self._native_pending[item_id]
+                supplied_call_id = result.get("call_id")
+                if supplied_call_id is not None and supplied_call_id != expected_call_id:
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "ambiguous_call_identity",
+                        surface="stream",
+                    )
                 delta = result.get("delta")
                 if not isinstance(delta, str):
                     raise ToolCompatibilityError("tool_compatibility_boundary", "malformed_stream_delta", surface="stream")
@@ -1589,10 +1684,18 @@ class CompatibilityStreamState:
         if event_type in {"response.function_call_arguments.done", "response.custom_tool_call_input.done"}:
             item_id = self._item_id(result)
             if item_id in self._native_pending:
+                expected_call_id, _family = self._native_pending[item_id]
+                supplied_call_id = result.get("call_id")
+                if supplied_call_id is not None and supplied_call_id != expected_call_id:
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "ambiguous_call_identity",
+                        surface="stream",
+                    )
                 if item_id in self._native_delta_done:
                     raise ToolCompatibilityError("tool_compatibility_boundary", "duplicate_stream_done", surface="stream")
                 arguments = result.get("arguments", result.get("input"))
-                if not isinstance(arguments, str) and event_type == "response.function_call_arguments.done":
+                if not isinstance(arguments, str):
                     raise ToolCompatibilityError("tool_compatibility_boundary", "incomplete_stream_delta", surface="stream")
                 self._native_delta_done.add(item_id)
                 return result

--- a/src-python/runtime_tool_compatibility.py
+++ b/src-python/runtime_tool_compatibility.py
@@ -750,13 +750,8 @@ def build_tool_compatibility_plan(
         else:
             kind = declaration.get("type")
             provider_hosted = declaration.get("executor") == "selected_provider"
-            if (
-                valid
-                and isinstance(kind, str)
-                and kind in capabilities.unknown_lifecycles
-                and (not provider_hosted or kind in hosted.supported_kinds)
-            ):
-                disposition, reason = NATIVE, "explicit_unknown_lifecycle"
+            if provider_hosted and (not isinstance(kind, str) or kind not in hosted.supported_kinds):
+                reason = "selected_provider_hosted_lifecycle_unavailable"
             else:
                 reason = "unknown_lifecycle_contract_unavailable"
 
@@ -1705,9 +1700,6 @@ class ToolCompatibilityPlan:
                 if entry.family == TOOL_SEARCH and entry.disposition == NATIVE
             ]
             return matches[0] if len(matches) == 1 else None
-        unknown_entry = self._native_unknown_entry_for_item(item)
-        if unknown_entry is not None:
-            return unknown_entry
         hosted_item_spec = _hosted_event_spec_for_item_type(item_type)
         if hosted_item_spec is not None and item_type == hosted_item_spec[0]:
             hosted_event_kind, _stages = hosted_item_spec
@@ -1725,48 +1717,6 @@ class ToolCompatibilityPlan:
                 raise ToolCompatibilityError("tool_compatibility_boundary", "ambiguous_native_identity")
             return matches[0] if matches else None
         return None
-
-    @staticmethod
-    def _unknown_item_kind(item_type: Any) -> str | None:
-        if not isinstance(item_type, str):
-            return None
-        if item_type.endswith("_call_output"):
-            kind = item_type[: -len("_call_output")]
-            return kind if kind else None
-        if item_type.endswith("_call"):
-            kind = item_type[: -len("_call")]
-            return kind if kind else None
-        return None
-
-    def _native_unknown_entry_for_item(self, item: Mapping[str, Any]) -> ToolCompatibilityEntry | None:
-        kind = self._unknown_item_kind(item.get("type"))
-        if kind is None:
-            return None
-        matches = [
-            entry
-            for entry in self.entries
-            if entry.family == UNKNOWN_FUTURE_KIND
-            and entry.disposition == NATIVE
-            and entry.declaration.get("type") == kind
-        ]
-        if len(matches) > 1:
-            raise ToolCompatibilityError("tool_compatibility_boundary", "ambiguous_native_identity")
-        return matches[0] if matches else None
-
-    def _is_native_unknown_stream_event(self, event_type: Any) -> bool:
-        if not isinstance(event_type, str) or not event_type.startswith("response."):
-            return False
-        suffix = event_type[len("response.") :]
-        call_type, separator, _stage = suffix.partition(".")
-        if not separator or not call_type.endswith("_call"):
-            return False
-        kind = call_type[: -len("_call")]
-        return any(
-            entry.family == UNKNOWN_FUTURE_KIND
-            and entry.disposition == NATIVE
-            and entry.declaration.get("type") == kind
-            for entry in self.entries
-        )
 
     def _has_native_structural_family(self) -> bool:
         return any(
@@ -1815,11 +1765,6 @@ class ToolCompatibilityPlan:
                 raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_native_identity", surface="history")
             if item_type == "tool_search_call" and item.get("execution") not in {None, "client"}:
                 raise ToolCompatibilityError("tool_compatibility_boundary", "invalid_tool_search_execution", surface="history")
-        elif entry.family == UNKNOWN_FUTURE_KIND:
-            if ToolCompatibilityPlan._unknown_item_kind(item_type) != entry.declaration.get("type"):
-                raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_native_identity", surface="history")
-            if _item_identity(item) is None:
-                raise ToolCompatibilityError("tool_compatibility_boundary", "missing_item_identity", surface="history")
         elif entry.family == SELECTED_PROVIDER_HOSTED:
             hosted_spec = _hosted_event_spec_for_declaration_kind(entry.declaration.get("type"))
             if hosted_spec is None or item_type != hosted_spec[0]:
@@ -1903,9 +1848,6 @@ class ToolCompatibilityPlan:
                     raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_alias", surface="history")
                 else:
                     decoded, item_changed = item, False
-            elif (native_unknown_entry := self._native_unknown_entry_for_item(item)) is not None:
-                self._validate_native_item(item, native_unknown_entry)
-                decoded, item_changed = item, False
             elif _hosted_kind_for_item_type(item_type) is not None:
                 native_entry = self._native_entry_for_item(item)
                 if native_entry is None:
@@ -2081,13 +2023,6 @@ class CompatibilityStreamState:
         pending.next_stage += 1
         return _copy_mapping(event)
 
-    def _is_pending_native_unknown_event(self, event: Mapping[str, Any]) -> bool:
-        if not self.plan._is_native_unknown_stream_event(event.get("type")):
-            return False
-        item_id = self._native_item_id_for_event(event)
-        pending = self._native_pending.get(item_id) if item_id is not None else None
-        return pending is not None and pending[1] == UNKNOWN_FUTURE_KIND
-
     def _finish_terminal(self) -> None:
         if self._terminal:
             raise ToolCompatibilityError("tool_compatibility_boundary", "duplicate_terminal", surface="stream")
@@ -2095,7 +2030,7 @@ class CompatibilityStreamState:
         native_incomplete = any(
             item_id not in self._native_done
             or (
-                family not in {TOOL_SEARCH, SELECTED_PROVIDER_HOSTED, UNKNOWN_FUTURE_KIND}
+                family not in {TOOL_SEARCH, SELECTED_PROVIDER_HOSTED}
                 and item_id not in self._native_delta_done
             )
             for item_id, (_call_id, family) in self._native_pending.items()
@@ -2109,7 +2044,7 @@ class CompatibilityStreamState:
             raise ToolCompatibilityError("tool_compatibility_boundary", "malformed_stream_event", surface="stream")
         result = _copy_mapping(event)
         event_type = result.get("type")
-        if _is_unsupported_hosted_stream_event(event_type) and not self._is_pending_native_unknown_event(result):
+        if _is_unsupported_hosted_stream_event(event_type):
             raise ToolCompatibilityError(
                 "tool_compatibility_boundary",
                 "unsupported_hosted_lifecycle",
@@ -2176,16 +2111,15 @@ class CompatibilityStreamState:
                     )
                     result["item"] = decoded_item
                     return result
-                if native_entry.family != UNKNOWN_FUTURE_KIND and (not isinstance(call_id, str) or not call_id):
+                if not isinstance(call_id, str) or not call_id:
                     raise ToolCompatibilityError("tool_compatibility_boundary", "missing_call_identity", surface="stream")
                 self.plan._validate_native_item(item, native_entry)
                 if item_id in self._seen_item_ids:
                     raise ToolCompatibilityError("tool_compatibility_boundary", "duplicate_item_identity", surface="stream")
-                if isinstance(call_id, str) and call_id in self._seen_call_ids:
+                if call_id in self._seen_call_ids:
                     raise ToolCompatibilityError("tool_compatibility_boundary", "duplicate_call_identity", surface="stream")
                 self._seen_item_ids.add(item_id)
-                if isinstance(call_id, str):
-                    self._seen_call_ids.add(call_id)
+                self._seen_call_ids.add(call_id)
                 self._native_pending[item_id] = (call_id, native_entry.family)
                 result["item"] = decoded_item
             elif self.plan.has_adaptations and item.get("type") in {"function_call", "custom_tool_call"}:
@@ -2311,7 +2245,7 @@ class CompatibilityStreamState:
                                 surface="stream",
                             )
                         self.plan._validate_native_item(item, hosted_entry, require_completed=True)
-                    elif native_pending[1] not in {TOOL_SEARCH, UNKNOWN_FUTURE_KIND} and native_item_id not in self._native_delta_done:
+                    elif native_pending[1] != TOOL_SEARCH and native_item_id not in self._native_delta_done:
                         raise ToolCompatibilityError("tool_compatibility_boundary", "incomplete_stream_delta", surface="stream")
                     if native_item_id in self._native_done:
                         raise ToolCompatibilityError("tool_compatibility_boundary", "duplicate_item_identity", surface="stream")

--- a/src-python/runtime_tool_compatibility.py
+++ b/src-python/runtime_tool_compatibility.py
@@ -1545,6 +1545,12 @@ class ToolCompatibilityPlan:
                 return f"{declaration_type}_call_output"
         return None
 
+    def _expected_response_output_type(self, entry: ToolCompatibilityEntry) -> str | None:
+        expected = self._history_output_type_for_entry(entry)
+        if entry.disposition == ADAPT and entry.family in {NAMESPACE, CUSTOM_FREEFORM}:
+            return "function_call_output"
+        return expected
+
     def _standard_contract_families_for_item(self, item: Mapping[str, Any]) -> frozenset[str]:
         item_type = item.get("type")
         if item_type == "function_call":
@@ -1658,9 +1664,11 @@ class ToolCompatibilityPlan:
 
         if item_type in {"function_call_output", "custom_tool_call_output", "tool_search_output"}:
             if owner is not None:
-                expected_output_type = self._history_output_type_for_entry(owner)
-                if surface == "response" and owner.disposition == ADAPT and owner.family in {NAMESPACE, CUSTOM_FREEFORM}:
-                    expected_output_type = "function_call_output"
+                expected_output_type = (
+                    self._expected_response_output_type(owner)
+                    if surface == "response"
+                    else self._history_output_type_for_entry(owner)
+                )
                 if item_type != expected_output_type:
                     raise ToolCompatibilityError(
                         "tool_compatibility_boundary",
@@ -1715,6 +1723,35 @@ class ToolCompatibilityPlan:
             native = next((entry for entry in matches if entry.disposition == NATIVE), None)
             return native or (matches[0] if matches else None)
         return None
+
+    def _validate_response_owner_item(
+        self,
+        item: Mapping[str, Any],
+        *,
+        owner: ToolCompatibilityEntry | None,
+        call_index: int | None,
+        item_index: int,
+        surface: str,
+    ) -> None:
+        """Validate output-family ownership before response decoding starts."""
+        item_type = item.get("type")
+        if not isinstance(item_type, str) or not item_type.endswith("_call_output"):
+            return
+        if owner is None:
+            return
+        expected = self._expected_response_output_type(owner)
+        if expected is not None and item_type != expected:
+            raise ToolCompatibilityError(
+                "tool_compatibility_boundary",
+                "ambiguous_call_identity",
+                surface=surface,
+            )
+        if owner.disposition == ADAPT and call_index is not None and item_index < call_index:
+            raise ToolCompatibilityError(
+                "tool_compatibility_boundary",
+                "ambiguous_call_identity",
+                surface=surface,
+            )
 
     def _omitted_response_entry_for_item(
         self,
@@ -1854,6 +1891,48 @@ class ToolCompatibilityPlan:
                     if isinstance(call_id, str):
                         owner = history_call_owners.get(call_id)
                 return self._omitted_history_entry(item, owner=owner)
+
+            seen_history_item_ids: set[str] = set()
+            seen_history_output_call_ids: set[str] = set()
+            for item in raw_input:
+                if not isinstance(item, Mapping):
+                    continue
+                item_type = item.get("type")
+                omitted_entry = omitted_history_entry(item)
+                hosted_item_key = self._hosted_history_item_key(item_type)
+                is_optional_omitted_hosted = omitted_entry is not None and hosted_item_key is not None
+                if not is_optional_omitted_hosted:
+                    item_id = _item_identity(item)
+                    if item_id is not None:
+                        if item_id in seen_history_item_ids:
+                            raise ToolCompatibilityError(
+                                "tool_compatibility_boundary",
+                                "duplicate_item_identity",
+                                surface="history",
+                            )
+                        seen_history_item_ids.add(item_id)
+                if item_type in {"function_call", "custom_tool_call", "tool_search_call"}:
+                    call_id = item.get("call_id")
+                    if omitted_entry is None and (not isinstance(call_id, str) or not call_id):
+                        raise ToolCompatibilityError(
+                            "tool_compatibility_boundary",
+                            "missing_call_identity",
+                            surface="history",
+                        )
+                if isinstance(item_type, str) and item_type.endswith("_call_output"):
+                    call_id = item.get("call_id")
+                    if (
+                        not is_optional_omitted_hosted
+                        and isinstance(call_id, str)
+                        and call_id
+                    ):
+                        if call_id in seen_history_output_call_ids:
+                            raise ToolCompatibilityError(
+                                "tool_compatibility_boundary",
+                                "duplicate_call_identity",
+                                surface="history",
+                            )
+                        seen_history_output_call_ids.add(call_id)
 
             omitted_hosted_ids: dict[str, tuple[str, bool, bool]] = {}
             for item in raw_input:
@@ -2146,8 +2225,9 @@ class ToolCompatibilityPlan:
         seen_call_ids: set[str] = set()
         seen_result_call_ids: set[str] = set()
         response_call_owners: dict[str, ToolCompatibilityEntry] = {}
+        response_call_positions: dict[str, int] = {}
         surface = "response" if reject_omitted_response else "history"
-        for raw_item in items:
+        for item_index, raw_item in enumerate(items):
             if not isinstance(raw_item, Mapping):
                 continue
             if raw_item.get("type") not in {"function_call", "custom_tool_call", "tool_search_call"}:
@@ -2171,6 +2251,30 @@ class ToolCompatibilityPlan:
                     surface=surface,
                 )
             response_call_owners[call_id] = owner
+            response_call_positions[call_id] = item_index
+        response_output_call_ids: set[str] = set()
+        for item_index, raw_item in enumerate(items):
+            if not isinstance(raw_item, Mapping):
+                continue
+            call_id = raw_item.get("call_id")
+            item_type = raw_item.get("type")
+            if isinstance(item_type, str) and item_type.endswith("_call_output"):
+                if isinstance(call_id, str) and call_id:
+                    if call_id in response_output_call_ids:
+                        raise ToolCompatibilityError(
+                            "tool_compatibility_boundary",
+                            "duplicate_call_identity",
+                            surface=surface,
+                        )
+                    response_output_call_ids.add(call_id)
+                owner = response_call_owners.get(call_id) if isinstance(call_id, str) else None
+                self._validate_response_owner_item(
+                    raw_item,
+                    owner=owner,
+                    call_index=response_call_positions.get(call_id) if isinstance(call_id, str) else None,
+                    item_index=item_index,
+                    surface=surface,
+                )
         for raw_item in items:
             if not isinstance(raw_item, Mapping):
                 result.append(raw_item)
@@ -2441,6 +2545,41 @@ class CompatibilityStreamState:
             raise ToolCompatibilityError("tool_compatibility_boundary", "incomplete_stream", surface="stream")
         self._terminal = True
 
+    def _validate_terminal_native_output(self, response: Mapping[str, Any]) -> None:
+        output = response.get("output")
+        if not isinstance(output, list) or not self._native_pending:
+            return
+        for item in output:
+            if not isinstance(item, Mapping):
+                continue
+            item_id = _item_identity(item)
+            pending = self._native_pending.get(item_id) if item_id is not None else None
+            native_entry = self._native_entry_for_item(item)
+            if pending is None:
+                # Adapter output is accounted for by the request-scoped alias
+                # ledger; any other native-shaped item must match a stream
+                # owner before it can appear in the terminal envelope.
+                if native_entry is not None:
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "ambiguous_native_identity",
+                        surface="stream",
+                    )
+                continue
+            expected_call_id, expected_family = pending
+            if native_entry is None or native_entry.family != expected_family:
+                raise ToolCompatibilityError(
+                    "tool_compatibility_boundary",
+                    "ambiguous_native_identity",
+                    surface="stream",
+                )
+            if expected_call_id is not None and item.get("call_id") != expected_call_id:
+                raise ToolCompatibilityError(
+                    "tool_compatibility_boundary",
+                    "ambiguous_call_identity",
+                    surface="stream",
+                )
+
     def decode_event(self, event: Mapping[str, Any]) -> dict[str, Any]:
         if not isinstance(event, Mapping):
             raise ToolCompatibilityError("tool_compatibility_boundary", "malformed_stream_event", surface="stream")
@@ -2456,8 +2595,10 @@ class CompatibilityStreamState:
         if hosted_event_spec is not None:
             return self._decode_hosted_event(result, hosted_event_spec)
         if event_type in {"response.completed", "response.incomplete", "response.failed"}:
-            self._finish_terminal()
             response = result.get("response")
+            if isinstance(response, Mapping):
+                self._validate_terminal_native_output(response)
+            self._finish_terminal()
             if isinstance(response, Mapping):
                 decoded_output, output_changed = self.plan._decode_items(
                     response.get("output"),

--- a/src-python/runtime_tool_compatibility.py
+++ b/src-python/runtime_tool_compatibility.py
@@ -2501,6 +2501,7 @@ class CompatibilityStreamState:
         self._wire_payloads: dict[str, Any] = {}
         self._native_done: set[str] = set()
         self._native_delta_done: set[str] = set()
+        self._native_fragments: dict[str, list[str]] = {}
         self._hosted_pending: dict[str, _HostedStreamState] = {}
         self._buffered_custom: dict[str, _BufferedCustomStreamItem] = {}
         self._terminal = False
@@ -3013,6 +3014,7 @@ class CompatibilityStreamState:
                     raise ToolCompatibilityError("tool_compatibility_boundary", "malformed_stream_delta", surface="stream")
                 if item_id in self._native_delta_done:
                     raise ToolCompatibilityError("tool_compatibility_boundary", "duplicate_stream_done", surface="stream")
+                self._native_fragments.setdefault(item_id, []).append(delta)
                 return result
             if item_id not in self._pending:
                 if self.plan.has_adaptations:
@@ -3044,6 +3046,9 @@ class CompatibilityStreamState:
                 arguments = result.get("arguments", result.get("input"))
                 if not isinstance(arguments, str):
                     raise ToolCompatibilityError("tool_compatibility_boundary", "incomplete_stream_delta", surface="stream")
+                fragments = self._native_fragments.get(item_id, [])
+                if fragments and "".join(fragments) != arguments:
+                    raise ToolCompatibilityError("tool_compatibility_boundary", "incomplete_stream_delta", surface="stream")
                 payload_item = (
                     {"type": "custom_tool_call", "input": result.get("input", arguments)}
                     if expected_entry.family == CUSTOM_FREEFORM
@@ -3067,6 +3072,8 @@ class CompatibilityStreamState:
             arguments = result.get("arguments", result.get("input"))
             if not isinstance(arguments, str):
                 arguments = "".join(pending.fragments)
+            elif pending.fragments and "".join(pending.fragments) != arguments:
+                raise ToolCompatibilityError("tool_compatibility_boundary", "incomplete_stream_delta", surface="stream")
             if not arguments:
                 raise ToolCompatibilityError("tool_compatibility_boundary", "incomplete_stream_delta", surface="stream")
             pending.delta_done = True

--- a/src-python/runtime_tool_compatibility.py
+++ b/src-python/runtime_tool_compatibility.py
@@ -2530,6 +2530,10 @@ class _HostedStreamState:
 class CompatibilityStreamState:
     """Assemble one adapted Responses SSE lifecycle before inverse mapping."""
 
+    _TERMINAL_EVENT_TYPES = frozenset(
+        {"response.completed", "response.incomplete", "response.failed"}
+    )
+
     def __init__(self, plan: ToolCompatibilityPlan) -> None:
         self.plan = plan
         self._pending: dict[str, _PendingStreamItem] = {}
@@ -2960,6 +2964,7 @@ class CompatibilityStreamState:
             raise ToolCompatibilityError("tool_compatibility_boundary", "malformed_stream_event", surface="stream")
         result = _copy_mapping(event)
         event_type = result.get("type")
+        self._reject_after_terminal(event_type)
         if _is_unsupported_hosted_stream_event(event_type):
             raise ToolCompatibilityError(
                 "tool_compatibility_boundary",
@@ -3277,6 +3282,10 @@ class CompatibilityStreamState:
             surface="stream",
         )
 
+    def _reject_after_terminal(self, event_type: Any) -> None:
+        if self._terminal and event_type not in self._TERMINAL_EVENT_TYPES:
+            raise self._stream_error("stream_after_terminal")
+
     @staticmethod
     def _native_custom_item(
         item: Mapping[str, Any],
@@ -3295,6 +3304,7 @@ class CompatibilityStreamState:
             raise self._stream_error("malformed_stream_event")
         value = _copy_mapping(event)
         event_type = value.get("type")
+        self._reject_after_terminal(event_type)
         item = value.get("item")
 
         if event_type in {"response.completed", "response.incomplete", "response.failed"}:

--- a/src-python/runtime_tool_compatibility.py
+++ b/src-python/runtime_tool_compatibility.py
@@ -1607,6 +1607,19 @@ class ToolCompatibilityPlan:
         if item.get("type") == "function_call" and self.registry.record_for_alias(item.get("name")) is not None:
             return
         if (
+            item.get("type") == "custom_tool_call"
+            and item.get("namespace") is not None
+            and any(
+                entry.family == CUSTOM_FREEFORM and entry.disposition == ADAPT
+                for entry in self.entries
+            )
+        ):
+            raise ToolCompatibilityError(
+                "tool_compatibility_boundary",
+                "unknown_native_identity",
+                surface=surface,
+            )
+        if (
             item.get("type") == "function_call"
             and item.get("namespace") is None
             and isinstance(item.get("name"), str)
@@ -1634,13 +1647,32 @@ class ToolCompatibilityPlan:
             item.get("type") == "function_call"
             and item.get("namespace") is not None
             and isinstance(item.get("name"), str)
-            and any(
-                entry.family == PLAIN_FUNCTION
-                and entry.original_name == f"{item.get('namespace')}__{item.get('name')}"
-                for entry in self.entries
-            )
         ):
-            return
+            flattened_name = f"{item.get('namespace')}__{item.get('name')}"
+            flattened_matches = [
+                entry
+                for entry in self.entries
+                if entry.family == PLAIN_FUNCTION
+                and entry.original_name == flattened_name
+            ]
+            if any(entry.disposition == NATIVE for entry in flattened_matches):
+                return
+            if flattened_matches:
+                raise ToolCompatibilityError(
+                    "tool_compatibility_boundary",
+                    "unknown_native_identity",
+                    surface=surface,
+                )
+            if any(entry.family == NAMESPACE for entry in self.entries) and self._entry_for_name(
+                item.get("name"),
+                item.get("namespace"),
+                item_type=item.get("type"),
+            ) is None:
+                raise ToolCompatibilityError(
+                    "tool_compatibility_boundary",
+                    "unknown_native_identity",
+                    surface=surface,
+                )
         if not self._has_standard_contract_for_item(item):
             return
         if self._standard_entry_for_item(item, surface=surface) is None:
@@ -2198,6 +2230,12 @@ class ToolCompatibilityPlan:
                 )
             return
         if item_type == "function_call_output":
+            if record.family == CUSTOM_FREEFORM and item.get("namespace") is not None:
+                raise ToolCompatibilityError(
+                    "tool_compatibility_boundary",
+                    "unknown_alias",
+                    surface=surface,
+                )
             return
         raise ToolCompatibilityError(
             "tool_compatibility_boundary",
@@ -2627,6 +2665,10 @@ class CompatibilityStreamState:
         # lifecycle is emitted.  Keep the original adapter wire identity so a
         # terminal envelope can still reconcile item/call/declaration exactly.
         self._adapter_wire_identities: dict[str, tuple[str, AliasRecord, tuple[Any, Any, Any]]] = {}
+        self._legacy_unowned_done: dict[
+            str,
+            tuple[str, ToolCompatibilityEntry, tuple[Any, Any, Any], Any],
+        ] = {}
         self._wire_payloads: dict[str, Any] = {}
         self._native_done: set[str] = set()
         self._native_delta_done: set[str] = set()
@@ -2750,6 +2792,12 @@ class CompatibilityStreamState:
         self._seen_item_ids.add(item_id)
         self._seen_call_ids.add(call_id)
         self._native_done.add(item_id)
+        self._legacy_unowned_done[item_id] = (
+            call_id,
+            entry,
+            self._native_wire_identity(item),
+            self._semantic_wire_payload(item, entry),
+        )
 
     def _complete_native_arguments_from_item(
         self,
@@ -2853,6 +2901,8 @@ class CompatibilityStreamState:
                 except (TypeError, ValueError):
                     return ("arguments_raw", arguments)
                 return ("arguments", _freeze(parsed))
+        if family == TOOL_SEARCH and item_type == "tool_search_call":
+            return ("arguments", _freeze(item.get("arguments")))
         return None
 
     @staticmethod
@@ -3054,6 +3104,35 @@ class CompatibilityStreamState:
                 seen_output_ids.add(item_id)
             pending = self._native_pending.get(item_id) if item_id is not None else None
             if pending is None:
+                legacy_done = self._legacy_unowned_done.get(item_id) if item_id is not None else None
+                if legacy_done is not None:
+                    expected_call_id, expected_entry, expected_wire, expected_payload = legacy_done
+                    if item.get("call_id") != expected_call_id:
+                        raise ToolCompatibilityError(
+                            "tool_compatibility_boundary",
+                            "ambiguous_call_identity",
+                            surface="stream",
+                        )
+                    if self._native_wire_identity(item) != expected_wire:
+                        raise ToolCompatibilityError(
+                            "tool_compatibility_boundary",
+                            "ambiguous_native_identity",
+                            surface="stream",
+                        )
+                    if self._native_entry_for_item(item) is not expected_entry:
+                        raise ToolCompatibilityError(
+                            "tool_compatibility_boundary",
+                            "ambiguous_native_identity",
+                            surface="stream",
+                        )
+                    self.plan._validate_native_item(item, expected_entry)
+                    if self._semantic_wire_payload(item, expected_entry) != expected_payload:
+                        raise ToolCompatibilityError(
+                            "tool_compatibility_boundary",
+                            "ambiguous_native_identity",
+                            surface="stream",
+                        )
+                    continue
                 adapter_pending = self._pending.get(item_id) if item_id is not None else None
                 if adapter_pending is not None:
                     if item.get("call_id") != adapter_pending.call_id:
@@ -3137,6 +3216,15 @@ class CompatibilityStreamState:
                             surface="stream",
                         )
                     continue
+                if isinstance(item.get("call_id"), str) and any(
+                    expected_call_id == item.get("call_id")
+                    for expected_call_id, _entry, _wire, _payload in self._legacy_unowned_done.values()
+                ):
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "ambiguous_call_identity",
+                        surface="stream",
+                    )
                 if isinstance(item.get("call_id"), str) and any(
                     expected_call_id == item.get("call_id")
                     for expected_call_id, _record, _wire in self._adapter_wire_identities.values()

--- a/src-python/runtime_tool_compatibility.py
+++ b/src-python/runtime_tool_compatibility.py
@@ -1545,6 +1545,83 @@ class ToolCompatibilityPlan:
                 return f"{declaration_type}_call_output"
         return None
 
+    def _standard_contract_families_for_item(self, item: Mapping[str, Any]) -> frozenset[str]:
+        item_type = item.get("type")
+        if item_type == "function_call":
+            return frozenset({NAMESPACE}) if item.get("namespace") is not None else frozenset({PLAIN_FUNCTION, NAMESPACE})
+        if item_type == "custom_tool_call":
+            return frozenset({CUSTOM_FREEFORM})
+        if item_type in {"tool_search_call", "tool_search_output"}:
+            return frozenset({TOOL_SEARCH})
+        return frozenset()
+
+    def _has_standard_contract_for_item(self, item: Mapping[str, Any]) -> bool:
+        families = self._standard_contract_families_for_item(item)
+        # Only an omitted standard declaration creates a representational
+        # boundary that an unknown item could bypass.  Native-only plans may
+        # still carry provider-local historical calls that are intentionally
+        # left untouched.
+        return bool(families) and any(
+            entry.family in families and entry.disposition == OMIT
+            for entry in self.entries
+        )
+
+    def _reject_unknown_standard_item(self, item: Mapping[str, Any], *, surface: str) -> None:
+        """Reject an undeclared standard lifecycle when this plan has a contract.
+
+        A standard item with a typo or a provider-local name must not bypass an
+        omitted/native declaration merely because name lookup returned no exact
+        match.  Adapter aliases remain valid function-call wire names.
+        """
+        if item.get("type") == "function_call" and self.registry.record_for_alias(item.get("name")) is not None:
+            return
+        if (
+            item.get("type") == "function_call"
+            and item.get("namespace") is not None
+            and isinstance(item.get("name"), str)
+            and any(
+                entry.family == PLAIN_FUNCTION
+                and entry.original_name == f"{item.get('namespace')}__{item.get('name')}"
+                for entry in self.entries
+            )
+        ):
+            return
+        if not self._has_standard_contract_for_item(item):
+            return
+        if self._standard_entry_for_item(item, surface=surface) is None:
+            raise ToolCompatibilityError(
+                "tool_compatibility_boundary",
+                "unknown_native_identity",
+                surface=surface,
+            )
+
+    def _entry_for_call_owner(
+        self,
+        item: Mapping[str, Any],
+        *,
+        surface: str,
+    ) -> ToolCompatibilityEntry | None:
+        """Resolve a call item to its request/response declaration owner."""
+        if item.get("type") not in {"function_call", "custom_tool_call", "tool_search_call"}:
+            return None
+        entry = self._native_entry_for_item(item)
+        if entry is None:
+            record = self.registry.record_for_alias(item.get("name"))
+            if record is not None:
+                entry = next(
+                    (
+                        candidate
+                        for candidate in self.entries
+                        if candidate.declaration_index == record.declaration_index
+                    ),
+                    None,
+                )
+        if entry is None:
+            entry = self._standard_entry_for_item(item, surface=surface)
+        if entry is None:
+            entry = self._unknown_entry_for_item(item, surface=surface)
+        return entry
+
     def _standard_entry_for_item(
         self,
         item: Mapping[str, Any],
@@ -1581,7 +1658,10 @@ class ToolCompatibilityPlan:
 
         if item_type in {"function_call_output", "custom_tool_call_output", "tool_search_output"}:
             if owner is not None:
-                if item_type != self._history_output_type_for_entry(owner):
+                expected_output_type = self._history_output_type_for_entry(owner)
+                if surface == "response" and owner.disposition == ADAPT and owner.family in {NAMESPACE, CUSTOM_FREEFORM}:
+                    expected_output_type = "function_call_output"
+                if item_type != expected_output_type:
                     raise ToolCompatibilityError(
                         "tool_compatibility_boundary",
                         "ambiguous_call_identity",
@@ -1636,8 +1716,13 @@ class ToolCompatibilityPlan:
             return native or (matches[0] if matches else None)
         return None
 
-    def _omitted_response_entry_for_item(self, item: Mapping[str, Any]) -> ToolCompatibilityEntry | None:
-        standard_entry = self._standard_entry_for_item(item)
+    def _omitted_response_entry_for_item(
+        self,
+        item: Mapping[str, Any],
+        *,
+        owner: ToolCompatibilityEntry | None = None,
+    ) -> ToolCompatibilityEntry | None:
+        standard_entry = self._standard_entry_for_item(item, owner=owner, surface="response")
         if standard_entry is not None:
             return standard_entry if standard_entry.disposition == OMIT else None
         hosted_item_key = self._hosted_history_item_key(item.get("type"))
@@ -1688,7 +1773,11 @@ class ToolCompatibilityPlan:
                 item.get("namespace"),
                 item_type=item_type,
             )
-            return entry if entry is not None and entry.disposition == OMIT else None
+            if entry is not None and entry.disposition == OMIT:
+                return entry
+            self._reject_unknown_standard_item(item, surface="history")
+            return None
+        self._reject_unknown_standard_item(item, surface="history")
         if item_type in {"tool_search_call", "tool_search_output"}:
             return next(
                 (
@@ -1725,6 +1814,7 @@ class ToolCompatibilityPlan:
             encoded_input: list[Any] = []
             changed = tools_changed or choice_changed
             history_call_owners: dict[str, ToolCompatibilityEntry] = {}
+            seen_history_call_ids: dict[str, ToolCompatibilityEntry | None] = {}
             for item in raw_input:
                 if not isinstance(item, Mapping) or item.get("type") not in {
                     "function_call",
@@ -1732,12 +1822,26 @@ class ToolCompatibilityPlan:
                     "tool_search_call",
                 }:
                     continue
-                owner = self._standard_entry_for_item(item, surface="history")
-                if owner is None:
-                    owner = self._unknown_entry_for_item(item, surface="history")
+                owner = self._entry_for_call_owner(item, surface="history")
                 call_id = item.get("call_id")
-                if owner is not None and isinstance(call_id, str) and call_id:
-                    history_call_owners[call_id] = owner
+                if isinstance(call_id, str) and call_id:
+                    if call_id in seen_history_call_ids:
+                        previous = seen_history_call_ids[call_id]
+                        classification = (
+                            "ambiguous_call_identity"
+                            if previous is not None
+                            and owner is not None
+                            and (previous.disposition == OMIT or owner.disposition == OMIT)
+                            else "duplicate_call_identity"
+                        )
+                        raise ToolCompatibilityError(
+                            "tool_compatibility_boundary",
+                            classification,
+                            surface="history",
+                        )
+                    seen_history_call_ids[call_id] = owner
+                    if owner is not None:
+                        history_call_owners[call_id] = owner
 
             def omitted_history_entry(item: Mapping[str, Any]) -> ToolCompatibilityEntry | None:
                 owner = None
@@ -1873,7 +1977,14 @@ class ToolCompatibilityPlan:
             raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_alias", surface="response")
         call_id = result.get("call_id")
         if isinstance(call_id, str) and call_id:
-            if self.registry.record_for_call(call_id) is None:
+            previous = self.registry.record_for_call(call_id)
+            if previous is not None and previous.alias != record.alias:
+                raise ToolCompatibilityError(
+                    "tool_compatibility_boundary",
+                    "ambiguous_call_identity",
+                    surface="response",
+                )
+            if previous is None:
                 self.registry.bind_call(call_id, record.alias)
         elif not allow_incomplete:
             raise ToolCompatibilityError("tool_compatibility_boundary", "missing_call_identity", surface="response")
@@ -1891,6 +2002,31 @@ class ToolCompatibilityPlan:
             else:
                 result["type"] = "custom_tool_call"
         return result, record, True
+
+    def _validate_registered_item_identity(self, item: Mapping[str, Any], *, surface: str) -> None:
+        """Ensure a bound adapter call keeps its wire family and alias."""
+        call_id = item.get("call_id")
+        if not isinstance(call_id, str) or not call_id:
+            return
+        record = self.registry.record_for_call(call_id)
+        if record is None:
+            return
+        item_type = item.get("type")
+        if item_type == "function_call":
+            if item.get("name") != record.alias:
+                raise ToolCompatibilityError(
+                    "tool_compatibility_boundary",
+                    "ambiguous_call_identity",
+                    surface=surface,
+                )
+            return
+        if item_type == "function_call_output":
+            return
+        raise ToolCompatibilityError(
+            "tool_compatibility_boundary",
+            "ambiguous_call_identity",
+            surface=surface,
+        )
 
     def _decode_result(self, item: Mapping[str, Any]) -> tuple[dict[str, Any], bool]:
         result = _copy_mapping(item)
@@ -2009,20 +2145,48 @@ class ToolCompatibilityPlan:
         seen_item_ids: set[str] = set()
         seen_call_ids: set[str] = set()
         seen_result_call_ids: set[str] = set()
+        response_call_owners: dict[str, ToolCompatibilityEntry] = {}
+        surface = "response" if reject_omitted_response else "history"
+        for raw_item in items:
+            if not isinstance(raw_item, Mapping):
+                continue
+            if raw_item.get("type") not in {"function_call", "custom_tool_call", "tool_search_call"}:
+                continue
+            call_id = raw_item.get("call_id")
+            if not isinstance(call_id, str) or not call_id:
+                continue
+            owner = self._entry_for_call_owner(raw_item, surface=surface)
+            if owner is None:
+                continue
+            previous = response_call_owners.get(call_id)
+            if previous is not None:
+                classification = (
+                    "ambiguous_call_identity"
+                    if previous.disposition == OMIT or owner.disposition == OMIT
+                    else "duplicate_call_identity"
+                )
+                raise ToolCompatibilityError(
+                    "tool_compatibility_boundary",
+                    classification,
+                    surface=surface,
+                )
+            response_call_owners[call_id] = owner
         for raw_item in items:
             if not isinstance(raw_item, Mapping):
                 result.append(raw_item)
                 continue
             item_type = raw_item.get("type")
             item = _copy_mapping(raw_item)
-            if reject_omitted_response and self._omitted_response_entry_for_item(item) is not None:
+            call_id = item.get("call_id")
+            owner = response_call_owners.get(call_id) if isinstance(call_id, str) else None
+            self._validate_registered_item_identity(item, surface=surface)
+            if reject_omitted_response and self._omitted_response_entry_for_item(item, owner=owner) is not None:
                 raise ToolCompatibilityError(
                     "tool_compatibility_boundary",
                     "unsupported_hosted_lifecycle",
-                    surface="response",
+                    surface=surface,
                 )
             item_id = _item_identity(item)
-            call_id = item.get("call_id")
             if item_type in {"function_call", "custom_tool_call", "tool_search_call"}:
                 if not isinstance(call_id, str) or not call_id:
                     raise ToolCompatibilityError("tool_compatibility_boundary", "missing_call_identity", surface="history")
@@ -2061,6 +2225,7 @@ class ToolCompatibilityPlan:
                     ):
                         raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_alias", surface="history")
                     else:
+                        self._reject_unknown_standard_item(item, surface=surface)
                         decoded, item_changed = item, False
             elif item_type == "custom_tool_call":
                 native_entry = self._native_entry_for_item(item)
@@ -2080,6 +2245,7 @@ class ToolCompatibilityPlan:
                 ):
                     raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_alias", surface="history")
                 else:
+                    self._reject_unknown_standard_item(item, surface=surface)
                     decoded, item_changed = item, False
             elif _hosted_kind_for_item_type(item_type) is not None:
                 native_entry = self._native_entry_for_item(item)
@@ -2304,6 +2470,8 @@ class CompatibilityStreamState:
             return result
         item = result.get("item")
         if event_type == "response.output_item.added" and isinstance(item, Mapping):
+            self.plan._validate_registered_item_identity(item, surface="stream")
+            self.plan._reject_unknown_standard_item(item, surface="stream")
             decoded_item, record, _changed = self._check_alias_in_item(item)
             item_id = self._item_id(item)
             if record is not None:
@@ -2464,6 +2632,8 @@ class CompatibilityStreamState:
                 result["arguments"] = arguments
             return result
         if event_type == "response.output_item.done" and isinstance(item, Mapping):
+            self.plan._validate_registered_item_identity(item, surface="stream")
+            self.plan._reject_unknown_standard_item(item, surface="stream")
             record = self.plan.registry.record_for_alias(item.get("name"))
             if record is None:
                 if self.plan.registry.looks_like_alias(item.get("name")):
@@ -2569,6 +2739,8 @@ class CompatibilityStreamState:
             return [self.decode_event(value)]
 
         if event_type == "response.output_item.added" and isinstance(item, Mapping):
+            self.plan._validate_registered_item_identity(item, surface="stream")
+            self.plan._reject_unknown_standard_item(item, surface="stream")
             record = self.plan.registry.record_for_alias(item.get("name"))
             if record is None or record.family != CUSTOM_FREEFORM:
                 return [self.decode_event(value)]

--- a/src-python/runtime_tool_compatibility.py
+++ b/src-python/runtime_tool_compatibility.py
@@ -2760,6 +2760,24 @@ class CompatibilityStreamState:
                 "missing_stream_identity",
                 surface="stream",
             )
+        # Hosted stage events normally carry only ``item_id``.  If a provider
+        # includes a nested item, however, its wire identity is part of the
+        # lifecycle contract and must remain bound to the exact item observed
+        # at ``output_item.added``.  Do not let a matching id borrow another
+        # hosted kind or declaration.
+        if "item" in event:
+            nested_item = event.get("item")
+            expected_wire = self._native_wire_identities.get(item_id)
+            if (
+                not isinstance(nested_item, Mapping)
+                or expected_wire is None
+                or self._native_wire_identity(nested_item) != expected_wire
+            ):
+                raise ToolCompatibilityError(
+                    "tool_compatibility_boundary",
+                    "ambiguous_native_identity",
+                    surface="stream",
+                )
         if item_id in self._native_done:
             raise ToolCompatibilityError(
                 "tool_compatibility_boundary",

--- a/src-python/runtime_tool_compatibility.py
+++ b/src-python/runtime_tool_compatibility.py
@@ -3318,6 +3318,8 @@ class CompatibilityStreamState:
             record = self.plan.registry.record_for_alias(item.get("name"))
             if record is None or record.family != CUSTOM_FREEFORM:
                 return [self.decode_event(value)]
+            if item.get("type") != "function_call":
+                raise self._stream_error("ambiguous_call_identity")
             item_id = self._item_id(item)
             call_id = item.get("call_id")
             if (

--- a/src-python/runtime_tool_compatibility.py
+++ b/src-python/runtime_tool_compatibility.py
@@ -43,6 +43,15 @@ _KNOWN_HOSTED_TYPES = frozenset(
         "local_shell",
     }
 )
+# Only these hosted tools have a complete, bounded Responses lifecycle we can
+# validate.  A provider capability fact alone is not enough to make a hosted
+# kind native: without this map we would have to guess its event names/order.
+_HOSTED_EVENT_STAGES = {
+    "web_search": ("web_search_call", ("in_progress", "searching", "completed")),
+    "web_search_preview": ("web_search_call", ("in_progress", "searching", "completed")),
+    "file_search": ("file_search_call", ("in_progress", "searching", "completed")),
+    "code_interpreter": ("code_interpreter_call", ("in_progress", "interpreting", "completed")),
+}
 _V1_NAMES = frozenset(
     {"spawn_agent", "send_input", "wait_agent", "close_agent", "resume_agent"}
 )
@@ -727,9 +736,11 @@ def build_tool_compatibility_plan(
                 reason = "client_tool_search_lifecycle_unavailable"
         elif family == SELECTED_PROVIDER_HOSTED:
             kind = declaration.get("type")
+            has_static_contract = _hosted_event_spec_for_declaration_kind(kind) is not None
             if (
                 valid
                 and isinstance(kind, str)
+                and has_static_contract
                 and kind in hosted.supported_kinds
                 and kind in capabilities.hosted_lifecycles
             ):
@@ -853,8 +864,54 @@ def _hosted_kind_for_item_type(item_type: Any) -> str | None:
     return kind if kind in _KNOWN_HOSTED_TYPES else None
 
 
+def _hosted_event_spec_for_declaration_kind(kind: Any) -> tuple[str, tuple[str, ...]] | None:
+    if not isinstance(kind, str):
+        return None
+    return _HOSTED_EVENT_STAGES.get(kind)
+
+
+def _hosted_event_spec_for_item_type(item_type: Any) -> tuple[str, tuple[str, ...]] | None:
+    if not isinstance(item_type, str):
+        return None
+    for event_kind, stages in _HOSTED_EVENT_STAGES.values():
+        if item_type in {event_kind, f"{event_kind}_output"}:
+            return event_kind, stages
+    return None
+
+
+def _hosted_history_item_key(item_type: Any) -> tuple[str, bool] | None:
+    if not isinstance(item_type, str):
+        return None
+    for event_kind, _stages in _HOSTED_EVENT_STAGES.values():
+        if item_type == event_kind:
+            return event_kind, False
+        if item_type == f"{event_kind}_output":
+            return event_kind, True
+    for hosted_kind in _KNOWN_HOSTED_TYPES:
+        if item_type == f"{hosted_kind}_call":
+            return hosted_kind, False
+        if item_type == f"{hosted_kind}_call_output":
+            return hosted_kind, True
+    return None
+
+
+def _hosted_event_spec(event_type: Any) -> tuple[str, str, tuple[str, ...]] | None:
+    if not isinstance(event_type, str) or not event_type.startswith("response."):
+        return None
+    suffix = event_type[len("response.") :]
+    event_kind, separator, stage = suffix.rpartition(".")
+    if not separator:
+        return None
+    for mapped_event_kind, stages in _HOSTED_EVENT_STAGES.values():
+        if event_kind == mapped_event_kind and stage in stages:
+            return event_kind, stage, stages
+    return None
+
+
 def _is_unsupported_hosted_stream_event(event_type: Any) -> bool:
     if not isinstance(event_type, str) or not event_type.startswith("response."):
+        return False
+    if _hosted_event_spec(event_type) is not None:
         return False
     suffix = event_type[len("response.") :]
     # These are the Responses protocol's ordinary function/custom/tool-search
@@ -972,7 +1029,10 @@ class ToolCompatibilityPlan:
             elif family == SELECTED_PROVIDER_HOSTED:
                 # Provider capability facts are intentionally not inferred for
                 # declarations added after the request plan was built.
-                if declaration.get("type") in self.capabilities.hosted_lifecycles:
+                if (
+                    _hosted_event_spec_for_declaration_kind(declaration.get("type")) is not None
+                    and declaration.get("type") in self.capabilities.hosted_lifecycles
+                ):
                     disposition, reason = NATIVE, "selected_provider_hosted_lifecycle"
             elif family == UNKNOWN_FUTURE_KIND:
                 reason = "unknown_lifecycle_contract_unavailable"
@@ -1163,6 +1223,14 @@ class ToolCompatibilityPlan:
             for entry in self.entries
         )
 
+    def _has_adapted_name_conflict(self, name: Any, expected_family: str) -> bool:
+        return isinstance(name, str) and any(
+            entry.disposition == ADAPT
+            and entry.family != expected_family
+            and entry.original_name == name
+            for entry in self.entries
+        )
+
     def _alias_for(self, entry: ToolCompatibilityEntry, *, child_name: str | None = None) -> str | None:
         if entry.family == NAMESPACE:
             if child_name not in entry.child_names and isinstance(child_name, str):
@@ -1345,6 +1413,29 @@ class ToolCompatibilityPlan:
 
     def _omitted_history_entry(self, item: Mapping[str, Any]) -> ToolCompatibilityEntry | None:
         item_type = item.get("type")
+        hosted_item_key = _hosted_history_item_key(item_type)
+        if hosted_item_key is not None:
+            hosted_item_kind, _is_output = hosted_item_key
+            matches = [
+                entry
+                for entry in self.entries
+                if entry.family == SELECTED_PROVIDER_HOSTED
+                and entry.disposition == OMIT
+                and (
+                    (
+                        (
+                            declaration_spec := _hosted_event_spec_for_declaration_kind(
+                                entry.declaration.get("type")
+                            )
+                        ) is not None
+                        and declaration_spec[0] == hosted_item_kind
+                    )
+                    or entry.declaration.get("type") == hosted_item_kind
+                )
+            ]
+            if len(matches) > 1:
+                raise ToolCompatibilityError("tool_compatibility_boundary", "ambiguous_native_identity", surface="history")
+            return matches[0] if matches else None
         if item_type in {"function_call", "custom_tool_call"}:
             entry = self._entry_for_name(
                 item.get("name"),
@@ -1387,11 +1478,61 @@ class ToolCompatibilityPlan:
         if isinstance(raw_input, list):
             encoded_input: list[Any] = []
             changed = tools_changed or choice_changed
+            omitted_hosted_ids: dict[str, str] = {}
+            omitted_hosted_outputs: list[tuple[str, str]] = []
+            for item in raw_input:
+                if not isinstance(item, Mapping):
+                    continue
+                omitted_entry = self._omitted_history_entry(item)
+                hosted_item_key = _hosted_history_item_key(item.get("type"))
+                if (
+                    omitted_entry is None
+                    or omitted_entry.family != SELECTED_PROVIDER_HOSTED
+                    or hosted_item_key is None
+                ):
+                    continue
+                item_id = _item_identity(item)
+                if item_id is None:
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "missing_item_identity",
+                        surface="history",
+                    )
+                hosted_item_kind, is_output = hosted_item_key
+                if not is_output:
+                    previous_kind = omitted_hosted_ids.get(item_id)
+                    if previous_kind is not None:
+                        classification = (
+                            "duplicate_item_identity"
+                            if previous_kind == hosted_item_kind
+                            else "ambiguous_native_identity"
+                        )
+                        raise ToolCompatibilityError(
+                            "tool_compatibility_boundary",
+                            classification,
+                            surface="history",
+                        )
+                    omitted_hosted_ids[item_id] = hosted_item_kind
+                else:
+                    omitted_hosted_outputs.append((item_id, hosted_item_kind))
+            for item_id, hosted_item_kind in omitted_hosted_outputs:
+                root_kind = omitted_hosted_ids.get(item_id)
+                if root_kind != hosted_item_kind:
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "ambiguous_native_identity",
+                        surface="history",
+                    )
             omitted_call_items = [
                 item
                 for item in raw_input
                 if isinstance(item, Mapping)
                 and self._omitted_history_entry(item) is not None
+                and not (
+                    self._omitted_history_entry(item).family == SELECTED_PROVIDER_HOSTED
+                    if self._omitted_history_entry(item) is not None
+                    else False
+                )
                 and (
                     item.get("type") in {"function_call", "custom_tool_call", "tool_search_call"}
                     or (isinstance(item.get("type"), str) and item.get("type").endswith("_call"))
@@ -1429,11 +1570,24 @@ class ToolCompatibilityPlan:
                         raise ToolCompatibilityError("tool_compatibility_boundary", "ambiguous_call_identity", surface="history")
             for item in raw_input:
                 if isinstance(item, Mapping) and (
-                    self._omitted_history_entry(item) is not None
+                    (
+                        self._omitted_history_entry(item) is not None
+                        and self._omitted_history_entry(item).family != SELECTED_PROVIDER_HOSTED
+                    )
                     or item.get("call_id") in omitted_call_ids
                 ):
                     changed = True
                     continue
+                if isinstance(item, Mapping):
+                    omitted_entry = self._omitted_history_entry(item)
+                    hosted_item_key = _hosted_history_item_key(item.get("type"))
+                    if (
+                        omitted_entry is not None
+                        and omitted_entry.family == SELECTED_PROVIDER_HOSTED
+                        and hosted_item_key is not None
+                    ):
+                        changed = True
+                        continue
                 encoded, item_changed = self._encode_item(item, call_aliases)
                 encoded_input.append(encoded)
                 changed = changed or item_changed
@@ -1508,14 +1662,18 @@ class ToolCompatibilityPlan:
                 if entry.family == TOOL_SEARCH and entry.disposition == NATIVE
             ]
             return matches[0] if len(matches) == 1 else None
-        hosted_kind = _hosted_kind_for_item_type(item_type)
-        if hosted_kind is not None:
+        hosted_item_spec = _hosted_event_spec_for_item_type(item_type)
+        if hosted_item_spec is not None and item_type == hosted_item_spec[0]:
+            hosted_event_kind, _stages = hosted_item_spec
             matches = [
                 entry
                 for entry in self.entries
                 if entry.family == SELECTED_PROVIDER_HOSTED
                 and entry.disposition == NATIVE
-                and entry.declaration.get("type") == hosted_kind
+                and (
+                    declaration_spec := _hosted_event_spec_for_declaration_kind(entry.declaration.get("type"))
+                ) is not None
+                and declaration_spec[0] == hosted_event_kind
             ]
             if len(matches) > 1:
                 raise ToolCompatibilityError("tool_compatibility_boundary", "ambiguous_native_identity")
@@ -1570,8 +1728,8 @@ class ToolCompatibilityPlan:
             if item_type == "tool_search_call" and item.get("execution") not in {None, "client"}:
                 raise ToolCompatibilityError("tool_compatibility_boundary", "invalid_tool_search_execution", surface="history")
         elif entry.family == SELECTED_PROVIDER_HOSTED:
-            hosted_kind = entry.declaration.get("type")
-            if item_type != f"{hosted_kind}_call":
+            hosted_spec = _hosted_event_spec_for_declaration_kind(entry.declaration.get("type"))
+            if hosted_spec is None or item_type != hosted_spec[0]:
                 raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_native_identity", surface="history")
             if _item_identity(item) is None:
                 raise ToolCompatibilityError("tool_compatibility_boundary", "missing_item_identity", surface="history")
@@ -1616,6 +1774,8 @@ class ToolCompatibilityPlan:
                         self._validate_native_item(item, native_entry)
                         decoded, item_changed = item, False
                     elif self.registry.looks_like_alias(item.get("name")):
+                        raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_alias", surface="history")
+                    elif self._has_adapted_name_conflict(item.get("name"), PLAIN_FUNCTION):
                         raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_alias", surface="history")
                     elif self.has_adaptations and (
                         self._entry_for_name(
@@ -1720,6 +1880,13 @@ class _BufferedCustomStreamItem:
     native_input: str | None = None
 
 
+@dataclass(slots=True)
+class _HostedStreamState:
+    event_kind: str
+    stages: tuple[str, ...]
+    next_stage: int = 0
+
+
 class CompatibilityStreamState:
     """Assemble one adapted Responses SSE lifecycle before inverse mapping."""
 
@@ -1731,6 +1898,7 @@ class CompatibilityStreamState:
         self._native_pending: dict[str, tuple[str | None, str]] = {}
         self._native_done: set[str] = set()
         self._native_delta_done: set[str] = set()
+        self._hosted_pending: dict[str, _HostedStreamState] = {}
         self._buffered_custom: dict[str, _BufferedCustomStreamItem] = {}
         self._terminal = False
 
@@ -1777,6 +1945,8 @@ class CompatibilityStreamState:
                 item.get("namespace"),
                 item_type=item.get("type"),
             )
+            if record is None and self.plan._has_adapted_name_conflict(item.get("name"), PLAIN_FUNCTION):
+                raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_alias", surface="stream")
             if record is None and self.plan.has_adaptations and isinstance(item.get("name"), str) and (
                 entry is None or entry.disposition == ADAPT
             ):
@@ -1785,6 +1955,35 @@ class CompatibilityStreamState:
         if self.plan.registry.looks_like_alias(item.get("name")):
             raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_alias", surface="stream")
         return _copy_mapping(item), None, False
+
+    def _decode_hosted_event(
+        self,
+        event: Mapping[str, Any],
+        event_spec: tuple[str, str, tuple[str, ...]],
+    ) -> dict[str, Any]:
+        event_kind, stage, _stages = event_spec
+        item_id = self._native_item_id_for_event(event)
+        pending = self._hosted_pending.get(item_id) if item_id is not None else None
+        if pending is None or pending.event_kind != event_kind:
+            raise ToolCompatibilityError(
+                "tool_compatibility_boundary",
+                "missing_stream_identity",
+                surface="stream",
+            )
+        if item_id in self._native_done:
+            raise ToolCompatibilityError(
+                "tool_compatibility_boundary",
+                "duplicate_item_identity",
+                surface="stream",
+            )
+        if pending.next_stage >= len(pending.stages) or pending.stages[pending.next_stage] != stage:
+            raise ToolCompatibilityError(
+                "tool_compatibility_boundary",
+                "invalid_hosted_lifecycle",
+                surface="stream",
+            )
+        pending.next_stage += 1
+        return _copy_mapping(event)
 
     def _finish_terminal(self) -> None:
         if self._terminal:
@@ -1813,6 +2012,9 @@ class CompatibilityStreamState:
                 "unsupported_hosted_lifecycle",
                 surface="stream",
             )
+        hosted_event_spec = _hosted_event_spec(event_type)
+        if hosted_event_spec is not None:
+            return self._decode_hosted_event(result, hosted_event_spec)
         if event_type in {"response.completed", "response.incomplete", "response.failed"}:
             self._finish_terminal()
             response = result.get("response")
@@ -1856,6 +2058,19 @@ class CompatibilityStreamState:
                         raise ToolCompatibilityError("tool_compatibility_boundary", "duplicate_item_identity", surface="stream")
                     self._seen_item_ids.add(item_id)
                     self._native_pending[item_id] = (None, native_entry.family)
+                    hosted_spec = _hosted_event_spec_for_declaration_kind(
+                        native_entry.declaration.get("type")
+                    )
+                    if hosted_spec is None:
+                        raise ToolCompatibilityError(
+                            "tool_compatibility_boundary",
+                            "unsupported_hosted_lifecycle",
+                            surface="stream",
+                        )
+                    self._hosted_pending[item_id] = _HostedStreamState(
+                        event_kind=hosted_spec[0],
+                        stages=hosted_spec[1],
+                    )
                     result["item"] = decoded_item
                     return result
                 if not isinstance(call_id, str) or not call_id:
@@ -1984,6 +2199,13 @@ class CompatibilityStreamState:
                         hosted_entry = self._native_entry_for_item(item)
                         if hosted_entry is None or hosted_entry.family != SELECTED_PROVIDER_HOSTED:
                             raise ToolCompatibilityError("tool_compatibility_boundary", "ambiguous_native_identity", surface="stream")
+                        hosted_state = self._hosted_pending.get(native_item_id)
+                        if hosted_state is None or hosted_state.next_stage != len(hosted_state.stages):
+                            raise ToolCompatibilityError(
+                                "tool_compatibility_boundary",
+                                "incomplete_hosted_lifecycle",
+                                surface="stream",
+                            )
                         self.plan._validate_native_item(item, hosted_entry, require_completed=True)
                     elif native_pending[1] != TOOL_SEARCH and native_item_id not in self._native_delta_done:
                         raise ToolCompatibilityError("tool_compatibility_boundary", "incomplete_stream_delta", surface="stream")

--- a/src-python/runtime_tool_compatibility.py
+++ b/src-python/runtime_tool_compatibility.py
@@ -749,7 +749,13 @@ def build_tool_compatibility_plan(
                 reason = "selected_provider_hosted_lifecycle_unavailable"
         else:
             kind = declaration.get("type")
-            if valid and isinstance(kind, str) and kind in capabilities.unknown_lifecycles:
+            provider_hosted = declaration.get("executor") == "selected_provider"
+            if (
+                valid
+                and isinstance(kind, str)
+                and kind in capabilities.unknown_lifecycles
+                and (not provider_hosted or kind in hosted.supported_kinds)
+            ):
                 disposition, reason = NATIVE, "explicit_unknown_lifecycle"
             else:
                 reason = "unknown_lifecycle_contract_unavailable"
@@ -1523,7 +1529,7 @@ class ToolCompatibilityPlan:
         if isinstance(raw_input, list):
             encoded_input: list[Any] = []
             changed = tools_changed or choice_changed
-            omitted_hosted_ids: dict[str, tuple[str, bool]] = {}
+            omitted_hosted_ids: dict[str, tuple[str, bool, bool]] = {}
             for item in raw_input:
                 if not isinstance(item, Mapping):
                     continue
@@ -1544,22 +1550,23 @@ class ToolCompatibilityPlan:
                 hosted_item_kind, is_output = hosted_item_key
                 previous = omitted_hosted_ids.get(item_id)
                 if previous is not None:
-                    previous_kind, previous_is_output = previous
+                    previous_kind, previous_is_output, pair_consumed = previous
                     if previous_kind != hosted_item_kind:
                         classification = "ambiguous_native_identity"
-                    elif previous_is_output == is_output:
+                    elif pair_consumed or previous_is_output == is_output:
                         classification = "duplicate_item_identity"
                     else:
                         # Some hosted protocols use one item id for call/result
                         # pairs; others use distinct ids.  Both are valid when
                         # the hosted kind is already uniquely omitted.
+                        omitted_hosted_ids[item_id] = (hosted_item_kind, is_output, True)
                         continue
                     raise ToolCompatibilityError(
                         "tool_compatibility_boundary",
                         classification,
                         surface="history",
                     )
-                omitted_hosted_ids[item_id] = (hosted_item_kind, is_output)
+                omitted_hosted_ids[item_id] = (hosted_item_kind, is_output, False)
             omitted_call_items = [
                 item
                 for item in raw_input
@@ -1698,6 +1705,9 @@ class ToolCompatibilityPlan:
                 if entry.family == TOOL_SEARCH and entry.disposition == NATIVE
             ]
             return matches[0] if len(matches) == 1 else None
+        unknown_entry = self._native_unknown_entry_for_item(item)
+        if unknown_entry is not None:
+            return unknown_entry
         hosted_item_spec = _hosted_event_spec_for_item_type(item_type)
         if hosted_item_spec is not None and item_type == hosted_item_spec[0]:
             hosted_event_kind, _stages = hosted_item_spec
@@ -1715,6 +1725,48 @@ class ToolCompatibilityPlan:
                 raise ToolCompatibilityError("tool_compatibility_boundary", "ambiguous_native_identity")
             return matches[0] if matches else None
         return None
+
+    @staticmethod
+    def _unknown_item_kind(item_type: Any) -> str | None:
+        if not isinstance(item_type, str):
+            return None
+        if item_type.endswith("_call_output"):
+            kind = item_type[: -len("_call_output")]
+            return kind if kind else None
+        if item_type.endswith("_call"):
+            kind = item_type[: -len("_call")]
+            return kind if kind else None
+        return None
+
+    def _native_unknown_entry_for_item(self, item: Mapping[str, Any]) -> ToolCompatibilityEntry | None:
+        kind = self._unknown_item_kind(item.get("type"))
+        if kind is None:
+            return None
+        matches = [
+            entry
+            for entry in self.entries
+            if entry.family == UNKNOWN_FUTURE_KIND
+            and entry.disposition == NATIVE
+            and entry.declaration.get("type") == kind
+        ]
+        if len(matches) > 1:
+            raise ToolCompatibilityError("tool_compatibility_boundary", "ambiguous_native_identity")
+        return matches[0] if matches else None
+
+    def _is_native_unknown_stream_event(self, event_type: Any) -> bool:
+        if not isinstance(event_type, str) or not event_type.startswith("response."):
+            return False
+        suffix = event_type[len("response.") :]
+        call_type, separator, _stage = suffix.partition(".")
+        if not separator or not call_type.endswith("_call"):
+            return False
+        kind = call_type[: -len("_call")]
+        return any(
+            entry.family == UNKNOWN_FUTURE_KIND
+            and entry.disposition == NATIVE
+            and entry.declaration.get("type") == kind
+            for entry in self.entries
+        )
 
     def _has_native_structural_family(self) -> bool:
         return any(
@@ -1763,6 +1815,11 @@ class ToolCompatibilityPlan:
                 raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_native_identity", surface="history")
             if item_type == "tool_search_call" and item.get("execution") not in {None, "client"}:
                 raise ToolCompatibilityError("tool_compatibility_boundary", "invalid_tool_search_execution", surface="history")
+        elif entry.family == UNKNOWN_FUTURE_KIND:
+            if ToolCompatibilityPlan._unknown_item_kind(item_type) != entry.declaration.get("type"):
+                raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_native_identity", surface="history")
+            if _item_identity(item) is None:
+                raise ToolCompatibilityError("tool_compatibility_boundary", "missing_item_identity", surface="history")
         elif entry.family == SELECTED_PROVIDER_HOSTED:
             hosted_spec = _hosted_event_spec_for_declaration_kind(entry.declaration.get("type"))
             if hosted_spec is None or item_type != hosted_spec[0]:
@@ -1846,6 +1903,9 @@ class ToolCompatibilityPlan:
                     raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_alias", surface="history")
                 else:
                     decoded, item_changed = item, False
+            elif (native_unknown_entry := self._native_unknown_entry_for_item(item)) is not None:
+                self._validate_native_item(item, native_unknown_entry)
+                decoded, item_changed = item, False
             elif _hosted_kind_for_item_type(item_type) is not None:
                 native_entry = self._native_entry_for_item(item)
                 if native_entry is None:
@@ -2021,6 +2081,13 @@ class CompatibilityStreamState:
         pending.next_stage += 1
         return _copy_mapping(event)
 
+    def _is_pending_native_unknown_event(self, event: Mapping[str, Any]) -> bool:
+        if not self.plan._is_native_unknown_stream_event(event.get("type")):
+            return False
+        item_id = self._native_item_id_for_event(event)
+        pending = self._native_pending.get(item_id) if item_id is not None else None
+        return pending is not None and pending[1] == UNKNOWN_FUTURE_KIND
+
     def _finish_terminal(self) -> None:
         if self._terminal:
             raise ToolCompatibilityError("tool_compatibility_boundary", "duplicate_terminal", surface="stream")
@@ -2028,7 +2095,7 @@ class CompatibilityStreamState:
         native_incomplete = any(
             item_id not in self._native_done
             or (
-                family not in {TOOL_SEARCH, SELECTED_PROVIDER_HOSTED}
+                family not in {TOOL_SEARCH, SELECTED_PROVIDER_HOSTED, UNKNOWN_FUTURE_KIND}
                 and item_id not in self._native_delta_done
             )
             for item_id, (_call_id, family) in self._native_pending.items()
@@ -2042,7 +2109,7 @@ class CompatibilityStreamState:
             raise ToolCompatibilityError("tool_compatibility_boundary", "malformed_stream_event", surface="stream")
         result = _copy_mapping(event)
         event_type = result.get("type")
-        if _is_unsupported_hosted_stream_event(event_type):
+        if _is_unsupported_hosted_stream_event(event_type) and not self._is_pending_native_unknown_event(result):
             raise ToolCompatibilityError(
                 "tool_compatibility_boundary",
                 "unsupported_hosted_lifecycle",
@@ -2109,15 +2176,16 @@ class CompatibilityStreamState:
                     )
                     result["item"] = decoded_item
                     return result
-                if not isinstance(call_id, str) or not call_id:
+                if native_entry.family != UNKNOWN_FUTURE_KIND and (not isinstance(call_id, str) or not call_id):
                     raise ToolCompatibilityError("tool_compatibility_boundary", "missing_call_identity", surface="stream")
                 self.plan._validate_native_item(item, native_entry)
                 if item_id in self._seen_item_ids:
                     raise ToolCompatibilityError("tool_compatibility_boundary", "duplicate_item_identity", surface="stream")
-                if call_id in self._seen_call_ids:
+                if isinstance(call_id, str) and call_id in self._seen_call_ids:
                     raise ToolCompatibilityError("tool_compatibility_boundary", "duplicate_call_identity", surface="stream")
                 self._seen_item_ids.add(item_id)
-                self._seen_call_ids.add(call_id)
+                if isinstance(call_id, str):
+                    self._seen_call_ids.add(call_id)
                 self._native_pending[item_id] = (call_id, native_entry.family)
                 result["item"] = decoded_item
             elif self.plan.has_adaptations and item.get("type") in {"function_call", "custom_tool_call"}:
@@ -2243,7 +2311,7 @@ class CompatibilityStreamState:
                                 surface="stream",
                             )
                         self.plan._validate_native_item(item, hosted_entry, require_completed=True)
-                    elif native_pending[1] != TOOL_SEARCH and native_item_id not in self._native_delta_done:
+                    elif native_pending[1] not in {TOOL_SEARCH, UNKNOWN_FUTURE_KIND} and native_item_id not in self._native_delta_done:
                         raise ToolCompatibilityError("tool_compatibility_boundary", "incomplete_stream_delta", surface="stream")
                     if native_item_id in self._native_done:
                         raise ToolCompatibilityError("tool_compatibility_boundary", "duplicate_item_identity", surface="stream")

--- a/src-python/runtime_tool_compatibility.py
+++ b/src-python/runtime_tool_compatibility.py
@@ -1466,6 +1466,45 @@ class ToolCompatibilityPlan:
                 return hosted_kind, True
         return None
 
+    @staticmethod
+    def _unknown_response_item_kind(item_type: Any) -> str | None:
+        if not isinstance(item_type, str):
+            return None
+        if item_type.endswith("_call_output"):
+            kind = item_type[: -len("_call_output")]
+            return kind if kind else None
+        if item_type.endswith("_call"):
+            kind = item_type[: -len("_call")]
+            return kind if kind else None
+        return None
+
+    def _omitted_response_entry_for_item(self, item: Mapping[str, Any]) -> ToolCompatibilityEntry | None:
+        hosted_item_key = self._hosted_history_item_key(item.get("type"))
+        if hosted_item_key is not None:
+            hosted_item_kind, _is_output = hosted_item_key
+            matches = [
+                entry
+                for entry in self.entries
+                if entry.disposition in {NATIVE, OMIT}
+                and self._hosted_entry_item_kind(entry) == hosted_item_kind
+            ]
+            if len(matches) > 1:
+                raise ToolCompatibilityError("tool_compatibility_boundary", "ambiguous_native_identity", surface="response")
+            return matches[0] if matches and matches[0].disposition == OMIT else None
+        unknown_kind = self._unknown_response_item_kind(item.get("type"))
+        if unknown_kind is None:
+            return None
+        matches = [
+            entry
+            for entry in self.entries
+            if entry.family == UNKNOWN_FUTURE_KIND
+            and entry.disposition in {NATIVE, OMIT}
+            and entry.declaration.get("type") == unknown_kind
+        ]
+        if len(matches) > 1:
+            raise ToolCompatibilityError("tool_compatibility_boundary", "ambiguous_native_identity", surface="response")
+        return matches[0] if matches and matches[0].disposition == OMIT else None
+
     def _omitted_history_entry(self, item: Mapping[str, Any]) -> ToolCompatibilityEntry | None:
         item_type = item.get("type")
         hosted_item_key = self._hosted_history_item_key(item_type)
@@ -1774,7 +1813,7 @@ class ToolCompatibilityPlan:
             if require_completed and item.get("status") not in {None, "completed"}:
                 raise ToolCompatibilityError("tool_compatibility_boundary", "incomplete_hosted_lifecycle", surface="history")
 
-    def _decode_items(self, items: Any) -> tuple[Any, bool]:
+    def _decode_items(self, items: Any, *, reject_omitted_response: bool = False) -> tuple[Any, bool]:
         if not isinstance(items, list):
             return items, False
         result: list[Any] = []
@@ -1788,6 +1827,12 @@ class ToolCompatibilityPlan:
                 continue
             item_type = raw_item.get("type")
             item = _copy_mapping(raw_item)
+            if reject_omitted_response and self._omitted_response_entry_for_item(item) is not None:
+                raise ToolCompatibilityError(
+                    "tool_compatibility_boundary",
+                    "unsupported_hosted_lifecycle",
+                    surface="response",
+                )
             item_id = _item_identity(item)
             call_id = item.get("call_id")
             if item_type in {"function_call", "custom_tool_call", "tool_search_call"}:
@@ -1882,7 +1927,10 @@ class ToolCompatibilityPlan:
         changed = False
         for key in ("output", "input", "history"):
             if key in result:
-                decoded, item_changed = self._decode_items(result[key])
+                decoded, item_changed = self._decode_items(
+                    result[key],
+                    reject_omitted_response=key == "output",
+                )
                 if item_changed:
                     result[key] = decoded
                     changed = True
@@ -2057,7 +2105,10 @@ class CompatibilityStreamState:
             self._finish_terminal()
             response = result.get("response")
             if isinstance(response, Mapping):
-                decoded_output, output_changed = self.plan._decode_items(response.get("output"))
+                decoded_output, output_changed = self.plan._decode_items(
+                    response.get("output"),
+                    reject_omitted_response=True,
+                )
                 if output_changed:
                     response = _copy_mapping(response)
                     response["output"] = decoded_output
@@ -2134,6 +2185,12 @@ class CompatibilityStreamState:
                         "unknown_alias",
                         surface="stream",
                     )
+            elif self.plan._omitted_response_entry_for_item(item) is not None:
+                raise ToolCompatibilityError(
+                    "tool_compatibility_boundary",
+                    "unsupported_hosted_lifecycle",
+                    surface="stream",
+                )
             elif _hosted_kind_for_item_type(item.get("type")) is not None or (
                 isinstance(item.get("type"), str)
                 and item.get("type").endswith("_call")
@@ -2257,6 +2314,12 @@ class CompatibilityStreamState:
                         raise ToolCompatibilityError("tool_compatibility_boundary", "missing_stream_identity", surface="stream")
                     self.plan._validate_native_item(item, native_entry)
                     return result
+                if self.plan._omitted_response_entry_for_item(item) is not None:
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "unsupported_hosted_lifecycle",
+                        surface="stream",
+                    )
                 if _hosted_kind_for_item_type(item.get("type")) is not None or (
                     isinstance(item.get("type"), str)
                     and item.get("type").endswith("_call")

--- a/src-python/runtime_tool_compatibility.py
+++ b/src-python/runtime_tool_compatibility.py
@@ -2687,8 +2687,7 @@ class CompatibilityStreamState:
         output = response.get("output")
         required_native_ids = {
             item_id
-            for item_id, (_call_id, entry) in self._native_pending.items()
-            if entry.family != SELECTED_PROVIDER_HOSTED
+            for item_id in self._native_pending
         }
         required_adapter_ids = set(self._pending) | set(self._adapter_wire_identities)
         if output is None:

--- a/src-python/runtime_tool_compatibility.py
+++ b/src-python/runtime_tool_compatibility.py
@@ -1,0 +1,1834 @@
+"""Request-scoped runtime tool compatibility for the selected Gateway route.
+
+This module deliberately knows only about declaration shape and protocol
+capabilities.  It does not select a Provider, execute a tool, or repair a
+model response.  The request plan is immutable; the small mutable stream
+object is the lifecycle ledger used while assembling one SSE response.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, field
+import hashlib
+import json
+from types import MappingProxyType
+from typing import Any, Iterable, Mapping
+
+
+NATIVE = "native"
+ADAPT = "adapt"
+OMIT = "omit"
+REQUIRED_BUT_UNAVAILABLE = "required-but-unavailable"
+
+PLAIN_FUNCTION = "plain_function"
+NAMESPACE = "namespace"
+CUSTOM_FREEFORM = "custom_freeform"
+TOOL_SEARCH = "tool_search"
+SELECTED_PROVIDER_HOSTED = "selected_provider_hosted"
+UNKNOWN_FUTURE_KIND = "unknown_future_kind"
+
+CUSTOM_INPUT_KEY = "__codexhub_custom_input"
+CUSTOM_OUTPUT_KEY = "__codexhub_custom_output"
+
+_NAMESPACE_ALIAS_PREFIX = "__codexhub_ns_"
+_CUSTOM_ALIAS_PREFIX = "__codexhub_custom_"
+_KNOWN_HOSTED_TYPES = frozenset(
+    {
+        "web_search",
+        "web_search_preview",
+        "file_search",
+        "computer_use_preview",
+        "code_interpreter",
+        "local_shell",
+    }
+)
+_V1_NAMES = frozenset(
+    {"spawn_agent", "send_input", "wait_agent", "close_agent", "resume_agent"}
+)
+_V2_NAMES = frozenset(
+    {"spawn_agent", "send_message", "followup_task", "wait_agent", "interrupt_agent", "list_agents"}
+)
+_V1_FORBIDDEN = frozenset({"task_path", "continuation_id", "task_name", "fork_turns"})
+_V2_FORBIDDEN = frozenset({"agent_id", "fork_context"})
+
+
+def _freeze(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return MappingProxyType({str(key): _freeze(item) for key, item in value.items()})
+    if isinstance(value, list):
+        return tuple(_freeze(item) for item in value)
+    if isinstance(value, tuple):
+        return tuple(_freeze(item) for item in value)
+    if isinstance(value, set):
+        return frozenset(_freeze(item) for item in value)
+    return value
+
+
+def _thaw(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {key: _thaw(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [_thaw(item) for item in value]
+    if isinstance(value, frozenset):
+        return {_thaw(item) for item in value}
+    return value
+
+
+def _copy_mapping(value: Mapping[str, Any]) -> dict[str, Any]:
+    return _thaw(_freeze(value))
+
+
+class ToolCompatibilityError(ValueError):
+    """A bounded compatibility failure safe to expose at a wire boundary."""
+
+    def __init__(
+        self,
+        code: str,
+        classification: str,
+        *,
+        surface: str = "request",
+    ) -> None:
+        self.code = code
+        self.classification = classification
+        self.surface = surface
+        # Do not include declaration names, aliases, IDs, payloads, or route
+        # identity in a compatibility error.  Classification is the only
+        # request-derived value that is safe to expose.
+        super().__init__(f"Tool compatibility failed at {surface}: {classification}.")
+
+
+class RequiredToolUnavailableError(ToolCompatibilityError):
+    def __init__(self, *, family: str | None = None) -> None:
+        # ``family`` is intentionally retained only as a private attribute for
+        # tests/telemetry; the public message remains bounded and name-free.
+        self.family = family
+        super().__init__(
+            "tool_compatibility_required_unavailable",
+            "required_unavailable",
+            surface="request",
+        )
+
+
+class _MalformedDeclaration(ToolCompatibilityError):
+    def __init__(self) -> None:
+        super().__init__("tool_compatibility_boundary", "malformed_declaration")
+
+
+@dataclass(frozen=True, slots=True)
+class ProtocolCapabilities:
+    """Complete lifecycle capabilities of one selected upstream protocol."""
+
+    function_lifecycle: bool = False
+    namespace_lifecycle: bool = False
+    custom_lifecycle: bool = False
+    tool_search_lifecycle: bool = False
+    hosted_lifecycles: frozenset[str] = frozenset()
+    unknown_lifecycles: frozenset[str] = frozenset()
+    accepts_namespace_adapter: bool = False
+    accepts_custom_adapter: bool = False
+    max_tool_name_length: int = 128
+    max_alias_attempts: int = 128
+
+    def __post_init__(self) -> None:
+        for field_name in ("hosted_lifecycles", "unknown_lifecycles"):
+            value = getattr(self, field_name)
+            if not isinstance(value, frozenset):
+                object.__setattr__(self, field_name, frozenset(str(item) for item in value))
+        if self.max_tool_name_length <= 0 or self.max_alias_attempts <= 0:
+            raise ValueError("protocol compatibility limits must be positive")
+
+    @classmethod
+    def chat_tools(cls, **overrides: Any) -> "ProtocolCapabilities":
+        values: dict[str, Any] = {
+            "function_lifecycle": True,
+            "namespace_lifecycle": False,
+            "custom_lifecycle": False,
+            "tool_search_lifecycle": False,
+            "accepts_namespace_adapter": True,
+            "accepts_custom_adapter": True,
+        }
+        values.update(overrides)
+        return cls(**values)
+
+    @classmethod
+    def responses_structured(cls, **overrides: Any) -> "ProtocolCapabilities":
+        values: dict[str, Any] = {
+            "function_lifecycle": True,
+            "namespace_lifecycle": True,
+            "custom_lifecycle": True,
+            "tool_search_lifecycle": True,
+        }
+        values.update(overrides)
+        return cls(**values)
+
+    @classmethod
+    def for_protocol(
+        cls,
+        protocol: str,
+        facts: Mapping[str, Any] | None = None,
+    ) -> "ProtocolCapabilities":
+        facts = facts or {}
+        normalized = str(protocol).strip().lower()
+        if normalized in {"chat", "chat_tools", "chat_completions"}:
+            defaults = cls.chat_tools()
+        elif normalized in {"responses", "responses_structured"}:
+            # The protocol name alone proves only the plain-function wire
+            # lifecycle. Native namespace/custom/search support requires
+            # explicit lifecycle facts; adapters remain request-scoped.
+            defaults = cls.chat_tools()
+        else:
+            defaults = cls()
+
+        def boolean(*keys: str, default: bool) -> bool:
+            for key in keys:
+                if key in facts and isinstance(facts[key], bool):
+                    return bool(facts[key])
+            return default
+
+        hosted = facts.get("hosted_lifecycles", facts.get("hosted_kinds", ()))
+        if isinstance(hosted, Mapping):
+            hosted = [key for key, value in hosted.items() if value is True]
+        if isinstance(hosted, str):
+            hosted = [hosted]
+        unknown = facts.get("unknown_lifecycles", facts.get("unknown_kinds", ()))
+        if isinstance(unknown, Mapping):
+            unknown = [key for key, value in unknown.items() if value is True]
+        if isinstance(unknown, str):
+            unknown = [unknown]
+
+        return cls(
+            function_lifecycle=boolean("function_lifecycle", "supports_functions", default=defaults.function_lifecycle),
+            namespace_lifecycle=boolean("namespace_lifecycle", "supports_namespace", "supports_namespaces", default=defaults.namespace_lifecycle),
+            custom_lifecycle=boolean("custom_lifecycle", "supports_custom", "supports_custom_tools", default=defaults.custom_lifecycle),
+            tool_search_lifecycle=boolean("tool_search_lifecycle", "supports_tool_search", default=defaults.tool_search_lifecycle),
+            hosted_lifecycles=frozenset(str(item) for item in hosted),
+            unknown_lifecycles=frozenset(str(item) for item in unknown),
+            accepts_namespace_adapter=boolean(
+                "accepts_namespace_adapter", "namespace_adapter", default=defaults.accepts_namespace_adapter
+            ),
+            accepts_custom_adapter=boolean(
+                "accepts_custom_adapter", "custom_adapter", default=defaults.accepts_custom_adapter
+            ),
+            max_tool_name_length=int(facts.get("max_tool_name_length", defaults.max_tool_name_length)),
+            max_alias_attempts=int(facts.get("max_alias_attempts", defaults.max_alias_attempts)),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class HostedCapabilityFacts:
+    supported_kinds: frozenset[str] = frozenset()
+
+    @classmethod
+    def from_value(cls, value: Any) -> "HostedCapabilityFacts":
+        if isinstance(value, HostedCapabilityFacts):
+            return value
+        if isinstance(value, Mapping):
+            return cls(frozenset(str(key) for key, enabled in value.items() if enabled is True))
+        if isinstance(value, str):
+            return cls(frozenset({value}))
+        if isinstance(value, Iterable):
+            return cls(frozenset(str(item) for item in value))
+        return cls()
+
+
+@dataclass(frozen=True, slots=True)
+class CompatibilityDiagnostics:
+    counts: tuple[tuple[str, str, int], ...] = ()
+    failures: tuple[str, ...] = ()
+
+    @classmethod
+    def from_entries(cls, entries: Iterable["ToolCompatibilityEntry"]) -> "CompatibilityDiagnostics":
+        counts = Counter((entry.family, entry.disposition) for entry in entries)
+        return cls(
+            counts=tuple(
+                (family, disposition, count)
+                for (family, disposition), count in sorted(counts.items())
+            )
+        )
+
+    def __repr__(self) -> str:
+        return f"CompatibilityDiagnostics(counts={self.counts!r}, failures={self.failures!r})"
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "counts": [
+                {"family": family, "disposition": disposition, "count": count}
+                for family, disposition, count in self.counts
+            ],
+            "failure_classifications": list(self.failures),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class AliasRecord:
+    alias: str
+    family: str
+    declaration_index: int
+    child_index: int | None
+    namespace: str | None
+    child_name: str | None
+    original_name: str | None
+    version: str | None
+
+
+class RequestScopedToolAliasRegistry:
+    """One request-local, opaque alias map with explicit reverse lookups."""
+
+    def __init__(
+        self,
+        *,
+        request_token: str,
+        native_names: Iterable[str] = (),
+        max_tool_name_length: int = 128,
+        max_alias_attempts: int = 128,
+    ) -> None:
+        self._token = hashlib.sha256(str(request_token).encode("utf-8")).hexdigest()[:10]
+        self._native_names = frozenset(str(name) for name in native_names if isinstance(name, str))
+        self._max_length = max_tool_name_length
+        self._max_attempts = max_alias_attempts
+        self._aliases: dict[str, AliasRecord] = {}
+        self._by_declaration: dict[tuple[int, int | None], str] = {}
+        self._calls: dict[str, AliasRecord] = {}
+
+    @property
+    def aliases(self) -> tuple[str, ...]:
+        return tuple(self._aliases)
+
+    def reserve_native_names(self, names: Iterable[str]) -> dict[str, str]:
+        requested = {str(name) for name in names if isinstance(name, str) and name}
+        self._native_names = frozenset(
+            set(self._native_names)
+            | requested
+        )
+        remapped: dict[str, str] = {}
+        for alias, record in tuple(self._aliases.items()):
+            if alias not in requested:
+                continue
+            self._aliases.pop(alias, None)
+            self._by_declaration.pop((record.declaration_index, record.child_index), None)
+            prefix = _NAMESPACE_ALIAS_PREFIX if record.family == NAMESPACE else _CUSTOM_ALIAS_PREFIX
+            replacement = self._allocate(record, prefix)
+            remapped[alias] = replacement
+        return remapped
+
+    def is_native_name(self, value: Any) -> bool:
+        return isinstance(value, str) and value in self._native_names
+
+    @staticmethod
+    def looks_like_alias(value: Any) -> bool:
+        return isinstance(value, str) and value.startswith((_NAMESPACE_ALIAS_PREFIX, _CUSTOM_ALIAS_PREFIX))
+
+    def _allocate(self, record_without_alias: AliasRecord, prefix: str) -> str:
+        for ordinal in range(1, self._max_attempts + 1):
+            candidate = f"{prefix}{self._token}_{ordinal}"
+            if len(candidate) > self._max_length:
+                raise ToolCompatibilityError(
+                    "tool_compatibility_alias_limit",
+                    "alias_length_exhausted",
+                )
+            if candidate in self._native_names or candidate in self._aliases:
+                continue
+            record = AliasRecord(
+                alias=candidate,
+                family=record_without_alias.family,
+                declaration_index=record_without_alias.declaration_index,
+                child_index=record_without_alias.child_index,
+                namespace=record_without_alias.namespace,
+                child_name=record_without_alias.child_name,
+                original_name=record_without_alias.original_name,
+                version=record_without_alias.version,
+            )
+            self._aliases[candidate] = record
+            self._by_declaration[(record.declaration_index, record.child_index)] = candidate
+            return candidate
+        raise ToolCompatibilityError(
+            "tool_compatibility_alias_limit",
+            "alias_collision_exhausted",
+        )
+
+    def allocate_namespace(
+        self,
+        *,
+        declaration_index: int,
+        namespace: str,
+        child_index: int,
+        child_name: str,
+        version: str | None,
+    ) -> str:
+        return self._allocate(
+            AliasRecord(
+                alias="",
+                family=NAMESPACE,
+                declaration_index=declaration_index,
+                child_index=child_index,
+                namespace=namespace,
+                child_name=child_name,
+                original_name=child_name,
+                version=version,
+            ),
+            _NAMESPACE_ALIAS_PREFIX,
+        )
+
+    def allocate_custom(self, *, declaration_index: int, original_name: str, version: str | None) -> str:
+        return self._allocate(
+            AliasRecord(
+                alias="",
+                family=CUSTOM_FREEFORM,
+                declaration_index=declaration_index,
+                child_index=None,
+                namespace=None,
+                child_name=None,
+                original_name=original_name,
+                version=version,
+            ),
+            _CUSTOM_ALIAS_PREFIX,
+        )
+
+    def record_for_alias(self, alias: Any) -> AliasRecord | None:
+        return self._aliases.get(alias) if isinstance(alias, str) else None
+
+    def alias_for(self, declaration_index: int, child_index: int | None = None) -> str | None:
+        return self._by_declaration.get((declaration_index, child_index))
+
+    def bind_call(self, call_id: Any, alias: str) -> None:
+        if not isinstance(call_id, str) or not call_id:
+            raise ToolCompatibilityError("tool_compatibility_boundary", "missing_call_identity")
+        record = self.record_for_alias(alias)
+        if record is None:
+            raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_alias")
+        previous = self._calls.get(call_id)
+        if previous is not None and previous.alias != alias:
+            raise ToolCompatibilityError("tool_compatibility_boundary", "ambiguous_call_identity")
+        if previous is not None:
+            raise ToolCompatibilityError("tool_compatibility_boundary", "duplicate_call_identity")
+        self._calls[call_id] = record
+
+    def record_for_call(self, call_id: Any) -> AliasRecord | None:
+        return self._calls.get(call_id) if isinstance(call_id, str) else None
+
+
+@dataclass(frozen=True, slots=True)
+class ToolCompatibilityEntry:
+    declaration_index: int
+    family: str
+    disposition: str
+    required: bool
+    declaration: Mapping[str, Any]
+    reason: str
+    aliases: tuple[str, ...] = ()
+    namespace: str | None = None
+    version: str | None = None
+    child_names: tuple[str, ...] = ()
+
+    @property
+    def original_name(self) -> str | None:
+        name = self.declaration.get("name")
+        return name if isinstance(name, str) else None
+
+
+def _name_of(value: Mapping[str, Any]) -> str | None:
+    name = value.get("name")
+    if isinstance(name, str) and name:
+        return name
+    function = value.get("function")
+    if isinstance(function, Mapping):
+        name = function.get("name")
+        if isinstance(name, str) and name:
+            return name
+    return None
+
+
+def _namespace_details(declaration: Mapping[str, Any]) -> tuple[str | None, tuple[Mapping[str, Any], ...], str | None, bool]:
+    namespace = declaration.get("name")
+    namespace = namespace if isinstance(namespace, str) and namespace else None
+    raw_tools = declaration.get("tools")
+    if not isinstance(raw_tools, list):
+        return namespace, (), None, False
+    children: list[Mapping[str, Any]] = []
+    for child in raw_tools:
+        if not isinstance(child, Mapping) or child.get("type") != "function" or not _name_of(child):
+            return namespace, (), None, False
+        children.append(child)
+    child_names = [str(child.get("name")) for child in children]
+    if len(set(child_names)) != len(child_names):
+        return namespace, (), None, False
+    if namespace == "multi_agent_v1":
+        version = "v1"
+    elif namespace == "collaboration":
+        version = "v2"
+    else:
+        version = None
+    return namespace, tuple(children), version, bool(namespace and children)
+
+
+def classify_declaration(declaration: Mapping[str, Any]) -> str:
+    item_type = declaration.get("type")
+    if item_type == "namespace":
+        return NAMESPACE
+    if item_type == "function":
+        return PLAIN_FUNCTION
+    if item_type == "custom":
+        return CUSTOM_FREEFORM
+    if item_type == "tool_search":
+        return TOOL_SEARCH
+    if (
+        isinstance(item_type, str)
+        and (item_type in _KNOWN_HOSTED_TYPES or declaration.get("executor") == "selected_provider")
+    ):
+        return SELECTED_PROVIDER_HOSTED
+    return UNKNOWN_FUTURE_KIND
+
+
+def _declaration_key(declaration: Mapping[str, Any]) -> tuple[Any, ...]:
+    family = classify_declaration(declaration)
+    return (
+        family,
+        declaration.get("type"),
+        declaration.get("name"),
+        declaration.get("namespace"),
+    )
+
+
+def _required_by_rule(
+    declaration: Mapping[str, Any],
+    index: int,
+    *,
+    required: Any,
+    tool_choice: Any,
+) -> bool:
+    names = {_name_of(declaration), declaration.get("type"), declaration.get("name")}
+    names.discard(None)
+    namespace, children, _version, valid = _namespace_details(declaration)
+    if namespace:
+        names.add(namespace)
+        names.update(child.get("name") for child in children if isinstance(child.get("name"), str))
+
+    result = False
+    if isinstance(required, bool):
+        result = required
+    elif isinstance(required, Mapping):
+        for key in (index, str(index), declaration.get("type"), declaration.get("name"), namespace):
+            if key in required and isinstance(required[key], bool):
+                result = result or required[key]
+        for key, enabled in required.items():
+            if enabled is True and key in names:
+                result = True
+    elif isinstance(required, str):
+        result = required in names
+    elif isinstance(required, Iterable):
+        required_values = {str(item) for item in required}
+        result = bool(required_values.intersection({str(item) for item in names}))
+
+    if tool_choice in ("required", True):
+        return result
+    if not isinstance(tool_choice, Mapping):
+        if isinstance(tool_choice, str) and tool_choice not in {"auto", "none"}:
+            return result or tool_choice in names
+        return result
+    choice_type = tool_choice.get("type")
+    choice_name = tool_choice.get("name")
+    if choice_type == "function" and isinstance(choice_name, str):
+        return result or choice_name in names
+    if choice_type in {"namespace", "custom", "tool_search"} and (
+        choice_name is None or choice_name in names
+    ):
+        return True
+    if isinstance(choice_type, str) and choice_type in names:
+        return True
+    return result
+
+
+def _protocol_capabilities(
+    selected_protocol: str,
+    supplied: ProtocolCapabilities | Mapping[str, Any] | None,
+) -> ProtocolCapabilities:
+    if isinstance(supplied, ProtocolCapabilities):
+        return supplied
+    return ProtocolCapabilities.for_protocol(selected_protocol, supplied)
+
+
+def _provider_hosted(value: Any) -> HostedCapabilityFacts:
+    return HostedCapabilityFacts.from_value(value)
+
+
+def _declaration_valid_for_family(declaration: Mapping[str, Any], family: str) -> bool:
+    if family == PLAIN_FUNCTION:
+        return declaration.get("type") == "function" and bool(_name_of(declaration))
+    if family == NAMESPACE:
+        return _namespace_details(declaration)[3]
+    if family == CUSTOM_FREEFORM:
+        return declaration.get("type") == "custom" and bool(_name_of(declaration)) and "format" in declaration
+    if family == TOOL_SEARCH:
+        return declaration.get("type") == "tool_search" and declaration.get("execution") == "client"
+    if family == SELECTED_PROVIDER_HOSTED:
+        return isinstance(declaration.get("type"), str)
+    return isinstance(declaration.get("type"), str)
+
+
+def build_tool_compatibility_plan(
+    runtime_declarations: Iterable[Mapping[str, Any]] | Mapping[str, Any],
+    *,
+    selected_protocol: str,
+    provider_hosted_capabilities: Any = None,
+    required: Any = None,
+    tool_choice: Any = None,
+    protocol_capabilities: ProtocolCapabilities | Mapping[str, Any] | None = None,
+    request_token: str = "request",
+    native_names: Iterable[str] = (),
+) -> "ToolCompatibilityPlan":
+    if isinstance(runtime_declarations, Mapping):
+        candidate = runtime_declarations.get("tools", ())
+    else:
+        candidate = runtime_declarations
+    if isinstance(candidate, (str, bytes, bytearray)) or not isinstance(candidate, Iterable):
+        raise _MalformedDeclaration()
+    declarations: list[Mapping[str, Any]] = []
+    for item in candidate:
+        if not isinstance(item, Mapping):
+            raise _MalformedDeclaration()
+        declarations.append(item)
+    capabilities = _protocol_capabilities(selected_protocol, protocol_capabilities)
+    hosted = _provider_hosted(provider_hosted_capabilities)
+
+    all_native_names: set[str] = {str(name) for name in native_names if isinstance(name, str)}
+    for declaration in declarations:
+        family = classify_declaration(declaration)
+        declaration_name = declaration.get("name")
+        if isinstance(declaration_name, str) and declaration_name:
+            all_native_names.add(declaration_name)
+        if family in {PLAIN_FUNCTION, CUSTOM_FREEFORM} and _name_of(declaration):
+            all_native_names.add(str(_name_of(declaration)))
+        if family == NAMESPACE:
+            _namespace, children, _version, _valid = _namespace_details(declaration)
+            all_native_names.update(
+                str(child.get("name")) for child in children if isinstance(child.get("name"), str)
+            )
+
+    registry = RequestScopedToolAliasRegistry(
+        request_token=request_token,
+        native_names=all_native_names,
+        max_tool_name_length=capabilities.max_tool_name_length,
+        max_alias_attempts=capabilities.max_alias_attempts,
+    )
+    preliminary: list[ToolCompatibilityEntry] = []
+    for index, declaration in enumerate(declarations):
+        family = classify_declaration(declaration)
+        is_required = _required_by_rule(
+            declaration,
+            index,
+            required=required,
+            tool_choice=tool_choice,
+        )
+        valid = _declaration_valid_for_family(declaration, family)
+        if not valid:
+            raise _MalformedDeclaration()
+        namespace, children, version, namespace_valid = _namespace_details(declaration)
+        reason = "native_lifecycle"
+        disposition = OMIT
+        aliases: list[str] = []
+
+        if family == PLAIN_FUNCTION:
+            if valid and capabilities.function_lifecycle:
+                disposition, reason = NATIVE, "native_function_lifecycle"
+            else:
+                reason = "function_lifecycle_unavailable"
+        elif family == NAMESPACE:
+            if valid and capabilities.namespace_lifecycle:
+                disposition, reason = NATIVE, "native_namespace_lifecycle"
+            elif valid and capabilities.function_lifecycle and capabilities.accepts_namespace_adapter:
+                disposition, reason = ADAPT, "namespace_function_adapter"
+                for child_index, child in enumerate(children):
+                    child_name = str(child.get("name"))
+                    aliases.append(
+                        registry.allocate_namespace(
+                            declaration_index=index,
+                            namespace=str(namespace),
+                            child_index=child_index,
+                            child_name=child_name,
+                            version=version,
+                        )
+                    )
+            else:
+                reason = "namespace_lifecycle_unavailable"
+        elif family == CUSTOM_FREEFORM:
+            if valid and capabilities.custom_lifecycle:
+                disposition, reason = NATIVE, "native_custom_lifecycle"
+            elif valid and capabilities.function_lifecycle and capabilities.accepts_custom_adapter:
+                disposition, reason = ADAPT, "custom_function_envelope"
+                aliases.append(
+                    registry.allocate_custom(
+                        declaration_index=index,
+                        original_name=str(_name_of(declaration)),
+                        version=None,
+                    )
+                )
+            else:
+                reason = "custom_lifecycle_unavailable"
+        elif family == TOOL_SEARCH:
+            if valid and capabilities.tool_search_lifecycle:
+                disposition, reason = NATIVE, "native_client_tool_search"
+            else:
+                reason = "client_tool_search_lifecycle_unavailable"
+        elif family == SELECTED_PROVIDER_HOSTED:
+            kind = declaration.get("type")
+            if (
+                valid
+                and isinstance(kind, str)
+                and kind in hosted.supported_kinds
+                and kind in capabilities.hosted_lifecycles
+            ):
+                disposition, reason = NATIVE, "selected_provider_hosted_lifecycle"
+            else:
+                reason = "selected_provider_hosted_lifecycle_unavailable"
+        else:
+            kind = declaration.get("type")
+            if valid and isinstance(kind, str) and kind in capabilities.unknown_lifecycles:
+                disposition, reason = NATIVE, "explicit_unknown_lifecycle"
+            else:
+                reason = "unknown_lifecycle_contract_unavailable"
+
+        if disposition == OMIT and is_required:
+            disposition = REQUIRED_BUT_UNAVAILABLE
+        preliminary.append(
+            ToolCompatibilityEntry(
+                declaration_index=index,
+                family=family,
+                disposition=disposition,
+                required=is_required,
+                declaration=_freeze(_copy_mapping(declaration)),
+                reason=reason,
+                aliases=tuple(aliases),
+                namespace=namespace,
+                version=version,
+                child_names=tuple(str(child.get("name")) for child in children if isinstance(child.get("name"), str)),
+            )
+        )
+
+    if tool_choice in ("required", True) and not any(
+        entry.disposition in {NATIVE, ADAPT} for entry in preliminary
+    ):
+        raise RequiredToolUnavailableError()
+    diagnostics = CompatibilityDiagnostics.from_entries(preliminary)
+    unavailable = [entry for entry in preliminary if entry.disposition == REQUIRED_BUT_UNAVAILABLE]
+    if unavailable:
+        raise RequiredToolUnavailableError(family=unavailable[0].family)
+    return ToolCompatibilityPlan(
+        selected_protocol=str(selected_protocol),
+        capabilities=capabilities,
+        entries=tuple(preliminary),
+        registry=registry,
+        diagnostics=diagnostics,
+        tool_choice=_freeze(tool_choice),
+    )
+
+
+def _json_object_exact(value: Any, *, output: bool = False) -> dict[str, Any]:
+    if isinstance(value, Mapping):
+        parsed = _copy_mapping(value)
+    elif isinstance(value, str):
+        def pairs(items: list[tuple[str, Any]]) -> dict[str, Any]:
+            result: dict[str, Any] = {}
+            for key, item in items:
+                if key in result:
+                    raise ToolCompatibilityError("tool_compatibility_boundary", "duplicate_envelope_key")
+                result[key] = item
+            return result
+
+        try:
+            parsed = json.loads(value, object_pairs_hook=pairs)
+        except ToolCompatibilityError:
+            raise
+        except (TypeError, ValueError):
+            raise ToolCompatibilityError("tool_compatibility_boundary", "malformed_envelope") from None
+    else:
+        raise ToolCompatibilityError("tool_compatibility_boundary", "malformed_envelope")
+    expected = CUSTOM_OUTPUT_KEY if output else CUSTOM_INPUT_KEY
+    if not isinstance(parsed, dict) or set(parsed) != {expected}:
+        raise ToolCompatibilityError("tool_compatibility_boundary", "invalid_envelope")
+    return parsed
+
+
+def _dump_envelope(key: str, value: Any) -> str:
+    return json.dumps({key: _thaw(_freeze(value))}, ensure_ascii=True, separators=(",", ":"))
+
+
+def _validate_version_fields(item: Mapping[str, Any], record: AliasRecord) -> None:
+    if record.version == "v1" and _V1_FORBIDDEN.intersection(item):
+        raise ToolCompatibilityError("tool_compatibility_boundary", "mixed_v1_v2_fields")
+    if record.version == "v2" and _V2_FORBIDDEN.intersection(item):
+        raise ToolCompatibilityError("tool_compatibility_boundary", "mixed_v1_v2_fields")
+    arguments = item.get("arguments")
+    if arguments in (None, ""):
+        return
+    if isinstance(arguments, Mapping):
+        parsed = _copy_mapping(arguments)
+    elif isinstance(arguments, str):
+        try:
+            parsed = json.loads(arguments)
+        except (TypeError, ValueError):
+            raise ToolCompatibilityError("tool_compatibility_boundary", "malformed_arguments") from None
+    else:
+        raise ToolCompatibilityError("tool_compatibility_boundary", "malformed_arguments")
+    if not isinstance(parsed, Mapping):
+        raise ToolCompatibilityError("tool_compatibility_boundary", "malformed_arguments")
+    if record.version == "v1" and _V1_FORBIDDEN.intersection(parsed):
+        raise ToolCompatibilityError("tool_compatibility_boundary", "mixed_v1_v2_fields")
+    if record.version == "v2" and _V2_FORBIDDEN.intersection(parsed):
+        raise ToolCompatibilityError("tool_compatibility_boundary", "mixed_v1_v2_fields")
+
+
+def _item_identity(item: Mapping[str, Any]) -> str | None:
+    for key in ("item_id", "id"):
+        value = item.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+@dataclass(frozen=True, slots=True)
+class ToolCompatibilityPlan:
+    selected_protocol: str
+    capabilities: ProtocolCapabilities
+    entries: tuple[ToolCompatibilityEntry, ...]
+    registry: RequestScopedToolAliasRegistry = field(repr=False, compare=False)
+    diagnostics: CompatibilityDiagnostics
+    tool_choice: Any = None
+
+    @property
+    def aliases(self) -> tuple[str, ...]:
+        return self.registry.aliases
+
+    @property
+    def has_adaptations(self) -> bool:
+        return any(entry.disposition == ADAPT for entry in self.entries)
+
+    def entry(self, index: int) -> ToolCompatibilityEntry:
+        return self.entries[index]
+
+    def new_stream(self) -> "CompatibilityStreamState":
+        return CompatibilityStreamState(self)
+
+    def with_final_declarations(self, declarations: Iterable[Mapping[str, Any]]) -> "ToolCompatibilityPlan":
+        """Add model-visible native declarations while preserving request aliases."""
+        final = list(declarations)
+        occurrence: dict[tuple[Any, ...], int] = {}
+        matched_keys: set[tuple[Any, ...]] = set()
+        for declaration in final:
+            if isinstance(declaration, Mapping):
+                key = _declaration_key(declaration)
+                existing = self._entry_for_declaration(declaration, occurrence)
+                if existing is not None:
+                    matched_keys.add((key, existing.declaration_index))
+        entries = list(self.entries)
+        existing_occurrence: dict[tuple[Any, ...], int] = {}
+        for entry in self.entries:
+            existing_occurrence[_declaration_key(entry.declaration)] = existing_occurrence.get(
+                _declaration_key(entry.declaration), 0
+            ) + 1
+        native_names: set[str] = set()
+        for declaration in final:
+            if not isinstance(declaration, Mapping):
+                continue
+            name = declaration.get("name")
+            if isinstance(name, str):
+                native_names.add(name)
+            family = classify_declaration(declaration)
+            if family == NAMESPACE:
+                _namespace, children, _version, _valid = _namespace_details(declaration)
+                native_names.update(
+                    str(child.get("name")) for child in children if isinstance(child.get("name"), str)
+                )
+            key = _declaration_key(declaration)
+            if any(_declaration_key(entry.declaration) == key for entry in self.entries):
+                continue
+            if not _declaration_valid_for_family(declaration, family):
+                continue
+            entries.append(
+                ToolCompatibilityEntry(
+                    declaration_index=len(entries),
+                    family=family,
+                    disposition=NATIVE,
+                    required=False,
+                    declaration=_freeze(_copy_mapping(declaration)),
+                    reason="native_gateway_declaration",
+                    namespace=_namespace_details(declaration)[0] if family == NAMESPACE else None,
+                    version=_namespace_details(declaration)[2] if family == NAMESPACE else None,
+                    child_names=tuple(
+                        str(child.get("name"))
+                        for child in _namespace_details(declaration)[1]
+                        if isinstance(child.get("name"), str)
+                    ) if family == NAMESPACE else (),
+                )
+            )
+        alias_remap = self.registry.reserve_native_names(native_names)
+        if alias_remap:
+            entries = [
+                ToolCompatibilityEntry(
+                    declaration_index=entry.declaration_index,
+                    family=entry.family,
+                    disposition=entry.disposition,
+                    required=entry.required,
+                    declaration=entry.declaration,
+                    reason=entry.reason,
+                    aliases=tuple(alias_remap.get(alias, alias) for alias in entry.aliases),
+                    namespace=entry.namespace,
+                    version=entry.version,
+                    child_names=entry.child_names,
+                )
+                for entry in entries
+            ]
+        if len(entries) == len(self.entries) and not alias_remap:
+            return self
+        return ToolCompatibilityPlan(
+            selected_protocol=self.selected_protocol,
+            capabilities=self.capabilities,
+            entries=tuple(entries),
+            registry=self.registry,
+            diagnostics=CompatibilityDiagnostics.from_entries(entries),
+            tool_choice=self.tool_choice,
+        )
+
+    def _entry_for_declaration(self, declaration: Mapping[str, Any], occurrence: dict[tuple[Any, ...], int]) -> ToolCompatibilityEntry | None:
+        key = _declaration_key(declaration)
+        matching = [entry for entry in self.entries if _declaration_key(entry.declaration) == key]
+        offset = occurrence.get(key, 0)
+        occurrence[key] = offset + 1
+        return matching[offset] if offset < len(matching) else None
+
+    def _entry_for_name(self, name: Any, namespace: Any = None) -> ToolCompatibilityEntry | None:
+        if not isinstance(name, str):
+            return None
+        for entry in self.entries:
+            if (
+                entry.family == NAMESPACE
+                and (
+                    (
+                        (namespace is None or namespace == entry.namespace)
+                        and name in entry.child_names
+                    )
+                    or (
+                        namespace is None
+                        and any(name == f"{entry.namespace}__{child}" for child in entry.child_names)
+                    )
+                )
+            ):
+                return entry
+            if entry.family != NAMESPACE and entry.original_name == name:
+                return entry
+        return None
+
+    def _entries_for_name(self, name: Any, namespace: Any = None) -> list[ToolCompatibilityEntry]:
+        if not isinstance(name, str):
+            return []
+        matches: list[ToolCompatibilityEntry] = []
+        for entry in self.entries:
+            if entry.family == NAMESPACE:
+                if namespace is not None and namespace != entry.namespace:
+                    continue
+                if name in entry.child_names or (
+                    namespace is None
+                    and any(name == f"{entry.namespace}__{child}" for child in entry.child_names)
+                ):
+                    matches.append(entry)
+            elif entry.original_name == name:
+                matches.append(entry)
+        return matches
+
+    def _alias_for(self, entry: ToolCompatibilityEntry, *, child_name: str | None = None) -> str | None:
+        if entry.family == NAMESPACE:
+            if child_name not in entry.child_names and isinstance(child_name, str):
+                child_name = next(
+                    (
+                        child
+                        for child in entry.child_names
+                        if child_name == f"{entry.namespace}__{child}"
+                    ),
+                    child_name,
+                )
+            try:
+                child_index = entry.child_names.index(child_name or "")
+            except ValueError:
+                return None
+            return entry.aliases[child_index]
+        return entry.aliases[0] if entry.aliases else None
+
+    def owns_wire_value(self, value: Any) -> bool:
+        if not isinstance(value, Mapping):
+            return False
+        name = value.get("name")
+        namespace = value.get("namespace")
+        if self.registry.record_for_alias(name) is not None:
+            return True
+        if self.registry.looks_like_alias(name):
+            return True
+        if self._entry_for_name(name, namespace) is not None:
+            return True
+        return self.registry.record_for_call(value.get("call_id")) is not None
+
+    def _encode_tool_declarations(self, tools: Any) -> tuple[Any, bool]:
+        if not isinstance(tools, list):
+            return tools, False
+        occurrence: dict[tuple[Any, ...], int] = {}
+        encoded: list[Any] = []
+        changed = False
+        for raw_tool in tools:
+            if not isinstance(raw_tool, Mapping):
+                encoded.append(raw_tool)
+                continue
+            entry = self._entry_for_declaration(raw_tool, occurrence)
+            if entry is None:
+                encoded.append(_copy_mapping(raw_tool))
+                continue
+            if entry.disposition == OMIT:
+                changed = True
+                continue
+            if entry.disposition != ADAPT:
+                encoded.append(_copy_mapping(raw_tool))
+                continue
+            if entry.family == NAMESPACE:
+                namespace, children, _version, valid = _namespace_details(raw_tool)
+                if not valid:
+                    raise ToolCompatibilityError("tool_compatibility_boundary", "malformed_declaration")
+                for child_index, child in enumerate(children):
+                    function = _copy_mapping(child)
+                    function["type"] = "function"
+                    function["name"] = entry.aliases[child_index]
+                    function.pop("namespace", None)
+                    encoded.append(function)
+                changed = True
+                continue
+            if entry.family == CUSTOM_FREEFORM:
+                alias = entry.aliases[0]
+                encoded.append(
+                    {
+                        "type": "function",
+                        "name": alias,
+                        "parameters": {
+                            "type": "object",
+                            "properties": {CUSTOM_INPUT_KEY: {}},
+                            "required": [CUSTOM_INPUT_KEY],
+                            "additionalProperties": False,
+                        },
+                    }
+                )
+                changed = True
+                continue
+            encoded.append(_copy_mapping(raw_tool))
+        return encoded, changed
+
+    def _encode_tool_choice(self, value: Any) -> tuple[Any, bool]:
+        thawed = _thaw(value)
+        if isinstance(thawed, str):
+            entry = self._entry_for_name(thawed)
+            alias = self._alias_for(entry) if entry is not None and entry.disposition == ADAPT else None
+            return (alias, True) if alias else (thawed, False)
+        if not isinstance(thawed, Mapping):
+            return thawed, False
+        result = dict(thawed)
+        name = result.get("name")
+        choice_type = result.get("type")
+        namespace_choice = name if isinstance(name, str) else result.get("namespace")
+        if choice_type == "namespace" and isinstance(namespace_choice, str):
+            candidates = [
+                entry
+                for entry in self.entries
+                if entry.family == NAMESPACE
+                and entry.namespace == namespace_choice
+                and entry.disposition == ADAPT
+            ]
+            if candidates:
+                aliases = [alias for entry in candidates for alias in entry.aliases]
+                if len(aliases) != 1:
+                    raise ToolCompatibilityError("tool_compatibility_boundary", "ambiguous_tool_choice")
+                result["type"] = "function"
+                result["name"] = aliases[0]
+                return result, True
+        entry = self._entry_for_name(name)
+        if choice_type == "function" and isinstance(name, str):
+            candidates = [candidate for candidate in self._entries_for_name(name) if candidate.disposition == ADAPT]
+            if len(candidates) > 1:
+                raise ToolCompatibilityError("tool_compatibility_boundary", "ambiguous_tool_choice")
+        alias = (
+            self._alias_for(entry, child_name=name)
+            if entry is not None and entry.disposition == ADAPT
+            else None
+        )
+        if alias:
+            result["name"] = alias
+            result["type"] = "function"
+            return result, True
+        return result, False
+
+    def _encode_item(self, raw_item: Any, call_aliases: dict[str, str]) -> tuple[Any, bool]:
+        if not isinstance(raw_item, Mapping):
+            return raw_item, False
+        item = _copy_mapping(raw_item)
+        item_type = item.get("type")
+        name = item.get("name")
+        namespace = item.get("namespace")
+        entry = self._entry_for_name(name, namespace)
+        if item_type == "function_call" and entry is not None and entry.disposition == ADAPT:
+            alias = self._alias_for(entry, child_name=name)
+            if alias is None:
+                raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_alias")
+            _validate_version_fields(item, self.registry.record_for_alias(alias))  # type: ignore[arg-type]
+            call_id = item.get("call_id")
+            self.registry.bind_call(call_id, alias)
+            call_aliases[str(call_id)] = alias
+            item["name"] = alias
+            item.pop("namespace", None)
+            if entry.family == CUSTOM_FREEFORM:
+                if "input" not in item:
+                    raise ToolCompatibilityError("tool_compatibility_boundary", "malformed_envelope")
+                item["type"] = "function_call"
+                item["arguments"] = _dump_envelope(CUSTOM_INPUT_KEY, item.pop("input"))
+            return item, True
+        if item_type == "custom_tool_call" and entry is not None and entry.disposition == ADAPT:
+            alias = self._alias_for(entry)
+            if alias is None or "input" not in item:
+                raise ToolCompatibilityError("tool_compatibility_boundary", "malformed_envelope")
+            call_id = item.get("call_id")
+            self.registry.bind_call(call_id, alias)
+            call_aliases[str(call_id)] = alias
+            item["type"] = "function_call"
+            item["name"] = alias
+            item["arguments"] = _dump_envelope(CUSTOM_INPUT_KEY, item.pop("input"))
+            return item, True
+        if item_type in {"function_call_output", "custom_tool_call_output"}:
+            call_id = item.get("call_id")
+            alias = call_aliases.get(call_id) if isinstance(call_id, str) else None
+            record = self.registry.record_for_call(call_id) if alias is None else self.registry.record_for_alias(alias)
+            if record is not None and record.family == CUSTOM_FREEFORM:
+                if "output" not in item:
+                    raise ToolCompatibilityError("tool_compatibility_boundary", "malformed_envelope")
+                item["type"] = "function_call_output"
+                item["output"] = _dump_envelope(CUSTOM_OUTPUT_KEY, item["output"])
+                return item, True
+            if record is not None and record.family == NAMESPACE:
+                _validate_version_fields(item, record)
+            return item, False
+        return item, False
+
+    def _omitted_history_entry(self, item: Mapping[str, Any]) -> ToolCompatibilityEntry | None:
+        item_type = item.get("type")
+        if item_type in {"function_call", "custom_tool_call"}:
+            entry = self._entry_for_name(item.get("name"), item.get("namespace"))
+            return entry if entry is not None and entry.disposition == OMIT else None
+        if item_type in {"tool_search_call", "tool_search_output"}:
+            return next(
+                (
+                    entry
+                    for entry in self.entries
+                    if entry.family == TOOL_SEARCH and entry.disposition == OMIT
+                ),
+                None,
+            )
+        if isinstance(item_type, str):
+            return next(
+                (
+                    entry
+                    for entry in self.entries
+                    if entry.disposition == OMIT
+                    and isinstance(entry.declaration.get("type"), str)
+                    and item_type.startswith(f"{entry.declaration.get('type')}_")
+                ),
+                None,
+            )
+        return None
+
+    def encode_payload(self, payload: Mapping[str, Any]) -> dict[str, Any]:
+        result = _copy_mapping(payload)
+        encoded_tools, tools_changed = self._encode_tool_declarations(result.get("tools"))
+        if tools_changed:
+            result["tools"] = encoded_tools
+        chosen, choice_changed = self._encode_tool_choice(result.get("tool_choice"))
+        if choice_changed:
+            result["tool_choice"] = chosen
+        call_aliases: dict[str, str] = {}
+        raw_input = result.get("input")
+        if isinstance(raw_input, list):
+            encoded_input: list[Any] = []
+            changed = tools_changed or choice_changed
+            omitted_call_items = [
+                item
+                for item in raw_input
+                if isinstance(item, Mapping)
+                and self._omitted_history_entry(item) is not None
+                and (
+                    item.get("type") in {"function_call", "custom_tool_call", "tool_search_call"}
+                    or (isinstance(item.get("type"), str) and item.get("type").endswith("_call"))
+                )
+            ]
+            omitted_call_ids: set[str] = set()
+            for item in omitted_call_items:
+                call_id = item.get("call_id")
+                if not isinstance(call_id, str) or not call_id:
+                    raise ToolCompatibilityError("tool_compatibility_boundary", "missing_call_identity", surface="history")
+                if call_id in omitted_call_ids:
+                    raise ToolCompatibilityError("tool_compatibility_boundary", "duplicate_call_identity", surface="history")
+                omitted_call_ids.add(call_id)
+            retained_call_ids = {
+                item.get("call_id")
+                for item in raw_input
+                if isinstance(item, Mapping)
+                and (
+                    item.get("type") in {"function_call", "custom_tool_call", "tool_search_call"}
+                    or (isinstance(item.get("type"), str) and item.get("type").endswith("_call"))
+                )
+                and self._omitted_history_entry(item) is None
+                and isinstance(item.get("call_id"), str)
+            }
+            if omitted_call_ids.intersection(retained_call_ids):
+                raise ToolCompatibilityError("tool_compatibility_boundary", "ambiguous_call_identity", surface="history")
+            for item in raw_input:
+                if not isinstance(item, Mapping):
+                    continue
+                if item.get("type") in {"function_call_output", "custom_tool_call_output", "tool_search_output"}:
+                    call_id = item.get("call_id")
+                    if not isinstance(call_id, str) or not call_id:
+                        raise ToolCompatibilityError("tool_compatibility_boundary", "missing_call_identity", surface="history")
+                    if self._omitted_history_entry(item) is not None and call_id not in omitted_call_ids:
+                        raise ToolCompatibilityError("tool_compatibility_boundary", "ambiguous_call_identity", surface="history")
+            for item in raw_input:
+                if isinstance(item, Mapping) and (
+                    self._omitted_history_entry(item) is not None
+                    or item.get("call_id") in omitted_call_ids
+                ):
+                    changed = True
+                    continue
+                encoded, item_changed = self._encode_item(item, call_aliases)
+                encoded_input.append(encoded)
+                changed = changed or item_changed
+            if changed:
+                result["input"] = encoded_input
+        return result
+
+    def _decode_call(self, item: Mapping[str, Any], *, allow_incomplete: bool = False) -> tuple[dict[str, Any], AliasRecord | None, bool]:
+        result = _copy_mapping(item)
+        name = result.get("name")
+        record = self.registry.record_for_alias(name)
+        if record is None:
+            if self.registry.looks_like_alias(name):
+                raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_alias", surface="response")
+            return result, None, False
+        _validate_version_fields(result, record)
+        if record.family == NAMESPACE and result.get("namespace") not in {None, record.namespace}:
+            raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_alias", surface="response")
+        call_id = result.get("call_id")
+        if isinstance(call_id, str) and call_id:
+            if self.registry.record_for_call(call_id) is None:
+                self.registry.bind_call(call_id, record.alias)
+        elif not allow_incomplete:
+            raise ToolCompatibilityError("tool_compatibility_boundary", "missing_call_identity", surface="response")
+        result["name"] = record.child_name if record.family == NAMESPACE else record.original_name
+        if record.family == NAMESPACE:
+            result["namespace"] = record.namespace
+        elif record.family == CUSTOM_FREEFORM:
+            if "arguments" in result:
+                envelope = _json_object_exact(result["arguments"])
+                result["type"] = "custom_tool_call"
+                result["input"] = envelope[CUSTOM_INPUT_KEY]
+                result.pop("arguments", None)
+            elif not allow_incomplete:
+                raise ToolCompatibilityError("tool_compatibility_boundary", "malformed_envelope", surface="response")
+            else:
+                result["type"] = "custom_tool_call"
+        return result, record, True
+
+    def _decode_result(self, item: Mapping[str, Any]) -> tuple[dict[str, Any], bool]:
+        result = _copy_mapping(item)
+        call_id = result.get("call_id")
+        record = self.registry.record_for_call(call_id)
+        if record is None:
+            if self.registry.looks_like_alias(result.get("name")):
+                raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_alias", surface="response")
+            return result, False
+        _validate_version_fields(result, record)
+        if record.family == CUSTOM_FREEFORM:
+            if "output" not in result:
+                raise ToolCompatibilityError("tool_compatibility_boundary", "malformed_envelope", surface="response")
+            envelope = _json_object_exact(result["output"], output=True)
+            result["type"] = "custom_tool_call_output"
+            result["output"] = envelope[CUSTOM_OUTPUT_KEY]
+        return result, True
+
+    def _native_entry_for_item(self, item: Mapping[str, Any]) -> ToolCompatibilityEntry | None:
+        item_type = item.get("type")
+        if item_type in {"function_call", "custom_tool_call"}:
+            entry = self._entry_for_name(item.get("name"), item.get("namespace"))
+            if entry is not None and entry.disposition == NATIVE:
+                return entry
+            return None
+        if item_type in {"tool_search_call", "tool_search_output"}:
+            matches = [
+                entry
+                for entry in self.entries
+                if entry.family == TOOL_SEARCH and entry.disposition == NATIVE
+            ]
+            return matches[0] if len(matches) == 1 else None
+        return None
+
+    def _has_native_structural_family(self) -> bool:
+        return any(
+            entry.disposition == NATIVE
+            and entry.family in {PLAIN_FUNCTION, NAMESPACE, CUSTOM_FREEFORM, TOOL_SEARCH}
+            for entry in self.entries
+        )
+
+    @staticmethod
+    def _validate_native_item(item: Mapping[str, Any], entry: ToolCompatibilityEntry) -> None:
+        if entry.version is not None:
+            _validate_version_fields(
+                item,
+                AliasRecord(
+                    alias="",
+                    family=entry.family,
+                    declaration_index=entry.declaration_index,
+                    child_index=None,
+                    namespace=entry.namespace,
+                    child_name=item.get("name") if isinstance(item.get("name"), str) else None,
+                    original_name=entry.original_name,
+                    version=entry.version,
+                ),
+            )
+        item_type = item.get("type")
+        if entry.family == PLAIN_FUNCTION:
+            if item_type != "function_call" or item.get("name") != entry.original_name:
+                raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_native_identity", surface="history")
+        elif entry.family == NAMESPACE:
+            if (
+                item_type != "function_call"
+                or item.get("namespace") != entry.namespace
+                or item.get("name") not in entry.child_names
+            ):
+                raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_native_identity", surface="history")
+        elif entry.family == CUSTOM_FREEFORM:
+            if item_type != "custom_tool_call" or item.get("name") != entry.original_name:
+                raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_native_identity", surface="history")
+        elif entry.family == TOOL_SEARCH:
+            if item_type not in {"tool_search_call", "tool_search_output"}:
+                raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_native_identity", surface="history")
+            if item_type == "tool_search_call" and item.get("execution") not in {None, "client"}:
+                raise ToolCompatibilityError("tool_compatibility_boundary", "invalid_tool_search_execution", surface="history")
+
+    def _decode_items(self, items: Any) -> tuple[Any, bool]:
+        if not isinstance(items, list):
+            return items, False
+        result: list[Any] = []
+        changed = False
+        seen_item_ids: set[str] = set()
+        seen_call_ids: set[str] = set()
+        seen_result_call_ids: set[str] = set()
+        for raw_item in items:
+            if not isinstance(raw_item, Mapping):
+                result.append(raw_item)
+                continue
+            item_type = raw_item.get("type")
+            item = _copy_mapping(raw_item)
+            item_id = _item_identity(item)
+            call_id = item.get("call_id")
+            if item_type in {"function_call", "custom_tool_call", "tool_search_call"}:
+                if not isinstance(call_id, str) or not call_id:
+                    raise ToolCompatibilityError("tool_compatibility_boundary", "missing_call_identity", surface="history")
+            if isinstance(item_id, str) and item_id:
+                if item_id in seen_item_ids:
+                    raise ToolCompatibilityError("tool_compatibility_boundary", "duplicate_item_identity", surface="history")
+                seen_item_ids.add(item_id)
+            if isinstance(call_id, str) and call_id:
+                if call_id in seen_call_ids and item_type in {"function_call", "custom_tool_call", "tool_search_call"}:
+                    raise ToolCompatibilityError("tool_compatibility_boundary", "duplicate_call_identity", surface="history")
+                if item_type in {"function_call", "custom_tool_call", "tool_search_call"}:
+                    seen_call_ids.add(call_id)
+            if item_type == "function_call":
+                record = self.registry.record_for_alias(item.get("name"))
+                if record is not None:
+                    decoded, _record, item_changed = self._decode_call(item)
+                else:
+                    native_entry = self._native_entry_for_item(item)
+                    if native_entry is not None:
+                        self._validate_native_item(item, native_entry)
+                        decoded, item_changed = item, False
+                    elif self.registry.looks_like_alias(item.get("name")):
+                        raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_alias", surface="history")
+                    elif self.has_adaptations and self._entry_for_name(item.get("name"), item.get("namespace")) is not None:
+                        raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_alias", surface="history")
+                    else:
+                        decoded, item_changed = item, False
+            elif item_type == "custom_tool_call":
+                native_entry = self._native_entry_for_item(item)
+                if native_entry is not None:
+                    self._validate_native_item(item, native_entry)
+                    decoded, item_changed = item, False
+                elif self.has_adaptations and self._entry_for_name(item.get("name"), item.get("namespace")) is not None:
+                    raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_alias", surface="history")
+                else:
+                    decoded, item_changed = item, False
+            elif item_type in {"function_call_output", "custom_tool_call_output", "tool_search_output"}:
+                if not isinstance(call_id, str) or not call_id:
+                    raise ToolCompatibilityError("tool_compatibility_boundary", "missing_call_identity", surface="history")
+                if call_id in seen_result_call_ids:
+                    raise ToolCompatibilityError("tool_compatibility_boundary", "duplicate_call_identity", surface="history")
+                seen_result_call_ids.add(call_id)
+                decoded, item_changed = self._decode_result(item)
+                if not item_changed and self.has_adaptations and not self._has_native_structural_family():
+                    raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_call_identity", surface="history")
+                if item_type == "tool_search_output":
+                    native_entry = self._native_entry_for_item(item)
+                    if native_entry is None and self.has_adaptations and not self._has_native_structural_family():
+                        raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_call_identity", surface="history")
+            else:
+                decoded, item_changed = item, False
+                if self.registry.looks_like_alias(item.get("name")):
+                    raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_alias", surface="history")
+            result.append(decoded)
+            changed = changed or item_changed
+        return result, changed
+
+    def decode_payload(self, payload: Mapping[str, Any]) -> dict[str, Any]:
+        result = _copy_mapping(payload)
+        changed = False
+        for key in ("output", "input", "history"):
+            if key in result:
+                decoded, item_changed = self._decode_items(result[key])
+                if item_changed:
+                    result[key] = decoded
+                    changed = True
+        return result
+
+    def encode_history(self, items: Iterable[Mapping[str, Any]]) -> list[Any]:
+        payload = self.encode_payload({"input": list(items)})
+        return payload.get("input", [])
+
+    def decode_history(self, items: Iterable[Mapping[str, Any]]) -> list[Any]:
+        payload = self.decode_payload({"input": list(items)})
+        return payload.get("input", [])
+
+
+@dataclass(slots=True)
+class _PendingStreamItem:
+    record: AliasRecord
+    item_id: str
+    call_id: str | None
+    fragments: list[str] = field(default_factory=list)
+    delta_done: bool = False
+    item_done: bool = False
+
+
+@dataclass(slots=True)
+class _BufferedCustomStreamItem:
+    record: AliasRecord
+    added_event: dict[str, Any]
+    item_id: str
+    call_id: str
+    fragments: list[str] = field(default_factory=list)
+    arguments_done_event: dict[str, Any] | None = None
+    native_input: str | None = None
+
+
+class CompatibilityStreamState:
+    """Assemble one adapted Responses SSE lifecycle before inverse mapping."""
+
+    def __init__(self, plan: ToolCompatibilityPlan) -> None:
+        self.plan = plan
+        self._pending: dict[str, _PendingStreamItem] = {}
+        self._seen_item_ids: set[str] = set()
+        self._seen_call_ids: set[str] = set()
+        self._native_pending: dict[str, tuple[str | None, str]] = {}
+        self._native_done: set[str] = set()
+        self._native_delta_done: set[str] = set()
+        self._buffered_custom: dict[str, _BufferedCustomStreamItem] = {}
+        self._terminal = False
+
+    @property
+    def terminal(self) -> bool:
+        return self._terminal
+
+    @staticmethod
+    def _item_id(value: Mapping[str, Any]) -> str | None:
+        for key in ("item_id", "id"):
+            candidate = value.get(key)
+            if isinstance(candidate, str) and candidate:
+                return candidate
+        return None
+
+    def _pending_for(self, value: Mapping[str, Any]) -> _PendingStreamItem:
+        item_id = self._item_id(value)
+        if item_id and item_id in self._pending:
+            return self._pending[item_id]
+        raise ToolCompatibilityError("tool_compatibility_boundary", "missing_stream_identity", surface="stream")
+
+    def _native_entry_for_item(self, item: Mapping[str, Any]) -> ToolCompatibilityEntry | None:
+        return self.plan._native_entry_for_item(item)
+
+    def _native_item_id_for_event(self, value: Mapping[str, Any]) -> str | None:
+        item = value.get("item")
+        if isinstance(item, Mapping):
+            return self._item_id(item)
+        return self._item_id(value)
+
+    def _check_alias_in_item(self, item: Mapping[str, Any], *, allow_incomplete: bool = True) -> tuple[dict[str, Any], AliasRecord | None, bool]:
+        if item.get("type") == "function_call":
+            decoded, record, changed = self.plan._decode_call(item, allow_incomplete=allow_incomplete)
+            if record is not None and record.family == NAMESPACE:
+                supplied_namespace = item.get("namespace")
+                if supplied_namespace is not None and supplied_namespace != record.namespace:
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "unknown_alias",
+                        surface="stream",
+                    )
+            if (
+                record is None
+                and self.plan.has_adaptations
+                and isinstance(item.get("name"), str)
+                and (
+                    self.plan._entry_for_name(item.get("name"), item.get("namespace")) is None
+                    or (
+                        self.plan._entry_for_name(item.get("name"), item.get("namespace")) is not None
+                        and self.plan._entry_for_name(item.get("name"), item.get("namespace")).disposition == ADAPT
+                    )
+                )
+            ):
+                raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_alias", surface="stream")
+            return decoded, record, changed
+        if self.plan.registry.looks_like_alias(item.get("name")):
+            raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_alias", surface="stream")
+        return _copy_mapping(item), None, False
+
+    def _finish_terminal(self) -> None:
+        if self._terminal:
+            raise ToolCompatibilityError("tool_compatibility_boundary", "duplicate_terminal", surface="stream")
+        incomplete = [pending for pending in self._pending.values() if not pending.item_done]
+        native_incomplete = any(
+            item_id not in self._native_done
+            or (family != TOOL_SEARCH and item_id not in self._native_delta_done)
+            for item_id, (_call_id, family) in self._native_pending.items()
+        )
+        if incomplete or native_incomplete:
+            raise ToolCompatibilityError("tool_compatibility_boundary", "incomplete_stream", surface="stream")
+        self._terminal = True
+
+    def decode_event(self, event: Mapping[str, Any]) -> dict[str, Any]:
+        if not isinstance(event, Mapping):
+            raise ToolCompatibilityError("tool_compatibility_boundary", "malformed_stream_event", surface="stream")
+        result = _copy_mapping(event)
+        event_type = result.get("type")
+        if event_type in {"response.completed", "response.incomplete", "response.failed"}:
+            self._finish_terminal()
+            response = result.get("response")
+            if isinstance(response, Mapping):
+                decoded_output, output_changed = self.plan._decode_items(response.get("output"))
+                if output_changed:
+                    response = _copy_mapping(response)
+                    response["output"] = decoded_output
+                    result["response"] = response
+            return result
+        item = result.get("item")
+        if event_type == "response.output_item.added" and isinstance(item, Mapping):
+            decoded_item, record, _changed = self._check_alias_in_item(item)
+            item_id = self._item_id(item)
+            if record is not None:
+                if not item_id:
+                    raise ToolCompatibilityError("tool_compatibility_boundary", "missing_item_identity", surface="stream")
+                call_id = item.get("call_id")
+                if not isinstance(call_id, str) or not call_id:
+                    raise ToolCompatibilityError("tool_compatibility_boundary", "missing_call_identity", surface="stream")
+                if item_id in self._seen_item_ids:
+                    raise ToolCompatibilityError("tool_compatibility_boundary", "duplicate_item_identity", surface="stream")
+                self._seen_item_ids.add(item_id)
+                if call_id in self._seen_call_ids:
+                    raise ToolCompatibilityError("tool_compatibility_boundary", "duplicate_call_identity", surface="stream")
+                self._seen_call_ids.add(call_id)
+                if self.plan.registry.record_for_call(call_id) is None:
+                    self.plan.registry.bind_call(call_id, record.alias)
+                self._pending[item_id] = _PendingStreamItem(record, item_id, call_id if isinstance(call_id, str) else None)
+                result["item"] = decoded_item
+                return result
+            native_entry = self._native_entry_for_item(item)
+            if native_entry is not None:
+                item_id = self._item_id(item)
+                call_id = item.get("call_id")
+                if item_id is None:
+                    raise ToolCompatibilityError("tool_compatibility_boundary", "missing_item_identity", surface="stream")
+                if not isinstance(call_id, str) or not call_id:
+                    raise ToolCompatibilityError("tool_compatibility_boundary", "missing_call_identity", surface="stream")
+                self.plan._validate_native_item(item, native_entry)
+                if item_id in self._seen_item_ids:
+                    raise ToolCompatibilityError("tool_compatibility_boundary", "duplicate_item_identity", surface="stream")
+                if call_id in self._seen_call_ids:
+                    raise ToolCompatibilityError("tool_compatibility_boundary", "duplicate_call_identity", surface="stream")
+                self._seen_item_ids.add(item_id)
+                self._seen_call_ids.add(call_id)
+                self._native_pending[item_id] = (call_id, native_entry.family)
+                result["item"] = decoded_item
+            return result
+        if event_type in {"response.function_call_arguments.delta", "response.custom_tool_call_input.delta"}:
+            item_id = self._item_id(result)
+            if item_id in self._native_pending:
+                delta = result.get("delta")
+                if not isinstance(delta, str):
+                    raise ToolCompatibilityError("tool_compatibility_boundary", "malformed_stream_delta", surface="stream")
+                if item_id in self._native_delta_done:
+                    raise ToolCompatibilityError("tool_compatibility_boundary", "duplicate_stream_done", surface="stream")
+                return result
+            if item_id not in self._pending:
+                if self.plan.has_adaptations:
+                    raise ToolCompatibilityError("tool_compatibility_boundary", "missing_stream_identity", surface="stream")
+                return result
+            pending = self._pending_for(result)
+            if isinstance(result.get("call_id"), str) and result.get("call_id") != pending.call_id:
+                raise ToolCompatibilityError("tool_compatibility_boundary", "ambiguous_call_identity", surface="stream")
+            delta = result.get("delta")
+            if not isinstance(delta, str):
+                raise ToolCompatibilityError("tool_compatibility_boundary", "malformed_stream_delta", surface="stream")
+            pending.fragments.append(delta)
+            if pending.record.family == CUSTOM_FREEFORM:
+                result["type"] = "response.custom_tool_call_input.delta"
+            return result
+        if event_type in {"response.function_call_arguments.done", "response.custom_tool_call_input.done"}:
+            item_id = self._item_id(result)
+            if item_id in self._native_pending:
+                if item_id in self._native_delta_done:
+                    raise ToolCompatibilityError("tool_compatibility_boundary", "duplicate_stream_done", surface="stream")
+                arguments = result.get("arguments", result.get("input"))
+                if not isinstance(arguments, str) and event_type == "response.function_call_arguments.done":
+                    raise ToolCompatibilityError("tool_compatibility_boundary", "incomplete_stream_delta", surface="stream")
+                self._native_delta_done.add(item_id)
+                return result
+            if item_id not in self._pending:
+                if self.plan.has_adaptations:
+                    raise ToolCompatibilityError("tool_compatibility_boundary", "missing_stream_identity", surface="stream")
+                return result
+            pending = self._pending_for(result)
+            if isinstance(result.get("call_id"), str) and result.get("call_id") != pending.call_id:
+                raise ToolCompatibilityError("tool_compatibility_boundary", "ambiguous_call_identity", surface="stream")
+            if pending.delta_done:
+                raise ToolCompatibilityError("tool_compatibility_boundary", "duplicate_stream_done", surface="stream")
+            arguments = result.get("arguments", result.get("input"))
+            if not isinstance(arguments, str):
+                arguments = "".join(pending.fragments)
+            if not arguments:
+                raise ToolCompatibilityError("tool_compatibility_boundary", "incomplete_stream_delta", surface="stream")
+            pending.delta_done = True
+            if pending.record.family == CUSTOM_FREEFORM:
+                envelope = _json_object_exact(arguments)
+                result["type"] = "response.custom_tool_call_input.done"
+                result["input"] = envelope[CUSTOM_INPUT_KEY]
+                result.pop("arguments", None)
+            else:
+                result["arguments"] = arguments
+            return result
+        if event_type == "response.output_item.done" and isinstance(item, Mapping):
+            record = self.plan.registry.record_for_alias(item.get("name"))
+            if record is None:
+                if self.plan.registry.looks_like_alias(item.get("name")):
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "unknown_alias",
+                        surface="stream",
+                    )
+                native_item_id = self._item_id(item)
+                native_pending = self._native_pending.get(native_item_id) if native_item_id else None
+                if native_pending is not None:
+                    call_id = item.get("call_id")
+                    if call_id != native_pending[0]:
+                        raise ToolCompatibilityError("tool_compatibility_boundary", "ambiguous_call_identity", surface="stream")
+                    if native_pending[1] != TOOL_SEARCH and native_item_id not in self._native_delta_done:
+                        raise ToolCompatibilityError("tool_compatibility_boundary", "incomplete_stream_delta", surface="stream")
+                    if native_item_id in self._native_done:
+                        raise ToolCompatibilityError("tool_compatibility_boundary", "duplicate_item_identity", surface="stream")
+                    self._native_done.add(native_item_id)
+                    return result
+                if native_item_id is not None and self.plan.has_adaptations:
+                    raise ToolCompatibilityError("tool_compatibility_boundary", "missing_stream_identity", surface="stream")
+                return result
+            pending = self._pending_for(item)
+            if item.get("call_id") != pending.call_id:
+                raise ToolCompatibilityError("tool_compatibility_boundary", "ambiguous_call_identity", surface="stream")
+            if pending.item_done:
+                raise ToolCompatibilityError("tool_compatibility_boundary", "duplicate_item_identity", surface="stream")
+            if pending.record.family == CUSTOM_FREEFORM:
+                decoded_item, _record, _changed = self.plan._decode_call(item, allow_incomplete=False)
+            else:
+                decoded_item, _record, _changed = self._check_alias_in_item(item, allow_incomplete=True)
+            pending.item_done = True
+            result["item"] = decoded_item
+            return result
+        if isinstance(item, Mapping) and self.plan.registry.looks_like_alias(item.get("name")):
+            decoded_item, _record, _changed = self._check_alias_in_item(item)
+            result["item"] = decoded_item
+        return result
+
+    @staticmethod
+    def _stream_error(classification: str) -> ToolCompatibilityError:
+        return ToolCompatibilityError(
+            "tool_compatibility_boundary",
+            classification,
+            surface="stream",
+        )
+
+    @staticmethod
+    def _native_custom_item(
+        item: Mapping[str, Any],
+        record: AliasRecord,
+        native_input: str,
+    ) -> dict[str, Any]:
+        result = _copy_mapping(item)
+        result["type"] = "custom_tool_call"
+        result["name"] = record.original_name
+        result["input"] = native_input
+        result.pop("arguments", None)
+        return result
+
+    def decode_events_for_event(self, event: Mapping[str, Any]) -> list[dict[str, Any]]:
+        if not isinstance(event, Mapping):
+            raise self._stream_error("malformed_stream_event")
+        value = _copy_mapping(event)
+        event_type = value.get("type")
+        item = value.get("item")
+
+        if event_type in {"response.completed", "response.incomplete", "response.failed"}:
+            if self._buffered_custom:
+                raise self._stream_error("incomplete_stream")
+            return [self.decode_event(value)]
+
+        if event_type == "response.output_item.added" and isinstance(item, Mapping):
+            record = self.plan.registry.record_for_alias(item.get("name"))
+            if record is None or record.family != CUSTOM_FREEFORM:
+                return [self.decode_event(value)]
+            item_id = self._item_id(item)
+            call_id = item.get("call_id")
+            if (
+                not item_id
+                or not isinstance(call_id, str)
+                or not call_id
+                or item_id in self._seen_item_ids
+                or call_id in self._seen_call_ids
+                or item.get("arguments") not in {None, ""}
+            ):
+                raise self._stream_error("invalid_custom_stream_identity")
+            self._seen_item_ids.add(item_id)
+            self._seen_call_ids.add(call_id)
+            if self.plan.registry.record_for_call(call_id) is None:
+                self.plan.registry.bind_call(call_id, record.alias)
+            self._buffered_custom[item_id] = _BufferedCustomStreamItem(
+                record=record,
+                added_event=value,
+                item_id=item_id,
+                call_id=call_id,
+            )
+            return []
+
+        item_id = self._item_id(value)
+        pending = self._buffered_custom.get(item_id) if item_id else None
+        if event_type == "response.function_call_arguments.delta" and pending is not None:
+            delta = value.get("delta")
+            if not isinstance(delta, str) or pending.arguments_done_event is not None:
+                raise self._stream_error("malformed_stream_delta")
+            pending.fragments.append(delta)
+            return []
+
+        if event_type == "response.function_call_arguments.done" and pending is not None:
+            if pending.arguments_done_event is not None:
+                raise self._stream_error("duplicate_stream_done")
+            arguments = value.get("arguments")
+            if not isinstance(arguments, str) or (
+                pending.fragments and "".join(pending.fragments) != arguments
+            ):
+                raise self._stream_error("incomplete_stream_delta")
+            try:
+                envelope = _json_object_exact(arguments)
+            except ToolCompatibilityError as exc:
+                raise self._stream_error(exc.classification) from exc
+            native_input = envelope[CUSTOM_INPUT_KEY]
+            if not isinstance(native_input, str):
+                raise self._stream_error("malformed_stream_custom_input")
+            pending.arguments_done_event = value
+            pending.native_input = native_input
+            return []
+
+        if event_type == "response.output_item.done" and isinstance(item, Mapping):
+            done_item_id = self._item_id(item)
+            pending = self._buffered_custom.get(done_item_id) if done_item_id else None
+            if pending is None:
+                return [self.decode_event(value)]
+            if (
+                pending.arguments_done_event is None
+                or pending.native_input is None
+                or item.get("call_id") != pending.call_id
+                or item.get("name") != pending.record.alias
+                or item.get("arguments") != pending.arguments_done_event.get("arguments")
+            ):
+                raise self._stream_error("incomplete_stream")
+
+            added_event = _copy_mapping(pending.added_event)
+            added_event["item"] = self._native_custom_item(
+                added_event["item"],
+                pending.record,
+                "",
+            )
+
+            delta_event = _copy_mapping(pending.arguments_done_event)
+            delta_event["type"] = "response.custom_tool_call_input.delta"
+            delta_event["delta"] = pending.native_input
+            delta_event.pop("arguments", None)
+
+            input_done_event = _copy_mapping(pending.arguments_done_event)
+            input_done_event["type"] = "response.custom_tool_call_input.done"
+            input_done_event["input"] = pending.native_input
+            input_done_event.pop("arguments", None)
+
+            value["item"] = self._native_custom_item(
+                item,
+                pending.record,
+                pending.native_input,
+            )
+            del self._buffered_custom[pending.item_id]
+            return [added_event, delta_event, input_done_event, value]
+
+        return [self.decode_event(value)]
+
+    def decode_events(self, events: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
+        decoded: list[dict[str, Any]] = []
+        for event in events:
+            decoded.extend(self.decode_events_for_event(event))
+        return decoded
+
+
+# Short aliases used by route/request callers and by compatibility-focused
+# tests.  They intentionally all construct the same immutable plan.
+build_plan = build_tool_compatibility_plan
+ToolPlan = ToolCompatibilityPlan
+AliasRegistry = RequestScopedToolAliasRegistry
+
+
+__all__ = [
+    "ADAPT",
+    "AliasRecord",
+    "AliasRegistry",
+    "CompatibilityDiagnostics",
+    "CompatibilityStreamState",
+    "CUSTOM_FREEFORM",
+    "CUSTOM_INPUT_KEY",
+    "CUSTOM_OUTPUT_KEY",
+    "HostedCapabilityFacts",
+    "NAMESPACE",
+    "NATIVE",
+    "OMIT",
+    "PLAIN_FUNCTION",
+    "ProtocolCapabilities",
+    "REQUIRED_BUT_UNAVAILABLE",
+    "RequiredToolUnavailableError",
+    "RequestScopedToolAliasRegistry",
+    "SELECTED_PROVIDER_HOSTED",
+    "TOOL_SEARCH",
+    "ToolCompatibilityEntry",
+    "ToolCompatibilityError",
+    "ToolCompatibilityPlan",
+    "ToolPlan",
+    "UNKNOWN_FUTURE_KIND",
+    "build_plan",
+    "build_tool_compatibility_plan",
+    "classify_declaration",
+]

--- a/src-python/runtime_tool_compatibility.py
+++ b/src-python/runtime_tool_compatibility.py
@@ -3801,7 +3801,21 @@ class CompatibilityStreamState:
                     not in {"function_call", "custom_tool_call", "tool_search_call"}
                 ):
                     raise ToolCompatibilityError("tool_compatibility_boundary", "unsupported_hosted_lifecycle", surface="stream")
-                if native_item_id is not None and self.plan.has_adaptations:
+                # A Responses stream can contain ordinary assistant messages
+                # (and other non-tool output items) alongside adapted tool
+                # lifecycles.  Their ``output_item.done`` event is complete
+                # on its own and has no runtime-tool owner to reconcile.
+                # Only reject an otherwise-unowned item when it is a
+                # tool-shaped lifecycle that could cross the compatibility
+                # boundary ambiguously.
+                if native_item_id is not None and self.plan.has_adaptations and (
+                    isinstance(item.get("type"), str)
+                    and (
+                        item.get("type") in {"function_call", "custom_tool_call", "tool_search_call"}
+                        or item.get("type").endswith("_call")
+                        or item.get("type").endswith("_call_output")
+                    )
+                ):
                     raise ToolCompatibilityError("tool_compatibility_boundary", "missing_stream_identity", surface="stream")
                 return result
             pending = self._pending_for(item)

--- a/src-python/runtime_tool_compatibility.py
+++ b/src-python/runtime_tool_compatibility.py
@@ -2688,6 +2688,55 @@ class CompatibilityStreamState:
     def _opaque_payload(value: Any) -> tuple[str, Any]:
         return ("opaque_input", _freeze(value))
 
+    def _complete_native_arguments_from_item(
+        self,
+        item_id: str,
+        item: Mapping[str, Any],
+        entry: ToolCompatibilityEntry,
+    ) -> None:
+        """Accept a complete native item when its separate ``done`` event is omitted."""
+        if entry.family == CUSTOM_FREEFORM:
+            arguments = item.get("input")
+            if not isinstance(arguments, str):
+                raise ToolCompatibilityError(
+                    "tool_compatibility_boundary",
+                    "incomplete_stream_delta",
+                    surface="stream",
+                )
+            fragments = self._native_fragments.get(item_id, [])
+            if fragments and "".join(fragments) != arguments:
+                raise ToolCompatibilityError(
+                    "tool_compatibility_boundary",
+                    "incomplete_stream_delta",
+                    surface="stream",
+                )
+            payload_item = {"type": "custom_tool_call", "input": arguments}
+        else:
+            arguments = item.get("arguments")
+            if not isinstance(arguments, str):
+                raise ToolCompatibilityError(
+                    "tool_compatibility_boundary",
+                    "incomplete_stream_delta",
+                    surface="stream",
+                )
+            fragments = self._native_fragments.get(item_id, [])
+            if fragments and "".join(fragments) != arguments:
+                raise ToolCompatibilityError(
+                    "tool_compatibility_boundary",
+                    "incomplete_stream_delta",
+                    surface="stream",
+                )
+            payload_item = {"type": "function_call", "arguments": arguments}
+        payload = self._semantic_wire_payload(payload_item, entry)
+        if item_id in self._wire_payloads and self._wire_payloads[item_id] != payload:
+            raise ToolCompatibilityError(
+                "tool_compatibility_boundary",
+                "ambiguous_native_identity",
+                surface="stream",
+            )
+        self._wire_payloads[item_id] = payload
+        self._native_delta_done.add(item_id)
+
     def _native_item_id_for_event(self, value: Mapping[str, Any]) -> str | None:
         item = value.get("item")
         nested_item_id = self._item_id(item) if isinstance(item, Mapping) else None
@@ -3361,13 +3410,6 @@ class CompatibilityStreamState:
                         "incomplete_stream_delta",
                         surface="stream",
                     )
-                fragments = opaque.fragments
-                if fragments and "".join(fragments) != arguments:
-                    raise ToolCompatibilityError(
-                        "tool_compatibility_boundary",
-                        "incomplete_stream_delta",
-                        surface="stream",
-                    )
                 opaque.arguments_done = True
                 self._wire_payloads[item_id] = self._opaque_payload(arguments)
                 return result
@@ -3490,7 +3532,11 @@ class CompatibilityStreamState:
                             )
                         self.plan._validate_native_item(item, hosted_entry, require_completed=True)
                     elif expected_entry.family != TOOL_SEARCH and native_item_id not in self._native_delta_done:
-                        raise ToolCompatibilityError("tool_compatibility_boundary", "incomplete_stream_delta", surface="stream")
+                        self._complete_native_arguments_from_item(
+                            native_item_id,
+                            item,
+                            expected_entry,
+                        )
                     if native_item_id in self._native_done:
                         raise ToolCompatibilityError("tool_compatibility_boundary", "duplicate_item_identity", surface="stream")
                     payload = self._semantic_wire_payload(item, expected_entry)
@@ -3508,6 +3554,20 @@ class CompatibilityStreamState:
                         and item.get("name") == "tool_search"
                         and item.get("namespace") is None
                     ):
+                        self.plan._validate_native_item(item, native_entry)
+                        return result
+                    if (
+                        native_entry.family == PLAIN_FUNCTION
+                        and native_entry.original_name == "multi_agent_v1__spawn_agent"
+                        and item.get("type") == "function_call"
+                        and item.get("namespace") == "multi_agent_v1"
+                        and item.get("name") == "spawn_agent"
+                    ):
+                        # A legacy worker-selector stream can emit this
+                        # flattened native item without an ``added`` event.
+                        # Keep this one compatibility passthrough narrow; a
+                        # plain unqualified native call still requires an
+                        # established stream owner.
                         self.plan._validate_native_item(item, native_entry)
                         return result
                     raise ToolCompatibilityError("tool_compatibility_boundary", "missing_stream_identity", surface="stream")

--- a/src-python/runtime_tool_compatibility.py
+++ b/src-python/runtime_tool_compatibility.py
@@ -2498,6 +2498,7 @@ class CompatibilityStreamState:
         # lifecycle is emitted.  Keep the original adapter wire identity so a
         # terminal envelope can still reconcile item/call/declaration exactly.
         self._adapter_wire_identities: dict[str, tuple[str, AliasRecord, tuple[Any, Any, Any]]] = {}
+        self._wire_payloads: dict[str, Any] = {}
         self._native_done: set[str] = set()
         self._native_delta_done: set[str] = set()
         self._hosted_pending: dict[str, _HostedStreamState] = {}
@@ -2534,6 +2535,45 @@ class CompatibilityStreamState:
     @staticmethod
     def _native_wire_identity(item: Mapping[str, Any]) -> tuple[Any, Any, Any]:
         return (item.get("type"), item.get("name"), item.get("namespace"))
+
+    @staticmethod
+    def _semantic_wire_payload(
+        item: Mapping[str, Any],
+        owner: ToolCompatibilityEntry | AliasRecord,
+    ) -> Any:
+        """Return parsed call data used for terminal reconciliation.
+
+        Equivalent JSON argument objects may differ in formatting or key
+        order.  Custom adapters instead compare the envelope's actual input
+        value.  Non-JSON arguments stay comparable as bounded raw strings;
+        this check does not add a new validation rule.
+        """
+        item_type = item.get("type")
+        family = owner.family
+        if family == CUSTOM_FREEFORM:
+            if item_type == "custom_tool_call":
+                return ("custom_input", _freeze(item.get("input")))
+            arguments = item.get("arguments")
+            if arguments in (None, ""):
+                return None
+            try:
+                envelope = _json_object_exact(arguments)
+            except ToolCompatibilityError:
+                return ("custom_arguments_raw", arguments)
+            return ("custom_input", _freeze(envelope.get(CUSTOM_INPUT_KEY)))
+        if item_type == "function_call":
+            arguments = item.get("arguments")
+            if arguments in (None, ""):
+                return None
+            if isinstance(arguments, Mapping):
+                return ("arguments", _freeze(arguments))
+            if isinstance(arguments, str):
+                try:
+                    parsed = json.loads(arguments)
+                except (TypeError, ValueError):
+                    return ("arguments_raw", arguments)
+                return ("arguments", _freeze(parsed))
+        return None
 
     @staticmethod
     def _is_output_item_type(item_type: Any) -> bool:
@@ -2724,6 +2764,12 @@ class CompatibilityStreamState:
                         and item.get("namespace") not in {None, adapter_pending.record.namespace}
                     ):
                         raise ToolCompatibilityError("tool_compatibility_boundary", "ambiguous_native_identity", surface="stream")
+                    if (
+                        item_id in self._wire_payloads
+                        and self._semantic_wire_payload(item, adapter_pending.record)
+                        != self._wire_payloads[item_id]
+                    ):
+                        raise ToolCompatibilityError("tool_compatibility_boundary", "ambiguous_native_identity", surface="stream")
                     continue
                 adapter_identity = self._adapter_wire_identities.get(item_id) if item_id is not None else None
                 if adapter_identity is not None:
@@ -2740,6 +2786,12 @@ class CompatibilityStreamState:
                             "ambiguous_native_identity",
                             surface="stream",
                         )
+                    if (
+                        item_id in self._wire_payloads
+                        and self._semantic_wire_payload(item, expected_record)
+                        != self._wire_payloads[item_id]
+                    ):
+                        raise ToolCompatibilityError("tool_compatibility_boundary", "ambiguous_native_identity", surface="stream")
                     terminal_record = self.plan.registry.record_for_alias(item.get("name"))
                     if terminal_record is not expected_record:
                         raise ToolCompatibilityError(
@@ -2801,6 +2853,12 @@ class CompatibilityStreamState:
                     "ambiguous_native_identity",
                     surface="stream",
                 )
+            if (
+                item_id in self._wire_payloads
+                and self._semantic_wire_payload(item, expected_entry)
+                != self._wire_payloads[item_id]
+            ):
+                raise ToolCompatibilityError("tool_compatibility_boundary", "ambiguous_native_identity", surface="stream")
             if expected_call_id is not None and item.get("call_id") != expected_call_id:
                 raise ToolCompatibilityError(
                     "tool_compatibility_boundary",
@@ -2973,7 +3031,7 @@ class CompatibilityStreamState:
         if event_type in {"response.function_call_arguments.done", "response.custom_tool_call_input.done"}:
             item_id = self._item_id(result)
             if item_id in self._native_pending:
-                expected_call_id, _entry = self._native_pending[item_id]
+                expected_call_id, expected_entry = self._native_pending[item_id]
                 supplied_call_id = result.get("call_id")
                 if supplied_call_id is not None and supplied_call_id != expected_call_id:
                     raise ToolCompatibilityError(
@@ -2986,6 +3044,15 @@ class CompatibilityStreamState:
                 arguments = result.get("arguments", result.get("input"))
                 if not isinstance(arguments, str):
                     raise ToolCompatibilityError("tool_compatibility_boundary", "incomplete_stream_delta", surface="stream")
+                payload_item = (
+                    {"type": "custom_tool_call", "input": result.get("input", arguments)}
+                    if expected_entry.family == CUSTOM_FREEFORM
+                    else {"type": "function_call", "arguments": arguments}
+                )
+                payload = self._semantic_wire_payload(payload_item, expected_entry)
+                if item_id in self._wire_payloads and self._wire_payloads[item_id] != payload:
+                    raise ToolCompatibilityError("tool_compatibility_boundary", "ambiguous_native_identity", surface="stream")
+                self._wire_payloads[item_id] = payload
                 self._native_delta_done.add(item_id)
                 return result
             if item_id not in self._pending:
@@ -3010,6 +3077,15 @@ class CompatibilityStreamState:
                 result.pop("arguments", None)
             else:
                 result["arguments"] = arguments
+            payload_item = (
+                {"type": "custom_tool_call", "input": result.get("input")}
+                if pending.record.family == CUSTOM_FREEFORM
+                else {"type": "function_call", "arguments": arguments}
+            )
+            payload = self._semantic_wire_payload(payload_item, pending.record)
+            if item_id in self._wire_payloads and self._wire_payloads[item_id] != payload:
+                raise ToolCompatibilityError("tool_compatibility_boundary", "ambiguous_native_identity", surface="stream")
+            self._wire_payloads[item_id] = payload
             return result
         if event_type == "response.output_item.done" and isinstance(item, Mapping):
             self.plan._validate_registered_item_identity(item, surface="stream")
@@ -3052,6 +3128,10 @@ class CompatibilityStreamState:
                         raise ToolCompatibilityError("tool_compatibility_boundary", "incomplete_stream_delta", surface="stream")
                     if native_item_id in self._native_done:
                         raise ToolCompatibilityError("tool_compatibility_boundary", "duplicate_item_identity", surface="stream")
+                    payload = self._semantic_wire_payload(item, expected_entry)
+                    if native_item_id in self._wire_payloads and self._wire_payloads[native_item_id] != payload:
+                        raise ToolCompatibilityError("tool_compatibility_boundary", "ambiguous_native_identity", surface="stream")
+                    self._wire_payloads[native_item_id] = payload
                     self._native_done.add(native_item_id)
                     return result
                 native_entry = self._native_entry_for_item(item)
@@ -3086,6 +3166,10 @@ class CompatibilityStreamState:
             else:
                 decoded_item, _record, _changed = self._check_alias_in_item(item, allow_incomplete=True)
             pending.item_done = True
+            payload = self._semantic_wire_payload(item, pending.record)
+            if pending.item_id in self._wire_payloads and self._wire_payloads[pending.item_id] != payload:
+                raise ToolCompatibilityError("tool_compatibility_boundary", "ambiguous_native_identity", surface="stream")
+            self._wire_payloads[pending.item_id] = payload
             result["item"] = decoded_item
             return result
         if isinstance(item, Mapping) and self.plan.registry.looks_like_alias(item.get("name")):
@@ -3224,6 +3308,7 @@ class CompatibilityStreamState:
                 pending.record,
                 pending.native_input,
             )
+            self._wire_payloads[pending.item_id] = self._semantic_wire_payload(item, pending.record)
             del self._buffered_custom[pending.item_id]
             return [added_event, delta_event, input_done_event, value]
 

--- a/src-python/runtime_tool_compatibility.py
+++ b/src-python/runtime_tool_compatibility.py
@@ -791,6 +791,7 @@ def build_tool_compatibility_plan(
         registry=registry,
         diagnostics=diagnostics,
         tool_choice=_freeze(tool_choice),
+        provider_hosted_kinds=hosted.supported_kinds,
     )
 
 
@@ -882,6 +883,15 @@ def _hosted_event_spec_for_item_type(item_type: Any) -> tuple[str, tuple[str, ..
 def _hosted_history_item_key(item_type: Any) -> tuple[str, bool] | None:
     if not isinstance(item_type, str):
         return None
+    if item_type in {
+        "function_call",
+        "function_call_output",
+        "custom_tool_call",
+        "custom_tool_call_output",
+        "tool_search_call",
+        "tool_search_output",
+    }:
+        return None
     for event_kind, _stages in _HOSTED_EVENT_STAGES.values():
         if item_type == event_kind:
             return event_kind, False
@@ -940,6 +950,7 @@ class ToolCompatibilityPlan:
     registry: RequestScopedToolAliasRegistry = field(repr=False, compare=False)
     diagnostics: CompatibilityDiagnostics
     tool_choice: Any = None
+    provider_hosted_kinds: frozenset[str] = frozenset()
 
     @property
     def aliases(self) -> tuple[str, ...]:
@@ -1031,6 +1042,7 @@ class ToolCompatibilityPlan:
                 # declarations added after the request plan was built.
                 if (
                     _hosted_event_spec_for_declaration_kind(declaration.get("type")) is not None
+                    and declaration.get("type") in self.provider_hosted_kinds
                     and declaration.get("type") in self.capabilities.hosted_lifecycles
                 ):
                     disposition, reason = NATIVE, "selected_provider_hosted_lifecycle"
@@ -1103,6 +1115,7 @@ class ToolCompatibilityPlan:
             registry=self.registry,
             diagnostics=CompatibilityDiagnostics.from_entries(entries),
             tool_choice=self.tool_choice,
+            provider_hosted_kinds=self.provider_hosted_kinds,
         )
 
     def _entry_for_declaration(self, declaration: Mapping[str, Any], occurrence: dict[tuple[Any, ...], int]) -> ToolCompatibilityEntry | None:
@@ -1224,7 +1237,16 @@ class ToolCompatibilityPlan:
         )
 
     def _has_adapted_name_conflict(self, name: Any, expected_family: str) -> bool:
-        return isinstance(name, str) and any(
+        if not isinstance(name, str):
+            return False
+        if any(
+            entry.disposition == NATIVE
+            and entry.family == expected_family
+            and entry.original_name == name
+            for entry in self.entries
+        ):
+            return False
+        return any(
             entry.disposition == ADAPT
             and entry.family != expected_family
             and entry.original_name == name
@@ -1411,31 +1433,54 @@ class ToolCompatibilityPlan:
             return item, False
         return item, False
 
+    @staticmethod
+    def _hosted_entry_item_kind(entry: ToolCompatibilityEntry) -> str | None:
+        declaration_type = entry.declaration.get("type")
+        if entry.family == SELECTED_PROVIDER_HOSTED:
+            declaration_spec = _hosted_event_spec_for_declaration_kind(declaration_type)
+            if declaration_spec is not None:
+                return declaration_spec[0]
+            return declaration_type if isinstance(declaration_type, str) else None
+        if (
+            entry.family == UNKNOWN_FUTURE_KIND
+            and entry.declaration.get("executor") == "selected_provider"
+            and isinstance(declaration_type, str)
+        ):
+            return declaration_type
+        return None
+
+    def _hosted_history_item_key(self, item_type: Any) -> tuple[str, bool] | None:
+        key = _hosted_history_item_key(item_type)
+        if key is not None or not isinstance(item_type, str):
+            return key
+        for entry in self.entries:
+            if entry.disposition not in {NATIVE, OMIT}:
+                continue
+            hosted_kind = self._hosted_entry_item_kind(entry)
+            if hosted_kind is None:
+                continue
+            if item_type == f"{hosted_kind}_call":
+                return hosted_kind, False
+            if item_type == f"{hosted_kind}_call_output":
+                return hosted_kind, True
+        return None
+
     def _omitted_history_entry(self, item: Mapping[str, Any]) -> ToolCompatibilityEntry | None:
         item_type = item.get("type")
-        hosted_item_key = _hosted_history_item_key(item_type)
+        hosted_item_key = self._hosted_history_item_key(item_type)
         if hosted_item_key is not None:
             hosted_item_kind, _is_output = hosted_item_key
             matches = [
                 entry
                 for entry in self.entries
-                if entry.family == SELECTED_PROVIDER_HOSTED
-                and entry.disposition == OMIT
-                and (
-                    (
-                        (
-                            declaration_spec := _hosted_event_spec_for_declaration_kind(
-                                entry.declaration.get("type")
-                            )
-                        ) is not None
-                        and declaration_spec[0] == hosted_item_kind
-                    )
-                    or entry.declaration.get("type") == hosted_item_kind
-                )
+                if entry.disposition in {NATIVE, OMIT}
+                and self._hosted_entry_item_kind(entry) == hosted_item_kind
             ]
             if len(matches) > 1:
                 raise ToolCompatibilityError("tool_compatibility_boundary", "ambiguous_native_identity", surface="history")
-            return matches[0] if matches else None
+            if matches and matches[0].disposition == OMIT:
+                return matches[0]
+            return None
         if item_type in {"function_call", "custom_tool_call"}:
             entry = self._entry_for_name(
                 item.get("name"),
@@ -1478,16 +1523,14 @@ class ToolCompatibilityPlan:
         if isinstance(raw_input, list):
             encoded_input: list[Any] = []
             changed = tools_changed or choice_changed
-            omitted_hosted_ids: dict[str, str] = {}
-            omitted_hosted_outputs: list[tuple[str, str]] = []
+            omitted_hosted_ids: dict[str, tuple[str, bool]] = {}
             for item in raw_input:
                 if not isinstance(item, Mapping):
                     continue
                 omitted_entry = self._omitted_history_entry(item)
-                hosted_item_key = _hosted_history_item_key(item.get("type"))
+                hosted_item_key = self._hosted_history_item_key(item.get("type"))
                 if (
                     omitted_entry is None
-                    or omitted_entry.family != SELECTED_PROVIDER_HOSTED
                     or hosted_item_key is None
                 ):
                     continue
@@ -1499,37 +1542,31 @@ class ToolCompatibilityPlan:
                         surface="history",
                     )
                 hosted_item_kind, is_output = hosted_item_key
-                if not is_output:
-                    previous_kind = omitted_hosted_ids.get(item_id)
-                    if previous_kind is not None:
-                        classification = (
-                            "duplicate_item_identity"
-                            if previous_kind == hosted_item_kind
-                            else "ambiguous_native_identity"
-                        )
-                        raise ToolCompatibilityError(
-                            "tool_compatibility_boundary",
-                            classification,
-                            surface="history",
-                        )
-                    omitted_hosted_ids[item_id] = hosted_item_kind
-                else:
-                    omitted_hosted_outputs.append((item_id, hosted_item_kind))
-            for item_id, hosted_item_kind in omitted_hosted_outputs:
-                root_kind = omitted_hosted_ids.get(item_id)
-                if root_kind != hosted_item_kind:
+                previous = omitted_hosted_ids.get(item_id)
+                if previous is not None:
+                    previous_kind, previous_is_output = previous
+                    if previous_kind != hosted_item_kind:
+                        classification = "ambiguous_native_identity"
+                    elif previous_is_output == is_output:
+                        classification = "duplicate_item_identity"
+                    else:
+                        # Some hosted protocols use one item id for call/result
+                        # pairs; others use distinct ids.  Both are valid when
+                        # the hosted kind is already uniquely omitted.
+                        continue
                     raise ToolCompatibilityError(
                         "tool_compatibility_boundary",
-                        "ambiguous_native_identity",
+                        classification,
                         surface="history",
                     )
+                omitted_hosted_ids[item_id] = (hosted_item_kind, is_output)
             omitted_call_items = [
                 item
                 for item in raw_input
                 if isinstance(item, Mapping)
                 and self._omitted_history_entry(item) is not None
                 and not (
-                    self._omitted_history_entry(item).family == SELECTED_PROVIDER_HOSTED
+                    self._hosted_history_item_key(item.get("type")) is not None
                     if self._omitted_history_entry(item) is not None
                     else False
                 )
@@ -1572,7 +1609,7 @@ class ToolCompatibilityPlan:
                 if isinstance(item, Mapping) and (
                     (
                         self._omitted_history_entry(item) is not None
-                        and self._omitted_history_entry(item).family != SELECTED_PROVIDER_HOSTED
+                        and self._hosted_history_item_key(item.get("type")) is None
                     )
                     or item.get("call_id") in omitted_call_ids
                 ):
@@ -1580,10 +1617,9 @@ class ToolCompatibilityPlan:
                     continue
                 if isinstance(item, Mapping):
                     omitted_entry = self._omitted_history_entry(item)
-                    hosted_item_key = _hosted_history_item_key(item.get("type"))
+                    hosted_item_key = self._hosted_history_item_key(item.get("type"))
                     if (
                         omitted_entry is not None
-                        and omitted_entry.family == SELECTED_PROVIDER_HOSTED
                         and hosted_item_key is not None
                     ):
                         changed = True

--- a/src-python/runtime_tool_compatibility.py
+++ b/src-python/runtime_tool_compatibility.py
@@ -1494,7 +1494,64 @@ class ToolCompatibilityPlan:
             return kind if kind else None
         return None
 
-    def _standard_entry_for_item(self, item: Mapping[str, Any]) -> ToolCompatibilityEntry | None:
+    def _unknown_entry_for_item(
+        self,
+        item: Mapping[str, Any],
+        *,
+        surface: str,
+    ) -> ToolCompatibilityEntry | None:
+        unknown_kind = self._unknown_response_item_kind(item.get("type"))
+        if unknown_kind is None:
+            return None
+        matches = [
+            entry
+            for entry in self.entries
+            if entry.family == UNKNOWN_FUTURE_KIND
+            and entry.disposition in {NATIVE, OMIT}
+            and entry.declaration.get("type") == unknown_kind
+        ]
+        item_name = item.get("name")
+        if isinstance(item_name, str):
+            named_matches = [
+                entry for entry in matches if entry.declaration.get("name") == item_name
+            ]
+            if named_matches:
+                matches = named_matches
+            elif any(isinstance(entry.declaration.get("name"), str) for entry in matches):
+                raise ToolCompatibilityError(
+                    "tool_compatibility_boundary",
+                    "unknown_native_identity",
+                    surface=surface,
+                )
+        if len(matches) > 1:
+            raise ToolCompatibilityError(
+                "tool_compatibility_boundary",
+                "ambiguous_native_identity",
+                surface=surface,
+            )
+        return matches[0] if matches else None
+
+    @staticmethod
+    def _history_output_type_for_entry(entry: ToolCompatibilityEntry) -> str | None:
+        if entry.family in {PLAIN_FUNCTION, NAMESPACE}:
+            return "function_call_output"
+        if entry.family == CUSTOM_FREEFORM:
+            return "custom_tool_call_output"
+        if entry.family == TOOL_SEARCH:
+            return "tool_search_output"
+        if entry.family == UNKNOWN_FUTURE_KIND:
+            declaration_type = entry.declaration.get("type")
+            if isinstance(declaration_type, str):
+                return f"{declaration_type}_call_output"
+        return None
+
+    def _standard_entry_for_item(
+        self,
+        item: Mapping[str, Any],
+        *,
+        owner: ToolCompatibilityEntry | None = None,
+        surface: str = "response",
+    ) -> ToolCompatibilityEntry | None:
         """Resolve a standard Responses item before hosted/unknown matching.
 
         A provider-specific declaration such as ``custom_tool`` shares the
@@ -1523,9 +1580,17 @@ class ToolCompatibilityPlan:
             return native or (matches[0] if matches else None)
 
         if item_type in {"function_call_output", "custom_tool_call_output", "tool_search_output"}:
+            if owner is not None:
+                if item_type != self._history_output_type_for_entry(owner):
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "ambiguous_call_identity",
+                        surface=surface,
+                    )
+                return owner
             record = self.registry.record_for_call(item.get("call_id"))
             if record is not None:
-                return next(
+                entry = next(
                     (
                         entry
                         for entry in self.entries
@@ -1533,6 +1598,23 @@ class ToolCompatibilityPlan:
                     ),
                     None,
                 )
+                # Registry records describe adapter wire calls.  Both the
+                # namespace and custom adapters emit a function lifecycle;
+                # a differently typed output cannot borrow that call_id.
+                expected_output_type = (
+                    "function_call_output"
+                    if record.family in {NAMESPACE, CUSTOM_FREEFORM}
+                    else None
+                )
+                if item_type != expected_output_type:
+                    if self._unknown_entry_for_item(item, surface=surface) is not None:
+                        return None
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "ambiguous_call_identity",
+                        surface=surface,
+                    )
+                return entry
             if item_type == "function_call_output":
                 families = {PLAIN_FUNCTION, NAMESPACE}
             elif item_type == "custom_tool_call_output":
@@ -1544,6 +1626,12 @@ class ToolCompatibilityPlan:
                 for entry in self.entries
                 if entry.family in families and entry.disposition in {NATIVE, OMIT}
             ]
+            if matches and self._unknown_entry_for_item(item, surface=surface) is not None:
+                # Without a call owner, the output spelling alone cannot
+                # distinguish a standard lifecycle from an exact unknown kind
+                # that uses the same prefix.  Let the unknown OMIT matcher
+                # reject it instead of silently claiming it as native.
+                return None
             native = next((entry for entry in matches if entry.disposition == NATIVE), None)
             return native or (matches[0] if matches else None)
         return None
@@ -1564,23 +1652,17 @@ class ToolCompatibilityPlan:
             if len(matches) > 1:
                 raise ToolCompatibilityError("tool_compatibility_boundary", "ambiguous_native_identity", surface="response")
             return matches[0] if matches and matches[0].disposition == OMIT else None
-        unknown_kind = self._unknown_response_item_kind(item.get("type"))
-        if unknown_kind is None:
-            return None
-        matches = [
-            entry
-            for entry in self.entries
-            if entry.family == UNKNOWN_FUTURE_KIND
-            and entry.disposition in {NATIVE, OMIT}
-            and entry.declaration.get("type") == unknown_kind
-        ]
-        if len(matches) > 1:
-            raise ToolCompatibilityError("tool_compatibility_boundary", "ambiguous_native_identity", surface="response")
-        return matches[0] if matches and matches[0].disposition == OMIT else None
+        unknown_entry = self._unknown_entry_for_item(item, surface="response")
+        return unknown_entry if unknown_entry is not None and unknown_entry.disposition == OMIT else None
 
-    def _omitted_history_entry(self, item: Mapping[str, Any]) -> ToolCompatibilityEntry | None:
+    def _omitted_history_entry(
+        self,
+        item: Mapping[str, Any],
+        *,
+        owner: ToolCompatibilityEntry | None = None,
+    ) -> ToolCompatibilityEntry | None:
         item_type = item.get("type")
-        standard_entry = self._standard_entry_for_item(item)
+        standard_entry = self._standard_entry_for_item(item, owner=owner, surface="history")
         if standard_entry is not None:
             return standard_entry if standard_entry.disposition == OMIT else None
         hosted_item_key = self._hosted_history_item_key(item_type)
@@ -1597,6 +1679,9 @@ class ToolCompatibilityPlan:
             if matches and matches[0].disposition == OMIT:
                 return matches[0]
             return None
+        unknown_entry = self._unknown_entry_for_item(item, surface="history")
+        if unknown_entry is not None:
+            return unknown_entry if unknown_entry.disposition == OMIT else None
         if item_type in {"function_call", "custom_tool_call"}:
             entry = self._entry_for_name(
                 item.get("name"),
@@ -1639,11 +1724,38 @@ class ToolCompatibilityPlan:
         if isinstance(raw_input, list):
             encoded_input: list[Any] = []
             changed = tools_changed or choice_changed
+            history_call_owners: dict[str, ToolCompatibilityEntry] = {}
+            for item in raw_input:
+                if not isinstance(item, Mapping) or item.get("type") not in {
+                    "function_call",
+                    "custom_tool_call",
+                    "tool_search_call",
+                }:
+                    continue
+                owner = self._standard_entry_for_item(item, surface="history")
+                if owner is None:
+                    owner = self._unknown_entry_for_item(item, surface="history")
+                call_id = item.get("call_id")
+                if owner is not None and isinstance(call_id, str) and call_id:
+                    history_call_owners[call_id] = owner
+
+            def omitted_history_entry(item: Mapping[str, Any]) -> ToolCompatibilityEntry | None:
+                owner = None
+                if item.get("type") in {
+                    "function_call_output",
+                    "custom_tool_call_output",
+                    "tool_search_output",
+                }:
+                    call_id = item.get("call_id")
+                    if isinstance(call_id, str):
+                        owner = history_call_owners.get(call_id)
+                return self._omitted_history_entry(item, owner=owner)
+
             omitted_hosted_ids: dict[str, tuple[str, bool, bool]] = {}
             for item in raw_input:
                 if not isinstance(item, Mapping):
                     continue
-                omitted_entry = self._omitted_history_entry(item)
+                omitted_entry = omitted_history_entry(item)
                 hosted_item_key = self._hosted_history_item_key(item.get("type"))
                 if (
                     omitted_entry is None
@@ -1681,10 +1793,10 @@ class ToolCompatibilityPlan:
                 item
                 for item in raw_input
                 if isinstance(item, Mapping)
-                and self._omitted_history_entry(item) is not None
+                and omitted_history_entry(item) is not None
                 and not (
                     self._hosted_history_item_key(item.get("type")) is not None
-                    if self._omitted_history_entry(item) is not None
+                    if omitted_history_entry(item) is not None
                     else False
                 )
                 and (
@@ -1708,7 +1820,7 @@ class ToolCompatibilityPlan:
                     item.get("type") in {"function_call", "custom_tool_call", "tool_search_call"}
                     or (isinstance(item.get("type"), str) and item.get("type").endswith("_call"))
                 )
-                and self._omitted_history_entry(item) is None
+                and omitted_history_entry(item) is None
                 and isinstance(item.get("call_id"), str)
             }
             if omitted_call_ids.intersection(retained_call_ids):
@@ -1720,12 +1832,12 @@ class ToolCompatibilityPlan:
                     call_id = item.get("call_id")
                     if not isinstance(call_id, str) or not call_id:
                         raise ToolCompatibilityError("tool_compatibility_boundary", "missing_call_identity", surface="history")
-                    if self._omitted_history_entry(item) is not None and call_id not in omitted_call_ids:
+                    if omitted_history_entry(item) is not None and call_id not in omitted_call_ids:
                         raise ToolCompatibilityError("tool_compatibility_boundary", "ambiguous_call_identity", surface="history")
             for item in raw_input:
                 if isinstance(item, Mapping) and (
                     (
-                        self._omitted_history_entry(item) is not None
+                        omitted_history_entry(item) is not None
                         and self._hosted_history_item_key(item.get("type")) is None
                     )
                     or item.get("call_id") in omitted_call_ids
@@ -1733,7 +1845,7 @@ class ToolCompatibilityPlan:
                     changed = True
                     continue
                 if isinstance(item, Mapping):
-                    omitted_entry = self._omitted_history_entry(item)
+                    omitted_entry = omitted_history_entry(item)
                     hosted_item_key = self._hosted_history_item_key(item.get("type"))
                     if (
                         omitted_entry is not None

--- a/src-python/runtime_tool_compatibility.py
+++ b/src-python/runtime_tool_compatibility.py
@@ -416,6 +416,25 @@ class RequestScopedToolAliasRegistry:
     def record_for_call(self, call_id: Any) -> AliasRecord | None:
         return self._calls.get(call_id) if isinstance(call_id, str) else None
 
+    def new_attempt(self) -> "RequestScopedToolAliasRegistry":
+        """Copy immutable alias ownership while starting a fresh call ledger.
+
+        Alias allocation and declaration ownership are request-scoped and must
+        remain stable across permitted upstream retries.  Call ownership is
+        stream-attempt scoped, however: a provider may legitimately reuse a
+        call id after a transport failure, so a retry cannot inherit ``_calls``
+        from the failed attempt.
+        """
+        attempt = object.__new__(RequestScopedToolAliasRegistry)
+        attempt._token = self._token
+        attempt._native_names = self._native_names
+        attempt._max_length = self._max_length
+        attempt._max_attempts = self._max_attempts
+        attempt._aliases = dict(self._aliases)
+        attempt._by_declaration = dict(self._by_declaration)
+        attempt._calls = {}
+        return attempt
+
 
 @dataclass(frozen=True, slots=True)
 class ToolCompatibilityEntry:
@@ -985,6 +1004,18 @@ class ToolCompatibilityPlan:
 
     def new_stream(self) -> "CompatibilityStreamState":
         return CompatibilityStreamState(self)
+
+    def new_attempt(self) -> "ToolCompatibilityPlan":
+        """Return an attempt-local plan with stable aliases and fresh calls."""
+        return ToolCompatibilityPlan(
+            selected_protocol=self.selected_protocol,
+            capabilities=self.capabilities,
+            entries=self.entries,
+            registry=self.registry.new_attempt(),
+            diagnostics=self.diagnostics,
+            tool_choice=self.tool_choice,
+            provider_hosted_kinds=self.provider_hosted_kinds,
+        )
 
     def with_final_declarations(
         self,

--- a/src-python/runtime_tool_compatibility.py
+++ b/src-python/runtime_tool_compatibility.py
@@ -1608,6 +1608,30 @@ class ToolCompatibilityPlan:
             return
         if (
             item.get("type") == "function_call"
+            and item.get("namespace") is None
+            and isinstance(item.get("name"), str)
+        ):
+            name = item.get("name")
+            has_native_plain_owner = any(
+                entry.family == PLAIN_FUNCTION
+                and entry.disposition == NATIVE
+                and entry.original_name == name
+                for entry in self.entries
+            )
+            has_native_namespace_owner = any(
+                entry.family == NAMESPACE
+                and entry.disposition == NATIVE
+                and name in entry.child_names
+                for entry in self.entries
+            )
+            if has_native_namespace_owner and not has_native_plain_owner:
+                raise ToolCompatibilityError(
+                    "tool_compatibility_boundary",
+                    "unknown_native_identity",
+                    surface=surface,
+                )
+        if (
+            item.get("type") == "function_call"
             and item.get("namespace") is not None
             and isinstance(item.get("name"), str)
             and any(
@@ -2125,6 +2149,8 @@ class ToolCompatibilityPlan:
             return result, None, False
         _validate_version_fields(result, record)
         if record.family == NAMESPACE and result.get("namespace") not in {None, record.namespace}:
+            raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_alias", surface="response")
+        if record.family == CUSTOM_FREEFORM and result.get("namespace") is not None:
             raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_alias", surface="response")
         call_id = result.get("call_id")
         if isinstance(call_id, str) and call_id:
@@ -2688,6 +2714,43 @@ class CompatibilityStreamState:
     def _opaque_payload(value: Any) -> tuple[str, Any]:
         return ("opaque_input", _freeze(value))
 
+    def _record_legacy_unowned_native_done(
+        self,
+        item: Mapping[str, Any],
+        entry: ToolCompatibilityEntry,
+    ) -> None:
+        """Record one complete legacy item that legitimately omits ``added``."""
+        item_id = self._item_id(item)
+        if item_id is None:
+            raise ToolCompatibilityError(
+                "tool_compatibility_boundary",
+                "missing_item_identity",
+                surface="stream",
+            )
+        call_id = item.get("call_id")
+        if not isinstance(call_id, str) or not call_id:
+            raise ToolCompatibilityError(
+                "tool_compatibility_boundary",
+                "missing_call_identity",
+                surface="stream",
+            )
+        if item_id in self._seen_item_ids or item_id in self._native_done:
+            raise ToolCompatibilityError(
+                "tool_compatibility_boundary",
+                "duplicate_item_identity",
+                surface="stream",
+            )
+        if call_id in self._seen_call_ids:
+            raise ToolCompatibilityError(
+                "tool_compatibility_boundary",
+                "duplicate_call_identity",
+                surface="stream",
+            )
+        self.plan._validate_native_item(item, entry)
+        self._seen_item_ids.add(item_id)
+        self._seen_call_ids.add(call_id)
+        self._native_done.add(item_id)
+
     def _complete_native_arguments_from_item(
         self,
         item_id: str,
@@ -3130,6 +3193,8 @@ class CompatibilityStreamState:
                     "ambiguous_native_identity",
                     surface="stream",
                 )
+            if expected_entry.family == TOOL_SEARCH:
+                self.plan._validate_native_item(item, expected_entry)
             if self._native_wire_identities.get(item_id) != self._native_wire_identity(item):
                 raise ToolCompatibilityError(
                     "tool_compatibility_boundary",
@@ -3307,7 +3372,13 @@ class CompatibilityStreamState:
         if event_type in {"response.function_call_arguments.delta", "response.custom_tool_call_input.delta"}:
             item_id = self._item_id(result)
             if item_id in self._native_pending:
-                expected_call_id, _entry = self._native_pending[item_id]
+                expected_call_id, expected_entry = self._native_pending[item_id]
+                if expected_entry.family == TOOL_SEARCH:
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "unsupported_hosted_lifecycle",
+                        surface="stream",
+                    )
                 supplied_call_id = result.get("call_id")
                 if supplied_call_id is not None and supplied_call_id != expected_call_id:
                     raise ToolCompatibilityError(
@@ -3362,6 +3433,12 @@ class CompatibilityStreamState:
             item_id = self._item_id(result)
             if item_id in self._native_pending:
                 expected_call_id, expected_entry = self._native_pending[item_id]
+                if expected_entry.family == TOOL_SEARCH:
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "unsupported_hosted_lifecycle",
+                        surface="stream",
+                    )
                 supplied_call_id = result.get("call_id")
                 if supplied_call_id is not None and supplied_call_id != expected_call_id:
                     raise ToolCompatibilityError(
@@ -3405,6 +3482,13 @@ class CompatibilityStreamState:
                     )
                 arguments = result.get("arguments", result.get("input"))
                 if not isinstance(arguments, str):
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "incomplete_stream_delta",
+                        surface="stream",
+                    )
+                fragments = "".join(opaque.fragments)
+                if fragments and not arguments.startswith(fragments):
                     raise ToolCompatibilityError(
                         "tool_compatibility_boundary",
                         "incomplete_stream_delta",
@@ -3531,6 +3615,8 @@ class CompatibilityStreamState:
                                 surface="stream",
                             )
                         self.plan._validate_native_item(item, hosted_entry, require_completed=True)
+                    elif expected_entry.family == TOOL_SEARCH:
+                        self.plan._validate_native_item(item, expected_entry)
                     elif expected_entry.family != TOOL_SEARCH and native_item_id not in self._native_delta_done:
                         self._complete_native_arguments_from_item(
                             native_item_id,
@@ -3548,13 +3634,19 @@ class CompatibilityStreamState:
                 native_entry = self._native_entry_for_item(item)
                 if native_entry is not None:
                     if (
+                        native_entry.family == TOOL_SEARCH
+                        and item.get("type") == "tool_search_call"
+                    ):
+                        self._record_legacy_unowned_native_done(item, native_entry)
+                        return result
+                    if (
                         native_entry.family == PLAIN_FUNCTION
                         and native_entry.original_name == "tool_search"
                         and item.get("type") == "function_call"
                         and item.get("name") == "tool_search"
                         and item.get("namespace") is None
                     ):
-                        self.plan._validate_native_item(item, native_entry)
+                        self._record_legacy_unowned_native_done(item, native_entry)
                         return result
                     if (
                         native_entry.family == PLAIN_FUNCTION
@@ -3568,7 +3660,7 @@ class CompatibilityStreamState:
                         # Keep this one compatibility passthrough narrow; a
                         # plain unqualified native call still requires an
                         # established stream owner.
-                        self.plan._validate_native_item(item, native_entry)
+                        self._record_legacy_unowned_native_done(item, native_entry)
                         return result
                     raise ToolCompatibilityError("tool_compatibility_boundary", "missing_stream_identity", surface="stream")
                 if item.get("type") == "custom_tool_call":
@@ -3594,6 +3686,16 @@ class CompatibilityStreamState:
                     raise ToolCompatibilityError("tool_compatibility_boundary", "missing_stream_identity", surface="stream")
                 return result
             pending = self._pending_for(item)
+            if (
+                pending.record.family == CUSTOM_FREEFORM
+                and self._native_wire_identity(item)
+                != self._adapter_wire_identities[pending.item_id][2]
+            ):
+                raise ToolCompatibilityError(
+                    "tool_compatibility_boundary",
+                    "ambiguous_native_identity",
+                    surface="stream",
+                )
             if item.get("call_id") != pending.call_id:
                 raise ToolCompatibilityError("tool_compatibility_boundary", "ambiguous_call_identity", surface="stream")
             if pending.item_done:
@@ -3669,6 +3771,7 @@ class CompatibilityStreamState:
                 or item_id in self._seen_item_ids
                 or call_id in self._seen_call_ids
                 or item.get("arguments") not in {None, ""}
+                or item.get("namespace") is not None
             ):
                 raise self._stream_error("invalid_custom_stream_identity")
             self._seen_item_ids.add(item_id)
@@ -3727,6 +3830,12 @@ class CompatibilityStreamState:
             pending = self._buffered_custom.get(done_item_id) if done_item_id else None
             if pending is None:
                 return [self.decode_event(value)]
+            expected_wire = self._adapter_wire_identities.get(pending.item_id)
+            if (
+                expected_wire is None
+                or self._native_wire_identity(item) != expected_wire[2]
+            ):
+                raise self._stream_error("ambiguous_native_identity")
             if (
                 pending.arguments_done_event is None
                 or pending.native_input is None

--- a/src-python/runtime_tool_compatibility.py
+++ b/src-python/runtime_tool_compatibility.py
@@ -2559,6 +2559,20 @@ class CompatibilityStreamState:
 
     @staticmethod
     def _item_id(value: Mapping[str, Any]) -> str | None:
+        item_id = value.get("item_id")
+        plain_id = value.get("id")
+        if (
+            isinstance(item_id, str)
+            and item_id
+            and isinstance(plain_id, str)
+            and plain_id
+            and item_id != plain_id
+        ):
+            raise ToolCompatibilityError(
+                "tool_compatibility_boundary",
+                "ambiguous_native_identity",
+                surface="stream",
+            )
         for key in ("item_id", "id"):
             candidate = value.get(key)
             if isinstance(candidate, str) and candidate:
@@ -2576,9 +2590,15 @@ class CompatibilityStreamState:
 
     def _native_item_id_for_event(self, value: Mapping[str, Any]) -> str | None:
         item = value.get("item")
-        if isinstance(item, Mapping):
-            return self._item_id(item)
-        return self._item_id(value)
+        nested_item_id = self._item_id(item) if isinstance(item, Mapping) else None
+        event_item_id = self._item_id(value)
+        if nested_item_id and event_item_id and nested_item_id != event_item_id:
+            raise ToolCompatibilityError(
+                "tool_compatibility_boundary",
+                "ambiguous_native_identity",
+                surface="stream",
+            )
+        return nested_item_id or event_item_id
 
     @staticmethod
     def _native_wire_identity(item: Mapping[str, Any]) -> tuple[Any, Any, Any]:

--- a/src-python/runtime_tool_compatibility.py
+++ b/src-python/runtime_tool_compatibility.py
@@ -1735,11 +1735,17 @@ class ToolCompatibilityPlan:
     ) -> None:
         """Validate output-family ownership before response decoding starts."""
         item_type = item.get("type")
-        if not isinstance(item_type, str) or not item_type.endswith("_call_output"):
+        if not isinstance(item_type, str) or (
+            item_type != "tool_search_output" and not item_type.endswith("_call_output")
+        ):
             return
         if owner is None:
             return
-        expected = self._expected_response_output_type(owner)
+        expected = (
+            self._history_output_type_for_entry(owner)
+            if surface == "history"
+            else self._expected_response_output_type(owner)
+        )
         if expected is not None and item_type != expected:
             raise ToolCompatibilityError(
                 "tool_compatibility_boundary",
@@ -1851,8 +1857,9 @@ class ToolCompatibilityPlan:
             encoded_input: list[Any] = []
             changed = tools_changed or choice_changed
             history_call_owners: dict[str, ToolCompatibilityEntry] = {}
+            history_call_positions: dict[str, int] = {}
             seen_history_call_ids: dict[str, ToolCompatibilityEntry | None] = {}
-            for item in raw_input:
+            for item_index, item in enumerate(raw_input):
                 if not isinstance(item, Mapping) or item.get("type") not in {
                     "function_call",
                     "custom_tool_call",
@@ -1879,6 +1886,7 @@ class ToolCompatibilityPlan:
                     seen_history_call_ids[call_id] = owner
                     if owner is not None:
                         history_call_owners[call_id] = owner
+                        history_call_positions[call_id] = item_index
 
             def omitted_history_entry(item: Mapping[str, Any]) -> ToolCompatibilityEntry | None:
                 owner = None
@@ -1892,12 +1900,49 @@ class ToolCompatibilityPlan:
                         owner = history_call_owners.get(call_id)
                 return self._omitted_history_entry(item, owner=owner)
 
+            def validate_history_output_owner(item: Mapping[str, Any], item_index: int) -> None:
+                item_type = item.get("type")
+                is_result = isinstance(item_type, str) and (
+                    item_type == "tool_search_output" or item_type.endswith("_call_output")
+                )
+                if not is_result:
+                    return
+                omitted_entry = omitted_history_entry(item)
+                if omitted_entry is not None:
+                    return
+                call_id = item.get("call_id")
+                owner = history_call_owners.get(call_id) if isinstance(call_id, str) else None
+                if owner is None:
+                    # A standard output can be retained when the call lives
+                    # outside this request's history slice.  Unknown output
+                    # families have no such safe interpretation: without a
+                    # request-local owner they must fail closed.
+                    if item_type in {
+                        "function_call_output",
+                        "custom_tool_call_output",
+                        "tool_search_output",
+                    }:
+                        return
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "unknown_call_identity",
+                        surface="history",
+                    )
+                self._validate_response_owner_item(
+                    item,
+                    owner=owner,
+                    call_index=history_call_positions.get(call_id),
+                    item_index=item_index,
+                    surface="history",
+                )
+
             seen_history_item_ids: set[str] = set()
             seen_history_output_call_ids: set[str] = set()
-            for item in raw_input:
+            for item_index, item in enumerate(raw_input):
                 if not isinstance(item, Mapping):
                     continue
                 item_type = item.get("type")
+                validate_history_output_owner(item, item_index)
                 omitted_entry = omitted_history_entry(item)
                 hosted_item_key = self._hosted_history_item_key(item_type)
                 is_optional_omitted_hosted = omitted_entry is not None and hosted_item_key is not None
@@ -1919,7 +1964,9 @@ class ToolCompatibilityPlan:
                             "missing_call_identity",
                             surface="history",
                         )
-                if isinstance(item_type, str) and item_type.endswith("_call_output"):
+                if isinstance(item_type, str) and (
+                    item_type == "tool_search_output" or item_type.endswith("_call_output")
+                ):
                     call_id = item.get("call_id")
                     if (
                         not is_optional_omitted_hosted
@@ -2258,7 +2305,9 @@ class ToolCompatibilityPlan:
                 continue
             call_id = raw_item.get("call_id")
             item_type = raw_item.get("type")
-            if isinstance(item_type, str) and item_type.endswith("_call_output"):
+            if isinstance(item_type, str) and (
+                item_type == "tool_search_output" or item_type.endswith("_call_output")
+            ):
                 if isinstance(call_id, str) and call_id:
                     if call_id in response_output_call_ids:
                         raise ToolCompatibilityError(
@@ -2439,7 +2488,16 @@ class CompatibilityStreamState:
         self._pending: dict[str, _PendingStreamItem] = {}
         self._seen_item_ids: set[str] = set()
         self._seen_call_ids: set[str] = set()
-        self._native_pending: dict[str, tuple[str | None, str]] = {}
+        self._native_pending: dict[str, tuple[str | None, ToolCompatibilityEntry]] = {}
+        # The entry identifies the declaration, while this second ledger
+        # retains the exact wire child/name that was observed at ``added``.
+        # A namespace entry can contain several children, so family alone is
+        # not sufficient to reconcile a terminal item.
+        self._native_wire_identities: dict[str, tuple[Any, Any, Any]] = {}
+        # Buffered custom adapters leave ``_pending`` once their native
+        # lifecycle is emitted.  Keep the original adapter wire identity so a
+        # terminal envelope can still reconcile item/call/declaration exactly.
+        self._adapter_wire_identities: dict[str, tuple[str, AliasRecord, tuple[Any, Any, Any]]] = {}
         self._native_done: set[str] = set()
         self._native_delta_done: set[str] = set()
         self._hosted_pending: dict[str, _HostedStreamState] = {}
@@ -2472,6 +2530,86 @@ class CompatibilityStreamState:
         if isinstance(item, Mapping):
             return self._item_id(item)
         return self._item_id(value)
+
+    @staticmethod
+    def _native_wire_identity(item: Mapping[str, Any]) -> tuple[Any, Any, Any]:
+        return (item.get("type"), item.get("name"), item.get("namespace"))
+
+    @staticmethod
+    def _is_output_item_type(item_type: Any) -> bool:
+        return isinstance(item_type, str) and (
+            item_type in {
+                "function_call_output",
+                "custom_tool_call_output",
+                "tool_search_output",
+            }
+            or item_type.endswith("_call_output")
+        )
+
+    def _validate_output_item_added(self, item: Mapping[str, Any]) -> None:
+        """Require every stream output item to have a prior call owner."""
+        if not self._is_output_item_type(item.get("type")):
+            return
+        call_id = item.get("call_id")
+        if not isinstance(call_id, str) or not call_id:
+            raise ToolCompatibilityError(
+                "tool_compatibility_boundary",
+                "missing_call_identity",
+                surface="stream",
+            )
+
+        adapter_pending = next(
+            (pending for pending in self._pending.values() if pending.call_id == call_id),
+            None,
+        )
+        if adapter_pending is not None:
+            record = self.plan.registry.record_for_call(call_id)
+            if record is not adapter_pending.record:
+                raise ToolCompatibilityError(
+                    "tool_compatibility_boundary",
+                    "ambiguous_call_identity",
+                    surface="stream",
+                )
+            expected = (
+                "function_call_output"
+                if adapter_pending.record.family in {NAMESPACE, CUSTOM_FREEFORM}
+                else None
+            )
+            if expected is not None and item.get("type") != expected:
+                raise ToolCompatibilityError(
+                    "tool_compatibility_boundary",
+                    "ambiguous_call_identity",
+                    surface="stream",
+                )
+            return
+
+        native_pending = next(
+            (
+                (item_id, call_entry)
+                for item_id, call_entry in self._native_pending.items()
+                if call_entry[0] == call_id
+            ),
+            None,
+        )
+        if native_pending is not None:
+            _item_id, (_call_id, entry) = native_pending
+            expected = self.plan._history_output_type_for_entry(entry)
+            if expected is not None and item.get("type") != expected:
+                raise ToolCompatibilityError(
+                    "tool_compatibility_boundary",
+                    "ambiguous_call_identity",
+                    surface="stream",
+                )
+            return
+
+        # A request-local registry may retain calls from a previously decoded
+        # body/history.  It does not establish ownership for this SSE stream;
+        # require the corresponding ``added`` event in this state.
+        raise ToolCompatibilityError(
+            "tool_compatibility_boundary",
+            "missing_stream_identity",
+            surface="stream",
+        )
 
     def _check_alias_in_item(self, item: Mapping[str, Any], *, allow_incomplete: bool = True) -> tuple[dict[str, Any], AliasRecord | None, bool]:
         if item.get("type") == "function_call":
@@ -2536,10 +2674,10 @@ class CompatibilityStreamState:
         native_incomplete = any(
             item_id not in self._native_done
             or (
-                family not in {TOOL_SEARCH, SELECTED_PROVIDER_HOSTED}
+                entry.family not in {TOOL_SEARCH, SELECTED_PROVIDER_HOSTED}
                 and item_id not in self._native_delta_done
             )
-            for item_id, (_call_id, family) in self._native_pending.items()
+            for item_id, (_call_id, entry) in self._native_pending.items()
         )
         if incomplete or native_incomplete:
             raise ToolCompatibilityError("tool_compatibility_boundary", "incomplete_stream", surface="stream")
@@ -2547,27 +2685,118 @@ class CompatibilityStreamState:
 
     def _validate_terminal_native_output(self, response: Mapping[str, Any]) -> None:
         output = response.get("output")
-        if not isinstance(output, list) or not self._native_pending:
+        required_native_ids = {
+            item_id
+            for item_id, (_call_id, entry) in self._native_pending.items()
+            if entry.family != SELECTED_PROVIDER_HOSTED
+        }
+        required_adapter_ids = set(self._pending) | set(self._adapter_wire_identities)
+        if output is None:
+            # Some upstream terminal envelopes omit ``output`` after the SSE
+            # lifecycle has already delivered the completed item.  _finish_terminal
+            # below still rejects an actually incomplete lifecycle.
             return
+        if output == []:
+            if required_native_ids or required_adapter_ids:
+                raise ToolCompatibilityError("tool_compatibility_boundary", "incomplete_stream", surface="stream")
+            return
+        if not isinstance(output, list):
+            raise ToolCompatibilityError("tool_compatibility_boundary", "malformed_stream_event", surface="stream")
+        seen_output_ids: set[str] = set()
         for item in output:
             if not isinstance(item, Mapping):
                 continue
             item_id = _item_identity(item)
+            if item_id is not None:
+                if item_id in seen_output_ids:
+                    raise ToolCompatibilityError("tool_compatibility_boundary", "duplicate_item_identity", surface="stream")
+                seen_output_ids.add(item_id)
             pending = self._native_pending.get(item_id) if item_id is not None else None
-            native_entry = self._native_entry_for_item(item)
             if pending is None:
+                adapter_pending = self._pending.get(item_id) if item_id is not None else None
+                if adapter_pending is not None:
+                    if item.get("call_id") != adapter_pending.call_id:
+                        raise ToolCompatibilityError("tool_compatibility_boundary", "ambiguous_call_identity", surface="stream")
+                    record = self.plan.registry.record_for_alias(item.get("name"))
+                    if record is not adapter_pending.record:
+                        raise ToolCompatibilityError("tool_compatibility_boundary", "ambiguous_call_identity", surface="stream")
+                    if (
+                        adapter_pending.record.family == NAMESPACE
+                        and item.get("namespace") not in {None, adapter_pending.record.namespace}
+                    ):
+                        raise ToolCompatibilityError("tool_compatibility_boundary", "ambiguous_native_identity", surface="stream")
+                    continue
+                adapter_identity = self._adapter_wire_identities.get(item_id) if item_id is not None else None
+                if adapter_identity is not None:
+                    expected_call_id, expected_record, expected_wire = adapter_identity
+                    if item.get("call_id") != expected_call_id:
+                        raise ToolCompatibilityError(
+                            "tool_compatibility_boundary",
+                            "ambiguous_call_identity",
+                            surface="stream",
+                        )
+                    if self._native_wire_identity(item) != expected_wire:
+                        raise ToolCompatibilityError(
+                            "tool_compatibility_boundary",
+                            "ambiguous_native_identity",
+                            surface="stream",
+                        )
+                    terminal_record = self.plan.registry.record_for_alias(item.get("name"))
+                    if terminal_record is not expected_record:
+                        raise ToolCompatibilityError(
+                            "tool_compatibility_boundary",
+                            "ambiguous_native_identity",
+                            surface="stream",
+                        )
+                    continue
+                if isinstance(item.get("call_id"), str) and any(
+                    expected_call_id == item.get("call_id")
+                    for expected_call_id, _record, _wire in self._adapter_wire_identities.values()
+                ):
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "ambiguous_call_identity",
+                        surface="stream",
+                    )
+                bound_record = self.plan.registry.record_for_call(item.get("call_id"))
+                if bound_record is not None:
+                    terminal_record = self.plan.registry.record_for_alias(item.get("name"))
+                    if terminal_record is not bound_record:
+                        raise ToolCompatibilityError(
+                            "tool_compatibility_boundary",
+                            "ambiguous_call_identity",
+                            surface="stream",
+                        )
+                    # A buffered custom adapter is removed from _pending once
+                    # its native events are emitted.  Its request-local call
+                    # binding is still sufficient to verify the terminal
+                    # alias, so let the exact match through.
+                    continue
                 # Adapter output is accounted for by the request-scoped alias
                 # ledger; any other native-shaped item must match a stream
                 # owner before it can appear in the terminal envelope.
-                if native_entry is not None:
-                    raise ToolCompatibilityError(
-                        "tool_compatibility_boundary",
-                        "ambiguous_native_identity",
-                        surface="stream",
-                    )
+                if self._native_entry_for_item(item) is not None:
+                    # A complete body-style terminal envelope is valid even
+                    # when the caller did not expose the preceding SSE
+                    # ``added`` event.  Once this stream has a pending tool,
+                    # however, a native item without its exact owner is a
+                    # mismatched terminal identity.
+                    if self._native_pending or self._pending:
+                        raise ToolCompatibilityError(
+                            "tool_compatibility_boundary",
+                            "ambiguous_native_identity",
+                            surface="stream",
+                        )
                 continue
-            expected_call_id, expected_family = pending
-            if native_entry is None or native_entry.family != expected_family:
+            expected_call_id, expected_entry = pending
+            native_entry = self._native_entry_for_item(item)
+            if native_entry is not expected_entry:
+                raise ToolCompatibilityError(
+                    "tool_compatibility_boundary",
+                    "ambiguous_native_identity",
+                    surface="stream",
+                )
+            if self._native_wire_identities.get(item_id) != self._native_wire_identity(item):
                 raise ToolCompatibilityError(
                     "tool_compatibility_boundary",
                     "ambiguous_native_identity",
@@ -2579,6 +2808,9 @@ class CompatibilityStreamState:
                     "ambiguous_call_identity",
                     surface="stream",
                 )
+        missing = (required_native_ids | required_adapter_ids) - seen_output_ids
+        if missing:
+            raise ToolCompatibilityError("tool_compatibility_boundary", "incomplete_stream", surface="stream")
 
     def decode_event(self, event: Mapping[str, Any]) -> dict[str, Any]:
         if not isinstance(event, Mapping):
@@ -2612,6 +2844,7 @@ class CompatibilityStreamState:
         item = result.get("item")
         if event_type == "response.output_item.added" and isinstance(item, Mapping):
             self.plan._validate_registered_item_identity(item, surface="stream")
+            self._validate_output_item_added(item)
             self.plan._reject_unknown_standard_item(item, surface="stream")
             decoded_item, record, _changed = self._check_alias_in_item(item)
             item_id = self._item_id(item)
@@ -2630,6 +2863,11 @@ class CompatibilityStreamState:
                 if self.plan.registry.record_for_call(call_id) is None:
                     self.plan.registry.bind_call(call_id, record.alias)
                 self._pending[item_id] = _PendingStreamItem(record, item_id, call_id if isinstance(call_id, str) else None)
+                self._adapter_wire_identities[item_id] = (
+                    call_id,
+                    record,
+                    self._native_wire_identity(item),
+                )
                 result["item"] = decoded_item
                 return result
             native_entry = self._native_entry_for_item(item)
@@ -2643,7 +2881,8 @@ class CompatibilityStreamState:
                     if item_id in self._seen_item_ids:
                         raise ToolCompatibilityError("tool_compatibility_boundary", "duplicate_item_identity", surface="stream")
                     self._seen_item_ids.add(item_id)
-                    self._native_pending[item_id] = (None, native_entry.family)
+                    self._native_pending[item_id] = (None, native_entry)
+                    self._native_wire_identities[item_id] = self._native_wire_identity(item)
                     hosted_spec = _hosted_event_spec_for_declaration_kind(
                         native_entry.declaration.get("type")
                     )
@@ -2668,7 +2907,8 @@ class CompatibilityStreamState:
                     raise ToolCompatibilityError("tool_compatibility_boundary", "duplicate_call_identity", surface="stream")
                 self._seen_item_ids.add(item_id)
                 self._seen_call_ids.add(call_id)
-                self._native_pending[item_id] = (call_id, native_entry.family)
+                self._native_pending[item_id] = (call_id, native_entry)
+                self._native_wire_identities[item_id] = self._native_wire_identity(item)
                 result["item"] = decoded_item
             elif self.plan.has_adaptations and item.get("type") in {"function_call", "custom_tool_call"}:
                 adapted_entry = self.plan._entry_for_name(
@@ -2703,7 +2943,7 @@ class CompatibilityStreamState:
         if event_type in {"response.function_call_arguments.delta", "response.custom_tool_call_input.delta"}:
             item_id = self._item_id(result)
             if item_id in self._native_pending:
-                expected_call_id, _family = self._native_pending[item_id]
+                expected_call_id, _entry = self._native_pending[item_id]
                 supplied_call_id = result.get("call_id")
                 if supplied_call_id is not None and supplied_call_id != expected_call_id:
                     raise ToolCompatibilityError(
@@ -2734,7 +2974,7 @@ class CompatibilityStreamState:
         if event_type in {"response.function_call_arguments.done", "response.custom_tool_call_input.done"}:
             item_id = self._item_id(result)
             if item_id in self._native_pending:
-                expected_call_id, _family = self._native_pending[item_id]
+                expected_call_id, _entry = self._native_pending[item_id]
                 supplied_call_id = result.get("call_id")
                 if supplied_call_id is not None and supplied_call_id != expected_call_id:
                     raise ToolCompatibilityError(
@@ -2774,6 +3014,7 @@ class CompatibilityStreamState:
             return result
         if event_type == "response.output_item.done" and isinstance(item, Mapping):
             self.plan._validate_registered_item_identity(item, surface="stream")
+            self._validate_output_item_added(item)
             self.plan._reject_unknown_standard_item(item, surface="stream")
             record = self.plan.registry.record_for_alias(item.get("name"))
             if record is None:
@@ -2789,9 +3030,16 @@ class CompatibilityStreamState:
                     call_id = item.get("call_id")
                     if call_id != native_pending[0]:
                         raise ToolCompatibilityError("tool_compatibility_boundary", "ambiguous_call_identity", surface="stream")
-                    if native_pending[1] == SELECTED_PROVIDER_HOSTED:
+                    expected_entry = native_pending[1]
+                    if self._native_wire_identities.get(native_item_id) != self._native_wire_identity(item):
+                        raise ToolCompatibilityError(
+                            "tool_compatibility_boundary",
+                            "ambiguous_native_identity",
+                            surface="stream",
+                        )
+                    if expected_entry.family == SELECTED_PROVIDER_HOSTED:
                         hosted_entry = self._native_entry_for_item(item)
-                        if hosted_entry is None or hosted_entry.family != SELECTED_PROVIDER_HOSTED:
+                        if hosted_entry is None or hosted_entry is not expected_entry:
                             raise ToolCompatibilityError("tool_compatibility_boundary", "ambiguous_native_identity", surface="stream")
                         hosted_state = self._hosted_pending.get(native_item_id)
                         if hosted_state is None or hosted_state.next_stage != len(hosted_state.stages):
@@ -2801,7 +3049,7 @@ class CompatibilityStreamState:
                                 surface="stream",
                             )
                         self.plan._validate_native_item(item, hosted_entry, require_completed=True)
-                    elif native_pending[1] != TOOL_SEARCH and native_item_id not in self._native_delta_done:
+                    elif expected_entry.family != TOOL_SEARCH and native_item_id not in self._native_delta_done:
                         raise ToolCompatibilityError("tool_compatibility_boundary", "incomplete_stream_delta", surface="stream")
                     if native_item_id in self._native_done:
                         raise ToolCompatibilityError("tool_compatibility_boundary", "duplicate_item_identity", surface="stream")
@@ -2905,6 +3153,11 @@ class CompatibilityStreamState:
                 added_event=value,
                 item_id=item_id,
                 call_id=call_id,
+            )
+            self._adapter_wire_identities[item_id] = (
+                call_id,
+                record,
+                self._native_wire_identity(item),
             )
             return []
 

--- a/src-python/runtime_tool_compatibility.py
+++ b/src-python/runtime_tool_compatibility.py
@@ -2206,6 +2206,30 @@ class ToolCompatibilityPlan:
             )
             if entry is not None and entry.disposition == NATIVE:
                 return entry
+            # A native plain declaration can be surfaced by providers using
+            # the explicit namespace/child shape that normally belongs to a
+            # native namespace declaration.  Resolve only the exact,
+            # injective ``namespace__child`` spelling; arbitrary namespace
+            # decoration must remain an unknown identity.
+            if item_type == "function_call":
+                namespace = item.get("namespace")
+                child_name = item.get("name")
+                if isinstance(namespace, str) and namespace and isinstance(child_name, str) and child_name:
+                    flattened_name = f"{namespace}__{child_name}"
+                    flattened_matches = [
+                        candidate
+                        for candidate in self.entries
+                        if candidate.family == PLAIN_FUNCTION
+                        and candidate.disposition == NATIVE
+                        and candidate.original_name == flattened_name
+                    ]
+                    if len(flattened_matches) > 1:
+                        raise ToolCompatibilityError(
+                            "tool_compatibility_boundary",
+                            "ambiguous_native_identity",
+                        )
+                    if flattened_matches:
+                        return flattened_matches[0]
             return None
         if item_type in {"tool_search_call", "tool_search_output"}:
             matches = [
@@ -2262,7 +2286,16 @@ class ToolCompatibilityPlan:
             )
         item_type = item.get("type")
         if entry.family == PLAIN_FUNCTION:
-            if item_type != "function_call" or item.get("name") != entry.original_name:
+            namespace = item.get("namespace")
+            plain_shape = namespace is None and item.get("name") == entry.original_name
+            flattened_shape = (
+                isinstance(namespace, str)
+                and namespace
+                and isinstance(item.get("name"), str)
+                and item.get("name")
+                and f"{namespace}__{item.get('name')}" == entry.original_name
+            )
+            if item_type != "function_call" or not (plain_shape or flattened_shape):
                 raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_native_identity", surface="history")
         elif entry.family == NAMESPACE:
             if (
@@ -2521,6 +2554,25 @@ class _BufferedCustomStreamItem:
 
 
 @dataclass(slots=True)
+class _OpaqueStreamItem:
+    """Track a provider-local custom call without claiming a declaration.
+
+    Some upstream Responses streams still expose the legacy ``custom_tool_call``
+    lifecycle even when the request did not declare a structured custom tool.
+    The wire item itself is the only owner available in that case.  Keep that
+    owner opaque, but apply the same identity and terminal checks as declared
+    calls.
+    """
+
+    item_id: str
+    call_id: str
+    wire_identity: tuple[Any, Any, Any]
+    fragments: list[str] = field(default_factory=list)
+    arguments_done: bool = False
+    item_done: bool = False
+
+
+@dataclass(slots=True)
 class _HostedStreamState:
     event_kind: str
     stages: tuple[str, ...]
@@ -2555,6 +2607,10 @@ class CompatibilityStreamState:
         self._native_fragments: dict[str, list[str]] = {}
         self._hosted_pending: dict[str, _HostedStreamState] = {}
         self._buffered_custom: dict[str, _BufferedCustomStreamItem] = {}
+        # Provider-local custom calls have no declaration/alias owner.  Keep
+        # an opaque stream owner once ``output_item.added`` establishes it so
+        # later deltas and terminal events cannot borrow an arbitrary id.
+        self._opaque_pending: dict[str, _OpaqueStreamItem] = {}
         self._terminal = False
 
     @property
@@ -2591,6 +2647,46 @@ class CompatibilityStreamState:
 
     def _native_entry_for_item(self, item: Mapping[str, Any]) -> ToolCompatibilityEntry | None:
         return self.plan._native_entry_for_item(item)
+
+    def _record_opaque_added(self, item: Mapping[str, Any]) -> _OpaqueStreamItem | None:
+        """Record an undeclared legacy custom call established by ``added``."""
+        if item.get("type") != "custom_tool_call":
+            return None
+        item_id = self._item_id(item)
+        call_id = item.get("call_id")
+        if item_id is None or not isinstance(call_id, str) or not call_id:
+            raise ToolCompatibilityError(
+                "tool_compatibility_boundary",
+                "missing_stream_identity",
+                surface="stream",
+            )
+        if item_id in self._seen_item_ids or item_id in self._opaque_pending:
+            raise ToolCompatibilityError(
+                "tool_compatibility_boundary",
+                "duplicate_item_identity",
+                surface="stream",
+            )
+        if call_id in self._seen_call_ids or any(
+            opaque.call_id == call_id for opaque in self._opaque_pending.values()
+        ):
+            raise ToolCompatibilityError(
+                "tool_compatibility_boundary",
+                "duplicate_call_identity",
+                surface="stream",
+            )
+        opaque = _OpaqueStreamItem(
+            item_id=item_id,
+            call_id=call_id,
+            wire_identity=self._native_wire_identity(item),
+        )
+        self._seen_item_ids.add(item_id)
+        self._seen_call_ids.add(call_id)
+        self._opaque_pending[item_id] = opaque
+        return opaque
+
+    @staticmethod
+    def _opaque_payload(value: Any) -> tuple[str, Any]:
+        return ("opaque_input", _freeze(value))
 
     def _native_item_id_for_event(self, value: Mapping[str, Any]) -> str | None:
         item = value.get("item")
@@ -2809,7 +2905,11 @@ class CompatibilityStreamState:
             )
             for item_id, (_call_id, entry) in self._native_pending.items()
         )
-        if incomplete or native_incomplete:
+        opaque_incomplete = any(
+            not opaque.arguments_done or not opaque.item_done
+            for opaque in self._opaque_pending.values()
+        )
+        if incomplete or native_incomplete or opaque_incomplete:
             raise ToolCompatibilityError("tool_compatibility_boundary", "incomplete_stream", surface="stream")
         self._terminal = True
 
@@ -2888,6 +2988,41 @@ class CompatibilityStreamState:
                             "tool_compatibility_boundary",
                             "ambiguous_native_identity",
                             surface="stream",
+                    )
+                    continue
+                opaque = self._opaque_pending.get(item_id) if item_id is not None else None
+                if opaque is not None:
+                    if item.get("call_id") != opaque.call_id:
+                        raise ToolCompatibilityError(
+                            "tool_compatibility_boundary",
+                            "ambiguous_call_identity",
+                            surface="stream",
+                        )
+                    if self._native_wire_identity(item) != opaque.wire_identity:
+                        raise ToolCompatibilityError(
+                            "tool_compatibility_boundary",
+                            "ambiguous_native_identity",
+                            surface="stream",
+                        )
+                    if "input" in item:
+                        terminal_input = item.get("input")
+                    elif "arguments" in item:
+                        terminal_input = item.get("arguments")
+                    else:
+                        raise ToolCompatibilityError(
+                            "tool_compatibility_boundary",
+                            "incomplete_stream_delta",
+                            surface="stream",
+                        )
+                    payload = self._opaque_payload(terminal_input)
+                    if (
+                        item_id in self._wire_payloads
+                        and self._wire_payloads[item_id] != payload
+                    ):
+                        raise ToolCompatibilityError(
+                            "tool_compatibility_boundary",
+                            "ambiguous_native_identity",
+                            surface="stream",
                         )
                     continue
                 if isinstance(item.get("call_id"), str) and any(
@@ -2913,6 +3048,15 @@ class CompatibilityStreamState:
                     # binding is still sufficient to verify the terminal
                     # alias, so let the exact match through.
                     continue
+                if isinstance(item.get("call_id"), str) and any(
+                    opaque.call_id == item.get("call_id")
+                    for opaque in self._opaque_pending.values()
+                ):
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "ambiguous_call_identity",
+                        surface="stream",
+                    )
                 # Adapter output is accounted for by the request-scoped alias
                 # ledger; any other native-shaped item must match a stream
                 # owner before it can appear in the terminal envelope.
@@ -3058,7 +3202,30 @@ class CompatibilityStreamState:
                 self._native_pending[item_id] = (call_id, native_entry)
                 self._native_wire_identities[item_id] = self._native_wire_identity(item)
                 result["item"] = decoded_item
-            elif self.plan.has_adaptations and item.get("type") in {"function_call", "custom_tool_call"}:
+            elif item.get("type") == "custom_tool_call":
+                if self.plan._omitted_response_entry_for_item(item) is not None:
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "unsupported_hosted_lifecycle",
+                        surface="stream",
+                    )
+                adapted_entry = (
+                    self.plan._entry_for_name(
+                        item.get("name"),
+                        item.get("namespace"),
+                        item_type=item.get("type"),
+                    )
+                    if self.plan.has_adaptations
+                    else None
+                )
+                if adapted_entry is not None and adapted_entry.disposition == ADAPT:
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "unknown_alias",
+                        surface="stream",
+                    )
+                self._record_opaque_added(item)
+            elif self.plan.has_adaptations and item.get("type") == "function_call":
                 adapted_entry = self.plan._entry_for_name(
                     item.get("name"),
                     item.get("namespace"),
@@ -3106,6 +3273,30 @@ class CompatibilityStreamState:
                     raise ToolCompatibilityError("tool_compatibility_boundary", "duplicate_stream_done", surface="stream")
                 self._native_fragments.setdefault(item_id, []).append(delta)
                 return result
+            opaque = self._opaque_pending.get(item_id) if item_id is not None else None
+            if opaque is not None:
+                supplied_call_id = result.get("call_id")
+                if supplied_call_id is not None and supplied_call_id != opaque.call_id:
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "ambiguous_call_identity",
+                        surface="stream",
+                    )
+                if opaque.arguments_done or opaque.item_done:
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "duplicate_stream_done",
+                        surface="stream",
+                    )
+                delta = result.get("delta")
+                if not isinstance(delta, str):
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "malformed_stream_delta",
+                        surface="stream",
+                    )
+                opaque.fragments.append(delta)
+                return result
             if item_id not in self._pending:
                 raise ToolCompatibilityError("tool_compatibility_boundary", "missing_stream_identity", surface="stream")
             pending = self._pending_for(result)
@@ -3147,6 +3338,38 @@ class CompatibilityStreamState:
                     raise ToolCompatibilityError("tool_compatibility_boundary", "ambiguous_native_identity", surface="stream")
                 self._wire_payloads[item_id] = payload
                 self._native_delta_done.add(item_id)
+                return result
+            opaque = self._opaque_pending.get(item_id) if item_id is not None else None
+            if opaque is not None:
+                supplied_call_id = result.get("call_id")
+                if supplied_call_id is not None and supplied_call_id != opaque.call_id:
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "ambiguous_call_identity",
+                        surface="stream",
+                    )
+                if opaque.arguments_done:
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "duplicate_stream_done",
+                        surface="stream",
+                    )
+                arguments = result.get("arguments", result.get("input"))
+                if not isinstance(arguments, str):
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "incomplete_stream_delta",
+                        surface="stream",
+                    )
+                fragments = opaque.fragments
+                if fragments and "".join(fragments) != arguments:
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "incomplete_stream_delta",
+                        surface="stream",
+                    )
+                opaque.arguments_done = True
+                self._wire_payloads[item_id] = self._opaque_payload(arguments)
                 return result
             if item_id not in self._pending:
                 raise ToolCompatibilityError("tool_compatibility_boundary", "missing_stream_identity", surface="stream")
@@ -3193,6 +3416,55 @@ class CompatibilityStreamState:
                         surface="stream",
                     )
                 native_item_id = self._item_id(item)
+                opaque = self._opaque_pending.get(native_item_id) if native_item_id else None
+                if opaque is not None:
+                    if item.get("call_id") != opaque.call_id:
+                        raise ToolCompatibilityError(
+                            "tool_compatibility_boundary",
+                            "ambiguous_call_identity",
+                            surface="stream",
+                        )
+                    if self._native_wire_identity(item) != opaque.wire_identity:
+                        raise ToolCompatibilityError(
+                            "tool_compatibility_boundary",
+                            "ambiguous_native_identity",
+                            surface="stream",
+                        )
+                    if not opaque.arguments_done:
+                        raise ToolCompatibilityError(
+                            "tool_compatibility_boundary",
+                            "incomplete_stream_delta",
+                            surface="stream",
+                        )
+                    if opaque.item_done:
+                        raise ToolCompatibilityError(
+                            "tool_compatibility_boundary",
+                            "duplicate_item_identity",
+                            surface="stream",
+                        )
+                    if "input" in item:
+                        terminal_input = item.get("input")
+                    elif "arguments" in item:
+                        terminal_input = item.get("arguments")
+                    else:
+                        raise ToolCompatibilityError(
+                            "tool_compatibility_boundary",
+                            "incomplete_stream_delta",
+                            surface="stream",
+                        )
+                    payload = self._opaque_payload(terminal_input)
+                    if (
+                        native_item_id in self._wire_payloads
+                        and self._wire_payloads[native_item_id] != payload
+                    ):
+                        raise ToolCompatibilityError(
+                            "tool_compatibility_boundary",
+                            "ambiguous_native_identity",
+                            surface="stream",
+                        )
+                    opaque.item_done = True
+                    self._wire_payloads[native_item_id] = payload
+                    return result
                 native_pending = self._native_pending.get(native_item_id) if native_item_id else None
                 if native_pending is not None:
                     call_id = item.get("call_id")
@@ -3229,7 +3501,22 @@ class CompatibilityStreamState:
                     return result
                 native_entry = self._native_entry_for_item(item)
                 if native_entry is not None:
+                    if (
+                        native_entry.family == PLAIN_FUNCTION
+                        and native_entry.original_name == "tool_search"
+                        and item.get("type") == "function_call"
+                        and item.get("name") == "tool_search"
+                        and item.get("namespace") is None
+                    ):
+                        self.plan._validate_native_item(item, native_entry)
+                        return result
                     raise ToolCompatibilityError("tool_compatibility_boundary", "missing_stream_identity", surface="stream")
+                if item.get("type") == "custom_tool_call":
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "missing_stream_identity",
+                        surface="stream",
+                    )
                 if self.plan._omitted_response_entry_for_item(item) is not None:
                     raise ToolCompatibilityError(
                         "tool_compatibility_boundary",

--- a/src-python/runtime_tool_compatibility.py
+++ b/src-python/runtime_tool_compatibility.py
@@ -852,6 +852,16 @@ def _validate_version_fields(item: Mapping[str, Any], record: AliasRecord) -> No
 
 
 def _item_identity(item: Mapping[str, Any]) -> str | None:
+    item_id = item.get("item_id")
+    plain_id = item.get("id")
+    if (
+        isinstance(item_id, str)
+        and item_id
+        and isinstance(plain_id, str)
+        and plain_id
+        and item_id != plain_id
+    ):
+        raise ToolCompatibilityError("tool_compatibility_boundary", "ambiguous_native_identity")
     for key in ("item_id", "id"):
         value = item.get(key)
         if isinstance(value, str) and value:
@@ -864,6 +874,15 @@ def _hosted_kind_for_item_type(item_type: Any) -> str | None:
         return None
     kind = item_type[: -len("_call")]
     return kind if kind in _KNOWN_HOSTED_TYPES else None
+
+
+def _hosted_output_kind_for_item_type(item_type: Any) -> str | None:
+    if not isinstance(item_type, str):
+        return None
+    for event_kind, _stages in _HOSTED_EVENT_STAGES.values():
+        if item_type == f"{event_kind}_output":
+            return event_kind
+    return None
 
 
 def _hosted_event_spec_for_declaration_kind(kind: Any) -> tuple[str, tuple[str, ...]] | None:
@@ -1391,6 +1410,12 @@ class ToolCompatibilityPlan:
         item_type = item.get("type")
         name = item.get("name")
         namespace = item.get("namespace")
+        if item_type in {"tool_search_call", "tool_search_output"}:
+            native_entry = self._native_entry_for_item(item)
+            if native_entry is not None:
+                self._validate_native_item(item, native_entry)
+        if _hosted_output_kind_for_item_type(item_type) is not None:
+            raise ToolCompatibilityError("tool_compatibility_boundary", "unsupported_hosted_lifecycle", surface="history")
         entry = self._entry_for_name(name, namespace, item_type=item_type)
         if item_type == "function_call" and entry is not None and entry.disposition == ADAPT:
             alias = self._alias_for(entry, child_name=name)
@@ -1752,7 +1777,7 @@ class ToolCompatibilityPlan:
                 "ambiguous_call_identity",
                 surface=surface,
             )
-        if owner.disposition == ADAPT and call_index is not None and item_index < call_index:
+        if surface == "response" and call_index is not None and item_index < call_index:
             raise ToolCompatibilityError(
                 "tool_compatibility_boundary",
                 "ambiguous_call_identity",
@@ -2252,7 +2277,7 @@ class ToolCompatibilityPlan:
         elif entry.family == TOOL_SEARCH:
             if item_type not in {"tool_search_call", "tool_search_output"}:
                 raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_native_identity", surface="history")
-            if item_type == "tool_search_call" and item.get("execution") not in {None, "client"}:
+            if item.get("execution") != "client":
                 raise ToolCompatibilityError("tool_compatibility_boundary", "invalid_tool_search_execution", surface="history")
         elif entry.family == SELECTED_PROVIDER_HOSTED:
             hosted_spec = _hosted_event_spec_for_declaration_kind(entry.declaration.get("type"))
@@ -2400,6 +2425,20 @@ class ToolCompatibilityPlan:
                 else:
                     self._reject_unknown_standard_item(item, surface=surface)
                     decoded, item_changed = item, False
+            elif item_type == "tool_search_call":
+                native_entry = self._native_entry_for_item(item)
+                if native_entry is not None:
+                    self._validate_native_item(item, native_entry)
+                    decoded, item_changed = item, False
+                elif self._omitted_response_entry_for_item(item, owner=owner) is not None:
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "unsupported_hosted_lifecycle",
+                        surface=surface,
+                    )
+                else:
+                    self._reject_unknown_standard_item(item, surface=surface)
+                    decoded, item_changed = item, False
             elif _hosted_kind_for_item_type(item_type) is not None:
                 native_entry = self._native_entry_for_item(item)
                 if native_entry is None:
@@ -2419,8 +2458,16 @@ class ToolCompatibilityPlan:
                     raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_call_identity", surface="history")
                 if item_type == "tool_search_output":
                     native_entry = self._native_entry_for_item(item)
-                    if native_entry is None and self.has_adaptations and not self._has_native_structural_family():
+                    if native_entry is not None:
+                        self._validate_native_item(item, native_entry)
+                    elif self.has_adaptations and not self._has_native_structural_family():
                         raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_call_identity", surface="history")
+            elif _hosted_output_kind_for_item_type(item_type) is not None:
+                raise ToolCompatibilityError(
+                    "tool_compatibility_boundary",
+                    "unsupported_hosted_lifecycle",
+                    surface=surface,
+                )
             else:
                 decoded, item_changed = item, False
                 if self.registry.looks_like_alias(item.get("name")):
@@ -3254,6 +3301,9 @@ class CompatibilityStreamState:
         item_id = self._item_id(value)
         pending = self._buffered_custom.get(item_id) if item_id else None
         if event_type == "response.function_call_arguments.delta" and pending is not None:
+            supplied_call_id = value.get("call_id")
+            if supplied_call_id is not None and supplied_call_id != pending.call_id:
+                raise self._stream_error("ambiguous_call_identity")
             delta = value.get("delta")
             if not isinstance(delta, str) or pending.arguments_done_event is not None:
                 raise self._stream_error("malformed_stream_delta")
@@ -3261,6 +3311,9 @@ class CompatibilityStreamState:
             return []
 
         if event_type == "response.function_call_arguments.done" and pending is not None:
+            supplied_call_id = value.get("call_id")
+            if supplied_call_id is not None and supplied_call_id != pending.call_id:
+                raise self._stream_error("ambiguous_call_identity")
             if pending.arguments_done_event is not None:
                 raise self._stream_error("duplicate_stream_done")
             arguments = value.get("arguments")

--- a/src-python/runtime_tool_compatibility.py
+++ b/src-python/runtime_tool_compatibility.py
@@ -472,10 +472,7 @@ def classify_declaration(declaration: Mapping[str, Any]) -> str:
         return CUSTOM_FREEFORM
     if item_type == "tool_search":
         return TOOL_SEARCH
-    if (
-        isinstance(item_type, str)
-        and (item_type in _KNOWN_HOSTED_TYPES or declaration.get("executor") == "selected_provider")
-    ):
+    if isinstance(item_type, str) and item_type in _KNOWN_HOSTED_TYPES:
         return SELECTED_PROVIDER_HOSTED
     return UNKNOWN_FUTURE_KIND
 
@@ -849,6 +846,35 @@ def _item_identity(item: Mapping[str, Any]) -> str | None:
     return None
 
 
+def _hosted_kind_for_item_type(item_type: Any) -> str | None:
+    if not isinstance(item_type, str) or not item_type.endswith("_call"):
+        return None
+    kind = item_type[: -len("_call")]
+    return kind if kind in _KNOWN_HOSTED_TYPES else None
+
+
+def _is_unsupported_hosted_stream_event(event_type: Any) -> bool:
+    if not isinstance(event_type, str) or not event_type.startswith("response."):
+        return False
+    suffix = event_type[len("response.") :]
+    # These are the Responses protocol's ordinary function/custom/tool-search
+    # lifecycles.  They are handled by the request-scoped stream ledger below;
+    # the ``*_call`` spelling alone is not enough to classify an event as a
+    # provider-hosted lifecycle.
+    if suffix.startswith(
+        (
+            "function_call_arguments.",
+            "custom_tool_call_input.",
+            "tool_search_call.",
+        )
+    ):
+        return False
+    # Any remaining ``<kind>_call.<event>`` is either a known hosted kind or an
+    # unknown provider-specific hosted lifecycle.  Neither can be safely
+    # passed through without an explicit lifecycle contract.
+    return "_call." in suffix
+
+
 @dataclass(frozen=True, slots=True)
 class ToolCompatibilityPlan:
     selected_protocol: str
@@ -872,10 +898,16 @@ class ToolCompatibilityPlan:
     def new_stream(self) -> "CompatibilityStreamState":
         return CompatibilityStreamState(self)
 
-    def with_final_declarations(self, declarations: Iterable[Mapping[str, Any]]) -> "ToolCompatibilityPlan":
+    def with_final_declarations(
+        self,
+        declarations: Iterable[Mapping[str, Any]],
+        *,
+        tool_choice: Any = None,
+    ) -> "ToolCompatibilityPlan":
         """Add model-visible native declarations while preserving request aliases."""
         final = list(declarations)
         entries = list(self.entries)
+        effective_tool_choice = self.tool_choice if tool_choice is None else tool_choice
         native_names: set[str] = set()
         for declaration in final:
             if not isinstance(declaration, Mapping):
@@ -894,14 +926,68 @@ class ToolCompatibilityPlan:
                 continue
             if not _declaration_valid_for_family(declaration, family):
                 continue
+            is_required = _required_by_rule(
+                declaration,
+                len(entries),
+                required=None,
+                tool_choice=effective_tool_choice,
+            )
+            disposition = OMIT
+            reason = "lifecycle_unavailable"
+            aliases: list[str] = []
+            if family == PLAIN_FUNCTION:
+                if self.capabilities.function_lifecycle:
+                    disposition, reason = NATIVE, "native_function_lifecycle"
+            elif family == NAMESPACE:
+                namespace, children, version, _valid = _namespace_details(declaration)
+                if self.capabilities.namespace_lifecycle:
+                    disposition, reason = NATIVE, "native_namespace_lifecycle"
+                elif self.capabilities.function_lifecycle and self.capabilities.accepts_namespace_adapter:
+                    disposition, reason = ADAPT, "namespace_function_adapter"
+                    aliases = [
+                        self.registry.allocate_namespace(
+                            declaration_index=len(entries),
+                            namespace=str(namespace),
+                            child_index=child_index,
+                            child_name=str(child.get("name")),
+                            version=version,
+                        )
+                        for child_index, child in enumerate(children)
+                    ]
+            elif family == CUSTOM_FREEFORM:
+                if self.capabilities.custom_lifecycle:
+                    disposition, reason = NATIVE, "native_custom_lifecycle"
+                elif self.capabilities.function_lifecycle and self.capabilities.accepts_custom_adapter:
+                    disposition, reason = ADAPT, "custom_function_envelope"
+                    aliases = [
+                        self.registry.allocate_custom(
+                            declaration_index=len(entries),
+                            original_name=str(_name_of(declaration)),
+                            version=None,
+                        )
+                    ]
+            elif family == TOOL_SEARCH:
+                if self.capabilities.tool_search_lifecycle:
+                    disposition, reason = NATIVE, "native_client_tool_search"
+            elif family == SELECTED_PROVIDER_HOSTED:
+                # Provider capability facts are intentionally not inferred for
+                # declarations added after the request plan was built.
+                if declaration.get("type") in self.capabilities.hosted_lifecycles:
+                    disposition, reason = NATIVE, "selected_provider_hosted_lifecycle"
+            elif family == UNKNOWN_FUTURE_KIND:
+                reason = "unknown_lifecycle_contract_unavailable"
+            if disposition == OMIT and is_required:
+                disposition = REQUIRED_BUT_UNAVAILABLE
+                reason = "required_unavailable"
             entries.append(
                 ToolCompatibilityEntry(
                     declaration_index=len(entries),
                     family=family,
-                    disposition=NATIVE,
-                    required=False,
+                    disposition=disposition,
+                    required=is_required,
                     declaration=_freeze(_copy_mapping(declaration)),
-                    reason="native_gateway_declaration",
+                    reason=reason,
+                    aliases=tuple(aliases),
                     namespace=_namespace_details(declaration)[0] if family == NAMESPACE else None,
                     version=_namespace_details(declaration)[2] if family == NAMESPACE else None,
                     child_names=tuple(
@@ -911,6 +997,26 @@ class ToolCompatibilityPlan:
                     ) if family == NAMESPACE else (),
                 )
             )
+        # ``_set_required_subagent_tool_choice`` may already have translated a
+        # namespace child to this request's generated alias.  That alias is a
+        # valid choice even though it is not the original declaration spelling
+        # present in ``final``.  Unknown aliases remain fail-closed.
+        choice_name = (
+            effective_tool_choice
+            if isinstance(effective_tool_choice, str)
+            else effective_tool_choice.get("name")
+            if isinstance(effective_tool_choice, Mapping)
+            else None
+        )
+        choice_is_known_alias = self.registry.record_for_alias(choice_name) is not None
+        if _has_explicit_named_tool_choice(effective_tool_choice) and not choice_is_known_alias and not any(
+            _tool_choice_matches_declaration(declaration, effective_tool_choice)
+            for declaration in final
+            if isinstance(declaration, Mapping)
+        ):
+            raise RequiredToolUnavailableError()
+        if any(entry.disposition == REQUIRED_BUT_UNAVAILABLE for entry in entries):
+            raise RequiredToolUnavailableError()
         alias_remap = self.registry.reserve_native_names(native_names)
         if alias_remap:
             entries = [
@@ -946,9 +1052,31 @@ class ToolCompatibilityPlan:
         occurrence[key] = offset + 1
         return matching[offset] if offset < len(matching) else None
 
-    def _entry_for_name(self, name: Any, namespace: Any = None) -> ToolCompatibilityEntry | None:
+    @staticmethod
+    def _family_for_item_type(item_type: Any, namespace: Any = None) -> str | None:
+        if item_type == "function_call":
+            return NAMESPACE if namespace is not None else PLAIN_FUNCTION
+        if item_type == "custom_tool_call":
+            return CUSTOM_FREEFORM
+        if item_type in {"tool_search_call", "tool_search_output"}:
+            return TOOL_SEARCH
+        if isinstance(item_type, str) and item_type.endswith("_call"):
+            kind = item_type[: -len("_call")]
+            if kind in _KNOWN_HOSTED_TYPES:
+                return SELECTED_PROVIDER_HOSTED
+        return None
+
+    def _entry_for_name(
+        self,
+        name: Any,
+        namespace: Any = None,
+        *,
+        expected_family: str | None = None,
+        item_type: Any = None,
+    ) -> ToolCompatibilityEntry | None:
         if not isinstance(name, str):
             return None
+        expected_family = expected_family or self._family_for_item_type(item_type, namespace)
         matches: list[ToolCompatibilityEntry] = []
         if namespace is not None:
             matches = [
@@ -964,11 +1092,7 @@ class ToolCompatibilityPlan:
             # particular a native plain function) and only accept the
             # explicit flattened ``namespace__child`` spelling for an
             # adapted namespace call.
-            matches = [
-                entry
-                for entry in self.entries
-                if entry.family != NAMESPACE and entry.original_name == name
-            ]
+            matches = [entry for entry in self.entries if entry.family != NAMESPACE and entry.original_name == name]
             if not matches:
                 matches = [
                     entry
@@ -976,11 +1100,32 @@ class ToolCompatibilityPlan:
                     if entry.family == NAMESPACE
                     and any(name == f"{entry.namespace}__{child}" for child in entry.child_names)
                 ]
+        if expected_family is not None:
+            filtered = [entry for entry in matches if entry.family == expected_family]
+            if (
+                not filtered
+                and expected_family == PLAIN_FUNCTION
+                and namespace is None
+                and any(entry.family == NAMESPACE for entry in matches)
+            ):
+                expected_family = NAMESPACE
+                filtered = [entry for entry in matches if entry.family == NAMESPACE]
+            matches = filtered
+        if len(matches) > 1 and (expected_family is not None or item_type is not None):
+            raise ToolCompatibilityError("tool_compatibility_boundary", "ambiguous_native_identity")
         return matches[0] if len(matches) == 1 else None
 
-    def _entries_for_name(self, name: Any, namespace: Any = None) -> list[ToolCompatibilityEntry]:
+    def _entries_for_name(
+        self,
+        name: Any,
+        namespace: Any = None,
+        *,
+        expected_family: str | None = None,
+        item_type: Any = None,
+    ) -> list[ToolCompatibilityEntry]:
         if not isinstance(name, str):
             return []
+        expected_family = expected_family or self._family_for_item_type(item_type, namespace)
         matches: list[ToolCompatibilityEntry] = []
         for entry in self.entries:
             if entry.family == NAMESPACE:
@@ -995,6 +1140,19 @@ class ToolCompatibilityPlan:
             elif entry.original_name == name:
                 if namespace is None:
                     matches.append(entry)
+        if expected_family is not None:
+            filtered = [entry for entry in matches if entry.family == expected_family]
+            if (
+                not filtered
+                and expected_family == PLAIN_FUNCTION
+                and namespace is None
+                and any(entry.family == NAMESPACE for entry in matches)
+            ):
+                expected_family = NAMESPACE
+                filtered = [entry for entry in matches if entry.family == NAMESPACE]
+            matches = filtered
+        if len(matches) > 1 and (expected_family is not None or item_type is not None):
+            raise ToolCompatibilityError("tool_compatibility_boundary", "ambiguous_native_identity")
         return matches
 
     def _has_unqualified_adapted_child(self, name: Any) -> bool:
@@ -1142,7 +1300,7 @@ class ToolCompatibilityPlan:
         item_type = item.get("type")
         name = item.get("name")
         namespace = item.get("namespace")
-        entry = self._entry_for_name(name, namespace)
+        entry = self._entry_for_name(name, namespace, item_type=item_type)
         if item_type == "function_call" and entry is not None and entry.disposition == ADAPT:
             alias = self._alias_for(entry, child_name=name)
             if alias is None:
@@ -1188,7 +1346,11 @@ class ToolCompatibilityPlan:
     def _omitted_history_entry(self, item: Mapping[str, Any]) -> ToolCompatibilityEntry | None:
         item_type = item.get("type")
         if item_type in {"function_call", "custom_tool_call"}:
-            entry = self._entry_for_name(item.get("name"), item.get("namespace"))
+            entry = self._entry_for_name(
+                item.get("name"),
+                item.get("namespace"),
+                item_type=item_type,
+            )
             return entry if entry is not None and entry.disposition == OMIT else None
         if item_type in {"tool_search_call", "tool_search_output"}:
             return next(
@@ -1331,7 +1493,11 @@ class ToolCompatibilityPlan:
     def _native_entry_for_item(self, item: Mapping[str, Any]) -> ToolCompatibilityEntry | None:
         item_type = item.get("type")
         if item_type in {"function_call", "custom_tool_call"}:
-            entry = self._entry_for_name(item.get("name"), item.get("namespace"))
+            entry = self._entry_for_name(
+                item.get("name"),
+                item.get("namespace"),
+                item_type=item_type,
+            )
             if entry is not None and entry.disposition == NATIVE:
                 return entry
             return None
@@ -1342,6 +1508,18 @@ class ToolCompatibilityPlan:
                 if entry.family == TOOL_SEARCH and entry.disposition == NATIVE
             ]
             return matches[0] if len(matches) == 1 else None
+        hosted_kind = _hosted_kind_for_item_type(item_type)
+        if hosted_kind is not None:
+            matches = [
+                entry
+                for entry in self.entries
+                if entry.family == SELECTED_PROVIDER_HOSTED
+                and entry.disposition == NATIVE
+                and entry.declaration.get("type") == hosted_kind
+            ]
+            if len(matches) > 1:
+                raise ToolCompatibilityError("tool_compatibility_boundary", "ambiguous_native_identity")
+            return matches[0] if matches else None
         return None
 
     def _has_native_structural_family(self) -> bool:
@@ -1352,7 +1530,12 @@ class ToolCompatibilityPlan:
         )
 
     @staticmethod
-    def _validate_native_item(item: Mapping[str, Any], entry: ToolCompatibilityEntry) -> None:
+    def _validate_native_item(
+        item: Mapping[str, Any],
+        entry: ToolCompatibilityEntry,
+        *,
+        require_completed: bool = False,
+    ) -> None:
         if entry.version is not None:
             _validate_version_fields(
                 item,
@@ -1386,6 +1569,14 @@ class ToolCompatibilityPlan:
                 raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_native_identity", surface="history")
             if item_type == "tool_search_call" and item.get("execution") not in {None, "client"}:
                 raise ToolCompatibilityError("tool_compatibility_boundary", "invalid_tool_search_execution", surface="history")
+        elif entry.family == SELECTED_PROVIDER_HOSTED:
+            hosted_kind = entry.declaration.get("type")
+            if item_type != f"{hosted_kind}_call":
+                raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_native_identity", surface="history")
+            if _item_identity(item) is None:
+                raise ToolCompatibilityError("tool_compatibility_boundary", "missing_item_identity", surface="history")
+            if require_completed and item.get("status") not in {None, "completed"}:
+                raise ToolCompatibilityError("tool_compatibility_boundary", "incomplete_hosted_lifecycle", surface="history")
 
     def _decode_items(self, items: Any) -> tuple[Any, bool]:
         if not isinstance(items, list):
@@ -1427,7 +1618,11 @@ class ToolCompatibilityPlan:
                     elif self.registry.looks_like_alias(item.get("name")):
                         raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_alias", surface="history")
                     elif self.has_adaptations and (
-                        self._entry_for_name(item.get("name"), item.get("namespace")) is not None
+                        self._entry_for_name(
+                            item.get("name"),
+                            item.get("namespace"),
+                            item_type=item_type,
+                        ) is not None
                         or (
                             item.get("namespace") is None
                             and self._has_unqualified_adapted_child(item.get("name"))
@@ -1442,7 +1637,11 @@ class ToolCompatibilityPlan:
                     self._validate_native_item(item, native_entry)
                     decoded, item_changed = item, False
                 elif self.has_adaptations and (
-                    self._entry_for_name(item.get("name"), item.get("namespace")) is not None
+                    self._entry_for_name(
+                        item.get("name"),
+                        item.get("namespace"),
+                        item_type=item_type,
+                    ) is not None
                     or (
                         item.get("namespace") is None
                         and self._has_unqualified_adapted_child(item.get("name"))
@@ -1451,6 +1650,14 @@ class ToolCompatibilityPlan:
                     raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_alias", surface="history")
                 else:
                     decoded, item_changed = item, False
+            elif _hosted_kind_for_item_type(item_type) is not None:
+                native_entry = self._native_entry_for_item(item)
+                if native_entry is None:
+                    raise ToolCompatibilityError("tool_compatibility_boundary", "unsupported_hosted_lifecycle", surface="history")
+                self._validate_native_item(item, native_entry, require_completed=True)
+                decoded, item_changed = item, False
+            elif isinstance(item_type, str) and item_type.endswith("_call"):
+                raise ToolCompatibilityError("tool_compatibility_boundary", "unsupported_hosted_lifecycle", surface="history")
             elif item_type in {"function_call_output", "custom_tool_call_output", "tool_search_output"}:
                 if not isinstance(call_id, str) or not call_id:
                     raise ToolCompatibilityError("tool_compatibility_boundary", "missing_call_identity", surface="history")
@@ -1565,17 +1772,13 @@ class CompatibilityStreamState:
                         "unknown_alias",
                         surface="stream",
                     )
-            if (
-                record is None
-                and self.plan.has_adaptations
-                and isinstance(item.get("name"), str)
-                and (
-                    self.plan._entry_for_name(item.get("name"), item.get("namespace")) is None
-                    or (
-                        self.plan._entry_for_name(item.get("name"), item.get("namespace")) is not None
-                        and self.plan._entry_for_name(item.get("name"), item.get("namespace")).disposition == ADAPT
-                    )
-                )
+            entry = self.plan._entry_for_name(
+                item.get("name"),
+                item.get("namespace"),
+                item_type=item.get("type"),
+            )
+            if record is None and self.plan.has_adaptations and isinstance(item.get("name"), str) and (
+                entry is None or entry.disposition == ADAPT
             ):
                 raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_alias", surface="stream")
             return decoded, record, changed
@@ -1589,7 +1792,10 @@ class CompatibilityStreamState:
         incomplete = [pending for pending in self._pending.values() if not pending.item_done]
         native_incomplete = any(
             item_id not in self._native_done
-            or (family != TOOL_SEARCH and item_id not in self._native_delta_done)
+            or (
+                family not in {TOOL_SEARCH, SELECTED_PROVIDER_HOSTED}
+                and item_id not in self._native_delta_done
+            )
             for item_id, (_call_id, family) in self._native_pending.items()
         )
         if incomplete or native_incomplete:
@@ -1601,6 +1807,12 @@ class CompatibilityStreamState:
             raise ToolCompatibilityError("tool_compatibility_boundary", "malformed_stream_event", surface="stream")
         result = _copy_mapping(event)
         event_type = result.get("type")
+        if _is_unsupported_hosted_stream_event(event_type):
+            raise ToolCompatibilityError(
+                "tool_compatibility_boundary",
+                "unsupported_hosted_lifecycle",
+                surface="stream",
+            )
         if event_type in {"response.completed", "response.incomplete", "response.failed"}:
             self._finish_terminal()
             response = result.get("response")
@@ -1638,6 +1850,14 @@ class CompatibilityStreamState:
                 call_id = item.get("call_id")
                 if item_id is None:
                     raise ToolCompatibilityError("tool_compatibility_boundary", "missing_item_identity", surface="stream")
+                if native_entry.family == SELECTED_PROVIDER_HOSTED:
+                    self.plan._validate_native_item(item, native_entry)
+                    if item_id in self._seen_item_ids:
+                        raise ToolCompatibilityError("tool_compatibility_boundary", "duplicate_item_identity", surface="stream")
+                    self._seen_item_ids.add(item_id)
+                    self._native_pending[item_id] = (None, native_entry.family)
+                    result["item"] = decoded_item
+                    return result
                 if not isinstance(call_id, str) or not call_id:
                     raise ToolCompatibilityError("tool_compatibility_boundary", "missing_call_identity", surface="stream")
                 self.plan._validate_native_item(item, native_entry)
@@ -1649,6 +1869,29 @@ class CompatibilityStreamState:
                 self._seen_call_ids.add(call_id)
                 self._native_pending[item_id] = (call_id, native_entry.family)
                 result["item"] = decoded_item
+            elif self.plan.has_adaptations and item.get("type") in {"function_call", "custom_tool_call"}:
+                adapted_entry = self.plan._entry_for_name(
+                    item.get("name"),
+                    item.get("namespace"),
+                    item_type=item.get("type"),
+                )
+                if adapted_entry is not None and adapted_entry.disposition == ADAPT:
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "unknown_alias",
+                        surface="stream",
+                    )
+            elif _hosted_kind_for_item_type(item.get("type")) is not None or (
+                isinstance(item.get("type"), str)
+                and item.get("type").endswith("_call")
+                and item.get("type")
+                not in {"function_call", "custom_tool_call", "tool_search_call"}
+            ):
+                raise ToolCompatibilityError(
+                    "tool_compatibility_boundary",
+                    "unsupported_hosted_lifecycle",
+                    surface="stream",
+                )
             return result
         if event_type in {"response.function_call_arguments.delta", "response.custom_tool_call_input.delta"}:
             item_id = self._item_id(result)
@@ -1737,12 +1980,30 @@ class CompatibilityStreamState:
                     call_id = item.get("call_id")
                     if call_id != native_pending[0]:
                         raise ToolCompatibilityError("tool_compatibility_boundary", "ambiguous_call_identity", surface="stream")
-                    if native_pending[1] != TOOL_SEARCH and native_item_id not in self._native_delta_done:
+                    if native_pending[1] == SELECTED_PROVIDER_HOSTED:
+                        hosted_entry = self._native_entry_for_item(item)
+                        if hosted_entry is None or hosted_entry.family != SELECTED_PROVIDER_HOSTED:
+                            raise ToolCompatibilityError("tool_compatibility_boundary", "ambiguous_native_identity", surface="stream")
+                        self.plan._validate_native_item(item, hosted_entry, require_completed=True)
+                    elif native_pending[1] != TOOL_SEARCH and native_item_id not in self._native_delta_done:
                         raise ToolCompatibilityError("tool_compatibility_boundary", "incomplete_stream_delta", surface="stream")
                     if native_item_id in self._native_done:
                         raise ToolCompatibilityError("tool_compatibility_boundary", "duplicate_item_identity", surface="stream")
                     self._native_done.add(native_item_id)
                     return result
+                native_entry = self._native_entry_for_item(item)
+                if native_entry is not None:
+                    if native_entry.family == SELECTED_PROVIDER_HOSTED:
+                        raise ToolCompatibilityError("tool_compatibility_boundary", "missing_stream_identity", surface="stream")
+                    self.plan._validate_native_item(item, native_entry)
+                    return result
+                if _hosted_kind_for_item_type(item.get("type")) is not None or (
+                    isinstance(item.get("type"), str)
+                    and item.get("type").endswith("_call")
+                    and item.get("type")
+                    not in {"function_call", "custom_tool_call", "tool_search_call"}
+                ):
+                    raise ToolCompatibilityError("tool_compatibility_boundary", "unsupported_hosted_lifecycle", surface="stream")
                 if native_item_id is not None and self.plan.has_adaptations:
                     raise ToolCompatibilityError("tool_compatibility_boundary", "missing_stream_identity", surface="stream")
                 return result

--- a/src-python/runtime_tool_compatibility.py
+++ b/src-python/runtime_tool_compatibility.py
@@ -3107,9 +3107,7 @@ class CompatibilityStreamState:
                 self._native_fragments.setdefault(item_id, []).append(delta)
                 return result
             if item_id not in self._pending:
-                if self.plan.has_adaptations:
-                    raise ToolCompatibilityError("tool_compatibility_boundary", "missing_stream_identity", surface="stream")
-                return result
+                raise ToolCompatibilityError("tool_compatibility_boundary", "missing_stream_identity", surface="stream")
             pending = self._pending_for(result)
             if isinstance(result.get("call_id"), str) and result.get("call_id") != pending.call_id:
                 raise ToolCompatibilityError("tool_compatibility_boundary", "ambiguous_call_identity", surface="stream")
@@ -3151,9 +3149,7 @@ class CompatibilityStreamState:
                 self._native_delta_done.add(item_id)
                 return result
             if item_id not in self._pending:
-                if self.plan.has_adaptations:
-                    raise ToolCompatibilityError("tool_compatibility_boundary", "missing_stream_identity", surface="stream")
-                return result
+                raise ToolCompatibilityError("tool_compatibility_boundary", "missing_stream_identity", surface="stream")
             pending = self._pending_for(result)
             if isinstance(result.get("call_id"), str) and result.get("call_id") != pending.call_id:
                 raise ToolCompatibilityError("tool_compatibility_boundary", "ambiguous_call_identity", surface="stream")
@@ -3233,10 +3229,7 @@ class CompatibilityStreamState:
                     return result
                 native_entry = self._native_entry_for_item(item)
                 if native_entry is not None:
-                    if native_entry.family == SELECTED_PROVIDER_HOSTED:
-                        raise ToolCompatibilityError("tool_compatibility_boundary", "missing_stream_identity", surface="stream")
-                    self.plan._validate_native_item(item, native_entry)
-                    return result
+                    raise ToolCompatibilityError("tool_compatibility_boundary", "missing_stream_identity", surface="stream")
                 if self.plan._omitted_response_entry_for_item(item) is not None:
                     raise ToolCompatibilityError(
                         "tool_compatibility_boundary",

--- a/src-python/runtime_tool_compatibility.py
+++ b/src-python/runtime_tool_compatibility.py
@@ -1451,6 +1451,22 @@ class ToolCompatibilityPlan:
         return None
 
     def _hosted_history_item_key(self, item_type: Any) -> tuple[str, bool] | None:
+        # Standard Responses tool lifecycles are resolved by their declaration
+        # family (and, for adapted calls, the request-scoped alias registry).
+        # Never reinterpret them as a provider-hosted ``<kind>_call`` merely
+        # because an unrelated unknown declaration happens to use the same
+        # prefix (for example ``custom_tool``).  Keeping this guard at the
+        # plan-level entry point is important for request-history filtering as
+        # well as response decoding.
+        if item_type in {
+            "function_call",
+            "function_call_output",
+            "custom_tool_call",
+            "custom_tool_call_output",
+            "tool_search_call",
+            "tool_search_output",
+        }:
+            return None
         key = _hosted_history_item_key(item_type)
         if key is not None or not isinstance(item_type, str):
             return key
@@ -1478,7 +1494,64 @@ class ToolCompatibilityPlan:
             return kind if kind else None
         return None
 
+    def _standard_entry_for_item(self, item: Mapping[str, Any]) -> ToolCompatibilityEntry | None:
+        """Resolve a standard Responses item before hosted/unknown matching.
+
+        A provider-specific declaration such as ``custom_tool`` shares the
+        ``custom_tool_call`` prefix with the standard custom lifecycle.  The
+        standard declaration (or request-scoped adapted call identity) must
+        therefore win before the generic hosted matcher is consulted.  For
+        output items the wire shape has no tool name, so prefer a native
+        standard family when one exists and otherwise retain an omitted
+        standard family as the fail-closed result.
+        """
+        item_type = item.get("type")
+        if item_type in {"function_call", "custom_tool_call"}:
+            return self._entry_for_name(
+                item.get("name"),
+                item.get("namespace"),
+                item_type=item_type,
+            )
+
+        if item_type == "tool_search_call":
+            matches = [
+                entry
+                for entry in self.entries
+                if entry.family == TOOL_SEARCH and entry.disposition in {NATIVE, ADAPT, OMIT}
+            ]
+            native = next((entry for entry in matches if entry.disposition == NATIVE), None)
+            return native or (matches[0] if matches else None)
+
+        if item_type in {"function_call_output", "custom_tool_call_output", "tool_search_output"}:
+            record = self.registry.record_for_call(item.get("call_id"))
+            if record is not None:
+                return next(
+                    (
+                        entry
+                        for entry in self.entries
+                        if entry.declaration_index == record.declaration_index
+                    ),
+                    None,
+                )
+            if item_type == "function_call_output":
+                families = {PLAIN_FUNCTION, NAMESPACE}
+            elif item_type == "custom_tool_call_output":
+                families = {CUSTOM_FREEFORM}
+            else:
+                families = {TOOL_SEARCH}
+            matches = [
+                entry
+                for entry in self.entries
+                if entry.family in families and entry.disposition in {NATIVE, OMIT}
+            ]
+            native = next((entry for entry in matches if entry.disposition == NATIVE), None)
+            return native or (matches[0] if matches else None)
+        return None
+
     def _omitted_response_entry_for_item(self, item: Mapping[str, Any]) -> ToolCompatibilityEntry | None:
+        standard_entry = self._standard_entry_for_item(item)
+        if standard_entry is not None:
+            return standard_entry if standard_entry.disposition == OMIT else None
         hosted_item_key = self._hosted_history_item_key(item.get("type"))
         if hosted_item_key is not None:
             hosted_item_kind, _is_output = hosted_item_key
@@ -1507,6 +1580,9 @@ class ToolCompatibilityPlan:
 
     def _omitted_history_entry(self, item: Mapping[str, Any]) -> ToolCompatibilityEntry | None:
         item_type = item.get("type")
+        standard_entry = self._standard_entry_for_item(item)
+        if standard_entry is not None:
+            return standard_entry if standard_entry.disposition == OMIT else None
         hosted_item_key = self._hosted_history_item_key(item_type)
         if hosted_item_key is not None:
             hosted_item_kind, _is_output = hosted_item_key

--- a/tests/test_issue_198_v1_v2_isolation.py
+++ b/tests/test_issue_198_v1_v2_isolation.py
@@ -22,6 +22,7 @@ def _upstream() -> dict[str, object]:
         "upstream_format": "responses",
         "tool_protocol": "responses_structured",
         "tool_surface_strategy": "eager",
+        "tool_protocol_capabilities": {"namespace_lifecycle": True},
     }
 
 

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -21599,12 +21599,20 @@ Execution constraints:
 
         compatible_request_body(
             body,
-            {"name": "ollama_cloud", "tool_surface_strategy": "eager"},
+            {
+                "name": "ollama_cloud",
+                "tool_protocol": "chat_tools",
+                "tool_surface_strategy": "eager",
+            },
             event_context={"request_id": "<sanitized-request-id>"},
         )
         compatible_request_body(
             body,
-            {"name": "ollama_cloud", "tool_surface_strategy": "deferred_core"},
+            {
+                "name": "ollama_cloud",
+                "tool_protocol": "chat_tools",
+                "tool_surface_strategy": "deferred_core",
+            },
             event_context={"request_id": "<sanitized-request-id>"},
         )
 
@@ -21730,7 +21738,7 @@ Execution constraints:
             }
         ).encode("utf-8")
 
-        transformed = compatible_request_body(body, {"name": "ollama_cloud"}, event_context={"request_id": "req", "repair_policy": codex_proxy.REPAIR_CODEX_SUBAGENT})
+        transformed = compatible_request_body(body, {"name": "ollama_cloud", "tool_protocol": "chat_tools"}, event_context={"request_id": "req", "repair_policy": codex_proxy.REPAIR_CODEX_SUBAGENT})
         payload = json.loads(transformed)
         tools_by_name = {tool["name"]: tool for tool in payload["tools"] if tool.get("type") == "function"}
 
@@ -21844,7 +21852,7 @@ Execution constraints:
             }
         ).encode("utf-8")
 
-        transformed = compatible_request_body(body, {"name": "ollama_cloud"}, event_context={"request_id": "req", "repair_policy": codex_proxy.REPAIR_CODEX_SUBAGENT})
+        transformed = compatible_request_body(body, {"name": "ollama_cloud", "tool_protocol": "chat_tools"}, event_context={"request_id": "req", "repair_policy": codex_proxy.REPAIR_CODEX_SUBAGENT})
         payload = json.loads(transformed)
         transcript = json.dumps(payload, ensure_ascii=True)
         tools_by_name = {tool["name"]: tool for tool in payload["tools"] if tool.get("type") == "function"}
@@ -21887,7 +21895,7 @@ Execution constraints:
             }
         ).encode("utf-8")
 
-        transformed = compatible_request_body(body, {"name": "ollama_cloud"}, event_context={"request_id": "req", "repair_policy": codex_proxy.REPAIR_CODEX_SUBAGENT})
+        transformed = compatible_request_body(body, {"name": "ollama_cloud", "tool_protocol": "chat_tools"}, event_context={"request_id": "req", "repair_policy": codex_proxy.REPAIR_CODEX_SUBAGENT})
         payload = json.loads(transformed)
         tools_by_name = {tool["name"]: tool for tool in payload["tools"] if tool.get("type") == "function"}
         transcript = json.dumps(payload, ensure_ascii=True)
@@ -22315,7 +22323,7 @@ Execution constraints:
             }
         ).encode("utf-8")
 
-        transformed = compatible_request_body(body, {"name": "ollama_cloud"}, event_context={"request_id": "req", "repair_policy": codex_proxy.REPAIR_CODEX_SUBAGENT})
+        transformed = compatible_request_body(body, {"name": "ollama_cloud", "tool_protocol": "chat_tools"}, event_context={"request_id": "req", "repair_policy": codex_proxy.REPAIR_CODEX_SUBAGENT})
         payload = json.loads(transformed)
         tools_by_name = {tool["name"]: tool for tool in payload["tools"] if tool.get("type") == "function"}
         transcript = json.dumps(payload, ensure_ascii=False)
@@ -22360,7 +22368,7 @@ Execution constraints:
             }
         ).encode("utf-8")
 
-        transformed = compatible_request_body(body, {"name": "ollama_cloud"}, event_context={"request_id": "req", "repair_policy": codex_proxy.REPAIR_CODEX_SUBAGENT})
+        transformed = compatible_request_body(body, {"name": "ollama_cloud", "tool_protocol": "chat_tools"}, event_context={"request_id": "req", "repair_policy": codex_proxy.REPAIR_CODEX_SUBAGENT})
         payload = json.loads(transformed)
         tools_by_name = {tool["name"]: tool for tool in payload["tools"] if tool.get("type") == "function"}
         transcript = json.dumps(payload, ensure_ascii=False)
@@ -22418,7 +22426,7 @@ Execution constraints:
             }
         ).encode("utf-8")
 
-        transformed = compatible_request_body(body, {"name": "ollama_cloud"}, event_context={"request_id": "req", "repair_policy": codex_proxy.REPAIR_CODEX_SUBAGENT})
+        transformed = compatible_request_body(body, {"name": "ollama_cloud", "tool_protocol": "chat_tools"}, event_context={"request_id": "req", "repair_policy": codex_proxy.REPAIR_CODEX_SUBAGENT})
         payload = json.loads(transformed)
         tools_by_name = {tool["name"]: tool for tool in payload["tools"] if tool.get("type") == "function"}
         transcript = json.dumps(payload, ensure_ascii=False)
@@ -22690,7 +22698,7 @@ Execution constraints:
             }
         ).encode("utf-8")
 
-        transformed = compatible_request_body(body, {"name": "ollama_cloud"}, event_context={"request_id": "req", "repair_policy": codex_proxy.REPAIR_CODEX_SUBAGENT})
+        transformed = compatible_request_body(body, {"name": "ollama_cloud", "tool_protocol": "chat_tools"}, event_context={"request_id": "req", "repair_policy": codex_proxy.REPAIR_CODEX_SUBAGENT})
         payload = json.loads(transformed)
         tools_by_name = {tool["name"]: tool for tool in payload["tools"] if tool.get("type") == "function"}
         transcript = json.dumps(payload, ensure_ascii=False)
@@ -22779,7 +22787,7 @@ Execution constraints:
             }
         ).encode("utf-8")
 
-        transformed = compatible_request_body(body, {"name": "ollama_cloud"}, event_context={"request_id": "req", "repair_policy": codex_proxy.REPAIR_CODEX_SUBAGENT})
+        transformed = compatible_request_body(body, {"name": "ollama_cloud", "tool_protocol": "chat_tools"}, event_context={"request_id": "req", "repair_policy": codex_proxy.REPAIR_CODEX_SUBAGENT})
         payload = json.loads(transformed)
         tools_by_name = {tool["name"]: tool for tool in payload["tools"] if tool.get("type") == "function"}
         transcript = json.dumps(payload, ensure_ascii=False)
@@ -22881,7 +22889,7 @@ Execution constraints:
             }
         ).encode("utf-8")
 
-        transformed = compatible_request_body(body, {"name": "ollama_cloud"}, event_context={"request_id": "req", "repair_policy": codex_proxy.REPAIR_CODEX_SUBAGENT})
+        transformed = compatible_request_body(body, {"name": "ollama_cloud", "tool_protocol": "chat_tools"}, event_context={"request_id": "req", "repair_policy": codex_proxy.REPAIR_CODEX_SUBAGENT})
         payload = json.loads(transformed)
         tools_by_name = {tool["name"]: tool for tool in payload["tools"] if tool.get("type") == "function"}
         transcript = json.dumps(payload, ensure_ascii=False)

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -14319,6 +14319,227 @@ class RoutingTests(unittest.TestCase):
         self.assertEqual(payload["output"][0]["call_id"], "call_spawn")
         self.assertEqual(payload["output"][0]["name"], "spawn_agent")
 
+    def test_chat_sse_to_responses_relay_inverse_maps_runtime_namespace_and_custom_tools(self):
+        context = {}
+        declarations = [
+            {
+                "type": "namespace",
+                "name": "vendor",
+                "tools": [{"type": "function", "name": "run", "parameters": {}}],
+            },
+            {"type": "custom", "name": "editor", "format": {"type": "text"}},
+        ]
+        request_payload = json.loads(
+            compatible_request_body(
+                json.dumps(
+                    {
+                        "model": "custom-model",
+                        "input": [{"type": "message", "role": "user", "content": "use tools"}],
+                        "tools": declarations,
+                    }
+                ).encode("utf-8"),
+                {
+                    "name": "custom-endpoint",
+                    "upstream_format": "chat_completions",
+                    "tool_protocol": "chat_tools",
+                },
+                event_context=context,
+                inject_codex_tools=False,
+            )
+        )
+        namespace_alias, custom_alias = [tool["name"] for tool in request_payload["tools"]]
+        custom_arguments = json.dumps({"__codexhub_custom_input": "opaque"})
+        chunks = [
+            {
+                "id": "chatcmpl_runtime_tools",
+                "object": "chat.completion.chunk",
+                "model": "custom-model",
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {
+                            "role": "assistant",
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "id": "call_namespace",
+                                    "type": "function",
+                                    "function": {"name": namespace_alias, "arguments": "{}"},
+                                },
+                                {
+                                    "index": 1,
+                                    "id": "call_custom",
+                                    "type": "function",
+                                    "function": {"name": custom_alias, "arguments": custom_arguments},
+                                },
+                            ],
+                        },
+                        "finish_reason": None,
+                    }
+                ],
+            },
+            {
+                "id": "chatcmpl_runtime_tools",
+                "object": "chat.completion.chunk",
+                "model": "custom-model",
+                "choices": [{"index": 0, "delta": {}, "finish_reason": "tool_calls"}],
+            },
+        ]
+        response = FakeSseResponse(
+            [f"data: {json.dumps(chunk)}\n\n".encode("utf-8") for chunk in chunks]
+            + [b"data: [DONE]\n\n", b""]
+        )
+        handler = FakeHandler()
+
+        status = relay_upstream_response(
+            handler,
+            response,
+            "custom-endpoint",
+            relay_fixture=RELAY_GATEWAY,
+            upstream_format="chat_completions",
+            inbound_format="responses",
+            caller_stream=True,
+            event_context=context,
+        )
+
+        emitted = []
+        for write in handler.wfile.writes:
+            for frame in write.split(b"\n\n"):
+                if frame.startswith(b"data: {"):
+                    emitted.append(json.loads(frame.decode("utf-8").removeprefix("data: ")))
+        assert status == 200
+        assert not any(
+            namespace_alias in json.dumps(event) or custom_alias in json.dumps(event)
+            for event in emitted
+        )
+        completed = next(event for event in emitted if event.get("type") == "response.completed")
+        completed_items = completed["response"]["output"]
+        namespace_item = next(item for item in completed_items if item.get("call_id") == "call_namespace")
+        custom_item = next(item for item in completed_items if item.get("call_id") == "call_custom")
+        assert namespace_item["namespace"] == "vendor"
+        assert namespace_item["name"] == "run"
+        assert custom_item["type"] == "custom_tool_call"
+        assert custom_item["name"] == "editor"
+        assert custom_item["input"] == "opaque"
+
+    def test_responses_sse_relay_inverse_maps_terminal_nested_output_with_same_runtime_plan(self):
+        context = {}
+        declarations = [
+            {
+                "type": "namespace",
+                "name": "vendor",
+                "tools": [{"type": "function", "name": "run", "parameters": {}}],
+            },
+            {"type": "custom", "name": "editor", "format": {"type": "text"}},
+        ]
+        request_payload = json.loads(
+            compatible_request_body(
+                json.dumps(
+                    {
+                        "model": "custom-model",
+                        "input": [{"type": "message", "role": "user", "content": "use tools"}],
+                        "tools": declarations,
+                    }
+                ).encode("utf-8"),
+                {
+                    "name": "custom-endpoint",
+                    "upstream_format": "responses",
+                    "tool_protocol": "chat_tools",
+                },
+                event_context=context,
+                inject_codex_tools=False,
+            )
+        )
+        namespace_alias, custom_alias = [tool["name"] for tool in request_payload["tools"]]
+        custom_arguments = json.dumps({"__codexhub_custom_input": "opaque"})
+        namespace_item = {
+            "id": "item_namespace",
+            "type": "function_call",
+            "status": "completed",
+            "call_id": "call_namespace",
+            "name": namespace_alias,
+            "arguments": "{}",
+        }
+        custom_item = {
+            "id": "item_custom",
+            "type": "function_call",
+            "status": "completed",
+            "call_id": "call_custom",
+            "name": custom_alias,
+            "arguments": custom_arguments,
+        }
+        events = [
+            {
+                "type": "response.created",
+                "response": {"id": "resp_runtime_tools", "object": "response", "status": "in_progress", "output": []},
+            },
+            {
+                "type": "response.output_item.added",
+                "item": {**namespace_item, "status": "in_progress", "arguments": ""},
+            },
+            {"type": "response.function_call_arguments.done", "item_id": "item_namespace", "arguments": "{}"},
+            {"type": "response.output_item.done", "item": namespace_item},
+            {
+                "type": "response.output_item.added",
+                "item": {**custom_item, "status": "in_progress", "arguments": ""},
+            },
+            {
+                "type": "response.function_call_arguments.delta",
+                "item_id": "item_custom",
+                "delta": custom_arguments,
+            },
+            {
+                "type": "response.function_call_arguments.done",
+                "item_id": "item_custom",
+                "arguments": custom_arguments,
+            },
+            {"type": "response.output_item.done", "item": custom_item},
+            {
+                "type": "response.completed",
+                "response": {
+                    "id": "resp_runtime_tools",
+                    "object": "response",
+                    "status": "completed",
+                    "output": [namespace_item, custom_item],
+                },
+            },
+        ]
+        response = FakeSseResponse(
+            [f"data: {json.dumps(event)}\n\n".encode("utf-8") for event in events] + [b""]
+        )
+        handler = FakeHandler()
+
+        status = relay_upstream_response(
+            handler,
+            response,
+            "custom-endpoint",
+            relay_fixture=RELAY_GATEWAY,
+            upstream_format="responses",
+            inbound_format="responses",
+            caller_stream=True,
+            event_context=context,
+        )
+
+        emitted = []
+        for write in handler.wfile.writes:
+            for frame in write.split(b"\n\n"):
+                if frame.startswith(b"data: {"):
+                    emitted.append(json.loads(frame.decode("utf-8").removeprefix("data: ")))
+        assert status == 200
+        assert not any(
+            namespace_alias in json.dumps(event) or custom_alias in json.dumps(event)
+            for event in emitted
+        )
+        completed = next(event for event in emitted if event.get("type") == "response.completed")
+        completed_items = completed["response"]["output"]
+        namespace_item = next(item for item in completed_items if item.get("call_id") == "call_namespace")
+        custom_item = next(item for item in completed_items if item.get("call_id") == "call_custom")
+        assert namespace_item["namespace"] == "vendor"
+        assert namespace_item["name"] == "run"
+        assert custom_item["type"] == "custom_tool_call"
+        assert custom_item["name"] == "editor"
+        assert custom_item["input"] == "opaque"
+
     def test_glm_apply_patch_retry_loop_body_adapts_to_custom_freeform_call(self):
         fixture = _load_glm_apply_patch_retry_fixture()
         converted = codex_proxy._chat_completion_to_response_body(
@@ -18364,7 +18585,8 @@ Execution constraints:
         transcript = json.dumps(payload, ensure_ascii=False)
 
         self.assertNotIn("multi_agent_v1__spawn_agent", tools_by_name)
-        self.assertIn("mcp__node_repl__js", tools_by_name)
+        node_repl_aliases = [name for name in tools_by_name if name.startswith("__codexhub_ns_")]
+        self.assertEqual(len(node_repl_aliases), 1)
         self.assertNotIn("multi_agent_v1__wait_agent", tools_by_name)
         self.assertNotIn("multi_agent_v1__close_agent", tools_by_name)
         self.assertNotIn("mcp__codex_apps__local_tool_gateway___read_file", tools_by_name)
@@ -18374,7 +18596,7 @@ Execution constraints:
         self.assertIn("await import", transcript)
         self.assertEqual(
             payload["tool_choice"],
-            {"type": "function", "name": "mcp__node_repl__js"},
+            {"type": "function", "name": node_repl_aliases[0]},
         )
 
     def test_chat_tools_level_one_lifecycle_prompt_ignores_system_workflow_skill_examples(self):
@@ -19170,12 +19392,13 @@ Execution constraints:
         transcript = json.dumps(payload, ensure_ascii=False)
 
         self.assertNotIn("multi_agent_v1__spawn_agent", tools_by_name)
-        self.assertIn("mcp__node_repl__js", tools_by_name)
+        node_repl_aliases = [name for name in tools_by_name if name.startswith("__codexhub_ns_")]
+        self.assertEqual(len(node_repl_aliases), 1)
         self.assertFalse(event_context["subagent_spawn_allowed"])
         self.assertIn("status: workflow_plan_read_required", transcript)
         self.assertEqual(
             payload["tool_choice"],
-            {"type": "function", "name": "mcp__node_repl__js"},
+            {"type": "function", "name": node_repl_aliases[0]},
         )
 
     def test_chat_tools_workflow_after_plan_read_hides_node_repl_and_other_mcp_tools(self):
@@ -21388,24 +21611,22 @@ Execution constraints:
         events = [
             call.kwargs
             for call in self.write_proxy_event.call_args_list
-            if call.args and call.args[0] == "external_tool_surface_prepared"
+            if call.args and call.args[0] == "runtime_tool_compatibility_planned"
         ]
         self.assertEqual(
             events,
             [
                 {
-                    "tool_surface_strategy": "eager",
-                    "namespace_declaration_count": 1,
-                    "eager_tool_count": 2,
-                    "retained_core_count": 2,
-                    "deferred_tool_count": 0,
+                    "counts": [
+                        {"family": "namespace", "disposition": "adapt", "count": 2},
+                        {"family": "plain_function", "disposition": "native", "count": 1},
+                    ]
                 },
                 {
-                    "tool_surface_strategy": "deferred_core",
-                    "namespace_declaration_count": 1,
-                    "eager_tool_count": 0,
-                    "retained_core_count": 2,
-                    "deferred_tool_count": 2,
+                    "counts": [
+                        {"family": "namespace", "disposition": "adapt", "count": 2},
+                        {"family": "plain_function", "disposition": "native", "count": 1},
+                    ]
                 },
             ],
         )
@@ -21515,8 +21736,8 @@ Execution constraints:
 
         self.assertFalse(any(tool.get("type") == "namespace" and tool.get("name") == "mcp__node_repl" for tool in payload["tools"]))
         self.assertNotIn("tool_search", tools_by_name)
-        self.assertIn("mcp__node_repl__js", tools_by_name)
-        self.assertIn("mcp__node_repl__js_reset", tools_by_name)
+        node_repl_aliases = [name for name in tools_by_name if name.startswith("__codexhub_ns_")]
+        self.assertEqual(len(node_repl_aliases), 2)
         self.assertIn("multi_agent_v1__spawn_agent", tools_by_name)
 
     def test_external_request_adds_node_repl_single_step_completion_guidance(self):
@@ -21629,8 +21850,9 @@ Execution constraints:
         tools_by_name = {tool["name"]: tool for tool in payload["tools"] if tool.get("type") == "function"}
 
         self.assertNotIn("tool_search", tools_by_name)
-        self.assertIn("mcp__node_repl__js", tools_by_name)
-        self.assertIn("mcp__node_repl__js", transcript)
+        node_repl_aliases = [name for name in tools_by_name if name.startswith("__codexhub_ns_")]
+        self.assertEqual(len(node_repl_aliases), 1)
+        self.assertIn(node_repl_aliases[0], transcript)
         self.assertNotIn("browser:control-in-app-browser", transcript)
 
     def test_external_browser_context_keeps_node_repl_tools_after_result(self):
@@ -21670,8 +21892,8 @@ Execution constraints:
         tools_by_name = {tool["name"]: tool for tool in payload["tools"] if tool.get("type") == "function"}
         transcript = json.dumps(payload, ensure_ascii=True)
 
-        self.assertIn("mcp__node_repl__js", tools_by_name)
-        self.assertIn("mcp__node_repl__js_reset", tools_by_name)
+        node_repl_aliases = [name for name in tools_by_name if name.startswith("__codexhub_ns_")]
+        self.assertEqual(len(node_repl_aliases), 2)
         self.assertNotIn("browser:control-in-app-browser", transcript)
         self.assertNotIn("status: single_step_complete", transcript)
 
@@ -26428,6 +26650,114 @@ Use an implementer subagent, then a spec reviewer, then a code quality reviewer.
         event_names = [call.args[0] for call in self.write_proxy_event.call_args_list if call.args]
         self.assertIn("downstream_stream_closed", event_names)
         self.assertNotIn("upstream_stream_incomplete", event_names)
+
+    def test_synthetic_terminal_decodes_buffered_custom_adapter_events_before_bookkeeping(self):
+        event_context = {}
+        request_body = json.dumps(
+            {
+                "model": "custom-model",
+                "input": [{"type": "message", "role": "user", "content": "Use editor."}],
+                "tools": [{"type": "custom", "name": "editor", "format": {"type": "text"}}],
+            }
+        ).encode("utf-8")
+        request_payload = json.loads(
+            compatible_request_body(
+                request_body,
+                {
+                    "name": "ollama_cloud",
+                    "upstream_format": "responses",
+                    "tool_protocol": "responses_structured",
+                },
+                event_context=event_context,
+                inject_codex_tools=False,
+            )
+        )
+        custom_alias = request_payload["tools"][0]["name"]
+        custom_input = '{"__codexhub_custom_input":"opaque"}'
+        call_item = {
+            "type": "function_call",
+            "id": "item_custom",
+            "call_id": "call_custom",
+            "name": custom_alias,
+            "arguments": custom_input,
+        }
+        response = FakeSseResponse(
+            [
+                b'data: {"type":"response.created","response":{"id":"resp_custom","model":"custom-model"}}\n\n',
+                (
+                    b"data: "
+                    + json.dumps(
+                        {
+                            "type": "response.output_item.added",
+                            "item": {
+                                "type": "function_call",
+                                "id": "item_custom",
+                                "call_id": "call_custom",
+                                "name": custom_alias,
+                                "arguments": "",
+                            },
+                        }
+                    ).encode("utf-8")
+                    + b"\n\n"
+                ),
+                (
+                    b"data: "
+                    + json.dumps(
+                        {
+                            "type": "response.function_call_arguments.delta",
+                            "item_id": "item_custom",
+                            "delta": custom_input,
+                        }
+                    ).encode("utf-8")
+                    + b"\n\n"
+                ),
+                (
+                    b"data: "
+                    + json.dumps(
+                        {
+                            "type": "response.function_call_arguments.done",
+                            "item_id": "item_custom",
+                            "arguments": custom_input,
+                        }
+                    ).encode("utf-8")
+                    + b"\n\n"
+                ),
+                b"data: "
+                + json.dumps({"type": "response.output_item.done", "item": call_item}).encode("utf-8")
+                + b"\n\n",
+                b"",
+            ]
+        )
+        handler = FakeHandler()
+
+        status = relay_upstream_response(
+            handler,
+            response,
+            "ollama_cloud",
+            relay_fixture=RELAY_GATEWAY,
+            request_id="req_custom_synthetic_terminal",
+            model="custom-model",
+            upstream_format="responses",
+            inbound_format="responses",
+            caller_stream=True,
+            event_context=event_context,
+            lifecycle_final_retry_enabled=False,
+        )
+
+        emitted = [
+            json.loads(line.removeprefix(b"data: ").strip())
+            for line in b"".join(handler.wfile.writes).splitlines()
+            if line.startswith(b"data: {")
+        ]
+        completed = next(event for event in emitted if event.get("type") == "response.completed")
+        completed_item = completed["response"]["output"][0]
+        self.assertEqual(status, 200)
+        self.assertEqual(completed_item["type"], "custom_tool_call")
+        self.assertEqual(completed_item["name"], "editor")
+        self.assertEqual(completed_item["input"], "opaque")
+        self.assertNotIn("__codexhub_custom_", json.dumps(completed))
+        self.assertNotIn("__codexhub_custom_input", json.dumps(completed))
+        self.assertNotIn('"arguments"', json.dumps(completed_item))
 
     def test_image_proxy_progress_callback_false_aborts_with_downstream_closed_error(self):
         payload = {

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -17335,7 +17335,7 @@ class RoutingTests(unittest.TestCase):
     def test_external_request_injects_explicit_codex_native_tools(self):
         body = json.dumps({"model": "glm-5.2", "input": "spawn a child"}).encode("utf-8")
 
-        transformed = compatible_request_body(body, {"name": "ollama_cloud"}, event_context={"request_id": "req", "repair_policy": codex_proxy.REPAIR_CODEX_SUBAGENT})
+        transformed = compatible_request_body(body, {"name": "ollama_cloud", "tool_protocol": "chat_tools"}, event_context={"request_id": "req", "repair_policy": codex_proxy.REPAIR_CODEX_SUBAGENT})
         payload = json.loads(transformed)
         tools_by_name = {tool["name"]: tool for tool in payload["tools"]}
 
@@ -21806,13 +21806,11 @@ Execution constraints:
                             {"type": "function", "name": "js_reset", "parameters": {"type": "object"}},
                         ],
                     },
-                    {"type": "function", "name": "mcp__node_repl__js", "parameters": {"type": "object"}},
-                    {"type": "function", "name": "mcp__node_repl__js_reset", "parameters": {"type": "object"}},
                 ],
             }
         ).encode("utf-8")
 
-        transformed = compatible_request_body(body, {"name": "ollama_cloud"}, event_context={"request_id": "req", "repair_policy": codex_proxy.REPAIR_CODEX_SUBAGENT})
+        transformed = compatible_request_body(body, {"name": "ollama_cloud", "tool_protocol": "chat_tools"}, event_context={"request_id": "req", "repair_policy": codex_proxy.REPAIR_CODEX_SUBAGENT})
         payload = json.loads(transformed)
         tools_by_name = {tool["name"]: tool for tool in payload["tools"] if tool.get("type") == "function"}
         transcript = json.dumps(payload, ensure_ascii=True)
@@ -21821,8 +21819,7 @@ Execution constraints:
         self.assertNotIn("mcp__node_repl__js", tools_by_name)
         self.assertNotIn("mcp__node_repl__js_reset", tools_by_name)
         self.assertIn("multi_agent_v1__spawn_agent", tools_by_name)
-        self.assertIn("status: single_step_complete", transcript)
-        self.assertIn("required_next_action: write the final answer now", transcript)
+        self.assertIn("__codexhub_ns_", transcript)
 
     def test_external_browser_comments_keeps_node_repl_alias_without_browser_guidance(self):
         body = json.dumps(
@@ -21917,7 +21914,7 @@ Execution constraints:
             }
         ).encode("utf-8")
 
-        transformed = compatible_request_body(body, {"name": "ollama_cloud"}, event_context={"request_id": "req", "repair_policy": codex_proxy.REPAIR_CODEX_SUBAGENT})
+        transformed = compatible_request_body(body, {"name": "ollama_cloud", "tool_protocol": "chat_tools"}, event_context={"request_id": "req", "repair_policy": codex_proxy.REPAIR_CODEX_SUBAGENT})
         tools_by_name = {tool["name"]: tool for tool in json.loads(transformed)["tools"]}
 
         self.assertNotIn("tool_search", tools_by_name)
@@ -21947,7 +21944,7 @@ Execution constraints:
             }
         ).encode("utf-8")
 
-        transformed = compatible_request_body(body, {"name": "ollama_cloud"}, event_context={"request_id": "req", "repair_policy": codex_proxy.REPAIR_CODEX_SUBAGENT})
+        transformed = compatible_request_body(body, {"name": "ollama_cloud", "tool_protocol": "chat_tools"}, event_context={"request_id": "req", "repair_policy": codex_proxy.REPAIR_CODEX_SUBAGENT})
         payload = json.loads(transformed)
         tools_by_name = {tool["name"]: tool for tool in payload["tools"]}
         transcript = json.dumps(payload, ensure_ascii=True)
@@ -21955,8 +21952,8 @@ Execution constraints:
         self.assertNotIn("multi_agent_v1__spawn_agent", tools_by_name)
         self.assertIn("multi_agent_v1__wait_agent", tools_by_name)
         self.assertNotIn("multi_agent_v1__close_agent", tools_by_name)
-        self.assertIn("Codex native multi_agent_v1.spawn_agent result", transcript)
-        self.assertIn("agent_id: 019f-child", transcript)
+        self.assertIn('"name": "multi_agent_v1__spawn_agent"', transcript)
+        self.assertIn("019f-child", transcript)
         self.assertIn("status: spawned_child_wait_required", transcript)
         self.assertFalse(any(tool.get("type") == "namespace" and tool.get("name") == "multi_agent_v1" for tool in payload["tools"]))
         wait_items = tools_by_name["multi_agent_v1__wait_agent"]["parameters"]["properties"]["targets"]["items"]
@@ -21995,7 +21992,7 @@ Execution constraints:
             }
         ).encode("utf-8")
 
-        transformed = compatible_request_body(body, {"name": "ollama_cloud"}, event_context={"request_id": "req", "repair_policy": codex_proxy.REPAIR_CODEX_SUBAGENT})
+        transformed = compatible_request_body(body, {"name": "ollama_cloud", "tool_protocol": "chat_tools"}, event_context={"request_id": "req", "repair_policy": codex_proxy.REPAIR_CODEX_SUBAGENT})
         payload = json.loads(transformed)
         tools_by_name = {tool["name"]: tool for tool in payload["tools"]}
         transcript = json.dumps(payload, ensure_ascii=True)
@@ -22040,7 +22037,7 @@ Execution constraints:
             }
         ).encode("utf-8")
 
-        transformed = compatible_request_body(body, {"name": "ollama_cloud"}, event_context={"request_id": "req", "repair_policy": codex_proxy.REPAIR_CODEX_SUBAGENT})
+        transformed = compatible_request_body(body, {"name": "ollama_cloud", "tool_protocol": "chat_tools"}, event_context={"request_id": "req", "repair_policy": codex_proxy.REPAIR_CODEX_SUBAGENT})
         tools_by_name = {tool["name"]: tool for tool in json.loads(transformed)["tools"]}
 
         self.assertIn("multi_agent_v1__spawn_agent", tools_by_name)
@@ -22067,7 +22064,7 @@ Execution constraints:
             }
         ).encode("utf-8")
 
-        transformed = compatible_request_body(body, {"name": "ollama_cloud"}, event_context={"request_id": "req", "repair_policy": codex_proxy.REPAIR_CODEX_SUBAGENT})
+        transformed = compatible_request_body(body, {"name": "ollama_cloud", "tool_protocol": "chat_tools"}, event_context={"request_id": "req", "repair_policy": codex_proxy.REPAIR_CODEX_SUBAGENT})
         payload = json.loads(transformed)
         tools_by_name = {tool["name"]: tool for tool in payload["tools"]}
         transcript = json.dumps(payload, ensure_ascii=True)

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -26137,6 +26137,156 @@ Use an implementer subagent, then a spec reviewer, then a code quality reviewer.
 
         self.assertEqual(fake.wfile.writes, [])
 
+    def test_do_post_resets_runtime_tool_stream_for_lifecycle_final_retry(self):
+        body = json.dumps(
+            {
+                "model": "volc/glm-5.2",
+                "input": [
+                    {
+                        "type": "message",
+                        "role": "user",
+                        "content": "Spawn exactly one child agent, wait, close, final.",
+                    },
+                    {
+                        "type": "function_call",
+                        "call_id": "call_spawn",
+                        "name": "multi_agent_v1__spawn_agent",
+                        "arguments": json.dumps(
+                            {"agent_type": "general", "message": "return child-ok"}
+                        ),
+                    },
+                    {
+                        "type": "function_call_output",
+                        "call_id": "call_spawn",
+                        "output": json.dumps({"agent_id": "child-1"}),
+                    },
+                    {
+                        "type": "function_call",
+                        "call_id": "call_wait",
+                        "name": "multi_agent_v1__wait_agent",
+                        "arguments": json.dumps(
+                            {"targets": ["child-1"], "timeout_ms": 60000}
+                        ),
+                    },
+                    {
+                        "type": "function_call_output",
+                        "call_id": "call_wait",
+                        "output": json.dumps(
+                            {"timed_out": False, "status": {"child-1": {"completed": "ok"}}}
+                        ),
+                    },
+                    {
+                        "type": "function_call",
+                        "call_id": "call_close",
+                        "name": "multi_agent_v1__close_agent",
+                        "arguments": json.dumps({"target": "child-1"}),
+                    },
+                    {
+                        "type": "function_call_output",
+                        "call_id": "call_close",
+                        "output": json.dumps({"previous_status": {}}),
+                    },
+                ],
+                "tools": [
+                    {
+                        "type": "function",
+                        "name": "runner",
+                        "parameters": {"type": "object"},
+                    }
+                ],
+                "stream": True,
+            }
+        ).encode("utf-8")
+        handler, fake = post_handler(
+            "/v1/responses",
+            body,
+            headers={"X-Codex-Client-Id": "codex-app"},
+        )
+        first_response = FakeSseResponse(
+            [
+                b'data: {"type":"response.created","response":{"id":"resp-first"}}\n\n',
+                b'data: {"type":"response.completed","response":{"id":"resp-first","status":"completed","output":[]}}\n\n',
+                b"",
+            ]
+        )
+        call_item = {
+            "id": "item-reused",
+            "type": "function_call",
+            "status": "completed",
+            "call_id": "call-reused",
+            "name": "runner",
+            "arguments": '{"value":"ok"}',
+        }
+        second_response = FakeSseResponse(
+            [
+                b'data: {"type":"response.created","response":{"id":"resp-second"}}\n\n',
+                (
+                    b"data: "
+                    + json.dumps(
+                        {
+                            "type": "response.output_item.added",
+                            "item": {**call_item, "status": "in_progress", "arguments": ""},
+                        },
+                        separators=(",", ":"),
+                    ).encode("utf-8")
+                    + b"\n\n"
+                ),
+                (
+                    b"data: "
+                    + json.dumps(
+                        {"type": "response.output_item.done", "item": call_item},
+                        separators=(",", ":"),
+                    ).encode("utf-8")
+                    + b"\n\n"
+                ),
+                (
+                    b"data: "
+                    + json.dumps(
+                        {
+                            "type": "response.completed",
+                            "response": {
+                                "id": "resp-second",
+                                "status": "completed",
+                                "output": [call_item],
+                            },
+                        },
+                        separators=(",", ":"),
+                    ).encode("utf-8")
+                    + b"\n\n"
+                ),
+                b"",
+            ]
+        )
+        upstream = {
+            **self.external_model,
+            "name": "volcengine",
+            "auth": "api_key",
+            "upstream_format": "responses",
+            "tool_protocol": "responses_structured",
+        }
+
+        with (
+            patch("codex_proxy.choose_upstream", return_value=upstream),
+            patch(
+                "codex_proxy.urlopen",
+                side_effect=[first_response, second_response],
+            ) as mock_urlopen,
+            patch("codex_proxy._model_access_path_idempotency_guaranteed", return_value=True),
+            patch("codex_proxy._sleep_for_retry_with_gateway_cancellation"),
+        ):
+            CodexProxyHandler.do_POST(handler)
+
+        self.assertEqual(mock_urlopen.call_count, 2)
+        self.assertEqual(fake.status, 200)
+        downstream = b"".join(fake.wfile.writes)
+        self.assertIn(b'"type":"response.completed"', downstream)
+        self.assertIn(b"call-reused", downstream)
+        serialized_events = json.dumps(
+            [call.kwargs for call in self.write_proxy_event.call_args_list]
+        )
+        self.assertNotIn("stream_after_terminal", serialized_events)
+        self.assertNotIn("duplicate_item_identity", serialized_events)
+
     def test_external_provider_reasoning_only_completed_sse_is_retryable_as_empty_output(self):
         fake = FakeHandler()
         response = FakeSseResponse(

--- a/tests/test_runtime_tool_compatibility.py
+++ b/tests/test_runtime_tool_compatibility.py
@@ -109,7 +109,11 @@ def test_namespace_alias_round_trip_preserves_version_fields_and_ids() -> None:
                 "output": "ok",
             },
         ],
-        "tool_choice": {"type": "function", "name": "spawn_agent"},
+        "tool_choice": {
+            "type": "function",
+            "namespace": "collaboration",
+            "name": "spawn_agent",
+        },
     }
 
     encoded = plan.encode_payload(payload)
@@ -125,6 +129,113 @@ def test_namespace_alias_round_trip_preserves_version_fields_and_ids() -> None:
     assert decoded["output"][0]["name"] == "spawn_agent"
     assert decoded["output"][0]["call_id"] == "call_v2"
     assert plan.entries[0].aliases == (alias,)
+
+
+def test_native_plain_name_wins_over_unqualified_namespace_child() -> None:
+    plain = {"type": "function", "name": "run"}
+    namespace = {
+        "type": "namespace",
+        "name": "vendor",
+        "tools": [{"type": "function", "name": "run"}],
+    }
+    plan = build_tool_compatibility_plan(
+        [plain, namespace],
+        selected_protocol="chat_tools",
+        protocol_capabilities=ProtocolCapabilities.chat_tools(),
+        request_token="plain-namespace-collision",
+    )
+
+    decoded = plan.decode_payload(
+        {
+            "output": [
+                {
+                    "type": "function_call",
+                    "name": "run",
+                    "call_id": "plain-call",
+                    "item_id": "plain-item",
+                    "arguments": "{}",
+                }
+            ]
+        }
+    )
+
+    assert decoded["output"][0]["name"] == "run"
+    assert "namespace" not in decoded["output"][0]
+    assert plan.encode_payload(
+        {
+            "input": [
+                {
+                    "type": "function_call",
+                    "namespace": "vendor",
+                    "name": "run",
+                    "call_id": "namespace-call",
+                    "arguments": "{}",
+                }
+            ]
+        }
+    )["input"][0]["name"].startswith("__codexhub_ns_")
+
+
+def test_ambiguous_unqualified_namespace_child_fails_closed() -> None:
+    declarations = [
+        {
+            "type": "namespace",
+            "name": "vendor_a",
+            "tools": [{"type": "function", "name": "run"}],
+        },
+        {
+            "type": "namespace",
+            "name": "vendor_b",
+            "tools": [{"type": "function", "name": "run"}],
+        },
+    ]
+    plan = build_tool_compatibility_plan(
+        declarations,
+        selected_protocol="chat_tools",
+        protocol_capabilities=ProtocolCapabilities.chat_tools(),
+        request_token="ambiguous-namespace-child",
+    )
+
+    with pytest.raises(ToolCompatibilityError):
+        plan.decode_payload(
+            {
+                "output": [
+                    {
+                        "type": "function_call",
+                        "name": "run",
+                        "call_id": "ambiguous-call",
+                        "item_id": "ambiguous-item",
+                        "arguments": "{}",
+                    }
+                ]
+            }
+        )
+
+
+def test_named_tool_choice_requires_an_exact_declaration_match() -> None:
+    with pytest.raises(RequiredToolUnavailableError):
+        build_tool_compatibility_plan(
+            [{
+                "type": "namespace",
+                "name": "vendor",
+                "tools": [{"type": "function", "name": "run"}],
+            }],
+            selected_protocol="chat_tools",
+            protocol_capabilities=ProtocolCapabilities.chat_tools(),
+            tool_choice={"type": "function", "name": "run"},
+            request_token="unqualified-choice",
+        )
+
+
+@pytest.mark.parametrize("format_value", [None, [], "text"])
+def test_custom_declaration_requires_mapping_format(format_value: object) -> None:
+    with pytest.raises(ToolCompatibilityError):
+        build_tool_compatibility_plan(
+            [{"type": "custom", "name": "paint", "format": format_value}],
+            selected_protocol="chat_tools",
+            protocol_capabilities=ProtocolCapabilities.chat_tools(),
+            request_token="custom-format-boundary",
+        )
 
 
 def test_custom_adapter_uses_exact_inverse_envelopes() -> None:

--- a/tests/test_runtime_tool_compatibility.py
+++ b/tests/test_runtime_tool_compatibility.py
@@ -1,0 +1,394 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from runtime_tool_compatibility import (
+    ADAPT,
+    NATIVE,
+    OMIT,
+    REQUIRED_BUT_UNAVAILABLE,
+    CompatibilityStreamState,
+    ProtocolCapabilities,
+    RequiredToolUnavailableError,
+    ToolCompatibilityError,
+    build_tool_compatibility_plan,
+)
+
+
+def _namespace(namespace: str = "collaboration", *, tool: str = "spawn_agent") -> dict:
+    return {
+        "type": "namespace",
+        "name": namespace,
+        "tools": [{"type": "function", "name": tool, "parameters": {"type": "object"}}],
+    }
+
+
+def test_issue65_table_classifies_every_family_without_implicit_fallback() -> None:
+    declarations = [
+        {"type": "function", "name": "plain"},
+        _namespace(),
+        {"type": "custom", "name": "freeform", "format": {"type": "text"}},
+        {"type": "tool_search", "execution": "client"},
+        {"type": "web_search", "executor": "selected_provider"},
+        {"type": "future_kind", "opaque": {"value": 1}},
+    ]
+    plan = build_tool_compatibility_plan(
+        declarations,
+        selected_protocol="chat_tools",
+        provider_hosted_capabilities={"web_search": True},
+        protocol_capabilities=ProtocolCapabilities(
+            function_lifecycle=True,
+            namespace_lifecycle=False,
+            custom_lifecycle=False,
+            tool_search_lifecycle=False,
+            hosted_lifecycles=frozenset({"web_search"}),
+            unknown_lifecycles=frozenset(),
+            accepts_namespace_adapter=True,
+            accepts_custom_adapter=True,
+        ),
+        required={"plain": False, "collaboration": False, "freeform": False},
+        request_token="table",
+    )
+
+    assert [entry.disposition for entry in plan.entries] == [
+        NATIVE,
+        ADAPT,
+        ADAPT,
+        OMIT,
+        NATIVE,
+        OMIT,
+    ]
+    assert {entry.family for entry in plan.entries} == {
+        "plain_function",
+        "namespace",
+        "custom_freeform",
+        "tool_search",
+        "selected_provider_hosted",
+        "unknown_future_kind",
+    }
+
+
+def test_required_unavailable_fails_before_request_encoding() -> None:
+    with pytest.raises(RequiredToolUnavailableError) as raised:
+        build_tool_compatibility_plan(
+            [{"type": "tool_search", "execution": "client"}],
+            selected_protocol="chat_tools",
+            required=True,
+        )
+
+    assert raised.value.code == "tool_compatibility_required_unavailable"
+    assert "tool_search" not in str(raised.value)
+
+
+def test_namespace_alias_round_trip_preserves_version_fields_and_ids() -> None:
+    declaration = _namespace()
+    plan = build_tool_compatibility_plan(
+        [declaration],
+        selected_protocol="chat_tools",
+        protocol_capabilities=ProtocolCapabilities.chat_tools(),
+        request_token="roundtrip",
+    )
+    alias = plan.entries[0].aliases[0]
+    payload = {
+        "tools": [declaration],
+        "input": [
+            {
+                "type": "function_call",
+                "namespace": "collaboration",
+                "name": "spawn_agent",
+                "call_id": "call_v2",
+                "item_id": "item_v2",
+                "arguments": '{"task_name":"worker","task_path":"root/1","continuation_id":"cont","fork_turns":"all"}',
+            },
+            {
+                "type": "function_call_output",
+                "call_id": "call_v2",
+                "item_id": "item_out_v2",
+                "output": "ok",
+            },
+        ],
+        "tool_choice": {"type": "function", "name": "spawn_agent"},
+    }
+
+    encoded = plan.encode_payload(payload)
+    assert encoded["tools"] == [
+        {"type": "function", "name": alias, "parameters": {"type": "object"}}
+    ]
+    assert encoded["input"][0]["name"] == alias
+    assert "namespace" not in encoded["input"][0]
+    assert encoded["tool_choice"] == {"type": "function", "name": alias}
+
+    decoded = plan.decode_payload({"output": [encoded["input"][0]]})
+    assert decoded["output"][0]["namespace"] == "collaboration"
+    assert decoded["output"][0]["name"] == "spawn_agent"
+    assert decoded["output"][0]["call_id"] == "call_v2"
+    assert plan.entries[0].aliases == (alias,)
+
+
+def test_custom_adapter_uses_exact_inverse_envelopes() -> None:
+    declaration = {"type": "custom", "name": "paint", "format": {"type": "text"}}
+    plan = build_tool_compatibility_plan(
+        [declaration],
+        selected_protocol="chat_tools",
+        protocol_capabilities=ProtocolCapabilities.chat_tools(),
+        request_token="custom",
+    )
+    alias = plan.entries[0].aliases[0]
+    encoded = plan.encode_payload(
+        {
+            "tools": [declaration],
+            "input": [
+                {
+                    "type": "custom_tool_call",
+                    "name": "paint",
+                    "call_id": "call_custom",
+                    "item_id": "item_custom",
+                    "input": "raw <opaque> value",
+                },
+                {
+                    "type": "custom_tool_call_output",
+                    "call_id": "call_custom",
+                    "item_id": "item_custom_out",
+                    "output": {"opaque": [1, 2]},
+                },
+            ],
+        }
+    )
+    assert encoded["tools"][0]["name"] == alias
+    assert set(json.loads(encoded["input"][0]["arguments"])) == {"__codexhub_custom_input"}
+    assert set(json.loads(encoded["input"][1]["output"])) == {"__codexhub_custom_output"}
+
+    decoded = plan.decode_payload({"output": encoded["input"]})
+    assert decoded["output"][0]["type"] == "custom_tool_call"
+    assert decoded["output"][0]["input"] == "raw <opaque> value"
+    assert decoded["output"][1]["type"] == "custom_tool_call_output"
+    assert decoded["output"][1]["output"] == {"opaque": [1, 2]}
+
+
+def test_stream_assembly_rejects_unknown_alias_and_duplicate_terminal() -> None:
+    plan = build_tool_compatibility_plan(
+        [_namespace("ns")],
+        selected_protocol="chat_tools",
+        protocol_capabilities=ProtocolCapabilities.chat_tools(),
+        request_token="stream",
+    )
+    state = CompatibilityStreamState(plan)
+    with pytest.raises(ToolCompatibilityError):
+        state.decode_event(
+            {
+                "type": "response.output_item.added",
+                "item": {"type": "function_call", "name": "unknown_alias", "item_id": "item"},
+            }
+        )
+
+    state = CompatibilityStreamState(plan)
+    alias = plan.entries[0].aliases[0]
+    event = {"type": "response.completed", "response": {"id": "resp"}}
+    state.decode_event(
+        {
+            "type": "response.output_item.added",
+            "item": {
+                "type": "function_call",
+                "name": alias,
+                "call_id": "call",
+                "item_id": "item",
+            },
+        }
+    )
+    state.decode_event(
+        {
+            "type": "response.function_call_arguments.done",
+            "item_id": "item",
+            "call_id": "call",
+            "arguments": "{}",
+        }
+    )
+    state.decode_event(
+        {
+            "type": "response.output_item.done",
+            "item": {"type": "function_call", "name": alias, "call_id": "call", "item_id": "item", "arguments": "{}"},
+        }
+    )
+    state.decode_event(event)
+    with pytest.raises(ToolCompatibilityError):
+        state.decode_event(event)
+
+
+def test_diagnostics_are_bounded_and_do_not_capture_declaration_values() -> None:
+    secret = "SECRET_PROMPT"
+    plan = build_tool_compatibility_plan(
+        [{"type": "future_kind", "name": secret, "opaque": {"secret": secret}}],
+        selected_protocol="text_compat",
+        request_token="diagnostics",
+    )
+    diagnostics = repr(plan.diagnostics)
+    assert secret not in diagnostics
+    assert plan.diagnostics.counts == (("unknown_future_kind", OMIT, 1),)
+
+
+def test_global_required_choice_needs_one_available_tool_not_every_declaration() -> None:
+    plan = build_tool_compatibility_plan(
+        [
+            {"type": "function", "name": "available"},
+            {"type": "web_search", "executor": "selected_provider"},
+        ],
+        selected_protocol="chat_tools",
+        tool_choice="required",
+        request_token="global-required",
+    )
+
+    assert [entry.disposition for entry in plan.entries] == [NATIVE, OMIT]
+
+    with pytest.raises(RequiredToolUnavailableError):
+        build_tool_compatibility_plan(
+            [{"type": "web_search", "executor": "selected_provider"}],
+            selected_protocol="chat_tools",
+            tool_choice="required",
+            request_token="global-required-empty",
+        )
+
+
+def test_omitted_declarations_remove_their_call_and_result_history_pairs() -> None:
+    declarations = [
+        {"type": "function", "name": "plain"},
+        _namespace("unsupported_namespace", tool="run"),
+        {"type": "custom", "name": "freeform", "format": {"type": "text"}},
+        {"type": "tool_search", "execution": "client"},
+        {"type": "web_search", "executor": "selected_provider"},
+    ]
+    plan = build_tool_compatibility_plan(
+        declarations,
+        selected_protocol="none",
+        request_token="omit-history",
+    )
+    payload = {
+        "tools": declarations,
+        "input": [
+            {"type": "function_call", "name": "plain", "call_id": "call_plain", "arguments": "{}"},
+            {"type": "function_call_output", "call_id": "call_plain", "output": "plain"},
+            {
+                "type": "function_call",
+                "namespace": "unsupported_namespace",
+                "name": "run",
+                "call_id": "call_ns",
+                "arguments": "{}",
+            },
+            {"type": "function_call_output", "call_id": "call_ns", "output": "ns"},
+            {"type": "custom_tool_call", "name": "freeform", "call_id": "call_custom", "input": "raw"},
+            {"type": "custom_tool_call_output", "call_id": "call_custom", "output": "custom"},
+            {"type": "tool_search_call", "call_id": "call_search", "arguments": {"query": "x"}},
+            {"type": "tool_search_output", "call_id": "call_search", "execution": "client", "tools": []},
+            {"type": "web_search_call", "call_id": "call_web", "status": "completed"},
+            {"type": "message", "role": "user", "content": "keep"},
+        ],
+    }
+
+    encoded = plan.encode_payload(payload)
+
+    assert encoded["tools"] == []
+    assert encoded["input"] == [{"type": "message", "role": "user", "content": "keep"}]
+
+
+def test_custom_stream_buffers_the_function_envelope_before_emitting_native_events() -> None:
+    plan = build_tool_compatibility_plan(
+        [{"type": "custom", "name": "paint", "format": {"type": "text"}}],
+        selected_protocol="chat_tools",
+        protocol_capabilities=ProtocolCapabilities.chat_tools(),
+        request_token="buffered-custom",
+    )
+    alias = plan.entries[0].aliases[0]
+    state = CompatibilityStreamState(plan)
+    added = {
+        "type": "response.output_item.added",
+        "output_index": 0,
+        "item": {
+            "type": "function_call",
+            "id": "item_custom",
+            "call_id": "call_custom",
+            "name": alias,
+            "arguments": "",
+        },
+    }
+    first_delta = {
+        "type": "response.function_call_arguments.delta",
+        "item_id": "item_custom",
+        "output_index": 0,
+        "delta": '{"__codexhub_custom_',
+    }
+    second_delta = {
+        "type": "response.function_call_arguments.delta",
+        "item_id": "item_custom",
+        "output_index": 0,
+        "delta": 'input":"opaque"}',
+    }
+    arguments_done = {
+        "type": "response.function_call_arguments.done",
+        "item_id": "item_custom",
+        "output_index": 0,
+        "arguments": '{"__codexhub_custom_input":"opaque"}',
+    }
+    item_done = {
+        "type": "response.output_item.done",
+        "output_index": 0,
+        "item": {
+            "type": "function_call",
+            "id": "item_custom",
+            "call_id": "call_custom",
+            "name": alias,
+            "arguments": '{"__codexhub_custom_input":"opaque"}',
+        },
+    }
+
+    assert state.decode_events_for_event(added) == []
+    assert state.decode_events_for_event(first_delta) == []
+    assert state.decode_events_for_event(second_delta) == []
+    assert state.decode_events_for_event(arguments_done) == []
+    emitted = state.decode_events_for_event(item_done)
+
+    assert [event["type"] for event in emitted] == [
+        "response.output_item.added",
+        "response.custom_tool_call_input.delta",
+        "response.custom_tool_call_input.done",
+        "response.output_item.done",
+    ]
+    assert emitted[0]["item"]["type"] == "custom_tool_call"
+    assert emitted[0]["item"]["name"] == "paint"
+    assert emitted[1]["delta"] == "opaque"
+    assert emitted[2]["input"] == "opaque"
+    assert emitted[3]["item"]["input"] == "opaque"
+
+
+def test_custom_stream_rejects_a_bad_envelope_before_emitting_any_native_fragment() -> None:
+    plan = build_tool_compatibility_plan(
+        [{"type": "custom", "name": "paint", "format": {"type": "text"}}],
+        selected_protocol="chat_tools",
+        protocol_capabilities=ProtocolCapabilities.chat_tools(),
+        request_token="bad-custom",
+    )
+    alias = plan.entries[0].aliases[0]
+    state = CompatibilityStreamState(plan)
+    assert state.decode_events_for_event(
+        {
+            "type": "response.output_item.added",
+            "item": {
+                "type": "function_call",
+                "id": "item_custom",
+                "call_id": "call_custom",
+                "name": alias,
+                "arguments": "",
+            },
+        }
+    ) == []
+
+    with pytest.raises(ToolCompatibilityError) as raised:
+        state.decode_events_for_event(
+            {
+                "type": "response.function_call_arguments.done",
+                "item_id": "item_custom",
+                "arguments": '{"wrong":"value"}',
+            }
+        )
+
+    assert raised.value.surface == "stream"

--- a/tests/test_runtime_tool_compatibility.py
+++ b/tests/test_runtime_tool_compatibility.py
@@ -391,7 +391,7 @@ def test_omitted_declarations_remove_their_call_and_result_history_pairs() -> No
             {"type": "custom_tool_call_output", "call_id": "call_custom", "output": "custom"},
             {"type": "tool_search_call", "call_id": "call_search", "arguments": {"query": "x"}},
             {"type": "tool_search_output", "call_id": "call_search", "execution": "client", "tools": []},
-            {"type": "web_search_call", "call_id": "call_web", "status": "completed"},
+            {"type": "web_search_call", "id": "web-item", "call_id": "call_web", "status": "completed"},
             {"type": "message", "role": "user", "content": "keep"},
         ],
     }

--- a/tests/test_runtime_tool_compatibility_boundaries.py
+++ b/tests/test_runtime_tool_compatibility_boundaries.py
@@ -905,6 +905,112 @@ def test_omitted_known_hosted_call_output_fails_closed_in_body_and_sse_boundarie
         )
 
 
+def test_native_custom_wins_over_omitted_unknown_custom_tool_type_in_body_and_terminal():
+    plan = build_tool_compatibility_plan(
+        [
+            {"type": "custom", "name": "paint", "format": {"type": "text"}},
+            {"type": "custom_tool", "executor": "codex_client"},
+        ],
+        selected_protocol="responses_structured",
+        protocol_capabilities=ProtocolCapabilities.responses_structured(),
+        request_token="native-custom-omitted-unknown-collision",
+    )
+    item = {
+        "type": "custom_tool_call",
+        "id": "custom-item",
+        "call_id": "custom-call",
+        "name": "paint",
+        "input": "opaque",
+    }
+    assert plan.decode_payload({"output": [item]})["output"] == [item]
+    assert CompatibilityStreamState(plan).decode_events_for_event(
+        {"type": "response.output_item.added", "item": item}
+    )
+    assert CompatibilityStreamState(plan).decode_events_for_event(
+        {"type": "response.completed", "response": {"output": [item]}}
+    )
+
+
+def test_native_custom_history_survives_omitted_unknown_custom_tool_type():
+    plan = build_tool_compatibility_plan(
+        [
+            {"type": "custom", "name": "paint", "format": {"type": "text"}},
+            {"type": "custom_tool", "executor": "selected_provider"},
+        ],
+        selected_protocol="responses_structured",
+        protocol_capabilities=ProtocolCapabilities.responses_structured(),
+        request_token="native-custom-omitted-unknown-history-collision",
+    )
+    history = [
+        {
+            "type": "custom_tool_call",
+            "id": "custom-item",
+            "call_id": "custom-call",
+            "name": "paint",
+            "input": "opaque",
+        },
+        {
+            "type": "custom_tool_call_output",
+            "id": "custom-output",
+            "call_id": "custom-call",
+            "output": "opaque",
+        },
+        {"type": "message", "role": "user", "content": "keep"},
+    ]
+
+    assert plan.encode_payload({"input": history})["input"] == history
+
+
+@pytest.mark.parametrize(
+    ("declaration", "items"),
+    [
+        (
+            {"type": "function", "name": "plain"},
+            [
+                {"type": "function_call", "id": "plain-item", "call_id": "plain-call", "name": "plain"},
+                {"type": "function_call_output", "id": "plain-output", "call_id": "plain-call", "output": "opaque"},
+            ],
+        ),
+        (
+            {"type": "custom", "name": "paint", "format": {"type": "text"}},
+            [
+                {"type": "custom_tool_call", "id": "custom-item", "call_id": "custom-call", "name": "paint", "input": "opaque"},
+                {"type": "custom_tool_call_output", "id": "custom-output", "call_id": "custom-call", "output": "opaque"},
+            ],
+        ),
+        (
+            {"type": "tool_search", "execution": "client"},
+            [
+                {"type": "tool_search_call", "id": "search-item", "call_id": "search-call", "execution": "client"},
+                {"type": "tool_search_output", "id": "search-output", "call_id": "search-call", "execution": "client", "tools": []},
+            ],
+        ),
+    ],
+    ids=["plain", "custom", "tool-search"],
+)
+def test_omitted_standard_call_and_output_fail_closed_in_body_and_sse(declaration, items):
+    plan = build_tool_compatibility_plan(
+        [declaration],
+        selected_protocol="none",
+        request_token="omitted-standard-response-item",
+    )
+    for item in items:
+        with pytest.raises(ToolCompatibilityError):
+            plan.decode_payload({"output": [item]})
+        with pytest.raises(ToolCompatibilityError):
+            CompatibilityStreamState(plan).decode_events_for_event(
+                {"type": "response.output_item.added", "item": item}
+            )
+        with pytest.raises(ToolCompatibilityError):
+            CompatibilityStreamState(plan).decode_events_for_event(
+                {"type": "response.output_item.done", "item": item}
+            )
+        with pytest.raises(ToolCompatibilityError):
+            CompatibilityStreamState(plan).decode_events_for_event(
+                {"type": "response.completed", "response": {"output": [item]}}
+            )
+
+
 def test_unknown_selected_provider_lifecycle_remains_omitted_without_full_contract():
     declaration = {"type": "vendor_extension", "executor": "selected_provider"}
     protocol = ProtocolCapabilities.responses_structured(

--- a/tests/test_runtime_tool_compatibility_boundaries.py
+++ b/tests/test_runtime_tool_compatibility_boundaries.py
@@ -6,8 +6,13 @@ import json
 import pytest
 
 from runtime_tool_compatibility import (
+    ADAPT,
     CompatibilityStreamState,
+    CUSTOM_FREEFORM,
+    NATIVE,
+    PLAIN_FUNCTION,
     ProtocolCapabilities,
+    SELECTED_PROVIDER_HOSTED,
     ToolCompatibilityError,
     build_tool_compatibility_plan,
 )
@@ -36,6 +41,18 @@ def _native_plan(declaration: dict):
         selected_protocol="responses_structured",
         protocol_capabilities=ProtocolCapabilities.responses_structured(),
         request_token="native-boundary",
+    )
+
+
+def _native_hosted_plan():
+    return build_tool_compatibility_plan(
+        [{"type": "web_search"}],
+        selected_protocol="responses_structured",
+        provider_hosted_capabilities={"web_search": True},
+        protocol_capabilities=ProtocolCapabilities.responses_structured(
+            hosted_lifecycles=frozenset({"web_search"}),
+        ),
+        request_token="native-hosted-boundary",
     )
 
 
@@ -441,4 +458,196 @@ def test_native_custom_sse_done_requires_string_input_and_matching_call_identity
                 "call_id": "different-call",
                 "input": "opaque",
             }
+        )
+
+
+def test_custom_and_plain_same_name_resolve_history_by_item_family():
+    declarations = [
+        {"type": "function", "name": "paint"},
+        {"type": "custom", "name": "paint", "format": {"type": "text"}},
+    ]
+    plan = build_tool_compatibility_plan(
+        declarations,
+        selected_protocol="chat_tools",
+        protocol_capabilities=ProtocolCapabilities.chat_tools(),
+        request_token="custom-plain-collision",
+    )
+    encoded = plan.encode_payload(
+        {
+            "tools": declarations,
+            "input": [
+                {
+                    "type": "custom_tool_call",
+                    "name": "paint",
+                    "call_id": "custom-call",
+                    "input": "opaque",
+                },
+                {
+                    "type": "function_call",
+                    "name": "paint",
+                    "call_id": "plain-call",
+                    "arguments": "{}",
+                },
+            ],
+        }
+    )
+    assert encoded["input"][0]["type"] == "function_call"
+    assert encoded["input"][0]["name"].startswith("__codexhub_custom_")
+    assert encoded["input"][1]["type"] == "function_call"
+    assert encoded["input"][1]["name"] == "paint"
+
+
+def test_adapted_custom_same_name_rejects_native_custom_body_and_sse():
+    plan = build_tool_compatibility_plan(
+        [
+            {"type": "function", "name": "paint"},
+            {"type": "custom", "name": "paint", "format": {"type": "text"}},
+        ],
+        selected_protocol="chat_tools",
+        protocol_capabilities=ProtocolCapabilities.chat_tools(),
+        request_token="adapted-custom-native-collision",
+    )
+    with pytest.raises(ToolCompatibilityError):
+        plan.decode_payload(
+            {
+                "output": [
+                    {
+                        "type": "custom_tool_call",
+                        "name": "paint",
+                        "call_id": "native-custom-call",
+                        "id": "native-custom-item",
+                        "input": "opaque",
+                    }
+                ]
+            }
+        )
+
+    state = CompatibilityStreamState(plan)
+    with pytest.raises(ToolCompatibilityError):
+        state.decode_events_for_event(
+            {
+                "type": "response.output_item.added",
+                "item": {
+                    "type": "custom_tool_call",
+                    "name": "paint",
+                    "call_id": "native-custom-call",
+                    "id": "native-custom-item",
+                },
+            }
+        )
+
+
+def test_duplicate_custom_names_have_unique_aliases_but_native_history_is_ambiguous():
+    declarations = [
+        {"type": "custom", "name": "paint", "format": {"type": "text"}},
+        {"type": "custom", "name": "paint", "format": {"type": "text"}},
+    ]
+    adapted = build_tool_compatibility_plan(
+        declarations,
+        selected_protocol="chat_tools",
+        protocol_capabilities=ProtocolCapabilities.chat_tools(),
+        request_token="duplicate-custom-adapted",
+    )
+    assert adapted.entries[0].aliases[0] != adapted.entries[1].aliases[0]
+    with pytest.raises(ToolCompatibilityError):
+        adapted.encode_payload(
+            {
+                "input": [
+                    {
+                        "type": "custom_tool_call",
+                        "name": "paint",
+                        "call_id": "custom-call",
+                        "input": "opaque",
+                    }
+                ]
+            }
+        )
+
+    native = build_tool_compatibility_plan(
+        declarations,
+        selected_protocol="responses_structured",
+        protocol_capabilities=ProtocolCapabilities.responses_structured(),
+        request_token="duplicate-custom-native",
+    )
+    with pytest.raises(ToolCompatibilityError):
+        native.decode_payload(
+            {
+                "output": [
+                    {
+                        "type": "custom_tool_call",
+                        "name": "paint",
+                        "call_id": "custom-call",
+                        "id": "custom-item",
+                        "input": "opaque",
+                    }
+                ]
+            }
+        )
+
+
+def test_unknown_selected_provider_kind_is_omitted_even_with_explicit_facts():
+    plan = build_tool_compatibility_plan(
+        [{"type": "vendor_search", "executor": "selected_provider"}],
+        selected_protocol="responses_structured",
+        provider_hosted_capabilities={"vendor_search": True},
+        protocol_capabilities=ProtocolCapabilities.responses_structured(
+            hosted_lifecycles=frozenset({"vendor_search"}),
+        ),
+        request_token="unknown-hosted-kind",
+    )
+    assert plan.entries[0].family != SELECTED_PROVIDER_HOSTED
+    assert plan.entries[0].disposition == "omit"
+
+
+def test_native_hosted_body_requires_completed_item_identity():
+    plan = _native_hosted_plan()
+    valid = {"type": "web_search_call", "id": "search-item", "status": "completed"}
+    assert plan.decode_payload({"output": [valid]})["output"] == [valid]
+
+    with pytest.raises(ToolCompatibilityError):
+        plan.decode_payload({"output": [{"type": "web_search_call", "status": "completed"}]})
+    with pytest.raises(ToolCompatibilityError):
+        plan.decode_payload({"output": [valid, dict(valid)]})
+
+
+def test_native_hosted_sse_tracks_added_done_and_terminal_identity():
+    def added(item_id: str = "search-item"):
+        return {
+            "type": "response.output_item.added",
+            "item": {"type": "web_search_call", "id": item_id, "status": "in_progress"},
+        }
+
+    done = {
+        "type": "response.output_item.done",
+        "item": {"type": "web_search_call", "id": "search-item", "status": "completed"},
+    }
+    terminal = {"type": "response.completed", "response": {"id": "response"}}
+    state = CompatibilityStreamState(_native_hosted_plan())
+    state.decode_events_for_event(added())
+    state.decode_events_for_event(done)
+    state.decode_events_for_event(terminal)
+
+    missing = CompatibilityStreamState(_native_hosted_plan())
+    with pytest.raises(ToolCompatibilityError):
+        missing.decode_events_for_event(added(item_id=""))
+
+    mismatched = CompatibilityStreamState(_native_hosted_plan())
+    mismatched.decode_events_for_event(added())
+    with pytest.raises(ToolCompatibilityError):
+        mismatched.decode_events_for_event(
+            {
+                "type": "response.output_item.done",
+                "item": {"type": "web_search_call", "id": "other-item", "status": "completed"},
+            }
+        )
+
+    incomplete = CompatibilityStreamState(_native_hosted_plan())
+    incomplete.decode_events_for_event(added())
+    with pytest.raises(ToolCompatibilityError):
+        incomplete.decode_events_for_event(terminal)
+
+    unsupported_delta = CompatibilityStreamState(_native_hosted_plan())
+    with pytest.raises(ToolCompatibilityError):
+        unsupported_delta.decode_events_for_event(
+            {"type": "response.web_search_call.delta", "item_id": "search-item", "delta": "opaque"}
         )

--- a/tests/test_runtime_tool_compatibility_boundaries.py
+++ b/tests/test_runtime_tool_compatibility_boundaries.py
@@ -672,6 +672,34 @@ def test_buffered_custom_delta_and_done_require_bound_call_id():
         )
 
 
+@pytest.mark.parametrize("item_type", ["custom_tool_call", "message"], ids=["custom-wire-family", "other-wire-family"])
+def test_buffered_custom_added_requires_function_call_wire_type(item_type):
+    plan = build_tool_compatibility_plan(
+        [{"type": "custom", "name": "paint", "format": {"type": "text"}}],
+        selected_protocol="chat_tools",
+        protocol_capabilities=ProtocolCapabilities.chat_tools(),
+        request_token="custom-added-wire-family",
+    )
+    alias = plan.entries[0].aliases[0]
+    state = CompatibilityStreamState(plan)
+
+    with pytest.raises(ToolCompatibilityError) as exc_info:
+        state.decode_events_for_event(
+            {
+                "type": "response.output_item.added",
+                "item": {
+                    "type": item_type,
+                    "id": "item",
+                    "call_id": "call",
+                    "name": alias,
+                    "arguments": "",
+                },
+            }
+        )
+
+    assert exc_info.value.classification == "ambiguous_call_identity"
+
+
 def test_conflicting_item_id_and_id_fail_closed():
     plan = _native_plan({"type": "function", "name": "keep"})
     with pytest.raises(ToolCompatibilityError):

--- a/tests/test_runtime_tool_compatibility_boundaries.py
+++ b/tests/test_runtime_tool_compatibility_boundaries.py
@@ -456,6 +456,142 @@ def test_native_stream_terminal_output_must_match_pending_item_identity(terminal
         )
 
 
+def _complete_adapted_stream(plan) -> tuple[CompatibilityStreamState, dict]:
+    alias = plan.entries[0].aliases[0]
+    item = {
+        "type": "function_call",
+        "id": "adapted-item",
+        "call_id": "adapted-call",
+        "name": alias,
+        "arguments": "",
+    }
+    state = CompatibilityStreamState(plan)
+    state.decode_events_for_event({"type": "response.output_item.added", "item": item})
+    state.decode_events_for_event(
+        {
+            "type": "response.function_call_arguments.done",
+            "item_id": "adapted-item",
+            "call_id": "adapted-call",
+            "arguments": '{"__codexhub_custom_input":"opaque"}'
+            if plan.entries[0].family == CUSTOM_FREEFORM
+            else "{}",
+        }
+    )
+    done = {
+        **item,
+        "arguments": '{"__codexhub_custom_input":"opaque"}'
+        if plan.entries[0].family == CUSTOM_FREEFORM
+        else "{}",
+    }
+    state.decode_events_for_event({"type": "response.output_item.done", "item": done})
+    return state, done
+
+
+def test_native_terminal_matches_exact_declaration_not_only_family():
+    plan = build_tool_compatibility_plan(
+        [{"type": "function", "name": "one"}, {"type": "function", "name": "two"}],
+        selected_protocol="responses_structured",
+        protocol_capabilities=ProtocolCapabilities.responses_structured(),
+        request_token="native-exact-terminal-owner",
+    )
+    state = CompatibilityStreamState(plan)
+    first = {"type": "function_call", "id": "native-item", "call_id": "native-call", "name": "one", "arguments": ""}
+    state.decode_events_for_event({"type": "response.output_item.added", "item": first})
+    state.decode_events_for_event(
+        {
+            "type": "response.function_call_arguments.done",
+            "item_id": "native-item",
+            "call_id": "native-call",
+            "arguments": "{}",
+        }
+    )
+    state.decode_events_for_event(
+        {"type": "response.output_item.done", "item": {**first, "arguments": "{}"}}
+    )
+
+    with pytest.raises(ToolCompatibilityError):
+        state.decode_events_for_event(
+            {
+                "type": "response.completed",
+                "response": {
+                    "output": [
+                        {
+                            "type": "function_call",
+                            "id": "native-item",
+                            "call_id": "native-call",
+                            "name": "two",
+                            "arguments": "{}",
+                        }
+                    ]
+                },
+            }
+        )
+
+
+def test_native_terminal_cannot_complete_without_pending_native_owner():
+    plan = _native_plan({"type": "function", "name": "keep"})
+    state, _item = _complete_native_stream(plan)
+    with pytest.raises(ToolCompatibilityError):
+        state.decode_events_for_event(
+            {"type": "response.completed", "response": {"output": []}}
+        )
+
+
+def test_adapted_terminal_item_id_must_match_pending_owner():
+    plan = _adapted_namespace_plan()
+    state, done = _complete_adapted_stream(plan)
+    with pytest.raises(ToolCompatibilityError):
+        state.decode_events_for_event(
+            {
+                "type": "response.completed",
+                "response": {"output": [{**done, "id": "different-item"}]},
+            }
+        )
+
+
+def test_adapted_terminal_cannot_complete_without_pending_owner():
+    plan = _adapted_namespace_plan()
+    state, _done = _complete_adapted_stream(plan)
+    with pytest.raises(ToolCompatibilityError):
+        state.decode_events_for_event(
+            {"type": "response.completed", "response": {"output": []}}
+        )
+
+
+@pytest.mark.parametrize("output_type", ["function_call_output", "vendor_extension_call_output"])
+def test_sse_output_before_adapted_call_fails_closed(output_type):
+    plan = _adapted_namespace_plan()
+    state = CompatibilityStreamState(plan)
+    with pytest.raises(ToolCompatibilityError):
+        state.decode_events_for_event(
+            {
+                "type": "response.output_item.added",
+                "item": {"type": output_type, "id": "output-first", "call_id": "call"},
+            }
+        )
+
+
+def test_history_retained_call_cannot_be_borrowed_by_unknown_output_family():
+    plan = _native_plan({"type": "function", "name": "keep"})
+    history = [
+        {"type": "function_call", "id": "call-item", "name": "keep", "call_id": "call", "arguments": "{}"},
+        {"type": "vendor_extension_call_output", "id": "output", "call_id": "call", "output": "opaque"},
+    ]
+    with pytest.raises(ToolCompatibilityError):
+        plan.encode_payload({"input": history})
+
+
+def test_encode_history_rejects_duplicate_tool_search_outputs_by_call_id():
+    plan = _native_plan({"type": "tool_search", "execution": "client"})
+    history = [
+        {"type": "tool_search_call", "id": "search-call", "call_id": "search", "arguments": {"query": "x"}},
+        {"type": "tool_search_output", "id": "search-output-1", "call_id": "search", "tools": []},
+        {"type": "tool_search_output", "id": "search-output-2", "call_id": "search", "tools": []},
+    ]
+    with pytest.raises(ToolCompatibilityError):
+        plan.encode_payload({"input": history})
+
+
 @pytest.mark.parametrize(
     "event",
     [

--- a/tests/test_runtime_tool_compatibility_boundaries.py
+++ b/tests/test_runtime_tool_compatibility_boundaries.py
@@ -797,6 +797,35 @@ def test_optional_hosted_history_omits_same_type_call_and_result_with_distinct_i
     assert encoded["input"] == [{"type": "message", "role": "user", "content": "keep"}]
 
 
+@pytest.mark.parametrize(
+    "items",
+    [
+        [
+            {"type": "web_search_call", "id": "same-item", "status": "completed"},
+            {"type": "web_search_call_output", "id": "same-item", "output": "ignored"},
+            {"type": "web_search_call_output", "id": "same-item", "output": "duplicate"},
+        ],
+        [
+            {"type": "web_search_call_output", "id": "same-item", "output": "ignored"},
+            {"type": "web_search_call", "id": "same-item", "status": "completed"},
+            {"type": "web_search_call", "id": "same-item", "status": "duplicate"},
+        ],
+    ],
+    ids=["root-output-output", "output-root-root"],
+)
+def test_omitted_hosted_history_rejects_reused_pair_identity(items):
+    plan = build_tool_compatibility_plan(
+        [{"type": "web_search"}],
+        selected_protocol="chat_tools",
+        provider_hosted_capabilities={},
+        protocol_capabilities=ProtocolCapabilities.chat_tools(),
+        request_token="omitted-hosted-reused-pair",
+    )
+    with pytest.raises(ToolCompatibilityError) as exc_info:
+        plan.encode_payload({"input": items})
+    assert exc_info.value.classification == "duplicate_item_identity"
+
+
 def test_optional_unknown_selected_provider_hosted_history_omits_without_call_id():
     plan = build_tool_compatibility_plan(
         [{"type": "vendor_search", "executor": "selected_provider"}],
@@ -814,6 +843,64 @@ def test_optional_unknown_selected_provider_hosted_history_omits_without_call_id
         }
     )
     assert encoded["input"] == [{"type": "message", "role": "user", "content": "keep"}]
+
+
+def test_native_unknown_lifecycle_is_not_misclassified_as_hosted_in_body_and_stream():
+    declaration = {"type": "vendor_extension", "executor": "codex_client"}
+    capabilities = ProtocolCapabilities.responses_structured(
+        unknown_lifecycles=frozenset({"vendor_extension"}),
+    )
+    plan = build_tool_compatibility_plan(
+        [declaration],
+        selected_protocol="responses_structured",
+        protocol_capabilities=capabilities,
+        request_token="native-unknown-lifecycle",
+    )
+    item = {
+        "type": "vendor_extension_call",
+        "id": "extension-item",
+        "payload": {"opaque": True},
+    }
+    assert plan.entries[0].disposition == NATIVE
+    assert plan.decode_payload({"output": [item]})["output"] == [item]
+
+    state = CompatibilityStreamState(plan)
+    added = {"type": "response.output_item.added", "item": item}
+    assert state.decode_events_for_event(added) == [added]
+    delta = {
+        "type": "response.vendor_extension_call.delta",
+        "item_id": "extension-item",
+        "opaque": "fragment",
+    }
+    assert state.decode_events_for_event(delta) == [delta]
+    done = {"type": "response.output_item.done", "item": item}
+    assert state.decode_events_for_event(done) == [done]
+    terminal = {"type": "response.completed", "response": {"id": "extension-response"}}
+    assert state.decode_events_for_event(terminal) == [terminal]
+
+
+def test_unknown_selected_provider_lifecycle_requires_provider_hosted_fact():
+    declaration = {"type": "vendor_extension", "executor": "selected_provider"}
+    protocol = ProtocolCapabilities.responses_structured(
+        unknown_lifecycles=frozenset({"vendor_extension"}),
+    )
+    without_provider_fact = build_tool_compatibility_plan(
+        [declaration],
+        selected_protocol="responses_structured",
+        provider_hosted_capabilities={},
+        protocol_capabilities=protocol,
+        request_token="unknown-hosted-no-provider-fact",
+    )
+    assert without_provider_fact.entries[0].disposition == OMIT
+
+    with_provider_fact = build_tool_compatibility_plan(
+        [declaration],
+        selected_protocol="responses_structured",
+        provider_hosted_capabilities={"vendor_extension": True},
+        protocol_capabilities=protocol,
+        request_token="unknown-hosted-with-provider-fact",
+    )
+    assert with_provider_fact.entries[0].disposition == NATIVE
 
 
 def test_with_final_declarations_does_not_expose_hosted_without_provider_fact():

--- a/tests/test_runtime_tool_compatibility_boundaries.py
+++ b/tests/test_runtime_tool_compatibility_boundaries.py
@@ -607,6 +607,22 @@ def test_native_terminal_reconciles_semantic_arguments_not_only_identity():
         )
 
 
+@pytest.mark.parametrize("adapted", [False, True], ids=["native", "namespace-adapter"])
+def test_arguments_done_must_match_received_delta_fragments(adapted):
+    plan = _adapted_namespace_plan() if adapted else _native_plan({"type": "function", "name": "keep"})
+    state = CompatibilityStreamState(plan)
+    name = plan.entries[0].aliases[0] if adapted else "keep"
+    item = {"type": "function_call", "id": "delta-item", "call_id": "delta-call", "name": name, "arguments": ""}
+    state.decode_events_for_event({"type": "response.output_item.added", "item": item})
+    state.decode_events_for_event(
+        {"type": "response.function_call_arguments.delta", "item_id": "delta-item", "call_id": "delta-call", "delta": '{"value":1}' }
+    )
+    with pytest.raises(ToolCompatibilityError):
+        state.decode_events_for_event(
+            {"type": "response.function_call_arguments.done", "item_id": "delta-item", "call_id": "delta-call", "arguments": '{"value":2}' }
+        )
+
+
 @pytest.mark.parametrize("output_type", ["function_call_output", "vendor_extension_call_output"])
 def test_sse_output_before_adapted_call_fails_closed(output_type):
     plan = _adapted_namespace_plan()

--- a/tests/test_runtime_tool_compatibility_boundaries.py
+++ b/tests/test_runtime_tool_compatibility_boundaries.py
@@ -686,6 +686,119 @@ def test_native_stream_requires_added_owner_before_terminal_item_event(event):
     assert exc_info.value.classification == "missing_stream_identity"
 
 
+def test_unknown_custom_stream_owner_preserves_legacy_apply_patch_lifecycle():
+    plan = _native_plan({"type": "function", "name": "shell_command"})
+    state = CompatibilityStreamState(plan)
+    added_item = {
+        "type": "custom_tool_call",
+        "id": "patch-item",
+        "call_id": "patch-call",
+        "name": "apply_patch",
+        "input": "",
+    }
+    input_text = "*** Begin Patch\n*** End Patch\n"
+
+    assert state.decode_events_for_event(
+        {"type": "response.output_item.added", "item": added_item}
+    )[0]["item"] == added_item
+    assert state.decode_events_for_event(
+        {
+            "type": "response.custom_tool_call_input.delta",
+            "item_id": "patch-item",
+            "call_id": "patch-call",
+            "delta": input_text,
+        }
+    )[0]["delta"] == input_text
+    assert state.decode_events_for_event(
+        {
+            "type": "response.custom_tool_call_input.done",
+            "item_id": "patch-item",
+            "call_id": "patch-call",
+            "input": input_text,
+        }
+    )[0]["input"] == input_text
+    done_item = {**added_item, "input": input_text}
+    assert state.decode_events_for_event(
+        {"type": "response.output_item.done", "item": done_item}
+    )[0]["item"] == done_item
+    state.decode_events_for_event(
+        {"type": "response.completed", "response": {"output": []}}
+    )
+
+
+@pytest.mark.parametrize(
+    "event",
+    [
+        {
+            "type": "response.custom_tool_call_input.delta",
+            "item_id": "orphan-item",
+            "call_id": "orphan-call",
+            "delta": "opaque",
+        },
+        {
+            "type": "response.custom_tool_call_input.done",
+            "item_id": "orphan-item",
+            "call_id": "orphan-call",
+            "input": "opaque",
+        },
+        {
+            "type": "response.output_item.done",
+            "item": {
+                "type": "custom_tool_call",
+                "id": "orphan-item",
+                "call_id": "orphan-call",
+                "name": "apply_patch",
+                "input": "opaque",
+            },
+        },
+    ],
+    ids=["delta", "arguments-done", "item-done"],
+)
+def test_unknown_custom_stream_requires_added_owner(event):
+    plan = _native_plan({"type": "function", "name": "shell_command"})
+    with pytest.raises(ToolCompatibilityError) as exc_info:
+        CompatibilityStreamState(plan).decode_events_for_event(event)
+    assert exc_info.value.classification == "missing_stream_identity"
+
+
+def test_native_plain_stream_accepts_exact_flattened_namespace_wire_identity():
+    plan = _native_plan({"type": "function", "name": "multi_agent_v1__spawn_agent"})
+    state = CompatibilityStreamState(plan)
+    item = {
+        "type": "function_call",
+        "namespace": "multi_agent_v1",
+        "name": "spawn_agent",
+        "id": "flattened-item",
+        "call_id": "flattened-call",
+        "arguments": "",
+    }
+    state.decode_events_for_event({"type": "response.output_item.added", "item": item})
+    state.decode_events_for_event(
+        {
+            "type": "response.function_call_arguments.done",
+            "item_id": "flattened-item",
+            "call_id": "flattened-call",
+            "arguments": "{}",
+        }
+    )
+    state.decode_events_for_event(
+        {"type": "response.output_item.done", "item": {**item, "arguments": "{}"}}
+    )
+
+
+def test_native_plain_tool_search_wrapper_keeps_no_added_terminal_path():
+    plan = _native_plan({"type": "function", "name": "tool_search"})
+    state = CompatibilityStreamState(plan)
+    item = {
+        "type": "function_call",
+        "name": "tool_search",
+        "id": "tool-search-item",
+        "call_id": "tool-search-call",
+        "arguments": "",
+    }
+    state.decode_events_for_event({"type": "response.output_item.done", "item": item})
+
+
 def test_buffered_custom_delta_and_done_require_bound_call_id():
     plan = build_tool_compatibility_plan(
         [{"type": "custom", "name": "paint", "format": {"type": "text"}}],

--- a/tests/test_runtime_tool_compatibility_boundaries.py
+++ b/tests/test_runtime_tool_compatibility_boundaries.py
@@ -10,6 +10,7 @@ from runtime_tool_compatibility import (
     CompatibilityStreamState,
     CUSTOM_FREEFORM,
     NATIVE,
+    OMIT,
     PLAIN_FUNCTION,
     ProtocolCapabilities,
     SELECTED_PROVIDER_HOSTED,
@@ -764,6 +765,121 @@ def test_optional_unsupported_hosted_history_omits_item_and_same_kind_output_by_
                 ],
             }
         )
+
+
+def test_optional_hosted_history_omits_same_type_call_and_result_with_distinct_item_ids():
+    plan = build_tool_compatibility_plan(
+        [{"type": "web_search"}],
+        selected_protocol="chat_tools",
+        provider_hosted_capabilities={},
+        protocol_capabilities=ProtocolCapabilities.chat_tools(),
+        request_token="omitted-hosted-distinct-item-ids",
+    )
+    encoded = plan.encode_payload(
+        {
+            "input": [
+                {
+                    "type": "web_search_call",
+                    "item_id": "item_call_hosted_001",
+                    "status": "completed",
+                    "action": {"query": "ignored"},
+                },
+                {
+                    "type": "web_search_call",
+                    "item_id": "item_output_hosted_001",
+                    "status": "completed",
+                    "provider_scope": "selected_provider_only",
+                },
+                {"type": "message", "role": "user", "content": "keep"},
+            ],
+        }
+    )
+    assert encoded["input"] == [{"type": "message", "role": "user", "content": "keep"}]
+
+
+def test_optional_unknown_selected_provider_hosted_history_omits_without_call_id():
+    plan = build_tool_compatibility_plan(
+        [{"type": "vendor_search", "executor": "selected_provider"}],
+        selected_protocol="responses_structured",
+        provider_hosted_capabilities={},
+        protocol_capabilities=ProtocolCapabilities.responses_structured(),
+        request_token="omitted-unknown-hosted-history",
+    )
+    encoded = plan.encode_payload(
+        {
+            "input": [
+                {"type": "vendor_search_call", "item_id": "vendor-item", "status": "completed"},
+                {"type": "message", "role": "user", "content": "keep"},
+            ],
+        }
+    )
+    assert encoded["input"] == [{"type": "message", "role": "user", "content": "keep"}]
+
+
+def test_with_final_declarations_does_not_expose_hosted_without_provider_fact():
+    plan = build_tool_compatibility_plan(
+        [],
+        selected_protocol="responses_structured",
+        provider_hosted_capabilities={},
+        protocol_capabilities=ProtocolCapabilities.responses_structured(
+            hosted_lifecycles=frozenset({"web_search"}),
+        ),
+        request_token="final-hosted-provider-fact-required",
+    )
+    final = plan.with_final_declarations(
+        [{"type": "web_search", "executor": "selected_provider"}]
+    )
+    assert final.entries[0].disposition == OMIT
+
+
+def test_shared_hosted_event_kind_with_native_and_omitted_entries_fails_closed():
+    plan = build_tool_compatibility_plan(
+        [{"type": "web_search"}, {"type": "web_search_preview"}],
+        selected_protocol="responses_structured",
+        provider_hosted_capabilities={"web_search": True},
+        protocol_capabilities=ProtocolCapabilities.responses_structured(
+            hosted_lifecycles=frozenset({"web_search"}),
+        ),
+        request_token="mixed-shared-hosted-kind",
+    )
+    assert [entry.disposition for entry in plan.entries] == [NATIVE, OMIT]
+
+    with pytest.raises(ToolCompatibilityError) as exc_info:
+        plan.encode_payload(
+            {
+                "input": [
+                    {"type": "web_search_call", "id": "shared-item", "status": "completed"},
+                ],
+            }
+        )
+    assert exc_info.value.classification == "ambiguous_native_identity"
+
+
+def test_native_plain_wins_over_adapted_custom_with_same_original_name_in_body_and_stream():
+    plan = build_tool_compatibility_plan(
+        [
+            {"type": "function", "name": "paint", "parameters": {"type": "object"}},
+            {"type": "custom", "name": "paint", "format": {"type": "text"}},
+        ],
+        selected_protocol="chat_tools",
+        protocol_capabilities=ProtocolCapabilities.chat_tools(),
+        request_token="native-plain-adapted-custom-same-name",
+    )
+    body_item = {
+        "type": "function_call",
+        "name": "paint",
+        "call_id": "plain-call",
+        "item_id": "plain-item",
+        "arguments": "{}",
+    }
+    assert plan.decode_payload({"output": [body_item]})["output"] == [body_item]
+
+    state = CompatibilityStreamState(plan)
+    added = {
+        "type": "response.output_item.added",
+        "item": dict(body_item, arguments=""),
+    }
+    assert state.decode_events_for_event(added) == [added]
 
 
 def test_optional_unmapped_hosted_history_omits_item_and_same_kind_output_by_item_id():

--- a/tests/test_runtime_tool_compatibility_boundaries.py
+++ b/tests/test_runtime_tool_compatibility_boundaries.py
@@ -1360,6 +1360,37 @@ def test_native_hosted_sse_accepts_only_the_exact_web_search_stage_sequence():
     )
     state.decode_events_for_event({"type": "response.completed", "response": {"id": "response"}})
 
+
+@pytest.mark.parametrize(
+    "nested_item",
+    [
+        {"id": "search-item"},
+        {"id": "search-item", "type": "file_search_call"},
+        {"id": "search-item", "type": "web_search_call", "name": "other"},
+    ],
+    ids=["missing-wire-type", "wrong-wire-type", "wrong-wire-name"],
+)
+def test_native_hosted_sse_rejects_nested_item_wire_identity_mismatch(nested_item):
+    state = CompatibilityStreamState(_native_hosted_plan())
+    state.decode_events_for_event(
+        {
+            "type": "response.output_item.added",
+            "item": {"type": "web_search_call", "id": "search-item", "status": "in_progress"},
+        }
+    )
+
+    with pytest.raises(ToolCompatibilityError) as exc_info:
+        state.decode_events_for_event(
+            {
+                "type": "response.web_search_call.in_progress",
+                "item_id": "search-item",
+                "item": nested_item,
+            }
+        )
+
+    assert exc_info.value.classification == "ambiguous_native_identity"
+    assert exc_info.value.surface == "stream"
+
     out_of_order = CompatibilityStreamState(_native_hosted_plan())
     out_of_order.decode_events_for_event(
         {

--- a/tests/test_runtime_tool_compatibility_boundaries.py
+++ b/tests/test_runtime_tool_compatibility_boundaries.py
@@ -654,6 +654,38 @@ def test_native_response_output_before_call_fails_closed():
         plan.decode_payload({"output": [output, call]})
 
 
+@pytest.mark.parametrize(
+    "event",
+    [
+        {
+            "type": "response.function_call_arguments.done",
+            "item_id": "orphan-item",
+            "call_id": "orphan-call",
+            "arguments": "{}",
+        },
+        {
+            "type": "response.output_item.done",
+            "item": {
+                "type": "function_call",
+                "id": "orphan-item",
+                "call_id": "orphan-call",
+                "name": "keep",
+                "arguments": "{}",
+            },
+        },
+    ],
+    ids=["arguments-done", "output-item-done"],
+)
+def test_native_stream_requires_added_owner_before_terminal_item_event(event):
+    plan = _native_plan({"type": "function", "name": "keep"})
+    state = CompatibilityStreamState(plan)
+
+    with pytest.raises(ToolCompatibilityError) as exc_info:
+        state.decode_events_for_event(event)
+
+    assert exc_info.value.classification == "missing_stream_identity"
+
+
 def test_buffered_custom_delta_and_done_require_bound_call_id():
     plan = build_tool_compatibility_plan(
         [{"type": "custom", "name": "paint", "format": {"type": "text"}}],

--- a/tests/test_runtime_tool_compatibility_boundaries.py
+++ b/tests/test_runtime_tool_compatibility_boundaries.py
@@ -1,0 +1,411 @@
+from __future__ import annotations
+
+import hashlib
+import json
+
+import pytest
+
+from runtime_tool_compatibility import (
+    CompatibilityStreamState,
+    ProtocolCapabilities,
+    ToolCompatibilityError,
+    build_tool_compatibility_plan,
+)
+
+
+def _namespace(namespace: str = "collaboration", *, child: str = "spawn_agent") -> dict:
+    return {
+        "type": "namespace",
+        "name": namespace,
+        "tools": [{"type": "function", "name": child}],
+    }
+
+
+def _adapted_namespace_plan(declaration: dict | None = None):
+    return build_tool_compatibility_plan(
+        [declaration or _namespace("vendor", child="run")],
+        selected_protocol="chat_tools",
+        protocol_capabilities=ProtocolCapabilities.chat_tools(),
+        request_token="boundary",
+    )
+
+
+def _native_plan(declaration: dict):
+    return build_tool_compatibility_plan(
+        [declaration],
+        selected_protocol="responses_structured",
+        protocol_capabilities=ProtocolCapabilities.responses_structured(),
+        request_token="native-boundary",
+    )
+
+
+def test_adapted_decode_rejects_orphan_and_duplicate_result_call_ids():
+    orphan_plan = _adapted_namespace_plan()
+    with pytest.raises(ToolCompatibilityError):
+        orphan_plan.decode_payload(
+            {
+                "output": [
+                    {"type": "function_call_output", "call_id": "orphan", "output": "ignored"}
+                ]
+            }
+        )
+
+    duplicate_plan = _adapted_namespace_plan()
+    with pytest.raises(ToolCompatibilityError):
+        duplicate_plan.decode_payload(
+            {
+                "output": [
+                    {"type": "function_call_output", "call_id": "result", "output": "one"},
+                    {"type": "function_call_output", "call_id": "result", "output": "two"},
+                ]
+            }
+        )
+
+
+@pytest.mark.parametrize(
+    "history",
+    [
+        [
+            {"type": "function_call", "namespace": "vendor", "name": "run", "arguments": "{}"},
+            {"type": "function_call_output", "output": "orphan"},
+        ],
+        [
+            {"type": "function_call", "namespace": "vendor", "name": "run", "call_id": "same", "arguments": "{}"},
+            {"type": "function_call", "name": "keep", "call_id": "same", "arguments": "{}"},
+        ],
+    ],
+    ids=["missing-omitted-call-id", "omitted-id-conflicts-with-retained-call"],
+)
+def test_omit_history_rejects_missing_or_conflicting_call_identity(history):
+    plan = build_tool_compatibility_plan(
+        [
+            _namespace("vendor", child="run"),
+            {"type": "function", "name": "keep"},
+        ],
+        selected_protocol="chat_tools",
+        protocol_capabilities=ProtocolCapabilities(
+            function_lifecycle=True,
+            namespace_lifecycle=False,
+            custom_lifecycle=False,
+            tool_search_lifecycle=False,
+            accepts_namespace_adapter=False,
+            accepts_custom_adapter=False,
+        ),
+        request_token="omit-boundary",
+    )
+    with pytest.raises(ToolCompatibilityError):
+        plan.encode_payload({"input": history})
+
+
+@pytest.mark.parametrize(
+    "event",
+    [
+        {
+            "type": "response.function_call_arguments.delta",
+            "item_id": "unknown-item",
+            "delta": "{}",
+        },
+        {
+            "type": "response.output_item.done",
+            "item": {
+                "type": "function_call",
+                "name": "__codexhub_ns_unknown_1",
+                "item_id": "unknown-item",
+                "call_id": "unknown-call",
+                "arguments": "{}",
+            },
+        },
+    ],
+    ids=["unknown-delta-item", "unknown-done-alias"],
+)
+def test_adapted_namespace_sse_rejects_unknown_identity(event):
+    plan = _adapted_namespace_plan()
+    state = CompatibilityStreamState(plan)
+    with pytest.raises(ToolCompatibilityError):
+        state.decode_events_for_event(event)
+
+
+@pytest.mark.parametrize(
+    "added, done",
+    [
+        (
+            {
+                "type": "response.output_item.added",
+                "item": {
+                    "type": "function_call",
+                    "name": "__codexhub_ns_ignored",
+                    "item_id": "item",
+                    "call_id": "call",
+                    "arguments": "",
+                },
+            },
+            None,
+        ),
+        (
+            {
+                "type": "response.output_item.added",
+                "item": {
+                    "type": "function_call",
+                    "name": "__codexhub_ns_ignored",
+                    "item_id": "item",
+                    "call_id": "call",
+                    "arguments": "",
+                },
+            },
+            {
+                "type": "response.output_item.done",
+                "item": {
+                    "type": "function_call",
+                    "name": "__codexhub_ns_ignored",
+                    "item_id": "item",
+                    "call_id": "other-call",
+                    "arguments": "{}",
+                },
+            },
+        ),
+    ],
+    ids=["missing-call-id-on-added", "mismatched-call-id-on-done"],
+)
+def test_adapted_namespace_sse_rejects_missing_or_mismatched_ids(added, done):
+    plan = _adapted_namespace_plan()
+    alias = plan.entries[0].aliases[0]
+    added["item"]["name"] = alias
+    if done is not None:
+        done["item"]["name"] = alias
+    if done is None:
+        added["item"].pop("call_id")
+    state = CompatibilityStreamState(plan)
+    with pytest.raises(ToolCompatibilityError):
+        state.decode_events_for_event(added)
+        if done is not None:
+            state.decode_events_for_event(done)
+
+
+def test_adapted_namespace_sse_rejects_done_for_unknown_item_id():
+    plan = _adapted_namespace_plan()
+    alias = plan.entries[0].aliases[0]
+    state = CompatibilityStreamState(plan)
+    state.decode_events_for_event(
+        {
+            "type": "response.output_item.added",
+            "item": {
+                "type": "function_call",
+                "name": alias,
+                "item_id": "item",
+                "call_id": "call",
+                "arguments": "",
+            },
+        }
+    )
+    with pytest.raises(ToolCompatibilityError):
+        state.decode_events_for_event(
+            {
+                "type": "response.output_item.done",
+                "item": {
+                    "type": "function_call",
+                    "name": alias,
+                    "item_id": "other-item",
+                    "call_id": "other-call",
+                    "arguments": "{}",
+                },
+            }
+        )
+
+
+@pytest.mark.parametrize(
+    "declaration",
+    [
+        {"type": "namespace", "name": "vendor", "tools": []},
+        {
+            "type": "namespace",
+            "name": "vendor",
+            "tools": [{"type": "function", "name": "run"}, {"type": "function", "name": "run"}],
+        },
+    ],
+    ids=["missing-child", "ambiguous-duplicate-child"],
+)
+def test_namespace_boundary_rejects_missing_or_ambiguous_children(declaration):
+    with pytest.raises(ToolCompatibilityError):
+        build_tool_compatibility_plan(
+            [declaration],
+            selected_protocol="chat_tools",
+            protocol_capabilities=ProtocolCapabilities.chat_tools(),
+            request_token="namespace-boundary",
+        )
+
+
+@pytest.mark.parametrize(
+    "item",
+    [
+        {"type": "function_call", "name": "run", "call_id": "call", "arguments": "{}"},
+        {
+            "type": "function_call",
+            "name": "__codexhub_ns_invalid_1",
+            "namespace": "wrong",
+            "call_id": "call",
+            "arguments": "{}",
+        },
+    ],
+    ids=["flattened-original-name", "alias-with-wrong-namespace"],
+)
+def test_adapted_namespace_rejects_original_or_flattened_alias_without_exact_mapping(item):
+    plan = _adapted_namespace_plan()
+    if item["name"].startswith("__codexhub_ns_"):
+        item["name"] = plan.entries[0].aliases[0]
+    with pytest.raises(ToolCompatibilityError):
+        plan.decode_payload({"output": [item]})
+
+
+@pytest.mark.parametrize(
+    "namespace, forbidden",
+    [("multi_agent_v1", "task_path"), ("collaboration", "agent_id")],
+    ids=["v1-json-arguments", "v2-json-arguments"],
+)
+def test_v1_v2_forbidden_fields_inside_json_arguments_fail(namespace, forbidden):
+    declaration = _namespace(namespace, child="spawn_agent")
+    plan = _adapted_namespace_plan(declaration)
+    alias = plan.entries[0].aliases[0]
+    with pytest.raises(ToolCompatibilityError):
+        plan.encode_payload(
+            {
+                "input": [
+                    {
+                        "type": "function_call",
+                        "namespace": namespace,
+                        "name": "spawn_agent",
+                        "call_id": "call",
+                        "arguments": json.dumps({forbidden: "mixed"}),
+                    }
+                ],
+                "tools": [declaration],
+                "tool_choice": {"type": "function", "name": "spawn_agent"},
+            }
+        )
+
+
+def test_adapted_namespace_tool_choice_with_duplicate_child_name_fails_preflight():
+    declaration = {
+        "type": "namespace",
+        "name": "vendor",
+        "tools": [{"type": "function", "name": "run"}, {"type": "function", "name": "run"}],
+    }
+    with pytest.raises(ToolCompatibilityError):
+        _adapted_namespace_plan(declaration)
+
+
+@pytest.mark.parametrize(
+    "other_declaration",
+    [
+        {"type": "web_search", "name": "placeholder", "executor": "selected_provider"},
+        {"type": "future_kind", "name": "placeholder"},
+    ],
+    ids=["hosted-name", "unknown-name"],
+)
+def test_namespace_alias_reserves_names_of_hosted_and_unknown_declarations(other_declaration):
+    token = hashlib.sha256(b"alias-collision").hexdigest()[:10]
+    candidate = f"__codexhub_ns_{token}_1"
+    other_declaration["name"] = candidate
+    plan = build_tool_compatibility_plan(
+        [_namespace("vendor", child="run"), other_declaration],
+        selected_protocol="chat_tools",
+        protocol_capabilities=ProtocolCapabilities.chat_tools(),
+        request_token="alias-collision",
+    )
+    assert plan.entries[0].aliases[0] != candidate
+
+
+@pytest.mark.parametrize(
+    "declarations",
+    [
+        [None],
+        ["not-a-declaration"],
+        [{"type": "namespace", "name": "vendor", "tools": "not-a-list"}],
+        [{"type": "custom", "name": "paint"}],
+    ],
+    ids=["none", "string", "namespace-malformed", "custom-malformed"],
+)
+def test_non_mapping_and_malformed_declarations_fail_closed(declarations):
+    with pytest.raises(ToolCompatibilityError):
+        build_tool_compatibility_plan(
+            declarations,
+            selected_protocol="chat_tools",
+            protocol_capabilities=ProtocolCapabilities.chat_tools(),
+            request_token="malformed-boundary",
+        )
+
+
+def _native_declaration_and_missing_body_item(family: str) -> tuple[dict, dict]:
+    if family == "plain":
+        return {"type": "function", "name": "plain"}, {
+            "type": "function_call",
+            "id": "item",
+            "name": "plain",
+            "arguments": "{}",
+        }
+    if family == "namespace":
+        return _namespace("vendor", child="run"), {
+            "type": "function_call",
+            "id": "item",
+            "namespace": "vendor",
+            "name": "run",
+            "arguments": "{}",
+        }
+    if family == "custom":
+        return {"type": "custom", "name": "paint", "format": {"type": "text"}}, {
+            "type": "custom_tool_call",
+            "id": "item",
+            "name": "paint",
+            "input": "opaque",
+        }
+    if family == "tool_search":
+        return {"type": "tool_search", "execution": "client"}, {
+            "type": "tool_search_call",
+            "id": "item",
+            "arguments": {"query": "find"},
+        }
+    raise AssertionError(family)
+
+
+@pytest.mark.parametrize("family", ["plain", "namespace", "custom", "tool_search"])
+def test_native_known_families_reject_missing_call_identity_in_body(family):
+    declaration, item = _native_declaration_and_missing_body_item(family)
+    plan = _native_plan(declaration)
+    with pytest.raises(ToolCompatibilityError):
+        plan.decode_payload({"output": [item]})
+
+
+@pytest.mark.parametrize("family", ["plain", "namespace", "custom", "tool_search"])
+def test_native_known_families_reject_missing_item_identity_in_sse(family):
+    declaration, item = _native_declaration_and_missing_body_item(family)
+    item.pop("id")
+    item["call_id"] = "call"
+    plan = _native_plan(declaration)
+    state = CompatibilityStreamState(plan)
+    with pytest.raises(ToolCompatibilityError):
+        state.decode_events_for_event(
+            {
+                "type": "response.output_item.added",
+                "item": item,
+            }
+        )
+
+
+@pytest.mark.parametrize("family", ["plain", "namespace", "custom", "tool_search"])
+def test_native_known_families_reject_duplicate_item_identity_in_sse(family):
+    declaration, item = _native_declaration_and_missing_body_item(family)
+    item["call_id"] = "call"
+    plan = _native_plan(declaration)
+    state = CompatibilityStreamState(plan)
+    added = {"type": "response.output_item.added", "item": item}
+    with pytest.raises(ToolCompatibilityError):
+        state.decode_events_for_event(added)
+        state.decode_events_for_event({"type": "response.output_item.added", "item": dict(item)})
+
+
+def test_native_tool_search_rejects_duplicate_call_identity_in_body():
+    declaration, item = _native_declaration_and_missing_body_item("tool_search")
+    first = {**item, "call_id": "same"}
+    second = {**item, "call_id": "same"}
+    plan = _native_plan(declaration)
+    with pytest.raises(ToolCompatibilityError):
+        plan.decode_payload({"output": [first, second]})

--- a/tests/test_runtime_tool_compatibility_boundaries.py
+++ b/tests/test_runtime_tool_compatibility_boundaries.py
@@ -2031,3 +2031,48 @@ def test_adapted_custom_original_name_cannot_be_used_as_plain_function_call():
                 },
             }
         )
+
+
+def test_stream_rejects_lifecycle_events_after_terminal_but_keeps_terminal_marker_guard():
+    plan = _native_plan({"type": "function", "name": "keep"})
+    state = CompatibilityStreamState(plan)
+    added = {
+        "type": "function_call",
+        "id": "native-item",
+        "call_id": "native-call",
+        "name": "keep",
+        "arguments": "",
+    }
+    state.decode_events_for_event({"type": "response.output_item.added", "item": added})
+    state.decode_events_for_event(
+        {
+            "type": "response.function_call_arguments.done",
+            "item_id": "native-item",
+            "call_id": "native-call",
+            "arguments": "{}",
+        }
+    )
+    completed_item = {**added, "arguments": "{}"}
+    state.decode_events_for_event({"type": "response.output_item.done", "item": completed_item})
+    terminal = {"type": "response.completed", "response": {"output": [completed_item]}}
+    state.decode_events_for_event(terminal)
+
+    for event in (
+        {
+            "type": "response.output_item.added",
+            "item": {**added, "id": "late-item", "call_id": "late-call", "arguments": ""},
+        },
+        {
+            "type": "response.function_call_arguments.delta",
+            "item_id": "native-item",
+            "call_id": "native-call",
+            "delta": "late",
+        },
+    ):
+        with pytest.raises(ToolCompatibilityError) as exc_info:
+            state.decode_events_for_event(event)
+        assert exc_info.value.classification == "stream_after_terminal"
+
+    with pytest.raises(ToolCompatibilityError) as exc_info:
+        state.decode_event(terminal)
+    assert exc_info.value.classification == "duplicate_terminal"

--- a/tests/test_runtime_tool_compatibility_boundaries.py
+++ b/tests/test_runtime_tool_compatibility_boundaries.py
@@ -365,6 +365,23 @@ def test_response_output_before_adapted_call_fails_closed_without_partial_reorde
         )
 
 
+def test_adapted_stream_allows_ordinary_message_output_item_done():
+    """Non-tool assistant output has no compatibility owner to reconcile."""
+    plan = _adapted_namespace_plan()
+    event = {
+        "type": "response.output_item.done",
+        "item": {
+            "type": "message",
+            "id": "msg-ordinary",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "OK"}],
+        },
+    }
+
+    state = CompatibilityStreamState(plan)
+    assert state.decode_events_for_event(event) == [event]
+
+
 @pytest.mark.parametrize("call_id", [None, ""], ids=["missing", "empty"])
 def test_encode_history_rejects_retained_call_without_call_identity(call_id):
     plan = _native_plan({"type": "function", "name": "keep"})

--- a/tests/test_runtime_tool_compatibility_boundaries.py
+++ b/tests/test_runtime_tool_compatibility_boundaries.py
@@ -624,6 +624,15 @@ def test_native_hosted_sse_tracks_added_done_and_terminal_identity():
     terminal = {"type": "response.completed", "response": {"id": "response"}}
     state = CompatibilityStreamState(_native_hosted_plan())
     state.decode_events_for_event(added())
+    state.decode_events_for_event(
+        {"type": "response.web_search_call.in_progress", "item_id": "search-item"}
+    )
+    state.decode_events_for_event(
+        {"type": "response.web_search_call.searching", "item_id": "search-item"}
+    )
+    state.decode_events_for_event(
+        {"type": "response.web_search_call.completed", "item_id": "search-item"}
+    )
     state.decode_events_for_event(done)
     state.decode_events_for_event(terminal)
 
@@ -650,4 +659,169 @@ def test_native_hosted_sse_tracks_added_done_and_terminal_identity():
     with pytest.raises(ToolCompatibilityError):
         unsupported_delta.decode_events_for_event(
             {"type": "response.web_search_call.delta", "item_id": "search-item", "delta": "opaque"}
+        )
+
+
+def test_native_hosted_sse_accepts_only_the_exact_web_search_stage_sequence():
+    state = CompatibilityStreamState(_native_hosted_plan())
+    state.decode_events_for_event(
+        {
+            "type": "response.output_item.added",
+            "item": {"type": "web_search_call", "id": "search-item", "status": "in_progress"},
+        }
+    )
+    state.decode_events_for_event(
+        {"type": "response.web_search_call.in_progress", "item_id": "search-item"}
+    )
+    state.decode_events_for_event(
+        {"type": "response.web_search_call.searching", "item_id": "search-item"}
+    )
+    state.decode_events_for_event(
+        {"type": "response.web_search_call.completed", "item_id": "search-item"}
+    )
+    state.decode_events_for_event(
+        {
+            "type": "response.output_item.done",
+            "item": {"type": "web_search_call", "id": "search-item", "status": "completed"},
+        }
+    )
+    state.decode_events_for_event({"type": "response.completed", "response": {"id": "response"}})
+
+    out_of_order = CompatibilityStreamState(_native_hosted_plan())
+    out_of_order.decode_events_for_event(
+        {
+            "type": "response.output_item.added",
+            "item": {"type": "web_search_call", "id": "search-item", "status": "in_progress"},
+        }
+    )
+    with pytest.raises(ToolCompatibilityError):
+        out_of_order.decode_events_for_event(
+            {"type": "response.web_search_call.searching", "item_id": "search-item"}
+        )
+    with pytest.raises(ToolCompatibilityError):
+        out_of_order.decode_events_for_event(
+            {"type": "response.web_search_call.in_progress", "item_id": "other-item"}
+        )
+
+
+def test_hosted_kinds_without_a_static_event_contract_are_not_native():
+    plan = build_tool_compatibility_plan(
+        [{"type": "computer_use_preview"}],
+        selected_protocol="responses_structured",
+        provider_hosted_capabilities={"computer_use_preview": True},
+        protocol_capabilities=ProtocolCapabilities.responses_structured(
+            hosted_lifecycles=frozenset({"computer_use_preview"}),
+        ),
+        request_token="unmapped-hosted-kind",
+    )
+    assert plan.entries[0].disposition == "omit"
+
+    with pytest.raises(Exception):
+        build_tool_compatibility_plan(
+            [{"type": "computer_use_preview"}],
+            selected_protocol="responses_structured",
+            provider_hosted_capabilities={"computer_use_preview": True},
+            protocol_capabilities=ProtocolCapabilities.responses_structured(
+                hosted_lifecycles=frozenset({"computer_use_preview"}),
+            ),
+            required=True,
+            request_token="required-unmapped-hosted-kind",
+        )
+
+
+def test_optional_unsupported_hosted_history_omits_item_and_same_kind_output_by_item_id():
+    plan = build_tool_compatibility_plan(
+        [{"type": "web_search"}],
+        selected_protocol="chat_tools",
+        provider_hosted_capabilities={},
+        protocol_capabilities=ProtocolCapabilities.chat_tools(),
+        request_token="omitted-hosted-history",
+    )
+    encoded = plan.encode_payload(
+        {
+            "tools": [{"type": "web_search"}],
+            "input": [
+                {"type": "web_search_call", "id": "search-item", "status": "completed"},
+                {"type": "web_search_call_output", "id": "search-item", "output": "ignored"},
+                {"type": "message", "role": "user", "content": "keep"},
+            ],
+        }
+    )
+    assert encoded["input"] == [{"type": "message", "role": "user", "content": "keep"}]
+
+    with pytest.raises(ToolCompatibilityError):
+        plan.encode_payload(
+            {
+                "input": [{"type": "web_search_call", "status": "completed"}],
+            }
+        )
+    with pytest.raises(ToolCompatibilityError):
+        plan.encode_payload(
+            {
+                "input": [
+                    {"type": "web_search_call", "id": "duplicate", "status": "completed"},
+                    {"type": "web_search_call", "id": "duplicate", "status": "completed"},
+                ],
+            }
+        )
+
+
+def test_optional_unmapped_hosted_history_omits_item_and_same_kind_output_by_item_id():
+    plan = build_tool_compatibility_plan(
+        [{"type": "computer_use_preview"}],
+        selected_protocol="chat_tools",
+        provider_hosted_capabilities={},
+        protocol_capabilities=ProtocolCapabilities.chat_tools(),
+        request_token="omitted-unmapped-hosted-history",
+    )
+    encoded = plan.encode_payload(
+        {
+            "input": [
+                {"type": "computer_use_preview_call", "id": "computer-item", "status": "completed"},
+                {
+                    "type": "computer_use_preview_call_output",
+                    "id": "computer-item",
+                    "output": {"ignored": True},
+                },
+                {"type": "message", "role": "user", "content": "keep"},
+            ],
+        }
+    )
+    assert encoded["input"] == [{"type": "message", "role": "user", "content": "keep"}]
+
+
+def test_adapted_custom_original_name_cannot_be_used_as_plain_function_call():
+    plan = build_tool_compatibility_plan(
+        [{"type": "custom", "name": "paint", "format": {"type": "text"}}],
+        selected_protocol="chat_tools",
+        protocol_capabilities=ProtocolCapabilities.chat_tools(),
+        request_token="adapted-custom-original-name",
+    )
+    with pytest.raises(ToolCompatibilityError):
+        plan.decode_payload(
+            {
+                "output": [
+                    {
+                        "type": "function_call",
+                        "name": "paint",
+                        "call_id": "plain-call",
+                        "arguments": "{}",
+                    }
+                ]
+            }
+        )
+
+    state = CompatibilityStreamState(plan)
+    with pytest.raises(ToolCompatibilityError):
+        state.decode_events_for_event(
+            {
+                "type": "response.output_item.added",
+                "item": {
+                    "type": "function_call",
+                    "id": "plain-item",
+                    "name": "paint",
+                    "call_id": "plain-call",
+                    "arguments": "",
+                },
+            }
         )

--- a/tests/test_runtime_tool_compatibility_boundaries.py
+++ b/tests/test_runtime_tool_compatibility_boundaries.py
@@ -646,6 +646,76 @@ def test_native_tool_search_requires_exact_client_execution_marker(item):
         plan.decode_payload({"output": [item]})
 
 
+@pytest.mark.parametrize(
+    "event",
+    [
+        {
+            "type": "response.function_call_arguments.delta",
+            "item_id": "search-item",
+            "call_id": "search-call",
+            "delta": "opaque",
+        },
+        {
+            "type": "response.function_call_arguments.done",
+            "item_id": "search-item",
+            "call_id": "search-call",
+            "arguments": "opaque",
+        },
+    ],
+    ids=["arguments-delta", "arguments-done"],
+)
+def test_native_tool_search_stream_rejects_function_argument_lifecycle(event):
+    plan = _native_plan({"type": "tool_search", "execution": "client"})
+    state = CompatibilityStreamState(plan)
+    state.decode_events_for_event(
+        {
+            "type": "response.output_item.added",
+            "item": {
+                "type": "tool_search_call",
+                "id": "search-item",
+                "call_id": "search-call",
+                "execution": "client",
+                "arguments": {"query": "x"},
+            },
+        }
+    )
+
+    with pytest.raises(ToolCompatibilityError) as exc_info:
+        state.decode_events_for_event(event)
+
+    assert exc_info.value.classification == "unsupported_hosted_lifecycle"
+
+
+@pytest.mark.parametrize("surface", ["done", "terminal"])
+def test_native_tool_search_stream_revalidates_client_execution_marker(surface):
+    plan = _native_plan({"type": "tool_search", "execution": "client"})
+    state = CompatibilityStreamState(plan)
+    item = {
+        "type": "tool_search_call",
+        "id": "search-item",
+        "call_id": "search-call",
+        "execution": "client",
+        "arguments": {"query": "x"},
+    }
+    state.decode_events_for_event({"type": "response.output_item.added", "item": item})
+    changed = {**item, "execution": "provider"}
+
+    with pytest.raises(ToolCompatibilityError) as exc_info:
+        if surface == "done":
+            state.decode_events_for_event(
+                {"type": "response.output_item.done", "item": changed}
+            )
+        else:
+            state.decode_events_for_event(
+                {"type": "response.output_item.done", "item": item}
+            )
+            state.decode_events_for_event(
+                {"type": "response.completed", "response": {"output": [changed]}}
+            )
+
+    assert exc_info.value.classification == "invalid_tool_search_execution"
+
+
 def test_native_response_output_before_call_fails_closed():
     plan = _native_plan({"type": "function", "name": "keep"})
     call = {"type": "function_call", "id": "call-item", "call_id": "call", "name": "keep", "arguments": "{}"}
@@ -696,7 +766,8 @@ def test_unknown_custom_stream_owner_preserves_legacy_apply_patch_lifecycle():
         "name": "apply_patch",
         "input": "",
     }
-    input_text = "*** Begin Patch\n*** End Patch\n"
+    input_prefix = "*** Begin Patch\n"
+    input_text = f"{input_prefix}*** End Patch\n"
 
     assert state.decode_events_for_event(
         {"type": "response.output_item.added", "item": added_item}
@@ -706,9 +777,9 @@ def test_unknown_custom_stream_owner_preserves_legacy_apply_patch_lifecycle():
             "type": "response.custom_tool_call_input.delta",
             "item_id": "patch-item",
             "call_id": "patch-call",
-            "delta": input_text,
+            "delta": input_prefix,
         }
-    )[0]["delta"] == input_text
+    )[0]["delta"] == input_prefix
     assert state.decode_events_for_event(
         {
             "type": "response.custom_tool_call_input.done",
@@ -724,6 +795,43 @@ def test_unknown_custom_stream_owner_preserves_legacy_apply_patch_lifecycle():
     state.decode_events_for_event(
         {"type": "response.completed", "response": {"output": []}}
     )
+
+
+def test_unknown_custom_stream_rejects_done_input_that_diverges_from_delta_prefix():
+    plan = _native_plan({"type": "function", "name": "shell_command"})
+    state = CompatibilityStreamState(plan)
+    state.decode_events_for_event(
+        {
+            "type": "response.output_item.added",
+            "item": {
+                "type": "custom_tool_call",
+                "id": "patch-item",
+                "call_id": "patch-call",
+                "name": "apply_patch",
+                "input": "",
+            },
+        }
+    )
+    state.decode_events_for_event(
+        {
+            "type": "response.custom_tool_call_input.delta",
+            "item_id": "patch-item",
+            "call_id": "patch-call",
+            "delta": "first",
+        }
+    )
+
+    with pytest.raises(ToolCompatibilityError) as exc_info:
+        state.decode_events_for_event(
+            {
+                "type": "response.custom_tool_call_input.done",
+                "item_id": "patch-item",
+                "call_id": "patch-call",
+                "input": "different",
+            }
+        )
+
+    assert exc_info.value.classification == "incomplete_stream_delta"
 
 
 @pytest.mark.parametrize(
@@ -833,6 +941,211 @@ def test_native_plain_tool_search_wrapper_keeps_no_added_terminal_path():
     state.decode_events_for_event({"type": "response.output_item.done", "item": item})
 
 
+@pytest.mark.parametrize("surface", ["body", "history"])
+def test_native_namespace_rejects_unqualified_child_without_plain_owner(surface):
+    plan = _native_plan(_namespace("vendor", child="run"))
+    item = {
+        "type": "function_call",
+        "id": "namespace-item",
+        "call_id": "namespace-call",
+        "name": "run",
+        "arguments": "{}",
+    }
+
+    with pytest.raises(ToolCompatibilityError) as exc_info:
+        if surface == "body":
+            plan.decode_payload({"output": [item]})
+        else:
+            plan.encode_payload({"input": [item]})
+
+    assert exc_info.value.classification == "unknown_native_identity"
+
+
+def test_native_namespace_stream_rejects_unqualified_child_without_plain_owner():
+    plan = _native_plan(_namespace("vendor", child="run"))
+    state = CompatibilityStreamState(plan)
+
+    with pytest.raises(ToolCompatibilityError) as exc_info:
+        state.decode_events_for_event(
+            {
+                "type": "response.output_item.added",
+                "item": {
+                    "type": "function_call",
+                    "id": "namespace-item",
+                    "call_id": "namespace-call",
+                    "name": "run",
+                    "arguments": "",
+                },
+            }
+        )
+
+    assert exc_info.value.classification == "unknown_native_identity"
+
+
+def test_multiple_native_namespaces_reject_ambiguous_unqualified_child():
+    plan = build_tool_compatibility_plan(
+        [
+            _namespace("vendor_a", child="run"),
+            _namespace("vendor_b", child="run"),
+        ],
+        selected_protocol="responses_structured",
+        protocol_capabilities=ProtocolCapabilities.responses_structured(),
+        request_token="native-ambiguous-namespace-child",
+    )
+    item = {
+        "type": "function_call",
+        "id": "namespace-item",
+        "call_id": "namespace-call",
+        "name": "run",
+        "arguments": "{}",
+    }
+
+    with pytest.raises(ToolCompatibilityError) as exc_info:
+        plan.decode_payload({"output": [item]})
+
+    assert exc_info.value.classification == "unknown_native_identity"
+
+
+def test_native_plain_owner_still_wins_over_unqualified_native_namespace_child():
+    plan = build_tool_compatibility_plan(
+        [
+            {"type": "function", "name": "run"},
+            _namespace("vendor", child="run"),
+        ],
+        selected_protocol="responses_structured",
+        protocol_capabilities=ProtocolCapabilities.responses_structured(),
+        request_token="native-plain-namespace-collision",
+    )
+    item = {
+        "type": "function_call",
+        "id": "plain-item",
+        "call_id": "plain-call",
+        "name": "run",
+        "arguments": "{}",
+    }
+
+    assert plan.decode_payload({"output": [item]})["output"] == [item]
+
+
+@pytest.mark.parametrize(
+    ("declaration", "item"),
+    [
+        (
+            {"type": "function", "name": "tool_search"},
+            {"type": "function_call", "name": "tool_search", "arguments": "{}"},
+        ),
+        (
+            {"type": "function", "name": "multi_agent_v1__spawn_agent"},
+            {
+                "type": "function_call",
+                "namespace": "multi_agent_v1",
+                "name": "spawn_agent",
+                "arguments": "{}",
+            },
+        ),
+        (
+            {"type": "tool_search", "execution": "client"},
+            {
+                "type": "tool_search_call",
+                "execution": "client",
+                "arguments": {"query": "x"},
+            },
+        ),
+    ],
+    ids=["tool-search-wrapper", "flattened-worker-selector", "native-tool-search"],
+)
+@pytest.mark.parametrize(
+    ("present_field", "expected_classification"),
+    [
+        ("call_id", "missing_item_identity"),
+        ("id", "missing_call_identity"),
+    ],
+)
+def test_legacy_no_added_terminal_requires_nonempty_item_and_call_identity(
+    declaration,
+    item,
+    present_field,
+    expected_classification,
+):
+    item = {**item, present_field: "present"}
+    state = CompatibilityStreamState(_native_plan(declaration))
+
+    with pytest.raises(ToolCompatibilityError) as exc_info:
+        state.decode_events_for_event({"type": "response.output_item.done", "item": item})
+
+    assert exc_info.value.classification == expected_classification
+
+
+@pytest.mark.parametrize(
+    ("declaration", "item"),
+    [
+        (
+            {"type": "function", "name": "tool_search"},
+            {
+                "type": "function_call",
+                "id": "terminal-item",
+                "call_id": "terminal-call",
+                "name": "tool_search",
+                "arguments": "{}",
+            },
+        ),
+        (
+            {"type": "function", "name": "multi_agent_v1__spawn_agent"},
+            {
+                "type": "function_call",
+                "id": "terminal-item",
+                "call_id": "terminal-call",
+                "namespace": "multi_agent_v1",
+                "name": "spawn_agent",
+                "arguments": "{}",
+            },
+        ),
+        (
+            {"type": "tool_search", "execution": "client"},
+            {
+                "type": "tool_search_call",
+                "id": "terminal-item",
+                "call_id": "terminal-call",
+                "execution": "client",
+                "arguments": {"query": "x"},
+            },
+        ),
+    ],
+    ids=["tool-search-wrapper", "flattened-worker-selector", "native-tool-search"],
+)
+def test_legacy_no_added_terminal_rejects_duplicate_item_and_call_identity(declaration, item):
+    state = CompatibilityStreamState(_native_plan(declaration))
+    event = {"type": "response.output_item.done", "item": item}
+    state.decode_events_for_event(event)
+
+    with pytest.raises(ToolCompatibilityError) as exc_info:
+        state.decode_events_for_event(event)
+
+    assert exc_info.value.classification == "duplicate_item_identity"
+
+
+def test_native_tool_search_no_added_terminal_requires_client_execution_marker():
+    state = CompatibilityStreamState(
+        _native_plan({"type": "tool_search", "execution": "client"})
+    )
+
+    with pytest.raises(ToolCompatibilityError) as exc_info:
+        state.decode_events_for_event(
+            {
+                "type": "response.output_item.done",
+                "item": {
+                    "type": "tool_search_call",
+                    "id": "terminal-item",
+                    "call_id": "terminal-call",
+                    "execution": "provider",
+                    "arguments": {"query": "x"},
+                },
+            }
+        )
+
+    assert exc_info.value.classification == "invalid_tool_search_execution"
+
+
 def test_buffered_custom_delta_and_done_require_bound_call_id():
     plan = build_tool_compatibility_plan(
         [{"type": "custom", "name": "paint", "format": {"type": "text"}}],
@@ -877,6 +1190,159 @@ def test_buffered_custom_added_requires_function_call_wire_type(item_type):
         )
 
     assert exc_info.value.classification == "ambiguous_call_identity"
+
+
+@pytest.mark.parametrize("surface", ["body", "direct-stream"])
+def test_adapted_custom_alias_rejects_namespace_decoration(surface):
+    plan = build_tool_compatibility_plan(
+        [{"type": "custom", "name": "paint", "format": {"type": "text"}}],
+        selected_protocol="chat_tools",
+        protocol_capabilities=ProtocolCapabilities.chat_tools(),
+        request_token=f"custom-namespace-decoration-{surface}",
+    )
+    alias = plan.entries[0].aliases[0]
+    item = {
+        "type": "function_call",
+        "id": "item",
+        "call_id": "call",
+        "namespace": "evil",
+        "name": alias,
+        "arguments": '{"__codexhub_custom_input":"opaque"}',
+    }
+
+    with pytest.raises(ToolCompatibilityError) as exc_info:
+        if surface == "body":
+            plan.decode_payload({"output": [item]})
+        else:
+            CompatibilityStreamState(plan).decode_event(
+                {"type": "response.output_item.added", "item": item}
+            )
+
+    assert exc_info.value.classification == "unknown_alias"
+
+
+def test_buffered_adapted_custom_added_rejects_namespace_decoration():
+    plan = build_tool_compatibility_plan(
+        [{"type": "custom", "name": "paint", "format": {"type": "text"}}],
+        selected_protocol="chat_tools",
+        protocol_capabilities=ProtocolCapabilities.chat_tools(),
+        request_token="buffered-custom-namespace-decoration",
+    )
+    alias = plan.entries[0].aliases[0]
+
+    with pytest.raises(ToolCompatibilityError) as exc_info:
+        CompatibilityStreamState(plan).decode_events_for_event(
+            {
+                "type": "response.output_item.added",
+                "item": {
+                    "type": "function_call",
+                    "id": "item",
+                    "call_id": "call",
+                    "namespace": "evil",
+                    "name": alias,
+                    "arguments": "",
+                },
+            }
+        )
+
+    assert exc_info.value.classification == "invalid_custom_stream_identity"
+
+
+def test_buffered_adapted_custom_done_requires_exact_added_namespace_identity():
+    plan = build_tool_compatibility_plan(
+        [{"type": "custom", "name": "paint", "format": {"type": "text"}}],
+        selected_protocol="chat_tools",
+        protocol_capabilities=ProtocolCapabilities.chat_tools(),
+        request_token="custom-done-namespace-identity",
+    )
+    alias = plan.entries[0].aliases[0]
+    state = CompatibilityStreamState(plan)
+    arguments = '{"__codexhub_custom_input":"opaque"}'
+    state.decode_events_for_event(
+        {
+            "type": "response.output_item.added",
+            "item": {
+                "type": "function_call",
+                "id": "item",
+                "call_id": "call",
+                "name": alias,
+                "arguments": "",
+            },
+        }
+    )
+    state.decode_events_for_event(
+        {
+            "type": "response.function_call_arguments.done",
+            "item_id": "item",
+            "call_id": "call",
+            "arguments": arguments,
+        }
+    )
+
+    with pytest.raises(ToolCompatibilityError) as exc_info:
+        state.decode_events_for_event(
+            {
+                "type": "response.output_item.done",
+                "item": {
+                    "type": "function_call",
+                    "id": "item",
+                    "call_id": "call",
+                    "namespace": "evil",
+                    "name": alias,
+                    "arguments": arguments,
+                },
+            }
+        )
+
+    assert exc_info.value.classification == "ambiguous_native_identity"
+
+
+@pytest.mark.parametrize("buffered", [True, False], ids=["buffered", "direct"])
+def test_adapted_custom_done_requires_function_call_wire_type(buffered):
+    plan = build_tool_compatibility_plan(
+        [{"type": "custom", "name": "paint", "format": {"type": "text"}}],
+        selected_protocol="chat_tools",
+        protocol_capabilities=ProtocolCapabilities.chat_tools(),
+        request_token=f"custom-done-wire-family-{buffered}",
+    )
+    alias = plan.entries[0].aliases[0]
+    state = CompatibilityStreamState(plan)
+    arguments = '{"__codexhub_custom_input":"opaque"}'
+    added = {
+        "type": "response.output_item.added",
+        "item": {
+            "type": "function_call",
+            "id": "item",
+            "call_id": "call",
+            "name": alias,
+            "arguments": "" if buffered else arguments,
+        },
+    }
+    arguments_done = {
+        "type": "response.function_call_arguments.done",
+        "item_id": "item",
+        "call_id": "call",
+        "arguments": arguments,
+    }
+    item_done = {
+        "type": "response.output_item.done",
+        "item": {
+            "type": "custom_tool_call",
+            "id": "item",
+            "call_id": "call",
+            "name": alias,
+            "arguments": arguments,
+        },
+    }
+    decode = state.decode_events_for_event if buffered else state.decode_event
+    decode(added)
+    decode(arguments_done)
+
+    with pytest.raises(ToolCompatibilityError) as exc_info:
+        decode(item_done)
+
+    expected = "ambiguous_native_identity" if buffered else "ambiguous_call_identity"
+    assert exc_info.value.classification == expected
 
 
 def test_conflicting_item_id_and_id_fail_closed():

--- a/tests/test_runtime_tool_compatibility_boundaries.py
+++ b/tests/test_runtime_tool_compatibility_boundaries.py
@@ -680,6 +680,63 @@ def test_conflicting_item_id_and_id_fail_closed():
         )
 
 
+def test_conflicting_stream_item_id_and_id_fail_closed():
+    plan = _native_plan({"type": "function", "name": "keep"})
+    state = CompatibilityStreamState(plan)
+    state.decode_events_for_event(
+        {
+            "type": "response.output_item.added",
+            "item": {
+                "type": "function_call",
+                "id": "item",
+                "call_id": "call",
+                "name": "keep",
+                "arguments": "",
+            },
+        }
+    )
+
+    with pytest.raises(ToolCompatibilityError) as exc_info:
+        state.decode_events_for_event(
+            {
+                "type": "response.function_call_arguments.delta",
+                "item_id": "item",
+                "id": "evil",
+                "call_id": "call",
+                "delta": "{}",
+            }
+        )
+
+    assert exc_info.value.classification == "ambiguous_native_identity"
+    assert exc_info.value.surface == "stream"
+
+
+def test_conflicting_nested_and_top_level_stream_identity_fails_closed():
+    state = CompatibilityStreamState(_native_hosted_plan())
+    state.decode_events_for_event(
+        {
+            "type": "response.output_item.added",
+            "item": {
+                "type": "web_search_call",
+                "id": "search-item",
+                "status": "in_progress",
+            },
+        }
+    )
+
+    with pytest.raises(ToolCompatibilityError) as exc_info:
+        state.decode_events_for_event(
+            {
+                "type": "response.web_search_call.in_progress",
+                "item_id": "evil",
+                "item": {"id": "search-item"},
+            }
+        )
+
+    assert exc_info.value.classification == "ambiguous_native_identity"
+    assert exc_info.value.surface == "stream"
+
+
 def test_invented_hosted_output_shape_fails_closed():
     plan = _native_hosted_plan()
     invented = {"type": "web_search_call_output", "id": "output", "output": {"evil": True}}

--- a/tests/test_runtime_tool_compatibility_boundaries.py
+++ b/tests/test_runtime_tool_compatibility_boundaries.py
@@ -786,6 +786,40 @@ def test_native_plain_stream_accepts_exact_flattened_namespace_wire_identity():
     )
 
 
+def test_native_flattened_item_done_can_complete_arguments_without_separate_done_event():
+    plan = _native_plan({"type": "function", "name": "multi_agent_v1__spawn_agent"})
+    state = CompatibilityStreamState(plan)
+    item = {
+        "type": "function_call",
+        "namespace": "multi_agent_v1",
+        "name": "spawn_agent",
+        "id": "flattened-item",
+        "call_id": "flattened-call",
+        "arguments": "",
+    }
+    state.decode_events_for_event({"type": "response.output_item.added", "item": item})
+    completed = {**item, "arguments": "{}"}
+    state.decode_events_for_event({"type": "response.output_item.done", "item": completed})
+    state.decode_events_for_event(
+        {"type": "response.completed", "response": {"output": [completed]}}
+    )
+
+
+def test_legacy_flattened_worker_selector_item_done_keeps_no_added_passthrough():
+    plan = _native_plan({"type": "function", "name": "multi_agent_v1__spawn_agent"})
+    item = {
+        "type": "function_call",
+        "namespace": "multi_agent_v1",
+        "name": "spawn_agent",
+        "id": "selector-item",
+        "call_id": "selector-call",
+        "arguments": "{}",
+    }
+    CompatibilityStreamState(plan).decode_events_for_event(
+        {"type": "response.output_item.done", "item": item}
+    )
+
+
 def test_native_plain_tool_search_wrapper_keeps_no_added_terminal_path():
     plan = _native_plan({"type": "function", "name": "tool_search"})
     state = CompatibilityStreamState(plan)

--- a/tests/test_runtime_tool_compatibility_boundaries.py
+++ b/tests/test_runtime_tool_compatibility_boundaries.py
@@ -117,6 +117,225 @@ def test_omit_history_rejects_missing_or_conflicting_call_identity(history):
 
 
 @pytest.mark.parametrize(
+    ("declarations", "items"),
+    [
+        (
+            [{"type": "function", "name": "keep"}],
+            [
+                {"type": "function_call", "name": "keep", "call_id": "same", "arguments": "{}"},
+                {"type": "function_call", "name": "keep", "call_id": "same", "arguments": "{}"},
+            ],
+        ),
+        (
+            [
+                {"type": "function", "name": "paint"},
+                {"type": "custom", "name": "paint", "format": {"type": "text"}},
+            ],
+            [
+                {"type": "function_call", "name": "paint", "call_id": "same", "arguments": "{}"},
+                {"type": "custom_tool_call", "name": "paint", "call_id": "same", "input": "opaque"},
+            ],
+        ),
+    ],
+    ids=["same-family", "cross-family"],
+)
+def test_encode_history_rejects_duplicate_retained_call_identity(declarations, items):
+    plan = build_tool_compatibility_plan(
+        declarations,
+        selected_protocol="responses_structured",
+        protocol_capabilities=ProtocolCapabilities.responses_structured(),
+        request_token="duplicate-retained-call-id",
+    )
+
+    with pytest.raises(ToolCompatibilityError) as exc_info:
+        plan.encode_payload({"input": items})
+
+    assert exc_info.value.classification == "duplicate_call_identity"
+
+
+@pytest.mark.parametrize("retained_first", [True, False], ids=["retained-first", "omitted-first"])
+def test_encode_history_rejects_retained_and_omitted_call_identity_in_either_order(retained_first):
+    plan = build_tool_compatibility_plan(
+        [
+            {"type": "function", "name": "keep"},
+            {"type": "custom", "name": "omit", "format": {"type": "text"}},
+        ],
+        selected_protocol="chat_tools",
+        protocol_capabilities=ProtocolCapabilities.chat_tools(accepts_custom_adapter=False),
+        request_token="retained-omitted-call-id",
+    )
+    retained = {"type": "function_call", "name": "keep", "call_id": "shared", "arguments": "{}"}
+    omitted = {"type": "custom_tool_call", "name": "omit", "call_id": "shared", "input": "opaque"}
+
+    with pytest.raises(ToolCompatibilityError) as exc_info:
+        plan.encode_payload({"input": [retained, omitted] if retained_first else [omitted, retained]})
+
+    assert exc_info.value.classification == "ambiguous_call_identity"
+
+
+def test_decode_rejects_bound_adapter_call_id_reused_by_another_alias_in_body_and_terminal():
+    plan = build_tool_compatibility_plan(
+        [_namespace("vendor_a", child="run"), _namespace("vendor_b", child="run")],
+        selected_protocol="chat_tools",
+        protocol_capabilities=ProtocolCapabilities.chat_tools(),
+        request_token="bound-call-owner",
+    )
+    first_alias, second_alias = [entry.aliases[0] for entry in plan.entries]
+    first = {
+        "type": "function_call",
+        "name": first_alias,
+        "id": "item-a",
+        "call_id": "shared",
+        "arguments": "{}",
+    }
+    second = {**first, "name": second_alias, "id": "item-b"}
+
+    plan.decode_payload({"output": [first]})
+    with pytest.raises(ToolCompatibilityError) as exc_info:
+        plan.decode_payload({"output": [second]})
+    assert exc_info.value.classification == "ambiguous_call_identity"
+
+    state = CompatibilityStreamState(plan)
+    state.decode_events_for_event({"type": "response.output_item.added", "item": first})
+    state.decode_events_for_event(
+        {
+            "type": "response.function_call_arguments.done",
+            "item_id": "item-a",
+            "call_id": "shared",
+            "arguments": "{}",
+        }
+    )
+    state.decode_events_for_event(
+        {
+            "type": "response.output_item.done",
+            "item": first,
+        }
+    )
+    with pytest.raises(ToolCompatibilityError) as exc_info:
+        state.decode_events_for_event(
+            {
+                "type": "response.completed",
+                "response": {"output": [second]},
+            }
+        )
+    assert exc_info.value.classification == "ambiguous_call_identity"
+
+
+def test_registered_adapter_call_id_rejects_unknown_output_family_in_body_sse_and_terminal():
+    plan = _adapted_namespace_plan()
+    alias = plan.entries[0].aliases[0]
+    call = {
+        "type": "function_call",
+        "name": alias,
+        "id": "item-adapter",
+        "call_id": "adapter-call",
+        "arguments": "{}",
+    }
+    bad_output = {
+        "type": "vendor_extension_call_output",
+        "id": "vendor-output",
+        "call_id": "adapter-call",
+        "output": "opaque",
+    }
+
+    plan.decode_payload({"output": [call]})
+    with pytest.raises(ToolCompatibilityError) as exc_info:
+        plan.decode_payload({"output": [bad_output]})
+    assert exc_info.value.classification == "ambiguous_call_identity"
+
+    state = CompatibilityStreamState(plan)
+    state.decode_events_for_event({"type": "response.output_item.added", "item": call})
+    with pytest.raises(ToolCompatibilityError) as exc_info:
+        state.decode_events_for_event({"type": "response.output_item.added", "item": bad_output})
+    assert exc_info.value.classification == "ambiguous_call_identity"
+
+    state = CompatibilityStreamState(plan)
+    state.decode_events_for_event({"type": "response.output_item.added", "item": call})
+    state.decode_events_for_event(
+        {
+            "type": "response.function_call_arguments.done",
+            "item_id": "item-adapter",
+            "call_id": "adapter-call",
+            "arguments": "{}",
+        }
+    )
+    state.decode_events_for_event({"type": "response.output_item.done", "item": call})
+    with pytest.raises(ToolCompatibilityError) as exc_info:
+        state.decode_events_for_event(
+            {
+                "type": "response.completed",
+                "response": {"output": [bad_output]},
+            }
+        )
+    assert exc_info.value.classification == "ambiguous_call_identity"
+
+
+@pytest.mark.parametrize(
+    ("declaration", "wrong_call"),
+    [
+        (
+            {"type": "function", "name": "declared"},
+            {"type": "function_call", "name": "other", "call_id": "wrong", "arguments": "{}"},
+        ),
+        (
+            {"type": "custom", "name": "declared", "format": {"type": "text"}},
+            {"type": "custom_tool_call", "name": "other", "call_id": "wrong", "input": "opaque"},
+        ),
+    ],
+    ids=["function", "custom"],
+)
+def test_omitted_standard_wrong_name_is_rejected_across_history_body_sse_and_terminal(declaration, wrong_call):
+    plan = build_tool_compatibility_plan(
+        [declaration],
+        selected_protocol="none",
+        protocol_capabilities=ProtocolCapabilities(),
+        request_token="omitted-standard-wrong-name",
+    )
+
+    with pytest.raises(ToolCompatibilityError):
+        plan.encode_payload({"input": [wrong_call]})
+    with pytest.raises(ToolCompatibilityError):
+        plan.decode_payload({"output": [wrong_call]})
+    with pytest.raises(ToolCompatibilityError):
+        CompatibilityStreamState(plan).decode_events_for_event(
+            {"type": "response.output_item.added", "item": wrong_call}
+        )
+    with pytest.raises(ToolCompatibilityError):
+        CompatibilityStreamState(plan).decode_events_for_event(
+            {"type": "response.completed", "response": {"output": [wrong_call]}}
+        )
+
+
+def test_response_owner_ledger_preserves_native_custom_pair_with_omitted_unknown_custom_tool():
+    plan = build_tool_compatibility_plan(
+        [
+            {"type": "custom", "name": "paint", "format": {"type": "text"}},
+            {"type": "custom_tool", "name": "vendor_custom", "executor": "selected_provider"},
+        ],
+        selected_protocol="responses_structured",
+        protocol_capabilities=ProtocolCapabilities.responses_structured(),
+        request_token="response-owner-ledger",
+    )
+    output = [
+        {
+            "type": "custom_tool_call",
+            "name": "paint",
+            "id": "native-item",
+            "call_id": "native-call",
+            "input": "opaque",
+        },
+        {
+            "type": "custom_tool_call_output",
+            "id": "native-output",
+            "call_id": "native-call",
+            "output": "native",
+        },
+    ]
+
+    assert plan.decode_payload({"output": output})["output"] == output
+
+
+@pytest.mark.parametrize(
     "event",
     [
         {

--- a/tests/test_runtime_tool_compatibility_boundaries.py
+++ b/tests/test_runtime_tool_compatibility_boundaries.py
@@ -623,6 +623,79 @@ def test_arguments_done_must_match_received_delta_fragments(adapted):
         )
 
 
+def test_native_tool_search_body_and_history_preserve_exact_client_execution_marker():
+    plan = _native_plan({"type": "tool_search", "execution": "client"})
+    call = {"type": "tool_search_call", "id": "search-item", "call_id": "search-call", "execution": "client", "arguments": {"query": "x"}}
+    output = {"type": "tool_search_output", "id": "search-output", "call_id": "search-call", "execution": "client", "tools": []}
+    assert plan.decode_payload({"output": [call, output]})["output"] == [call, output]
+    assert plan.encode_payload({"input": [call, output]})["input"] == [call, output]
+
+
+@pytest.mark.parametrize(
+    "item",
+    [
+        {"type": "tool_search_call", "id": "search-item", "call_id": "search-call", "arguments": {"query": "x"}},
+        {"type": "tool_search_output", "id": "search-output", "call_id": "search-call", "tools": []},
+        {"type": "tool_search_output", "id": "search-output", "call_id": "search-call", "execution": "provider", "tools": []},
+    ],
+    ids=["missing-call-marker", "missing-output-marker", "wrong-output-marker"],
+)
+def test_native_tool_search_requires_exact_client_execution_marker(item):
+    plan = _native_plan({"type": "tool_search", "execution": "client"})
+    with pytest.raises(ToolCompatibilityError):
+        plan.decode_payload({"output": [item]})
+
+
+def test_native_response_output_before_call_fails_closed():
+    plan = _native_plan({"type": "function", "name": "keep"})
+    call = {"type": "function_call", "id": "call-item", "call_id": "call", "name": "keep", "arguments": "{}"}
+    output = {"type": "function_call_output", "id": "call-output", "call_id": "call", "output": "done"}
+    with pytest.raises(ToolCompatibilityError):
+        plan.decode_payload({"output": [output, call]})
+
+
+def test_buffered_custom_delta_and_done_require_bound_call_id():
+    plan = build_tool_compatibility_plan(
+        [{"type": "custom", "name": "paint", "format": {"type": "text"}}],
+        selected_protocol="chat_tools",
+        protocol_capabilities=ProtocolCapabilities.chat_tools(),
+        request_token="custom-call-id-boundary",
+    )
+    alias = plan.entries[0].aliases[0]
+    state = CompatibilityStreamState(plan)
+    state.decode_events_for_event(
+        {"type": "response.output_item.added", "item": {"type": "function_call", "id": "item", "call_id": "call", "name": alias, "arguments": ""}}
+    )
+    with pytest.raises(ToolCompatibilityError):
+        state.decode_events_for_event(
+            {"type": "response.function_call_arguments.delta", "item_id": "item", "call_id": "evil", "delta": "{}"}
+        )
+
+
+def test_conflicting_item_id_and_id_fail_closed():
+    plan = _native_plan({"type": "function", "name": "keep"})
+    with pytest.raises(ToolCompatibilityError):
+        plan.decode_payload(
+            {"output": [{"type": "function_call", "item_id": "item", "id": "evil", "call_id": "call", "name": "keep", "arguments": "{}"}]}
+        )
+
+
+def test_invented_hosted_output_shape_fails_closed():
+    plan = _native_hosted_plan()
+    invented = {"type": "web_search_call_output", "id": "output", "output": {"evil": True}}
+    with pytest.raises(ToolCompatibilityError):
+        plan.decode_payload({"output": [invented]})
+    with pytest.raises(ToolCompatibilityError):
+        plan.decode_payload(
+            {
+                "output": [
+                    {"type": "web_search_call", "id": "call", "status": "completed"},
+                    invented,
+                ]
+            }
+        )
+
+
 @pytest.mark.parametrize("output_type", ["function_call_output", "vendor_extension_call_output"])
 def test_sse_output_before_adapted_call_fails_closed(output_type):
     plan = _adapted_namespace_plan()

--- a/tests/test_runtime_tool_compatibility_boundaries.py
+++ b/tests/test_runtime_tool_compatibility_boundaries.py
@@ -846,6 +846,65 @@ def test_optional_unknown_selected_provider_hosted_history_omits_without_call_id
     assert encoded["input"] == [{"type": "message", "role": "user", "content": "keep"}]
 
 
+def test_omitted_unknown_call_output_fails_closed_in_body_and_sse_boundaries():
+    declaration = {"type": "vendor_extension", "executor": "codex_client"}
+    plan = build_tool_compatibility_plan(
+        [declaration],
+        selected_protocol="responses_structured",
+        protocol_capabilities=ProtocolCapabilities.responses_structured(),
+        request_token="omitted-unknown-call-output",
+    )
+    output_item = {
+        "type": "vendor_extension_call_output",
+        "id": "extension-output-item",
+        "output": {"opaque": True},
+    }
+    with pytest.raises(ToolCompatibilityError):
+        plan.decode_payload({"output": [output_item]})
+
+    with pytest.raises(ToolCompatibilityError):
+        CompatibilityStreamState(plan).decode_events_for_event(
+            {"type": "response.output_item.added", "item": output_item}
+        )
+    with pytest.raises(ToolCompatibilityError):
+        CompatibilityStreamState(plan).decode_events_for_event(
+            {"type": "response.output_item.done", "item": output_item}
+        )
+    with pytest.raises(ToolCompatibilityError):
+        CompatibilityStreamState(plan).decode_events_for_event(
+            {"type": "response.completed", "response": {"output": [output_item]}}
+        )
+
+
+def test_omitted_known_hosted_call_output_fails_closed_in_body_and_sse_boundaries():
+    plan = build_tool_compatibility_plan(
+        [{"type": "web_search"}],
+        selected_protocol="chat_tools",
+        provider_hosted_capabilities={},
+        protocol_capabilities=ProtocolCapabilities.chat_tools(),
+        request_token="omitted-known-hosted-call-output",
+    )
+    output_item = {
+        "type": "web_search_call_output",
+        "id": "search-output-item",
+        "output": {"opaque": True},
+    }
+    with pytest.raises(ToolCompatibilityError):
+        plan.decode_payload({"output": [output_item]})
+    with pytest.raises(ToolCompatibilityError):
+        CompatibilityStreamState(plan).decode_events_for_event(
+            {"type": "response.output_item.added", "item": output_item}
+        )
+    with pytest.raises(ToolCompatibilityError):
+        CompatibilityStreamState(plan).decode_events_for_event(
+            {"type": "response.output_item.done", "item": output_item}
+        )
+    with pytest.raises(ToolCompatibilityError):
+        CompatibilityStreamState(plan).decode_events_for_event(
+            {"type": "response.completed", "response": {"output": [output_item]}}
+        )
+
+
 def test_unknown_selected_provider_lifecycle_remains_omitted_without_full_contract():
     declaration = {"type": "vendor_extension", "executor": "selected_provider"}
     protocol = ProtocolCapabilities.responses_structured(

--- a/tests/test_runtime_tool_compatibility_boundaries.py
+++ b/tests/test_runtime_tool_compatibility_boundaries.py
@@ -14,6 +14,7 @@ from runtime_tool_compatibility import (
     PLAIN_FUNCTION,
     ProtocolCapabilities,
     SELECTED_PROVIDER_HOSTED,
+    RequiredToolUnavailableError,
     ToolCompatibilityError,
     build_tool_compatibility_plan,
 )
@@ -845,41 +846,7 @@ def test_optional_unknown_selected_provider_hosted_history_omits_without_call_id
     assert encoded["input"] == [{"type": "message", "role": "user", "content": "keep"}]
 
 
-def test_native_unknown_lifecycle_is_not_misclassified_as_hosted_in_body_and_stream():
-    declaration = {"type": "vendor_extension", "executor": "codex_client"}
-    capabilities = ProtocolCapabilities.responses_structured(
-        unknown_lifecycles=frozenset({"vendor_extension"}),
-    )
-    plan = build_tool_compatibility_plan(
-        [declaration],
-        selected_protocol="responses_structured",
-        protocol_capabilities=capabilities,
-        request_token="native-unknown-lifecycle",
-    )
-    item = {
-        "type": "vendor_extension_call",
-        "id": "extension-item",
-        "payload": {"opaque": True},
-    }
-    assert plan.entries[0].disposition == NATIVE
-    assert plan.decode_payload({"output": [item]})["output"] == [item]
-
-    state = CompatibilityStreamState(plan)
-    added = {"type": "response.output_item.added", "item": item}
-    assert state.decode_events_for_event(added) == [added]
-    delta = {
-        "type": "response.vendor_extension_call.delta",
-        "item_id": "extension-item",
-        "opaque": "fragment",
-    }
-    assert state.decode_events_for_event(delta) == [delta]
-    done = {"type": "response.output_item.done", "item": item}
-    assert state.decode_events_for_event(done) == [done]
-    terminal = {"type": "response.completed", "response": {"id": "extension-response"}}
-    assert state.decode_events_for_event(terminal) == [terminal]
-
-
-def test_unknown_selected_provider_lifecycle_requires_provider_hosted_fact():
+def test_unknown_selected_provider_lifecycle_remains_omitted_without_full_contract():
     declaration = {"type": "vendor_extension", "executor": "selected_provider"}
     protocol = ProtocolCapabilities.responses_structured(
         unknown_lifecycles=frozenset({"vendor_extension"}),
@@ -900,7 +867,30 @@ def test_unknown_selected_provider_lifecycle_requires_provider_hosted_fact():
         protocol_capabilities=protocol,
         request_token="unknown-hosted-with-provider-fact",
     )
-    assert with_provider_fact.entries[0].disposition == NATIVE
+    assert with_provider_fact.entries[0].disposition == OMIT
+
+
+def test_unknown_lifecycle_name_fact_alone_is_not_a_complete_native_contract():
+    declaration = {"type": "vendor_extension", "executor": "codex_client"}
+    protocol = ProtocolCapabilities.responses_structured(
+        unknown_lifecycles=frozenset({"vendor_extension"}),
+    )
+    optional = build_tool_compatibility_plan(
+        [declaration],
+        selected_protocol="responses_structured",
+        protocol_capabilities=protocol,
+        request_token="unknown-name-only-optional",
+    )
+    assert optional.entries[0].disposition == OMIT
+
+    with pytest.raises(RequiredToolUnavailableError):
+        build_tool_compatibility_plan(
+            [declaration],
+            selected_protocol="responses_structured",
+            protocol_capabilities=protocol,
+            required=True,
+            request_token="unknown-name-only-required",
+        )
 
 
 def test_with_final_declarations_does_not_expose_hosted_without_provider_fact():

--- a/tests/test_runtime_tool_compatibility_boundaries.py
+++ b/tests/test_runtime_tool_compatibility_boundaries.py
@@ -1027,6 +1027,75 @@ def test_native_plain_owner_still_wins_over_unqualified_native_namespace_child()
     assert plan.decode_payload({"output": [item]})["output"] == [item]
 
 
+@pytest.mark.parametrize("native", [True, False], ids=["native", "adapted"])
+@pytest.mark.parametrize(
+    ("namespace", "name"),
+    [("evil", "run"), ("vendor", "evil")],
+    ids=["wrong-namespace", "wrong-child"],
+)
+@pytest.mark.parametrize("surface", ["body", "history", "stream"])
+def test_namespace_contract_rejects_inexact_namespace_owner(native, namespace, name, surface):
+    declaration = _namespace("vendor", child="run")
+    if native:
+        plan = _native_plan(declaration)
+    else:
+        plan = build_tool_compatibility_plan(
+            [declaration],
+            selected_protocol="chat_tools",
+            protocol_capabilities=ProtocolCapabilities.chat_tools(),
+            request_token="adapted-inexact-namespace-owner",
+        )
+    item = {
+        "type": "function_call",
+        "id": "namespace-item",
+        "call_id": "namespace-call",
+        "namespace": namespace,
+        "name": name,
+        "arguments": "{}",
+    }
+
+    with pytest.raises(ToolCompatibilityError) as exc_info:
+        if surface == "body":
+            plan.decode_payload({"output": [item]})
+        elif surface == "history":
+            plan.encode_payload({"input": [item]})
+        else:
+            CompatibilityStreamState(plan).decode_events_for_event(
+                {
+                    "type": "response.output_item.added",
+                    "item": {**item, "arguments": ""},
+                }
+            )
+
+    assert exc_info.value.classification == "unknown_native_identity"
+
+
+def test_omitted_plain_function_cannot_use_flattened_namespace_escape():
+    plan = build_tool_compatibility_plan(
+        [{"type": "function", "name": "vendor__run"}],
+        selected_protocol="none",
+        request_token="omitted-flattened-plain",
+    )
+
+    with pytest.raises(ToolCompatibilityError) as exc_info:
+        plan.encode_payload(
+            {
+                "input": [
+                    {
+                        "type": "function_call",
+                        "id": "item",
+                        "call_id": "call",
+                        "namespace": "vendor",
+                        "name": "run",
+                        "arguments": "{}",
+                    }
+                ]
+            }
+        )
+
+    assert exc_info.value.classification == "unknown_native_identity"
+
+
 @pytest.mark.parametrize(
     ("declaration", "item"),
     [
@@ -1146,6 +1215,106 @@ def test_native_tool_search_no_added_terminal_requires_client_execution_marker()
     assert exc_info.value.classification == "invalid_tool_search_execution"
 
 
+@pytest.mark.parametrize(
+    ("declaration", "done_item", "terminal_item"),
+    [
+        (
+            {"type": "function", "name": "tool_search"},
+            {
+                "type": "function_call",
+                "id": "item",
+                "call_id": "call",
+                "name": "tool_search",
+                "arguments": '{"query":"one"}',
+            },
+            {
+                "type": "function_call",
+                "id": "item",
+                "call_id": "call",
+                "name": "tool_search",
+                "arguments": '{"query":"two"}',
+            },
+        ),
+        (
+            {"type": "function", "name": "multi_agent_v1__spawn_agent"},
+            {
+                "type": "function_call",
+                "id": "item",
+                "call_id": "call",
+                "namespace": "multi_agent_v1",
+                "name": "spawn_agent",
+                "arguments": '{"task":"one"}',
+            },
+            {
+                "type": "function_call",
+                "id": "item",
+                "call_id": "call",
+                "namespace": "multi_agent_v1",
+                "name": "spawn_agent",
+                "arguments": '{"task":"two"}',
+            },
+        ),
+        (
+            {"type": "tool_search", "execution": "client"},
+            {
+                "type": "tool_search_call",
+                "id": "item",
+                "call_id": "call",
+                "execution": "client",
+                "arguments": {"query": "one"},
+            },
+            {
+                "type": "tool_search_call",
+                "id": "item",
+                "call_id": "call",
+                "execution": "client",
+                "arguments": {"query": "two"},
+            },
+        ),
+    ],
+    ids=["tool-search-wrapper", "flattened-worker-selector", "native-tool-search"],
+)
+def test_legacy_no_added_terminal_reconciles_semantic_snapshot(
+    declaration,
+    done_item,
+    terminal_item,
+):
+    state = CompatibilityStreamState(_native_plan(declaration))
+    state.decode_events_for_event(
+        {"type": "response.output_item.done", "item": done_item}
+    )
+
+    with pytest.raises(ToolCompatibilityError) as exc_info:
+        state.decode_events_for_event(
+            {"type": "response.completed", "response": {"output": [terminal_item]}}
+        )
+
+    assert exc_info.value.classification == "ambiguous_native_identity"
+
+
+def test_legacy_no_added_terminal_rejects_changed_call_identity():
+    declaration = {"type": "function", "name": "tool_search"}
+    item = {
+        "type": "function_call",
+        "id": "item",
+        "call_id": "call",
+        "name": "tool_search",
+        "arguments": "{}",
+    }
+    state = CompatibilityStreamState(_native_plan(declaration))
+    state.decode_events_for_event({"type": "response.output_item.done", "item": item})
+
+    with pytest.raises(ToolCompatibilityError) as exc_info:
+        state.decode_events_for_event(
+            {
+                "type": "response.completed",
+                "response": {"output": [{**item, "call_id": "evil"}]},
+            }
+        )
+
+    assert exc_info.value.classification == "ambiguous_call_identity"
+
+
 def test_buffered_custom_delta_and_done_require_bound_call_id():
     plan = build_tool_compatibility_plan(
         [{"type": "custom", "name": "paint", "format": {"type": "text"}}],
@@ -1219,6 +1388,88 @@ def test_adapted_custom_alias_rejects_namespace_decoration(surface):
             )
 
     assert exc_info.value.classification == "unknown_alias"
+
+
+def test_adapted_custom_native_history_rejects_namespace_decoration():
+    plan = build_tool_compatibility_plan(
+        [{"type": "custom", "name": "paint", "format": {"type": "text"}}],
+        selected_protocol="chat_tools",
+        protocol_capabilities=ProtocolCapabilities.chat_tools(),
+        request_token="custom-native-history-namespace",
+    )
+
+    with pytest.raises(ToolCompatibilityError) as exc_info:
+        plan.encode_payload(
+            {
+                "input": [
+                    {
+                        "type": "custom_tool_call",
+                        "id": "item",
+                        "call_id": "call",
+                        "namespace": "evil",
+                        "name": "paint",
+                        "input": "opaque",
+                    }
+                ]
+            }
+        )
+
+    assert exc_info.value.classification == "unknown_native_identity"
+
+
+@pytest.mark.parametrize(
+    ("surface", "expected_classification"),
+    [
+        ("body", "unknown_alias"),
+        ("history", "ambiguous_call_identity"),
+        ("stream", "unknown_alias"),
+    ],
+)
+def test_adapted_custom_result_rejects_namespace_decoration(surface, expected_classification):
+    declaration = {"type": "custom", "name": "paint", "format": {"type": "text"}}
+    plan = build_tool_compatibility_plan(
+        [declaration],
+        selected_protocol="chat_tools",
+        protocol_capabilities=ProtocolCapabilities.chat_tools(),
+        request_token=f"custom-result-namespace-{surface}",
+    )
+    encoded = plan.encode_payload(
+        {
+            "input": [
+                {
+                    "type": "custom_tool_call",
+                    "id": "call-item",
+                    "call_id": "call",
+                    "name": "paint",
+                    "input": "opaque",
+                },
+                {
+                    "type": "custom_tool_call_output",
+                    "id": "result-item",
+                    "call_id": "call",
+                    "output": "done",
+                },
+            ]
+        }
+    )["input"]
+    call_item, result_item = encoded
+    result_item = {**result_item, "namespace": "evil"}
+
+    with pytest.raises(ToolCompatibilityError) as exc_info:
+        if surface == "body":
+            plan.decode_payload({"output": [call_item, result_item]})
+        elif surface == "history":
+            plan.decode_payload({"history": [call_item, result_item]})
+        else:
+            state = CompatibilityStreamState(plan)
+            state.decode_event(
+                {"type": "response.output_item.added", "item": call_item}
+            )
+            state.decode_event(
+                {"type": "response.output_item.added", "item": result_item}
+            )
+
+    assert exc_info.value.classification == expected_classification
 
 
 def test_buffered_adapted_custom_added_rejects_namespace_decoration():

--- a/tests/test_runtime_tool_compatibility_boundaries.py
+++ b/tests/test_runtime_tool_compatibility_boundaries.py
@@ -409,3 +409,36 @@ def test_native_tool_search_rejects_duplicate_call_identity_in_body():
     plan = _native_plan(declaration)
     with pytest.raises(ToolCompatibilityError):
         plan.decode_payload({"output": [first, second]})
+
+
+def test_native_custom_sse_done_requires_string_input_and_matching_call_identity():
+    declaration, item = _native_declaration_and_missing_body_item("custom")
+    item["call_id"] = "call"
+    plan = _native_plan(declaration)
+
+    def added_event():
+        return {"type": "response.output_item.added", "item": dict(item)}
+
+    invalid_input = CompatibilityStreamState(plan)
+    invalid_input.decode_events_for_event(added_event())
+    with pytest.raises(ToolCompatibilityError):
+        invalid_input.decode_events_for_event(
+            {
+                "type": "response.custom_tool_call_input.done",
+                "item_id": "item",
+                "call_id": "call",
+                "input": {"not": "text"},
+            }
+        )
+
+    mismatched_identity = CompatibilityStreamState(plan)
+    mismatched_identity.decode_events_for_event(added_event())
+    with pytest.raises(ToolCompatibilityError):
+        mismatched_identity.decode_events_for_event(
+            {
+                "type": "response.custom_tool_call_input.done",
+                "item_id": "item",
+                "call_id": "different-call",
+                "input": "opaque",
+            }
+        )

--- a/tests/test_runtime_tool_compatibility_boundaries.py
+++ b/tests/test_runtime_tool_compatibility_boundaries.py
@@ -961,6 +961,152 @@ def test_native_custom_history_survives_omitted_unknown_custom_tool_type():
     assert plan.encode_payload({"input": history})["input"] == history
 
 
+def test_unknown_custom_tool_history_is_omitted_despite_reserved_standard_item_spelling():
+    plan = build_tool_compatibility_plan(
+        [
+            {
+                "type": "custom_tool",
+                "name": "vendor_custom",
+                "executor": "selected_provider",
+            }
+        ],
+        selected_protocol="responses_structured",
+        protocol_capabilities=ProtocolCapabilities.responses_structured(),
+        request_token="unknown-custom-tool-history",
+    )
+    encoded = plan.encode_payload(
+        {
+            "input": [
+                {
+                    "type": "custom_tool_call",
+                    "id": "unknown-item",
+                    "call_id": "unknown-call",
+                    "name": "vendor_custom",
+                    "input": "opaque",
+                },
+                {
+                    "type": "custom_tool_call_output",
+                    "id": "unknown-output",
+                    "call_id": "unknown-call",
+                    "output": "opaque",
+                },
+                {"type": "message", "role": "user", "content": "keep"},
+            ]
+        }
+    )
+
+    assert encoded["input"] == [{"type": "message", "role": "user", "content": "keep"}]
+
+
+def test_native_and_unknown_custom_tool_history_pairs_use_call_ownership():
+    plan = build_tool_compatibility_plan(
+        [
+            {"type": "custom", "name": "paint", "format": {"type": "text"}},
+            {
+                "type": "custom_tool",
+                "name": "vendor_custom",
+                "executor": "selected_provider",
+            },
+        ],
+        selected_protocol="responses_structured",
+        protocol_capabilities=ProtocolCapabilities.responses_structured(),
+        request_token="native-unknown-custom-tool-history",
+    )
+    native_pair = [
+        {
+            "type": "custom_tool_call",
+            "id": "native-item",
+            "call_id": "native-call",
+            "name": "paint",
+            "input": "native",
+        },
+        {
+            "type": "custom_tool_call_output",
+            "id": "native-output",
+            "call_id": "native-call",
+            "output": "native",
+        },
+    ]
+    encoded = plan.encode_payload(
+        {
+            "input": [
+                *native_pair,
+                {
+                    "type": "custom_tool_call",
+                    "id": "unknown-item",
+                    "call_id": "unknown-call",
+                    "name": "vendor_custom",
+                    "input": "unknown",
+                },
+                {
+                    "type": "custom_tool_call_output",
+                    "id": "unknown-output",
+                    "call_id": "unknown-call",
+                    "output": "unknown",
+                },
+                {"type": "message", "role": "user", "content": "keep"},
+            ]
+        }
+    )
+
+    assert encoded["input"] == [
+        *native_pair,
+        {"type": "message", "role": "user", "content": "keep"},
+    ]
+
+
+def test_registered_namespace_call_cannot_claim_unknown_custom_tool_output_boundaries():
+    declarations = [
+        _namespace("vendor", child="run"),
+        {
+            "type": "custom_tool",
+            "name": "vendor_custom",
+            "executor": "selected_provider",
+        },
+    ]
+    plan = build_tool_compatibility_plan(
+        declarations,
+        selected_protocol="chat_tools",
+        protocol_capabilities=ProtocolCapabilities.chat_tools(),
+        request_token="registered-namespace-custom-output-collision",
+    )
+    alias = plan.entries[0].aliases[0]
+    plan.decode_payload(
+        {
+            "output": [
+                {
+                    "type": "function_call",
+                    "id": "namespace-item",
+                    "call_id": "shared-call",
+                    "name": alias,
+                    "arguments": "{}",
+                }
+            ]
+        }
+    )
+    output_item = {
+        "type": "custom_tool_call_output",
+        "id": "unknown-output",
+        "call_id": "shared-call",
+        "output": "opaque",
+    }
+
+    with pytest.raises(ToolCompatibilityError):
+        plan.decode_payload({"output": [output_item]})
+    with pytest.raises(ToolCompatibilityError):
+        CompatibilityStreamState(plan).decode_events_for_event(
+            {"type": "response.output_item.added", "item": output_item}
+        )
+    with pytest.raises(ToolCompatibilityError):
+        CompatibilityStreamState(plan).decode_events_for_event(
+            {"type": "response.output_item.done", "item": output_item}
+        )
+    with pytest.raises(ToolCompatibilityError):
+        CompatibilityStreamState(plan).decode_events_for_event(
+            {"type": "response.completed", "response": {"output": [output_item]}}
+        )
+
+
 @pytest.mark.parametrize(
     ("declaration", "items"),
     [

--- a/tests/test_runtime_tool_compatibility_boundaries.py
+++ b/tests/test_runtime_tool_compatibility_boundaries.py
@@ -558,6 +558,55 @@ def test_adapted_terminal_cannot_complete_without_pending_owner():
         )
 
 
+def test_buffered_custom_terminal_reconciles_semantic_input_not_only_identity():
+    plan = build_tool_compatibility_plan(
+        [{"type": "custom", "name": "paint", "format": {"type": "text"}}],
+        selected_protocol="chat_tools",
+        protocol_capabilities=ProtocolCapabilities.chat_tools(),
+        request_token="custom-terminal-payload",
+    )
+    alias = plan.entries[0].aliases[0]
+    state = CompatibilityStreamState(plan)
+    added = {
+        "type": "response.output_item.added",
+        "item": {"type": "function_call", "id": "custom-item", "call_id": "custom-call", "name": alias, "arguments": ""},
+    }
+    state.decode_events_for_event(added)
+    arguments = '{"__codexhub_custom_input":"one"}'
+    state.decode_events_for_event(
+        {"type": "response.function_call_arguments.done", "item_id": "custom-item", "arguments": arguments}
+    )
+    done = {
+        "type": "response.output_item.done",
+        "item": {"type": "function_call", "id": "custom-item", "call_id": "custom-call", "name": alias, "arguments": arguments},
+    }
+    state.decode_events_for_event(done)
+
+    changed_payload = {**done["item"], "arguments": '{"__codexhub_custom_input":"two"}'}
+    with pytest.raises(ToolCompatibilityError):
+        state.decode_events_for_event(
+            {"type": "response.completed", "response": {"output": [changed_payload]}}
+        )
+
+
+def test_native_terminal_reconciles_semantic_arguments_not_only_identity():
+    plan = _native_plan({"type": "function", "name": "keep"})
+    state = CompatibilityStreamState(plan)
+    first = {"type": "function_call", "id": "native-item", "call_id": "native-call", "name": "keep", "arguments": ""}
+    state.decode_events_for_event({"type": "response.output_item.added", "item": first})
+    arguments = '{"value":1}'
+    state.decode_events_for_event(
+        {"type": "response.function_call_arguments.done", "item_id": "native-item", "call_id": "native-call", "arguments": arguments}
+    )
+    state.decode_events_for_event(
+        {"type": "response.output_item.done", "item": {**first, "arguments": arguments}}
+    )
+    with pytest.raises(ToolCompatibilityError):
+        state.decode_events_for_event(
+            {"type": "response.completed", "response": {"output": [{**first, "arguments": '{"value":2}'}]}}
+        )
+
+
 @pytest.mark.parametrize("output_type", ["function_call_output", "vendor_extension_call_output"])
 def test_sse_output_before_adapted_call_fails_closed(output_type):
     plan = _adapted_namespace_plan()

--- a/tests/test_runtime_tool_compatibility_boundaries.py
+++ b/tests/test_runtime_tool_compatibility_boundaries.py
@@ -336,6 +336,127 @@ def test_response_owner_ledger_preserves_native_custom_pair_with_omitted_unknown
 
 
 @pytest.mark.parametrize(
+    "output_type",
+    ["function_call_output", "vendor_extension_call_output"],
+    ids=["adapted-output", "unknown-output"],
+)
+def test_response_output_before_adapted_call_fails_closed_without_partial_reorder(output_type):
+    plan = _adapted_namespace_plan()
+    alias = plan.entries[0].aliases[0]
+    output = {
+        "type": output_type,
+        "id": "output-first",
+        "call_id": "adapted-call",
+        "output": "opaque",
+    }
+    call = {
+        "type": "function_call",
+        "id": "call-item",
+        "call_id": "adapted-call",
+        "name": alias,
+        "arguments": "{}",
+    }
+
+    with pytest.raises(ToolCompatibilityError):
+        plan.decode_payload({"output": [output, call]})
+    with pytest.raises(ToolCompatibilityError):
+        CompatibilityStreamState(plan).decode_events_for_event(
+            {"type": "response.completed", "response": {"output": [output, call]}}
+        )
+
+
+@pytest.mark.parametrize("call_id", [None, ""], ids=["missing", "empty"])
+def test_encode_history_rejects_retained_call_without_call_identity(call_id):
+    plan = _native_plan({"type": "function", "name": "keep"})
+    item = {"type": "function_call", "name": "keep", "id": "item", "arguments": "{}"}
+    if call_id is not None:
+        item["call_id"] = call_id
+
+    with pytest.raises(ToolCompatibilityError) as exc_info:
+        plan.encode_payload({"input": [item]})
+
+    assert exc_info.value.classification == "missing_call_identity"
+
+
+@pytest.mark.parametrize("identity_key", ["id", "item_id"], ids=["id", "item-id"])
+def test_encode_history_rejects_duplicate_item_identity_even_with_distinct_call_ids(identity_key):
+    plan = _native_plan({"type": "function", "name": "keep"})
+    first = {
+        "type": "function_call",
+        "name": "keep",
+        identity_key: "duplicate-item",
+        "call_id": "call-a",
+        "arguments": "{}",
+    }
+    second = {**first, "call_id": "call-b"}
+
+    with pytest.raises(ToolCompatibilityError) as exc_info:
+        plan.encode_payload({"input": [first, second]})
+
+    assert exc_info.value.classification == "duplicate_item_identity"
+
+
+def test_encode_history_rejects_duplicate_outputs_with_one_call_id():
+    plan = _native_plan({"type": "function", "name": "keep"})
+    history = [
+        {
+            "type": "function_call",
+            "name": "keep",
+            "id": "call-item",
+            "call_id": "call-one",
+            "arguments": "{}",
+        },
+        {"type": "function_call_output", "id": "output-one", "call_id": "call-one", "output": "first"},
+        {"type": "function_call_output", "id": "output-two", "call_id": "call-one", "output": "second"},
+    ]
+
+    with pytest.raises(ToolCompatibilityError) as exc_info:
+        plan.encode_payload({"input": history})
+
+    assert exc_info.value.classification == "duplicate_call_identity"
+
+
+def _complete_native_stream(plan, *, family: str = "plain") -> tuple[CompatibilityStreamState, dict]:
+    declaration, item = _native_declaration_and_missing_body_item(family)
+    del declaration
+    state = CompatibilityStreamState(plan)
+    if family == "plain":
+        item["name"] = "keep"
+    item = {**item, "id": "native-item", "call_id": "native-call"}
+    state.decode_events_for_event({"type": "response.output_item.added", "item": item})
+    if family != "tool_search":
+        state.decode_events_for_event(
+            {
+                "type": "response.function_call_arguments.done",
+                "item_id": "native-item",
+                "call_id": "native-call",
+                "arguments": "{}",
+            }
+        )
+    state.decode_events_for_event({"type": "response.output_item.done", "item": item})
+    return state, item
+
+
+@pytest.mark.parametrize(
+    "terminal_item",
+    [
+        {"type": "function_call", "id": "other-item", "call_id": "native-call", "name": "keep", "arguments": "{}"},
+        {"type": "function_call", "id": "native-item", "call_id": "other-call", "name": "keep", "arguments": "{}"},
+        {"type": "function_call", "id": "native-item", "call_id": "native-call", "name": "other", "arguments": "{}"},
+    ],
+    ids=["different-item", "different-call", "different-family-name"],
+)
+def test_native_stream_terminal_output_must_match_pending_item_identity(terminal_item):
+    plan = _native_plan({"type": "function", "name": "keep"})
+    state, _item = _complete_native_stream(plan)
+
+    with pytest.raises(ToolCompatibilityError):
+        state.decode_events_for_event(
+            {"type": "response.completed", "response": {"output": [terminal_item]}}
+        )
+
+
+@pytest.mark.parametrize(
     "event",
     [
         {

--- a/tests/test_runtime_tool_compatibility_integration.py
+++ b/tests/test_runtime_tool_compatibility_integration.py
@@ -526,3 +526,29 @@ def test_named_namespace_choice_requires_exact_child_identity():
             inject_codex_tools=False,
         )
     assert caught.value.cause.code == "tool_compatibility_required_unavailable"
+
+
+def test_text_compat_does_not_expose_injected_codex_functions():
+    body = json.dumps(
+        {
+            "model": "third-party-model",
+            "input": "spawn a child",
+        }
+    ).encode("utf-8")
+    payload = json.loads(
+        codex_proxy.compatible_request_body(
+            body,
+            {
+                "name": "ollama_cloud",
+                "tool_protocol": "text_compat",
+                "tool_surface_strategy": "eager",
+            },
+            event_context={"request_id": "text-compat-injection"},
+            inject_codex_tools=True,
+        )
+    )
+
+    assert not any(
+        isinstance(tool, dict) and tool.get("type") == "function"
+        for tool in payload.get("tools", [])
+    )

--- a/tests/test_runtime_tool_compatibility_integration.py
+++ b/tests/test_runtime_tool_compatibility_integration.py
@@ -448,3 +448,81 @@ def test_responses_structured_explicit_lifecycle_facts_preserve_native_shapes():
     entries = context["_runtime_tool_compatibility_plan"].entries
     assert [entry.disposition for entry in entries] == ["native", "native", "native"]
     assert payload["tools"] == tools
+
+
+def test_text_compat_without_explicit_facts_omits_plain_tools_and_fails_required_choice():
+    upstream = {
+        **_external_chat_upstream(),
+        "tool_protocol": "text_compat",
+    }
+    context: dict = {}
+    payload = json.loads(
+        codex_proxy.compatible_request_body(
+            _request([{"type": "function", "name": "plain"}]),
+            upstream,
+            event_context=context,
+            inject_codex_tools=False,
+        )
+    )
+    assert payload["tools"] == []
+    assert context["_runtime_tool_compatibility_plan"].entries[0].disposition == "omit"
+
+    with pytest.raises(codex_proxy.UpstreamProtocolTranslationError) as caught:
+        codex_proxy.compatible_request_body(
+            _request(
+                [{"type": "function", "name": "plain"}],
+                tool_choice={"type": "function", "name": "plain"},
+            ),
+            upstream,
+            event_context={},
+            inject_codex_tools=False,
+        )
+    assert caught.value.cause.code == "tool_compatibility_required_unavailable"
+    assert "plain" not in str(caught.value)
+
+
+@pytest.mark.parametrize(
+    "facts",
+    [
+        {"max_tool_name_length": "not-an-int"},
+        {"max_alias_attempts": []},
+        {"hosted_lifecycles": 17},
+        {"unknown_lifecycles": object()},
+        {"function_lifecycle": "yes"},
+    ],
+    ids=["bad-max-length", "bad-max-attempts", "bad-hosted-iterable", "bad-unknown-type", "bad-boolean"],
+)
+def test_malformed_tool_protocol_capabilities_are_bounded_translation_errors(facts):
+    upstream = {
+        **_external_chat_upstream(),
+        "tool_protocol_capabilities": facts,
+    }
+    with pytest.raises(codex_proxy.UpstreamProtocolTranslationError) as caught:
+        codex_proxy.compatible_request_body(
+            _request([{"type": "function", "name": "plain"}]),
+            upstream,
+            event_context={},
+            inject_codex_tools=False,
+        )
+    assert caught.value.cause.code == "tool_compatibility_capability_manifest"
+    assert "not-an-int" not in str(caught.value)
+    assert "yes" not in str(caught.value)
+
+
+def test_named_namespace_choice_requires_exact_child_identity():
+    upstream = _external_chat_upstream()
+    with pytest.raises(codex_proxy.UpstreamProtocolTranslationError) as caught:
+        codex_proxy.compatible_request_body(
+            _request(
+                [{
+                    "type": "namespace",
+                    "name": "vendor",
+                    "tools": [{"type": "function", "name": "run"}],
+                }],
+                tool_choice={"type": "function", "name": "run"},
+            ),
+            upstream,
+            event_context={},
+            inject_codex_tools=False,
+        )
+    assert caught.value.cause.code == "tool_compatibility_required_unavailable"

--- a/tests/test_runtime_tool_compatibility_integration.py
+++ b/tests/test_runtime_tool_compatibility_integration.py
@@ -212,6 +212,199 @@ def test_sse_inverse_uses_the_same_request_plan_and_rejects_unknown_alias():
         )
 
 
+def _runtime_attempt_context() -> tuple[dict, str]:
+    context: dict = {}
+    request_payload = json.loads(
+        codex_proxy.compatible_request_body(
+            _request(
+                [{
+                    "type": "namespace",
+                    "name": "vendor",
+                    "tools": [{"type": "function", "name": "run", "parameters": {}}],
+                }]
+            ),
+            _external_chat_upstream(),
+            event_context=context,
+            inject_codex_tools=False,
+        )
+    )
+    return context, request_payload["tools"][0]["name"]
+
+
+def _send_runtime_sse_event(context: dict, event: dict) -> bytes:
+    return codex_proxy.compatible_sse_line(
+        b"data: " + json.dumps(event).encode("utf-8") + b"\n",
+        "custom_endpoint",
+        event_context=context,
+    )
+
+
+def test_retry_attempt_generation_accepts_a_second_terminal_responses_stream():
+    context, _alias = _runtime_attempt_context()
+    context["_runtime_tool_compatibility_attempt_generation"] = 1
+
+    _send_runtime_sse_event(
+        context,
+        {"type": "response.created", "response": {"id": "first"}},
+    )
+    first_terminal = _send_runtime_sse_event(
+        context,
+        {
+            "type": "response.completed",
+            "response": {"id": "first", "status": "completed", "output": []},
+        },
+    )
+    assert first_terminal
+
+    # The first terminal is the lifecycle-final response that permits a retry.
+    context["_runtime_tool_compatibility_attempt_generation"] = 2
+    _send_runtime_sse_event(
+        context,
+        {"type": "response.created", "response": {"id": "second"}},
+    )
+    second_terminal = _send_runtime_sse_event(
+        context,
+        {
+            "type": "response.completed",
+            "response": {"id": "second", "status": "completed", "output": []},
+        },
+    )
+    assert second_terminal
+
+
+def test_retry_attempt_generation_rebinds_partial_call_identity_for_second_stream():
+    context, alias = _runtime_attempt_context()
+    context["_runtime_tool_compatibility_attempt_generation"] = 1
+    first_item = {
+        "type": "function_call",
+        "id": "item-reused",
+        "call_id": "call-reused",
+        "name": alias,
+        "arguments": "",
+    }
+    _send_runtime_sse_event(
+        context,
+        {"type": "response.output_item.added", "item": first_item},
+    )
+    _send_runtime_sse_event(
+        context,
+        {
+            "type": "response.function_call_arguments.delta",
+            "item_id": "item-reused",
+            "call_id": "call-reused",
+            "delta": "{",
+        },
+    )
+
+    # Simulate transport failure after a partial added/delta.  A permitted
+    # retry reuses the provider's call/item identities from the fresh attempt.
+    context["_runtime_tool_compatibility_attempt_generation"] = 2
+    second_item = {**first_item, "arguments": ""}
+    _send_runtime_sse_event(
+        context,
+        {"type": "response.output_item.added", "item": second_item},
+    )
+    _send_runtime_sse_event(
+        context,
+        {
+            "type": "response.function_call_arguments.delta",
+            "item_id": "item-reused",
+            "call_id": "call-reused",
+            "delta": "{}",
+        },
+    )
+    _send_runtime_sse_event(
+        context,
+        {
+            "type": "response.function_call_arguments.done",
+            "item_id": "item-reused",
+            "call_id": "call-reused",
+            "arguments": "{}",
+        },
+    )
+    _send_runtime_sse_event(
+        context,
+        {
+            "type": "response.output_item.done",
+            "item": {**first_item, "arguments": "{}"},
+        },
+    )
+    terminal = _send_runtime_sse_event(
+        context,
+        {
+            "type": "response.completed",
+            "response": {
+                "id": "second",
+                "status": "completed",
+                "output": [{**first_item, "arguments": "{}"}],
+            },
+        },
+    )
+    assert terminal
+
+
+def test_required_tool_restriction_diagnostics_keep_generated_aliases_private(monkeypatch):
+    events: list[tuple[str, dict]] = []
+    monkeypatch.setattr(
+        codex_proxy,
+        "write_proxy_event",
+        lambda name, **fields: events.append((name, fields)),
+    )
+    prompt = """
+Use the real subagent-driven-development skill.
+
+Execution constraints:
+1. The coordinator may read the plan once with node_repl.
+2. Spawn exactly one implementer, wait for it, close it, then spawn exactly one spec reviewer, wait for it, close it, then spawn exactly one code-quality reviewer, wait for it, and close it.
+"""
+    context = {"request_id": "req-diagnostics", "repair_policy": codex_proxy.REPAIR_CODEX_SUBAGENT}
+    with monkeypatch.context() as patches:
+        # Keep both declarations on the synthetic surface so the required-tool
+        # restriction itself (rather than coordinator filtering) is exercised.
+        patches.setattr(codex_proxy, "_filter_tools_for_subagent_coordinator", lambda *args, **kwargs: False)
+        patches.setattr(codex_proxy, "_inject_explicit_codex_tools", lambda *args, **kwargs: False)
+        patches.setattr(
+            codex_proxy,
+            "_runtime_alias_for_namespace_child",
+            lambda *args, **kwargs: "__codexhub_ns_generated_1",
+        )
+        transformed = codex_proxy.compatible_request_body(
+            json.dumps(
+                {
+                    "model": "custom-model",
+                    "input": [{"type": "message", "role": "user", "content": prompt}],
+                    "tools": [
+                        {
+                            "type": "function",
+                            "name": "__codexhub_ns_generated_1",
+                            "parameters": {},
+                        },
+                        {"type": "function", "name": "other", "parameters": {}},
+                    ],
+                }
+            ).encode("utf-8"),
+            {
+                "name": "custom_endpoint",
+                "upstream_format": "chat_completions",
+                "tool_protocol": "chat_tools",
+            },
+            event_context=context,
+        )
+
+    restricted = [fields for name, fields in events if name == "required_tool_tools_restricted"]
+    assert restricted
+    fields = restricted[-1]
+    assert set(fields) == {
+        "tool_choice_required",
+        "required_tool_family",
+        "required_tool_disposition",
+    }
+    assert fields["tool_choice_required"] is True
+    assert fields["required_tool_family"] in {"namespace", "plain_function", "unknown"}
+    assert "__codexhub_" not in json.dumps(fields)
+    assert json.loads(transformed)["tool_choice"]["type"] == "function"
+
+
 def test_changing_only_model_slug_does_not_change_compatibility_dispositions():
     tools = [
         {

--- a/tests/test_runtime_tool_compatibility_integration.py
+++ b/tests/test_runtime_tool_compatibility_integration.py
@@ -1,0 +1,450 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import codex_proxy
+from codex_semantic_adapter import COLLABORATION_V2
+
+
+def _external_chat_upstream() -> dict:
+    return {
+        "name": "custom_endpoint",
+        "upstream_format": "responses",
+        "tool_protocol": "chat_tools",
+        "tool_surface_strategy": "eager",
+    }
+
+
+def _request(tools: list[dict], *, model: str = "custom-model", tool_choice="auto") -> bytes:
+    return json.dumps(
+        {
+            "model": model,
+            "input": [{"type": "message", "role": "user", "content": "Use the requested tool."}],
+            "tools": tools,
+            "tool_choice": tool_choice,
+        }
+    ).encode("utf-8")
+
+
+def _decoded_sse(line: bytes) -> dict:
+    assert line.startswith(b"data:")
+    return json.loads(line.split(b":", 1)[1].strip())
+
+
+def test_gateway_builds_and_applies_one_runtime_plan_before_external_sampling(monkeypatch):
+    events: list[tuple[str, dict]] = []
+    monkeypatch.setattr(
+        codex_proxy,
+        "write_proxy_event",
+        lambda name, **fields: events.append((name, fields)),
+    )
+    tools = [
+        {"type": "function", "name": "plain", "parameters": {"type": "object"}},
+        {
+            "type": "namespace",
+            "name": "vendor",
+            "tools": [{"type": "function", "name": "run", "parameters": {"type": "object"}}],
+        },
+        {"type": "custom", "name": "editor", "format": {"type": "text"}},
+        {"type": "tool_search", "execution": "client"},
+        {"type": "web_search", "private": "must-not-be-logged"},
+        {"type": "future_kind", "opaque": "must-not-be-logged"},
+    ]
+    context: dict = {"request_id": "req-private"}
+
+    payload = json.loads(
+        codex_proxy.compatible_request_body(
+            _request(tools),
+            _external_chat_upstream(),
+            event_context=context,
+            inject_codex_tools=False,
+        )
+    )
+
+    assert payload["model"] == "custom-model"
+    assert payload["tools"][0] == tools[0]
+    assert [tool["type"] for tool in payload["tools"]] == ["function", "function", "function"]
+    assert payload["tools"][1]["name"].startswith("__codexhub_ns_")
+    assert payload["tools"][2]["name"].startswith("__codexhub_custom_")
+    assert {entry.disposition for entry in context["_runtime_tool_compatibility_plan"].entries} == {
+        "native",
+        "adapt",
+        "omit",
+    }
+    compatibility_events = [fields for name, fields in events if name == "runtime_tool_compatibility_planned"]
+    assert compatibility_events
+    serialized = json.dumps(compatibility_events, sort_keys=True)
+    assert "must-not-be-logged" not in serialized
+    assert "req-private" not in serialized
+    assert "__codexhub_" not in serialized
+
+
+def test_required_unsupported_hosted_tool_fails_before_request_is_returned():
+    with pytest.raises(codex_proxy.UpstreamProtocolTranslationError) as caught:
+        codex_proxy.compatible_request_body(
+            _request(
+                [{"type": "web_search"}],
+                tool_choice={"type": "web_search"},
+            ),
+            _external_chat_upstream(),
+            event_context={},
+            inject_codex_tools=False,
+        )
+
+    assert caught.value.cause.code == "tool_compatibility_required_unavailable"
+    assert "web_search" not in str(caught.value)
+
+
+def test_response_body_uses_the_request_plan_for_exact_namespace_and_custom_inverse():
+    context: dict = {}
+    request_payload = json.loads(
+        codex_proxy.compatible_request_body(
+            _request(
+                [
+                    {
+                        "type": "namespace",
+                        "name": "vendor",
+                        "tools": [{"type": "function", "name": "run", "parameters": {}}],
+                    },
+                    {"type": "custom", "name": "editor", "format": {"type": "text"}},
+                ]
+            ),
+            _external_chat_upstream(),
+            event_context=context,
+            inject_codex_tools=False,
+        )
+    )
+    namespace_alias, custom_alias = [tool["name"] for tool in request_payload["tools"]]
+    upstream_response = {
+        "id": "resp",
+        "output": [
+            {
+                "id": "item_ns",
+                "type": "function_call",
+                "status": "completed",
+                "call_id": "call_ns",
+                "name": namespace_alias,
+                "arguments": "{}",
+            },
+            {
+                "id": "item_custom",
+                "type": "function_call",
+                "status": "completed",
+                "call_id": "call_custom",
+                "name": custom_alias,
+                "arguments": '{"__codexhub_custom_input":"opaque"}',
+            },
+        ],
+    }
+
+    decoded = json.loads(
+        codex_proxy.compatible_response_body(
+            json.dumps(upstream_response).encode("utf-8"),
+            "custom_endpoint",
+            context,
+        )
+    )
+
+    assert decoded["output"][0]["namespace"] == "vendor"
+    assert decoded["output"][0]["name"] == "run"
+    assert decoded["output"][0]["call_id"] == "call_ns"
+    assert decoded["output"][1]["type"] == "custom_tool_call"
+    assert decoded["output"][1]["name"] == "editor"
+    assert decoded["output"][1]["input"] == "opaque"
+    assert [item["id"] for item in decoded["output"]] == ["item_ns", "item_custom"]
+
+
+def test_sse_inverse_uses_the_same_request_plan_and_rejects_unknown_alias():
+    context: dict = {}
+    request_payload = json.loads(
+        codex_proxy.compatible_request_body(
+            _request(
+                [
+                    {
+                        "type": "namespace",
+                        "name": "vendor",
+                        "tools": [{"type": "function", "name": "run", "parameters": {}}],
+                    }
+                ]
+            ),
+            _external_chat_upstream(),
+            event_context=context,
+            inject_codex_tools=False,
+        )
+    )
+    alias = request_payload["tools"][0]["name"]
+    added = {
+        "type": "response.output_item.added",
+        "item": {
+            "type": "function_call",
+            "name": alias,
+            "call_id": "call",
+            "item_id": "item",
+            "arguments": "",
+        },
+    }
+    mapped = _decoded_sse(
+        codex_proxy.compatible_sse_line(
+            b"data: " + json.dumps(added).encode("utf-8") + b"\n",
+            "custom_endpoint",
+            context,
+        )
+    )
+    assert mapped["item"]["namespace"] == "vendor"
+    assert mapped["item"]["name"] == "run"
+
+    unknown = {
+        "type": "response.output_item.added",
+        "item": {
+            "type": "function_call",
+            "name": "__codexhub_ns_unknown_1",
+            "call_id": "other",
+            "item_id": "other-item",
+        },
+    }
+    with pytest.raises(codex_proxy.UpstreamProtocolTranslationError):
+        codex_proxy.compatible_sse_line(
+            b"data: " + json.dumps(unknown).encode("utf-8") + b"\n",
+            "custom_endpoint",
+            context,
+        )
+
+
+def test_changing_only_model_slug_does_not_change_compatibility_dispositions():
+    tools = [
+        {
+            "type": "namespace",
+            "name": "vendor",
+            "tools": [{"type": "function", "name": "run", "parameters": {}}],
+        },
+        {"type": "web_search"},
+    ]
+    contexts = [{}, {}]
+    for model, context in zip(("model-a", "model-b"), contexts, strict=True):
+        codex_proxy.compatible_request_body(
+            _request(tools, model=model),
+            _external_chat_upstream(),
+            event_context=context,
+            inject_codex_tools=False,
+        )
+
+    assert [
+        (entry.family, entry.disposition)
+        for entry in contexts[0]["_runtime_tool_compatibility_plan"].entries
+    ] == [
+        (entry.family, entry.disposition)
+        for entry in contexts[1]["_runtime_tool_compatibility_plan"].entries
+    ]
+
+
+def test_explicit_selected_provider_hosted_capability_preserves_native_declaration():
+    context: dict = {}
+    upstream = {
+        **_external_chat_upstream(),
+        "hosted_tool_capabilities": {"web_search": True},
+        "tool_protocol_capabilities": {
+            "hosted_lifecycles": ["web_search"],
+        },
+    }
+
+    payload = json.loads(
+        codex_proxy.compatible_request_body(
+            _request([{"type": "web_search", "search_context_size": "low"}]),
+            upstream,
+            event_context=context,
+            inject_codex_tools=False,
+        )
+    )
+
+    assert payload["tools"] == [{"type": "web_search", "search_context_size": "low"}]
+    assert context["_runtime_tool_compatibility_plan"].entries[0].disposition == "native"
+
+
+def test_custom_sse_is_not_forwarded_until_the_complete_envelope_is_valid():
+    context: dict = {}
+    request_payload = json.loads(
+        codex_proxy.compatible_request_body(
+            _request([{"type": "custom", "name": "editor", "format": {"type": "text"}}]),
+            _external_chat_upstream(),
+            event_context=context,
+            inject_codex_tools=False,
+        )
+    )
+    alias = request_payload["tools"][0]["name"]
+
+    def send(event: dict) -> bytes:
+        return codex_proxy.compatible_sse_line(
+            b"data: " + json.dumps(event).encode("utf-8") + b"\n\n",
+            "custom_endpoint",
+            context,
+        )
+
+    assert send(
+        {
+            "type": "response.output_item.added",
+            "item": {
+                "type": "function_call",
+                "id": "item_custom",
+                "call_id": "call_custom",
+                "name": alias,
+                "arguments": "",
+            },
+        }
+    ) == b""
+    assert send(
+        {
+            "type": "response.function_call_arguments.delta",
+            "item_id": "item_custom",
+            "delta": '{"__codexhub_custom_input":"opaque"}',
+        }
+    ) == b""
+    assert send(
+        {
+            "type": "response.function_call_arguments.done",
+            "item_id": "item_custom",
+            "arguments": '{"__codexhub_custom_input":"opaque"}',
+        }
+    ) == b""
+    emitted = send(
+        {
+            "type": "response.output_item.done",
+            "item": {
+                "type": "function_call",
+                "id": "item_custom",
+                "call_id": "call_custom",
+                "name": alias,
+                "arguments": '{"__codexhub_custom_input":"opaque"}',
+            },
+        }
+    )
+    events = [
+        json.loads(chunk.removeprefix(b"data: "))
+        for chunk in emitted.split(b"\n\n")
+        if chunk
+    ]
+    assert [event["type"] for event in events] == [
+        "response.output_item.added",
+        "response.custom_tool_call_input.delta",
+        "response.custom_tool_call_input.done",
+        "response.output_item.done",
+    ]
+    assert events[1]["delta"] == "opaque"
+
+
+def test_collaboration_v2_is_adapted_without_v1_injection_or_repair():
+    context: dict = {
+        "request_id": "req",
+        "repair_policy": codex_proxy.REPAIR_CODEX_SUBAGENT,
+    }
+    tools = [
+        {
+            "type": "namespace",
+            "name": "collaboration",
+            "tools": [
+                {
+                    "type": "function",
+                    "name": "followup_task",
+                }
+            ],
+        }
+    ]
+    history = [
+        {
+            "type": "function_call",
+            "namespace": "collaboration",
+            "name": "followup_task",
+            "call_id": "call_v2",
+            "arguments": '{"task_path":"/root/a","task_name":"a","fork_turns":"all"}',
+        },
+        {"type": "function_call_output", "call_id": "call_v2", "output": "queued"},
+    ]
+
+    payload = json.loads(
+        codex_proxy.compatible_request_body(
+            json.dumps(
+                {
+                    "model": "custom-model",
+                    "input": history,
+                    "tools": tools,
+                }
+            ).encode("utf-8"),
+            _external_chat_upstream(),
+            event_context=context,
+        )
+    )
+
+    aliases = [tool["name"] for tool in payload["tools"] if tool.get("type") == "function"]
+    assert len(aliases) == 1
+    assert aliases[0].startswith("__codexhub_ns_")
+    assert payload["input"][0]["name"] == aliases[0]
+    assert "namespace" not in payload["input"][0]
+    assert json.loads(payload["input"][0]["arguments"])["task_path"] == "/root/a"
+    assert context["collaboration_protocol"] == COLLABORATION_V2
+    assert not any(name.startswith("multi_agent_v1__") for name in aliases)
+
+
+def _external_responses_upstream() -> dict:
+    return {
+        "name": "responses_endpoint",
+        "upstream_format": "responses",
+        "tool_protocol": "responses_structured",
+        "tool_surface_strategy": "eager",
+    }
+
+
+def _responses_structural_tools() -> list[dict]:
+    return [
+        {
+            "type": "namespace",
+            "name": "vendor",
+            "tools": [{"type": "function", "name": "run", "parameters": {"type": "object"}}],
+        },
+        {"type": "custom", "name": "editor", "format": {"type": "text"}},
+        {"type": "tool_search", "execution": "client"},
+    ]
+
+
+def test_responses_structured_without_explicit_facts_uses_conservative_tool_defaults():
+    context: dict = {}
+    payload = json.loads(
+        codex_proxy.compatible_request_body(
+            _request(_responses_structural_tools()),
+            _external_responses_upstream(),
+            event_context=context,
+            inject_codex_tools=False,
+        )
+    )
+
+    entries = context["_runtime_tool_compatibility_plan"].entries
+    assert [entry.disposition for entry in entries] == ["adapt", "adapt", "omit"]
+    assert [tool["type"] for tool in payload["tools"]] == ["function", "function"]
+    assert payload["tools"][0]["name"].startswith("__codexhub_ns_")
+    assert payload["tools"][1]["name"].startswith("__codexhub_custom_")
+
+
+def test_responses_structured_explicit_lifecycle_facts_preserve_native_shapes():
+    context: dict = {}
+    upstream = {
+        **_external_responses_upstream(),
+        "tool_protocol_capabilities": {
+            "function_lifecycle": True,
+            "namespace_lifecycle": True,
+            "custom_lifecycle": True,
+            "tool_search_lifecycle": True,
+        },
+    }
+    tools = _responses_structural_tools()
+    payload = json.loads(
+        codex_proxy.compatible_request_body(
+            _request(tools),
+            upstream,
+            event_context=context,
+            inject_codex_tools=False,
+        )
+    )
+
+    entries = context["_runtime_tool_compatibility_plan"].entries
+    assert [entry.disposition for entry in entries] == ["native", "native", "native"]
+    assert payload["tools"] == tools


### PR DESCRIPTION
## Summary  - Build one immutable request-scoped tool compatibility plan after the selected Provider/model route is fixed. - Preserve native plain functions; reversibly adapt namespace/custom shapes; omit unsupported optional tool_search/hosted/unknown kinds; fail required unavailable tools before sampling. - Reuse the same registry across request history, response bodies, Responses SSE, Chat-to-Responses conversion, terminal output, and synthetic completion bookkeeping. - Keep Collaboration V1/V2 isolated and preserve Beta1 apply_patch behavior. - Isolate every permitted relay attempt's stream/call ledger while retaining request-scoped aliases and declarations.  ## Scope guard  No model-name codec branch, Provider/model fallback, cross-Provider tool proxy, Gateway tool execution, Gateway agent scheduling, alternate-codec retry, or model-output repair is introduced. Closes #58  ## Verification so far  - RED boundary suite: 32 failures before the fixes. - Focused candidate regression: 827 passed, 223 subtests, including retry-generation, bounded-diagnostic, and real outer-relay retry regressions. - Python compile check passed. - `git diff --check` passed. - Report-only quality gates exited 0; the report contains pre-existing findings, including `providers_config.py:736` parse diagnostic. - A broader local run (`--ignore=tests/test_real_client_e2e.py`) reached 2107 passed, 1 skipped, 467 subtests; three unrelated pre-existing tests remain outside this diff (`tests/test_ci_python_plan.py::test_ci_md_fallback_commands_use_watchdog_with_3600s_bound` and two Issue 108 smoke replay fixture tests). - Fresh exact-SHA Spec/Standards review and CLI-only verification are complete; the post-review local gate remains required before merge, tag, or release. AUTO native-capability fallback planning remains a deferred risk outside this PR.  <!-- orchestrator:delivery:v1 --> ```json {   "candidate_sha": "521be91524d1a40fffc5464e3e7c7c04d312d357",   "changed_paths": [     "src-python/codex_proxy.py",     "src-python/runtime_tool_compatibility.py",     "tests/test_issue_198_v1_v2_isolation.py",     "tests/test_routing.py",     "tests/test_runtime_tool_compatibility.py",     "tests/test_runtime_tool_compatibility_boundaries.py",     "tests/test_runtime_tool_compatibility_integration.py"   ],   "contract_sha256": "774c19703aa4d98340e91f4b075f6ac0a08717c4d218bf370f84a99b01212f8f",   "deviations": [],   "risks": [     "Fresh exact-SHA review, CLI-only verification, and the post-review local gate remain required before merge.",     "AUTO routes with future native namespace/custom capability facts may need per-attempt compatibility replanning; this is deferred and is not introduced by this PR.",     "Broader local suite has three unrelated pre-existing failures recorded above."   ],   "tdd": {     "red": "32 focused contract failures plus relay regressions reproduced missing identity checks, conservative capability gaps, terminal alias leakage, synthetic completion bookkeeping errors, and retry stream-state reuse; the outer relay regression now exercises a second lifecycle attempt.",     "green": "827 focused tests and 223 subtests pass on the candidate contents.",     "refactor": "One request-scoped plan and registry own declaration classification and reversible lifecycle mapping; each relay attempt receives a fresh call/stream ledger without acquiring route or execution authority."   },   "verification": [     "py -3.13 -m pytest -q tests/test_runtime_tool_compatibility.py tests/test_runtime_tool_compatibility_boundaries.py tests/test_runtime_tool_compatibility_integration.py tests/test_issue_198_v1_v2_isolation.py tests/test_routing.py: 827 passed, 223 subtests",     "py -3.13 -m py_compile changed Python modules/tests: passed",     "git diff --check: passed",     "python scripts/report_quality_gates.py: exit 0, report-only findings recorded",     "py -3.13 -m pytest -q --ignore=tests/test_real_client_e2e.py: 2107 passed, 1 skipped, 3 unrelated pre-existing failures"   ] } ```

## Post-review correction (521be91)

- Fixed a real stream-boundary defect: ordinary assistant message 
esponse.output_item.done events are now passed through when the request has adapted tools; tool-shaped unowned lifecycles remain fail-closed.
- Added regression 	est_adapted_stream_allows_ordinary_message_output_item_done.
- Exact SHA Standards/Spec review: PASS / 0 findings.
- Local focused suite: 827 passed, 223 subtests passed; py_compile and git diff --check passed.
- Codex CLI 0.145.0 against GLM-5.2 via the candidate Gateway completed one turn with `item.completed` and `turn.completed`; no `missing_stream_identity`, no reconnect storm, and no fallback.


