### PR TITLE
release: promote 0.1.8 Beta 3.2

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codexhub-frontend",
-  "version": "0.1.8-beta.3.1",
+  "version": "0.1.8-beta.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codexhub-frontend",
-      "version": "0.1.8-beta.3.1",
+      "version": "0.1.8-beta.3.2",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codexhub-frontend",
   "private": true,
-  "version": "0.1.8-beta.3.1",
+  "version": "0.1.8-beta.3.2",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/src-python/catalog_sync.py
+++ b/src-python/catalog_sync.py
@@ -2355,6 +2355,12 @@ def apply_ollama_model_limits(model: dict[str, Any], slug: str, model_metadata: 
     if isinstance(dynamic_max_output_tokens, int) and dynamic_max_output_tokens > 0:
         model["max_output_tokens"] = dynamic_max_output_tokens
 
+    effective_max_output_tokens = model.get("max_output_tokens")
+    if not isinstance(effective_max_output_tokens, int) or effective_max_output_tokens <= 0:
+        effective_context_window = model.get("context_window")
+        if isinstance(effective_context_window, int) and effective_context_window > 0:
+            model["max_output_tokens"] = effective_context_window
+
     input_modalities = dynamic_metadata.get("input_modalities")
     if isinstance(input_modalities, list) and input_modalities:
         model["input_modalities"] = [str(value) for value in input_modalities if str(value)]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "codexhub"
-version = "0.1.8-beta.3.1"
+version = "0.1.8-beta.3.2"
 dependencies = [
  "dirs 5.0.1",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codexhub"
-version = "0.1.8-beta.3.1"
+version = "0.1.8-beta.3.2"
 description = "CodexHub desktop backend and CLI"
 authors = ["CodexHub"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "CodexHub",
-  "version": "0.1.8-beta.3.1",
+  "version": "0.1.8-beta.3.2",
   "identifier": "com.codexhub.app",
   "build": {
     "frontendDist": "../frontend/dist",

--- a/tests/test_catalog_sync.py
+++ b/tests/test_catalog_sync.py
@@ -398,6 +398,32 @@ class CatalogSyncTests(unittest.TestCase):
         self.assertEqual(model["codex_proxy_metadata"]["context_source"], "providers_toml")
         self.assertEqual(model["codex_proxy_metadata"]["max_output_source"], "providers_toml")
 
+    def test_build_catalog_runtime_versioned_ollama_defaults_missing_output_limit_to_context_window(self):
+        slug = "deepseek-v4-flash:0731"
+        metadata = catalog_sync.ollama_provider_model_metadata(
+            [
+                {
+                    "upstream_model": slug,
+                    "context_window": 1_048_576,
+                }
+            ]
+        )
+
+        catalog = build_codex_catalog(
+            [],
+            [slug],
+            self.policy,
+            "0.146.0",
+            ollama_model_metadata=metadata,
+            use_ollama_policy_allowlist=False,
+        )
+
+        model = next(model for model in catalog["models"] if model["slug"] == slug)
+        self.assertEqual(model["slug"], slug)
+        self.assertEqual(model["context_window"], 1_048_576)
+        self.assertEqual(model.get("max_output_tokens"), 1_048_576)
+        self.assertEqual(model["codex_proxy_metadata"]["provider"], "ollama-cloud")
+
     def test_build_catalog_applies_official_model_sort_order(self):
         official = [
             {"slug": "gpt-5.5", "display_name": "GPT-5.5", "visibility": "list"},

--- a/tests/test_release_channel_scripts.py
+++ b/tests/test_release_channel_scripts.py
@@ -20,7 +20,7 @@ def test_official_transport_wheel_is_pinned_and_packaged():
 
 
 def test_release_version_is_consistent_across_manifests():
-    expected = "0.1.8-beta.3.1"
+    expected = "0.1.8-beta.3.2"
     tauri = json.loads((ROOT / "src-tauri" / "tauri.conf.json").read_text(encoding="utf-8"))
     cargo = tomllib.loads((ROOT / "src-tauri" / "Cargo.toml").read_text(encoding="utf-8"))
     cargo_lock = tomllib.loads((ROOT / "src-tauri" / "Cargo.lock").read_text(encoding="utf-8"))
@@ -356,7 +356,7 @@ def test_release_plan_places_both_flavors_in_one_immutable_release(tmp_path):
 def test_release_plan_marks_semver_prerelease_versions_as_prereleases(tmp_path):
     repo, main_commit, _ = _release_repo(tmp_path)
 
-    result = _plan(repo, "normal", "0.1.8-beta.3.1", main_commit)
+    result = _plan(repo, "normal", "0.1.8-beta.3.2", main_commit)
 
     assert result.returncode == 0, result.stderr
     plan = json.loads(result.stdout)
@@ -364,18 +364,18 @@ def test_release_plan_marks_semver_prerelease_versions_as_prereleases(tmp_path):
         "name": "latest.json",
         "asset_url": (
             "https://github.com/NOirBRight/CodexHub/releases/download/"
-            "v0.1.8-beta.3.1/CodexHub_0.1.8-beta.3.1_x64-setup.exe"
+            "v0.1.8-beta.3.2/CodexHub_0.1.8-beta.3.2_x64-setup.exe"
         ),
     }
-    assert plan["immutable_release"]["tag"] == "v0.1.8-beta.3.1"
+    assert plan["immutable_release"]["tag"] == "v0.1.8-beta.3.2"
     assert plan["immutable_release"]["prerelease"] is True
     assert plan["immutable_release"]["assets"] == [
-        "CodexHub_0.1.8-beta.3.1_x64-setup.exe",
-        "CodexHub_0.1.8-beta.3.1_x64-setup.exe.sig",
+        "CodexHub_0.1.8-beta.3.2_x64-setup.exe",
+        "CodexHub_0.1.8-beta.3.2_x64-setup.exe.sig",
         "latest.json",
-        f"CodexHub_0.1.8-beta.3.1_portable_{main_commit[:8]}.zip",
-        "CodexHub_0.1.8-beta.3.1_debug_x64-setup.exe",
-        "CodexHub_0.1.8-beta.3.1_debug_x64-setup.exe.sig",
+        f"CodexHub_0.1.8-beta.3.2_portable_{main_commit[:8]}.zip",
+        "CodexHub_0.1.8-beta.3.2_debug_x64-setup.exe",
+        "CodexHub_0.1.8-beta.3.2_debug_x64-setup.exe.sig",
         "latest-debug.json",
     ]
 

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -3329,6 +3329,27 @@ class RoutingTests(unittest.TestCase):
             self.assertEqual(fields["mutation_summary"], [codex_proxy.RouteMutation.MODEL_ALIAS.value])
 
     def test_model_switch_gateway_request_response_path_uses_selected_model_in_both_directions(self):
+        versioned_slug = "deepseek-v4-flash:0731"
+        versioned_catalog = catalog_sync.build_codex_catalog(
+            [],
+            [versioned_slug],
+            catalog_sync.CatalogPolicy(
+                denied_models=set(),
+                denied_substrings=set(),
+                display_names={},
+            ),
+            "0.146.0",
+            ollama_model_metadata={
+                versioned_slug: {
+                    "context_window": 1_048_576,
+                    "context_source": "providers_toml",
+                }
+            },
+            use_ollama_policy_allowlist=False,
+        )
+        versioned_catalog_by_slug = {
+            model["slug"]: model for model in versioned_catalog["models"]
+        }
         fixture = _load_model_switch_fixture()
         self.assertEqual(fixture["schema_version"], "codexhub.model-switch.v1")
         self.assertEqual(fixture["expected"], {
@@ -3439,6 +3460,10 @@ class RoutingTests(unittest.TestCase):
                 event_offset = len(self.write_proxy_event.call_args_list)
                 with (
                     patch("codex_proxy.choose_upstream", return_value=upstream),
+                    patch(
+                        "codex_proxy.generated_catalog_by_slug",
+                        return_value=versioned_catalog_by_slug,
+                    ),
                     patch("codex_proxy.codex_access_token", return_value="fixture-access-token"),
                     patch("codex_proxy.codex_account_id", return_value="fixture-account-id"),
                     patch(
@@ -3452,6 +3477,8 @@ class RoutingTests(unittest.TestCase):
                 open_upstream.assert_called_once()
                 forwarded = json.loads(open_upstream.call_args.args[0].data.decode("utf-8"))
                 self.assertEqual(forwarded["model"], model)
+                if model == versioned_slug:
+                    self.assertEqual(forwarded.get("max_output_tokens"), 1_048_576)
 
                 events = [
                     (event_call.args[0], event_call.kwargs)


### PR DESCRIPTION
## Summary

Promote `0.1.8-beta.3.2` from `dev` to `main`.

This promotion contains exactly:

- #378: versioned Ollama Cloud output-limit fallback and deterministic catalog/Gateway request regressions
- #379: `0.1.8-beta.3.2` release preparation

## Acceptance

For literal slug `deepseek-v4-flash:0731` with runtime `context_window = 1048576` and no output limit:

- generated catalog: `max_output_tokens = 1048576`
- forwarded Gateway request: `max_output_tokens = 1048576`

The regression uses the exact selected slug and does not infer the task model from global `config.toml`.

## Frozen dev SHA

`a36114c41bd5eae49383e1bc2e8a437e540d6a9b`

## Local release gate

- Python core: `2215 passed, 3 skipped, 473 subtests passed`
- Synthetic real-client: `146 passed`
- Python partitions: disjoint and complete (`2364 = 2218 + 146`)
- Frontend build and UI contract: `146 passed`
- Rust: `539 passed, 1 ignored`
- Clippy: passed with `-D warnings`
- Release-channel contract: `17 passed`
- Report-only parse errors: `0`
- Diff hygiene: passed

After merge, the exact `main` merge SHA will be used for the `v0.1.8-beta.3.2` tag and all seven immutable assets.