### PR TITLE
fix: complete Kimi K3 Chat-to-Responses compatibility

### DIFF
--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -9344,7 +9344,7 @@ def _rewrite_internal_input_items(
     return changed
 
 
-def _rewrite_v2_unsupported_custom_tool_history(
+def _rewrite_v2_unsupported_tool_history(
     payload: dict[str, Any],
     *,
     upstream: Mapping[str, Any],
@@ -11463,7 +11463,7 @@ def compatible_request_body(
             if history_changed:
                 payload["input"] = adapted_items
                 changed = True
-        if _rewrite_v2_unsupported_custom_tool_history(
+        if _rewrite_v2_unsupported_tool_history(
             payload,
             upstream=upstream,
             tool_protocol=tool_protocol,

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -5244,6 +5244,73 @@ def _chat_stream_shape_summary(chunks: list[Mapping[str, Any] | str]) -> dict[st
     return summary
 
 
+CHAT_RAW_REASONING_FIELDS = frozenset({"reasoning", "reasoning_content"})
+
+
+def _suppress_chat_reasoning_extensions(
+    chunks: list[Mapping[str, Any] | str],
+    *,
+    event_context: Mapping[str, Any] | None,
+    upstream_name: str | None,
+) -> tuple[list[Mapping[str, Any] | str], bool]:
+    """Drop third-party Chat reasoning extensions before Responses conversion."""
+    rewritten_chunks: list[Mapping[str, Any] | str] = []
+    field_count = 0
+    chunk_count = 0
+
+    for chunk in chunks:
+        if not isinstance(chunk, Mapping):
+            rewritten_chunks.append(chunk)
+            continue
+        choices = chunk.get("choices")
+        if not isinstance(choices, list):
+            rewritten_chunks.append(chunk)
+            continue
+
+        rewritten_choices: list[Any] = []
+        chunk_changed = False
+        for choice in choices:
+            if not isinstance(choice, Mapping):
+                rewritten_choices.append(choice)
+                continue
+            rewritten_choice: Mapping[str, Any] = choice
+            for source_name in ("delta", "message"):
+                source = choice.get(source_name)
+                if not isinstance(source, Mapping):
+                    continue
+                fields = CHAT_RAW_REASONING_FIELDS.intersection(source)
+                if not fields:
+                    continue
+                if rewritten_choice is choice:
+                    rewritten_choice = dict(choice)
+                rewritten_source = dict(source)
+                for field in fields:
+                    rewritten_source.pop(field, None)
+                rewritten_choice[source_name] = rewritten_source
+                field_count += len(fields)
+                chunk_changed = True
+            rewritten_choices.append(rewritten_choice)
+
+        if chunk_changed:
+            rewritten_chunk = dict(chunk)
+            rewritten_chunk["choices"] = rewritten_choices
+            rewritten_chunks.append(rewritten_chunk)
+            chunk_count += 1
+        else:
+            rewritten_chunks.append(chunk)
+
+    if not field_count:
+        return chunks, False
+    _write_adapter_event(
+        event_context,
+        "chat_reasoning_extensions_suppressed",
+        upstream=upstream_name,
+        field_count=field_count,
+        chunk_count=chunk_count,
+    )
+    return rewritten_chunks, True
+
+
 def _chat_stream_is_empty_lifecycle_final(
     summary: Mapping[str, Any],
     event_context: Mapping[str, Any] | None,
@@ -9286,7 +9353,7 @@ def _rewrite_v2_unsupported_custom_tool_history(
     event_context: Mapping[str, Any] | None,
     upstream_name: str | None,
 ) -> bool:
-    """Keep V2 Collaboration calls native without leaking other custom items.
+    """Keep V2 Collaboration calls native while adapting stale tool history.
 
     Collaboration V2 is a boundary for the ``collaboration`` namespace, not a
     blanket exemption from the third-party input-item adapter.  Codex Desktop
@@ -9294,7 +9361,9 @@ def _rewrite_v2_unsupported_custom_tool_history(
     beside V2 calls.  Responses providers generally expose only the plain
     function lifecycle unless an explicit custom lifecycle capability is
     supplied, so those opaque items must become transcript messages before the
-    request reaches the provider.
+    request reaches the provider. A uniquely paired plain-function lifecycle
+    from an older tool surface is likewise retained as a read-only transcript
+    when the current immutable plan has no owner for its identity.
     """
     input_items = payload.get("input")
     if not isinstance(input_items, list):
@@ -9354,12 +9423,70 @@ def _rewrite_v2_unsupported_custom_tool_history(
         and preserve_custom_call(item)
     }
 
+    def plan_owns_plain_function_call(item: Mapping[str, Any]) -> bool:
+        if compatibility_plan is None:
+            return True
+        name = item.get("name")
+        call_id = item.get("call_id")
+        if compatibility_plan.registry.record_for_alias(name) is not None:
+            return True
+        if compatibility_plan.registry.record_for_call(call_id) is not None:
+            return True
+        return any(
+            entry.family == "plain_function"
+            and entry.original_name == name
+            for entry in compatibility_plan.entries
+        )
+
+    positions_by_call_id: dict[str, list[int]] = {}
+    for index, item in enumerate(input_items):
+        if not isinstance(item, Mapping):
+            continue
+        call_id = item.get("call_id")
+        if isinstance(call_id, str) and call_id:
+            positions_by_call_id.setdefault(call_id, []).append(index)
+
+    stale_function_pair_indexes: set[int] = set()
+    stale_function_pair_count = 0
+    for call_index, item in enumerate(input_items):
+        if (
+            not isinstance(item, Mapping)
+            or not _is_standard_responses_function_call(item)
+            or item.get("status") != "completed"
+            or item.get("namespace") is not None
+            or not isinstance(item.get("arguments"), str)
+            or plan_owns_plain_function_call(item)
+        ):
+            continue
+        call_id = item["call_id"]
+        positions = positions_by_call_id.get(call_id, [])
+        if len(positions) != 2 or positions[0] != call_index:
+            continue
+        output_index = positions[1]
+        output_item = input_items[output_index]
+        if (
+            not isinstance(output_item, Mapping)
+            or output_item.get("type") != "function_call_output"
+            or "output" not in output_item
+        ):
+            continue
+        stale_function_pair_indexes.update((call_index, output_index))
+        stale_function_pair_count += 1
+
     rewritten_items: list[Any] = []
     changed = False
-    rewritten_count = 0
-    for item in input_items:
+    custom_rewritten_count = 0
+    for index, item in enumerate(input_items):
         if not isinstance(item, Mapping):
             rewritten_items.append(item)
+            continue
+        if index in stale_function_pair_indexes:
+            replacement = _compatible_internal_message(item)
+            if replacement is not None:
+                rewritten_items.append(replacement)
+                changed = True
+            else:
+                rewritten_items.append(item)
             continue
         item_type = item.get("type")
         if item_type == "custom_tool_call" and not preserve_custom_call(item):
@@ -9367,7 +9494,7 @@ def _rewrite_v2_unsupported_custom_tool_history(
             if replacement is not None:
                 rewritten_items.append(replacement)
                 changed = True
-                rewritten_count += 1
+                custom_rewritten_count += 1
             else:
                 rewritten_items.append(item)
             continue
@@ -9379,7 +9506,7 @@ def _rewrite_v2_unsupported_custom_tool_history(
             if replacement is not None:
                 rewritten_items.append(replacement)
                 changed = True
-                rewritten_count += 1
+                custom_rewritten_count += 1
             else:
                 rewritten_items.append(item)
             continue
@@ -9388,12 +9515,20 @@ def _rewrite_v2_unsupported_custom_tool_history(
     if not changed:
         return False
     payload["input"] = rewritten_items
-    _write_adapter_event(
-        event_context,
-        "v2_custom_tool_history_rewritten",
-        upstream=upstream_name,
-        count=rewritten_count,
-    )
+    if custom_rewritten_count:
+        _write_adapter_event(
+            event_context,
+            "v2_custom_tool_history_rewritten",
+            upstream=upstream_name,
+            count=custom_rewritten_count,
+        )
+    if stale_function_pair_count:
+        _write_adapter_event(
+            event_context,
+            "v2_stale_function_history_rewritten",
+            upstream=upstream_name,
+            pair_count=stale_function_pair_count,
+        )
     return True
 
 
@@ -19610,11 +19745,7 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 **proxy_request_context,
             )
             if downstream_sse_started:
-                if (
-                    is_apply_patch_adapter_error
-                    and inbound_format == "responses"
-                    and selected_native_responses_tool_codec == "strict_apply_patch"
-                ):
+                if inbound_format == "responses":
                     if not self._write_sse_event(
                         "response.failed",
                         _responses_failed_event_for_stream_error(
@@ -19630,16 +19761,20 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                     ):
                         finish_downstream_write_failure()
                         return
-                    write_proxy_event(
-                        "third_party_apply_patch_terminal",
-                        request_id=request_id,
-                        model=canonical_model_id(model) if model else None,
-                        upstream=upstream_name,
-                        codec=selected_native_responses_tool_codec,
-                        disposition="response.failed",
-                        failure_class=RETRY_FAILURE_PERMANENT,
-                        retry_count=0,
-                    )
+                    if (
+                        is_apply_patch_adapter_error
+                        and selected_native_responses_tool_codec == "strict_apply_patch"
+                    ):
+                        write_proxy_event(
+                            "third_party_apply_patch_terminal",
+                            request_id=request_id,
+                            model=canonical_model_id(model) if model else None,
+                            upstream=upstream_name,
+                            codec=selected_native_responses_tool_codec,
+                            disposition="response.failed",
+                            failure_class=RETRY_FAILURE_PERMANENT,
+                            retry_count=0,
+                        )
                     self.close_connection = True
                 else:
                     if not self._write_downstream_sse_error(
@@ -22755,6 +22890,12 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                         )
                     _capture_usage(usage_capture, None, missing_reason="stream_incomplete")
                     return 502
+                if upstream_name != "official" and not want_chat_output:
+                    chunks, _ = _suppress_chat_reasoning_extensions(
+                        chunks,
+                        event_context=event_context,
+                        upstream_name=upstream_name,
+                    )
                 chat_summary = _chat_stream_shape_summary(chunks)
                 _write_adapter_event(
                     event_context,

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -9438,6 +9438,52 @@ def _rewrite_v2_unsupported_custom_tool_history(
             for entry in compatibility_plan.entries
         )
 
+    def has_valid_optional_item_identity(item: Mapping[str, Any]) -> bool:
+        identities = []
+        for field in ("id", "item_id"):
+            if field not in item:
+                continue
+            value = item.get(field)
+            if not isinstance(value, str) or not value:
+                return False
+            identities.append(value)
+        return len(set(identities)) <= 1
+
+    def is_well_formed_stale_function_call(item: Mapping[str, Any]) -> bool:
+        allowed_fields = {
+            "type",
+            "id",
+            "item_id",
+            "status",
+            "call_id",
+            "name",
+            "arguments",
+        }
+        return (
+            set(item).issubset(allowed_fields)
+            and _is_standard_responses_function_call(item)
+            and item.get("status") == "completed"
+            and isinstance(item.get("arguments"), str)
+            and has_valid_optional_item_identity(item)
+        )
+
+    def is_well_formed_stale_function_output(item: Mapping[str, Any]) -> bool:
+        allowed_fields = {
+            "type",
+            "id",
+            "item_id",
+            "status",
+            "call_id",
+            "output",
+        }
+        return (
+            set(item).issubset(allowed_fields)
+            and item.get("type") == "function_call_output"
+            and item.get("status") in (None, "completed")
+            and isinstance(item.get("output"), str)
+            and has_valid_optional_item_identity(item)
+        )
+
     positions_by_call_id: dict[str, list[int]] = {}
     for index, item in enumerate(input_items):
         if not isinstance(item, Mapping):
@@ -9451,10 +9497,7 @@ def _rewrite_v2_unsupported_custom_tool_history(
     for call_index, item in enumerate(input_items):
         if (
             not isinstance(item, Mapping)
-            or not _is_standard_responses_function_call(item)
-            or item.get("status") != "completed"
-            or item.get("namespace") is not None
-            or not isinstance(item.get("arguments"), str)
+            or not is_well_formed_stale_function_call(item)
             or plan_owns_plain_function_call(item)
         ):
             continue
@@ -9466,8 +9509,7 @@ def _rewrite_v2_unsupported_custom_tool_history(
         output_item = input_items[output_index]
         if (
             not isinstance(output_item, Mapping)
-            or output_item.get("type") != "function_call_output"
-            or "output" not in output_item
+            or not is_well_formed_stale_function_output(output_item)
         ):
             continue
         stale_function_pair_indexes.update((call_index, output_index))

--- a/src-python/protocol_translation.py
+++ b/src-python/protocol_translation.py
@@ -1678,10 +1678,11 @@ def chat_stream_chunks_to_response_events(
                 continue
             _validate_chat_stream_source(source)
             content = source.get("content")
-            if isinstance(content, str) and content:
-                if message_output_index is None:
-                    message_output_index = allocate_output_index()
-                text_parts.append(content)
+            if isinstance(content, str):
+                if content:
+                    if message_output_index is None:
+                        message_output_index = allocate_output_index()
+                    text_parts.append(content)
             elif content is not None:
                 raise UnsupportedProtocolTranslationError(
                     "unsupported_protocol_semantics",
@@ -2793,18 +2794,19 @@ class ChatToResponsesStreamConverter:
             if isinstance(delta, Mapping):
                 _validate_chat_stream_source(delta)
                 content = delta.get("content")
-                if isinstance(content, str) and content:
-                    self.text_parts.append(content)
-                    events.extend(self._message_start_events())
-                    events.append(
-                        {
-                            "type": "response.output_text.delta",
-                            "item_id": self.item_id,
-                            "output_index": self.message_output_index if self.message_output_index is not None else 0,
-                            "content_index": 0,
-                            "delta": content,
-                        }
-                    )
+                if isinstance(content, str):
+                    if content:
+                        self.text_parts.append(content)
+                        events.extend(self._message_start_events())
+                        events.append(
+                            {
+                                "type": "response.output_text.delta",
+                                "item_id": self.item_id,
+                                "output_index": self.message_output_index if self.message_output_index is not None else 0,
+                                "content_index": 0,
+                                "delta": content,
+                            }
+                        )
                 elif content is not None:
                     raise UnsupportedProtocolTranslationError(
                         "unsupported_protocol_semantics",

--- a/tests/test_protocol_translation.py
+++ b/tests/test_protocol_translation.py
@@ -1372,6 +1372,45 @@ class ProtocolTranslationTests(unittest.TestCase):
             converter.events_for_chunk(chunk)
         self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
 
+    def test_chat_stream_empty_string_content_is_ignored_in_both_modes(self):
+        empty_chunk = {
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"role": "assistant", "content": ""},
+                    "finish_reason": None,
+                }
+            ]
+        }
+        text_chunk = {
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"content": "ok"},
+                    "finish_reason": "stop",
+                }
+            ]
+        }
+
+        events = protocol_translation.chat_stream_chunks_to_response_events(
+            [empty_chunk, text_chunk, "[DONE]"]
+        )
+        self.assertEqual(events[-1]["type"], "response.completed")
+        self.assertEqual(
+            events[-1]["response"]["output"][0]["content"][0]["text"],
+            "ok",
+        )
+
+        converter = protocol_translation.ChatToResponsesStreamConverter()
+        converter.events_for_chunk(empty_chunk)
+        converter.events_for_chunk(text_chunk)
+        incremental_events = converter.events_for_done()
+        self.assertEqual(incremental_events[-1]["type"], "response.completed")
+        self.assertEqual(
+            incremental_events[-1]["response"]["output"][0]["content"][0]["text"],
+            "ok",
+        )
+
     def test_chat_stream_rejects_multiple_or_nonzero_choices_before_translation(self):
         chunks = (
             {

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -18513,6 +18513,9 @@ class RoutingTests(unittest.TestCase):
             "unpaired": [stale_call],
             "duplicate_output": [stale_call, stale_output, stale_output],
             "malformed_call": [{key: value for key, value in stale_call.items() if key != "arguments"}, stale_output],
+            "unknown_call_field": [{**stale_call, "unexpected": True}, stale_output],
+            "unknown_output_field": [stale_call, {**stale_output, "unexpected": True}],
+            "non_string_output": [stale_call, {**stale_output, "output": {"unexpected": True}}],
         }
 
         for name, history in cases.items():

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -7633,7 +7633,7 @@ class RoutingTests(unittest.TestCase):
                         {
                             "index": 0,
                             "delta": {
-                                "reasoning_content": "SECRET_CHAT_UNSUPPORTED_DELTA"
+                                "audio": {"data": "SECRET_CHAT_UNSUPPORTED_DELTA"}
                             },
                             "finish_reason": None,
                         }
@@ -7959,7 +7959,7 @@ class RoutingTests(unittest.TestCase):
             headers={"X-Codex-Client-Id": "opencode"},
         )
         frames = [
-            b'data: {"choices":[{"index":0,"delta":{"reasoning_content":"SECRET_BUFFERED_CONVERSION"},"finish_reason":null}]}\n\n',
+            b'data: {"choices":[{"index":0,"delta":{"audio":{"data":"SECRET_BUFFERED_CONVERSION"}},"finish_reason":null}]}\n\n',
             b'data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\n',
             b"data: [DONE]\n\n",
             b"",
@@ -15214,7 +15214,7 @@ class RoutingTests(unittest.TestCase):
         self.assertNotIn("arguments_not_exact", rendered_payload)
         self.assertNotIn(private_patch, rendered_payload)
 
-    def test_apply_patch_adapter_rejection_sse_terminal_is_codec_scoped_and_preserves_response_id(self):
+    def test_apply_patch_adapter_rejection_sse_uses_failed_terminal_with_codec_scoped_telemetry(self):
         private_patch = "*** Begin Patch\n*** Update File: secret.txt\n"
         malformed_item = {
             "id": "fc_apply_patch",
@@ -15236,10 +15236,10 @@ class RoutingTests(unittest.TestCase):
             }
         ).encode("utf-8")
         cases = (
-            ("unselected", "none", b"event: error\n"),
-            ("selected", "strict_apply_patch", b"event: response.failed\n"),
+            ("unselected", "none"),
+            ("selected", "strict_apply_patch"),
         )
-        for case, codec, expected_prefix in cases:
+        for case, codec in cases:
             with self.subTest(case=case):
                 self.write_proxy_event.reset_mock()
                 response = FakeSseResponse(
@@ -15273,20 +15273,9 @@ class RoutingTests(unittest.TestCase):
                 self.assertEqual(fake.status, 200)
                 frames = b"".join(fake.wfile.writes).split(b"\n\n")
                 terminal_frames = [
-                    frame for frame in frames if frame.startswith(expected_prefix)
+                    frame for frame in frames if frame.startswith(b"event: response.failed\n")
                 ]
                 self.assertEqual(len(terminal_frames), 1)
-
-                if codec == "none":
-                    self.assertFalse(
-                        any(
-                            frame.startswith(b"event: response.failed\n")
-                            for frame in frames
-                        )
-                    )
-                    self.assertNotIn("third_party_apply_patch_terminal", event_names)
-                    continue
-
                 self.assertFalse(
                     any(frame.startswith(b"event: error\n") for frame in frames)
                 )
@@ -15310,6 +15299,9 @@ class RoutingTests(unittest.TestCase):
                 self.assertFalse(payload["response"]["error"]["retryable"])
                 self.assertNotIn("arguments_not_exact", json.dumps(payload))
                 self.assertNotIn(private_patch, json.dumps(payload))
+                if codec == "none":
+                    self.assertNotIn("third_party_apply_patch_terminal", event_names)
+                    continue
                 terminal_event = next(
                     call.kwargs
                     for call in self.write_proxy_event.call_args_list
@@ -15381,7 +15373,7 @@ class RoutingTests(unittest.TestCase):
         )
         self.assertFalse(payload["codexhub_error"]["retryable"])
 
-    def test_unrelated_protocol_translation_sse_keeps_stream_error_envelope(self):
+    def test_unrelated_protocol_translation_sse_uses_responses_failed_terminal(self):
         translation_error = codex_proxy.UpstreamProtocolTranslationError(
             codex_proxy.UnsupportedProtocolTranslationError(
                 "unsupported_protocol_semantics",
@@ -15419,20 +15411,27 @@ class RoutingTests(unittest.TestCase):
         relay_upstream.assert_called_once()
         self.assertEqual(fake.status, 200)
         frames = b"".join(fake.wfile.writes).split(b"\n\n")
-        error_frame = next(frame for frame in frames if frame.startswith(b"event: error\n"))
-        error_line = next(line for line in error_frame.splitlines() if line.startswith(b"data: "))
-        payload = json.loads(error_line.removeprefix(b"data: "))
-        self.assertEqual(payload["type"], "upstream_stream_error")
-        self.assertEqual(payload["status"], 400)
-        self.assertEqual(payload["error"], "unsupported_protocol_semantics")
-        self.assertEqual(payload["retry_owner"], "client")
-        self.assertEqual(payload["failure_class"], codex_proxy.RETRY_FAILURE_PERMANENT)
-        self.assertFalse(payload["retryable"])
-        self.assertEqual(payload["codexhub_error"]["code"], "upstream.error")
-        self.assertEqual(
-            payload["codexhub_error"]["details"]["type"],
-            "upstream_stream_error",
+        self.assertFalse(any(frame.startswith(b"event: error\n") for frame in frames))
+        failed_frames = [
+            frame for frame in frames if frame.startswith(b"event: response.failed\n")
+        ]
+        self.assertEqual(len(failed_frames), 1)
+        failed_line = next(
+            line for line in failed_frames[0].splitlines() if line.startswith(b"data: ")
         )
+        payload = json.loads(failed_line.removeprefix(b"data: "))
+        self.assertEqual(payload["type"], "response.failed")
+        self.assertEqual(payload["response"]["status"], "failed")
+        self.assertEqual(
+            payload["response"]["error"]["code"],
+            "unsupported_protocol_semantics",
+        )
+        self.assertEqual(payload["response"]["error"]["status"], 400)
+        self.assertEqual(
+            payload["response"]["error"]["failure_class"],
+            codex_proxy.RETRY_FAILURE_PERMANENT,
+        )
+        self.assertFalse(payload["response"]["error"]["retryable"])
 
     def test_apply_patch_adapter_rejects_conflicting_item_fields_and_custom_call_id_collisions(self):
         fixture = _load_glm_apply_patch_retry_fixture()
@@ -16137,6 +16136,97 @@ class RoutingTests(unittest.TestCase):
         output = completed["response"]["output"][0]
         self.assertEqual(output["type"], "message")
         self.assertEqual(output["content"][0]["text"], "hello")
+
+    def test_chat_completions_sse_relay_suppresses_kimi_reasoning_and_completes_responses(self):
+        handler = FakeHandler()
+        chunks = [
+            {
+                "id": "chatcmpl_kimi_reasoning",
+                "object": "chat.completion.chunk",
+                "model": "kimi-k3",
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {"role": "assistant", "content": ""},
+                        "finish_reason": None,
+                    }
+                ],
+            },
+            {
+                "id": "chatcmpl_kimi_reasoning",
+                "object": "chat.completion.chunk",
+                "model": "kimi-k3",
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {"reasoning_content": "SECRET_KIMI_REASONING"},
+                        "finish_reason": None,
+                    }
+                ],
+            },
+            {
+                "id": "chatcmpl_kimi_reasoning",
+                "object": "chat.completion.chunk",
+                "model": "kimi-k3",
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {"content": "ok"},
+                        "finish_reason": None,
+                    }
+                ],
+            },
+            {
+                "id": "chatcmpl_kimi_reasoning",
+                "object": "chat.completion.chunk",
+                "model": "kimi-k3",
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {},
+                        "finish_reason": "stop",
+                    }
+                ],
+            },
+        ]
+        response = FakeSseResponse(
+            [f"data: {json.dumps(chunk)}\n\n".encode("utf-8") for chunk in chunks]
+            + [b"data: [DONE]\n\n", b""]
+        )
+
+        status = relay_upstream_response(
+            handler,
+            response,
+            "kimi",
+            relay_fixture=RELAY_GATEWAY,
+            upstream_format="chat_completions",
+            inbound_format="responses",
+            event_context={"request_id": "req-kimi-reasoning"},
+        )
+
+        written = b"".join(handler.wfile.writes)
+        payloads = [
+            json.loads(write.decode("utf-8").removeprefix("data: "))
+            for write in handler.wfile.writes
+            if write.startswith(b"data: {")
+        ]
+        completed = next(payload for payload in payloads if payload["type"] == "response.completed")
+        self.assertEqual(status, 200)
+        self.assertEqual(
+            completed["response"]["output"][0]["content"][0]["text"],
+            "ok",
+        )
+        self.assertNotIn(b"SECRET_KIMI_REASONING", written)
+        self.assertFalse(any(payload["type"] == "response.failed" for payload in payloads))
+        suppression_event = next(
+            call.kwargs
+            for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] == "chat_reasoning_extensions_suppressed"
+        )
+        self.assertEqual(suppression_event["field_count"], 1)
+        self.assertEqual(suppression_event["chunk_count"], 1)
+        for forbidden in ("content", "reasoning", "reasoning_content", "text"):
+            self.assertNotIn(forbidden, suppression_event)
 
     def test_transparent_chat_to_responses_stream_treats_terminal_commit_failure_as_downstream_close(self):
         handler = FakeHandler()
@@ -18330,6 +18420,129 @@ class RoutingTests(unittest.TestCase):
         self.assertEqual(history_events[0]["count"], 1)
         for forbidden in ("call_id", "name", "input", "output", "patch", "arguments"):
             self.assertNotIn(forbidden, history_events[0])
+
+    def test_collaboration_v2_rewrites_unique_stale_plain_function_history_as_transcript(self):
+        transformed = compatible_request_body(
+            json.dumps(
+                {
+                    "model": "kimi-k3",
+                    "input": [
+                        {
+                            "type": "function_call",
+                            "status": "completed",
+                            "call_id": "call_stale_wait",
+                            "name": "wait",
+                            "arguments": json.dumps({"cell_id": "stale-cell"}),
+                        },
+                        {
+                            "type": "function_call_output",
+                            "call_id": "call_stale_wait",
+                            "output": "stale result",
+                        },
+                        {
+                            "type": "function_call",
+                            "status": "completed",
+                            "call_id": "call_current_shell",
+                            "name": "shell_command",
+                            "arguments": json.dumps({"command": "Write-Output ok"}),
+                        },
+                        {
+                            "type": "function_call_output",
+                            "call_id": "call_current_shell",
+                            "output": "ok",
+                        },
+                        {"type": "message", "role": "user", "content": "continue"},
+                    ],
+                    "tools": [
+                        {
+                            "type": "function",
+                            "name": "shell_command",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {"command": {"type": "string"}},
+                            },
+                        }
+                    ],
+                }
+            ).encode("utf-8"),
+            {
+                "name": "kimi",
+                "upstream_model": "kimi-k3",
+                "upstream_format": "chat_completions",
+                "tool_protocol": "none",
+            },
+            event_context={
+                "request_id": "request-stale-wait",
+                "collaboration_protocol": "collaboration_v2",
+            },
+            inject_codex_tools=False,
+        )
+        payload = json.loads(transformed)
+
+        self.assertEqual(
+            [(item["type"], item["role"]) for item in payload["input"]],
+            [("message", "developer"), ("message", "developer"), ("message", "user")],
+        )
+        self.assertIn("function: wait", payload["input"][0]["content"])
+        self.assertIn("call_id: call_stale_wait", payload["input"][0]["content"])
+        self.assertIn("call_id: call_stale_wait", payload["input"][1]["content"])
+        self.assertNotIn("shell_command", json.dumps(payload["input"]))
+        rewrite_event = next(
+            call.kwargs
+            for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] == "v2_stale_function_history_rewritten"
+        )
+        self.assertEqual(rewrite_event["pair_count"], 1)
+        for forbidden in ("call_id", "name", "arguments", "output"):
+            self.assertNotIn(forbidden, rewrite_event)
+
+    def test_collaboration_v2_stale_function_history_must_be_unique_and_complete(self):
+        stale_call = {
+            "type": "function_call",
+            "status": "completed",
+            "call_id": "call_stale_wait",
+            "name": "wait",
+            "arguments": json.dumps({"cell_id": "stale-cell"}),
+        }
+        stale_output = {
+            "type": "function_call_output",
+            "call_id": "call_stale_wait",
+            "output": "stale result",
+        }
+        cases = {
+            "unpaired": [stale_call],
+            "duplicate_output": [stale_call, stale_output, stale_output],
+            "malformed_call": [{key: value for key, value in stale_call.items() if key != "arguments"}, stale_output],
+        }
+
+        for name, history in cases.items():
+            with self.subTest(name=name), self.assertRaises(codex_proxy.UpstreamProtocolTranslationError):
+                compatible_request_body(
+                    json.dumps(
+                        {
+                            "model": "kimi-k3",
+                            "input": history,
+                            "tools": [
+                                {
+                                    "type": "function",
+                                    "name": "shell_command",
+                                    "parameters": {"type": "object", "properties": {}},
+                                }
+                            ],
+                        }
+                    ).encode("utf-8"),
+                    {
+                        "name": "kimi",
+                        "upstream_model": "kimi-k3",
+                        "upstream_format": "chat_completions",
+                        "tool_protocol": "none",
+                    },
+                    event_context={
+                        "request_id": f"request-stale-wait-{name}",
+                        "collaboration_protocol": "collaboration_v2",
+                    },
+                    inject_codex_tools=False,
+                )
 
     def test_external_collaboration_v2_strips_official_reasoning_encrypted_content(self):
         encrypted_content = "gAAAA-official-secret"


### PR DESCRIPTION
## Summary
- accept legal empty-string Chat delta content during Chat-to-Responses conversion
- suppress third-party `reasoning` / `reasoning_content` extensions at the Kimi Chat-to-Responses boundary
- terminate post-commit Responses translation failures with a standard `response.failed` event
- adapt only uniquely paired, strict stale plain-function history when Collaboration V2 no longer owns that tool identity

## Verification
- focused regression set: 33 passed, 20 subtests passed
- Python core on `2b5c253`: 2222 passed, 1 skipped, 482 subtests passed
- Python partition completeness: 2369 full / 2223 core / 146 synthetic, disjoint and complete
- `git diff --check`
- report-only quality gates: exit 0, parse_errors 0
- spec and standards re-review: no findings
- isolated live Kimi K3 Gateway: HTTP 200, one `response.completed`, no `response.failed`, no reasoning leak
- Codex CLI 0.146.1 through the isolated Gateway: exit 0, visible marker received, zero reconnect markers
- existing Beta 3.2 Gateway on 127.0.0.1:9099 remained owned by PID 10684 before and after the live check

GitHub Actions is disabled; local verification is authoritative per repository policy.
