### PR TITLE
fix: publish 0.1.8-beta.2.2 custom history hotfix

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codexhub-frontend",
-  "version": "0.1.8-beta.2.1",
+  "version": "0.1.8-beta.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codexhub-frontend",
-      "version": "0.1.8-beta.2.1",
+      "version": "0.1.8-beta.2.2",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codexhub-frontend",
   "private": true,
-  "version": "0.1.8-beta.2.1",
+  "version": "0.1.8-beta.2.2",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -9061,13 +9061,43 @@ def _rewrite_v2_unsupported_custom_tool_history(
         if compatibility_plan is not None
         else _runtime_tool_protocol_capabilities(tool_protocol, upstream)
     )
+    tools = payload.get("tools")
+    if not isinstance(tools, list):
+        tools = []
+    declared_custom_names = {
+        tool.get("name")
+        for tool in tools
+        if isinstance(tool, Mapping)
+        and tool.get("type") == "custom"
+        and isinstance(tool.get("name"), str)
+    }
+
+    def plan_owns_custom_call(item: Mapping[str, Any]) -> bool:
+        if compatibility_plan is None:
+            return False
+        name = item.get("name")
+        if compatibility_plan.registry.record_for_alias(name) is not None:
+            return True
+        call_id = item.get("call_id")
+        if compatibility_plan.registry.record_for_call(call_id) is not None:
+            return True
+        return any(
+            entry.family == "custom_freeform"
+            and entry.original_name == name
+            for entry in compatibility_plan.entries
+        )
 
     def preserve_custom_call(item: Mapping[str, Any]) -> bool:
-        if capabilities.custom_lifecycle:
-            return True
-        # A declared custom tool may be adapted by the immutable plan later in
-        # this function.  Leave its wire item intact until that pass.
-        return compatibility_plan is not None and compatibility_plan.owns_wire_value(item)
+        # Preserve only a custom lifecycle that belongs to this request's
+        # immutable compatibility plan.  A provider capability fact alone does
+        # not establish ownership of an undeclared historical item (and must
+        # not let a plain-function name collision bypass sanitization).
+        if compatibility_plan is not None:
+            return plan_owns_custom_call(item)
+        return (
+            capabilities.custom_lifecycle
+            and item.get("name") in declared_custom_names
+        )
 
     preserved_call_ids = {
         item.get("call_id")

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -9033,6 +9033,94 @@ def _rewrite_internal_input_items(
     return changed
 
 
+def _rewrite_v2_unsupported_custom_tool_history(
+    payload: dict[str, Any],
+    *,
+    upstream: Mapping[str, Any],
+    tool_protocol: str,
+    compatibility_plan: RuntimeToolCompatibilityPlan | None,
+    event_context: Mapping[str, Any] | None,
+    upstream_name: str | None,
+) -> bool:
+    """Keep V2 Collaboration calls native without leaking other custom items.
+
+    Collaboration V2 is a boundary for the ``collaboration`` namespace, not a
+    blanket exemption from the third-party input-item adapter.  Codex Desktop
+    can place unrelated ``custom_tool_call`` history (for example ``exec``)
+    beside V2 calls.  Responses providers generally expose only the plain
+    function lifecycle unless an explicit custom lifecycle capability is
+    supplied, so those opaque items must become transcript messages before the
+    request reaches the provider.
+    """
+    input_items = payload.get("input")
+    if not isinstance(input_items, list):
+        return False
+
+    capabilities = (
+        compatibility_plan.capabilities
+        if compatibility_plan is not None
+        else _runtime_tool_protocol_capabilities(tool_protocol, upstream)
+    )
+
+    def preserve_custom_call(item: Mapping[str, Any]) -> bool:
+        if capabilities.custom_lifecycle:
+            return True
+        # A declared custom tool may be adapted by the immutable plan later in
+        # this function.  Leave its wire item intact until that pass.
+        return compatibility_plan is not None and compatibility_plan.owns_wire_value(item)
+
+    preserved_call_ids = {
+        item.get("call_id")
+        for item in input_items
+        if isinstance(item, Mapping)
+        and item.get("type") == "custom_tool_call"
+        and isinstance(item.get("call_id"), str)
+        and preserve_custom_call(item)
+    }
+
+    rewritten_items: list[Any] = []
+    changed = False
+    rewritten_count = 0
+    for item in input_items:
+        if not isinstance(item, Mapping):
+            rewritten_items.append(item)
+            continue
+        item_type = item.get("type")
+        if item_type == "custom_tool_call" and not preserve_custom_call(item):
+            replacement = _compatible_internal_message(item)
+            if replacement is not None:
+                rewritten_items.append(replacement)
+                changed = True
+                rewritten_count += 1
+            else:
+                rewritten_items.append(item)
+            continue
+        if (
+            item_type == "custom_tool_call_output"
+            and item.get("call_id") not in preserved_call_ids
+        ):
+            replacement = _compatible_internal_message(item)
+            if replacement is not None:
+                rewritten_items.append(replacement)
+                changed = True
+                rewritten_count += 1
+            else:
+                rewritten_items.append(item)
+            continue
+        rewritten_items.append(item)
+
+    if not changed:
+        return False
+    payload["input"] = rewritten_items
+    _write_adapter_event(
+        event_context,
+        "v2_custom_tool_history_rewritten",
+        upstream=upstream_name,
+        count=rewritten_count,
+    )
+    return True
+
+
 def _sanitize_unsupported_compaction_input_items(payload: dict[str, Any]) -> bool:
     input_items = payload.get("input")
     if not isinstance(input_items, list):
@@ -10884,6 +10972,15 @@ def compatible_request_body(
         ):
             changed = True
         runtime_tool_plan = _runtime_tool_compatibility_plan(event_context)
+    if collaboration_v2 and _rewrite_v2_unsupported_custom_tool_history(
+        payload,
+        upstream=upstream,
+        tool_protocol=tool_protocol,
+        compatibility_plan=runtime_tool_plan,
+        event_context=event_context,
+        upstream_name=upstream_name,
+    ):
+        changed = True
     if raw_provider_probe or collaboration_v2:
         pass
     else:

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -9076,10 +9076,12 @@ def _rewrite_v2_unsupported_custom_tool_history(
         if compatibility_plan is None:
             return False
         name = item.get("name")
-        if compatibility_plan.registry.record_for_alias(name) is not None:
+        alias_record = compatibility_plan.registry.record_for_alias(name)
+        if alias_record is not None and alias_record.family == "custom_freeform":
             return True
         call_id = item.get("call_id")
-        if compatibility_plan.registry.record_for_call(call_id) is not None:
+        call_record = compatibility_plan.registry.record_for_call(call_id)
+        if call_record is not None and call_record.family == "custom_freeform":
             return True
         return any(
             entry.family == "custom_freeform"

--- a/src-python/runtime_tool_compatibility.py
+++ b/src-python/runtime_tool_compatibility.py
@@ -1355,11 +1355,17 @@ class ToolCompatibilityPlan:
             return True
         name = value.get("name")
         namespace = value.get("namespace")
+        item_type = value.get("type")
         if self.registry.record_for_alias(name) is not None:
             return True
         if self.registry.looks_like_alias(name):
             return True
-        if self._entry_for_name(name, namespace) is not None:
+        if self._entry_for_name(
+            name,
+            namespace,
+            expected_family=self._family_for_item_type(item_type, namespace),
+            item_type=item_type,
+        ) is not None:
             return True
         return self.registry.record_for_call(value.get("call_id")) is not None
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "codexhub"
-version = "0.1.8-beta.2.1"
+version = "0.1.8-beta.2.2"
 dependencies = [
  "dirs 5.0.1",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codexhub"
-version = "0.1.8-beta.2.1"
+version = "0.1.8-beta.2.2"
 description = "CodexHub desktop backend and CLI"
 authors = ["CodexHub"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "CodexHub",
-  "version": "0.1.8-beta.2.1",
+  "version": "0.1.8-beta.2.2",
   "identifier": "com.codexhub.app",
   "build": {
     "frontendDist": "../frontend/dist",

--- a/tests/test_issue_198_v1_v2_isolation.py
+++ b/tests/test_issue_198_v1_v2_isolation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 from unittest.mock import patch
 
@@ -463,6 +464,68 @@ def test_v2_does_not_preserve_unknown_custom_alias_history() -> None:
         _upstream(),
         event_context=context,
     )
+    payload = json.loads(transformed)
+
+    assert all(
+        item.get("type") not in {"custom_tool_call", "custom_tool_call_output"}
+        for item in payload["input"]
+        if isinstance(item, dict)
+    )
+    assert "Read-only Codex tool call transcript" in payload["input"][1]["content"]
+    assert "Read-only Codex tool result transcript" in payload["input"][2]["content"]
+
+
+def test_v2_does_not_treat_namespace_alias_as_custom_history_owner() -> None:
+    context: dict[str, object] = {"request_id": "issue198-v2-namespace-alias-collision"}
+    token = "namespace-alias-test"
+    token_digest = hashlib.sha256(token.encode()).hexdigest()[:10]
+    namespace_alias = f"__codexhub_ns_{token_digest}_2"
+    body = {
+        "model": "deepseek-v4-flash:0731",
+        "input": [
+            _v2_spawn_call(),
+            {
+                "type": "custom_tool_call",
+                "status": "completed",
+                "call_id": "call_namespace_alias",
+                "name": namespace_alias,
+                "input": "echo sanitized",
+            },
+            {
+                "type": "custom_tool_call_output",
+                "call_id": "call_namespace_alias",
+                "output": "completed",
+            },
+        ],
+        "tools": [
+            {
+                "type": "namespace",
+                "name": "collaboration",
+                "tools": [{"type": "function", "name": "spawn_agent"}],
+            },
+            {
+                "type": "namespace",
+                "name": "other",
+                "tools": [{"type": "function", "name": "exec"}],
+            },
+        ],
+    }
+    upstream = {
+        **_upstream(),
+        "tool_protocol_capabilities": {
+            "function_lifecycle": True,
+            "namespace_lifecycle": False,
+            "accepts_namespace_adapter": True,
+        },
+    }
+
+    with patch("codex_proxy.uuid.uuid4") as uuid4:
+        uuid4.return_value.hex = token
+        transformed = codex_proxy.compatible_request_body(
+            json.dumps(body).encode(),
+            upstream,
+            event_context=context,
+        )
     payload = json.loads(transformed)
 
     assert all(

--- a/tests/test_issue_198_v1_v2_isolation.py
+++ b/tests/test_issue_198_v1_v2_isolation.py
@@ -285,6 +285,149 @@ def test_v2_request_preserves_native_namespace_and_does_not_inject_v1_tools() ->
     }
 
 
+def test_v2_preserves_collaboration_calls_but_rewrites_unsupported_custom_tool_history() -> None:
+    context: dict[str, object] = {"request_id": "issue198-v2-custom-history"}
+    custom_call = {
+        "type": "custom_tool_call",
+        "status": "completed",
+        "call_id": "call_exec_history",
+        "name": "exec",
+        "input": "echo sanitized",
+    }
+    custom_output = {
+        "type": "custom_tool_call_output",
+        "call_id": "call_exec_history",
+        "output": "completed",
+    }
+    body = {
+        "model": "glm-5.2",
+        "input": [
+            _v2_spawn_call(),
+            {"type": "function_call_output", "call_id": "call_v2_spawn", "output": "done"},
+            custom_call,
+            custom_output,
+            {"type": "message", "role": "user", "content": "continue"},
+        ],
+        "tools": [
+            {
+                "type": "namespace",
+                "name": "collaboration",
+                "tools": [{"type": "function", "name": "spawn_agent"}],
+            }
+        ],
+    }
+
+    transformed = codex_proxy.compatible_request_body(
+        json.dumps(body).encode(),
+        _upstream(),
+        event_context=context,
+    )
+    payload = json.loads(transformed)
+
+    assert context["collaboration_protocol"] == COLLABORATION_V2
+    assert payload["input"][0:2] == body["input"][0:2]
+    assert all(
+        item.get("type") not in {"custom_tool_call", "custom_tool_call_output"}
+        for item in payload["input"]
+        if isinstance(item, dict)
+    )
+    assert "Read-only Codex tool call transcript" in payload["input"][2]["content"]
+    assert "Read-only Codex tool result transcript" in payload["input"][3]["content"]
+
+
+def test_v2_does_not_preserve_custom_history_that_only_matches_a_plain_function() -> None:
+    context: dict[str, object] = {"request_id": "issue198-v2-custom-name-collision"}
+    body = {
+        "model": "deepseek-v4-flash:0731",
+        "input": [
+            _v2_spawn_call(),
+            {
+                "type": "custom_tool_call",
+                "status": "completed",
+                "call_id": "call_exec_history",
+                "name": "exec",
+                "input": "echo sanitized",
+            },
+            {
+                "type": "custom_tool_call_output",
+                "call_id": "call_exec_history",
+                "output": "completed",
+            },
+        ],
+        "tools": [
+            {
+                "type": "namespace",
+                "name": "collaboration",
+                "tools": [{"type": "function", "name": "spawn_agent"}],
+            },
+            {"type": "function", "name": "exec"},
+        ],
+    }
+
+    transformed = codex_proxy.compatible_request_body(
+        json.dumps(body).encode(),
+        _upstream(),
+        event_context=context,
+    )
+    payload = json.loads(transformed)
+
+    assert all(
+        item.get("type") not in {"custom_tool_call", "custom_tool_call_output"}
+        for item in payload["input"]
+        if isinstance(item, dict)
+    )
+
+
+def test_v2_preserves_custom_history_when_upstream_explicitly_supports_custom_lifecycle() -> None:
+    context: dict[str, object] = {"request_id": "issue198-v2-native-custom"}
+    upstream = {
+        **_upstream(),
+        "tool_protocol_capabilities": {
+            "namespace_lifecycle": True,
+            "custom_lifecycle": True,
+        },
+    }
+    body = {
+        "model": "glm-5.2",
+        "input": [
+            _v2_spawn_call(),
+            {
+                "type": "custom_tool_call",
+                "status": "completed",
+                "call_id": "call_exec_history",
+                "name": "exec",
+                "input": "echo native",
+            },
+            {
+                "type": "custom_tool_call_output",
+                "call_id": "call_exec_history",
+                "output": "completed",
+            },
+        ],
+        "tools": [
+            {
+                "type": "namespace",
+                "name": "collaboration",
+                "tools": [{"type": "function", "name": "spawn_agent"}],
+            },
+            {
+                "type": "custom",
+                "name": "exec",
+                "format": {"type": "text"},
+            },
+        ],
+    }
+
+    transformed = codex_proxy.compatible_request_body(
+        json.dumps(body).encode(),
+        upstream,
+        event_context=context,
+    )
+    payload = json.loads(transformed)
+
+    assert payload["input"][1:] == body["input"][1:]
+
+
 def test_v2_response_does_not_apply_v1_alias_repair() -> None:
     context = {"repair_policy": REPAIR_CODEX_SUBAGENT, "collaboration_protocol": COLLABORATION_V2}
     body = {

--- a/tests/test_issue_198_v1_v2_isolation.py
+++ b/tests/test_issue_198_v1_v2_isolation.py
@@ -378,6 +378,140 @@ def test_v2_does_not_preserve_custom_history_that_only_matches_a_plain_function(
     )
 
 
+def test_v2_does_not_preserve_undeclared_custom_history_when_capability_is_explicit() -> None:
+    context: dict[str, object] = {"request_id": "issue198-v2-custom-capability-collision"}
+    upstream = {
+        **_upstream(),
+        "tool_protocol_capabilities": {
+            "namespace_lifecycle": True,
+            "custom_lifecycle": True,
+        },
+    }
+    body = {
+        "model": "deepseek-v4-flash:0731",
+        "input": [
+            _v2_spawn_call(),
+            {
+                "type": "custom_tool_call",
+                "status": "completed",
+                "call_id": "call_exec_history",
+                "name": "exec",
+                "input": "echo sanitized",
+            },
+            {
+                "type": "custom_tool_call_output",
+                "call_id": "call_exec_history",
+                "output": "completed",
+            },
+        ],
+        "tools": [
+            {
+                "type": "namespace",
+                "name": "collaboration",
+                "tools": [{"type": "function", "name": "spawn_agent"}],
+            },
+            {"type": "function", "name": "exec"},
+        ],
+    }
+
+    transformed = codex_proxy.compatible_request_body(
+        json.dumps(body).encode(),
+        upstream,
+        event_context=context,
+    )
+    payload = json.loads(transformed)
+
+    assert all(
+        item.get("type") not in {"custom_tool_call", "custom_tool_call_output"}
+        for item in payload["input"]
+        if isinstance(item, dict)
+    )
+    assert "Read-only Codex tool call transcript" in payload["input"][1]["content"]
+    assert "Read-only Codex tool result transcript" in payload["input"][2]["content"]
+
+
+def test_v2_does_not_preserve_unknown_custom_alias_history() -> None:
+    context: dict[str, object] = {"request_id": "issue198-v2-unknown-custom-alias"}
+    body = {
+        "model": "deepseek-v4-flash:0731",
+        "input": [
+            _v2_spawn_call(),
+            {
+                "type": "custom_tool_call",
+                "status": "completed",
+                "call_id": "call_unknown_custom_alias",
+                "name": "__codexhub_custom_fake",
+                "input": "echo sanitized",
+            },
+            {
+                "type": "custom_tool_call_output",
+                "call_id": "call_unknown_custom_alias",
+                "output": "completed",
+            },
+        ],
+        "tools": [
+            {
+                "type": "namespace",
+                "name": "collaboration",
+                "tools": [{"type": "function", "name": "spawn_agent"}],
+            },
+        ],
+    }
+
+    transformed = codex_proxy.compatible_request_body(
+        json.dumps(body).encode(),
+        _upstream(),
+        event_context=context,
+    )
+    payload = json.loads(transformed)
+
+    assert all(
+        item.get("type") not in {"custom_tool_call", "custom_tool_call_output"}
+        for item in payload["input"]
+        if isinstance(item, dict)
+    )
+    assert "Read-only Codex tool call transcript" in payload["input"][1]["content"]
+    assert "Read-only Codex tool result transcript" in payload["input"][2]["content"]
+
+
+def test_v2_sanitizes_custom_history_when_tools_are_null() -> None:
+    context: dict[str, object] = {"request_id": "issue198-v2-null-tools"}
+    body = {
+        "model": "deepseek-v4-flash:0731",
+        "input": [
+            _v2_spawn_call(),
+            {
+                "type": "custom_tool_call",
+                "status": "completed",
+                "call_id": "call_null_tools",
+                "name": "exec",
+                "input": "echo sanitized",
+            },
+            {
+                "type": "custom_tool_call_output",
+                "call_id": "call_null_tools",
+                "output": "completed",
+            },
+        ],
+        "tools": None,
+    }
+
+    transformed = codex_proxy.compatible_request_body(
+        json.dumps(body).encode(),
+        _upstream(),
+        event_context=context,
+    )
+    payload = json.loads(transformed)
+
+    assert all(
+        item.get("type") not in {"custom_tool_call", "custom_tool_call_output"}
+        for item in payload["input"]
+        if isinstance(item, dict)
+    )
+    assert "Read-only Codex tool call transcript" in payload["input"][1]["content"]
+    assert "Read-only Codex tool result transcript" in payload["input"][2]["content"]
+
+
 def test_v2_preserves_custom_history_when_upstream_explicitly_supports_custom_lifecycle() -> None:
     context: dict[str, object] = {"request_id": "issue198-v2-native-custom"}
     upstream = {
@@ -426,6 +560,54 @@ def test_v2_preserves_custom_history_when_upstream_explicitly_supports_custom_li
     payload = json.loads(transformed)
 
     assert payload["input"][1:] == body["input"][1:]
+
+
+def test_v2_preserves_declared_custom_history_without_event_context() -> None:
+    body = {
+        "model": "glm-5.2",
+        "input": [
+            _v2_spawn_call(),
+            {
+                "type": "custom_tool_call",
+                "status": "completed",
+                "call_id": "call_exec_history",
+                "name": "exec",
+                "input": "echo native",
+            },
+            {
+                "type": "custom_tool_call_output",
+                "call_id": "call_exec_history",
+                "output": "completed",
+            },
+        ],
+        "tools": [
+            {
+                "type": "namespace",
+                "name": "collaboration",
+                "tools": [{"type": "function", "name": "spawn_agent"}],
+            },
+            {
+                "type": "custom",
+                "name": "exec",
+                "format": {"type": "text"},
+            },
+        ],
+    }
+    upstream = {
+        **_upstream(),
+        "tool_protocol_capabilities": {
+            "namespace_lifecycle": True,
+            "custom_lifecycle": True,
+        },
+    }
+
+    transformed = codex_proxy.compatible_request_body(
+        json.dumps(body).encode(),
+        upstream,
+    )
+    payload = json.loads(transformed)
+
+    assert payload["input"] == body["input"]
 
 
 def test_v2_response_does_not_apply_v1_alias_repair() -> None:

--- a/tests/test_release_channel_scripts.py
+++ b/tests/test_release_channel_scripts.py
@@ -20,7 +20,7 @@ def test_official_transport_wheel_is_pinned_and_packaged():
 
 
 def test_release_version_is_consistent_across_manifests():
-    expected = "0.1.8-beta.2.1"
+    expected = "0.1.8-beta.2.2"
     tauri = json.loads((ROOT / "src-tauri" / "tauri.conf.json").read_text(encoding="utf-8"))
     cargo = tomllib.loads((ROOT / "src-tauri" / "Cargo.toml").read_text(encoding="utf-8"))
     cargo_lock = tomllib.loads((ROOT / "src-tauri" / "Cargo.lock").read_text(encoding="utf-8"))
@@ -356,7 +356,7 @@ def test_release_plan_places_both_flavors_in_one_immutable_release(tmp_path):
 def test_release_plan_marks_semver_prerelease_versions_as_prereleases(tmp_path):
     repo, main_commit, _ = _release_repo(tmp_path)
 
-    result = _plan(repo, "normal", "0.1.8-beta.2.1", main_commit)
+    result = _plan(repo, "normal", "0.1.8-beta.2.2", main_commit)
 
     assert result.returncode == 0, result.stderr
     plan = json.loads(result.stdout)
@@ -364,18 +364,18 @@ def test_release_plan_marks_semver_prerelease_versions_as_prereleases(tmp_path):
         "name": "latest.json",
         "asset_url": (
             "https://github.com/NOirBRight/CodexHub/releases/download/"
-            "v0.1.8-beta.2.1/CodexHub_0.1.8-beta.2.1_x64-setup.exe"
+            "v0.1.8-beta.2.2/CodexHub_0.1.8-beta.2.2_x64-setup.exe"
         ),
     }
-    assert plan["immutable_release"]["tag"] == "v0.1.8-beta.2.1"
+    assert plan["immutable_release"]["tag"] == "v0.1.8-beta.2.2"
     assert plan["immutable_release"]["prerelease"] is True
     assert plan["immutable_release"]["assets"] == [
-        "CodexHub_0.1.8-beta.2.1_x64-setup.exe",
-        "CodexHub_0.1.8-beta.2.1_x64-setup.exe.sig",
+        "CodexHub_0.1.8-beta.2.2_x64-setup.exe",
+        "CodexHub_0.1.8-beta.2.2_x64-setup.exe.sig",
         "latest.json",
-        f"CodexHub_0.1.8-beta.2.1_portable_{main_commit[:8]}.zip",
-        "CodexHub_0.1.8-beta.2.1_debug_x64-setup.exe",
-        "CodexHub_0.1.8-beta.2.1_debug_x64-setup.exe.sig",
+        f"CodexHub_0.1.8-beta.2.2_portable_{main_commit[:8]}.zip",
+        "CodexHub_0.1.8-beta.2.2_debug_x64-setup.exe",
+        "CodexHub_0.1.8-beta.2.2_debug_x64-setup.exe.sig",
         "latest-debug.json",
     ]
 


### PR DESCRIPTION
## Summary

- sanitize unsupported/unowned `custom_tool_call` history on Collaboration V2 requests sent to third-party providers
- preserve native Collaboration V2 calls and declared custom lifecycles
- prevent ordinary-function, unknown alias, namespace alias, explicit-capability, and malformed `tools: null` collisions from leaking custom history
- set release metadata to `0.1.8-beta.2.2`

## Verification

- exact SHA: `084b092`
- exact review base: `v0.1.8-beta.2.1`
- Python 3.13 full core: `2150 passed, 1 skipped, 467 subtests passed`
- V2 isolation: `39 passed`
- focused runtime/release checks: `342 passed`
- `git diff --check`: passed

GitHub Actions are intentionally not used for this project release; local verification is the release gate.
