### PR TITLE
Fix V2 reasoning history for Kimi Chat upstreams

### DIFF
--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -9574,6 +9574,35 @@ def _rewrite_v2_unsupported_tool_history(
     return True
 
 
+def _drop_v2_chat_reasoning_history(
+    payload: dict[str, Any],
+    *,
+    event_context: Mapping[str, Any] | None,
+    upstream_name: str | None,
+) -> bool:
+    input_items = payload.get("input")
+    if not isinstance(input_items, list):
+        return False
+
+    rewritten_items = [
+        item
+        for item in input_items
+        if not (isinstance(item, Mapping) and item.get("type") == "reasoning")
+    ]
+    removed_count = len(input_items) - len(rewritten_items)
+    if not removed_count:
+        return False
+
+    payload["input"] = rewritten_items
+    _write_adapter_event(
+        event_context,
+        "v2_chat_reasoning_history_removed",
+        upstream=upstream_name,
+        count=removed_count,
+    )
+    return True
+
+
 def _sanitize_unsupported_compaction_input_items(payload: dict[str, Any]) -> bool:
     input_items = payload.get("input")
     if not isinstance(input_items, list):
@@ -11470,6 +11499,15 @@ def compatible_request_body(
             compatibility_plan=runtime_tool_plan,
             event_context=event_context,
             upstream_name=upstream_name,
+        ):
+            changed = True
+        if (
+            upstream.get("upstream_format") == "chat_completions"
+            and _drop_v2_chat_reasoning_history(
+                payload,
+                event_context=event_context,
+                upstream_name=upstream_name,
+            )
         ):
             changed = True
     else:

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -18584,6 +18584,65 @@ class RoutingTests(unittest.TestCase):
         self.assertNotIn("encrypted_content", payload["input"][0])
         self.assertNotIn(encrypted_content, transformed.decode("utf-8"))
 
+    def test_collaboration_v2_chat_drops_responses_reasoning_history_before_translation(self):
+        summary_text = "PRIVATE_REASONING_SUMMARY"
+        encrypted_content = "gAAAA-private-reasoning"
+        event_context = {
+            "request_id": "request-v2-chat-reasoning-history",
+            "collaboration_protocol": "collaboration_v2",
+        }
+        transformed = compatible_request_body(
+            json.dumps(
+                {
+                    "model": "kimi-k3",
+                    "input": [
+                        {
+                            "id": "rs_private",
+                            "type": "reasoning",
+                            "summary": [{"type": "summary_text", "text": summary_text}],
+                            "encrypted_content": encrypted_content,
+                        },
+                        {"type": "message", "role": "user", "content": "continue"},
+                    ],
+                    "tools": [_model_switch_tool_surface("collaboration_v2")],
+                    "stream": True,
+                }
+            ).encode("utf-8"),
+            {
+                "name": "kimi",
+                "upstream_model": "kimi-k3",
+                "upstream_format": "chat_completions",
+                "tool_protocol": "chat_tools",
+            },
+            event_context=event_context,
+            inject_codex_tools=False,
+        )
+        payload = json.loads(transformed)
+
+        self.assertEqual(
+            payload["input"],
+            [{"type": "message", "role": "user", "content": "continue"}],
+        )
+        chat_payload = json.loads(
+            _responses_request_to_chat_completion_body(
+                transformed,
+                drop_client_transport_fields=True,
+                drop_reasoning=True,
+            )
+        )
+        self.assertEqual(chat_payload["messages"], [{"role": "user", "content": "continue"}])
+        serialized = json.dumps(chat_payload, ensure_ascii=False)
+        self.assertNotIn(summary_text, serialized)
+        self.assertNotIn(encrypted_content, serialized)
+        removal_event = next(
+            call.kwargs
+            for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] == "v2_chat_reasoning_history_removed"
+        )
+        self.assertEqual(removal_event["count"], 1)
+        for forbidden in ("id", "summary", "content", "text", "encrypted_content"):
+            self.assertNotIn(forbidden, removal_event)
+
     def test_selected_native_responses_codec_round_trips_apply_patch_and_next_history_once(self):
         fixture = _load_glm_apply_patch_history_native_ids_fixture()
         apply_patch_tool = {


### PR DESCRIPTION
## Summary
- drop Responses reasoning history items only at the Collaboration V2 -> Chat Completions wire boundary
- keep Responses-upstream summaries and continue stripping encrypted reasoning content
- add a regression gate for Kimi Chat conversion and safe aggregate telemetry

## Verification
- targeted V2 routing checks: 5 passed, 627 deselected, 6 subtests passed
- Python core: 2223 passed, 1 skipped, 482 subtests passed
- Python partition checker: disjoint and complete
- report-only quality gates: completed, 0 parse errors
- two-axis candidate review: no Standards or Spec findings
- isolated live Kimi K3 old-history request: HTTP 200, sentinel returned, no response.failed, one reasoning item removed; production Gateway PID 34164 on port 9099 remained untouched