### PR TITLE
release: prepare 0.1.8-beta.3.1

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codexhub-frontend",
-  "version": "0.1.8-beta.3",
+  "version": "0.1.8-beta.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codexhub-frontend",
-      "version": "0.1.8-beta.3",
+      "version": "0.1.8-beta.3.1",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codexhub-frontend",
   "private": true,
-  "version": "0.1.8-beta.3",
+  "version": "0.1.8-beta.3.1",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "codexhub"
-version = "0.1.8-beta.3"
+version = "0.1.8-beta.3.1"
 dependencies = [
  "dirs 5.0.1",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codexhub"
-version = "0.1.8-beta.3"
+version = "0.1.8-beta.3.1"
 description = "CodexHub desktop backend and CLI"
 authors = ["CodexHub"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "CodexHub",
-  "version": "0.1.8-beta.3",
+  "version": "0.1.8-beta.3.1",
   "identifier": "com.codexhub.app",
   "build": {
     "frontendDist": "../frontend/dist",

--- a/tests/test_release_channel_scripts.py
+++ b/tests/test_release_channel_scripts.py
@@ -20,7 +20,7 @@ def test_official_transport_wheel_is_pinned_and_packaged():
 
 
 def test_release_version_is_consistent_across_manifests():
-    expected = "0.1.8-beta.3"
+    expected = "0.1.8-beta.3.1"
     tauri = json.loads((ROOT / "src-tauri" / "tauri.conf.json").read_text(encoding="utf-8"))
     cargo = tomllib.loads((ROOT / "src-tauri" / "Cargo.toml").read_text(encoding="utf-8"))
     cargo_lock = tomllib.loads((ROOT / "src-tauri" / "Cargo.lock").read_text(encoding="utf-8"))
@@ -356,7 +356,7 @@ def test_release_plan_places_both_flavors_in_one_immutable_release(tmp_path):
 def test_release_plan_marks_semver_prerelease_versions_as_prereleases(tmp_path):
     repo, main_commit, _ = _release_repo(tmp_path)
 
-    result = _plan(repo, "normal", "0.1.8-beta.3", main_commit)
+    result = _plan(repo, "normal", "0.1.8-beta.3.1", main_commit)
 
     assert result.returncode == 0, result.stderr
     plan = json.loads(result.stdout)
@@ -364,18 +364,18 @@ def test_release_plan_marks_semver_prerelease_versions_as_prereleases(tmp_path):
         "name": "latest.json",
         "asset_url": (
             "https://github.com/NOirBRight/CodexHub/releases/download/"
-            "v0.1.8-beta.3/CodexHub_0.1.8-beta.3_x64-setup.exe"
+            "v0.1.8-beta.3.1/CodexHub_0.1.8-beta.3.1_x64-setup.exe"
         ),
     }
-    assert plan["immutable_release"]["tag"] == "v0.1.8-beta.3"
+    assert plan["immutable_release"]["tag"] == "v0.1.8-beta.3.1"
     assert plan["immutable_release"]["prerelease"] is True
     assert plan["immutable_release"]["assets"] == [
-        "CodexHub_0.1.8-beta.3_x64-setup.exe",
-        "CodexHub_0.1.8-beta.3_x64-setup.exe.sig",
+        "CodexHub_0.1.8-beta.3.1_x64-setup.exe",
+        "CodexHub_0.1.8-beta.3.1_x64-setup.exe.sig",
         "latest.json",
-        f"CodexHub_0.1.8-beta.3_portable_{main_commit[:8]}.zip",
-        "CodexHub_0.1.8-beta.3_debug_x64-setup.exe",
-        "CodexHub_0.1.8-beta.3_debug_x64-setup.exe.sig",
+        f"CodexHub_0.1.8-beta.3.1_portable_{main_commit[:8]}.zip",
+        "CodexHub_0.1.8-beta.3.1_debug_x64-setup.exe",
+        "CodexHub_0.1.8-beta.3.1_debug_x64-setup.exe.sig",
         "latest-debug.json",
     ]
 


### PR DESCRIPTION
## Summary

- bump CodexHub from `0.1.8-beta.3` to `0.1.8-beta.3.1`
- keep npm, Cargo, Tauri, lockfiles, and release-channel expectations synchronized
- prepare the merged Beta 3 reasoning/output-limit hotfix for publication

## Verification

- release-channel tests: 17 passed
- normal portable dry-run: passed
- debug portable dry-run: passed
- Standards review: passed
- Spec review: passed
- `git diff --check`: passed

Release scope: #373 and #374.