### PR TITLE
fix: adapt V2 message phase for Chat upstreams

### DIFF
--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -9603,6 +9603,39 @@ def _drop_v2_chat_reasoning_history(
     return True
 
 
+def _drop_v2_chat_message_phase(
+    payload: dict[str, Any],
+    *,
+    event_context: Mapping[str, Any] | None,
+    upstream_name: str | None,
+) -> bool:
+    input_items = payload.get("input")
+    if not isinstance(input_items, list):
+        return False
+
+    removed_count = 0
+    rewritten_items: list[Any] = []
+    for item in input_items:
+        if isinstance(item, Mapping) and item.get("type") == "message" and "phase" in item:
+            rewritten = dict(item)
+            rewritten.pop("phase")
+            rewritten_items.append(rewritten)
+            removed_count += 1
+        else:
+            rewritten_items.append(item)
+    if not removed_count:
+        return False
+
+    payload["input"] = rewritten_items
+    _write_adapter_event(
+        event_context,
+        "v2_chat_message_phase_removed",
+        upstream=upstream_name,
+        count=removed_count,
+    )
+    return True
+
+
 def _sanitize_unsupported_compaction_input_items(payload: dict[str, Any]) -> bool:
     input_items = payload.get("input")
     if not isinstance(input_items, list):
@@ -11504,6 +11537,15 @@ def compatible_request_body(
         if (
             upstream.get("upstream_format") == "chat_completions"
             and _drop_v2_chat_reasoning_history(
+                payload,
+                event_context=event_context,
+                upstream_name=upstream_name,
+            )
+        ):
+            changed = True
+        if (
+            upstream.get("upstream_format") == "chat_completions"
+            and _drop_v2_chat_message_phase(
                 payload,
                 event_context=event_context,
                 upstream_name=upstream_name,

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -18584,7 +18584,7 @@ class RoutingTests(unittest.TestCase):
         self.assertNotIn("encrypted_content", payload["input"][0])
         self.assertNotIn(encrypted_content, transformed.decode("utf-8"))
 
-    def test_collaboration_v2_chat_drops_responses_reasoning_history_before_translation(self):
+    def test_collaboration_v2_chat_adapts_responses_only_history_before_translation(self):
         summary_text = "PRIVATE_REASONING_SUMMARY"
         encrypted_content = "gAAAA-private-reasoning"
         event_context = {
@@ -18602,6 +18602,13 @@ class RoutingTests(unittest.TestCase):
                             "summary": [{"type": "summary_text", "text": summary_text}],
                             "encrypted_content": encrypted_content,
                         },
+                        {
+                            "id": "msg_final",
+                            "type": "message",
+                            "role": "assistant",
+                            "phase": "final_answer",
+                            "content": [{"type": "output_text", "text": "Earlier answer."}],
+                        },
                         {"type": "message", "role": "user", "content": "continue"},
                     ],
                     "tools": [_model_switch_tool_surface("collaboration_v2")],
@@ -18612,7 +18619,7 @@ class RoutingTests(unittest.TestCase):
                 "name": "kimi",
                 "upstream_model": "kimi-k3",
                 "upstream_format": "chat_completions",
-                "tool_protocol": "chat_tools",
+                "tool_protocol": "none",
             },
             event_context=event_context,
             inject_codex_tools=False,
@@ -18621,7 +18628,15 @@ class RoutingTests(unittest.TestCase):
 
         self.assertEqual(
             payload["input"],
-            [{"type": "message", "role": "user", "content": "continue"}],
+            [
+                {
+                    "id": "msg_final",
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "Earlier answer."}],
+                },
+                {"type": "message", "role": "user", "content": "continue"},
+            ],
         )
         chat_payload = json.loads(
             _responses_request_to_chat_completion_body(
@@ -18630,7 +18645,13 @@ class RoutingTests(unittest.TestCase):
                 drop_reasoning=True,
             )
         )
-        self.assertEqual(chat_payload["messages"], [{"role": "user", "content": "continue"}])
+        self.assertEqual(
+            chat_payload["messages"],
+            [
+                {"role": "assistant", "content": "Earlier answer."},
+                {"role": "user", "content": "continue"},
+            ],
+        )
         serialized = json.dumps(chat_payload, ensure_ascii=False)
         self.assertNotIn(summary_text, serialized)
         self.assertNotIn(encrypted_content, serialized)
@@ -18642,6 +18663,52 @@ class RoutingTests(unittest.TestCase):
         self.assertEqual(removal_event["count"], 1)
         for forbidden in ("id", "summary", "content", "text", "encrypted_content"):
             self.assertNotIn(forbidden, removal_event)
+        phase_event = next(
+            call.kwargs
+            for call in self.write_proxy_event.call_args_list
+            if call.args and call.args[0] == "v2_chat_message_phase_removed"
+        )
+        self.assertEqual(phase_event["count"], 1)
+        for forbidden in ("id", "phase", "content", "text"):
+            self.assertNotIn(forbidden, phase_event)
+
+    def test_collaboration_v2_responses_preserves_message_phase(self):
+        transformed = compatible_request_body(
+            json.dumps(
+                {
+                    "model": "glm-5.2",
+                    "input": [
+                        {
+                            "id": "msg_final",
+                            "type": "message",
+                            "role": "assistant",
+                            "phase": "final_answer",
+                            "content": [{"type": "output_text", "text": "Earlier answer."}],
+                        },
+                        {"type": "message", "role": "user", "content": "Continue."},
+                    ],
+                }
+            ).encode("utf-8"),
+            {
+                "name": "ollama_cloud",
+                "upstream_format": "responses",
+                "tool_protocol": "responses_structured",
+            },
+            event_context={
+                "request_id": "request-v2-responses-message-phase",
+                "collaboration_protocol": "collaboration_v2",
+            },
+            inject_codex_tools=False,
+        )
+        payload = json.loads(transformed)
+
+        self.assertEqual(payload["input"][0]["phase"], "final_answer")
+        self.assertFalse(
+            any(
+                call.args and call.args[0] == "v2_chat_message_phase_removed"
+                for call in self.write_proxy_event.call_args_list
+            )
+        )
 
     def test_selected_native_responses_codec_round_trips_apply_patch_and_next_history_once(self):
         fixture = _load_glm_apply_patch_history_native_ids_fixture()


### PR DESCRIPTION
## Summary
- remove the Responses-only message \phase\ field only at the Collaboration V2 -> Chat Completions wire boundary
- preserve message role/content and keep Responses upstream payloads unchanged
- record only an aggregate removal count in Gateway telemetry

## Root cause
Codex stores \phase\ on historical assistant message items. The strict Responses-to-Chat converter correctly rejects unmapped fields, but the V2 Chat compatibility boundary had not explicitly adapted this Responses-only metadata.

## Verification
- targeted regression/protection tests: 2 passed
- strict unknown-field converter protection: 1 passed, 3 subtests passed
- Python core: 2224 passed, 1 skipped, 482 subtests passed
- synthetic real-client contract: 146 passed
- isolated random-port real Kimi K3 stream: HTTP 200, marker returned, \esponse.completed\, no failed event or reasoning leakage
- \git diff --check\: clean
- report-only quality gate: parse_errors=0; pre-existing findings only