### PR TITLE
fix: omit context-derived Ollama output caps

### DIFF
--- a/src-python/catalog_sync.py
+++ b/src-python/catalog_sync.py
@@ -103,6 +103,7 @@ OLLAMA_PRIORITY_BASE = 100
 DIRECT_OFFICIAL_CONTEXT_MAX_AGE_SECONDS = 12 * 60 * 60
 DIRECT_OFFICIAL_CACHE_STATUS_SOURCE = "direct_official_cache"
 OFFICIAL_PROXY_PROVIDER_ALIAS = "openai"
+CONTEXT_WINDOW_OUTPUT_FALLBACK_SOURCE = "context_window_fallback"
 
 
 OLLAMA_MODEL_LIMIT_OVERRIDES: dict[str, dict[str, Any]] = {
@@ -2360,6 +2361,9 @@ def apply_ollama_model_limits(model: dict[str, Any], slug: str, model_metadata: 
         effective_context_window = model.get("context_window")
         if isinstance(effective_context_window, int) and effective_context_window > 0:
             model["max_output_tokens"] = effective_context_window
+            proxy_metadata = dict(model.get("codex_proxy_metadata", {}))
+            proxy_metadata["max_output_source"] = CONTEXT_WINDOW_OUTPUT_FALLBACK_SOURCE
+            model["codex_proxy_metadata"] = proxy_metadata
 
     input_modalities = dynamic_metadata.get("input_modalities")
     if isinstance(input_modalities, list) and input_modalities:

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -119,6 +119,7 @@ from catalog import (
     should_include_model,
 )
 from catalog_sync import (
+    CONTEXT_WINDOW_OUTPUT_FALLBACK_SOURCE,
     GENERATED_CATALOG_PATH,
     LEGACY_GENERATED_CATALOG_PATH,
     POLICY_PATH,
@@ -3024,18 +3025,27 @@ def _resolve_ollama_cloud_model(
         ) from exc
 
 
-def catalog_max_output_tokens(model_id: str) -> int | None:
+def _catalog_output_limit(model_id: str) -> tuple[int | None, bool]:
     slug = canonical_model_id(model_id)
     model = generated_catalog_by_slug().get(_catalog_identity_slug(slug))
     if not model:
         cap = UPSTREAM_MAX_OUTPUT_TOKEN_CAPS.get(slug)
-        return cap if isinstance(cap, int) and cap > 0 else None
+        return (cap if isinstance(cap, int) and cap > 0 else None), False
     value = model.get("max_output_tokens")
     catalog_value = value if isinstance(value, int) and value > 0 else None
     cap = UPSTREAM_MAX_OUTPUT_TOKEN_CAPS.get(slug)
     if isinstance(cap, int) and cap > 0:
-        return min(catalog_value, cap) if catalog_value is not None else cap
-    return catalog_value
+        return (min(catalog_value, cap) if catalog_value is not None else cap), False
+    metadata = model.get("codex_proxy_metadata")
+    context_fallback = (
+        isinstance(metadata, Mapping)
+        and metadata.get("max_output_source") == CONTEXT_WINDOW_OUTPUT_FALLBACK_SOURCE
+    )
+    return catalog_value, context_fallback
+
+
+def catalog_max_output_tokens(model_id: str) -> int | None:
+    return _catalog_output_limit(model_id)[0]
 
 
 def policy_denies_model(model_id: Any, policy: Any) -> bool:
@@ -11848,10 +11858,19 @@ def compatible_request_body(
     ):
         changed = True
     model_id = payload.get("model")
-    max_output_tokens = catalog_max_output_tokens(model_id) if isinstance(model_id, str) else None
+    max_output_tokens, context_window_fallback = (
+        _catalog_output_limit(model_id) if isinstance(model_id, str) else (None, False)
+    )
     if max_output_tokens is not None:
         requested_max_output_tokens = payload.get("max_output_tokens")
-        if not isinstance(requested_max_output_tokens, int) or requested_max_output_tokens > max_output_tokens:
+        if context_window_fallback and (
+            not isinstance(requested_max_output_tokens, int)
+            or requested_max_output_tokens >= max_output_tokens
+        ):
+            if "max_output_tokens" in payload:
+                del payload["max_output_tokens"]
+                changed = True
+        elif not isinstance(requested_max_output_tokens, int) or requested_max_output_tokens > max_output_tokens:
             payload["max_output_tokens"] = max_output_tokens
             changed = True
 

--- a/tests/test_catalog_sync.py
+++ b/tests/test_catalog_sync.py
@@ -423,6 +423,10 @@ class CatalogSyncTests(unittest.TestCase):
         self.assertEqual(model["context_window"], 1_048_576)
         self.assertEqual(model.get("max_output_tokens"), 1_048_576)
         self.assertEqual(model["codex_proxy_metadata"]["provider"], "ollama-cloud")
+        self.assertEqual(
+            model["codex_proxy_metadata"]["max_output_source"],
+            "context_window_fallback",
+        )
 
     def test_build_catalog_applies_official_model_sort_order(self):
         official = [

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -539,6 +539,7 @@ class RoutingTests(unittest.TestCase):
                 "gemini-3-flash-preview",
                 "deepseek-v4-pro",
                 "deepseek-v4-flash",
+                "deepseek-v4-flash:0731",
                 "volc/glm-5.2",
                 "minimax-cn/MiniMax-M3",
                 "minimax-cn/minimax-m3",
@@ -579,6 +580,15 @@ class RoutingTests(unittest.TestCase):
                 "gemini-3-flash-preview": {"slug": "gemini-3-flash-preview", "max_output_tokens": 65536},
                 "deepseek-v4-pro": {"slug": "deepseek-v4-pro", "max_output_tokens": 393216},
                 "deepseek-v4-flash": {"slug": "deepseek-v4-flash", "max_output_tokens": 393216},
+                "deepseek-v4-flash:0731": {
+                    "slug": "deepseek-v4-flash:0731",
+                    "context_window": 1048576,
+                    "max_output_tokens": 1048576,
+                    "codex_proxy_metadata": {
+                        "provider": "ollama-cloud",
+                        "max_output_source": "context_window_fallback",
+                    },
+                },
                 "volc/glm-5.2": {"slug": "volc/glm-5.2", "max_output_tokens": 4096},
                 "minimax-cn/MiniMax-M3": {"slug": "minimax-cn/MiniMax-M3", "max_output_tokens": 524288},
                 "minimax-cn/minimax-m3": {"slug": "minimax-cn/minimax-m3", "max_output_tokens": 524288},
@@ -3457,6 +3467,21 @@ class RoutingTests(unittest.TestCase):
                     separators=(",", ":"),
                 ).encode("utf-8")
 
+                def open_model_switch_upstream(request, **_kwargs):
+                    forwarded_payload = json.loads(request.data.decode("utf-8"))
+                    if (
+                        model == versioned_slug
+                        and forwarded_payload.get("max_output_tokens", 0) > 65_536
+                    ):
+                        raise HTTPError(
+                            request.full_url,
+                            400,
+                            "max_tokens exceeds model maximum output tokens",
+                            {},
+                            io.BytesIO(b'{"error":"max_tokens exceeds model maximum output tokens"}'),
+                        )
+                    return FakeContextResponse(upstream_response)
+
                 event_offset = len(self.write_proxy_event.call_args_list)
                 with (
                     patch("codex_proxy.choose_upstream", return_value=upstream),
@@ -3468,7 +3493,7 @@ class RoutingTests(unittest.TestCase):
                     patch("codex_proxy.codex_account_id", return_value="fixture-account-id"),
                     patch(
                         "codex_proxy._open_upstream_response",
-                        return_value=FakeContextResponse(upstream_response),
+                        side_effect=open_model_switch_upstream,
                     ) as open_upstream,
                 ):
                     CodexProxyHandler.do_POST(handler)
@@ -3478,7 +3503,7 @@ class RoutingTests(unittest.TestCase):
                 forwarded = json.loads(open_upstream.call_args.args[0].data.decode("utf-8"))
                 self.assertEqual(forwarded["model"], model)
                 if model == versioned_slug:
-                    self.assertEqual(forwarded.get("max_output_tokens"), 1_048_576)
+                    self.assertNotIn("max_output_tokens", forwarded)
 
                 events = [
                     (event_call.args[0], event_call.kwargs)
@@ -12900,6 +12925,33 @@ class RoutingTests(unittest.TestCase):
         transformed = compatible_request_body(body, upstream)
 
         self.assertEqual(json.loads(transformed)["max_output_tokens"], 65536)
+
+    def test_ollama_body_keeps_context_fallback_limit_off_wire_unless_caller_uses_smaller_limit(self):
+        upstream = {
+            **choose_upstream("glm-5.2"),
+            "model_id": "deepseek-v4-flash:0731",
+            "upstream_model": "deepseek-v4-flash:0731",
+        }
+        cases = (
+            (b'{"model":"deepseek-v4-flash:0731","input":"hi"}', None),
+            (
+                b'{"model":"deepseek-v4-flash:0731","max_output_tokens":1048576,"input":"hi"}',
+                None,
+            ),
+            (
+                b'{"model":"deepseek-v4-flash:0731","max_output_tokens":65536,"input":"hi"}',
+                65536,
+            ),
+        )
+
+        for body, expected_wire_limit in cases:
+            with self.subTest(expected_wire_limit=expected_wire_limit):
+                transformed = compatible_request_body(body, upstream)
+                payload = json.loads(transformed)
+                if expected_wire_limit is None:
+                    self.assertNotIn("max_output_tokens", payload)
+                else:
+                    self.assertEqual(payload["max_output_tokens"], expected_wire_limit)
 
     def test_ollama_body_uses_catalog_output_limit_without_deepseek_gateway_cap(self):
         upstream = choose_upstream("deepseek-v4-pro")


### PR DESCRIPTION
Closes #377

## Summary

- keep the client-facing Ollama catalog fallback at `max_output_tokens = context_window`
- record when that value came only from the context-window fallback
- omit a fallback-derived default/equal-or-higher cap from Ollama Cloud wire requests while preserving smaller caller values
- preserve positive resolved, static, runtime, and otherwise authoritative provider output limits
- simulate Ollama Cloud's `>65536` rejection in the production Gateway regression

## Exact behavior

For literal `deepseek-v4-flash:0731` with runtime `context_window = 1048576` and no authoritative output limit:

- catalog: `max_output_tokens = 1048576`
- catalog provenance: `context_window_fallback`
- default/equal-or-higher Ollama Cloud wire request: `max_output_tokens` omitted
- smaller caller value such as `65536`: forwarded unchanged

The model-switch regression derives the model from the exact selected turn/slug rather than global `config.toml`.

## Verification

Exact candidate: `2c4f4fa04dd73f9168c721a698eea5b5fdc3f7fb`

- targeted catalog/wire/production Gateway regressions: `3 passed, 3 subtests passed`
- Python core: `2216 passed, 3 skipped, 476 subtests passed`
- Python partitions: `2365` total, `2219` core, `146` synthetic; disjoint and complete
- changed-path planner selected only `python_core`
- `git diff --check`: passed
- report-only quality scan: `parse_errors: 0`; pre-existing non-blocking findings recorded
- Standards review: 0 remaining findings
- Spec review: 0 findings

## Scope

No Official/generic external-provider behavior, abnormal-history cleanup, or old-task repair behavior changed. Live Ollama Cloud streaming verification will run on the frozen release candidate using an isolated port without stopping the user's current Gateway.
