### PR TITLE
fix: default versioned Ollama output limits

### DIFF
--- a/src-python/catalog_sync.py
+++ b/src-python/catalog_sync.py
@@ -2355,6 +2355,12 @@ def apply_ollama_model_limits(model: dict[str, Any], slug: str, model_metadata: 
     if isinstance(dynamic_max_output_tokens, int) and dynamic_max_output_tokens > 0:
         model["max_output_tokens"] = dynamic_max_output_tokens
 
+    effective_max_output_tokens = model.get("max_output_tokens")
+    if not isinstance(effective_max_output_tokens, int) or effective_max_output_tokens <= 0:
+        effective_context_window = model.get("context_window")
+        if isinstance(effective_context_window, int) and effective_context_window > 0:
+            model["max_output_tokens"] = effective_context_window
+
     input_modalities = dynamic_metadata.get("input_modalities")
     if isinstance(input_modalities, list) and input_modalities:
         model["input_modalities"] = [str(value) for value in input_modalities if str(value)]

--- a/tests/test_catalog_sync.py
+++ b/tests/test_catalog_sync.py
@@ -398,6 +398,32 @@ class CatalogSyncTests(unittest.TestCase):
         self.assertEqual(model["codex_proxy_metadata"]["context_source"], "providers_toml")
         self.assertEqual(model["codex_proxy_metadata"]["max_output_source"], "providers_toml")
 
+    def test_build_catalog_runtime_versioned_ollama_defaults_missing_output_limit_to_context_window(self):
+        slug = "deepseek-v4-flash:0731"
+        metadata = catalog_sync.ollama_provider_model_metadata(
+            [
+                {
+                    "upstream_model": slug,
+                    "context_window": 1_048_576,
+                }
+            ]
+        )
+
+        catalog = build_codex_catalog(
+            [],
+            [slug],
+            self.policy,
+            "0.146.0",
+            ollama_model_metadata=metadata,
+            use_ollama_policy_allowlist=False,
+        )
+
+        model = next(model for model in catalog["models"] if model["slug"] == slug)
+        self.assertEqual(model["slug"], slug)
+        self.assertEqual(model["context_window"], 1_048_576)
+        self.assertEqual(model.get("max_output_tokens"), 1_048_576)
+        self.assertEqual(model["codex_proxy_metadata"]["provider"], "ollama-cloud")
+
     def test_build_catalog_applies_official_model_sort_order(self):
         official = [
             {"slug": "gpt-5.5", "display_name": "GPT-5.5", "visibility": "list"},

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -3329,6 +3329,27 @@ class RoutingTests(unittest.TestCase):
             self.assertEqual(fields["mutation_summary"], [codex_proxy.RouteMutation.MODEL_ALIAS.value])
 
     def test_model_switch_gateway_request_response_path_uses_selected_model_in_both_directions(self):
+        versioned_slug = "deepseek-v4-flash:0731"
+        versioned_catalog = catalog_sync.build_codex_catalog(
+            [],
+            [versioned_slug],
+            catalog_sync.CatalogPolicy(
+                denied_models=set(),
+                denied_substrings=set(),
+                display_names={},
+            ),
+            "0.146.0",
+            ollama_model_metadata={
+                versioned_slug: {
+                    "context_window": 1_048_576,
+                    "context_source": "providers_toml",
+                }
+            },
+            use_ollama_policy_allowlist=False,
+        )
+        versioned_catalog_by_slug = {
+            model["slug"]: model for model in versioned_catalog["models"]
+        }
         fixture = _load_model_switch_fixture()
         self.assertEqual(fixture["schema_version"], "codexhub.model-switch.v1")
         self.assertEqual(fixture["expected"], {
@@ -3439,6 +3460,10 @@ class RoutingTests(unittest.TestCase):
                 event_offset = len(self.write_proxy_event.call_args_list)
                 with (
                     patch("codex_proxy.choose_upstream", return_value=upstream),
+                    patch(
+                        "codex_proxy.generated_catalog_by_slug",
+                        return_value=versioned_catalog_by_slug,
+                    ),
                     patch("codex_proxy.codex_access_token", return_value="fixture-access-token"),
                     patch("codex_proxy.codex_account_id", return_value="fixture-account-id"),
                     patch(
@@ -3452,6 +3477,8 @@ class RoutingTests(unittest.TestCase):
                 open_upstream.assert_called_once()
                 forwarded = json.loads(open_upstream.call_args.args[0].data.decode("utf-8"))
                 self.assertEqual(forwarded["model"], model)
+                if model == versioned_slug:
+                    self.assertEqual(forwarded.get("max_output_tokens"), 1_048_576)
 
                 events = [
                     (event_call.args[0], event_call.kwargs)


### PR DESCRIPTION
Closes #377

## Summary

- default a versioned Ollama Cloud model's missing/non-positive `max_output_tokens` to its effective positive `context_window`
- preserve positive explicit, resolved, static, and runtime output limits
- bind the existing model-switch production request test to a generated `deepseek-v4-flash:0731` catalog row and assert the actual forwarded limit

## Red/green evidence

Before the production change, both new assertions failed with `None != 1048576`:

- generated catalog row for `deepseek-v4-flash:0731`
- forwarded Gateway request for the exact selected model

After the production change:

- new catalog + Gateway regressions: `2 passed`
- focused precedence regressions: `4 passed`
- nearby routing limit/model-switch regressions: `3 passed, 624 deselected`

## Local gate

Exact candidate: `0f5f84a2cdf2c8492faad3b164b4e7566ca427cc`

- Python core: `2215 passed, 3 skipped, 473 subtests passed`
- Python partitions: `2364` total, `2218` core, `146` synthetic; disjoint and complete
- `git diff --check`: passed
- report-only quality scan: `parse_errors: 0`; pre-existing findings recorded, non-blocking

## Scope

No Official/external-provider behavior, reasoning-history sanitizer, opaque-text cleanup, or old-task repair behavior changed.