### PR TITLE
release: promote 0.1.8 Beta 3.1

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codexhub-frontend",
-  "version": "0.1.8-beta.3",
+  "version": "0.1.8-beta.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codexhub-frontend",
-      "version": "0.1.8-beta.3",
+      "version": "0.1.8-beta.3.1",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codexhub-frontend",
   "private": true,
-  "version": "0.1.8-beta.3",
+  "version": "0.1.8-beta.3.1",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/src-python/catalog_sync.py
+++ b/src-python/catalog_sync.py
@@ -2447,6 +2447,11 @@ def build_external_provider_model(
     max_output_tokens = external_model.get("max_output_tokens")
     if isinstance(max_output_tokens, int) and max_output_tokens > 0:
         model["max_output_tokens"] = max_output_tokens
+    else:
+        model.pop("max_output_tokens", None)
+        effective_context_window = model.get("context_window")
+        if isinstance(effective_context_window, int) and effective_context_window > 0:
+            model["max_output_tokens"] = effective_context_window
 
     inherited_metadata = model.get("codex_proxy_metadata")
     proxy_metadata = {

--- a/src-python/catalog_sync.py
+++ b/src-python/catalog_sync.py
@@ -2449,9 +2449,6 @@ def build_external_provider_model(
         model["max_output_tokens"] = max_output_tokens
     else:
         model.pop("max_output_tokens", None)
-        effective_context_window = model.get("context_window")
-        if isinstance(effective_context_window, int) and effective_context_window > 0:
-            model["max_output_tokens"] = effective_context_window
 
     inherited_metadata = model.get("codex_proxy_metadata")
     proxy_metadata = {
@@ -2481,6 +2478,10 @@ def build_external_provider_model(
             (str(external_model["provider_alias"]), str(external_model["upstream_model"]))
         ),
     )
+    if "max_output_tokens" not in model:
+        effective_context_window = model.get("context_window")
+        if isinstance(effective_context_window, int) and effective_context_window > 0:
+            model["max_output_tokens"] = effective_context_window
     stamp_catalog_owner_metadata(model)
     return model
 

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -534,8 +534,6 @@ OLLAMA_REASONING_EFFORT_ALIASES = {"xhigh": "max"}
 UNSUPPORTED_REASONING_MODEL_PREFIXES = ("kimi-k2.6", "kimi-k2.7")
 UPSTREAM_MAX_OUTPUT_TOKEN_CAPS = {
     "minimax-m3": 131072,
-    "deepseek-v4-pro": 65536,
-    "deepseek-v4-flash": 65536,
 }
 OFFICIAL_ENCRYPTED_CONTENT_PREFIX = "gAAAA"
 TOOL_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
@@ -11184,6 +11182,9 @@ def compatible_request_body(
         if not changed:
             return body
         return json.dumps(payload, ensure_ascii=True, separators=(",", ":")).encode("utf-8")
+
+    if _strip_reasoning_encrypted_content(payload):
+        changed = True
 
     raw_provider_probe = _is_raw_provider_probe_context(event_context)
     tool_protocol = (

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "codexhub"
-version = "0.1.8-beta.3"
+version = "0.1.8-beta.3.1"
 dependencies = [
  "dirs 5.0.1",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codexhub"
-version = "0.1.8-beta.3"
+version = "0.1.8-beta.3.1"
 description = "CodexHub desktop backend and CLI"
 authors = ["CodexHub"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "CodexHub",
-  "version": "0.1.8-beta.3",
+  "version": "0.1.8-beta.3.1",
   "identifier": "com.codexhub.app",
   "build": {
     "frontendDist": "../frontend/dist",

--- a/tests/test_catalog_sync.py
+++ b/tests/test_catalog_sync.py
@@ -2801,6 +2801,25 @@ class CatalogSyncTests(unittest.TestCase):
         )
         self.assertEqual(model["default_reasoning_level"], "max")
 
+    def test_external_model_defaults_missing_output_limit_to_context_window(self):
+        external_model = {
+            "alias": "volc/deepseek-v4-flash:0731",
+            "provider_alias": "volc",
+            "upstream_name": "volcengine",
+            "upstream_model": "deepseek-v4-flash:0731",
+            "context_window": 1_048_576,
+        }
+        fallback_template = {
+            "context_window": 128_000,
+            "max_context_window": 128_000,
+            "max_output_tokens": 65_536,
+        }
+
+        model = catalog_sync.build_external_provider_model(external_model, self.policy, fallback_template)
+
+        self.assertEqual(model["context_window"], 1_048_576)
+        self.assertEqual(model["max_output_tokens"], 1_048_576)
+
     def test_external_reasoning_default_ultra_falls_back_without_mapping_to_max(self):
         external_model = {
             "alias": "volc/glm-5.2",

--- a/tests/test_catalog_sync.py
+++ b/tests/test_catalog_sync.py
@@ -2820,6 +2820,20 @@ class CatalogSyncTests(unittest.TestCase):
         self.assertEqual(model["context_window"], 1_048_576)
         self.assertEqual(model["max_output_tokens"], 1_048_576)
 
+    def test_external_model_preserves_verified_output_limit_before_context_default(self):
+        external_model = {
+            "alias": "volc/glm-5.2",
+            "provider_alias": "volc",
+            "upstream_name": "volcengine",
+            "upstream_model": "glm-5.2",
+            "context_window": 1_024_000,
+        }
+
+        model = catalog_sync.build_external_provider_model(external_model, self.policy, None)
+
+        self.assertEqual(model["context_window"], 1_024_000)
+        self.assertEqual(model["max_output_tokens"], 8_192)
+
     def test_external_reasoning_default_ultra_falls_back_without_mapping_to_max(self):
         external_model = {
             "alias": "volc/glm-5.2",

--- a/tests/test_release_channel_scripts.py
+++ b/tests/test_release_channel_scripts.py
@@ -20,7 +20,7 @@ def test_official_transport_wheel_is_pinned_and_packaged():
 
 
 def test_release_version_is_consistent_across_manifests():
-    expected = "0.1.8-beta.3"
+    expected = "0.1.8-beta.3.1"
     tauri = json.loads((ROOT / "src-tauri" / "tauri.conf.json").read_text(encoding="utf-8"))
     cargo = tomllib.loads((ROOT / "src-tauri" / "Cargo.toml").read_text(encoding="utf-8"))
     cargo_lock = tomllib.loads((ROOT / "src-tauri" / "Cargo.lock").read_text(encoding="utf-8"))
@@ -356,7 +356,7 @@ def test_release_plan_places_both_flavors_in_one_immutable_release(tmp_path):
 def test_release_plan_marks_semver_prerelease_versions_as_prereleases(tmp_path):
     repo, main_commit, _ = _release_repo(tmp_path)
 
-    result = _plan(repo, "normal", "0.1.8-beta.3", main_commit)
+    result = _plan(repo, "normal", "0.1.8-beta.3.1", main_commit)
 
     assert result.returncode == 0, result.stderr
     plan = json.loads(result.stdout)
@@ -364,18 +364,18 @@ def test_release_plan_marks_semver_prerelease_versions_as_prereleases(tmp_path):
         "name": "latest.json",
         "asset_url": (
             "https://github.com/NOirBRight/CodexHub/releases/download/"
-            "v0.1.8-beta.3/CodexHub_0.1.8-beta.3_x64-setup.exe"
+            "v0.1.8-beta.3.1/CodexHub_0.1.8-beta.3.1_x64-setup.exe"
         ),
     }
-    assert plan["immutable_release"]["tag"] == "v0.1.8-beta.3"
+    assert plan["immutable_release"]["tag"] == "v0.1.8-beta.3.1"
     assert plan["immutable_release"]["prerelease"] is True
     assert plan["immutable_release"]["assets"] == [
-        "CodexHub_0.1.8-beta.3_x64-setup.exe",
-        "CodexHub_0.1.8-beta.3_x64-setup.exe.sig",
+        "CodexHub_0.1.8-beta.3.1_x64-setup.exe",
+        "CodexHub_0.1.8-beta.3.1_x64-setup.exe.sig",
         "latest.json",
-        f"CodexHub_0.1.8-beta.3_portable_{main_commit[:8]}.zip",
-        "CodexHub_0.1.8-beta.3_debug_x64-setup.exe",
-        "CodexHub_0.1.8-beta.3_debug_x64-setup.exe.sig",
+        f"CodexHub_0.1.8-beta.3.1_portable_{main_commit[:8]}.zip",
+        "CodexHub_0.1.8-beta.3.1_debug_x64-setup.exe",
+        "CodexHub_0.1.8-beta.3.1_debug_x64-setup.exe.sig",
         "latest-debug.json",
     ]
 

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -12874,13 +12874,13 @@ class RoutingTests(unittest.TestCase):
 
         self.assertEqual(json.loads(transformed)["max_output_tokens"], 65536)
 
-    def test_ollama_body_applies_upstream_output_token_cap(self):
+    def test_ollama_body_uses_catalog_output_limit_without_deepseek_gateway_cap(self):
         upstream = choose_upstream("deepseek-v4-pro")
         body = b'{"model":"deepseek-v4-pro","input":"hi"}'
 
         transformed = compatible_request_body(body, upstream)
 
-        self.assertEqual(json.loads(transformed)["max_output_tokens"], 65536)
+        self.assertEqual(json.loads(transformed)["max_output_tokens"], 393216)
 
     def test_ollama_body_applies_minimax_output_token_cap(self):
         upstream = choose_upstream("minimax-m3")
@@ -18251,6 +18251,43 @@ class RoutingTests(unittest.TestCase):
         self.assertEqual(history_events[0]["count"], 1)
         for forbidden in ("call_id", "name", "input", "output", "patch", "arguments"):
             self.assertNotIn(forbidden, history_events[0])
+
+    def test_external_collaboration_v2_strips_official_reasoning_encrypted_content(self):
+        encrypted_content = "gAAAA-official-secret"
+        transformed = compatible_request_body(
+            json.dumps(
+                {
+                    "model": "glm-5.2",
+                    "input": [
+                        {
+                            "type": "reasoning",
+                            "summary": [{"type": "summary_text", "text": "Portable summary."}],
+                            "encrypted_content": encrypted_content,
+                        },
+                        {"type": "message", "role": "user", "content": "continue"},
+                    ],
+                }
+            ).encode("utf-8"),
+            {
+                "name": "ollama_cloud",
+                "upstream_format": "responses",
+                "tool_protocol": "responses_structured",
+            },
+            event_context={
+                "request_id": "<sanitized-request-id>",
+                "collaboration_protocol": "collaboration_v2",
+            },
+            inject_codex_tools=False,
+        )
+        payload = json.loads(transformed)
+
+        self.assertEqual(payload["input"][0]["type"], "reasoning")
+        self.assertEqual(
+            payload["input"][0]["summary"],
+            [{"type": "summary_text", "text": "Portable summary."}],
+        )
+        self.assertNotIn("encrypted_content", payload["input"][0])
+        self.assertNotIn(encrypted_content, transformed.decode("utf-8"))
 
     def test_selected_native_responses_codec_round_trips_apply_patch_and_next_history_once(self):
         fixture = _load_glm_apply_patch_history_native_ids_fixture()


### PR DESCRIPTION
## Summary
- promote the reasoning compatibility hotfix from `dev` to `main`
- prevent external reasoning `encrypted_content` from leaking upstream
- remove the DeepSeek 65K gateway cap and default unknown external models to their context window
- publish the unified `0.1.8-beta.3.1` version metadata

## Verification
- Python core: 2216 passed, 1 skipped, 473 subtests
- synthetic real-client suite: 146 passed
- frontend UI contract: 146 passed
- release-channel tests: 17 passed
- Rust: 539 passed, 1 ignored
- `cargo clippy --locked --all-targets -- -D warnings`
- frontend production build
- normal/debug portable release dry-runs at `27746992b4cb43cd900e99f70f56a3033304c451`
- report-only quality gates completed (findings unchanged/non-blocking)

Closes #373
