### PR TITLE
release: prepare 0.1.8-beta.3.2

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codexhub-frontend",
-  "version": "0.1.8-beta.3.1",
+  "version": "0.1.8-beta.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codexhub-frontend",
-      "version": "0.1.8-beta.3.1",
+      "version": "0.1.8-beta.3.2",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codexhub-frontend",
   "private": true,
-  "version": "0.1.8-beta.3.1",
+  "version": "0.1.8-beta.3.2",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "codexhub"
-version = "0.1.8-beta.3.1"
+version = "0.1.8-beta.3.2"
 dependencies = [
  "dirs 5.0.1",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codexhub"
-version = "0.1.8-beta.3.1"
+version = "0.1.8-beta.3.2"
 description = "CodexHub desktop backend and CLI"
 authors = ["CodexHub"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "CodexHub",
-  "version": "0.1.8-beta.3.1",
+  "version": "0.1.8-beta.3.2",
   "identifier": "com.codexhub.app",
   "build": {
     "frontendDist": "../frontend/dist",

--- a/tests/test_release_channel_scripts.py
+++ b/tests/test_release_channel_scripts.py
@@ -20,7 +20,7 @@ def test_official_transport_wheel_is_pinned_and_packaged():
 
 
 def test_release_version_is_consistent_across_manifests():
-    expected = "0.1.8-beta.3.1"
+    expected = "0.1.8-beta.3.2"
     tauri = json.loads((ROOT / "src-tauri" / "tauri.conf.json").read_text(encoding="utf-8"))
     cargo = tomllib.loads((ROOT / "src-tauri" / "Cargo.toml").read_text(encoding="utf-8"))
     cargo_lock = tomllib.loads((ROOT / "src-tauri" / "Cargo.lock").read_text(encoding="utf-8"))
@@ -356,7 +356,7 @@ def test_release_plan_places_both_flavors_in_one_immutable_release(tmp_path):
 def test_release_plan_marks_semver_prerelease_versions_as_prereleases(tmp_path):
     repo, main_commit, _ = _release_repo(tmp_path)
 
-    result = _plan(repo, "normal", "0.1.8-beta.3.1", main_commit)
+    result = _plan(repo, "normal", "0.1.8-beta.3.2", main_commit)
 
     assert result.returncode == 0, result.stderr
     plan = json.loads(result.stdout)
@@ -364,18 +364,18 @@ def test_release_plan_marks_semver_prerelease_versions_as_prereleases(tmp_path):
         "name": "latest.json",
         "asset_url": (
             "https://github.com/NOirBRight/CodexHub/releases/download/"
-            "v0.1.8-beta.3.1/CodexHub_0.1.8-beta.3.1_x64-setup.exe"
+            "v0.1.8-beta.3.2/CodexHub_0.1.8-beta.3.2_x64-setup.exe"
         ),
     }
-    assert plan["immutable_release"]["tag"] == "v0.1.8-beta.3.1"
+    assert plan["immutable_release"]["tag"] == "v0.1.8-beta.3.2"
     assert plan["immutable_release"]["prerelease"] is True
     assert plan["immutable_release"]["assets"] == [
-        "CodexHub_0.1.8-beta.3.1_x64-setup.exe",
-        "CodexHub_0.1.8-beta.3.1_x64-setup.exe.sig",
+        "CodexHub_0.1.8-beta.3.2_x64-setup.exe",
+        "CodexHub_0.1.8-beta.3.2_x64-setup.exe.sig",
         "latest.json",
-        f"CodexHub_0.1.8-beta.3.1_portable_{main_commit[:8]}.zip",
-        "CodexHub_0.1.8-beta.3.1_debug_x64-setup.exe",
-        "CodexHub_0.1.8-beta.3.1_debug_x64-setup.exe.sig",
+        f"CodexHub_0.1.8-beta.3.2_portable_{main_commit[:8]}.zip",
+        "CodexHub_0.1.8-beta.3.2_debug_x64-setup.exe",
+        "CodexHub_0.1.8-beta.3.2_debug_x64-setup.exe.sig",
         "latest-debug.json",
     ]
 


### PR DESCRIPTION
## Summary

Prepare the application and immutable release contract for `0.1.8-beta.3.2` after the versioned Ollama output-limit fix merged through #378.

## Version files

- frontend package + lock
- Tauri config
- Cargo package + lock
- release-channel contract tests and seven immutable asset names

## Frozen candidate

`4b37718f14572fda54f06a3d621e1509e79355ef`

## Authoritative local gate

- Python core: `2215 passed, 3 skipped, 473 subtests passed`
- Synthetic real-client under Windows watchdog: `146 passed`
- Python partitions: `2364` total, `2218` core, `146` synthetic; disjoint and complete
- Release-channel contract: `17 passed`
- Frontend: `npm ci`, production build, and UI contract `146 passed`
- Rust: `539 passed, 1 ignored` using direct Python 3.13 on `PATH` and `--test-threads=1`
- Clippy: `cargo clippy --locked --all-targets -- -D warnings` passed
- Report-only quality scan: `parse_errors: 0`; existing findings remain non-blocking
- `git diff --check`: passed

The first non-authoritative Rust invocation inherited Python 3.11 and default parallelism; its environment-only failures were reproduced, diagnosed, and eliminated by the repository's required Python 3.13/single-thread invocation. No source changes were made in response.