### PR TITLE
Beta4: fix thinking-model tool probes and freeze Collaboration contract

### DIFF
--- a/docs/adr/0002-runtime-derived-tool-compatibility.md
+++ b/docs/adr/0002-runtime-derived-tool-compatibility.md
@@ -1,9 +1,9 @@
 # ADR-0002: Runtime-derived tool compatibility on an immutable selected route
 
 Date: 2026-08-04
-Status: Accepted for 0.1.8 Beta2; the generic implementation is delivered in
-Beta3, while generic third-party Collaboration V2 lifecycle work remains a
-later Beta4 follow-up.
+Status: Accepted for 0.1.8 Beta2; generic compatibility shipped in Beta3 and
+the exact frozen Collaboration V1/V2 contract was calibrated for Beta4 by
+#392.
 
 ## Context
 
@@ -58,6 +58,46 @@ user Provider/model selection
         -> ToolCompatibilityPlan (per declaration, per request)
         -> selected upstream wire request/response
 ```
+
+### Frozen Beta4 Collaboration selection contract
+
+Issue #392 supersedes the earlier source-only #64 assumption with isolated
+runtime captures from Codex CLI 0.146.1 and Codex Desktop 26.803.5235.0. On
+the Responses wire, both frozen clients expose:
+
+- Collaboration V1 as the `multi_agent_v1` namespace containing
+  `close_agent`, `resume_agent`, `send_input`, `spawn_agent`, and
+  `wait_agent`; and
+- Collaboration V2 as the `collaboration` namespace containing
+  `followup_task`, `interrupt_agent`, `list_agents`, `send_message`,
+  `spawn_agent`, and `wait_agent`.
+
+The V2 handlers begin as function specs inside the client, but the frozen
+request planner wraps them in the configured namespace before serialization.
+They are therefore not six top-level Responses function declarations. Both
+clients send `tool_choice: "auto"` and do not send `multi_agent_version` as
+request metadata. The authoritative request-visible discriminator is the
+complete namespace and normalized child schema. Dynamic descriptions are not
+a discriminator; child type, name, strictness, parameter types and nesting,
+encryption markers, required fields, and output-schema absence are. A shared
+name such as `spawn_agent` or `wait_agent`, or a partial/direct-function shape,
+cannot select a version. Missing, unknown, duplicate, mixed, or conflicting
+signals fail closed before repair, state, or scheduler behavior.
+
+Several uses of the word `collaboration` remain separate protocol layers:
+
+- the Codex client dispatch recipient group;
+- the Responses namespace declaration and `function_call.namespace`;
+- `function_call` / `function_call_output` stream and history items;
+- model-input `agent_message` items carrying author, recipient, and plaintext
+  or encrypted content parts;
+- rollout-only `multi_agent_version` fields; and
+- Desktop `agentMessage`, `collabAgentToolCall`, and `subAgentActivity` items.
+
+None of those layers authorizes the Gateway to create or schedule agents. The
+exact parameter/result schemas, stream boundaries, terminal forms, identity
+fields, and same-Home readback evidence are recorded in
+`docs/evidence/issue-392/collaboration-runtime-contract.json`.
 
 ### Four deterministic dispositions
 
@@ -202,15 +242,17 @@ isolated.
 - **#62** owns the bounded Codex CLI 0.146 runtime and Responses lifecycle
   inventory. Its fixtures are structural evidence, not a model qualification
   gate or a reason to proxy through another Provider.
-- **#64** owns the Collaboration V1/V2 schema boundary and the signal selected
-  before repair. This ADR consumes that boundary and does not qualify the full
-  V2 workflow.
+- **#64** owns the historical Collaboration V1/V2 inventory. Its source-only
+  structural assumption is superseded by the exact frozen-runtime contract in
+  **#392**, which owns the boundary selected before repair.
 - **#65** owns the model-agnostic compatibility table that applies these four
   dispositions to each observed declaration family. This ADR defines the
   contract; it is not the table or a production allowlist.
 - **#198** owns the implementation isolation that makes V1 repair structurally
   unable to run on V2. V2 namespace adaptation may establish representability,
   never Gateway-owned execution or a V2-to-V1 downgrade.
+- **#282** owns the Beta4 production implementation of the #392 contract, and
+  **#283** owns the final full-lifecycle CLI/Desktop qualification.
 - **#58** owns the runtime compatibility implementation, tests, diagnostics,
   and network/manual evidence. This ADR adds no product implementation and
   does not authorize behavior outside the contract above.

--- a/docs/evidence/issue-392/README.md
+++ b/docs/evidence/issue-392/README.md
@@ -33,12 +33,16 @@ change.
   encryption flags, required fields, strictness, and additional-properties
   behavior.
 - `collaboration-runtime-observations.json` is the sanitized output of the
-  runtime capture, not a hand-authored status list. Its five distinct
-  `home_binding_sha256` values bind the five newly empty Homes, and
+  runtime capture, not a hand-authored status list. Its eleven distinct
+  `home_binding_sha256` values bind the eleven newly empty Homes, and
   `capture_run_binding_sha256` binds the complete observation set.
 - `collaboration-runtime-contract.json` is generated from that committed
   observation artifact. The builder rejects missing, mutated, replay-reordered,
   identity-losing, or duplicate-Home observations before producing a contract.
+- Both frozen runtimes also consume controlled `response.incomplete`,
+  `response.failed`, and terminal-less truncated streams with retries disabled.
+  The artifact retains the exact sanitized event fields/types and the observed
+  non-zero client disposition for each control.
 
 ## Observed decision
 

--- a/docs/evidence/issue-392/README.md
+++ b/docs/evidence/issue-392/README.md
@@ -32,6 +32,13 @@ change.
   classification. The normalized structural schema retains types, nesting,
   encryption flags, required fields, strictness, and additional-properties
   behavior.
+- `collaboration-runtime-observations.json` is the sanitized output of the
+  runtime capture, not a hand-authored status list. Its five distinct
+  `home_binding_sha256` values bind the five newly empty Homes, and
+  `capture_run_binding_sha256` binds the complete observation set.
+- `collaboration-runtime-contract.json` is generated from that committed
+  observation artifact. The builder rejects missing, mutated, replay-reordered,
+  identity-losing, or duplicate-Home observations before producing a contract.
 
 ## Observed decision
 
@@ -48,17 +55,31 @@ change.
 
 ## Reproduction checks
 
-Regenerate and validate the bounded artifacts with Python 3.13:
+Re-run the frozen runtime capture only with the exact binaries and source trees
+listed above (all prompts and IDs remain in temporary Homes and are deleted):
 
 ```powershell
-python scripts/build_issue_392_collaboration_contract.py
-python scripts/build_issue_392_collaboration_contract.py --check
+python scripts/capture_issue_392_collaboration_runtime.py `
+  --enable-runtime-capture `
+  --cli-exe <codex-cli-0.146.1.exe> `
+  --desktop-exe <desktop-runtime-0.147.0-alpha.6.5.exe> `
+  --cli-source-root <rust-v0.146.1-source> `
+  --desktop-source-root <rust-v0.147.0-alpha.6.5-source>
+```
+
+Regenerate and validate the bounded derived artifacts with Python 3.13:
+
+```powershell
+python scripts/build_issue_392_collaboration_contract.py `
+  --source-observations docs/evidence/issue-392/collaboration-runtime-observations.json
+python scripts/build_issue_392_collaboration_contract.py --check `
+  --source-observations docs/evidence/issue-392/collaboration-runtime-observations.json
 python scripts/build_issue_64_collaboration_inventory.py
 python scripts/build_issue_64_collaboration_inventory.py --check
 python -m pytest -q tests/test_issue_392_collaboration_contract.py tests/test_issue_64_collaboration_inventory.py
 ```
 
-The builder binds every cited frozen source file to its Git blob. Re-running
-runtime capture requires the exact two binaries above and the same isolated
-loopback controls; a client, source, or binary change invalidates this evidence
-and requires a fresh capture rather than editing the artifact in place.
+The capture verifies every cited frozen source file against its Git blob before
+starting a client. A client, source, or binary change invalidates this evidence
+and requires a fresh isolated capture rather than editing either artifact in
+place.

--- a/docs/evidence/issue-392/README.md
+++ b/docs/evidence/issue-392/README.md
@@ -1,0 +1,64 @@
+# Issue #392 frozen Collaboration runtime contract
+
+This directory records the request-visible Collaboration V1/V2 contract used
+by CodexHub 0.1.8 Beta4. It supersedes the source-only shape assumption in the
+historical #64 inventory.
+
+## Frozen inputs
+
+| Client | Version | Binary SHA-256 | Source tag / commit |
+| --- | --- | --- | --- |
+| Codex CLI | 0.146.1 | `ae9d865f3d346a1a2a60c4e84775622d74e3e7ef53e0dede9c68b81eab306cca` | `rust-v0.146.1` / `79b4f03d35962b005b007a015113b38930711665` |
+| Codex Desktop | 26.803.5235.0 (runtime 0.147.0-alpha.6.5) | `fb5c760e14cf8fe86e12e49e8a3e7f237af06082d6b9fe1e411e463b7229c916` | `rust-v0.147.0-alpha.6.5` / `618b8e9111da9f57fe380b09d0f6516e3f343536` |
+
+The Beta4 implementation base is
+`be10f62f44b22fa8c84510238250ae11fb3ecab4`. That revision includes the
+Beta4 Kimi thinking-model Chat tool-probe fix and no #392 production routing
+change.
+
+## Capture controls
+
+- Every CLI, Desktop runtime, and app-server run used a newly created isolated
+  Codex Home and workspace.
+- A loopback protocol-controlled Responses server supplied deterministic V1,
+  V2 spawn, wait, child completion, and final response streams.
+- The V2 run observed declaration, call, result, `agent_message`, rollout
+  version metadata, same-Home process restart/readback, and Desktop
+  app-server item notifications.
+- No existing user Home or task was opened. The known crash task was not read.
+- Prompts, credentials, filesystem paths, thread/task IDs, call/item IDs, and
+  message content are not retained in the JSON artifact.
+- User-configured role and tool descriptions are dynamic and are excluded from
+  classification. The normalized structural schema retains types, nesting,
+  encryption flags, required fields, strictness, and additional-properties
+  behavior.
+
+## Observed decision
+
+- V1 is one `multi_agent_v1` Responses namespace.
+- V2 is one `collaboration` Responses namespace containing the six V2
+  function children; it is not six top-level Responses functions.
+- Both clients send `tool_choice: "auto"`.
+- Neither frozen request carries `multi_agent_version`; the complete namespace
+  and child schema is the request-visible discriminator.
+- The client dispatch recipient, Responses namespace, function call/result,
+  model-input `agent_message`, rollout metadata, and Desktop
+  `agentMessage`/`collabAgentToolCall`/`subAgentActivity` items are distinct
+  layers.
+
+## Reproduction checks
+
+Regenerate and validate the bounded artifacts with Python 3.13:
+
+```powershell
+python scripts/build_issue_392_collaboration_contract.py
+python scripts/build_issue_392_collaboration_contract.py --check
+python scripts/build_issue_64_collaboration_inventory.py
+python scripts/build_issue_64_collaboration_inventory.py --check
+python -m pytest -q tests/test_issue_392_collaboration_contract.py tests/test_issue_64_collaboration_inventory.py
+```
+
+The builder binds every cited frozen source file to its Git blob. Re-running
+runtime capture requires the exact two binaries above and the same isolated
+loopback controls; a client, source, or binary change invalidates this evidence
+and requires a fresh capture rather than editing the artifact in place.

--- a/docs/evidence/issue-392/collaboration-runtime-contract.json
+++ b/docs/evidence/issue-392/collaboration-runtime-contract.json
@@ -1,0 +1,1873 @@
+{
+  "candidate_revision": "be10f62f44b22fa8c84510238250ae11fb3ecab4",
+  "capture_scope": {
+    "content_or_credentials_retained": false,
+    "existing_user_home_read": false,
+    "existing_user_task_read": false,
+    "home": "new_isolated_home_per_runtime",
+    "isolated_observations": [
+      "cli_v1_request",
+      "cli_v2_request_call_result_agent_message_and_restart",
+      "desktop_v1_request",
+      "desktop_v2_request_call_result_agent_message_and_restart",
+      "desktop_app_thread_items_notifications_and_restart"
+    ],
+    "known_crash_task_read": false,
+    "opaque_identity_retained": false,
+    "upstream": "loopback_protocol_controlled_responses"
+  },
+  "captured_on": "2026-08-10",
+  "deferred_to_issue_283": [
+    "full_six_tool_two_child_lifecycle",
+    "cross_home_negative_cases",
+    "malformed_agent_message_and_identity_negative_cases"
+  ],
+  "gateway_boundary": {
+    "adaptation_requirements": [
+      "injective_request_scoped_aliases",
+      "preserve_namespace_and_child_name",
+      "preserve_call_and_item_identity",
+      "preserve_order_and_stream_boundaries",
+      "preserve_agent_message_author_and_recipient",
+      "preserve_rollout_and_same_home_replay_semantics"
+    ],
+    "allowed": "reversible_wire_adaptation_only",
+    "forbidden": [
+      "agent_execution",
+      "agent_scheduling",
+      "identity_fabrication",
+      "v2_to_v1_downgrade",
+      "model_or_provider_fallback",
+      "history_rewrite"
+    ],
+    "native_namespace": "pass_without_semantic_mutation"
+  },
+  "protocol_layers": {
+    "client_dispatch": {
+      "meaning": "client_tool_dispatch_group",
+      "recipient_namespace": "collaboration",
+      "wire_discriminator_by_itself": false
+    },
+    "desktop_app": {
+      "item_notifications": {
+        "agentMessage": [
+          "item/started",
+          "item/agentMessage/delta",
+          "item/completed"
+        ],
+        "collabAgentToolCall": [
+          "item/started",
+          "item/completed"
+        ],
+        "subAgentActivity": [
+          "item/started",
+          "item/completed"
+        ]
+      },
+      "same_home_thread_resume_and_read": "observed",
+      "thread_items": {
+        "agentMessage": [
+          "type",
+          "id",
+          "text",
+          "phase",
+          "memoryCitation"
+        ],
+        "collabAgentToolCall": [
+          "type",
+          "id",
+          "tool",
+          "status",
+          "senderThreadId",
+          "receiverThreadIds",
+          "prompt",
+          "model",
+          "reasoningEffort",
+          "agentsStates"
+        ],
+        "subAgentActivity": [
+          "type",
+          "id",
+          "kind",
+          "agentThreadId",
+          "agentPath"
+        ]
+      },
+      "turn_terminal_notification": "turn/completed",
+      "wire_item_equivalent": false
+    },
+    "model_input_agent_message": {
+      "content_variants": {
+        "encrypted_content": [
+          "type",
+          "encrypted_content"
+        ],
+        "input_text": [
+          "type",
+          "text"
+        ]
+      },
+      "fields": [
+        "type",
+        "id",
+        "author",
+        "recipient",
+        "content"
+      ],
+      "function_result": false,
+      "source_optional_field": "internal_chat_message_metadata_passthrough",
+      "task_identity_fields": [
+        "author",
+        "recipient"
+      ],
+      "type": "agent_message"
+    },
+    "responses_declaration_and_call": {
+      "call_namespace_field": true,
+      "call_type": "function_call",
+      "declaration_type": "namespace",
+      "namespace": "collaboration",
+      "tool_choice": "auto"
+    },
+    "rollout_metadata": {
+      "sent_as_request_metadata": false,
+      "session_meta_field": "multi_agent_version",
+      "turn_context_field": "multi_agent_version",
+      "values": [
+        "v1",
+        "v2"
+      ]
+    }
+  },
+  "protocols": {
+    "collaboration_v1": {
+      "call": {
+        "fields": [
+          "type",
+          "id",
+          "name",
+          "namespace",
+          "arguments",
+          "call_id"
+        ],
+        "identity_fields": [
+          "id",
+          "call_id"
+        ],
+        "type": "function_call"
+      },
+      "declaration": {
+        "child_fields": [
+          "type",
+          "name",
+          "description",
+          "strict",
+          "parameters"
+        ],
+        "child_output_schema_field": "absent",
+        "child_strict": false,
+        "child_type": "function",
+        "fields": [
+          "type",
+          "name",
+          "description",
+          "tools"
+        ],
+        "normalized_parameter_schemas": {
+          "close_agent": {
+            "additionalProperties": false,
+            "properties": {
+              "target": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "target"
+            ],
+            "type": "object"
+          },
+          "resume_agent": {
+            "additionalProperties": false,
+            "properties": {
+              "id": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id"
+            ],
+            "type": "object"
+          },
+          "send_input": {
+            "additionalProperties": false,
+            "properties": {
+              "interrupt": {
+                "type": "boolean"
+              },
+              "items": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "audio_url": {
+                      "type": "string"
+                    },
+                    "image_url": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "text": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "message": {
+                "type": "string"
+              },
+              "target": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "target"
+            ],
+            "type": "object"
+          },
+          "spawn_agent": {
+            "additionalProperties": false,
+            "properties": {
+              "agent_type": {
+                "type": "string"
+              },
+              "fork_context": {
+                "type": "boolean"
+              },
+              "items": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "audio_url": {
+                      "type": "string"
+                    },
+                    "image_url": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "text": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "message": {
+                "type": "string"
+              },
+              "model": {
+                "type": "string"
+              },
+              "reasoning_effort": {
+                "type": "string"
+              },
+              "service_tier": {
+                "type": "string"
+              }
+            },
+            "required": [],
+            "type": "object"
+          },
+          "wait_agent": {
+            "additionalProperties": false,
+            "properties": {
+              "targets": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "timeout_ms": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "targets"
+            ],
+            "type": "object"
+          }
+        },
+        "tool_names": [
+          "close_agent",
+          "resume_agent",
+          "send_input",
+          "spawn_agent",
+          "wait_agent"
+        ],
+        "type": "namespace"
+      },
+      "namespace": "multi_agent_v1",
+      "owner": "codex_client",
+      "result": {
+        "fields": [
+          "type",
+          "id",
+          "call_id",
+          "output"
+        ],
+        "identity_fields": [
+          "id",
+          "call_id"
+        ],
+        "output_wire_encoding": "json_text_string",
+        "spawn_identity": "agent_id",
+        "tool_output_schemas": {
+          "close_agent": {
+            "additionalProperties": false,
+            "properties": {
+              "previous_status": {
+                "oneOf": [
+                  {
+                    "enum": [
+                      "pending_init",
+                      "running",
+                      "interrupted",
+                      "shutdown",
+                      "not_found"
+                    ],
+                    "type": "string"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "completed": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "completed"
+                    ],
+                    "type": "object"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "errored": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "errored"
+                    ],
+                    "type": "object"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "previous_status"
+            ],
+            "type": "object"
+          },
+          "resume_agent": {
+            "additionalProperties": false,
+            "properties": {
+              "status": {
+                "oneOf": [
+                  {
+                    "enum": [
+                      "pending_init",
+                      "running",
+                      "interrupted",
+                      "shutdown",
+                      "not_found"
+                    ],
+                    "type": "string"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "completed": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "completed"
+                    ],
+                    "type": "object"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "errored": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "errored"
+                    ],
+                    "type": "object"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "status"
+            ],
+            "type": "object"
+          },
+          "send_input": {
+            "additionalProperties": false,
+            "properties": {
+              "submission_id": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "submission_id"
+            ],
+            "type": "object"
+          },
+          "spawn_agent": {
+            "additionalProperties": false,
+            "properties": {
+              "agent_id": {
+                "type": "string"
+              },
+              "nickname": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "agent_id",
+              "nickname"
+            ],
+            "type": "object"
+          },
+          "wait_agent": {
+            "additionalProperties": false,
+            "properties": {
+              "status": {
+                "additionalProperties": {
+                  "oneOf": [
+                    {
+                      "enum": [
+                        "pending_init",
+                        "running",
+                        "interrupted",
+                        "shutdown",
+                        "not_found"
+                      ],
+                      "type": "string"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "completed": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "completed"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "errored": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "errored"
+                      ],
+                      "type": "object"
+                    }
+                  ]
+                },
+                "type": "object"
+              },
+              "timed_out": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "status",
+              "timed_out"
+            ],
+            "type": "object"
+          }
+        },
+        "type": "function_call_output"
+      },
+      "target_identity": "agent_id"
+    },
+    "collaboration_v2": {
+      "call": {
+        "fields": [
+          "type",
+          "id",
+          "name",
+          "namespace",
+          "arguments",
+          "call_id"
+        ],
+        "identity_fields": [
+          "id",
+          "call_id"
+        ],
+        "type": "function_call"
+      },
+      "canonical_task_identity": "agent_path_serialized_as_task_name",
+      "continuation_id_field": "not_present",
+      "declaration": {
+        "child_fields": [
+          "type",
+          "name",
+          "description",
+          "strict",
+          "parameters"
+        ],
+        "child_output_schema_field": "absent",
+        "child_strict": false,
+        "child_type": "function",
+        "fields": [
+          "type",
+          "name",
+          "description",
+          "tools"
+        ],
+        "normalized_parameter_schemas": {
+          "followup_task": {
+            "additionalProperties": false,
+            "properties": {
+              "message": {
+                "encrypted": true,
+                "type": "string"
+              },
+              "target": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "target",
+              "message"
+            ],
+            "type": "object"
+          },
+          "interrupt_agent": {
+            "additionalProperties": false,
+            "properties": {
+              "target": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "target"
+            ],
+            "type": "object"
+          },
+          "list_agents": {
+            "additionalProperties": false,
+            "properties": {
+              "path_prefix": {
+                "type": "string"
+              }
+            },
+            "required": [],
+            "type": "object"
+          },
+          "send_message": {
+            "additionalProperties": false,
+            "properties": {
+              "message": {
+                "encrypted": true,
+                "type": "string"
+              },
+              "target": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "target",
+              "message"
+            ],
+            "type": "object"
+          },
+          "spawn_agent": {
+            "additionalProperties": false,
+            "properties": {
+              "agent_type": {
+                "type": "string"
+              },
+              "fork_turns": {
+                "type": "string"
+              },
+              "message": {
+                "encrypted": true,
+                "type": "string"
+              },
+              "model": {
+                "type": "string"
+              },
+              "reasoning_effort": {
+                "type": "string"
+              },
+              "task_name": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "task_name",
+              "message"
+            ],
+            "type": "object"
+          },
+          "wait_agent": {
+            "additionalProperties": false,
+            "properties": {
+              "timeout_ms": {
+                "type": "number"
+              }
+            },
+            "required": [],
+            "type": "object"
+          }
+        },
+        "tool_names": [
+          "followup_task",
+          "interrupt_agent",
+          "list_agents",
+          "send_message",
+          "spawn_agent",
+          "wait_agent"
+        ],
+        "type": "namespace"
+      },
+      "namespace": "collaboration",
+      "owner": "codex_client",
+      "result": {
+        "fields": [
+          "type",
+          "id",
+          "call_id",
+          "output"
+        ],
+        "identity_fields": [
+          "id",
+          "call_id"
+        ],
+        "output_wire_encoding": {
+          "followup_task": "plain_text",
+          "interrupt_agent": "json_text_string",
+          "list_agents": "json_text_string",
+          "send_message": "plain_text",
+          "spawn_agent": "json_text_string",
+          "wait_agent": "json_text_string"
+        },
+        "spawn_identity": "task_name",
+        "spawn_output_fields_default": [
+          "task_name"
+        ],
+        "tool_output_schemas": {
+          "followup_task": null,
+          "interrupt_agent": {
+            "additionalProperties": false,
+            "properties": {
+              "previous_status": {
+                "oneOf": [
+                  {
+                    "enum": [
+                      "pending_init",
+                      "running",
+                      "interrupted",
+                      "shutdown",
+                      "not_found"
+                    ],
+                    "type": "string"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "completed": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "completed"
+                    ],
+                    "type": "object"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "errored": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "errored"
+                    ],
+                    "type": "object"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "previous_status"
+            ],
+            "type": "object"
+          },
+          "list_agents": {
+            "additionalProperties": false,
+            "properties": {
+              "agents": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "agent_name": {
+                      "type": "string"
+                    },
+                    "agent_status": {
+                      "oneOf": [
+                        {
+                          "enum": [
+                            "pending_init",
+                            "running",
+                            "interrupted",
+                            "shutdown",
+                            "not_found"
+                          ],
+                          "type": "string"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "completed": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "completed"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "errored": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "errored"
+                          ],
+                          "type": "object"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "agent_name",
+                    "agent_status"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "agents"
+            ],
+            "type": "object"
+          },
+          "send_message": null,
+          "spawn_agent": {
+            "additionalProperties": false,
+            "properties": {
+              "task_name": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "task_name"
+            ],
+            "type": "object"
+          },
+          "wait_agent": {
+            "additionalProperties": false,
+            "properties": {
+              "message": {
+                "type": "string"
+              },
+              "timed_out": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "message",
+              "timed_out"
+            ],
+            "type": "object"
+          }
+        },
+        "type": "function_call_output"
+      },
+      "target_identity": "relative_or_canonical_task_name"
+    }
+  },
+  "qualification_status": "accepted_request_call_result_agent_message_and_readback",
+  "runtimes": [
+    {
+      "binary_sha256": "ae9d865f3d346a1a2a60c4e84775622d74e3e7ef53e0dede9c68b81eab306cca",
+      "client": "codex_cli",
+      "client_version": "0.146.1",
+      "observations": {
+        "desktop_thread_items_and_notifications": "not_applicable",
+        "tool_choice_auto": "observed",
+        "v1_namespace_declaration": "observed",
+        "v2_agent_message_input": "observed",
+        "v2_function_call_and_output": "observed",
+        "v2_namespace_declaration": "observed",
+        "v2_rollout_version_metadata": "observed",
+        "v2_same_home_restart_readback": "observed"
+      },
+      "runtime_version": "0.146.1",
+      "source_commit": "79b4f03d35962b005b007a015113b38930711665",
+      "source_files": {
+        "agent_message_and_rollout": {
+          "git_blob": "c692d040d292cf223777cae42dd577b03e85aab5",
+          "path": "codex-rs/protocol/src/protocol.rs"
+        },
+        "desktop_event_mapping": {
+          "git_blob": "b32b15272ba4791db5a253ecc50555bf29b4ef14",
+          "path": "codex-rs/app-server-protocol/src/protocol/event_mapping.rs"
+        },
+        "desktop_thread_items": {
+          "git_blob": "f3a3a65d20516ac9dc99ef0c981eaf399e151cfa",
+          "path": "codex-rs/app-server-protocol/src/protocol/v2/item.rs"
+        },
+        "multi_agent_output_serialization": {
+          "git_blob": "9bb7f76f9de0d799766d050c5811e33d3a7635ea",
+          "path": "codex-rs/core/src/tools/handlers/multi_agents_common.rs"
+        },
+        "multi_agent_tool_schemas": {
+          "git_blob": "2eb82e175b454db0fc8fb8bba61b37d07ab69d30",
+          "path": "codex-rs/core/src/tools/handlers/multi_agents_spec.rs"
+        },
+        "responses_items": {
+          "git_blob": "51e22d10fd57af6bffd7a11b60dc2d422a7ad607",
+          "path": "codex-rs/protocol/src/models.rs"
+        },
+        "responses_request_and_tool_choice": {
+          "git_blob": "b13242062022d9d37302a060dd493977d9c0c1f1",
+          "path": "codex-rs/core/src/client.rs"
+        },
+        "responses_stream_parser": {
+          "git_blob": "441d7bb3bfa743f2fc3fe089cfdb88ddec887aac",
+          "path": "codex-rs/codex-api/src/sse/responses.rs"
+        },
+        "tool_planning_and_namespace_override": {
+          "git_blob": "5ff9e392f3ebec0a510efd11305752133944ceda",
+          "path": "codex-rs/core/src/tools/spec_plan.rs"
+        },
+        "v2_interrupt_handler": {
+          "git_blob": "a418dec4a86550715080b95a3191ce3c72836e8f",
+          "path": "codex-rs/core/src/tools/handlers/multi_agents_v2/interrupt_agent.rs"
+        },
+        "v2_list_handler": {
+          "git_blob": "99e54e1ce91cbd0f182f52fd8ff16f9268f96233",
+          "path": "codex-rs/core/src/tools/handlers/multi_agents_v2/list_agents.rs"
+        },
+        "v2_message_handler": {
+          "git_blob": "62defe65c4114ffcdc661b98836d9964f09a7c64",
+          "path": "codex-rs/core/src/tools/handlers/multi_agents_v2/message_tool.rs"
+        },
+        "v2_spawn_handler": {
+          "git_blob": "67f8057e435b8522a82825f055c75ed420401975",
+          "path": "codex-rs/core/src/tools/handlers/multi_agents_v2/spawn.rs"
+        },
+        "v2_wait_handler": {
+          "git_blob": "4e2eced26037d4c876a8b9fcd28912fb4344953b",
+          "path": "codex-rs/core/src/tools/handlers/multi_agents_v2/wait.rs"
+        },
+        "version_selection_and_namespace_default": {
+          "git_blob": "216af994bc03e136c4797453525df473f579adf5",
+          "path": "codex-rs/core/src/config/mod.rs"
+        }
+      },
+      "source_tag": "rust-v0.146.1"
+    },
+    {
+      "binary_sha256": "fb5c760e14cf8fe86e12e49e8a3e7f237af06082d6b9fe1e411e463b7229c916",
+      "client": "codex_desktop",
+      "client_version": "26.803.5235.0",
+      "observations": {
+        "desktop_thread_items_and_notifications": "observed",
+        "tool_choice_auto": "observed",
+        "v1_namespace_declaration": "observed",
+        "v2_agent_message_input": "observed",
+        "v2_function_call_and_output": "observed",
+        "v2_namespace_declaration": "observed",
+        "v2_rollout_version_metadata": "observed",
+        "v2_same_home_restart_readback": "observed"
+      },
+      "runtime_version": "0.147.0-alpha.6.5",
+      "source_commit": "618b8e9111da9f57fe380b09d0f6516e3f343536",
+      "source_files": {
+        "agent_message_and_rollout": {
+          "git_blob": "93313c63c2dd185e02d20fff9eff31d43b461277",
+          "path": "codex-rs/protocol/src/protocol.rs"
+        },
+        "desktop_event_mapping": {
+          "git_blob": "b32b15272ba4791db5a253ecc50555bf29b4ef14",
+          "path": "codex-rs/app-server-protocol/src/protocol/event_mapping.rs"
+        },
+        "desktop_thread_items": {
+          "git_blob": "a98ec3f3b2e19f4fef57ae7a5451a54dc471fb9b",
+          "path": "codex-rs/app-server-protocol/src/protocol/v2/item.rs"
+        },
+        "multi_agent_output_serialization": {
+          "git_blob": "f8569c441ed24a01760a51674687787014dfde28",
+          "path": "codex-rs/core/src/tools/handlers/multi_agents_common.rs"
+        },
+        "multi_agent_tool_schemas": {
+          "git_blob": "757e111cc2d060f84b2618896426001225bba4ef",
+          "path": "codex-rs/core/src/tools/handlers/multi_agents_spec.rs"
+        },
+        "responses_items": {
+          "git_blob": "2c2a6d6b7aa49eee6309e5a9ba9e7587a1047d4e",
+          "path": "codex-rs/protocol/src/models.rs"
+        },
+        "responses_request_and_tool_choice": {
+          "git_blob": "d6b25864dfa4620682d163cf9b65a4747d8fcfa9",
+          "path": "codex-rs/core/src/client.rs"
+        },
+        "responses_stream_parser": {
+          "git_blob": "44ed78737ba4ecf9e777c9d38199005ea4e2c2cc",
+          "path": "codex-rs/codex-api/src/sse/responses.rs"
+        },
+        "tool_planning_and_namespace_override": {
+          "git_blob": "1047190cc37f34ec4cfcae348af170da2bacc4c7",
+          "path": "codex-rs/core/src/tools/spec_plan.rs"
+        },
+        "v2_interrupt_handler": {
+          "git_blob": "a418dec4a86550715080b95a3191ce3c72836e8f",
+          "path": "codex-rs/core/src/tools/handlers/multi_agents_v2/interrupt_agent.rs"
+        },
+        "v2_list_handler": {
+          "git_blob": "99e54e1ce91cbd0f182f52fd8ff16f9268f96233",
+          "path": "codex-rs/core/src/tools/handlers/multi_agents_v2/list_agents.rs"
+        },
+        "v2_message_handler": {
+          "git_blob": "eb1790480eeeb5d524cfb132846812ce073c674f",
+          "path": "codex-rs/core/src/tools/handlers/multi_agents_v2/message_tool.rs"
+        },
+        "v2_spawn_handler": {
+          "git_blob": "a6b5c46eec06931354fdc3109909fd574865611d",
+          "path": "codex-rs/core/src/tools/handlers/multi_agents_v2/spawn.rs"
+        },
+        "v2_wait_handler": {
+          "git_blob": "4e2eced26037d4c876a8b9fcd28912fb4344953b",
+          "path": "codex-rs/core/src/tools/handlers/multi_agents_v2/wait.rs"
+        },
+        "version_selection_and_namespace_default": {
+          "git_blob": "844184314f2fa3a2fe2f8238e8d351aaa1050a5e",
+          "path": "codex-rs/core/src/config/mod.rs"
+        }
+      },
+      "source_tag": "rust-v0.147.0-alpha.6.5"
+    }
+  ],
+  "schema": "codexhub.issue392.collaboration-runtime-contract.v1",
+  "selection_contract": {
+    "child_policy": "exact_type_name_strict_parameter_shape_and_no_output_schema",
+    "description_policy": "require_string_but_exclude_dynamic_text_from_matching",
+    "direct_function_policy": "not_a_frozen_runtime_collaboration_marker",
+    "markers": {
+      "collaboration_v1": {
+        "argument_contract": {
+          "close_agent": {
+            "additional_properties": false,
+            "client_result_schema": {
+              "additionalProperties": false,
+              "properties": {
+                "previous_status": {
+                  "oneOf": [
+                    {
+                      "enum": [
+                        "pending_init",
+                        "running",
+                        "interrupted",
+                        "shutdown",
+                        "not_found"
+                      ],
+                      "type": "string"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "completed": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "completed"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "errored": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "errored"
+                      ],
+                      "type": "object"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "previous_status"
+              ],
+              "type": "object"
+            },
+            "normalized_parameter_schema": {
+              "additionalProperties": false,
+              "properties": {
+                "target": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "target"
+              ],
+              "type": "object"
+            },
+            "optional": [],
+            "request_output_schema_field": "absent",
+            "required": [
+              "target"
+            ]
+          },
+          "resume_agent": {
+            "additional_properties": false,
+            "client_result_schema": {
+              "additionalProperties": false,
+              "properties": {
+                "status": {
+                  "oneOf": [
+                    {
+                      "enum": [
+                        "pending_init",
+                        "running",
+                        "interrupted",
+                        "shutdown",
+                        "not_found"
+                      ],
+                      "type": "string"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "completed": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "completed"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "errored": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "errored"
+                      ],
+                      "type": "object"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "status"
+              ],
+              "type": "object"
+            },
+            "normalized_parameter_schema": {
+              "additionalProperties": false,
+              "properties": {
+                "id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id"
+              ],
+              "type": "object"
+            },
+            "optional": [],
+            "request_output_schema_field": "absent",
+            "required": [
+              "id"
+            ]
+          },
+          "send_input": {
+            "additional_properties": false,
+            "client_result_schema": {
+              "additionalProperties": false,
+              "properties": {
+                "submission_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "submission_id"
+              ],
+              "type": "object"
+            },
+            "normalized_parameter_schema": {
+              "additionalProperties": false,
+              "properties": {
+                "interrupt": {
+                  "type": "boolean"
+                },
+                "items": {
+                  "items": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "audio_url": {
+                        "type": "string"
+                      },
+                      "image_url": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "path": {
+                        "type": "string"
+                      },
+                      "text": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [],
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "message": {
+                  "type": "string"
+                },
+                "target": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "target"
+              ],
+              "type": "object"
+            },
+            "optional": [
+              "interrupt",
+              "items",
+              "message"
+            ],
+            "request_output_schema_field": "absent",
+            "required": [
+              "target"
+            ]
+          },
+          "spawn_agent": {
+            "additional_properties": false,
+            "client_result_schema": {
+              "additionalProperties": false,
+              "properties": {
+                "agent_id": {
+                  "type": "string"
+                },
+                "nickname": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "required": [
+                "agent_id",
+                "nickname"
+              ],
+              "type": "object"
+            },
+            "normalized_parameter_schema": {
+              "additionalProperties": false,
+              "properties": {
+                "agent_type": {
+                  "type": "string"
+                },
+                "fork_context": {
+                  "type": "boolean"
+                },
+                "items": {
+                  "items": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "audio_url": {
+                        "type": "string"
+                      },
+                      "image_url": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "path": {
+                        "type": "string"
+                      },
+                      "text": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [],
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "message": {
+                  "type": "string"
+                },
+                "model": {
+                  "type": "string"
+                },
+                "reasoning_effort": {
+                  "type": "string"
+                },
+                "service_tier": {
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "type": "object"
+            },
+            "optional": [
+              "agent_type",
+              "fork_context",
+              "items",
+              "message",
+              "model",
+              "reasoning_effort",
+              "service_tier"
+            ],
+            "request_output_schema_field": "absent",
+            "required": []
+          },
+          "wait_agent": {
+            "additional_properties": false,
+            "client_result_schema": {
+              "additionalProperties": false,
+              "properties": {
+                "status": {
+                  "additionalProperties": {
+                    "oneOf": [
+                      {
+                        "enum": [
+                          "pending_init",
+                          "running",
+                          "interrupted",
+                          "shutdown",
+                          "not_found"
+                        ],
+                        "type": "string"
+                      },
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "completed": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "completed"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "errored": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "errored"
+                        ],
+                        "type": "object"
+                      }
+                    ]
+                  },
+                  "type": "object"
+                },
+                "timed_out": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "status",
+                "timed_out"
+              ],
+              "type": "object"
+            },
+            "normalized_parameter_schema": {
+              "additionalProperties": false,
+              "properties": {
+                "targets": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "timeout_ms": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "targets"
+              ],
+              "type": "object"
+            },
+            "optional": [
+              "timeout_ms"
+            ],
+            "request_output_schema_field": "absent",
+            "required": [
+              "targets"
+            ]
+          }
+        },
+        "namespace": "multi_agent_v1",
+        "tool_names": [
+          "close_agent",
+          "resume_agent",
+          "send_input",
+          "spawn_agent",
+          "wait_agent"
+        ],
+        "wire_type": "namespace"
+      },
+      "collaboration_v2": {
+        "argument_contract": {
+          "followup_task": {
+            "additional_properties": false,
+            "client_result_schema": null,
+            "normalized_parameter_schema": {
+              "additionalProperties": false,
+              "properties": {
+                "message": {
+                  "encrypted": true,
+                  "type": "string"
+                },
+                "target": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "target",
+                "message"
+              ],
+              "type": "object"
+            },
+            "optional": [],
+            "request_output_schema_field": "absent",
+            "required": [
+              "message",
+              "target"
+            ]
+          },
+          "interrupt_agent": {
+            "additional_properties": false,
+            "client_result_schema": {
+              "additionalProperties": false,
+              "properties": {
+                "previous_status": {
+                  "oneOf": [
+                    {
+                      "enum": [
+                        "pending_init",
+                        "running",
+                        "interrupted",
+                        "shutdown",
+                        "not_found"
+                      ],
+                      "type": "string"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "completed": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "completed"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "errored": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "errored"
+                      ],
+                      "type": "object"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "previous_status"
+              ],
+              "type": "object"
+            },
+            "normalized_parameter_schema": {
+              "additionalProperties": false,
+              "properties": {
+                "target": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "target"
+              ],
+              "type": "object"
+            },
+            "optional": [],
+            "request_output_schema_field": "absent",
+            "required": [
+              "target"
+            ]
+          },
+          "list_agents": {
+            "additional_properties": false,
+            "client_result_schema": {
+              "additionalProperties": false,
+              "properties": {
+                "agents": {
+                  "items": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "agent_name": {
+                        "type": "string"
+                      },
+                      "agent_status": {
+                        "oneOf": [
+                          {
+                            "enum": [
+                              "pending_init",
+                              "running",
+                              "interrupted",
+                              "shutdown",
+                              "not_found"
+                            ],
+                            "type": "string"
+                          },
+                          {
+                            "additionalProperties": false,
+                            "properties": {
+                              "completed": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "completed"
+                            ],
+                            "type": "object"
+                          },
+                          {
+                            "additionalProperties": false,
+                            "properties": {
+                              "errored": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "errored"
+                            ],
+                            "type": "object"
+                          }
+                        ]
+                      }
+                    },
+                    "required": [
+                      "agent_name",
+                      "agent_status"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "agents"
+              ],
+              "type": "object"
+            },
+            "normalized_parameter_schema": {
+              "additionalProperties": false,
+              "properties": {
+                "path_prefix": {
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "type": "object"
+            },
+            "optional": [
+              "path_prefix"
+            ],
+            "request_output_schema_field": "absent",
+            "required": []
+          },
+          "send_message": {
+            "additional_properties": false,
+            "client_result_schema": null,
+            "normalized_parameter_schema": {
+              "additionalProperties": false,
+              "properties": {
+                "message": {
+                  "encrypted": true,
+                  "type": "string"
+                },
+                "target": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "target",
+                "message"
+              ],
+              "type": "object"
+            },
+            "optional": [],
+            "request_output_schema_field": "absent",
+            "required": [
+              "message",
+              "target"
+            ]
+          },
+          "spawn_agent": {
+            "additional_properties": false,
+            "client_result_schema": {
+              "additionalProperties": false,
+              "properties": {
+                "task_name": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "task_name"
+              ],
+              "type": "object"
+            },
+            "normalized_parameter_schema": {
+              "additionalProperties": false,
+              "properties": {
+                "agent_type": {
+                  "type": "string"
+                },
+                "fork_turns": {
+                  "type": "string"
+                },
+                "message": {
+                  "encrypted": true,
+                  "type": "string"
+                },
+                "model": {
+                  "type": "string"
+                },
+                "reasoning_effort": {
+                  "type": "string"
+                },
+                "task_name": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "task_name",
+                "message"
+              ],
+              "type": "object"
+            },
+            "optional": [
+              "agent_type",
+              "fork_turns",
+              "model",
+              "reasoning_effort"
+            ],
+            "request_output_schema_field": "absent",
+            "required": [
+              "message",
+              "task_name"
+            ]
+          },
+          "wait_agent": {
+            "additional_properties": false,
+            "client_result_schema": {
+              "additionalProperties": false,
+              "properties": {
+                "message": {
+                  "type": "string"
+                },
+                "timed_out": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "message",
+                "timed_out"
+              ],
+              "type": "object"
+            },
+            "normalized_parameter_schema": {
+              "additionalProperties": false,
+              "properties": {
+                "timeout_ms": {
+                  "type": "number"
+                }
+              },
+              "required": [],
+              "type": "object"
+            },
+            "optional": [
+              "timeout_ms"
+            ],
+            "request_output_schema_field": "absent",
+            "required": []
+          }
+        },
+        "namespace": "collaboration",
+        "tool_names": [
+          "followup_task",
+          "interrupt_agent",
+          "list_agents",
+          "send_message",
+          "spawn_agent",
+          "wait_agent"
+        ],
+        "wire_type": "namespace"
+      }
+    },
+    "matching_policy": "complete_namespace_and_child_schema",
+    "request_metadata_version_field": "absent_in_both_frozen_runtimes",
+    "shared_tool_name_policy": "never_classify_from_child_name_alone",
+    "stage": "before_schema_repair_state_or_scheduler",
+    "tool_choice": {
+      "included_in_version_discriminator": false,
+      "observed_value": "auto",
+      "unexpected_value": "fail_closed_for_frozen_runtime_contract"
+    },
+    "unexpected_multi_agent_version_field": "fail_closed",
+    "unknown_missing_duplicate_conflicting_or_mixed": "fail_closed"
+  },
+  "wire_lifecycle": {
+    "function_call_stream": {
+      "assembly_rule": "ordered_delta_assembly_must_equal_done_arguments",
+      "event_order": [
+        "response.output_item.added",
+        "response.function_call_arguments.delta",
+        "response.function_call_arguments.done",
+        "response.output_item.done"
+      ],
+      "event_shapes": {
+        "response.function_call_arguments.delta": {
+          "fields": [
+            "type",
+            "item_id",
+            "output_index",
+            "delta"
+          ]
+        },
+        "response.function_call_arguments.done": {
+          "fields": [
+            "type",
+            "item_id",
+            "output_index",
+            "arguments"
+          ]
+        },
+        "response.output_item.added": {
+          "fields": [
+            "type",
+            "output_index",
+            "item"
+          ],
+          "item_fields": [
+            "type",
+            "id",
+            "status",
+            "name",
+            "namespace",
+            "arguments",
+            "call_id"
+          ],
+          "status": "in_progress"
+        },
+        "response.output_item.done": {
+          "fields": [
+            "type",
+            "output_index",
+            "item"
+          ],
+          "item_fields": [
+            "type",
+            "id",
+            "status",
+            "name",
+            "namespace",
+            "arguments",
+            "call_id"
+          ],
+          "status": "completed"
+        }
+      }
+    },
+    "history_items": [
+      "function_call",
+      "function_call_output",
+      "agent_message"
+    ],
+    "same_home_readback": {
+      "agent_message_author_recipient_and_content_kind_preserved": true,
+      "call_and_output_ids_preserved": true,
+      "call_namespace_preserved": true,
+      "call_output_order_preserved": true,
+      "clients": [
+        "codex_cli",
+        "codex_desktop"
+      ],
+      "desktop_thread_resume_and_read": "observed",
+      "session_meta_multi_agent_version": "v2",
+      "turn_context_multi_agent_version": "v2"
+    },
+    "terminal": {
+      "event_order_boundary": "after_output_item_done",
+      "event_shapes": {
+        "response.completed": {
+          "fields": [
+            "type",
+            "response"
+          ],
+          "response_fields": [
+            "id",
+            "status",
+            "output",
+            "usage"
+          ],
+          "status": "completed"
+        },
+        "response.failed": {
+          "fields": [
+            "type",
+            "response"
+          ],
+          "response_required_fields": [
+            "id",
+            "status",
+            "error"
+          ],
+          "status": "failed"
+        },
+        "response.incomplete": {
+          "fields": [
+            "type",
+            "response"
+          ],
+          "response_required_fields": [
+            "id",
+            "status",
+            "incomplete_details"
+          ],
+          "status": "incomplete"
+        }
+      },
+      "events": [
+        "response.completed",
+        "response.incomplete",
+        "response.failed"
+      ],
+      "stream_close_without_completed": "terminal_error"
+    }
+  }
+}

--- a/docs/evidence/issue-392/collaboration-runtime-contract.json
+++ b/docs/evidence/issue-392/collaboration-runtime-contract.json
@@ -8368,7 +8368,20 @@
           }
         }
       },
-      "event_order_boundary": "after_output_item_done",
+      "event_boundaries": {
+        "response.completed": {
+          "previous_event": "response.output_item.done"
+        },
+        "response.failed": {
+          "previous_event": "response.created"
+        },
+        "response.incomplete": {
+          "previous_event": "response.output_text.delta"
+        },
+        "stream_close_without_terminal": {
+          "last_observed_event": "response.output_text.delta"
+        }
+      },
       "event_shapes": {
         "response.completed": {
           "field_types": {

--- a/docs/evidence/issue-392/collaboration-runtime-contract.json
+++ b/docs/evidence/issue-392/collaboration-runtime-contract.json
@@ -6,11 +6,17 @@
     "existing_user_task_read": false,
     "home": "new_isolated_home_per_runtime",
     "isolated_home_bindings_sha256": [
-      "b7da348dba582272740fa1392545e7b468a5fbe50f08d257de451631fc8490a8",
-      "1d36f56fcb0744f35ade8cdc621e9588f24c55ad5efcf556c69f12ff1a9f8b28",
-      "8da0a0440f5dba6de038e2343dcf0a90aad1e9df7107f5f734031243fd50d551",
-      "c99dd6202b2a2fddc017c522c869e619b72803c8ec1393209ab3bb8c66528007",
-      "9ff014546ee3d0495ea5d21413bd8cc5e7ecf23f1e09bf0023e2b218526b7e04"
+      "a058ffe406e7af055b87f98bff09077031ffd72c21389c4e89f1ffa265b15fb9",
+      "17c8b4e96cc0744441c00a314e6ae14bc49454d0128559b35d2a00db7b4c7a50",
+      "f930beb2814989e633629ccc809f7f78b297e8e19ec3766f8cbcb813d7ac47ef",
+      "feb22d28648102219916510e7dfee43d38c2dd3a1fed7620ac8bd0b3d53e1733",
+      "8fe4b7034c95a910bfa3b42c5d6fc8f8e8422e50581405ba0d01871219f38836",
+      "8c77bace3858ed27914840ef6a7927f19b8effc9614b2af55279ad47fa82663d",
+      "772155b18d258cc15cd032c7b9a86423969968125802e9871214767a1479b4cb",
+      "824b4e8ff0667006a27c27c8b8b1668e574409585406da559d7e5f238234cfe0",
+      "6a5cbbb31fff06d91ebac181d783c6b569b7450e2212b6212ee75d3b5f2a7d14",
+      "15cf38a729af04feca92e316512bdfc7592fbc23704a0b524ef256718f2f2ea8",
+      "dee87876f539a243364378b32892cecb50ac21524d1262f96328247091cc57ab"
     ],
     "isolated_observations": [
       "cli_v1_request",
@@ -1345,12 +1351,18 @@
       "client": "codex_cli",
       "client_version": "0.146.1",
       "isolated_home_bindings_sha256": [
-        "b7da348dba582272740fa1392545e7b468a5fbe50f08d257de451631fc8490a8",
-        "1d36f56fcb0744f35ade8cdc621e9588f24c55ad5efcf556c69f12ff1a9f8b28"
+        "feb22d28648102219916510e7dfee43d38c2dd3a1fed7620ac8bd0b3d53e1733",
+        "8fe4b7034c95a910bfa3b42c5d6fc8f8e8422e50581405ba0d01871219f38836",
+        "17c8b4e96cc0744441c00a314e6ae14bc49454d0128559b35d2a00db7b4c7a50",
+        "a058ffe406e7af055b87f98bff09077031ffd72c21389c4e89f1ffa265b15fb9",
+        "f930beb2814989e633629ccc809f7f78b297e8e19ec3766f8cbcb813d7ac47ef"
       ],
       "observation_scenarios": [
         "cli_v1_request",
-        "cli_v2_lifecycle"
+        "cli_v2_lifecycle",
+        "cli_terminal_incomplete",
+        "cli_terminal_failed",
+        "cli_terminal_truncated"
       ],
       "observations": {
         "desktop_thread_items_and_notifications": "not_applicable",
@@ -1433,13 +1445,19 @@
       "client": "codex_desktop",
       "client_version": "26.803.5235.0",
       "isolated_home_bindings_sha256": [
-        "c99dd6202b2a2fddc017c522c869e619b72803c8ec1393209ab3bb8c66528007",
-        "9ff014546ee3d0495ea5d21413bd8cc5e7ecf23f1e09bf0023e2b218526b7e04",
-        "8da0a0440f5dba6de038e2343dcf0a90aad1e9df7107f5f734031243fd50d551"
+        "15cf38a729af04feca92e316512bdfc7592fbc23704a0b524ef256718f2f2ea8",
+        "dee87876f539a243364378b32892cecb50ac21524d1262f96328247091cc57ab",
+        "824b4e8ff0667006a27c27c8b8b1668e574409585406da559d7e5f238234cfe0",
+        "772155b18d258cc15cd032c7b9a86423969968125802e9871214767a1479b4cb",
+        "6a5cbbb31fff06d91ebac181d783c6b569b7450e2212b6212ee75d3b5f2a7d14",
+        "8c77bace3858ed27914840ef6a7927f19b8effc9614b2af55279ad47fa82663d"
       ],
       "observation_scenarios": [
         "desktop_v1_request",
         "desktop_v2_lifecycle",
+        "desktop_terminal_incomplete",
+        "desktop_terminal_failed",
+        "desktop_terminal_truncated",
         "desktop_app_v2_lifecycle"
       ],
       "observations": {
@@ -2244,14 +2262,1734 @@
     "unknown_missing_duplicate_conflicting_or_mixed": "fail_closed"
   },
   "source_observations": {
-    "canonical_sha256": "1d689f4521ae654b910eec849bc4cb7f6abafa116ecbfb730250f10c1d64e9b6",
-    "capture_run_binding_sha256": "beb7668c5330c396e38457446d7985ae0c126a7a690d964b682744a6609c52c1",
+    "canonical_sha256": "be54d311a4e1b0f1ef8f608d20885cbc7ef6e40b248a76653afed41642dbbbbd",
+    "capture_run_binding_sha256": "5dcc331df5a1be35dce1ffe9a10f9902416d954e9c4c1321bd66c9675d24fdfe",
     "path": "docs/evidence/issue-392/collaboration-runtime-observations.json",
     "schema": "codexhub.issue392.collaboration-runtime-observations.v1"
   },
   "wire_lifecycle": {
     "function_call_stream": {
       "assembly_rule": "ordered_delta_assembly_must_equal_done_arguments",
+      "captured_event_sequences": {
+        "codex_cli": [
+          {
+            "events": [
+              {
+                "field_types": {
+                  "response": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "response",
+                  "type"
+                ],
+                "response_field_types": {
+                  "id": "string",
+                  "model": "string",
+                  "object": "string",
+                  "output": "array",
+                  "status": "string"
+                },
+                "response_fields": [
+                  "id",
+                  "model",
+                  "object",
+                  "output",
+                  "status"
+                ],
+                "response_output_item_types": [],
+                "response_status": "in_progress",
+                "type": "response.created"
+              },
+              {
+                "field_types": {
+                  "item": "object",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "item",
+                  "output_index",
+                  "type"
+                ],
+                "item_field_types": {
+                  "arguments": "string",
+                  "call_id": "string",
+                  "id": "string",
+                  "name": "string",
+                  "namespace": "string",
+                  "status": "string",
+                  "type": "string"
+                },
+                "item_fields": [
+                  "arguments",
+                  "call_id",
+                  "id",
+                  "name",
+                  "namespace",
+                  "status",
+                  "type"
+                ],
+                "item_name": "spawn_agent",
+                "item_namespace": "collaboration",
+                "item_status": "in_progress",
+                "item_type": "function_call",
+                "type": "response.output_item.added"
+              },
+              {
+                "field_types": {
+                  "delta": "string",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "delta",
+                  "item_id",
+                  "output_index",
+                  "type"
+                ],
+                "type": "response.function_call_arguments.delta"
+              },
+              {
+                "field_types": {
+                  "arguments": "string",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "arguments",
+                  "item_id",
+                  "output_index",
+                  "type"
+                ],
+                "type": "response.function_call_arguments.done"
+              },
+              {
+                "field_types": {
+                  "item": "object",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "item",
+                  "output_index",
+                  "type"
+                ],
+                "item_field_types": {
+                  "arguments": "string",
+                  "call_id": "string",
+                  "id": "string",
+                  "name": "string",
+                  "namespace": "string",
+                  "status": "string",
+                  "type": "string"
+                },
+                "item_fields": [
+                  "arguments",
+                  "call_id",
+                  "id",
+                  "name",
+                  "namespace",
+                  "status",
+                  "type"
+                ],
+                "item_name": "spawn_agent",
+                "item_namespace": "collaboration",
+                "item_status": "completed",
+                "item_type": "function_call",
+                "type": "response.output_item.done"
+              },
+              {
+                "field_types": {
+                  "response": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "response",
+                  "type"
+                ],
+                "response_field_types": {
+                  "id": "string",
+                  "model": "string",
+                  "object": "string",
+                  "output": "array",
+                  "status": "string",
+                  "usage": "object"
+                },
+                "response_fields": [
+                  "id",
+                  "model",
+                  "object",
+                  "output",
+                  "status",
+                  "usage"
+                ],
+                "response_output_item_types": [
+                  "function_call"
+                ],
+                "response_status": "completed",
+                "type": "response.completed"
+              }
+            ],
+            "request_index": 1
+          },
+          {
+            "events": [
+              {
+                "field_types": {
+                  "response": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "response",
+                  "type"
+                ],
+                "response_field_types": {
+                  "id": "string",
+                  "model": "string",
+                  "object": "string",
+                  "output": "array",
+                  "status": "string"
+                },
+                "response_fields": [
+                  "id",
+                  "model",
+                  "object",
+                  "output",
+                  "status"
+                ],
+                "response_output_item_types": [],
+                "response_status": "in_progress",
+                "type": "response.created"
+              },
+              {
+                "field_types": {
+                  "item": "object",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "item",
+                  "output_index",
+                  "type"
+                ],
+                "item_field_types": {
+                  "arguments": "string",
+                  "call_id": "string",
+                  "id": "string",
+                  "name": "string",
+                  "namespace": "string",
+                  "status": "string",
+                  "type": "string"
+                },
+                "item_fields": [
+                  "arguments",
+                  "call_id",
+                  "id",
+                  "name",
+                  "namespace",
+                  "status",
+                  "type"
+                ],
+                "item_name": "wait_agent",
+                "item_namespace": "collaboration",
+                "item_status": "in_progress",
+                "item_type": "function_call",
+                "type": "response.output_item.added"
+              },
+              {
+                "field_types": {
+                  "delta": "string",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "delta",
+                  "item_id",
+                  "output_index",
+                  "type"
+                ],
+                "type": "response.function_call_arguments.delta"
+              },
+              {
+                "field_types": {
+                  "arguments": "string",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "arguments",
+                  "item_id",
+                  "output_index",
+                  "type"
+                ],
+                "type": "response.function_call_arguments.done"
+              },
+              {
+                "field_types": {
+                  "item": "object",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "item",
+                  "output_index",
+                  "type"
+                ],
+                "item_field_types": {
+                  "arguments": "string",
+                  "call_id": "string",
+                  "id": "string",
+                  "name": "string",
+                  "namespace": "string",
+                  "status": "string",
+                  "type": "string"
+                },
+                "item_fields": [
+                  "arguments",
+                  "call_id",
+                  "id",
+                  "name",
+                  "namespace",
+                  "status",
+                  "type"
+                ],
+                "item_name": "wait_agent",
+                "item_namespace": "collaboration",
+                "item_status": "completed",
+                "item_type": "function_call",
+                "type": "response.output_item.done"
+              },
+              {
+                "field_types": {
+                  "response": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "response",
+                  "type"
+                ],
+                "response_field_types": {
+                  "id": "string",
+                  "model": "string",
+                  "object": "string",
+                  "output": "array",
+                  "status": "string",
+                  "usage": "object"
+                },
+                "response_fields": [
+                  "id",
+                  "model",
+                  "object",
+                  "output",
+                  "status",
+                  "usage"
+                ],
+                "response_output_item_types": [
+                  "function_call"
+                ],
+                "response_status": "completed",
+                "type": "response.completed"
+              }
+            ],
+            "request_index": 2
+          },
+          {
+            "events": [
+              {
+                "field_types": {
+                  "response": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "response",
+                  "type"
+                ],
+                "response_field_types": {
+                  "id": "string",
+                  "model": "string",
+                  "object": "string",
+                  "output": "array",
+                  "status": "string"
+                },
+                "response_fields": [
+                  "id",
+                  "model",
+                  "object",
+                  "output",
+                  "status"
+                ],
+                "response_output_item_types": [],
+                "response_status": "in_progress",
+                "type": "response.created"
+              },
+              {
+                "field_types": {
+                  "item": "object",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "item",
+                  "output_index",
+                  "type"
+                ],
+                "item_field_types": {
+                  "content": "array",
+                  "id": "string",
+                  "role": "string",
+                  "type": "string"
+                },
+                "item_fields": [
+                  "content",
+                  "id",
+                  "role",
+                  "type"
+                ],
+                "item_type": "message",
+                "type": "response.output_item.added"
+              },
+              {
+                "field_types": {
+                  "content_index": "number",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "part": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "content_index",
+                  "item_id",
+                  "output_index",
+                  "part",
+                  "type"
+                ],
+                "part_field_types": {
+                  "annotations": "array",
+                  "text": "string",
+                  "type": "string"
+                },
+                "part_fields": [
+                  "annotations",
+                  "text",
+                  "type"
+                ],
+                "part_type": "output_text",
+                "type": "response.content_part.added"
+              },
+              {
+                "field_types": {
+                  "content_index": "number",
+                  "delta": "string",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "content_index",
+                  "delta",
+                  "item_id",
+                  "output_index",
+                  "type"
+                ],
+                "type": "response.output_text.delta"
+              },
+              {
+                "field_types": {
+                  "content_index": "number",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "text": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "content_index",
+                  "item_id",
+                  "output_index",
+                  "text",
+                  "type"
+                ],
+                "type": "response.output_text.done"
+              },
+              {
+                "field_types": {
+                  "item": "object",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "item",
+                  "output_index",
+                  "type"
+                ],
+                "item_field_types": {
+                  "content": "array",
+                  "id": "string",
+                  "role": "string",
+                  "type": "string"
+                },
+                "item_fields": [
+                  "content",
+                  "id",
+                  "role",
+                  "type"
+                ],
+                "item_type": "message",
+                "type": "response.output_item.done"
+              },
+              {
+                "field_types": {
+                  "response": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "response",
+                  "type"
+                ],
+                "response_field_types": {
+                  "id": "string",
+                  "model": "string",
+                  "object": "string",
+                  "output": "array",
+                  "status": "string",
+                  "usage": "object"
+                },
+                "response_fields": [
+                  "id",
+                  "model",
+                  "object",
+                  "output",
+                  "status",
+                  "usage"
+                ],
+                "response_output_item_types": [
+                  "message"
+                ],
+                "response_status": "completed",
+                "type": "response.completed"
+              }
+            ],
+            "request_index": 3
+          },
+          {
+            "events": [
+              {
+                "field_types": {
+                  "response": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "response",
+                  "type"
+                ],
+                "response_field_types": {
+                  "id": "string",
+                  "model": "string",
+                  "object": "string",
+                  "output": "array",
+                  "status": "string"
+                },
+                "response_fields": [
+                  "id",
+                  "model",
+                  "object",
+                  "output",
+                  "status"
+                ],
+                "response_output_item_types": [],
+                "response_status": "in_progress",
+                "type": "response.created"
+              },
+              {
+                "field_types": {
+                  "item": "object",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "item",
+                  "output_index",
+                  "type"
+                ],
+                "item_field_types": {
+                  "content": "array",
+                  "id": "string",
+                  "role": "string",
+                  "type": "string"
+                },
+                "item_fields": [
+                  "content",
+                  "id",
+                  "role",
+                  "type"
+                ],
+                "item_type": "message",
+                "type": "response.output_item.added"
+              },
+              {
+                "field_types": {
+                  "content_index": "number",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "part": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "content_index",
+                  "item_id",
+                  "output_index",
+                  "part",
+                  "type"
+                ],
+                "part_field_types": {
+                  "annotations": "array",
+                  "text": "string",
+                  "type": "string"
+                },
+                "part_fields": [
+                  "annotations",
+                  "text",
+                  "type"
+                ],
+                "part_type": "output_text",
+                "type": "response.content_part.added"
+              },
+              {
+                "field_types": {
+                  "content_index": "number",
+                  "delta": "string",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "content_index",
+                  "delta",
+                  "item_id",
+                  "output_index",
+                  "type"
+                ],
+                "type": "response.output_text.delta"
+              },
+              {
+                "field_types": {
+                  "content_index": "number",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "text": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "content_index",
+                  "item_id",
+                  "output_index",
+                  "text",
+                  "type"
+                ],
+                "type": "response.output_text.done"
+              },
+              {
+                "field_types": {
+                  "item": "object",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "item",
+                  "output_index",
+                  "type"
+                ],
+                "item_field_types": {
+                  "content": "array",
+                  "id": "string",
+                  "role": "string",
+                  "type": "string"
+                },
+                "item_fields": [
+                  "content",
+                  "id",
+                  "role",
+                  "type"
+                ],
+                "item_type": "message",
+                "type": "response.output_item.done"
+              },
+              {
+                "field_types": {
+                  "response": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "response",
+                  "type"
+                ],
+                "response_field_types": {
+                  "id": "string",
+                  "model": "string",
+                  "object": "string",
+                  "output": "array",
+                  "status": "string",
+                  "usage": "object"
+                },
+                "response_fields": [
+                  "id",
+                  "model",
+                  "object",
+                  "output",
+                  "status",
+                  "usage"
+                ],
+                "response_output_item_types": [
+                  "message"
+                ],
+                "response_status": "completed",
+                "type": "response.completed"
+              }
+            ],
+            "request_index": 4
+          },
+          {
+            "events": [
+              {
+                "field_types": {
+                  "response": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "response",
+                  "type"
+                ],
+                "response_field_types": {
+                  "id": "string",
+                  "model": "string",
+                  "object": "string",
+                  "output": "array",
+                  "status": "string"
+                },
+                "response_fields": [
+                  "id",
+                  "model",
+                  "object",
+                  "output",
+                  "status"
+                ],
+                "response_output_item_types": [],
+                "response_status": "in_progress",
+                "type": "response.created"
+              },
+              {
+                "field_types": {
+                  "item": "object",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "item",
+                  "output_index",
+                  "type"
+                ],
+                "item_field_types": {
+                  "content": "array",
+                  "id": "string",
+                  "role": "string",
+                  "type": "string"
+                },
+                "item_fields": [
+                  "content",
+                  "id",
+                  "role",
+                  "type"
+                ],
+                "item_type": "message",
+                "type": "response.output_item.added"
+              },
+              {
+                "field_types": {
+                  "content_index": "number",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "part": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "content_index",
+                  "item_id",
+                  "output_index",
+                  "part",
+                  "type"
+                ],
+                "part_field_types": {
+                  "annotations": "array",
+                  "text": "string",
+                  "type": "string"
+                },
+                "part_fields": [
+                  "annotations",
+                  "text",
+                  "type"
+                ],
+                "part_type": "output_text",
+                "type": "response.content_part.added"
+              },
+              {
+                "field_types": {
+                  "content_index": "number",
+                  "delta": "string",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "content_index",
+                  "delta",
+                  "item_id",
+                  "output_index",
+                  "type"
+                ],
+                "type": "response.output_text.delta"
+              },
+              {
+                "field_types": {
+                  "content_index": "number",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "text": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "content_index",
+                  "item_id",
+                  "output_index",
+                  "text",
+                  "type"
+                ],
+                "type": "response.output_text.done"
+              },
+              {
+                "field_types": {
+                  "item": "object",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "item",
+                  "output_index",
+                  "type"
+                ],
+                "item_field_types": {
+                  "content": "array",
+                  "id": "string",
+                  "role": "string",
+                  "type": "string"
+                },
+                "item_fields": [
+                  "content",
+                  "id",
+                  "role",
+                  "type"
+                ],
+                "item_type": "message",
+                "type": "response.output_item.done"
+              },
+              {
+                "field_types": {
+                  "response": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "response",
+                  "type"
+                ],
+                "response_field_types": {
+                  "id": "string",
+                  "model": "string",
+                  "object": "string",
+                  "output": "array",
+                  "status": "string",
+                  "usage": "object"
+                },
+                "response_fields": [
+                  "id",
+                  "model",
+                  "object",
+                  "output",
+                  "status",
+                  "usage"
+                ],
+                "response_output_item_types": [
+                  "message"
+                ],
+                "response_status": "completed",
+                "type": "response.completed"
+              }
+            ],
+            "request_index": 5
+          }
+        ],
+        "codex_desktop": [
+          {
+            "events": [
+              {
+                "field_types": {
+                  "response": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "response",
+                  "type"
+                ],
+                "response_field_types": {
+                  "id": "string",
+                  "model": "string",
+                  "object": "string",
+                  "output": "array",
+                  "status": "string"
+                },
+                "response_fields": [
+                  "id",
+                  "model",
+                  "object",
+                  "output",
+                  "status"
+                ],
+                "response_output_item_types": [],
+                "response_status": "in_progress",
+                "type": "response.created"
+              },
+              {
+                "field_types": {
+                  "item": "object",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "item",
+                  "output_index",
+                  "type"
+                ],
+                "item_field_types": {
+                  "arguments": "string",
+                  "call_id": "string",
+                  "id": "string",
+                  "name": "string",
+                  "namespace": "string",
+                  "status": "string",
+                  "type": "string"
+                },
+                "item_fields": [
+                  "arguments",
+                  "call_id",
+                  "id",
+                  "name",
+                  "namespace",
+                  "status",
+                  "type"
+                ],
+                "item_name": "spawn_agent",
+                "item_namespace": "collaboration",
+                "item_status": "in_progress",
+                "item_type": "function_call",
+                "type": "response.output_item.added"
+              },
+              {
+                "field_types": {
+                  "delta": "string",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "delta",
+                  "item_id",
+                  "output_index",
+                  "type"
+                ],
+                "type": "response.function_call_arguments.delta"
+              },
+              {
+                "field_types": {
+                  "arguments": "string",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "arguments",
+                  "item_id",
+                  "output_index",
+                  "type"
+                ],
+                "type": "response.function_call_arguments.done"
+              },
+              {
+                "field_types": {
+                  "item": "object",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "item",
+                  "output_index",
+                  "type"
+                ],
+                "item_field_types": {
+                  "arguments": "string",
+                  "call_id": "string",
+                  "id": "string",
+                  "name": "string",
+                  "namespace": "string",
+                  "status": "string",
+                  "type": "string"
+                },
+                "item_fields": [
+                  "arguments",
+                  "call_id",
+                  "id",
+                  "name",
+                  "namespace",
+                  "status",
+                  "type"
+                ],
+                "item_name": "spawn_agent",
+                "item_namespace": "collaboration",
+                "item_status": "completed",
+                "item_type": "function_call",
+                "type": "response.output_item.done"
+              },
+              {
+                "field_types": {
+                  "response": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "response",
+                  "type"
+                ],
+                "response_field_types": {
+                  "id": "string",
+                  "model": "string",
+                  "object": "string",
+                  "output": "array",
+                  "status": "string",
+                  "usage": "object"
+                },
+                "response_fields": [
+                  "id",
+                  "model",
+                  "object",
+                  "output",
+                  "status",
+                  "usage"
+                ],
+                "response_output_item_types": [
+                  "function_call"
+                ],
+                "response_status": "completed",
+                "type": "response.completed"
+              }
+            ],
+            "request_index": 1
+          },
+          {
+            "events": [
+              {
+                "field_types": {
+                  "response": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "response",
+                  "type"
+                ],
+                "response_field_types": {
+                  "id": "string",
+                  "model": "string",
+                  "object": "string",
+                  "output": "array",
+                  "status": "string"
+                },
+                "response_fields": [
+                  "id",
+                  "model",
+                  "object",
+                  "output",
+                  "status"
+                ],
+                "response_output_item_types": [],
+                "response_status": "in_progress",
+                "type": "response.created"
+              },
+              {
+                "field_types": {
+                  "item": "object",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "item",
+                  "output_index",
+                  "type"
+                ],
+                "item_field_types": {
+                  "arguments": "string",
+                  "call_id": "string",
+                  "id": "string",
+                  "name": "string",
+                  "namespace": "string",
+                  "status": "string",
+                  "type": "string"
+                },
+                "item_fields": [
+                  "arguments",
+                  "call_id",
+                  "id",
+                  "name",
+                  "namespace",
+                  "status",
+                  "type"
+                ],
+                "item_name": "wait_agent",
+                "item_namespace": "collaboration",
+                "item_status": "in_progress",
+                "item_type": "function_call",
+                "type": "response.output_item.added"
+              },
+              {
+                "field_types": {
+                  "delta": "string",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "delta",
+                  "item_id",
+                  "output_index",
+                  "type"
+                ],
+                "type": "response.function_call_arguments.delta"
+              },
+              {
+                "field_types": {
+                  "arguments": "string",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "arguments",
+                  "item_id",
+                  "output_index",
+                  "type"
+                ],
+                "type": "response.function_call_arguments.done"
+              },
+              {
+                "field_types": {
+                  "item": "object",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "item",
+                  "output_index",
+                  "type"
+                ],
+                "item_field_types": {
+                  "arguments": "string",
+                  "call_id": "string",
+                  "id": "string",
+                  "name": "string",
+                  "namespace": "string",
+                  "status": "string",
+                  "type": "string"
+                },
+                "item_fields": [
+                  "arguments",
+                  "call_id",
+                  "id",
+                  "name",
+                  "namespace",
+                  "status",
+                  "type"
+                ],
+                "item_name": "wait_agent",
+                "item_namespace": "collaboration",
+                "item_status": "completed",
+                "item_type": "function_call",
+                "type": "response.output_item.done"
+              },
+              {
+                "field_types": {
+                  "response": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "response",
+                  "type"
+                ],
+                "response_field_types": {
+                  "id": "string",
+                  "model": "string",
+                  "object": "string",
+                  "output": "array",
+                  "status": "string",
+                  "usage": "object"
+                },
+                "response_fields": [
+                  "id",
+                  "model",
+                  "object",
+                  "output",
+                  "status",
+                  "usage"
+                ],
+                "response_output_item_types": [
+                  "function_call"
+                ],
+                "response_status": "completed",
+                "type": "response.completed"
+              }
+            ],
+            "request_index": 2
+          },
+          {
+            "events": [
+              {
+                "field_types": {
+                  "response": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "response",
+                  "type"
+                ],
+                "response_field_types": {
+                  "id": "string",
+                  "model": "string",
+                  "object": "string",
+                  "output": "array",
+                  "status": "string"
+                },
+                "response_fields": [
+                  "id",
+                  "model",
+                  "object",
+                  "output",
+                  "status"
+                ],
+                "response_output_item_types": [],
+                "response_status": "in_progress",
+                "type": "response.created"
+              },
+              {
+                "field_types": {
+                  "item": "object",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "item",
+                  "output_index",
+                  "type"
+                ],
+                "item_field_types": {
+                  "content": "array",
+                  "id": "string",
+                  "role": "string",
+                  "type": "string"
+                },
+                "item_fields": [
+                  "content",
+                  "id",
+                  "role",
+                  "type"
+                ],
+                "item_type": "message",
+                "type": "response.output_item.added"
+              },
+              {
+                "field_types": {
+                  "content_index": "number",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "part": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "content_index",
+                  "item_id",
+                  "output_index",
+                  "part",
+                  "type"
+                ],
+                "part_field_types": {
+                  "annotations": "array",
+                  "text": "string",
+                  "type": "string"
+                },
+                "part_fields": [
+                  "annotations",
+                  "text",
+                  "type"
+                ],
+                "part_type": "output_text",
+                "type": "response.content_part.added"
+              },
+              {
+                "field_types": {
+                  "content_index": "number",
+                  "delta": "string",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "content_index",
+                  "delta",
+                  "item_id",
+                  "output_index",
+                  "type"
+                ],
+                "type": "response.output_text.delta"
+              },
+              {
+                "field_types": {
+                  "content_index": "number",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "text": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "content_index",
+                  "item_id",
+                  "output_index",
+                  "text",
+                  "type"
+                ],
+                "type": "response.output_text.done"
+              },
+              {
+                "field_types": {
+                  "item": "object",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "item",
+                  "output_index",
+                  "type"
+                ],
+                "item_field_types": {
+                  "content": "array",
+                  "id": "string",
+                  "role": "string",
+                  "type": "string"
+                },
+                "item_fields": [
+                  "content",
+                  "id",
+                  "role",
+                  "type"
+                ],
+                "item_type": "message",
+                "type": "response.output_item.done"
+              },
+              {
+                "field_types": {
+                  "response": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "response",
+                  "type"
+                ],
+                "response_field_types": {
+                  "id": "string",
+                  "model": "string",
+                  "object": "string",
+                  "output": "array",
+                  "status": "string",
+                  "usage": "object"
+                },
+                "response_fields": [
+                  "id",
+                  "model",
+                  "object",
+                  "output",
+                  "status",
+                  "usage"
+                ],
+                "response_output_item_types": [
+                  "message"
+                ],
+                "response_status": "completed",
+                "type": "response.completed"
+              }
+            ],
+            "request_index": 3
+          },
+          {
+            "events": [
+              {
+                "field_types": {
+                  "response": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "response",
+                  "type"
+                ],
+                "response_field_types": {
+                  "id": "string",
+                  "model": "string",
+                  "object": "string",
+                  "output": "array",
+                  "status": "string"
+                },
+                "response_fields": [
+                  "id",
+                  "model",
+                  "object",
+                  "output",
+                  "status"
+                ],
+                "response_output_item_types": [],
+                "response_status": "in_progress",
+                "type": "response.created"
+              },
+              {
+                "field_types": {
+                  "item": "object",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "item",
+                  "output_index",
+                  "type"
+                ],
+                "item_field_types": {
+                  "content": "array",
+                  "id": "string",
+                  "role": "string",
+                  "type": "string"
+                },
+                "item_fields": [
+                  "content",
+                  "id",
+                  "role",
+                  "type"
+                ],
+                "item_type": "message",
+                "type": "response.output_item.added"
+              },
+              {
+                "field_types": {
+                  "content_index": "number",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "part": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "content_index",
+                  "item_id",
+                  "output_index",
+                  "part",
+                  "type"
+                ],
+                "part_field_types": {
+                  "annotations": "array",
+                  "text": "string",
+                  "type": "string"
+                },
+                "part_fields": [
+                  "annotations",
+                  "text",
+                  "type"
+                ],
+                "part_type": "output_text",
+                "type": "response.content_part.added"
+              },
+              {
+                "field_types": {
+                  "content_index": "number",
+                  "delta": "string",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "content_index",
+                  "delta",
+                  "item_id",
+                  "output_index",
+                  "type"
+                ],
+                "type": "response.output_text.delta"
+              },
+              {
+                "field_types": {
+                  "content_index": "number",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "text": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "content_index",
+                  "item_id",
+                  "output_index",
+                  "text",
+                  "type"
+                ],
+                "type": "response.output_text.done"
+              },
+              {
+                "field_types": {
+                  "item": "object",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "item",
+                  "output_index",
+                  "type"
+                ],
+                "item_field_types": {
+                  "content": "array",
+                  "id": "string",
+                  "role": "string",
+                  "type": "string"
+                },
+                "item_fields": [
+                  "content",
+                  "id",
+                  "role",
+                  "type"
+                ],
+                "item_type": "message",
+                "type": "response.output_item.done"
+              },
+              {
+                "field_types": {
+                  "response": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "response",
+                  "type"
+                ],
+                "response_field_types": {
+                  "id": "string",
+                  "model": "string",
+                  "object": "string",
+                  "output": "array",
+                  "status": "string",
+                  "usage": "object"
+                },
+                "response_fields": [
+                  "id",
+                  "model",
+                  "object",
+                  "output",
+                  "status",
+                  "usage"
+                ],
+                "response_output_item_types": [
+                  "message"
+                ],
+                "response_status": "completed",
+                "type": "response.completed"
+              }
+            ],
+            "request_index": 4
+          },
+          {
+            "events": [
+              {
+                "field_types": {
+                  "response": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "response",
+                  "type"
+                ],
+                "response_field_types": {
+                  "id": "string",
+                  "model": "string",
+                  "object": "string",
+                  "output": "array",
+                  "status": "string"
+                },
+                "response_fields": [
+                  "id",
+                  "model",
+                  "object",
+                  "output",
+                  "status"
+                ],
+                "response_output_item_types": [],
+                "response_status": "in_progress",
+                "type": "response.created"
+              },
+              {
+                "field_types": {
+                  "item": "object",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "item",
+                  "output_index",
+                  "type"
+                ],
+                "item_field_types": {
+                  "content": "array",
+                  "id": "string",
+                  "role": "string",
+                  "type": "string"
+                },
+                "item_fields": [
+                  "content",
+                  "id",
+                  "role",
+                  "type"
+                ],
+                "item_type": "message",
+                "type": "response.output_item.added"
+              },
+              {
+                "field_types": {
+                  "content_index": "number",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "part": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "content_index",
+                  "item_id",
+                  "output_index",
+                  "part",
+                  "type"
+                ],
+                "part_field_types": {
+                  "annotations": "array",
+                  "text": "string",
+                  "type": "string"
+                },
+                "part_fields": [
+                  "annotations",
+                  "text",
+                  "type"
+                ],
+                "part_type": "output_text",
+                "type": "response.content_part.added"
+              },
+              {
+                "field_types": {
+                  "content_index": "number",
+                  "delta": "string",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "content_index",
+                  "delta",
+                  "item_id",
+                  "output_index",
+                  "type"
+                ],
+                "type": "response.output_text.delta"
+              },
+              {
+                "field_types": {
+                  "content_index": "number",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "text": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "content_index",
+                  "item_id",
+                  "output_index",
+                  "text",
+                  "type"
+                ],
+                "type": "response.output_text.done"
+              },
+              {
+                "field_types": {
+                  "item": "object",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "item",
+                  "output_index",
+                  "type"
+                ],
+                "item_field_types": {
+                  "content": "array",
+                  "id": "string",
+                  "role": "string",
+                  "type": "string"
+                },
+                "item_fields": [
+                  "content",
+                  "id",
+                  "role",
+                  "type"
+                ],
+                "item_type": "message",
+                "type": "response.output_item.done"
+              },
+              {
+                "field_types": {
+                  "response": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "response",
+                  "type"
+                ],
+                "response_field_types": {
+                  "id": "string",
+                  "model": "string",
+                  "object": "string",
+                  "output": "array",
+                  "status": "string",
+                  "usage": "object"
+                },
+                "response_fields": [
+                  "id",
+                  "model",
+                  "object",
+                  "output",
+                  "status",
+                  "usage"
+                ],
+                "response_output_item_types": [
+                  "message"
+                ],
+                "response_status": "completed",
+                "type": "response.completed"
+              }
+            ],
+            "request_index": 5
+          }
+        ]
+      },
       "event_order": [
         "response.output_item.added",
         "response.function_call_arguments.delta",
@@ -2260,54 +3998,104 @@
       ],
       "event_shapes": {
         "response.function_call_arguments.delta": {
+          "field_types": {
+            "delta": "string",
+            "item_id": "string",
+            "output_index": "number",
+            "type": "string"
+          },
           "fields": [
-            "type",
+            "delta",
             "item_id",
             "output_index",
-            "delta"
-          ]
+            "type"
+          ],
+          "type": "response.function_call_arguments.delta"
         },
         "response.function_call_arguments.done": {
+          "field_types": {
+            "arguments": "string",
+            "item_id": "string",
+            "output_index": "number",
+            "type": "string"
+          },
           "fields": [
-            "type",
+            "arguments",
             "item_id",
             "output_index",
-            "arguments"
-          ]
+            "type"
+          ],
+          "type": "response.function_call_arguments.done"
         },
         "response.output_item.added": {
+          "field_types": {
+            "item": "object",
+            "output_index": "number",
+            "type": "string"
+          },
           "fields": [
-            "type",
+            "item",
             "output_index",
-            "item"
+            "type"
           ],
+          "item_field_types": {
+            "arguments": "string",
+            "call_id": "string",
+            "id": "string",
+            "name": "string",
+            "namespace": "string",
+            "status": "string",
+            "type": "string"
+          },
           "item_fields": [
-            "type",
+            "arguments",
+            "call_id",
             "id",
-            "status",
             "name",
             "namespace",
-            "arguments",
-            "call_id"
+            "status",
+            "type"
           ],
-          "status": "in_progress"
+          "item_name": "spawn_agent",
+          "item_namespace": "collaboration",
+          "item_status": "in_progress",
+          "item_type": "function_call",
+          "type": "response.output_item.added"
         },
         "response.output_item.done": {
+          "field_types": {
+            "item": "object",
+            "output_index": "number",
+            "type": "string"
+          },
           "fields": [
-            "type",
+            "item",
             "output_index",
-            "item"
+            "type"
           ],
+          "item_field_types": {
+            "arguments": "string",
+            "call_id": "string",
+            "id": "string",
+            "name": "string",
+            "namespace": "string",
+            "status": "string",
+            "type": "string"
+          },
           "item_fields": [
-            "type",
+            "arguments",
+            "call_id",
             "id",
-            "status",
             "name",
             "namespace",
-            "arguments",
-            "call_id"
+            "status",
+            "type"
           ],
-          "status": "completed"
+          "item_name": "spawn_agent",
+          "item_namespace": "collaboration",
+          "item_status": "completed",
+          "item_type": "function_call",
+          "type": "response.output_item.done"
         }
       }
     },
@@ -4566,7 +6354,10 @@
       "call_namespace_preserved": true,
       "call_output_order_preserved": true,
       "cli_identity_relationships": {
+        "agent_message_addresses_nonempty": true,
         "agent_message_author_recipient_and_content_preserved": true,
+        "agent_message_item_ids_preserved": true,
+        "all_identity_fields_nonempty": true,
         "collaboration_item_order_preserved": true,
         "function_call_call_ids_preserved": true,
         "function_call_item_ids_preserved": true,
@@ -4579,6 +6370,7 @@
         "codex_desktop"
       ],
       "desktop_app_identity_relationships": {
+        "all_identity_fields_nonempty": true,
         "item_ids_preserved": true,
         "item_order_preserved": true,
         "structural_readback_preserved": true,
@@ -4586,7 +6378,10 @@
         "turn_ids_preserved": true
       },
       "desktop_identity_relationships": {
+        "agent_message_addresses_nonempty": true,
         "agent_message_author_recipient_and_content_preserved": true,
+        "agent_message_item_ids_preserved": true,
+        "all_identity_fields_nonempty": true,
         "collaboration_item_order_preserved": true,
         "function_call_call_ids_preserved": true,
         "function_call_item_ids_preserved": true,
@@ -4599,44 +6394,2071 @@
       "turn_context_multi_agent_version": "v2"
     },
     "terminal": {
+      "controls_by_client": {
+        "cli": {
+          "failed": {
+            "client_disposition": "rejected_nonzero_exit",
+            "completed_event_present": false,
+            "declaration": {
+              "children": [
+                {
+                  "description_type": "string",
+                  "fields": [
+                    "description",
+                    "name",
+                    "parameters",
+                    "strict",
+                    "type"
+                  ],
+                  "name": "followup_task",
+                  "parameters": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "message": {
+                        "encrypted": true,
+                        "type": "string"
+                      },
+                      "target": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "message",
+                      "target"
+                    ],
+                    "type": "object"
+                  },
+                  "strict": false,
+                  "type": "function"
+                },
+                {
+                  "description_type": "string",
+                  "fields": [
+                    "description",
+                    "name",
+                    "parameters",
+                    "strict",
+                    "type"
+                  ],
+                  "name": "interrupt_agent",
+                  "parameters": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "target": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "target"
+                    ],
+                    "type": "object"
+                  },
+                  "strict": false,
+                  "type": "function"
+                },
+                {
+                  "description_type": "string",
+                  "fields": [
+                    "description",
+                    "name",
+                    "parameters",
+                    "strict",
+                    "type"
+                  ],
+                  "name": "list_agents",
+                  "parameters": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "path_prefix": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [],
+                    "type": "object"
+                  },
+                  "strict": false,
+                  "type": "function"
+                },
+                {
+                  "description_type": "string",
+                  "fields": [
+                    "description",
+                    "name",
+                    "parameters",
+                    "strict",
+                    "type"
+                  ],
+                  "name": "send_message",
+                  "parameters": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "message": {
+                        "encrypted": true,
+                        "type": "string"
+                      },
+                      "target": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "message",
+                      "target"
+                    ],
+                    "type": "object"
+                  },
+                  "strict": false,
+                  "type": "function"
+                },
+                {
+                  "description_type": "string",
+                  "fields": [
+                    "description",
+                    "name",
+                    "parameters",
+                    "strict",
+                    "type"
+                  ],
+                  "name": "spawn_agent",
+                  "parameters": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "agent_type": {
+                        "type": "string"
+                      },
+                      "fork_turns": {
+                        "type": "string"
+                      },
+                      "message": {
+                        "encrypted": true,
+                        "type": "string"
+                      },
+                      "model": {
+                        "type": "string"
+                      },
+                      "reasoning_effort": {
+                        "type": "string"
+                      },
+                      "task_name": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "message",
+                      "task_name"
+                    ],
+                    "type": "object"
+                  },
+                  "strict": false,
+                  "type": "function"
+                },
+                {
+                  "description_type": "string",
+                  "fields": [
+                    "description",
+                    "name",
+                    "parameters",
+                    "strict",
+                    "type"
+                  ],
+                  "name": "wait_agent",
+                  "parameters": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "timeout_ms": {
+                        "type": "number"
+                      }
+                    },
+                    "required": [],
+                    "type": "object"
+                  },
+                  "strict": false,
+                  "type": "function"
+                }
+              ],
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "tools",
+                "type"
+              ],
+              "name": "collaboration",
+              "type": "namespace"
+            },
+            "request": {
+              "collaboration_items": [],
+              "field_types": {
+                "client_metadata": "object",
+                "include": "array",
+                "input": "array",
+                "instructions": "string",
+                "model": "string",
+                "parallel_tool_calls": "boolean",
+                "prompt_cache_key": "string",
+                "reasoning": "object",
+                "store": "boolean",
+                "stream": "boolean",
+                "tool_choice": "string",
+                "tools": "array"
+              },
+              "fields": [
+                "client_metadata",
+                "include",
+                "input",
+                "instructions",
+                "model",
+                "parallel_tool_calls",
+                "prompt_cache_key",
+                "reasoning",
+                "store",
+                "stream",
+                "tool_choice",
+                "tools"
+              ],
+              "input_type_order": [
+                "message",
+                "message",
+                "message",
+                "message",
+                "message"
+              ],
+              "multi_agent_version_locations": [],
+              "tool_choice": "auto"
+            },
+            "served_event_envelopes": [
+              {
+                "field_types": {
+                  "response": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "response",
+                  "type"
+                ],
+                "response_field_types": {
+                  "id": "string",
+                  "model": "string",
+                  "object": "string",
+                  "output": "array",
+                  "status": "string"
+                },
+                "response_fields": [
+                  "id",
+                  "model",
+                  "object",
+                  "output",
+                  "status"
+                ],
+                "response_output_item_types": [],
+                "response_status": "in_progress",
+                "type": "response.created"
+              },
+              {
+                "field_types": {
+                  "response": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "response",
+                  "type"
+                ],
+                "response_error_field_types": {
+                  "code": "string",
+                  "message": "string"
+                },
+                "response_error_fields": [
+                  "code",
+                  "message"
+                ],
+                "response_field_types": {
+                  "error": "object",
+                  "id": "string"
+                },
+                "response_fields": [
+                  "error",
+                  "id"
+                ],
+                "type": "response.failed"
+              }
+            ],
+            "terminal_control": "failed",
+            "terminal_event_present": true
+          },
+          "incomplete": {
+            "client_disposition": "rejected_nonzero_exit",
+            "completed_event_present": false,
+            "declaration": {
+              "children": [
+                {
+                  "description_type": "string",
+                  "fields": [
+                    "description",
+                    "name",
+                    "parameters",
+                    "strict",
+                    "type"
+                  ],
+                  "name": "followup_task",
+                  "parameters": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "message": {
+                        "encrypted": true,
+                        "type": "string"
+                      },
+                      "target": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "message",
+                      "target"
+                    ],
+                    "type": "object"
+                  },
+                  "strict": false,
+                  "type": "function"
+                },
+                {
+                  "description_type": "string",
+                  "fields": [
+                    "description",
+                    "name",
+                    "parameters",
+                    "strict",
+                    "type"
+                  ],
+                  "name": "interrupt_agent",
+                  "parameters": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "target": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "target"
+                    ],
+                    "type": "object"
+                  },
+                  "strict": false,
+                  "type": "function"
+                },
+                {
+                  "description_type": "string",
+                  "fields": [
+                    "description",
+                    "name",
+                    "parameters",
+                    "strict",
+                    "type"
+                  ],
+                  "name": "list_agents",
+                  "parameters": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "path_prefix": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [],
+                    "type": "object"
+                  },
+                  "strict": false,
+                  "type": "function"
+                },
+                {
+                  "description_type": "string",
+                  "fields": [
+                    "description",
+                    "name",
+                    "parameters",
+                    "strict",
+                    "type"
+                  ],
+                  "name": "send_message",
+                  "parameters": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "message": {
+                        "encrypted": true,
+                        "type": "string"
+                      },
+                      "target": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "message",
+                      "target"
+                    ],
+                    "type": "object"
+                  },
+                  "strict": false,
+                  "type": "function"
+                },
+                {
+                  "description_type": "string",
+                  "fields": [
+                    "description",
+                    "name",
+                    "parameters",
+                    "strict",
+                    "type"
+                  ],
+                  "name": "spawn_agent",
+                  "parameters": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "agent_type": {
+                        "type": "string"
+                      },
+                      "fork_turns": {
+                        "type": "string"
+                      },
+                      "message": {
+                        "encrypted": true,
+                        "type": "string"
+                      },
+                      "model": {
+                        "type": "string"
+                      },
+                      "reasoning_effort": {
+                        "type": "string"
+                      },
+                      "task_name": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "message",
+                      "task_name"
+                    ],
+                    "type": "object"
+                  },
+                  "strict": false,
+                  "type": "function"
+                },
+                {
+                  "description_type": "string",
+                  "fields": [
+                    "description",
+                    "name",
+                    "parameters",
+                    "strict",
+                    "type"
+                  ],
+                  "name": "wait_agent",
+                  "parameters": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "timeout_ms": {
+                        "type": "number"
+                      }
+                    },
+                    "required": [],
+                    "type": "object"
+                  },
+                  "strict": false,
+                  "type": "function"
+                }
+              ],
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "tools",
+                "type"
+              ],
+              "name": "collaboration",
+              "type": "namespace"
+            },
+            "request": {
+              "collaboration_items": [],
+              "field_types": {
+                "client_metadata": "object",
+                "include": "array",
+                "input": "array",
+                "instructions": "string",
+                "model": "string",
+                "parallel_tool_calls": "boolean",
+                "prompt_cache_key": "string",
+                "reasoning": "object",
+                "store": "boolean",
+                "stream": "boolean",
+                "tool_choice": "string",
+                "tools": "array"
+              },
+              "fields": [
+                "client_metadata",
+                "include",
+                "input",
+                "instructions",
+                "model",
+                "parallel_tool_calls",
+                "prompt_cache_key",
+                "reasoning",
+                "store",
+                "stream",
+                "tool_choice",
+                "tools"
+              ],
+              "input_type_order": [
+                "message",
+                "message",
+                "message",
+                "message",
+                "message"
+              ],
+              "multi_agent_version_locations": [],
+              "tool_choice": "auto"
+            },
+            "served_event_envelopes": [
+              {
+                "field_types": {
+                  "response": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "response",
+                  "type"
+                ],
+                "response_field_types": {
+                  "id": "string",
+                  "model": "string",
+                  "object": "string",
+                  "output": "array",
+                  "status": "string"
+                },
+                "response_fields": [
+                  "id",
+                  "model",
+                  "object",
+                  "output",
+                  "status"
+                ],
+                "response_output_item_types": [],
+                "response_status": "in_progress",
+                "type": "response.created"
+              },
+              {
+                "field_types": {
+                  "item": "object",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "item",
+                  "output_index",
+                  "type"
+                ],
+                "item_field_types": {
+                  "content": "array",
+                  "id": "string",
+                  "role": "string",
+                  "type": "string"
+                },
+                "item_fields": [
+                  "content",
+                  "id",
+                  "role",
+                  "type"
+                ],
+                "item_type": "message",
+                "type": "response.output_item.added"
+              },
+              {
+                "field_types": {
+                  "content_index": "number",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "part": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "content_index",
+                  "item_id",
+                  "output_index",
+                  "part",
+                  "type"
+                ],
+                "part_field_types": {
+                  "annotations": "array",
+                  "text": "string",
+                  "type": "string"
+                },
+                "part_fields": [
+                  "annotations",
+                  "text",
+                  "type"
+                ],
+                "part_type": "output_text",
+                "type": "response.content_part.added"
+              },
+              {
+                "field_types": {
+                  "content_index": "number",
+                  "delta": "string",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "content_index",
+                  "delta",
+                  "item_id",
+                  "output_index",
+                  "type"
+                ],
+                "type": "response.output_text.delta"
+              },
+              {
+                "field_types": {
+                  "response": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "response",
+                  "type"
+                ],
+                "response_field_types": {
+                  "error": "null",
+                  "id": "string",
+                  "incomplete_details": "object",
+                  "object": "string",
+                  "status": "string"
+                },
+                "response_fields": [
+                  "error",
+                  "id",
+                  "incomplete_details",
+                  "object",
+                  "status"
+                ],
+                "response_incomplete_details_field_types": {
+                  "reason": "string"
+                },
+                "response_incomplete_details_fields": [
+                  "reason"
+                ],
+                "response_status": "incomplete",
+                "type": "response.incomplete"
+              }
+            ],
+            "terminal_control": "incomplete",
+            "terminal_event_present": true
+          },
+          "truncated": {
+            "client_disposition": "rejected_nonzero_exit",
+            "completed_event_present": false,
+            "declaration": {
+              "children": [
+                {
+                  "description_type": "string",
+                  "fields": [
+                    "description",
+                    "name",
+                    "parameters",
+                    "strict",
+                    "type"
+                  ],
+                  "name": "followup_task",
+                  "parameters": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "message": {
+                        "encrypted": true,
+                        "type": "string"
+                      },
+                      "target": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "message",
+                      "target"
+                    ],
+                    "type": "object"
+                  },
+                  "strict": false,
+                  "type": "function"
+                },
+                {
+                  "description_type": "string",
+                  "fields": [
+                    "description",
+                    "name",
+                    "parameters",
+                    "strict",
+                    "type"
+                  ],
+                  "name": "interrupt_agent",
+                  "parameters": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "target": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "target"
+                    ],
+                    "type": "object"
+                  },
+                  "strict": false,
+                  "type": "function"
+                },
+                {
+                  "description_type": "string",
+                  "fields": [
+                    "description",
+                    "name",
+                    "parameters",
+                    "strict",
+                    "type"
+                  ],
+                  "name": "list_agents",
+                  "parameters": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "path_prefix": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [],
+                    "type": "object"
+                  },
+                  "strict": false,
+                  "type": "function"
+                },
+                {
+                  "description_type": "string",
+                  "fields": [
+                    "description",
+                    "name",
+                    "parameters",
+                    "strict",
+                    "type"
+                  ],
+                  "name": "send_message",
+                  "parameters": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "message": {
+                        "encrypted": true,
+                        "type": "string"
+                      },
+                      "target": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "message",
+                      "target"
+                    ],
+                    "type": "object"
+                  },
+                  "strict": false,
+                  "type": "function"
+                },
+                {
+                  "description_type": "string",
+                  "fields": [
+                    "description",
+                    "name",
+                    "parameters",
+                    "strict",
+                    "type"
+                  ],
+                  "name": "spawn_agent",
+                  "parameters": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "agent_type": {
+                        "type": "string"
+                      },
+                      "fork_turns": {
+                        "type": "string"
+                      },
+                      "message": {
+                        "encrypted": true,
+                        "type": "string"
+                      },
+                      "model": {
+                        "type": "string"
+                      },
+                      "reasoning_effort": {
+                        "type": "string"
+                      },
+                      "task_name": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "message",
+                      "task_name"
+                    ],
+                    "type": "object"
+                  },
+                  "strict": false,
+                  "type": "function"
+                },
+                {
+                  "description_type": "string",
+                  "fields": [
+                    "description",
+                    "name",
+                    "parameters",
+                    "strict",
+                    "type"
+                  ],
+                  "name": "wait_agent",
+                  "parameters": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "timeout_ms": {
+                        "type": "number"
+                      }
+                    },
+                    "required": [],
+                    "type": "object"
+                  },
+                  "strict": false,
+                  "type": "function"
+                }
+              ],
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "tools",
+                "type"
+              ],
+              "name": "collaboration",
+              "type": "namespace"
+            },
+            "request": {
+              "collaboration_items": [],
+              "field_types": {
+                "client_metadata": "object",
+                "include": "array",
+                "input": "array",
+                "instructions": "string",
+                "model": "string",
+                "parallel_tool_calls": "boolean",
+                "prompt_cache_key": "string",
+                "reasoning": "object",
+                "store": "boolean",
+                "stream": "boolean",
+                "tool_choice": "string",
+                "tools": "array"
+              },
+              "fields": [
+                "client_metadata",
+                "include",
+                "input",
+                "instructions",
+                "model",
+                "parallel_tool_calls",
+                "prompt_cache_key",
+                "reasoning",
+                "store",
+                "stream",
+                "tool_choice",
+                "tools"
+              ],
+              "input_type_order": [
+                "message",
+                "message",
+                "message",
+                "message",
+                "message"
+              ],
+              "multi_agent_version_locations": [],
+              "tool_choice": "auto"
+            },
+            "served_event_envelopes": [
+              {
+                "field_types": {
+                  "response": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "response",
+                  "type"
+                ],
+                "response_field_types": {
+                  "id": "string",
+                  "model": "string",
+                  "object": "string",
+                  "output": "array",
+                  "status": "string"
+                },
+                "response_fields": [
+                  "id",
+                  "model",
+                  "object",
+                  "output",
+                  "status"
+                ],
+                "response_output_item_types": [],
+                "response_status": "in_progress",
+                "type": "response.created"
+              },
+              {
+                "field_types": {
+                  "item": "object",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "item",
+                  "output_index",
+                  "type"
+                ],
+                "item_field_types": {
+                  "content": "array",
+                  "id": "string",
+                  "role": "string",
+                  "type": "string"
+                },
+                "item_fields": [
+                  "content",
+                  "id",
+                  "role",
+                  "type"
+                ],
+                "item_type": "message",
+                "type": "response.output_item.added"
+              },
+              {
+                "field_types": {
+                  "content_index": "number",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "part": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "content_index",
+                  "item_id",
+                  "output_index",
+                  "part",
+                  "type"
+                ],
+                "part_field_types": {
+                  "annotations": "array",
+                  "text": "string",
+                  "type": "string"
+                },
+                "part_fields": [
+                  "annotations",
+                  "text",
+                  "type"
+                ],
+                "part_type": "output_text",
+                "type": "response.content_part.added"
+              },
+              {
+                "field_types": {
+                  "content_index": "number",
+                  "delta": "string",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "content_index",
+                  "delta",
+                  "item_id",
+                  "output_index",
+                  "type"
+                ],
+                "type": "response.output_text.delta"
+              }
+            ],
+            "terminal_control": "truncated",
+            "terminal_event_present": false
+          }
+        },
+        "desktop": {
+          "failed": {
+            "client_disposition": "rejected_nonzero_exit",
+            "completed_event_present": false,
+            "declaration": {
+              "children": [
+                {
+                  "description_type": "string",
+                  "fields": [
+                    "description",
+                    "name",
+                    "parameters",
+                    "strict",
+                    "type"
+                  ],
+                  "name": "followup_task",
+                  "parameters": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "message": {
+                        "encrypted": true,
+                        "type": "string"
+                      },
+                      "target": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "message",
+                      "target"
+                    ],
+                    "type": "object"
+                  },
+                  "strict": false,
+                  "type": "function"
+                },
+                {
+                  "description_type": "string",
+                  "fields": [
+                    "description",
+                    "name",
+                    "parameters",
+                    "strict",
+                    "type"
+                  ],
+                  "name": "interrupt_agent",
+                  "parameters": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "target": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "target"
+                    ],
+                    "type": "object"
+                  },
+                  "strict": false,
+                  "type": "function"
+                },
+                {
+                  "description_type": "string",
+                  "fields": [
+                    "description",
+                    "name",
+                    "parameters",
+                    "strict",
+                    "type"
+                  ],
+                  "name": "list_agents",
+                  "parameters": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "path_prefix": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [],
+                    "type": "object"
+                  },
+                  "strict": false,
+                  "type": "function"
+                },
+                {
+                  "description_type": "string",
+                  "fields": [
+                    "description",
+                    "name",
+                    "parameters",
+                    "strict",
+                    "type"
+                  ],
+                  "name": "send_message",
+                  "parameters": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "message": {
+                        "encrypted": true,
+                        "type": "string"
+                      },
+                      "target": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "message",
+                      "target"
+                    ],
+                    "type": "object"
+                  },
+                  "strict": false,
+                  "type": "function"
+                },
+                {
+                  "description_type": "string",
+                  "fields": [
+                    "description",
+                    "name",
+                    "parameters",
+                    "strict",
+                    "type"
+                  ],
+                  "name": "spawn_agent",
+                  "parameters": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "agent_type": {
+                        "type": "string"
+                      },
+                      "fork_turns": {
+                        "type": "string"
+                      },
+                      "message": {
+                        "encrypted": true,
+                        "type": "string"
+                      },
+                      "model": {
+                        "type": "string"
+                      },
+                      "reasoning_effort": {
+                        "type": "string"
+                      },
+                      "task_name": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "message",
+                      "task_name"
+                    ],
+                    "type": "object"
+                  },
+                  "strict": false,
+                  "type": "function"
+                },
+                {
+                  "description_type": "string",
+                  "fields": [
+                    "description",
+                    "name",
+                    "parameters",
+                    "strict",
+                    "type"
+                  ],
+                  "name": "wait_agent",
+                  "parameters": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "timeout_ms": {
+                        "type": "number"
+                      }
+                    },
+                    "required": [],
+                    "type": "object"
+                  },
+                  "strict": false,
+                  "type": "function"
+                }
+              ],
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "tools",
+                "type"
+              ],
+              "name": "collaboration",
+              "type": "namespace"
+            },
+            "request": {
+              "collaboration_items": [],
+              "field_types": {
+                "client_metadata": "object",
+                "include": "array",
+                "input": "array",
+                "instructions": "string",
+                "model": "string",
+                "parallel_tool_calls": "boolean",
+                "prompt_cache_key": "string",
+                "reasoning": "object",
+                "store": "boolean",
+                "stream": "boolean",
+                "tool_choice": "string",
+                "tools": "array"
+              },
+              "fields": [
+                "client_metadata",
+                "include",
+                "input",
+                "instructions",
+                "model",
+                "parallel_tool_calls",
+                "prompt_cache_key",
+                "reasoning",
+                "store",
+                "stream",
+                "tool_choice",
+                "tools"
+              ],
+              "input_type_order": [
+                "message",
+                "message",
+                "message",
+                "message",
+                "message"
+              ],
+              "multi_agent_version_locations": [],
+              "tool_choice": "auto"
+            },
+            "served_event_envelopes": [
+              {
+                "field_types": {
+                  "response": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "response",
+                  "type"
+                ],
+                "response_field_types": {
+                  "id": "string",
+                  "model": "string",
+                  "object": "string",
+                  "output": "array",
+                  "status": "string"
+                },
+                "response_fields": [
+                  "id",
+                  "model",
+                  "object",
+                  "output",
+                  "status"
+                ],
+                "response_output_item_types": [],
+                "response_status": "in_progress",
+                "type": "response.created"
+              },
+              {
+                "field_types": {
+                  "response": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "response",
+                  "type"
+                ],
+                "response_error_field_types": {
+                  "code": "string",
+                  "message": "string"
+                },
+                "response_error_fields": [
+                  "code",
+                  "message"
+                ],
+                "response_field_types": {
+                  "error": "object",
+                  "id": "string"
+                },
+                "response_fields": [
+                  "error",
+                  "id"
+                ],
+                "type": "response.failed"
+              }
+            ],
+            "terminal_control": "failed",
+            "terminal_event_present": true
+          },
+          "incomplete": {
+            "client_disposition": "rejected_nonzero_exit",
+            "completed_event_present": false,
+            "declaration": {
+              "children": [
+                {
+                  "description_type": "string",
+                  "fields": [
+                    "description",
+                    "name",
+                    "parameters",
+                    "strict",
+                    "type"
+                  ],
+                  "name": "followup_task",
+                  "parameters": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "message": {
+                        "encrypted": true,
+                        "type": "string"
+                      },
+                      "target": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "message",
+                      "target"
+                    ],
+                    "type": "object"
+                  },
+                  "strict": false,
+                  "type": "function"
+                },
+                {
+                  "description_type": "string",
+                  "fields": [
+                    "description",
+                    "name",
+                    "parameters",
+                    "strict",
+                    "type"
+                  ],
+                  "name": "interrupt_agent",
+                  "parameters": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "target": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "target"
+                    ],
+                    "type": "object"
+                  },
+                  "strict": false,
+                  "type": "function"
+                },
+                {
+                  "description_type": "string",
+                  "fields": [
+                    "description",
+                    "name",
+                    "parameters",
+                    "strict",
+                    "type"
+                  ],
+                  "name": "list_agents",
+                  "parameters": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "path_prefix": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [],
+                    "type": "object"
+                  },
+                  "strict": false,
+                  "type": "function"
+                },
+                {
+                  "description_type": "string",
+                  "fields": [
+                    "description",
+                    "name",
+                    "parameters",
+                    "strict",
+                    "type"
+                  ],
+                  "name": "send_message",
+                  "parameters": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "message": {
+                        "encrypted": true,
+                        "type": "string"
+                      },
+                      "target": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "message",
+                      "target"
+                    ],
+                    "type": "object"
+                  },
+                  "strict": false,
+                  "type": "function"
+                },
+                {
+                  "description_type": "string",
+                  "fields": [
+                    "description",
+                    "name",
+                    "parameters",
+                    "strict",
+                    "type"
+                  ],
+                  "name": "spawn_agent",
+                  "parameters": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "agent_type": {
+                        "type": "string"
+                      },
+                      "fork_turns": {
+                        "type": "string"
+                      },
+                      "message": {
+                        "encrypted": true,
+                        "type": "string"
+                      },
+                      "model": {
+                        "type": "string"
+                      },
+                      "reasoning_effort": {
+                        "type": "string"
+                      },
+                      "task_name": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "message",
+                      "task_name"
+                    ],
+                    "type": "object"
+                  },
+                  "strict": false,
+                  "type": "function"
+                },
+                {
+                  "description_type": "string",
+                  "fields": [
+                    "description",
+                    "name",
+                    "parameters",
+                    "strict",
+                    "type"
+                  ],
+                  "name": "wait_agent",
+                  "parameters": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "timeout_ms": {
+                        "type": "number"
+                      }
+                    },
+                    "required": [],
+                    "type": "object"
+                  },
+                  "strict": false,
+                  "type": "function"
+                }
+              ],
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "tools",
+                "type"
+              ],
+              "name": "collaboration",
+              "type": "namespace"
+            },
+            "request": {
+              "collaboration_items": [],
+              "field_types": {
+                "client_metadata": "object",
+                "include": "array",
+                "input": "array",
+                "instructions": "string",
+                "model": "string",
+                "parallel_tool_calls": "boolean",
+                "prompt_cache_key": "string",
+                "reasoning": "object",
+                "store": "boolean",
+                "stream": "boolean",
+                "tool_choice": "string",
+                "tools": "array"
+              },
+              "fields": [
+                "client_metadata",
+                "include",
+                "input",
+                "instructions",
+                "model",
+                "parallel_tool_calls",
+                "prompt_cache_key",
+                "reasoning",
+                "store",
+                "stream",
+                "tool_choice",
+                "tools"
+              ],
+              "input_type_order": [
+                "message",
+                "message",
+                "message",
+                "message",
+                "message"
+              ],
+              "multi_agent_version_locations": [],
+              "tool_choice": "auto"
+            },
+            "served_event_envelopes": [
+              {
+                "field_types": {
+                  "response": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "response",
+                  "type"
+                ],
+                "response_field_types": {
+                  "id": "string",
+                  "model": "string",
+                  "object": "string",
+                  "output": "array",
+                  "status": "string"
+                },
+                "response_fields": [
+                  "id",
+                  "model",
+                  "object",
+                  "output",
+                  "status"
+                ],
+                "response_output_item_types": [],
+                "response_status": "in_progress",
+                "type": "response.created"
+              },
+              {
+                "field_types": {
+                  "item": "object",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "item",
+                  "output_index",
+                  "type"
+                ],
+                "item_field_types": {
+                  "content": "array",
+                  "id": "string",
+                  "role": "string",
+                  "type": "string"
+                },
+                "item_fields": [
+                  "content",
+                  "id",
+                  "role",
+                  "type"
+                ],
+                "item_type": "message",
+                "type": "response.output_item.added"
+              },
+              {
+                "field_types": {
+                  "content_index": "number",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "part": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "content_index",
+                  "item_id",
+                  "output_index",
+                  "part",
+                  "type"
+                ],
+                "part_field_types": {
+                  "annotations": "array",
+                  "text": "string",
+                  "type": "string"
+                },
+                "part_fields": [
+                  "annotations",
+                  "text",
+                  "type"
+                ],
+                "part_type": "output_text",
+                "type": "response.content_part.added"
+              },
+              {
+                "field_types": {
+                  "content_index": "number",
+                  "delta": "string",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "content_index",
+                  "delta",
+                  "item_id",
+                  "output_index",
+                  "type"
+                ],
+                "type": "response.output_text.delta"
+              },
+              {
+                "field_types": {
+                  "response": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "response",
+                  "type"
+                ],
+                "response_field_types": {
+                  "error": "null",
+                  "id": "string",
+                  "incomplete_details": "object",
+                  "object": "string",
+                  "status": "string"
+                },
+                "response_fields": [
+                  "error",
+                  "id",
+                  "incomplete_details",
+                  "object",
+                  "status"
+                ],
+                "response_incomplete_details_field_types": {
+                  "reason": "string"
+                },
+                "response_incomplete_details_fields": [
+                  "reason"
+                ],
+                "response_status": "incomplete",
+                "type": "response.incomplete"
+              }
+            ],
+            "terminal_control": "incomplete",
+            "terminal_event_present": true
+          },
+          "truncated": {
+            "client_disposition": "rejected_nonzero_exit",
+            "completed_event_present": false,
+            "declaration": {
+              "children": [
+                {
+                  "description_type": "string",
+                  "fields": [
+                    "description",
+                    "name",
+                    "parameters",
+                    "strict",
+                    "type"
+                  ],
+                  "name": "followup_task",
+                  "parameters": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "message": {
+                        "encrypted": true,
+                        "type": "string"
+                      },
+                      "target": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "message",
+                      "target"
+                    ],
+                    "type": "object"
+                  },
+                  "strict": false,
+                  "type": "function"
+                },
+                {
+                  "description_type": "string",
+                  "fields": [
+                    "description",
+                    "name",
+                    "parameters",
+                    "strict",
+                    "type"
+                  ],
+                  "name": "interrupt_agent",
+                  "parameters": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "target": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "target"
+                    ],
+                    "type": "object"
+                  },
+                  "strict": false,
+                  "type": "function"
+                },
+                {
+                  "description_type": "string",
+                  "fields": [
+                    "description",
+                    "name",
+                    "parameters",
+                    "strict",
+                    "type"
+                  ],
+                  "name": "list_agents",
+                  "parameters": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "path_prefix": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [],
+                    "type": "object"
+                  },
+                  "strict": false,
+                  "type": "function"
+                },
+                {
+                  "description_type": "string",
+                  "fields": [
+                    "description",
+                    "name",
+                    "parameters",
+                    "strict",
+                    "type"
+                  ],
+                  "name": "send_message",
+                  "parameters": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "message": {
+                        "encrypted": true,
+                        "type": "string"
+                      },
+                      "target": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "message",
+                      "target"
+                    ],
+                    "type": "object"
+                  },
+                  "strict": false,
+                  "type": "function"
+                },
+                {
+                  "description_type": "string",
+                  "fields": [
+                    "description",
+                    "name",
+                    "parameters",
+                    "strict",
+                    "type"
+                  ],
+                  "name": "spawn_agent",
+                  "parameters": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "agent_type": {
+                        "type": "string"
+                      },
+                      "fork_turns": {
+                        "type": "string"
+                      },
+                      "message": {
+                        "encrypted": true,
+                        "type": "string"
+                      },
+                      "model": {
+                        "type": "string"
+                      },
+                      "reasoning_effort": {
+                        "type": "string"
+                      },
+                      "task_name": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "message",
+                      "task_name"
+                    ],
+                    "type": "object"
+                  },
+                  "strict": false,
+                  "type": "function"
+                },
+                {
+                  "description_type": "string",
+                  "fields": [
+                    "description",
+                    "name",
+                    "parameters",
+                    "strict",
+                    "type"
+                  ],
+                  "name": "wait_agent",
+                  "parameters": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "timeout_ms": {
+                        "type": "number"
+                      }
+                    },
+                    "required": [],
+                    "type": "object"
+                  },
+                  "strict": false,
+                  "type": "function"
+                }
+              ],
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "tools",
+                "type"
+              ],
+              "name": "collaboration",
+              "type": "namespace"
+            },
+            "request": {
+              "collaboration_items": [],
+              "field_types": {
+                "client_metadata": "object",
+                "include": "array",
+                "input": "array",
+                "instructions": "string",
+                "model": "string",
+                "parallel_tool_calls": "boolean",
+                "prompt_cache_key": "string",
+                "reasoning": "object",
+                "store": "boolean",
+                "stream": "boolean",
+                "tool_choice": "string",
+                "tools": "array"
+              },
+              "fields": [
+                "client_metadata",
+                "include",
+                "input",
+                "instructions",
+                "model",
+                "parallel_tool_calls",
+                "prompt_cache_key",
+                "reasoning",
+                "store",
+                "stream",
+                "tool_choice",
+                "tools"
+              ],
+              "input_type_order": [
+                "message",
+                "message",
+                "message",
+                "message",
+                "message"
+              ],
+              "multi_agent_version_locations": [],
+              "tool_choice": "auto"
+            },
+            "served_event_envelopes": [
+              {
+                "field_types": {
+                  "response": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "response",
+                  "type"
+                ],
+                "response_field_types": {
+                  "id": "string",
+                  "model": "string",
+                  "object": "string",
+                  "output": "array",
+                  "status": "string"
+                },
+                "response_fields": [
+                  "id",
+                  "model",
+                  "object",
+                  "output",
+                  "status"
+                ],
+                "response_output_item_types": [],
+                "response_status": "in_progress",
+                "type": "response.created"
+              },
+              {
+                "field_types": {
+                  "item": "object",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "item",
+                  "output_index",
+                  "type"
+                ],
+                "item_field_types": {
+                  "content": "array",
+                  "id": "string",
+                  "role": "string",
+                  "type": "string"
+                },
+                "item_fields": [
+                  "content",
+                  "id",
+                  "role",
+                  "type"
+                ],
+                "item_type": "message",
+                "type": "response.output_item.added"
+              },
+              {
+                "field_types": {
+                  "content_index": "number",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "part": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "content_index",
+                  "item_id",
+                  "output_index",
+                  "part",
+                  "type"
+                ],
+                "part_field_types": {
+                  "annotations": "array",
+                  "text": "string",
+                  "type": "string"
+                },
+                "part_fields": [
+                  "annotations",
+                  "text",
+                  "type"
+                ],
+                "part_type": "output_text",
+                "type": "response.content_part.added"
+              },
+              {
+                "field_types": {
+                  "content_index": "number",
+                  "delta": "string",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "content_index",
+                  "delta",
+                  "item_id",
+                  "output_index",
+                  "type"
+                ],
+                "type": "response.output_text.delta"
+              }
+            ],
+            "terminal_control": "truncated",
+            "terminal_event_present": false
+          }
+        }
+      },
       "event_order_boundary": "after_output_item_done",
       "event_shapes": {
         "response.completed": {
+          "field_types": {
+            "response": "object",
+            "type": "string"
+          },
           "fields": [
-            "type",
-            "response"
+            "response",
+            "type"
           ],
+          "response_field_types": {
+            "id": "string",
+            "model": "string",
+            "object": "string",
+            "output": "array",
+            "status": "string",
+            "usage": "object"
+          },
           "response_fields": [
             "id",
-            "status",
+            "model",
+            "object",
             "output",
+            "status",
             "usage"
           ],
-          "status": "completed"
+          "response_output_item_types": [
+            "function_call"
+          ],
+          "response_status": "completed",
+          "type": "response.completed"
         },
         "response.failed": {
+          "field_types": {
+            "response": "object",
+            "type": "string"
+          },
           "fields": [
-            "type",
-            "response"
+            "response",
+            "type"
           ],
-          "response_required_fields": [
-            "id",
-            "status",
-            "error"
+          "response_error_field_types": {
+            "code": "string",
+            "message": "string"
+          },
+          "response_error_fields": [
+            "code",
+            "message"
           ],
-          "status": "failed"
+          "response_field_types": {
+            "error": "object",
+            "id": "string"
+          },
+          "response_fields": [
+            "error",
+            "id"
+          ],
+          "type": "response.failed"
         },
         "response.incomplete": {
+          "field_types": {
+            "response": "object",
+            "type": "string"
+          },
           "fields": [
-            "type",
-            "response"
+            "response",
+            "type"
           ],
-          "response_required_fields": [
+          "response_field_types": {
+            "error": "null",
+            "id": "string",
+            "incomplete_details": "object",
+            "object": "string",
+            "status": "string"
+          },
+          "response_fields": [
+            "error",
             "id",
-            "status",
-            "incomplete_details"
+            "incomplete_details",
+            "object",
+            "status"
           ],
-          "status": "incomplete"
+          "response_incomplete_details_field_types": {
+            "reason": "string"
+          },
+          "response_incomplete_details_fields": [
+            "reason"
+          ],
+          "response_status": "incomplete",
+          "type": "response.incomplete"
         }
       },
       "events": [
@@ -4644,7 +8466,7 @@
         "response.incomplete",
         "response.failed"
       ],
-      "stream_close_without_completed": "terminal_error"
+      "stream_close_without_completed": "rejected_nonzero_exit"
     }
   }
 }

--- a/docs/evidence/issue-392/collaboration-runtime-contract.json
+++ b/docs/evidence/issue-392/collaboration-runtime-contract.json
@@ -5,6 +5,13 @@
     "existing_user_home_read": false,
     "existing_user_task_read": false,
     "home": "new_isolated_home_per_runtime",
+    "isolated_home_bindings_sha256": [
+      "b7da348dba582272740fa1392545e7b468a5fbe50f08d257de451631fc8490a8",
+      "1d36f56fcb0744f35ade8cdc621e9588f24c55ad5efcf556c69f12ff1a9f8b28",
+      "8da0a0440f5dba6de038e2343dcf0a90aad1e9df7107f5f734031243fd50d551",
+      "c99dd6202b2a2fddc017c522c869e619b72803c8ec1393209ab3bb8c66528007",
+      "9ff014546ee3d0495ea5d21413bd8cc5e7ecf23f1e09bf0023e2b218526b7e04"
+    ],
     "isolated_observations": [
       "cli_v1_request",
       "cli_v2_request_call_result_agent_message_and_restart",
@@ -64,6 +71,304 @@
           "item/completed"
         ]
       },
+      "notification_envelopes": [
+        {
+          "item_field_types": {
+            "agentPath": "string",
+            "agentThreadId": "string",
+            "id": "string",
+            "kind": "string",
+            "type": "string"
+          },
+          "item_fields": [
+            "agentPath",
+            "agentThreadId",
+            "id",
+            "kind",
+            "type"
+          ],
+          "item_kind": "started",
+          "item_type": "subAgentActivity",
+          "method": "item/started",
+          "params_field_types": {
+            "item": "object",
+            "startedAtMs": "number",
+            "threadId": "string",
+            "turnId": "string"
+          },
+          "params_fields": [
+            "item",
+            "startedAtMs",
+            "threadId",
+            "turnId"
+          ]
+        },
+        {
+          "item_field_types": {
+            "agentPath": "string",
+            "agentThreadId": "string",
+            "id": "string",
+            "kind": "string",
+            "type": "string"
+          },
+          "item_fields": [
+            "agentPath",
+            "agentThreadId",
+            "id",
+            "kind",
+            "type"
+          ],
+          "item_kind": "started",
+          "item_type": "subAgentActivity",
+          "method": "item/completed",
+          "params_field_types": {
+            "completedAtMs": "number",
+            "item": "object",
+            "threadId": "string",
+            "turnId": "string"
+          },
+          "params_fields": [
+            "completedAtMs",
+            "item",
+            "threadId",
+            "turnId"
+          ]
+        },
+        {
+          "item_field_types": {
+            "agentsStates": "object",
+            "id": "string",
+            "model": "null",
+            "prompt": "null",
+            "reasoningEffort": "null",
+            "receiverThreadIds": "array",
+            "senderThreadId": "string",
+            "status": "string",
+            "tool": "string",
+            "type": "string"
+          },
+          "item_fields": [
+            "agentsStates",
+            "id",
+            "model",
+            "prompt",
+            "reasoningEffort",
+            "receiverThreadIds",
+            "senderThreadId",
+            "status",
+            "tool",
+            "type"
+          ],
+          "item_status": "inProgress",
+          "item_tool": "wait",
+          "item_type": "collabAgentToolCall",
+          "method": "item/started",
+          "params_field_types": {
+            "item": "object",
+            "startedAtMs": "number",
+            "threadId": "string",
+            "turnId": "string"
+          },
+          "params_fields": [
+            "item",
+            "startedAtMs",
+            "threadId",
+            "turnId"
+          ]
+        },
+        {
+          "item_field_types": {
+            "id": "string",
+            "memoryCitation": "null",
+            "phase": "null",
+            "text": "string",
+            "type": "string"
+          },
+          "item_fields": [
+            "id",
+            "memoryCitation",
+            "phase",
+            "text",
+            "type"
+          ],
+          "item_type": "agentMessage",
+          "method": "item/started",
+          "params_field_types": {
+            "item": "object",
+            "startedAtMs": "number",
+            "threadId": "string",
+            "turnId": "string"
+          },
+          "params_fields": [
+            "item",
+            "startedAtMs",
+            "threadId",
+            "turnId"
+          ]
+        },
+        {
+          "method": "item/agentMessage/delta",
+          "params_field_types": {
+            "delta": "string",
+            "itemId": "string",
+            "threadId": "string",
+            "turnId": "string"
+          },
+          "params_fields": [
+            "delta",
+            "itemId",
+            "threadId",
+            "turnId"
+          ]
+        },
+        {
+          "item_field_types": {
+            "id": "string",
+            "memoryCitation": "null",
+            "phase": "null",
+            "text": "string",
+            "type": "string"
+          },
+          "item_fields": [
+            "id",
+            "memoryCitation",
+            "phase",
+            "text",
+            "type"
+          ],
+          "item_type": "agentMessage",
+          "method": "item/completed",
+          "params_field_types": {
+            "completedAtMs": "number",
+            "item": "object",
+            "threadId": "string",
+            "turnId": "string"
+          },
+          "params_fields": [
+            "completedAtMs",
+            "item",
+            "threadId",
+            "turnId"
+          ]
+        },
+        {
+          "item_field_types": {
+            "agentsStates": "object",
+            "id": "string",
+            "model": "null",
+            "prompt": "null",
+            "reasoningEffort": "null",
+            "receiverThreadIds": "array",
+            "senderThreadId": "string",
+            "status": "string",
+            "tool": "string",
+            "type": "string"
+          },
+          "item_fields": [
+            "agentsStates",
+            "id",
+            "model",
+            "prompt",
+            "reasoningEffort",
+            "receiverThreadIds",
+            "senderThreadId",
+            "status",
+            "tool",
+            "type"
+          ],
+          "item_status": "completed",
+          "item_tool": "wait",
+          "item_type": "collabAgentToolCall",
+          "method": "item/completed",
+          "params_field_types": {
+            "completedAtMs": "number",
+            "item": "object",
+            "threadId": "string",
+            "turnId": "string"
+          },
+          "params_fields": [
+            "completedAtMs",
+            "item",
+            "threadId",
+            "turnId"
+          ]
+        },
+        {
+          "item_field_types": {
+            "id": "string",
+            "memoryCitation": "null",
+            "phase": "null",
+            "text": "string",
+            "type": "string"
+          },
+          "item_fields": [
+            "id",
+            "memoryCitation",
+            "phase",
+            "text",
+            "type"
+          ],
+          "item_type": "agentMessage",
+          "method": "item/started",
+          "params_field_types": {
+            "item": "object",
+            "startedAtMs": "number",
+            "threadId": "string",
+            "turnId": "string"
+          },
+          "params_fields": [
+            "item",
+            "startedAtMs",
+            "threadId",
+            "turnId"
+          ]
+        },
+        {
+          "method": "item/agentMessage/delta",
+          "params_field_types": {
+            "delta": "string",
+            "itemId": "string",
+            "threadId": "string",
+            "turnId": "string"
+          },
+          "params_fields": [
+            "delta",
+            "itemId",
+            "threadId",
+            "turnId"
+          ]
+        },
+        {
+          "item_field_types": {
+            "id": "string",
+            "memoryCitation": "null",
+            "phase": "null",
+            "text": "string",
+            "type": "string"
+          },
+          "item_fields": [
+            "id",
+            "memoryCitation",
+            "phase",
+            "text",
+            "type"
+          ],
+          "item_type": "agentMessage",
+          "method": "item/completed",
+          "params_field_types": {
+            "completedAtMs": "number",
+            "item": "object",
+            "threadId": "string",
+            "turnId": "string"
+          },
+          "params_fields": [
+            "completedAtMs",
+            "item",
+            "threadId",
+            "turnId"
+          ]
+        }
+      ],
       "same_home_thread_resume_and_read": "observed",
       "thread_items": {
         "agentMessage": [
@@ -91,6 +396,185 @@
           "kind",
           "agentThreadId",
           "agentPath"
+        ]
+      },
+      "thread_read_envelope": {
+        "field_types": {
+          "agentNickname": "null",
+          "agentRole": "null",
+          "canAcceptDirectInput": "boolean",
+          "cliVersion": "string",
+          "createdAt": "number",
+          "cwd": "string",
+          "ephemeral": "boolean",
+          "extra": "null",
+          "forkedFromId": "null",
+          "gitInfo": "object",
+          "historyMode": "string",
+          "id": "string",
+          "modelProvider": "string",
+          "name": "null",
+          "parentThreadId": "null",
+          "path": "string",
+          "preview": "string",
+          "recencyAt": "number",
+          "section": "null",
+          "sectionEnteredAt": "null",
+          "sessionId": "string",
+          "source": "string",
+          "status": "object",
+          "threadSource": "null",
+          "turns": "array",
+          "updatedAt": "number"
+        },
+        "fields": [
+          "agentNickname",
+          "agentRole",
+          "canAcceptDirectInput",
+          "cliVersion",
+          "createdAt",
+          "cwd",
+          "ephemeral",
+          "extra",
+          "forkedFromId",
+          "gitInfo",
+          "historyMode",
+          "id",
+          "modelProvider",
+          "name",
+          "parentThreadId",
+          "path",
+          "preview",
+          "recencyAt",
+          "section",
+          "sectionEnteredAt",
+          "sessionId",
+          "source",
+          "status",
+          "threadSource",
+          "turns",
+          "updatedAt"
+        ],
+        "status_field_types": {
+          "type": "string"
+        },
+        "status_fields": [
+          "type"
+        ],
+        "turns": [
+          {
+            "field_types": {
+              "completedAt": "number",
+              "durationMs": "number",
+              "error": "null",
+              "id": "string",
+              "items": "array",
+              "itemsView": "string",
+              "startedAt": "number",
+              "status": "string"
+            },
+            "fields": [
+              "completedAt",
+              "durationMs",
+              "error",
+              "id",
+              "items",
+              "itemsView",
+              "startedAt",
+              "status"
+            ],
+            "items": [
+              {
+                "field_types": {
+                  "clientId": "null",
+                  "content": "array",
+                  "id": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "clientId",
+                  "content",
+                  "id",
+                  "type"
+                ],
+                "type": "userMessage"
+              },
+              {
+                "field_types": {
+                  "agentPath": "string",
+                  "agentThreadId": "string",
+                  "id": "string",
+                  "kind": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "agentPath",
+                  "agentThreadId",
+                  "id",
+                  "kind",
+                  "type"
+                ],
+                "kind": "started",
+                "type": "subAgentActivity"
+              },
+              {
+                "field_types": {
+                  "id": "string",
+                  "memoryCitation": "null",
+                  "phase": "null",
+                  "text": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "id",
+                  "memoryCitation",
+                  "phase",
+                  "text",
+                  "type"
+                ],
+                "type": "agentMessage"
+              }
+            ],
+            "status": "completed"
+          }
+        ]
+      },
+      "thread_resume_result": {
+        "field_types": {
+          "activePermissionProfile": "object",
+          "approvalPolicy": "string",
+          "approvalsReviewer": "string",
+          "cwd": "string",
+          "initialTurnsPage": "null",
+          "instructionSources": "array",
+          "itemsBackwardsCursor": "null",
+          "model": "string",
+          "modelProvider": "string",
+          "multiAgentMode": "string",
+          "reasoningEffort": "string",
+          "runtimeWorkspaceRoots": "array",
+          "sandbox": "object",
+          "serviceTier": "null",
+          "thread": "object",
+          "turnsBackwardsCursor": "null"
+        },
+        "fields": [
+          "activePermissionProfile",
+          "approvalPolicy",
+          "approvalsReviewer",
+          "cwd",
+          "initialTurnsPage",
+          "instructionSources",
+          "itemsBackwardsCursor",
+          "model",
+          "modelProvider",
+          "multiAgentMode",
+          "reasoningEffort",
+          "runtimeWorkspaceRoots",
+          "sandbox",
+          "serviceTier",
+          "thread",
+          "turnsBackwardsCursor"
         ]
       },
       "turn_terminal_notification": "turn/completed",
@@ -860,6 +1344,14 @@
       "binary_sha256": "ae9d865f3d346a1a2a60c4e84775622d74e3e7ef53e0dede9c68b81eab306cca",
       "client": "codex_cli",
       "client_version": "0.146.1",
+      "isolated_home_bindings_sha256": [
+        "b7da348dba582272740fa1392545e7b468a5fbe50f08d257de451631fc8490a8",
+        "1d36f56fcb0744f35ade8cdc621e9588f24c55ad5efcf556c69f12ff1a9f8b28"
+      ],
+      "observation_scenarios": [
+        "cli_v1_request",
+        "cli_v2_lifecycle"
+      ],
       "observations": {
         "desktop_thread_items_and_notifications": "not_applicable",
         "tool_choice_auto": "observed",
@@ -940,6 +1432,16 @@
       "binary_sha256": "fb5c760e14cf8fe86e12e49e8a3e7f237af06082d6b9fe1e411e463b7229c916",
       "client": "codex_desktop",
       "client_version": "26.803.5235.0",
+      "isolated_home_bindings_sha256": [
+        "c99dd6202b2a2fddc017c522c869e619b72803c8ec1393209ab3bb8c66528007",
+        "9ff014546ee3d0495ea5d21413bd8cc5e7ecf23f1e09bf0023e2b218526b7e04",
+        "8da0a0440f5dba6de038e2343dcf0a90aad1e9df7107f5f734031243fd50d551"
+      ],
+      "observation_scenarios": [
+        "desktop_v1_request",
+        "desktop_v2_lifecycle",
+        "desktop_app_v2_lifecycle"
+      ],
       "observations": {
         "desktop_thread_items_and_notifications": "observed",
         "tool_choice_auto": "observed",
@@ -1741,6 +2243,12 @@
     "unexpected_multi_agent_version_field": "fail_closed",
     "unknown_missing_duplicate_conflicting_or_mixed": "fail_closed"
   },
+  "source_observations": {
+    "canonical_sha256": "1d689f4521ae654b910eec849bc4cb7f6abafa116ecbfb730250f10c1d64e9b6",
+    "capture_run_binding_sha256": "beb7668c5330c396e38457446d7985ae0c126a7a690d964b682744a6609c52c1",
+    "path": "docs/evidence/issue-392/collaboration-runtime-observations.json",
+    "schema": "codexhub.issue392.collaboration-runtime-observations.v1"
+  },
   "wire_lifecycle": {
     "function_call_stream": {
       "assembly_rule": "ordered_delta_assembly_must_equal_done_arguments",
@@ -1808,15 +2316,2284 @@
       "function_call_output",
       "agent_message"
     ],
+    "request_replay_envelopes": {
+      "codex_cli": {
+        "child_initial": {
+          "collaboration_items": [
+            {
+              "content_variants": [
+                {
+                  "field_types": {
+                    "text": "string",
+                    "type": "string"
+                  },
+                  "fields": [
+                    "text",
+                    "type"
+                  ],
+                  "type": "input_text"
+                },
+                {
+                  "field_types": {
+                    "encrypted_content": "string",
+                    "type": "string"
+                  },
+                  "fields": [
+                    "encrypted_content",
+                    "type"
+                  ],
+                  "type": "encrypted_content"
+                }
+              ],
+              "field_types": {
+                "author": "string",
+                "content": "array",
+                "id": "string",
+                "recipient": "string",
+                "type": "string"
+              },
+              "fields": [
+                "author",
+                "content",
+                "id",
+                "recipient",
+                "type"
+              ],
+              "type": "agent_message"
+            }
+          ],
+          "field_types": {
+            "client_metadata": "object",
+            "include": "array",
+            "input": "array",
+            "instructions": "string",
+            "model": "string",
+            "parallel_tool_calls": "boolean",
+            "prompt_cache_key": "string",
+            "reasoning": "object",
+            "store": "boolean",
+            "stream": "boolean",
+            "tool_choice": "string",
+            "tools": "array"
+          },
+          "fields": [
+            "client_metadata",
+            "include",
+            "input",
+            "instructions",
+            "model",
+            "parallel_tool_calls",
+            "prompt_cache_key",
+            "reasoning",
+            "store",
+            "stream",
+            "tool_choice",
+            "tools"
+          ],
+          "input_type_order": [
+            "message",
+            "message",
+            "message",
+            "message",
+            "message",
+            "agent_message"
+          ],
+          "multi_agent_version_locations": [],
+          "tool_choice": "auto"
+        },
+        "restart_replay": {
+          "collaboration_items": [
+            {
+              "argument_keys": [
+                "message",
+                "task_name"
+              ],
+              "arguments_json_type": "object",
+              "field_types": {
+                "arguments": "string",
+                "call_id": "string",
+                "id": "string",
+                "name": "string",
+                "namespace": "string",
+                "type": "string"
+              },
+              "fields": [
+                "arguments",
+                "call_id",
+                "id",
+                "name",
+                "namespace",
+                "type"
+              ],
+              "name": "spawn_agent",
+              "namespace": "collaboration",
+              "type": "function_call"
+            },
+            {
+              "decoded_output_keys": [
+                "task_name"
+              ],
+              "decoded_output_type": "object",
+              "field_types": {
+                "call_id": "string",
+                "id": "string",
+                "output": "string",
+                "type": "string"
+              },
+              "fields": [
+                "call_id",
+                "id",
+                "output",
+                "type"
+              ],
+              "output_wire_type": "string",
+              "type": "function_call_output"
+            },
+            {
+              "argument_keys": [
+                "timeout_ms"
+              ],
+              "arguments_json_type": "object",
+              "field_types": {
+                "arguments": "string",
+                "call_id": "string",
+                "id": "string",
+                "name": "string",
+                "namespace": "string",
+                "type": "string"
+              },
+              "fields": [
+                "arguments",
+                "call_id",
+                "id",
+                "name",
+                "namespace",
+                "type"
+              ],
+              "name": "wait_agent",
+              "namespace": "collaboration",
+              "type": "function_call"
+            },
+            {
+              "decoded_output_keys": [
+                "message",
+                "timed_out"
+              ],
+              "decoded_output_type": "object",
+              "field_types": {
+                "call_id": "string",
+                "id": "string",
+                "output": "string",
+                "type": "string"
+              },
+              "fields": [
+                "call_id",
+                "id",
+                "output",
+                "type"
+              ],
+              "output_wire_type": "string",
+              "type": "function_call_output"
+            },
+            {
+              "content_variants": [
+                {
+                  "field_types": {
+                    "text": "string",
+                    "type": "string"
+                  },
+                  "fields": [
+                    "text",
+                    "type"
+                  ],
+                  "type": "input_text"
+                }
+              ],
+              "field_types": {
+                "author": "string",
+                "content": "array",
+                "id": "string",
+                "recipient": "string",
+                "type": "string"
+              },
+              "fields": [
+                "author",
+                "content",
+                "id",
+                "recipient",
+                "type"
+              ],
+              "type": "agent_message"
+            }
+          ],
+          "field_types": {
+            "client_metadata": "object",
+            "include": "array",
+            "input": "array",
+            "instructions": "string",
+            "model": "string",
+            "parallel_tool_calls": "boolean",
+            "prompt_cache_key": "string",
+            "reasoning": "object",
+            "store": "boolean",
+            "stream": "boolean",
+            "tool_choice": "string",
+            "tools": "array"
+          },
+          "fields": [
+            "client_metadata",
+            "include",
+            "input",
+            "instructions",
+            "model",
+            "parallel_tool_calls",
+            "prompt_cache_key",
+            "reasoning",
+            "store",
+            "stream",
+            "tool_choice",
+            "tools"
+          ],
+          "input_type_order": [
+            "message",
+            "message",
+            "message",
+            "message",
+            "message",
+            "function_call",
+            "function_call_output",
+            "function_call",
+            "function_call_output",
+            "agent_message",
+            "message",
+            "message"
+          ],
+          "multi_agent_version_locations": [],
+          "tool_choice": "auto"
+        },
+        "root_after_spawn": {
+          "collaboration_items": [
+            {
+              "argument_keys": [
+                "message",
+                "task_name"
+              ],
+              "arguments_json_type": "object",
+              "field_types": {
+                "arguments": "string",
+                "call_id": "string",
+                "id": "string",
+                "name": "string",
+                "namespace": "string",
+                "type": "string"
+              },
+              "fields": [
+                "arguments",
+                "call_id",
+                "id",
+                "name",
+                "namespace",
+                "type"
+              ],
+              "name": "spawn_agent",
+              "namespace": "collaboration",
+              "type": "function_call"
+            },
+            {
+              "decoded_output_keys": [
+                "task_name"
+              ],
+              "decoded_output_type": "object",
+              "field_types": {
+                "call_id": "string",
+                "id": "string",
+                "output": "string",
+                "type": "string"
+              },
+              "fields": [
+                "call_id",
+                "id",
+                "output",
+                "type"
+              ],
+              "output_wire_type": "string",
+              "type": "function_call_output"
+            }
+          ],
+          "field_types": {
+            "client_metadata": "object",
+            "include": "array",
+            "input": "array",
+            "instructions": "string",
+            "model": "string",
+            "parallel_tool_calls": "boolean",
+            "prompt_cache_key": "string",
+            "reasoning": "object",
+            "store": "boolean",
+            "stream": "boolean",
+            "tool_choice": "string",
+            "tools": "array"
+          },
+          "fields": [
+            "client_metadata",
+            "include",
+            "input",
+            "instructions",
+            "model",
+            "parallel_tool_calls",
+            "prompt_cache_key",
+            "reasoning",
+            "store",
+            "stream",
+            "tool_choice",
+            "tools"
+          ],
+          "input_type_order": [
+            "message",
+            "message",
+            "message",
+            "message",
+            "message",
+            "function_call",
+            "function_call_output"
+          ],
+          "multi_agent_version_locations": [],
+          "tool_choice": "auto"
+        },
+        "root_after_wait": {
+          "collaboration_items": [
+            {
+              "argument_keys": [
+                "message",
+                "task_name"
+              ],
+              "arguments_json_type": "object",
+              "field_types": {
+                "arguments": "string",
+                "call_id": "string",
+                "id": "string",
+                "name": "string",
+                "namespace": "string",
+                "type": "string"
+              },
+              "fields": [
+                "arguments",
+                "call_id",
+                "id",
+                "name",
+                "namespace",
+                "type"
+              ],
+              "name": "spawn_agent",
+              "namespace": "collaboration",
+              "type": "function_call"
+            },
+            {
+              "decoded_output_keys": [
+                "task_name"
+              ],
+              "decoded_output_type": "object",
+              "field_types": {
+                "call_id": "string",
+                "id": "string",
+                "output": "string",
+                "type": "string"
+              },
+              "fields": [
+                "call_id",
+                "id",
+                "output",
+                "type"
+              ],
+              "output_wire_type": "string",
+              "type": "function_call_output"
+            },
+            {
+              "argument_keys": [
+                "timeout_ms"
+              ],
+              "arguments_json_type": "object",
+              "field_types": {
+                "arguments": "string",
+                "call_id": "string",
+                "id": "string",
+                "name": "string",
+                "namespace": "string",
+                "type": "string"
+              },
+              "fields": [
+                "arguments",
+                "call_id",
+                "id",
+                "name",
+                "namespace",
+                "type"
+              ],
+              "name": "wait_agent",
+              "namespace": "collaboration",
+              "type": "function_call"
+            },
+            {
+              "decoded_output_keys": [
+                "message",
+                "timed_out"
+              ],
+              "decoded_output_type": "object",
+              "field_types": {
+                "call_id": "string",
+                "id": "string",
+                "output": "string",
+                "type": "string"
+              },
+              "fields": [
+                "call_id",
+                "id",
+                "output",
+                "type"
+              ],
+              "output_wire_type": "string",
+              "type": "function_call_output"
+            },
+            {
+              "content_variants": [
+                {
+                  "field_types": {
+                    "text": "string",
+                    "type": "string"
+                  },
+                  "fields": [
+                    "text",
+                    "type"
+                  ],
+                  "type": "input_text"
+                }
+              ],
+              "field_types": {
+                "author": "string",
+                "content": "array",
+                "id": "string",
+                "recipient": "string",
+                "type": "string"
+              },
+              "fields": [
+                "author",
+                "content",
+                "id",
+                "recipient",
+                "type"
+              ],
+              "type": "agent_message"
+            }
+          ],
+          "field_types": {
+            "client_metadata": "object",
+            "include": "array",
+            "input": "array",
+            "instructions": "string",
+            "model": "string",
+            "parallel_tool_calls": "boolean",
+            "prompt_cache_key": "string",
+            "reasoning": "object",
+            "store": "boolean",
+            "stream": "boolean",
+            "tool_choice": "string",
+            "tools": "array"
+          },
+          "fields": [
+            "client_metadata",
+            "include",
+            "input",
+            "instructions",
+            "model",
+            "parallel_tool_calls",
+            "prompt_cache_key",
+            "reasoning",
+            "store",
+            "stream",
+            "tool_choice",
+            "tools"
+          ],
+          "input_type_order": [
+            "message",
+            "message",
+            "message",
+            "message",
+            "message",
+            "function_call",
+            "function_call_output",
+            "function_call",
+            "function_call_output",
+            "agent_message"
+          ],
+          "multi_agent_version_locations": [],
+          "tool_choice": "auto"
+        },
+        "root_initial": {
+          "collaboration_items": [],
+          "field_types": {
+            "client_metadata": "object",
+            "include": "array",
+            "input": "array",
+            "instructions": "string",
+            "model": "string",
+            "parallel_tool_calls": "boolean",
+            "prompt_cache_key": "string",
+            "reasoning": "object",
+            "store": "boolean",
+            "stream": "boolean",
+            "tool_choice": "string",
+            "tools": "array"
+          },
+          "fields": [
+            "client_metadata",
+            "include",
+            "input",
+            "instructions",
+            "model",
+            "parallel_tool_calls",
+            "prompt_cache_key",
+            "reasoning",
+            "store",
+            "stream",
+            "tool_choice",
+            "tools"
+          ],
+          "input_type_order": [
+            "message",
+            "message",
+            "message",
+            "message",
+            "message"
+          ],
+          "multi_agent_version_locations": [],
+          "tool_choice": "auto"
+        }
+      },
+      "codex_desktop": {
+        "child_initial": {
+          "collaboration_items": [
+            {
+              "content_variants": [
+                {
+                  "field_types": {
+                    "text": "string",
+                    "type": "string"
+                  },
+                  "fields": [
+                    "text",
+                    "type"
+                  ],
+                  "type": "input_text"
+                },
+                {
+                  "field_types": {
+                    "encrypted_content": "string",
+                    "type": "string"
+                  },
+                  "fields": [
+                    "encrypted_content",
+                    "type"
+                  ],
+                  "type": "encrypted_content"
+                }
+              ],
+              "field_types": {
+                "author": "string",
+                "content": "array",
+                "id": "string",
+                "recipient": "string",
+                "type": "string"
+              },
+              "fields": [
+                "author",
+                "content",
+                "id",
+                "recipient",
+                "type"
+              ],
+              "type": "agent_message"
+            }
+          ],
+          "field_types": {
+            "client_metadata": "object",
+            "include": "array",
+            "input": "array",
+            "instructions": "string",
+            "model": "string",
+            "parallel_tool_calls": "boolean",
+            "prompt_cache_key": "string",
+            "reasoning": "object",
+            "store": "boolean",
+            "stream": "boolean",
+            "tool_choice": "string",
+            "tools": "array"
+          },
+          "fields": [
+            "client_metadata",
+            "include",
+            "input",
+            "instructions",
+            "model",
+            "parallel_tool_calls",
+            "prompt_cache_key",
+            "reasoning",
+            "store",
+            "stream",
+            "tool_choice",
+            "tools"
+          ],
+          "input_type_order": [
+            "message",
+            "message",
+            "message",
+            "message",
+            "message",
+            "agent_message"
+          ],
+          "multi_agent_version_locations": [],
+          "tool_choice": "auto"
+        },
+        "restart_replay": {
+          "collaboration_items": [
+            {
+              "argument_keys": [
+                "message",
+                "task_name"
+              ],
+              "arguments_json_type": "object",
+              "field_types": {
+                "arguments": "string",
+                "call_id": "string",
+                "id": "string",
+                "name": "string",
+                "namespace": "string",
+                "type": "string"
+              },
+              "fields": [
+                "arguments",
+                "call_id",
+                "id",
+                "name",
+                "namespace",
+                "type"
+              ],
+              "name": "spawn_agent",
+              "namespace": "collaboration",
+              "type": "function_call"
+            },
+            {
+              "decoded_output_keys": [
+                "task_name"
+              ],
+              "decoded_output_type": "object",
+              "field_types": {
+                "call_id": "string",
+                "id": "string",
+                "output": "string",
+                "type": "string"
+              },
+              "fields": [
+                "call_id",
+                "id",
+                "output",
+                "type"
+              ],
+              "output_wire_type": "string",
+              "type": "function_call_output"
+            },
+            {
+              "argument_keys": [
+                "timeout_ms"
+              ],
+              "arguments_json_type": "object",
+              "field_types": {
+                "arguments": "string",
+                "call_id": "string",
+                "id": "string",
+                "name": "string",
+                "namespace": "string",
+                "type": "string"
+              },
+              "fields": [
+                "arguments",
+                "call_id",
+                "id",
+                "name",
+                "namespace",
+                "type"
+              ],
+              "name": "wait_agent",
+              "namespace": "collaboration",
+              "type": "function_call"
+            },
+            {
+              "decoded_output_keys": [
+                "message",
+                "timed_out"
+              ],
+              "decoded_output_type": "object",
+              "field_types": {
+                "call_id": "string",
+                "id": "string",
+                "output": "string",
+                "type": "string"
+              },
+              "fields": [
+                "call_id",
+                "id",
+                "output",
+                "type"
+              ],
+              "output_wire_type": "string",
+              "type": "function_call_output"
+            },
+            {
+              "content_variants": [
+                {
+                  "field_types": {
+                    "text": "string",
+                    "type": "string"
+                  },
+                  "fields": [
+                    "text",
+                    "type"
+                  ],
+                  "type": "input_text"
+                }
+              ],
+              "field_types": {
+                "author": "string",
+                "content": "array",
+                "id": "string",
+                "recipient": "string",
+                "type": "string"
+              },
+              "fields": [
+                "author",
+                "content",
+                "id",
+                "recipient",
+                "type"
+              ],
+              "type": "agent_message"
+            }
+          ],
+          "field_types": {
+            "client_metadata": "object",
+            "include": "array",
+            "input": "array",
+            "instructions": "string",
+            "model": "string",
+            "parallel_tool_calls": "boolean",
+            "prompt_cache_key": "string",
+            "reasoning": "object",
+            "store": "boolean",
+            "stream": "boolean",
+            "tool_choice": "string",
+            "tools": "array"
+          },
+          "fields": [
+            "client_metadata",
+            "include",
+            "input",
+            "instructions",
+            "model",
+            "parallel_tool_calls",
+            "prompt_cache_key",
+            "reasoning",
+            "store",
+            "stream",
+            "tool_choice",
+            "tools"
+          ],
+          "input_type_order": [
+            "message",
+            "message",
+            "message",
+            "message",
+            "message",
+            "function_call",
+            "function_call_output",
+            "function_call",
+            "function_call_output",
+            "agent_message",
+            "message",
+            "message"
+          ],
+          "multi_agent_version_locations": [],
+          "tool_choice": "auto"
+        },
+        "root_after_spawn": {
+          "collaboration_items": [
+            {
+              "argument_keys": [
+                "message",
+                "task_name"
+              ],
+              "arguments_json_type": "object",
+              "field_types": {
+                "arguments": "string",
+                "call_id": "string",
+                "id": "string",
+                "name": "string",
+                "namespace": "string",
+                "type": "string"
+              },
+              "fields": [
+                "arguments",
+                "call_id",
+                "id",
+                "name",
+                "namespace",
+                "type"
+              ],
+              "name": "spawn_agent",
+              "namespace": "collaboration",
+              "type": "function_call"
+            },
+            {
+              "decoded_output_keys": [
+                "task_name"
+              ],
+              "decoded_output_type": "object",
+              "field_types": {
+                "call_id": "string",
+                "id": "string",
+                "output": "string",
+                "type": "string"
+              },
+              "fields": [
+                "call_id",
+                "id",
+                "output",
+                "type"
+              ],
+              "output_wire_type": "string",
+              "type": "function_call_output"
+            }
+          ],
+          "field_types": {
+            "client_metadata": "object",
+            "include": "array",
+            "input": "array",
+            "instructions": "string",
+            "model": "string",
+            "parallel_tool_calls": "boolean",
+            "prompt_cache_key": "string",
+            "reasoning": "object",
+            "store": "boolean",
+            "stream": "boolean",
+            "tool_choice": "string",
+            "tools": "array"
+          },
+          "fields": [
+            "client_metadata",
+            "include",
+            "input",
+            "instructions",
+            "model",
+            "parallel_tool_calls",
+            "prompt_cache_key",
+            "reasoning",
+            "store",
+            "stream",
+            "tool_choice",
+            "tools"
+          ],
+          "input_type_order": [
+            "message",
+            "message",
+            "message",
+            "message",
+            "message",
+            "function_call",
+            "function_call_output"
+          ],
+          "multi_agent_version_locations": [],
+          "tool_choice": "auto"
+        },
+        "root_after_wait": {
+          "collaboration_items": [
+            {
+              "argument_keys": [
+                "message",
+                "task_name"
+              ],
+              "arguments_json_type": "object",
+              "field_types": {
+                "arguments": "string",
+                "call_id": "string",
+                "id": "string",
+                "name": "string",
+                "namespace": "string",
+                "type": "string"
+              },
+              "fields": [
+                "arguments",
+                "call_id",
+                "id",
+                "name",
+                "namespace",
+                "type"
+              ],
+              "name": "spawn_agent",
+              "namespace": "collaboration",
+              "type": "function_call"
+            },
+            {
+              "decoded_output_keys": [
+                "task_name"
+              ],
+              "decoded_output_type": "object",
+              "field_types": {
+                "call_id": "string",
+                "id": "string",
+                "output": "string",
+                "type": "string"
+              },
+              "fields": [
+                "call_id",
+                "id",
+                "output",
+                "type"
+              ],
+              "output_wire_type": "string",
+              "type": "function_call_output"
+            },
+            {
+              "argument_keys": [
+                "timeout_ms"
+              ],
+              "arguments_json_type": "object",
+              "field_types": {
+                "arguments": "string",
+                "call_id": "string",
+                "id": "string",
+                "name": "string",
+                "namespace": "string",
+                "type": "string"
+              },
+              "fields": [
+                "arguments",
+                "call_id",
+                "id",
+                "name",
+                "namespace",
+                "type"
+              ],
+              "name": "wait_agent",
+              "namespace": "collaboration",
+              "type": "function_call"
+            },
+            {
+              "decoded_output_keys": [
+                "message",
+                "timed_out"
+              ],
+              "decoded_output_type": "object",
+              "field_types": {
+                "call_id": "string",
+                "id": "string",
+                "output": "string",
+                "type": "string"
+              },
+              "fields": [
+                "call_id",
+                "id",
+                "output",
+                "type"
+              ],
+              "output_wire_type": "string",
+              "type": "function_call_output"
+            },
+            {
+              "content_variants": [
+                {
+                  "field_types": {
+                    "text": "string",
+                    "type": "string"
+                  },
+                  "fields": [
+                    "text",
+                    "type"
+                  ],
+                  "type": "input_text"
+                }
+              ],
+              "field_types": {
+                "author": "string",
+                "content": "array",
+                "id": "string",
+                "recipient": "string",
+                "type": "string"
+              },
+              "fields": [
+                "author",
+                "content",
+                "id",
+                "recipient",
+                "type"
+              ],
+              "type": "agent_message"
+            }
+          ],
+          "field_types": {
+            "client_metadata": "object",
+            "include": "array",
+            "input": "array",
+            "instructions": "string",
+            "model": "string",
+            "parallel_tool_calls": "boolean",
+            "prompt_cache_key": "string",
+            "reasoning": "object",
+            "store": "boolean",
+            "stream": "boolean",
+            "tool_choice": "string",
+            "tools": "array"
+          },
+          "fields": [
+            "client_metadata",
+            "include",
+            "input",
+            "instructions",
+            "model",
+            "parallel_tool_calls",
+            "prompt_cache_key",
+            "reasoning",
+            "store",
+            "stream",
+            "tool_choice",
+            "tools"
+          ],
+          "input_type_order": [
+            "message",
+            "message",
+            "message",
+            "message",
+            "message",
+            "function_call",
+            "function_call_output",
+            "function_call",
+            "function_call_output",
+            "agent_message"
+          ],
+          "multi_agent_version_locations": [],
+          "tool_choice": "auto"
+        },
+        "root_initial": {
+          "collaboration_items": [],
+          "field_types": {
+            "client_metadata": "object",
+            "include": "array",
+            "input": "array",
+            "instructions": "string",
+            "model": "string",
+            "parallel_tool_calls": "boolean",
+            "prompt_cache_key": "string",
+            "reasoning": "object",
+            "store": "boolean",
+            "stream": "boolean",
+            "tool_choice": "string",
+            "tools": "array"
+          },
+          "fields": [
+            "client_metadata",
+            "include",
+            "input",
+            "instructions",
+            "model",
+            "parallel_tool_calls",
+            "prompt_cache_key",
+            "reasoning",
+            "store",
+            "stream",
+            "tool_choice",
+            "tools"
+          ],
+          "input_type_order": [
+            "message",
+            "message",
+            "message",
+            "message",
+            "message"
+          ],
+          "multi_agent_version_locations": [],
+          "tool_choice": "auto"
+        }
+      }
+    },
+    "rollout_readback_envelopes": {
+      "codex_cli": [
+        {
+          "collaboration_items": [
+            {
+              "argument_keys": [
+                "message",
+                "task_name"
+              ],
+              "arguments_json_type": "object",
+              "field_types": {
+                "arguments": "string",
+                "call_id": "string",
+                "id": "string",
+                "internal_chat_message_metadata_passthrough": "object",
+                "name": "string",
+                "namespace": "string",
+                "type": "string"
+              },
+              "fields": [
+                "arguments",
+                "call_id",
+                "id",
+                "internal_chat_message_metadata_passthrough",
+                "name",
+                "namespace",
+                "type"
+              ],
+              "name": "spawn_agent",
+              "namespace": "collaboration",
+              "type": "function_call"
+            },
+            {
+              "decoded_output_keys": [
+                "task_name"
+              ],
+              "decoded_output_type": "object",
+              "field_types": {
+                "call_id": "string",
+                "id": "string",
+                "internal_chat_message_metadata_passthrough": "object",
+                "output": "string",
+                "type": "string"
+              },
+              "fields": [
+                "call_id",
+                "id",
+                "internal_chat_message_metadata_passthrough",
+                "output",
+                "type"
+              ],
+              "output_wire_type": "string",
+              "type": "function_call_output"
+            },
+            {
+              "argument_keys": [
+                "timeout_ms"
+              ],
+              "arguments_json_type": "object",
+              "field_types": {
+                "arguments": "string",
+                "call_id": "string",
+                "id": "string",
+                "internal_chat_message_metadata_passthrough": "object",
+                "name": "string",
+                "namespace": "string",
+                "type": "string"
+              },
+              "fields": [
+                "arguments",
+                "call_id",
+                "id",
+                "internal_chat_message_metadata_passthrough",
+                "name",
+                "namespace",
+                "type"
+              ],
+              "name": "wait_agent",
+              "namespace": "collaboration",
+              "type": "function_call"
+            },
+            {
+              "decoded_output_keys": [
+                "message",
+                "timed_out"
+              ],
+              "decoded_output_type": "object",
+              "field_types": {
+                "call_id": "string",
+                "id": "string",
+                "internal_chat_message_metadata_passthrough": "object",
+                "output": "string",
+                "type": "string"
+              },
+              "fields": [
+                "call_id",
+                "id",
+                "internal_chat_message_metadata_passthrough",
+                "output",
+                "type"
+              ],
+              "output_wire_type": "string",
+              "type": "function_call_output"
+            },
+            {
+              "content_variants": [
+                {
+                  "field_types": {
+                    "text": "string",
+                    "type": "string"
+                  },
+                  "fields": [
+                    "text",
+                    "type"
+                  ],
+                  "type": "input_text"
+                }
+              ],
+              "field_types": {
+                "author": "string",
+                "content": "array",
+                "id": "string",
+                "internal_chat_message_metadata_passthrough": "object",
+                "recipient": "string",
+                "type": "string"
+              },
+              "fields": [
+                "author",
+                "content",
+                "id",
+                "internal_chat_message_metadata_passthrough",
+                "recipient",
+                "type"
+              ],
+              "type": "agent_message"
+            }
+          ],
+          "metadata_records": [
+            {
+              "multi_agent_version": "v2",
+              "payload_field_types": {
+                "base_instructions": "object",
+                "cli_version": "string",
+                "context_window": "object",
+                "cwd": "string",
+                "git": "object",
+                "history_mode": "string",
+                "id": "string",
+                "model_provider": "string",
+                "multi_agent_version": "string",
+                "originator": "string",
+                "session_id": "string",
+                "source": "string",
+                "thread_source": "string",
+                "timestamp": "string"
+              },
+              "payload_fields": [
+                "base_instructions",
+                "cli_version",
+                "context_window",
+                "cwd",
+                "git",
+                "history_mode",
+                "id",
+                "model_provider",
+                "multi_agent_version",
+                "originator",
+                "session_id",
+                "source",
+                "thread_source",
+                "timestamp"
+              ],
+              "record_field_types": {
+                "payload": "object",
+                "timestamp": "string",
+                "type": "string"
+              },
+              "record_fields": [
+                "payload",
+                "timestamp",
+                "type"
+              ],
+              "record_type": "session_meta"
+            },
+            {
+              "multi_agent_version": "v2",
+              "payload_field_types": {
+                "approval_policy": "string",
+                "approvals_reviewer": "string",
+                "collaboration_mode": "object",
+                "current_date": "string",
+                "cwd": "string",
+                "effort": "string",
+                "model": "string",
+                "multi_agent_version": "string",
+                "permission_profile": "object",
+                "personality": "string",
+                "realtime_active": "boolean",
+                "sandbox_policy": "object",
+                "summary": "string",
+                "timezone": "string",
+                "turn_id": "string",
+                "workspace_roots": "array"
+              },
+              "payload_fields": [
+                "approval_policy",
+                "approvals_reviewer",
+                "collaboration_mode",
+                "current_date",
+                "cwd",
+                "effort",
+                "model",
+                "multi_agent_version",
+                "permission_profile",
+                "personality",
+                "realtime_active",
+                "sandbox_policy",
+                "summary",
+                "timezone",
+                "turn_id",
+                "workspace_roots"
+              ],
+              "record_field_types": {
+                "payload": "object",
+                "timestamp": "string",
+                "type": "string"
+              },
+              "record_fields": [
+                "payload",
+                "timestamp",
+                "type"
+              ],
+              "record_type": "turn_context"
+            },
+            {
+              "multi_agent_version": "v2",
+              "payload_field_types": {
+                "approval_policy": "string",
+                "approvals_reviewer": "string",
+                "collaboration_mode": "object",
+                "current_date": "string",
+                "cwd": "string",
+                "effort": "string",
+                "model": "string",
+                "multi_agent_version": "string",
+                "permission_profile": "object",
+                "personality": "string",
+                "realtime_active": "boolean",
+                "sandbox_policy": "object",
+                "summary": "string",
+                "timezone": "string",
+                "turn_id": "string",
+                "workspace_roots": "array"
+              },
+              "payload_fields": [
+                "approval_policy",
+                "approvals_reviewer",
+                "collaboration_mode",
+                "current_date",
+                "cwd",
+                "effort",
+                "model",
+                "multi_agent_version",
+                "permission_profile",
+                "personality",
+                "realtime_active",
+                "sandbox_policy",
+                "summary",
+                "timezone",
+                "turn_id",
+                "workspace_roots"
+              ],
+              "record_field_types": {
+                "payload": "object",
+                "timestamp": "string",
+                "type": "string"
+              },
+              "record_fields": [
+                "payload",
+                "timestamp",
+                "type"
+              ],
+              "record_type": "turn_context"
+            }
+          ],
+          "relevant_record_type_order": [
+            "session_meta",
+            "response_item",
+            "response_item",
+            "response_item",
+            "response_item",
+            "turn_context",
+            "response_item",
+            "response_item",
+            "response_item",
+            "response_item",
+            "response_item",
+            "response_item",
+            "response_item",
+            "turn_context",
+            "response_item",
+            "response_item"
+          ],
+          "role": "root"
+        },
+        {
+          "collaboration_items": [
+            {
+              "content_variants": [
+                {
+                  "field_types": {
+                    "text": "string",
+                    "type": "string"
+                  },
+                  "fields": [
+                    "text",
+                    "type"
+                  ],
+                  "type": "input_text"
+                },
+                {
+                  "field_types": {
+                    "encrypted_content": "string",
+                    "type": "string"
+                  },
+                  "fields": [
+                    "encrypted_content",
+                    "type"
+                  ],
+                  "type": "encrypted_content"
+                }
+              ],
+              "field_types": {
+                "author": "string",
+                "content": "array",
+                "id": "string",
+                "internal_chat_message_metadata_passthrough": "object",
+                "recipient": "string",
+                "type": "string"
+              },
+              "fields": [
+                "author",
+                "content",
+                "id",
+                "internal_chat_message_metadata_passthrough",
+                "recipient",
+                "type"
+              ],
+              "type": "agent_message"
+            }
+          ],
+          "metadata_records": [
+            {
+              "multi_agent_version": "v2",
+              "payload_field_types": {
+                "agent_nickname": "string",
+                "agent_path": "string",
+                "base_instructions": "object",
+                "cli_version": "string",
+                "context_window": "object",
+                "cwd": "string",
+                "forked_from_id": "string",
+                "git": "object",
+                "history_mode": "string",
+                "id": "string",
+                "model_provider": "string",
+                "multi_agent_version": "string",
+                "originator": "string",
+                "parent_thread_id": "string",
+                "session_id": "string",
+                "source": "object",
+                "thread_source": "string",
+                "timestamp": "string"
+              },
+              "payload_fields": [
+                "agent_nickname",
+                "agent_path",
+                "base_instructions",
+                "cli_version",
+                "context_window",
+                "cwd",
+                "forked_from_id",
+                "git",
+                "history_mode",
+                "id",
+                "model_provider",
+                "multi_agent_version",
+                "originator",
+                "parent_thread_id",
+                "session_id",
+                "source",
+                "thread_source",
+                "timestamp"
+              ],
+              "record_field_types": {
+                "payload": "object",
+                "timestamp": "string",
+                "type": "string"
+              },
+              "record_fields": [
+                "payload",
+                "timestamp",
+                "type"
+              ],
+              "record_type": "session_meta"
+            },
+            {
+              "multi_agent_version": "v2",
+              "payload_field_types": {
+                "base_instructions": "object",
+                "cli_version": "string",
+                "context_window": "object",
+                "cwd": "string",
+                "git": "object",
+                "history_mode": "string",
+                "id": "string",
+                "model_provider": "string",
+                "multi_agent_version": "string",
+                "originator": "string",
+                "session_id": "string",
+                "source": "string",
+                "thread_source": "string",
+                "timestamp": "string"
+              },
+              "payload_fields": [
+                "base_instructions",
+                "cli_version",
+                "context_window",
+                "cwd",
+                "git",
+                "history_mode",
+                "id",
+                "model_provider",
+                "multi_agent_version",
+                "originator",
+                "session_id",
+                "source",
+                "thread_source",
+                "timestamp"
+              ],
+              "record_field_types": {
+                "payload": "object",
+                "timestamp": "string",
+                "type": "string"
+              },
+              "record_fields": [
+                "payload",
+                "timestamp",
+                "type"
+              ],
+              "record_type": "session_meta"
+            },
+            {
+              "multi_agent_version": "v2",
+              "payload_field_types": {
+                "approval_policy": "string",
+                "approvals_reviewer": "string",
+                "collaboration_mode": "object",
+                "current_date": "string",
+                "cwd": "string",
+                "effort": "string",
+                "model": "string",
+                "multi_agent_version": "string",
+                "permission_profile": "object",
+                "personality": "string",
+                "realtime_active": "boolean",
+                "sandbox_policy": "object",
+                "summary": "string",
+                "timezone": "string",
+                "turn_id": "string",
+                "workspace_roots": "array"
+              },
+              "payload_fields": [
+                "approval_policy",
+                "approvals_reviewer",
+                "collaboration_mode",
+                "current_date",
+                "cwd",
+                "effort",
+                "model",
+                "multi_agent_version",
+                "permission_profile",
+                "personality",
+                "realtime_active",
+                "sandbox_policy",
+                "summary",
+                "timezone",
+                "turn_id",
+                "workspace_roots"
+              ],
+              "record_field_types": {
+                "payload": "object",
+                "timestamp": "string",
+                "type": "string"
+              },
+              "record_fields": [
+                "payload",
+                "timestamp",
+                "type"
+              ],
+              "record_type": "turn_context"
+            },
+            {
+              "multi_agent_version": "v2",
+              "payload_field_types": {
+                "approval_policy": "string",
+                "approvals_reviewer": "string",
+                "collaboration_mode": "object",
+                "current_date": "string",
+                "cwd": "string",
+                "effort": "string",
+                "model": "string",
+                "multi_agent_version": "string",
+                "permission_profile": "object",
+                "personality": "string",
+                "realtime_active": "boolean",
+                "sandbox_policy": "object",
+                "summary": "string",
+                "timezone": "string",
+                "turn_id": "string",
+                "workspace_roots": "array"
+              },
+              "payload_fields": [
+                "approval_policy",
+                "approvals_reviewer",
+                "collaboration_mode",
+                "current_date",
+                "cwd",
+                "effort",
+                "model",
+                "multi_agent_version",
+                "permission_profile",
+                "personality",
+                "realtime_active",
+                "sandbox_policy",
+                "summary",
+                "timezone",
+                "turn_id",
+                "workspace_roots"
+              ],
+              "record_field_types": {
+                "payload": "object",
+                "timestamp": "string",
+                "type": "string"
+              },
+              "record_fields": [
+                "payload",
+                "timestamp",
+                "type"
+              ],
+              "record_type": "turn_context"
+            }
+          ],
+          "relevant_record_type_order": [
+            "session_meta",
+            "session_meta",
+            "response_item",
+            "response_item",
+            "response_item",
+            "turn_context",
+            "response_item",
+            "response_item",
+            "turn_context",
+            "response_item",
+            "response_item"
+          ],
+          "role": "child"
+        }
+      ],
+      "codex_desktop": [
+        {
+          "collaboration_items": [
+            {
+              "argument_keys": [
+                "message",
+                "task_name"
+              ],
+              "arguments_json_type": "object",
+              "field_types": {
+                "arguments": "string",
+                "call_id": "string",
+                "id": "string",
+                "internal_chat_message_metadata_passthrough": "object",
+                "name": "string",
+                "namespace": "string",
+                "type": "string"
+              },
+              "fields": [
+                "arguments",
+                "call_id",
+                "id",
+                "internal_chat_message_metadata_passthrough",
+                "name",
+                "namespace",
+                "type"
+              ],
+              "name": "spawn_agent",
+              "namespace": "collaboration",
+              "type": "function_call"
+            },
+            {
+              "decoded_output_keys": [
+                "task_name"
+              ],
+              "decoded_output_type": "object",
+              "field_types": {
+                "call_id": "string",
+                "id": "string",
+                "internal_chat_message_metadata_passthrough": "object",
+                "output": "string",
+                "type": "string"
+              },
+              "fields": [
+                "call_id",
+                "id",
+                "internal_chat_message_metadata_passthrough",
+                "output",
+                "type"
+              ],
+              "output_wire_type": "string",
+              "type": "function_call_output"
+            },
+            {
+              "argument_keys": [
+                "timeout_ms"
+              ],
+              "arguments_json_type": "object",
+              "field_types": {
+                "arguments": "string",
+                "call_id": "string",
+                "id": "string",
+                "internal_chat_message_metadata_passthrough": "object",
+                "name": "string",
+                "namespace": "string",
+                "type": "string"
+              },
+              "fields": [
+                "arguments",
+                "call_id",
+                "id",
+                "internal_chat_message_metadata_passthrough",
+                "name",
+                "namespace",
+                "type"
+              ],
+              "name": "wait_agent",
+              "namespace": "collaboration",
+              "type": "function_call"
+            },
+            {
+              "decoded_output_keys": [
+                "message",
+                "timed_out"
+              ],
+              "decoded_output_type": "object",
+              "field_types": {
+                "call_id": "string",
+                "id": "string",
+                "internal_chat_message_metadata_passthrough": "object",
+                "output": "string",
+                "type": "string"
+              },
+              "fields": [
+                "call_id",
+                "id",
+                "internal_chat_message_metadata_passthrough",
+                "output",
+                "type"
+              ],
+              "output_wire_type": "string",
+              "type": "function_call_output"
+            },
+            {
+              "content_variants": [
+                {
+                  "field_types": {
+                    "text": "string",
+                    "type": "string"
+                  },
+                  "fields": [
+                    "text",
+                    "type"
+                  ],
+                  "type": "input_text"
+                }
+              ],
+              "field_types": {
+                "author": "string",
+                "content": "array",
+                "id": "string",
+                "internal_chat_message_metadata_passthrough": "object",
+                "recipient": "string",
+                "type": "string"
+              },
+              "fields": [
+                "author",
+                "content",
+                "id",
+                "internal_chat_message_metadata_passthrough",
+                "recipient",
+                "type"
+              ],
+              "type": "agent_message"
+            }
+          ],
+          "metadata_records": [
+            {
+              "multi_agent_version": "v2",
+              "payload_field_types": {
+                "base_instructions": "object",
+                "cli_version": "string",
+                "context_window": "object",
+                "cwd": "string",
+                "git": "object",
+                "history_mode": "string",
+                "id": "string",
+                "model_provider": "string",
+                "multi_agent_version": "string",
+                "originator": "string",
+                "session_id": "string",
+                "source": "string",
+                "thread_source": "string",
+                "timestamp": "string"
+              },
+              "payload_fields": [
+                "base_instructions",
+                "cli_version",
+                "context_window",
+                "cwd",
+                "git",
+                "history_mode",
+                "id",
+                "model_provider",
+                "multi_agent_version",
+                "originator",
+                "session_id",
+                "source",
+                "thread_source",
+                "timestamp"
+              ],
+              "record_field_types": {
+                "payload": "object",
+                "timestamp": "string",
+                "type": "string"
+              },
+              "record_fields": [
+                "payload",
+                "timestamp",
+                "type"
+              ],
+              "record_type": "session_meta"
+            },
+            {
+              "multi_agent_version": "v2",
+              "payload_field_types": {
+                "approval_policy": "string",
+                "approvals_reviewer": "string",
+                "collaboration_mode": "object",
+                "current_date": "string",
+                "cwd": "string",
+                "effort": "string",
+                "model": "string",
+                "multi_agent_version": "string",
+                "permission_profile": "object",
+                "personality": "string",
+                "realtime_active": "boolean",
+                "sandbox_policy": "object",
+                "summary": "string",
+                "timezone": "string",
+                "turn_id": "string",
+                "workspace_roots": "array"
+              },
+              "payload_fields": [
+                "approval_policy",
+                "approvals_reviewer",
+                "collaboration_mode",
+                "current_date",
+                "cwd",
+                "effort",
+                "model",
+                "multi_agent_version",
+                "permission_profile",
+                "personality",
+                "realtime_active",
+                "sandbox_policy",
+                "summary",
+                "timezone",
+                "turn_id",
+                "workspace_roots"
+              ],
+              "record_field_types": {
+                "payload": "object",
+                "timestamp": "string",
+                "type": "string"
+              },
+              "record_fields": [
+                "payload",
+                "timestamp",
+                "type"
+              ],
+              "record_type": "turn_context"
+            },
+            {
+              "multi_agent_version": "v2",
+              "payload_field_types": {
+                "approval_policy": "string",
+                "approvals_reviewer": "string",
+                "collaboration_mode": "object",
+                "current_date": "string",
+                "cwd": "string",
+                "effort": "string",
+                "model": "string",
+                "multi_agent_version": "string",
+                "permission_profile": "object",
+                "personality": "string",
+                "realtime_active": "boolean",
+                "sandbox_policy": "object",
+                "summary": "string",
+                "timezone": "string",
+                "turn_id": "string",
+                "workspace_roots": "array"
+              },
+              "payload_fields": [
+                "approval_policy",
+                "approvals_reviewer",
+                "collaboration_mode",
+                "current_date",
+                "cwd",
+                "effort",
+                "model",
+                "multi_agent_version",
+                "permission_profile",
+                "personality",
+                "realtime_active",
+                "sandbox_policy",
+                "summary",
+                "timezone",
+                "turn_id",
+                "workspace_roots"
+              ],
+              "record_field_types": {
+                "payload": "object",
+                "timestamp": "string",
+                "type": "string"
+              },
+              "record_fields": [
+                "payload",
+                "timestamp",
+                "type"
+              ],
+              "record_type": "turn_context"
+            }
+          ],
+          "relevant_record_type_order": [
+            "session_meta",
+            "response_item",
+            "response_item",
+            "response_item",
+            "response_item",
+            "turn_context",
+            "response_item",
+            "response_item",
+            "response_item",
+            "response_item",
+            "response_item",
+            "response_item",
+            "response_item",
+            "turn_context",
+            "response_item",
+            "response_item"
+          ],
+          "role": "root"
+        },
+        {
+          "collaboration_items": [
+            {
+              "content_variants": [
+                {
+                  "field_types": {
+                    "text": "string",
+                    "type": "string"
+                  },
+                  "fields": [
+                    "text",
+                    "type"
+                  ],
+                  "type": "input_text"
+                },
+                {
+                  "field_types": {
+                    "encrypted_content": "string",
+                    "type": "string"
+                  },
+                  "fields": [
+                    "encrypted_content",
+                    "type"
+                  ],
+                  "type": "encrypted_content"
+                }
+              ],
+              "field_types": {
+                "author": "string",
+                "content": "array",
+                "id": "string",
+                "internal_chat_message_metadata_passthrough": "object",
+                "recipient": "string",
+                "type": "string"
+              },
+              "fields": [
+                "author",
+                "content",
+                "id",
+                "internal_chat_message_metadata_passthrough",
+                "recipient",
+                "type"
+              ],
+              "type": "agent_message"
+            }
+          ],
+          "metadata_records": [
+            {
+              "multi_agent_version": "v2",
+              "payload_field_types": {
+                "agent_nickname": "string",
+                "agent_path": "string",
+                "base_instructions": "object",
+                "cli_version": "string",
+                "context_window": "object",
+                "cwd": "string",
+                "forked_from_id": "string",
+                "git": "object",
+                "history_mode": "string",
+                "id": "string",
+                "model_provider": "string",
+                "multi_agent_version": "string",
+                "originator": "string",
+                "parent_thread_id": "string",
+                "session_id": "string",
+                "source": "object",
+                "thread_source": "string",
+                "timestamp": "string"
+              },
+              "payload_fields": [
+                "agent_nickname",
+                "agent_path",
+                "base_instructions",
+                "cli_version",
+                "context_window",
+                "cwd",
+                "forked_from_id",
+                "git",
+                "history_mode",
+                "id",
+                "model_provider",
+                "multi_agent_version",
+                "originator",
+                "parent_thread_id",
+                "session_id",
+                "source",
+                "thread_source",
+                "timestamp"
+              ],
+              "record_field_types": {
+                "payload": "object",
+                "timestamp": "string",
+                "type": "string"
+              },
+              "record_fields": [
+                "payload",
+                "timestamp",
+                "type"
+              ],
+              "record_type": "session_meta"
+            },
+            {
+              "multi_agent_version": "v2",
+              "payload_field_types": {
+                "base_instructions": "object",
+                "cli_version": "string",
+                "context_window": "object",
+                "cwd": "string",
+                "git": "object",
+                "history_mode": "string",
+                "id": "string",
+                "model_provider": "string",
+                "multi_agent_version": "string",
+                "originator": "string",
+                "session_id": "string",
+                "source": "string",
+                "thread_source": "string",
+                "timestamp": "string"
+              },
+              "payload_fields": [
+                "base_instructions",
+                "cli_version",
+                "context_window",
+                "cwd",
+                "git",
+                "history_mode",
+                "id",
+                "model_provider",
+                "multi_agent_version",
+                "originator",
+                "session_id",
+                "source",
+                "thread_source",
+                "timestamp"
+              ],
+              "record_field_types": {
+                "payload": "object",
+                "timestamp": "string",
+                "type": "string"
+              },
+              "record_fields": [
+                "payload",
+                "timestamp",
+                "type"
+              ],
+              "record_type": "session_meta"
+            },
+            {
+              "multi_agent_version": "v2",
+              "payload_field_types": {
+                "approval_policy": "string",
+                "approvals_reviewer": "string",
+                "collaboration_mode": "object",
+                "current_date": "string",
+                "cwd": "string",
+                "effort": "string",
+                "model": "string",
+                "multi_agent_version": "string",
+                "permission_profile": "object",
+                "personality": "string",
+                "realtime_active": "boolean",
+                "sandbox_policy": "object",
+                "summary": "string",
+                "timezone": "string",
+                "turn_id": "string",
+                "workspace_roots": "array"
+              },
+              "payload_fields": [
+                "approval_policy",
+                "approvals_reviewer",
+                "collaboration_mode",
+                "current_date",
+                "cwd",
+                "effort",
+                "model",
+                "multi_agent_version",
+                "permission_profile",
+                "personality",
+                "realtime_active",
+                "sandbox_policy",
+                "summary",
+                "timezone",
+                "turn_id",
+                "workspace_roots"
+              ],
+              "record_field_types": {
+                "payload": "object",
+                "timestamp": "string",
+                "type": "string"
+              },
+              "record_fields": [
+                "payload",
+                "timestamp",
+                "type"
+              ],
+              "record_type": "turn_context"
+            },
+            {
+              "multi_agent_version": "v2",
+              "payload_field_types": {
+                "approval_policy": "string",
+                "approvals_reviewer": "string",
+                "collaboration_mode": "object",
+                "current_date": "string",
+                "cwd": "string",
+                "effort": "string",
+                "model": "string",
+                "multi_agent_version": "string",
+                "permission_profile": "object",
+                "personality": "string",
+                "realtime_active": "boolean",
+                "sandbox_policy": "object",
+                "summary": "string",
+                "timezone": "string",
+                "turn_id": "string",
+                "workspace_roots": "array"
+              },
+              "payload_fields": [
+                "approval_policy",
+                "approvals_reviewer",
+                "collaboration_mode",
+                "current_date",
+                "cwd",
+                "effort",
+                "model",
+                "multi_agent_version",
+                "permission_profile",
+                "personality",
+                "realtime_active",
+                "sandbox_policy",
+                "summary",
+                "timezone",
+                "turn_id",
+                "workspace_roots"
+              ],
+              "record_field_types": {
+                "payload": "object",
+                "timestamp": "string",
+                "type": "string"
+              },
+              "record_fields": [
+                "payload",
+                "timestamp",
+                "type"
+              ],
+              "record_type": "turn_context"
+            }
+          ],
+          "relevant_record_type_order": [
+            "session_meta",
+            "session_meta",
+            "response_item",
+            "response_item",
+            "response_item",
+            "turn_context",
+            "response_item",
+            "response_item",
+            "turn_context",
+            "response_item",
+            "response_item"
+          ],
+          "role": "child"
+        }
+      ]
+    },
     "same_home_readback": {
       "agent_message_author_recipient_and_content_kind_preserved": true,
       "call_and_output_ids_preserved": true,
       "call_namespace_preserved": true,
       "call_output_order_preserved": true,
+      "cli_identity_relationships": {
+        "agent_message_author_recipient_and_content_preserved": true,
+        "collaboration_item_order_preserved": true,
+        "function_call_call_ids_preserved": true,
+        "function_call_item_ids_preserved": true,
+        "function_output_call_ids_preserved": true,
+        "function_output_item_ids_preserved": true,
+        "function_outputs_link_to_calls": true
+      },
       "clients": [
         "codex_cli",
         "codex_desktop"
       ],
+      "desktop_app_identity_relationships": {
+        "item_ids_preserved": true,
+        "item_order_preserved": true,
+        "structural_readback_preserved": true,
+        "thread_id_preserved": true,
+        "turn_ids_preserved": true
+      },
+      "desktop_identity_relationships": {
+        "agent_message_author_recipient_and_content_preserved": true,
+        "collaboration_item_order_preserved": true,
+        "function_call_call_ids_preserved": true,
+        "function_call_item_ids_preserved": true,
+        "function_output_call_ids_preserved": true,
+        "function_output_item_ids_preserved": true,
+        "function_outputs_link_to_calls": true
+      },
       "desktop_thread_resume_and_read": "observed",
       "session_meta_multi_agent_version": "v2",
       "turn_context_multi_agent_version": "v2"

--- a/docs/evidence/issue-392/collaboration-runtime-observations.json
+++ b/docs/evidence/issue-392/collaboration-runtime-observations.json
@@ -1,0 +1,4590 @@
+{
+  "candidate_revision": "be10f62f44b22fa8c84510238250ae11fb3ecab4",
+  "capture_run_binding_sha256": "beb7668c5330c396e38457446d7985ae0c126a7a690d964b682744a6609c52c1",
+  "captured_on": "2026-08-10",
+  "controls": {
+    "existing_user_home_read": false,
+    "existing_user_task_read": false,
+    "explicit_runtime_capture": true,
+    "fresh_empty_home_per_scenario": true,
+    "known_crash_task_read": false,
+    "plugin_services_disabled": [
+      "plugins",
+      "remote_plugin",
+      "plugin_sharing"
+    ],
+    "protocol_upstream_loopback": true,
+    "raw_content_or_credentials_retained": false,
+    "raw_paths_or_opaque_identifiers_retained": false,
+    "sensitive_environment_credentials_removed": true,
+    "workspace_under_isolated_home": true
+  },
+  "runtimes": {
+    "codex_cli": {
+      "binary_sha256": "ae9d865f3d346a1a2a60c4e84775622d74e3e7ef53e0dede9c68b81eab306cca",
+      "client": "codex_cli",
+      "client_version": "0.146.1",
+      "runtime_version": "0.146.1",
+      "source_commit": "79b4f03d35962b005b007a015113b38930711665",
+      "source_files": {
+        "agent_message_and_rollout": {
+          "git_blob": "c692d040d292cf223777cae42dd577b03e85aab5",
+          "path": "codex-rs/protocol/src/protocol.rs"
+        },
+        "desktop_event_mapping": {
+          "git_blob": "b32b15272ba4791db5a253ecc50555bf29b4ef14",
+          "path": "codex-rs/app-server-protocol/src/protocol/event_mapping.rs"
+        },
+        "desktop_thread_items": {
+          "git_blob": "f3a3a65d20516ac9dc99ef0c981eaf399e151cfa",
+          "path": "codex-rs/app-server-protocol/src/protocol/v2/item.rs"
+        },
+        "multi_agent_output_serialization": {
+          "git_blob": "9bb7f76f9de0d799766d050c5811e33d3a7635ea",
+          "path": "codex-rs/core/src/tools/handlers/multi_agents_common.rs"
+        },
+        "multi_agent_tool_schemas": {
+          "git_blob": "2eb82e175b454db0fc8fb8bba61b37d07ab69d30",
+          "path": "codex-rs/core/src/tools/handlers/multi_agents_spec.rs"
+        },
+        "responses_items": {
+          "git_blob": "51e22d10fd57af6bffd7a11b60dc2d422a7ad607",
+          "path": "codex-rs/protocol/src/models.rs"
+        },
+        "responses_request_and_tool_choice": {
+          "git_blob": "b13242062022d9d37302a060dd493977d9c0c1f1",
+          "path": "codex-rs/core/src/client.rs"
+        },
+        "responses_stream_parser": {
+          "git_blob": "441d7bb3bfa743f2fc3fe089cfdb88ddec887aac",
+          "path": "codex-rs/codex-api/src/sse/responses.rs"
+        },
+        "tool_planning_and_namespace_override": {
+          "git_blob": "5ff9e392f3ebec0a510efd11305752133944ceda",
+          "path": "codex-rs/core/src/tools/spec_plan.rs"
+        },
+        "v2_interrupt_handler": {
+          "git_blob": "a418dec4a86550715080b95a3191ce3c72836e8f",
+          "path": "codex-rs/core/src/tools/handlers/multi_agents_v2/interrupt_agent.rs"
+        },
+        "v2_list_handler": {
+          "git_blob": "99e54e1ce91cbd0f182f52fd8ff16f9268f96233",
+          "path": "codex-rs/core/src/tools/handlers/multi_agents_v2/list_agents.rs"
+        },
+        "v2_message_handler": {
+          "git_blob": "62defe65c4114ffcdc661b98836d9964f09a7c64",
+          "path": "codex-rs/core/src/tools/handlers/multi_agents_v2/message_tool.rs"
+        },
+        "v2_spawn_handler": {
+          "git_blob": "67f8057e435b8522a82825f055c75ed420401975",
+          "path": "codex-rs/core/src/tools/handlers/multi_agents_v2/spawn.rs"
+        },
+        "v2_wait_handler": {
+          "git_blob": "4e2eced26037d4c876a8b9fcd28912fb4344953b",
+          "path": "codex-rs/core/src/tools/handlers/multi_agents_v2/wait.rs"
+        },
+        "version_selection_and_namespace_default": {
+          "git_blob": "216af994bc03e136c4797453525df473f579adf5",
+          "path": "codex-rs/core/src/config/mod.rs"
+        }
+      },
+      "source_tag": "rust-v0.146.1",
+      "version_output": "codex-cli 0.146.1"
+    },
+    "codex_desktop": {
+      "binary_sha256": "fb5c760e14cf8fe86e12e49e8a3e7f237af06082d6b9fe1e411e463b7229c916",
+      "client": "codex_desktop",
+      "client_version": "26.803.5235.0",
+      "runtime_version": "0.147.0-alpha.6.5",
+      "source_commit": "618b8e9111da9f57fe380b09d0f6516e3f343536",
+      "source_files": {
+        "agent_message_and_rollout": {
+          "git_blob": "93313c63c2dd185e02d20fff9eff31d43b461277",
+          "path": "codex-rs/protocol/src/protocol.rs"
+        },
+        "desktop_event_mapping": {
+          "git_blob": "b32b15272ba4791db5a253ecc50555bf29b4ef14",
+          "path": "codex-rs/app-server-protocol/src/protocol/event_mapping.rs"
+        },
+        "desktop_thread_items": {
+          "git_blob": "a98ec3f3b2e19f4fef57ae7a5451a54dc471fb9b",
+          "path": "codex-rs/app-server-protocol/src/protocol/v2/item.rs"
+        },
+        "multi_agent_output_serialization": {
+          "git_blob": "f8569c441ed24a01760a51674687787014dfde28",
+          "path": "codex-rs/core/src/tools/handlers/multi_agents_common.rs"
+        },
+        "multi_agent_tool_schemas": {
+          "git_blob": "757e111cc2d060f84b2618896426001225bba4ef",
+          "path": "codex-rs/core/src/tools/handlers/multi_agents_spec.rs"
+        },
+        "responses_items": {
+          "git_blob": "2c2a6d6b7aa49eee6309e5a9ba9e7587a1047d4e",
+          "path": "codex-rs/protocol/src/models.rs"
+        },
+        "responses_request_and_tool_choice": {
+          "git_blob": "d6b25864dfa4620682d163cf9b65a4747d8fcfa9",
+          "path": "codex-rs/core/src/client.rs"
+        },
+        "responses_stream_parser": {
+          "git_blob": "44ed78737ba4ecf9e777c9d38199005ea4e2c2cc",
+          "path": "codex-rs/codex-api/src/sse/responses.rs"
+        },
+        "tool_planning_and_namespace_override": {
+          "git_blob": "1047190cc37f34ec4cfcae348af170da2bacc4c7",
+          "path": "codex-rs/core/src/tools/spec_plan.rs"
+        },
+        "v2_interrupt_handler": {
+          "git_blob": "a418dec4a86550715080b95a3191ce3c72836e8f",
+          "path": "codex-rs/core/src/tools/handlers/multi_agents_v2/interrupt_agent.rs"
+        },
+        "v2_list_handler": {
+          "git_blob": "99e54e1ce91cbd0f182f52fd8ff16f9268f96233",
+          "path": "codex-rs/core/src/tools/handlers/multi_agents_v2/list_agents.rs"
+        },
+        "v2_message_handler": {
+          "git_blob": "eb1790480eeeb5d524cfb132846812ce073c674f",
+          "path": "codex-rs/core/src/tools/handlers/multi_agents_v2/message_tool.rs"
+        },
+        "v2_spawn_handler": {
+          "git_blob": "a6b5c46eec06931354fdc3109909fd574865611d",
+          "path": "codex-rs/core/src/tools/handlers/multi_agents_v2/spawn.rs"
+        },
+        "v2_wait_handler": {
+          "git_blob": "4e2eced26037d4c876a8b9fcd28912fb4344953b",
+          "path": "codex-rs/core/src/tools/handlers/multi_agents_v2/wait.rs"
+        },
+        "version_selection_and_namespace_default": {
+          "git_blob": "844184314f2fa3a2fe2f8238e8d351aaa1050a5e",
+          "path": "codex-rs/core/src/config/mod.rs"
+        }
+      },
+      "source_tag": "rust-v0.147.0-alpha.6.5",
+      "version_output": "codex-cli 0.147.0-alpha.6.5"
+    }
+  },
+  "scenarios": {
+    "cli_v1_request": {
+      "client": "codex_cli",
+      "fresh_empty_home_before_marker": true,
+      "home_binding_sha256": "b7da348dba582272740fa1392545e7b468a5fbe50f08d257de451631fc8490a8",
+      "loopback_request_count": 1,
+      "observed": {
+        "declaration": {
+          "children": [
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "close_agent",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "target": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "target"
+                ],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "resume_agent",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id"
+                ],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "send_input",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "interrupt": {
+                    "type": "boolean"
+                  },
+                  "items": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "audio_url": {
+                          "type": "string"
+                        },
+                        "image_url": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "path": {
+                          "type": "string"
+                        },
+                        "text": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "message": {
+                    "type": "string"
+                  },
+                  "target": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "target"
+                ],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "spawn_agent",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "agent_type": {
+                    "type": "string"
+                  },
+                  "fork_context": {
+                    "type": "boolean"
+                  },
+                  "items": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "audio_url": {
+                          "type": "string"
+                        },
+                        "image_url": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "path": {
+                          "type": "string"
+                        },
+                        "text": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "message": {
+                    "type": "string"
+                  },
+                  "model": {
+                    "type": "string"
+                  },
+                  "reasoning_effort": {
+                    "type": "string"
+                  },
+                  "service_tier": {
+                    "type": "string"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "wait_agent",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "targets": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "timeout_ms": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "targets"
+                ],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            }
+          ],
+          "description_type": "string",
+          "fields": [
+            "description",
+            "name",
+            "tools",
+            "type"
+          ],
+          "name": "multi_agent_v1",
+          "type": "namespace"
+        },
+        "request": {
+          "collaboration_items": [],
+          "field_types": {
+            "client_metadata": "object",
+            "include": "array",
+            "input": "array",
+            "instructions": "string",
+            "model": "string",
+            "parallel_tool_calls": "boolean",
+            "prompt_cache_key": "string",
+            "reasoning": "object",
+            "store": "boolean",
+            "stream": "boolean",
+            "tool_choice": "string",
+            "tools": "array"
+          },
+          "fields": [
+            "client_metadata",
+            "include",
+            "input",
+            "instructions",
+            "model",
+            "parallel_tool_calls",
+            "prompt_cache_key",
+            "reasoning",
+            "store",
+            "stream",
+            "tool_choice",
+            "tools"
+          ],
+          "input_type_order": [
+            "message",
+            "message",
+            "message"
+          ],
+          "multi_agent_version_locations": [],
+          "tool_choice": "auto"
+        }
+      },
+      "process_runs": 1,
+      "workspace_created_under_home": true
+    },
+    "cli_v2_lifecycle": {
+      "client": "codex_cli",
+      "fresh_empty_home_before_marker": true,
+      "home_binding_sha256": "1d36f56fcb0744f35ade8cdc621e9588f24c55ad5efcf556c69f12ff1a9f8b28",
+      "loopback_request_count": 5,
+      "observed": {
+        "declaration": {
+          "children": [
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "followup_task",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "message": {
+                    "encrypted": true,
+                    "type": "string"
+                  },
+                  "target": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "message",
+                  "target"
+                ],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "interrupt_agent",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "target": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "target"
+                ],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "list_agents",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "path_prefix": {
+                    "type": "string"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "send_message",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "message": {
+                    "encrypted": true,
+                    "type": "string"
+                  },
+                  "target": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "message",
+                  "target"
+                ],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "spawn_agent",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "agent_type": {
+                    "type": "string"
+                  },
+                  "fork_turns": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "encrypted": true,
+                    "type": "string"
+                  },
+                  "model": {
+                    "type": "string"
+                  },
+                  "reasoning_effort": {
+                    "type": "string"
+                  },
+                  "task_name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "message",
+                  "task_name"
+                ],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "wait_agent",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "timeout_ms": {
+                    "type": "number"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            }
+          ],
+          "description_type": "string",
+          "fields": [
+            "description",
+            "name",
+            "tools",
+            "type"
+          ],
+          "name": "collaboration",
+          "type": "namespace"
+        },
+        "identity_relationships": {
+          "agent_message_author_recipient_and_content_preserved": true,
+          "collaboration_item_order_preserved": true,
+          "function_call_call_ids_preserved": true,
+          "function_call_item_ids_preserved": true,
+          "function_output_call_ids_preserved": true,
+          "function_output_item_ids_preserved": true,
+          "function_outputs_link_to_calls": true
+        },
+        "request_arrival_order": [
+          "root_initial",
+          "root_after_spawn",
+          "child_initial",
+          "root_after_wait",
+          "restart_replay"
+        ],
+        "requests_by_phase": {
+          "child_initial": {
+            "collaboration_items": [
+              {
+                "content_variants": [
+                  {
+                    "field_types": {
+                      "text": "string",
+                      "type": "string"
+                    },
+                    "fields": [
+                      "text",
+                      "type"
+                    ],
+                    "type": "input_text"
+                  },
+                  {
+                    "field_types": {
+                      "encrypted_content": "string",
+                      "type": "string"
+                    },
+                    "fields": [
+                      "encrypted_content",
+                      "type"
+                    ],
+                    "type": "encrypted_content"
+                  }
+                ],
+                "field_types": {
+                  "author": "string",
+                  "content": "array",
+                  "id": "string",
+                  "recipient": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "author",
+                  "content",
+                  "id",
+                  "recipient",
+                  "type"
+                ],
+                "type": "agent_message"
+              }
+            ],
+            "field_types": {
+              "client_metadata": "object",
+              "include": "array",
+              "input": "array",
+              "instructions": "string",
+              "model": "string",
+              "parallel_tool_calls": "boolean",
+              "prompt_cache_key": "string",
+              "reasoning": "object",
+              "store": "boolean",
+              "stream": "boolean",
+              "tool_choice": "string",
+              "tools": "array"
+            },
+            "fields": [
+              "client_metadata",
+              "include",
+              "input",
+              "instructions",
+              "model",
+              "parallel_tool_calls",
+              "prompt_cache_key",
+              "reasoning",
+              "store",
+              "stream",
+              "tool_choice",
+              "tools"
+            ],
+            "input_type_order": [
+              "message",
+              "message",
+              "message",
+              "message",
+              "message",
+              "agent_message"
+            ],
+            "multi_agent_version_locations": [],
+            "tool_choice": "auto"
+          },
+          "restart_replay": {
+            "collaboration_items": [
+              {
+                "argument_keys": [
+                  "message",
+                  "task_name"
+                ],
+                "arguments_json_type": "object",
+                "field_types": {
+                  "arguments": "string",
+                  "call_id": "string",
+                  "id": "string",
+                  "name": "string",
+                  "namespace": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "arguments",
+                  "call_id",
+                  "id",
+                  "name",
+                  "namespace",
+                  "type"
+                ],
+                "name": "spawn_agent",
+                "namespace": "collaboration",
+                "type": "function_call"
+              },
+              {
+                "decoded_output_keys": [
+                  "task_name"
+                ],
+                "decoded_output_type": "object",
+                "field_types": {
+                  "call_id": "string",
+                  "id": "string",
+                  "output": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "call_id",
+                  "id",
+                  "output",
+                  "type"
+                ],
+                "output_wire_type": "string",
+                "type": "function_call_output"
+              },
+              {
+                "argument_keys": [
+                  "timeout_ms"
+                ],
+                "arguments_json_type": "object",
+                "field_types": {
+                  "arguments": "string",
+                  "call_id": "string",
+                  "id": "string",
+                  "name": "string",
+                  "namespace": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "arguments",
+                  "call_id",
+                  "id",
+                  "name",
+                  "namespace",
+                  "type"
+                ],
+                "name": "wait_agent",
+                "namespace": "collaboration",
+                "type": "function_call"
+              },
+              {
+                "decoded_output_keys": [
+                  "message",
+                  "timed_out"
+                ],
+                "decoded_output_type": "object",
+                "field_types": {
+                  "call_id": "string",
+                  "id": "string",
+                  "output": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "call_id",
+                  "id",
+                  "output",
+                  "type"
+                ],
+                "output_wire_type": "string",
+                "type": "function_call_output"
+              },
+              {
+                "content_variants": [
+                  {
+                    "field_types": {
+                      "text": "string",
+                      "type": "string"
+                    },
+                    "fields": [
+                      "text",
+                      "type"
+                    ],
+                    "type": "input_text"
+                  }
+                ],
+                "field_types": {
+                  "author": "string",
+                  "content": "array",
+                  "id": "string",
+                  "recipient": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "author",
+                  "content",
+                  "id",
+                  "recipient",
+                  "type"
+                ],
+                "type": "agent_message"
+              }
+            ],
+            "field_types": {
+              "client_metadata": "object",
+              "include": "array",
+              "input": "array",
+              "instructions": "string",
+              "model": "string",
+              "parallel_tool_calls": "boolean",
+              "prompt_cache_key": "string",
+              "reasoning": "object",
+              "store": "boolean",
+              "stream": "boolean",
+              "tool_choice": "string",
+              "tools": "array"
+            },
+            "fields": [
+              "client_metadata",
+              "include",
+              "input",
+              "instructions",
+              "model",
+              "parallel_tool_calls",
+              "prompt_cache_key",
+              "reasoning",
+              "store",
+              "stream",
+              "tool_choice",
+              "tools"
+            ],
+            "input_type_order": [
+              "message",
+              "message",
+              "message",
+              "message",
+              "message",
+              "function_call",
+              "function_call_output",
+              "function_call",
+              "function_call_output",
+              "agent_message",
+              "message",
+              "message"
+            ],
+            "multi_agent_version_locations": [],
+            "tool_choice": "auto"
+          },
+          "root_after_spawn": {
+            "collaboration_items": [
+              {
+                "argument_keys": [
+                  "message",
+                  "task_name"
+                ],
+                "arguments_json_type": "object",
+                "field_types": {
+                  "arguments": "string",
+                  "call_id": "string",
+                  "id": "string",
+                  "name": "string",
+                  "namespace": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "arguments",
+                  "call_id",
+                  "id",
+                  "name",
+                  "namespace",
+                  "type"
+                ],
+                "name": "spawn_agent",
+                "namespace": "collaboration",
+                "type": "function_call"
+              },
+              {
+                "decoded_output_keys": [
+                  "task_name"
+                ],
+                "decoded_output_type": "object",
+                "field_types": {
+                  "call_id": "string",
+                  "id": "string",
+                  "output": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "call_id",
+                  "id",
+                  "output",
+                  "type"
+                ],
+                "output_wire_type": "string",
+                "type": "function_call_output"
+              }
+            ],
+            "field_types": {
+              "client_metadata": "object",
+              "include": "array",
+              "input": "array",
+              "instructions": "string",
+              "model": "string",
+              "parallel_tool_calls": "boolean",
+              "prompt_cache_key": "string",
+              "reasoning": "object",
+              "store": "boolean",
+              "stream": "boolean",
+              "tool_choice": "string",
+              "tools": "array"
+            },
+            "fields": [
+              "client_metadata",
+              "include",
+              "input",
+              "instructions",
+              "model",
+              "parallel_tool_calls",
+              "prompt_cache_key",
+              "reasoning",
+              "store",
+              "stream",
+              "tool_choice",
+              "tools"
+            ],
+            "input_type_order": [
+              "message",
+              "message",
+              "message",
+              "message",
+              "message",
+              "function_call",
+              "function_call_output"
+            ],
+            "multi_agent_version_locations": [],
+            "tool_choice": "auto"
+          },
+          "root_after_wait": {
+            "collaboration_items": [
+              {
+                "argument_keys": [
+                  "message",
+                  "task_name"
+                ],
+                "arguments_json_type": "object",
+                "field_types": {
+                  "arguments": "string",
+                  "call_id": "string",
+                  "id": "string",
+                  "name": "string",
+                  "namespace": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "arguments",
+                  "call_id",
+                  "id",
+                  "name",
+                  "namespace",
+                  "type"
+                ],
+                "name": "spawn_agent",
+                "namespace": "collaboration",
+                "type": "function_call"
+              },
+              {
+                "decoded_output_keys": [
+                  "task_name"
+                ],
+                "decoded_output_type": "object",
+                "field_types": {
+                  "call_id": "string",
+                  "id": "string",
+                  "output": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "call_id",
+                  "id",
+                  "output",
+                  "type"
+                ],
+                "output_wire_type": "string",
+                "type": "function_call_output"
+              },
+              {
+                "argument_keys": [
+                  "timeout_ms"
+                ],
+                "arguments_json_type": "object",
+                "field_types": {
+                  "arguments": "string",
+                  "call_id": "string",
+                  "id": "string",
+                  "name": "string",
+                  "namespace": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "arguments",
+                  "call_id",
+                  "id",
+                  "name",
+                  "namespace",
+                  "type"
+                ],
+                "name": "wait_agent",
+                "namespace": "collaboration",
+                "type": "function_call"
+              },
+              {
+                "decoded_output_keys": [
+                  "message",
+                  "timed_out"
+                ],
+                "decoded_output_type": "object",
+                "field_types": {
+                  "call_id": "string",
+                  "id": "string",
+                  "output": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "call_id",
+                  "id",
+                  "output",
+                  "type"
+                ],
+                "output_wire_type": "string",
+                "type": "function_call_output"
+              },
+              {
+                "content_variants": [
+                  {
+                    "field_types": {
+                      "text": "string",
+                      "type": "string"
+                    },
+                    "fields": [
+                      "text",
+                      "type"
+                    ],
+                    "type": "input_text"
+                  }
+                ],
+                "field_types": {
+                  "author": "string",
+                  "content": "array",
+                  "id": "string",
+                  "recipient": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "author",
+                  "content",
+                  "id",
+                  "recipient",
+                  "type"
+                ],
+                "type": "agent_message"
+              }
+            ],
+            "field_types": {
+              "client_metadata": "object",
+              "include": "array",
+              "input": "array",
+              "instructions": "string",
+              "model": "string",
+              "parallel_tool_calls": "boolean",
+              "prompt_cache_key": "string",
+              "reasoning": "object",
+              "store": "boolean",
+              "stream": "boolean",
+              "tool_choice": "string",
+              "tools": "array"
+            },
+            "fields": [
+              "client_metadata",
+              "include",
+              "input",
+              "instructions",
+              "model",
+              "parallel_tool_calls",
+              "prompt_cache_key",
+              "reasoning",
+              "store",
+              "stream",
+              "tool_choice",
+              "tools"
+            ],
+            "input_type_order": [
+              "message",
+              "message",
+              "message",
+              "message",
+              "message",
+              "function_call",
+              "function_call_output",
+              "function_call",
+              "function_call_output",
+              "agent_message"
+            ],
+            "multi_agent_version_locations": [],
+            "tool_choice": "auto"
+          },
+          "root_initial": {
+            "collaboration_items": [],
+            "field_types": {
+              "client_metadata": "object",
+              "include": "array",
+              "input": "array",
+              "instructions": "string",
+              "model": "string",
+              "parallel_tool_calls": "boolean",
+              "prompt_cache_key": "string",
+              "reasoning": "object",
+              "store": "boolean",
+              "stream": "boolean",
+              "tool_choice": "string",
+              "tools": "array"
+            },
+            "fields": [
+              "client_metadata",
+              "include",
+              "input",
+              "instructions",
+              "model",
+              "parallel_tool_calls",
+              "prompt_cache_key",
+              "reasoning",
+              "store",
+              "stream",
+              "tool_choice",
+              "tools"
+            ],
+            "input_type_order": [
+              "message",
+              "message",
+              "message",
+              "message",
+              "message"
+            ],
+            "multi_agent_version_locations": [],
+            "tool_choice": "auto"
+          }
+        },
+        "rollout_readback": [
+          {
+            "collaboration_items": [
+              {
+                "argument_keys": [
+                  "message",
+                  "task_name"
+                ],
+                "arguments_json_type": "object",
+                "field_types": {
+                  "arguments": "string",
+                  "call_id": "string",
+                  "id": "string",
+                  "internal_chat_message_metadata_passthrough": "object",
+                  "name": "string",
+                  "namespace": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "arguments",
+                  "call_id",
+                  "id",
+                  "internal_chat_message_metadata_passthrough",
+                  "name",
+                  "namespace",
+                  "type"
+                ],
+                "name": "spawn_agent",
+                "namespace": "collaboration",
+                "type": "function_call"
+              },
+              {
+                "decoded_output_keys": [
+                  "task_name"
+                ],
+                "decoded_output_type": "object",
+                "field_types": {
+                  "call_id": "string",
+                  "id": "string",
+                  "internal_chat_message_metadata_passthrough": "object",
+                  "output": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "call_id",
+                  "id",
+                  "internal_chat_message_metadata_passthrough",
+                  "output",
+                  "type"
+                ],
+                "output_wire_type": "string",
+                "type": "function_call_output"
+              },
+              {
+                "argument_keys": [
+                  "timeout_ms"
+                ],
+                "arguments_json_type": "object",
+                "field_types": {
+                  "arguments": "string",
+                  "call_id": "string",
+                  "id": "string",
+                  "internal_chat_message_metadata_passthrough": "object",
+                  "name": "string",
+                  "namespace": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "arguments",
+                  "call_id",
+                  "id",
+                  "internal_chat_message_metadata_passthrough",
+                  "name",
+                  "namespace",
+                  "type"
+                ],
+                "name": "wait_agent",
+                "namespace": "collaboration",
+                "type": "function_call"
+              },
+              {
+                "decoded_output_keys": [
+                  "message",
+                  "timed_out"
+                ],
+                "decoded_output_type": "object",
+                "field_types": {
+                  "call_id": "string",
+                  "id": "string",
+                  "internal_chat_message_metadata_passthrough": "object",
+                  "output": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "call_id",
+                  "id",
+                  "internal_chat_message_metadata_passthrough",
+                  "output",
+                  "type"
+                ],
+                "output_wire_type": "string",
+                "type": "function_call_output"
+              },
+              {
+                "content_variants": [
+                  {
+                    "field_types": {
+                      "text": "string",
+                      "type": "string"
+                    },
+                    "fields": [
+                      "text",
+                      "type"
+                    ],
+                    "type": "input_text"
+                  }
+                ],
+                "field_types": {
+                  "author": "string",
+                  "content": "array",
+                  "id": "string",
+                  "internal_chat_message_metadata_passthrough": "object",
+                  "recipient": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "author",
+                  "content",
+                  "id",
+                  "internal_chat_message_metadata_passthrough",
+                  "recipient",
+                  "type"
+                ],
+                "type": "agent_message"
+              }
+            ],
+            "metadata_records": [
+              {
+                "multi_agent_version": "v2",
+                "payload_field_types": {
+                  "base_instructions": "object",
+                  "cli_version": "string",
+                  "context_window": "object",
+                  "cwd": "string",
+                  "git": "object",
+                  "history_mode": "string",
+                  "id": "string",
+                  "model_provider": "string",
+                  "multi_agent_version": "string",
+                  "originator": "string",
+                  "session_id": "string",
+                  "source": "string",
+                  "thread_source": "string",
+                  "timestamp": "string"
+                },
+                "payload_fields": [
+                  "base_instructions",
+                  "cli_version",
+                  "context_window",
+                  "cwd",
+                  "git",
+                  "history_mode",
+                  "id",
+                  "model_provider",
+                  "multi_agent_version",
+                  "originator",
+                  "session_id",
+                  "source",
+                  "thread_source",
+                  "timestamp"
+                ],
+                "record_field_types": {
+                  "payload": "object",
+                  "timestamp": "string",
+                  "type": "string"
+                },
+                "record_fields": [
+                  "payload",
+                  "timestamp",
+                  "type"
+                ],
+                "record_type": "session_meta"
+              },
+              {
+                "multi_agent_version": "v2",
+                "payload_field_types": {
+                  "approval_policy": "string",
+                  "approvals_reviewer": "string",
+                  "collaboration_mode": "object",
+                  "current_date": "string",
+                  "cwd": "string",
+                  "effort": "string",
+                  "model": "string",
+                  "multi_agent_version": "string",
+                  "permission_profile": "object",
+                  "personality": "string",
+                  "realtime_active": "boolean",
+                  "sandbox_policy": "object",
+                  "summary": "string",
+                  "timezone": "string",
+                  "turn_id": "string",
+                  "workspace_roots": "array"
+                },
+                "payload_fields": [
+                  "approval_policy",
+                  "approvals_reviewer",
+                  "collaboration_mode",
+                  "current_date",
+                  "cwd",
+                  "effort",
+                  "model",
+                  "multi_agent_version",
+                  "permission_profile",
+                  "personality",
+                  "realtime_active",
+                  "sandbox_policy",
+                  "summary",
+                  "timezone",
+                  "turn_id",
+                  "workspace_roots"
+                ],
+                "record_field_types": {
+                  "payload": "object",
+                  "timestamp": "string",
+                  "type": "string"
+                },
+                "record_fields": [
+                  "payload",
+                  "timestamp",
+                  "type"
+                ],
+                "record_type": "turn_context"
+              },
+              {
+                "multi_agent_version": "v2",
+                "payload_field_types": {
+                  "approval_policy": "string",
+                  "approvals_reviewer": "string",
+                  "collaboration_mode": "object",
+                  "current_date": "string",
+                  "cwd": "string",
+                  "effort": "string",
+                  "model": "string",
+                  "multi_agent_version": "string",
+                  "permission_profile": "object",
+                  "personality": "string",
+                  "realtime_active": "boolean",
+                  "sandbox_policy": "object",
+                  "summary": "string",
+                  "timezone": "string",
+                  "turn_id": "string",
+                  "workspace_roots": "array"
+                },
+                "payload_fields": [
+                  "approval_policy",
+                  "approvals_reviewer",
+                  "collaboration_mode",
+                  "current_date",
+                  "cwd",
+                  "effort",
+                  "model",
+                  "multi_agent_version",
+                  "permission_profile",
+                  "personality",
+                  "realtime_active",
+                  "sandbox_policy",
+                  "summary",
+                  "timezone",
+                  "turn_id",
+                  "workspace_roots"
+                ],
+                "record_field_types": {
+                  "payload": "object",
+                  "timestamp": "string",
+                  "type": "string"
+                },
+                "record_fields": [
+                  "payload",
+                  "timestamp",
+                  "type"
+                ],
+                "record_type": "turn_context"
+              }
+            ],
+            "relevant_record_type_order": [
+              "session_meta",
+              "response_item",
+              "response_item",
+              "response_item",
+              "response_item",
+              "turn_context",
+              "response_item",
+              "response_item",
+              "response_item",
+              "response_item",
+              "response_item",
+              "response_item",
+              "response_item",
+              "turn_context",
+              "response_item",
+              "response_item"
+            ],
+            "role": "root"
+          },
+          {
+            "collaboration_items": [
+              {
+                "content_variants": [
+                  {
+                    "field_types": {
+                      "text": "string",
+                      "type": "string"
+                    },
+                    "fields": [
+                      "text",
+                      "type"
+                    ],
+                    "type": "input_text"
+                  },
+                  {
+                    "field_types": {
+                      "encrypted_content": "string",
+                      "type": "string"
+                    },
+                    "fields": [
+                      "encrypted_content",
+                      "type"
+                    ],
+                    "type": "encrypted_content"
+                  }
+                ],
+                "field_types": {
+                  "author": "string",
+                  "content": "array",
+                  "id": "string",
+                  "internal_chat_message_metadata_passthrough": "object",
+                  "recipient": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "author",
+                  "content",
+                  "id",
+                  "internal_chat_message_metadata_passthrough",
+                  "recipient",
+                  "type"
+                ],
+                "type": "agent_message"
+              }
+            ],
+            "metadata_records": [
+              {
+                "multi_agent_version": "v2",
+                "payload_field_types": {
+                  "agent_nickname": "string",
+                  "agent_path": "string",
+                  "base_instructions": "object",
+                  "cli_version": "string",
+                  "context_window": "object",
+                  "cwd": "string",
+                  "forked_from_id": "string",
+                  "git": "object",
+                  "history_mode": "string",
+                  "id": "string",
+                  "model_provider": "string",
+                  "multi_agent_version": "string",
+                  "originator": "string",
+                  "parent_thread_id": "string",
+                  "session_id": "string",
+                  "source": "object",
+                  "thread_source": "string",
+                  "timestamp": "string"
+                },
+                "payload_fields": [
+                  "agent_nickname",
+                  "agent_path",
+                  "base_instructions",
+                  "cli_version",
+                  "context_window",
+                  "cwd",
+                  "forked_from_id",
+                  "git",
+                  "history_mode",
+                  "id",
+                  "model_provider",
+                  "multi_agent_version",
+                  "originator",
+                  "parent_thread_id",
+                  "session_id",
+                  "source",
+                  "thread_source",
+                  "timestamp"
+                ],
+                "record_field_types": {
+                  "payload": "object",
+                  "timestamp": "string",
+                  "type": "string"
+                },
+                "record_fields": [
+                  "payload",
+                  "timestamp",
+                  "type"
+                ],
+                "record_type": "session_meta"
+              },
+              {
+                "multi_agent_version": "v2",
+                "payload_field_types": {
+                  "base_instructions": "object",
+                  "cli_version": "string",
+                  "context_window": "object",
+                  "cwd": "string",
+                  "git": "object",
+                  "history_mode": "string",
+                  "id": "string",
+                  "model_provider": "string",
+                  "multi_agent_version": "string",
+                  "originator": "string",
+                  "session_id": "string",
+                  "source": "string",
+                  "thread_source": "string",
+                  "timestamp": "string"
+                },
+                "payload_fields": [
+                  "base_instructions",
+                  "cli_version",
+                  "context_window",
+                  "cwd",
+                  "git",
+                  "history_mode",
+                  "id",
+                  "model_provider",
+                  "multi_agent_version",
+                  "originator",
+                  "session_id",
+                  "source",
+                  "thread_source",
+                  "timestamp"
+                ],
+                "record_field_types": {
+                  "payload": "object",
+                  "timestamp": "string",
+                  "type": "string"
+                },
+                "record_fields": [
+                  "payload",
+                  "timestamp",
+                  "type"
+                ],
+                "record_type": "session_meta"
+              },
+              {
+                "multi_agent_version": "v2",
+                "payload_field_types": {
+                  "approval_policy": "string",
+                  "approvals_reviewer": "string",
+                  "collaboration_mode": "object",
+                  "current_date": "string",
+                  "cwd": "string",
+                  "effort": "string",
+                  "model": "string",
+                  "multi_agent_version": "string",
+                  "permission_profile": "object",
+                  "personality": "string",
+                  "realtime_active": "boolean",
+                  "sandbox_policy": "object",
+                  "summary": "string",
+                  "timezone": "string",
+                  "turn_id": "string",
+                  "workspace_roots": "array"
+                },
+                "payload_fields": [
+                  "approval_policy",
+                  "approvals_reviewer",
+                  "collaboration_mode",
+                  "current_date",
+                  "cwd",
+                  "effort",
+                  "model",
+                  "multi_agent_version",
+                  "permission_profile",
+                  "personality",
+                  "realtime_active",
+                  "sandbox_policy",
+                  "summary",
+                  "timezone",
+                  "turn_id",
+                  "workspace_roots"
+                ],
+                "record_field_types": {
+                  "payload": "object",
+                  "timestamp": "string",
+                  "type": "string"
+                },
+                "record_fields": [
+                  "payload",
+                  "timestamp",
+                  "type"
+                ],
+                "record_type": "turn_context"
+              },
+              {
+                "multi_agent_version": "v2",
+                "payload_field_types": {
+                  "approval_policy": "string",
+                  "approvals_reviewer": "string",
+                  "collaboration_mode": "object",
+                  "current_date": "string",
+                  "cwd": "string",
+                  "effort": "string",
+                  "model": "string",
+                  "multi_agent_version": "string",
+                  "permission_profile": "object",
+                  "personality": "string",
+                  "realtime_active": "boolean",
+                  "sandbox_policy": "object",
+                  "summary": "string",
+                  "timezone": "string",
+                  "turn_id": "string",
+                  "workspace_roots": "array"
+                },
+                "payload_fields": [
+                  "approval_policy",
+                  "approvals_reviewer",
+                  "collaboration_mode",
+                  "current_date",
+                  "cwd",
+                  "effort",
+                  "model",
+                  "multi_agent_version",
+                  "permission_profile",
+                  "personality",
+                  "realtime_active",
+                  "sandbox_policy",
+                  "summary",
+                  "timezone",
+                  "turn_id",
+                  "workspace_roots"
+                ],
+                "record_field_types": {
+                  "payload": "object",
+                  "timestamp": "string",
+                  "type": "string"
+                },
+                "record_fields": [
+                  "payload",
+                  "timestamp",
+                  "type"
+                ],
+                "record_type": "turn_context"
+              }
+            ],
+            "relevant_record_type_order": [
+              "session_meta",
+              "session_meta",
+              "response_item",
+              "response_item",
+              "response_item",
+              "turn_context",
+              "response_item",
+              "response_item",
+              "turn_context",
+              "response_item",
+              "response_item"
+            ],
+            "role": "child"
+          }
+        ],
+        "served_function_call_event_order": [
+          "response.output_item.added",
+          "response.function_call_arguments.delta",
+          "response.function_call_arguments.done",
+          "response.output_item.done",
+          "response.completed"
+        ],
+        "served_function_names": [
+          "spawn_agent",
+          "wait_agent"
+        ]
+      },
+      "process_runs": 2,
+      "workspace_created_under_home": true
+    },
+    "desktop_app_v2_lifecycle": {
+      "client": "codex_desktop",
+      "fresh_empty_home_before_marker": true,
+      "home_binding_sha256": "8da0a0440f5dba6de038e2343dcf0a90aad1e9df7107f5f734031243fd50d551",
+      "loopback_request_count": 4,
+      "observed": {
+        "declaration": {
+          "children": [
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "followup_task",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "message": {
+                    "encrypted": true,
+                    "type": "string"
+                  },
+                  "target": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "message",
+                  "target"
+                ],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "interrupt_agent",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "target": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "target"
+                ],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "list_agents",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "path_prefix": {
+                    "type": "string"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "send_message",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "message": {
+                    "encrypted": true,
+                    "type": "string"
+                  },
+                  "target": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "message",
+                  "target"
+                ],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "spawn_agent",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "agent_type": {
+                    "type": "string"
+                  },
+                  "fork_turns": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "encrypted": true,
+                    "type": "string"
+                  },
+                  "model": {
+                    "type": "string"
+                  },
+                  "reasoning_effort": {
+                    "type": "string"
+                  },
+                  "task_name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "message",
+                  "task_name"
+                ],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "wait_agent",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "timeout_ms": {
+                    "type": "number"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            }
+          ],
+          "description_type": "string",
+          "fields": [
+            "description",
+            "name",
+            "tools",
+            "type"
+          ],
+          "name": "collaboration",
+          "type": "namespace"
+        },
+        "identity_relationships": {
+          "item_ids_preserved": true,
+          "item_order_preserved": true,
+          "structural_readback_preserved": true,
+          "thread_id_preserved": true,
+          "turn_ids_preserved": true
+        },
+        "notifications": [
+          {
+            "item_field_types": {
+              "agentPath": "string",
+              "agentThreadId": "string",
+              "id": "string",
+              "kind": "string",
+              "type": "string"
+            },
+            "item_fields": [
+              "agentPath",
+              "agentThreadId",
+              "id",
+              "kind",
+              "type"
+            ],
+            "item_kind": "started",
+            "item_type": "subAgentActivity",
+            "method": "item/started",
+            "params_field_types": {
+              "item": "object",
+              "startedAtMs": "number",
+              "threadId": "string",
+              "turnId": "string"
+            },
+            "params_fields": [
+              "item",
+              "startedAtMs",
+              "threadId",
+              "turnId"
+            ]
+          },
+          {
+            "item_field_types": {
+              "agentPath": "string",
+              "agentThreadId": "string",
+              "id": "string",
+              "kind": "string",
+              "type": "string"
+            },
+            "item_fields": [
+              "agentPath",
+              "agentThreadId",
+              "id",
+              "kind",
+              "type"
+            ],
+            "item_kind": "started",
+            "item_type": "subAgentActivity",
+            "method": "item/completed",
+            "params_field_types": {
+              "completedAtMs": "number",
+              "item": "object",
+              "threadId": "string",
+              "turnId": "string"
+            },
+            "params_fields": [
+              "completedAtMs",
+              "item",
+              "threadId",
+              "turnId"
+            ]
+          },
+          {
+            "item_field_types": {
+              "agentsStates": "object",
+              "id": "string",
+              "model": "null",
+              "prompt": "null",
+              "reasoningEffort": "null",
+              "receiverThreadIds": "array",
+              "senderThreadId": "string",
+              "status": "string",
+              "tool": "string",
+              "type": "string"
+            },
+            "item_fields": [
+              "agentsStates",
+              "id",
+              "model",
+              "prompt",
+              "reasoningEffort",
+              "receiverThreadIds",
+              "senderThreadId",
+              "status",
+              "tool",
+              "type"
+            ],
+            "item_status": "inProgress",
+            "item_tool": "wait",
+            "item_type": "collabAgentToolCall",
+            "method": "item/started",
+            "params_field_types": {
+              "item": "object",
+              "startedAtMs": "number",
+              "threadId": "string",
+              "turnId": "string"
+            },
+            "params_fields": [
+              "item",
+              "startedAtMs",
+              "threadId",
+              "turnId"
+            ]
+          },
+          {
+            "item_field_types": {
+              "id": "string",
+              "memoryCitation": "null",
+              "phase": "null",
+              "text": "string",
+              "type": "string"
+            },
+            "item_fields": [
+              "id",
+              "memoryCitation",
+              "phase",
+              "text",
+              "type"
+            ],
+            "item_type": "agentMessage",
+            "method": "item/started",
+            "params_field_types": {
+              "item": "object",
+              "startedAtMs": "number",
+              "threadId": "string",
+              "turnId": "string"
+            },
+            "params_fields": [
+              "item",
+              "startedAtMs",
+              "threadId",
+              "turnId"
+            ]
+          },
+          {
+            "method": "item/agentMessage/delta",
+            "params_field_types": {
+              "delta": "string",
+              "itemId": "string",
+              "threadId": "string",
+              "turnId": "string"
+            },
+            "params_fields": [
+              "delta",
+              "itemId",
+              "threadId",
+              "turnId"
+            ]
+          },
+          {
+            "item_field_types": {
+              "id": "string",
+              "memoryCitation": "null",
+              "phase": "null",
+              "text": "string",
+              "type": "string"
+            },
+            "item_fields": [
+              "id",
+              "memoryCitation",
+              "phase",
+              "text",
+              "type"
+            ],
+            "item_type": "agentMessage",
+            "method": "item/completed",
+            "params_field_types": {
+              "completedAtMs": "number",
+              "item": "object",
+              "threadId": "string",
+              "turnId": "string"
+            },
+            "params_fields": [
+              "completedAtMs",
+              "item",
+              "threadId",
+              "turnId"
+            ]
+          },
+          {
+            "item_field_types": {
+              "agentsStates": "object",
+              "id": "string",
+              "model": "null",
+              "prompt": "null",
+              "reasoningEffort": "null",
+              "receiverThreadIds": "array",
+              "senderThreadId": "string",
+              "status": "string",
+              "tool": "string",
+              "type": "string"
+            },
+            "item_fields": [
+              "agentsStates",
+              "id",
+              "model",
+              "prompt",
+              "reasoningEffort",
+              "receiverThreadIds",
+              "senderThreadId",
+              "status",
+              "tool",
+              "type"
+            ],
+            "item_status": "completed",
+            "item_tool": "wait",
+            "item_type": "collabAgentToolCall",
+            "method": "item/completed",
+            "params_field_types": {
+              "completedAtMs": "number",
+              "item": "object",
+              "threadId": "string",
+              "turnId": "string"
+            },
+            "params_fields": [
+              "completedAtMs",
+              "item",
+              "threadId",
+              "turnId"
+            ]
+          },
+          {
+            "item_field_types": {
+              "id": "string",
+              "memoryCitation": "null",
+              "phase": "null",
+              "text": "string",
+              "type": "string"
+            },
+            "item_fields": [
+              "id",
+              "memoryCitation",
+              "phase",
+              "text",
+              "type"
+            ],
+            "item_type": "agentMessage",
+            "method": "item/started",
+            "params_field_types": {
+              "item": "object",
+              "startedAtMs": "number",
+              "threadId": "string",
+              "turnId": "string"
+            },
+            "params_fields": [
+              "item",
+              "startedAtMs",
+              "threadId",
+              "turnId"
+            ]
+          },
+          {
+            "method": "item/agentMessage/delta",
+            "params_field_types": {
+              "delta": "string",
+              "itemId": "string",
+              "threadId": "string",
+              "turnId": "string"
+            },
+            "params_fields": [
+              "delta",
+              "itemId",
+              "threadId",
+              "turnId"
+            ]
+          },
+          {
+            "item_field_types": {
+              "id": "string",
+              "memoryCitation": "null",
+              "phase": "null",
+              "text": "string",
+              "type": "string"
+            },
+            "item_fields": [
+              "id",
+              "memoryCitation",
+              "phase",
+              "text",
+              "type"
+            ],
+            "item_type": "agentMessage",
+            "method": "item/completed",
+            "params_field_types": {
+              "completedAtMs": "number",
+              "item": "object",
+              "threadId": "string",
+              "turnId": "string"
+            },
+            "params_fields": [
+              "completedAtMs",
+              "item",
+              "threadId",
+              "turnId"
+            ]
+          }
+        ],
+        "requests_by_phase": {
+          "child_initial": {
+            "collaboration_items": [
+              {
+                "content_variants": [
+                  {
+                    "field_types": {
+                      "text": "string",
+                      "type": "string"
+                    },
+                    "fields": [
+                      "text",
+                      "type"
+                    ],
+                    "type": "input_text"
+                  },
+                  {
+                    "field_types": {
+                      "encrypted_content": "string",
+                      "type": "string"
+                    },
+                    "fields": [
+                      "encrypted_content",
+                      "type"
+                    ],
+                    "type": "encrypted_content"
+                  }
+                ],
+                "field_types": {
+                  "author": "string",
+                  "content": "array",
+                  "id": "string",
+                  "recipient": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "author",
+                  "content",
+                  "id",
+                  "recipient",
+                  "type"
+                ],
+                "type": "agent_message"
+              }
+            ],
+            "field_types": {
+              "client_metadata": "object",
+              "include": "array",
+              "input": "array",
+              "instructions": "string",
+              "model": "string",
+              "parallel_tool_calls": "boolean",
+              "prompt_cache_key": "string",
+              "reasoning": "object",
+              "store": "boolean",
+              "stream": "boolean",
+              "tool_choice": "string",
+              "tools": "array"
+            },
+            "fields": [
+              "client_metadata",
+              "include",
+              "input",
+              "instructions",
+              "model",
+              "parallel_tool_calls",
+              "prompt_cache_key",
+              "reasoning",
+              "store",
+              "stream",
+              "tool_choice",
+              "tools"
+            ],
+            "input_type_order": [
+              "message",
+              "message",
+              "message",
+              "message",
+              "message",
+              "agent_message"
+            ],
+            "multi_agent_version_locations": [],
+            "tool_choice": "auto"
+          },
+          "root_after_spawn": {
+            "collaboration_items": [
+              {
+                "argument_keys": [
+                  "message",
+                  "task_name"
+                ],
+                "arguments_json_type": "object",
+                "field_types": {
+                  "arguments": "string",
+                  "call_id": "string",
+                  "id": "string",
+                  "name": "string",
+                  "namespace": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "arguments",
+                  "call_id",
+                  "id",
+                  "name",
+                  "namespace",
+                  "type"
+                ],
+                "name": "spawn_agent",
+                "namespace": "collaboration",
+                "type": "function_call"
+              },
+              {
+                "decoded_output_keys": [
+                  "task_name"
+                ],
+                "decoded_output_type": "object",
+                "field_types": {
+                  "call_id": "string",
+                  "id": "string",
+                  "output": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "call_id",
+                  "id",
+                  "output",
+                  "type"
+                ],
+                "output_wire_type": "string",
+                "type": "function_call_output"
+              }
+            ],
+            "field_types": {
+              "client_metadata": "object",
+              "include": "array",
+              "input": "array",
+              "instructions": "string",
+              "model": "string",
+              "parallel_tool_calls": "boolean",
+              "prompt_cache_key": "string",
+              "reasoning": "object",
+              "store": "boolean",
+              "stream": "boolean",
+              "tool_choice": "string",
+              "tools": "array"
+            },
+            "fields": [
+              "client_metadata",
+              "include",
+              "input",
+              "instructions",
+              "model",
+              "parallel_tool_calls",
+              "prompt_cache_key",
+              "reasoning",
+              "store",
+              "stream",
+              "tool_choice",
+              "tools"
+            ],
+            "input_type_order": [
+              "message",
+              "message",
+              "message",
+              "message",
+              "message",
+              "function_call",
+              "function_call_output"
+            ],
+            "multi_agent_version_locations": [],
+            "tool_choice": "auto"
+          },
+          "root_after_wait": {
+            "collaboration_items": [
+              {
+                "argument_keys": [
+                  "message",
+                  "task_name"
+                ],
+                "arguments_json_type": "object",
+                "field_types": {
+                  "arguments": "string",
+                  "call_id": "string",
+                  "id": "string",
+                  "name": "string",
+                  "namespace": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "arguments",
+                  "call_id",
+                  "id",
+                  "name",
+                  "namespace",
+                  "type"
+                ],
+                "name": "spawn_agent",
+                "namespace": "collaboration",
+                "type": "function_call"
+              },
+              {
+                "decoded_output_keys": [
+                  "task_name"
+                ],
+                "decoded_output_type": "object",
+                "field_types": {
+                  "call_id": "string",
+                  "id": "string",
+                  "output": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "call_id",
+                  "id",
+                  "output",
+                  "type"
+                ],
+                "output_wire_type": "string",
+                "type": "function_call_output"
+              },
+              {
+                "argument_keys": [
+                  "timeout_ms"
+                ],
+                "arguments_json_type": "object",
+                "field_types": {
+                  "arguments": "string",
+                  "call_id": "string",
+                  "id": "string",
+                  "name": "string",
+                  "namespace": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "arguments",
+                  "call_id",
+                  "id",
+                  "name",
+                  "namespace",
+                  "type"
+                ],
+                "name": "wait_agent",
+                "namespace": "collaboration",
+                "type": "function_call"
+              },
+              {
+                "decoded_output_keys": [
+                  "message",
+                  "timed_out"
+                ],
+                "decoded_output_type": "object",
+                "field_types": {
+                  "call_id": "string",
+                  "id": "string",
+                  "output": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "call_id",
+                  "id",
+                  "output",
+                  "type"
+                ],
+                "output_wire_type": "string",
+                "type": "function_call_output"
+              },
+              {
+                "content_variants": [
+                  {
+                    "field_types": {
+                      "text": "string",
+                      "type": "string"
+                    },
+                    "fields": [
+                      "text",
+                      "type"
+                    ],
+                    "type": "input_text"
+                  }
+                ],
+                "field_types": {
+                  "author": "string",
+                  "content": "array",
+                  "id": "string",
+                  "recipient": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "author",
+                  "content",
+                  "id",
+                  "recipient",
+                  "type"
+                ],
+                "type": "agent_message"
+              }
+            ],
+            "field_types": {
+              "client_metadata": "object",
+              "include": "array",
+              "input": "array",
+              "instructions": "string",
+              "model": "string",
+              "parallel_tool_calls": "boolean",
+              "prompt_cache_key": "string",
+              "reasoning": "object",
+              "store": "boolean",
+              "stream": "boolean",
+              "tool_choice": "string",
+              "tools": "array"
+            },
+            "fields": [
+              "client_metadata",
+              "include",
+              "input",
+              "instructions",
+              "model",
+              "parallel_tool_calls",
+              "prompt_cache_key",
+              "reasoning",
+              "store",
+              "stream",
+              "tool_choice",
+              "tools"
+            ],
+            "input_type_order": [
+              "message",
+              "message",
+              "message",
+              "message",
+              "message",
+              "function_call",
+              "function_call_output",
+              "function_call",
+              "function_call_output",
+              "agent_message"
+            ],
+            "multi_agent_version_locations": [],
+            "tool_choice": "auto"
+          },
+          "root_initial": {
+            "collaboration_items": [],
+            "field_types": {
+              "client_metadata": "object",
+              "include": "array",
+              "input": "array",
+              "instructions": "string",
+              "model": "string",
+              "parallel_tool_calls": "boolean",
+              "prompt_cache_key": "string",
+              "reasoning": "object",
+              "store": "boolean",
+              "stream": "boolean",
+              "tool_choice": "string",
+              "tools": "array"
+            },
+            "fields": [
+              "client_metadata",
+              "include",
+              "input",
+              "instructions",
+              "model",
+              "parallel_tool_calls",
+              "prompt_cache_key",
+              "reasoning",
+              "store",
+              "stream",
+              "tool_choice",
+              "tools"
+            ],
+            "input_type_order": [
+              "message",
+              "message",
+              "message",
+              "message",
+              "message"
+            ],
+            "multi_agent_version_locations": [],
+            "tool_choice": "auto"
+          }
+        },
+        "resume_result_field_types": {
+          "activePermissionProfile": "object",
+          "approvalPolicy": "string",
+          "approvalsReviewer": "string",
+          "cwd": "string",
+          "initialTurnsPage": "null",
+          "instructionSources": "array",
+          "itemsBackwardsCursor": "null",
+          "model": "string",
+          "modelProvider": "string",
+          "multiAgentMode": "string",
+          "reasoningEffort": "string",
+          "runtimeWorkspaceRoots": "array",
+          "sandbox": "object",
+          "serviceTier": "null",
+          "thread": "object",
+          "turnsBackwardsCursor": "null"
+        },
+        "resume_result_fields": [
+          "activePermissionProfile",
+          "approvalPolicy",
+          "approvalsReviewer",
+          "cwd",
+          "initialTurnsPage",
+          "instructionSources",
+          "itemsBackwardsCursor",
+          "model",
+          "modelProvider",
+          "multiAgentMode",
+          "reasoningEffort",
+          "runtimeWorkspaceRoots",
+          "sandbox",
+          "serviceTier",
+          "thread",
+          "turnsBackwardsCursor"
+        ],
+        "thread_read_after_restart": {
+          "field_types": {
+            "agentNickname": "null",
+            "agentRole": "null",
+            "canAcceptDirectInput": "boolean",
+            "cliVersion": "string",
+            "createdAt": "number",
+            "cwd": "string",
+            "ephemeral": "boolean",
+            "extra": "null",
+            "forkedFromId": "null",
+            "gitInfo": "object",
+            "historyMode": "string",
+            "id": "string",
+            "modelProvider": "string",
+            "name": "null",
+            "parentThreadId": "null",
+            "path": "string",
+            "preview": "string",
+            "recencyAt": "number",
+            "section": "null",
+            "sectionEnteredAt": "null",
+            "sessionId": "string",
+            "source": "string",
+            "status": "object",
+            "threadSource": "null",
+            "turns": "array",
+            "updatedAt": "number"
+          },
+          "fields": [
+            "agentNickname",
+            "agentRole",
+            "canAcceptDirectInput",
+            "cliVersion",
+            "createdAt",
+            "cwd",
+            "ephemeral",
+            "extra",
+            "forkedFromId",
+            "gitInfo",
+            "historyMode",
+            "id",
+            "modelProvider",
+            "name",
+            "parentThreadId",
+            "path",
+            "preview",
+            "recencyAt",
+            "section",
+            "sectionEnteredAt",
+            "sessionId",
+            "source",
+            "status",
+            "threadSource",
+            "turns",
+            "updatedAt"
+          ],
+          "status_field_types": {
+            "type": "string"
+          },
+          "status_fields": [
+            "type"
+          ],
+          "turns": [
+            {
+              "field_types": {
+                "completedAt": "number",
+                "durationMs": "number",
+                "error": "null",
+                "id": "string",
+                "items": "array",
+                "itemsView": "string",
+                "startedAt": "number",
+                "status": "string"
+              },
+              "fields": [
+                "completedAt",
+                "durationMs",
+                "error",
+                "id",
+                "items",
+                "itemsView",
+                "startedAt",
+                "status"
+              ],
+              "items": [
+                {
+                  "field_types": {
+                    "clientId": "null",
+                    "content": "array",
+                    "id": "string",
+                    "type": "string"
+                  },
+                  "fields": [
+                    "clientId",
+                    "content",
+                    "id",
+                    "type"
+                  ],
+                  "type": "userMessage"
+                },
+                {
+                  "field_types": {
+                    "agentPath": "string",
+                    "agentThreadId": "string",
+                    "id": "string",
+                    "kind": "string",
+                    "type": "string"
+                  },
+                  "fields": [
+                    "agentPath",
+                    "agentThreadId",
+                    "id",
+                    "kind",
+                    "type"
+                  ],
+                  "kind": "started",
+                  "type": "subAgentActivity"
+                },
+                {
+                  "field_types": {
+                    "id": "string",
+                    "memoryCitation": "null",
+                    "phase": "null",
+                    "text": "string",
+                    "type": "string"
+                  },
+                  "fields": [
+                    "id",
+                    "memoryCitation",
+                    "phase",
+                    "text",
+                    "type"
+                  ],
+                  "type": "agentMessage"
+                }
+              ],
+              "status": "completed"
+            }
+          ]
+        },
+        "thread_read_before_restart": {
+          "field_types": {
+            "agentNickname": "null",
+            "agentRole": "null",
+            "canAcceptDirectInput": "boolean",
+            "cliVersion": "string",
+            "createdAt": "number",
+            "cwd": "string",
+            "ephemeral": "boolean",
+            "extra": "null",
+            "forkedFromId": "null",
+            "gitInfo": "object",
+            "historyMode": "string",
+            "id": "string",
+            "modelProvider": "string",
+            "name": "null",
+            "parentThreadId": "null",
+            "path": "string",
+            "preview": "string",
+            "recencyAt": "number",
+            "section": "null",
+            "sectionEnteredAt": "null",
+            "sessionId": "string",
+            "source": "string",
+            "status": "object",
+            "threadSource": "null",
+            "turns": "array",
+            "updatedAt": "number"
+          },
+          "fields": [
+            "agentNickname",
+            "agentRole",
+            "canAcceptDirectInput",
+            "cliVersion",
+            "createdAt",
+            "cwd",
+            "ephemeral",
+            "extra",
+            "forkedFromId",
+            "gitInfo",
+            "historyMode",
+            "id",
+            "modelProvider",
+            "name",
+            "parentThreadId",
+            "path",
+            "preview",
+            "recencyAt",
+            "section",
+            "sectionEnteredAt",
+            "sessionId",
+            "source",
+            "status",
+            "threadSource",
+            "turns",
+            "updatedAt"
+          ],
+          "status_field_types": {
+            "type": "string"
+          },
+          "status_fields": [
+            "type"
+          ],
+          "turns": [
+            {
+              "field_types": {
+                "completedAt": "number",
+                "durationMs": "number",
+                "error": "null",
+                "id": "string",
+                "items": "array",
+                "itemsView": "string",
+                "startedAt": "number",
+                "status": "string"
+              },
+              "fields": [
+                "completedAt",
+                "durationMs",
+                "error",
+                "id",
+                "items",
+                "itemsView",
+                "startedAt",
+                "status"
+              ],
+              "items": [
+                {
+                  "field_types": {
+                    "clientId": "null",
+                    "content": "array",
+                    "id": "string",
+                    "type": "string"
+                  },
+                  "fields": [
+                    "clientId",
+                    "content",
+                    "id",
+                    "type"
+                  ],
+                  "type": "userMessage"
+                },
+                {
+                  "field_types": {
+                    "agentPath": "string",
+                    "agentThreadId": "string",
+                    "id": "string",
+                    "kind": "string",
+                    "type": "string"
+                  },
+                  "fields": [
+                    "agentPath",
+                    "agentThreadId",
+                    "id",
+                    "kind",
+                    "type"
+                  ],
+                  "kind": "started",
+                  "type": "subAgentActivity"
+                },
+                {
+                  "field_types": {
+                    "id": "string",
+                    "memoryCitation": "null",
+                    "phase": "null",
+                    "text": "string",
+                    "type": "string"
+                  },
+                  "fields": [
+                    "id",
+                    "memoryCitation",
+                    "phase",
+                    "text",
+                    "type"
+                  ],
+                  "type": "agentMessage"
+                }
+              ],
+              "status": "completed"
+            }
+          ]
+        }
+      },
+      "process_runs": 2,
+      "workspace_created_under_home": true
+    },
+    "desktop_v1_request": {
+      "client": "codex_desktop",
+      "fresh_empty_home_before_marker": true,
+      "home_binding_sha256": "c99dd6202b2a2fddc017c522c869e619b72803c8ec1393209ab3bb8c66528007",
+      "loopback_request_count": 1,
+      "observed": {
+        "declaration": {
+          "children": [
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "close_agent",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "target": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "target"
+                ],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "resume_agent",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id"
+                ],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "send_input",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "interrupt": {
+                    "type": "boolean"
+                  },
+                  "items": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "audio_url": {
+                          "type": "string"
+                        },
+                        "image_url": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "path": {
+                          "type": "string"
+                        },
+                        "text": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "message": {
+                    "type": "string"
+                  },
+                  "target": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "target"
+                ],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "spawn_agent",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "agent_type": {
+                    "type": "string"
+                  },
+                  "fork_context": {
+                    "type": "boolean"
+                  },
+                  "items": {
+                    "items": {
+                      "additionalProperties": false,
+                      "properties": {
+                        "audio_url": {
+                          "type": "string"
+                        },
+                        "image_url": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "path": {
+                          "type": "string"
+                        },
+                        "text": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "message": {
+                    "type": "string"
+                  },
+                  "model": {
+                    "type": "string"
+                  },
+                  "reasoning_effort": {
+                    "type": "string"
+                  },
+                  "service_tier": {
+                    "type": "string"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "wait_agent",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "targets": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "timeout_ms": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "targets"
+                ],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            }
+          ],
+          "description_type": "string",
+          "fields": [
+            "description",
+            "name",
+            "tools",
+            "type"
+          ],
+          "name": "multi_agent_v1",
+          "type": "namespace"
+        },
+        "request": {
+          "collaboration_items": [],
+          "field_types": {
+            "client_metadata": "object",
+            "include": "array",
+            "input": "array",
+            "instructions": "string",
+            "model": "string",
+            "parallel_tool_calls": "boolean",
+            "prompt_cache_key": "string",
+            "reasoning": "object",
+            "store": "boolean",
+            "stream": "boolean",
+            "tool_choice": "string",
+            "tools": "array"
+          },
+          "fields": [
+            "client_metadata",
+            "include",
+            "input",
+            "instructions",
+            "model",
+            "parallel_tool_calls",
+            "prompt_cache_key",
+            "reasoning",
+            "store",
+            "stream",
+            "tool_choice",
+            "tools"
+          ],
+          "input_type_order": [
+            "message",
+            "message",
+            "message"
+          ],
+          "multi_agent_version_locations": [],
+          "tool_choice": "auto"
+        }
+      },
+      "process_runs": 1,
+      "workspace_created_under_home": true
+    },
+    "desktop_v2_lifecycle": {
+      "client": "codex_desktop",
+      "fresh_empty_home_before_marker": true,
+      "home_binding_sha256": "9ff014546ee3d0495ea5d21413bd8cc5e7ecf23f1e09bf0023e2b218526b7e04",
+      "loopback_request_count": 5,
+      "observed": {
+        "declaration": {
+          "children": [
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "followup_task",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "message": {
+                    "encrypted": true,
+                    "type": "string"
+                  },
+                  "target": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "message",
+                  "target"
+                ],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "interrupt_agent",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "target": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "target"
+                ],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "list_agents",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "path_prefix": {
+                    "type": "string"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "send_message",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "message": {
+                    "encrypted": true,
+                    "type": "string"
+                  },
+                  "target": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "message",
+                  "target"
+                ],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "spawn_agent",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "agent_type": {
+                    "type": "string"
+                  },
+                  "fork_turns": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "encrypted": true,
+                    "type": "string"
+                  },
+                  "model": {
+                    "type": "string"
+                  },
+                  "reasoning_effort": {
+                    "type": "string"
+                  },
+                  "task_name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "message",
+                  "task_name"
+                ],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "wait_agent",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "timeout_ms": {
+                    "type": "number"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            }
+          ],
+          "description_type": "string",
+          "fields": [
+            "description",
+            "name",
+            "tools",
+            "type"
+          ],
+          "name": "collaboration",
+          "type": "namespace"
+        },
+        "identity_relationships": {
+          "agent_message_author_recipient_and_content_preserved": true,
+          "collaboration_item_order_preserved": true,
+          "function_call_call_ids_preserved": true,
+          "function_call_item_ids_preserved": true,
+          "function_output_call_ids_preserved": true,
+          "function_output_item_ids_preserved": true,
+          "function_outputs_link_to_calls": true
+        },
+        "request_arrival_order": [
+          "root_initial",
+          "root_after_spawn",
+          "child_initial",
+          "root_after_wait",
+          "restart_replay"
+        ],
+        "requests_by_phase": {
+          "child_initial": {
+            "collaboration_items": [
+              {
+                "content_variants": [
+                  {
+                    "field_types": {
+                      "text": "string",
+                      "type": "string"
+                    },
+                    "fields": [
+                      "text",
+                      "type"
+                    ],
+                    "type": "input_text"
+                  },
+                  {
+                    "field_types": {
+                      "encrypted_content": "string",
+                      "type": "string"
+                    },
+                    "fields": [
+                      "encrypted_content",
+                      "type"
+                    ],
+                    "type": "encrypted_content"
+                  }
+                ],
+                "field_types": {
+                  "author": "string",
+                  "content": "array",
+                  "id": "string",
+                  "recipient": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "author",
+                  "content",
+                  "id",
+                  "recipient",
+                  "type"
+                ],
+                "type": "agent_message"
+              }
+            ],
+            "field_types": {
+              "client_metadata": "object",
+              "include": "array",
+              "input": "array",
+              "instructions": "string",
+              "model": "string",
+              "parallel_tool_calls": "boolean",
+              "prompt_cache_key": "string",
+              "reasoning": "object",
+              "store": "boolean",
+              "stream": "boolean",
+              "tool_choice": "string",
+              "tools": "array"
+            },
+            "fields": [
+              "client_metadata",
+              "include",
+              "input",
+              "instructions",
+              "model",
+              "parallel_tool_calls",
+              "prompt_cache_key",
+              "reasoning",
+              "store",
+              "stream",
+              "tool_choice",
+              "tools"
+            ],
+            "input_type_order": [
+              "message",
+              "message",
+              "message",
+              "message",
+              "message",
+              "agent_message"
+            ],
+            "multi_agent_version_locations": [],
+            "tool_choice": "auto"
+          },
+          "restart_replay": {
+            "collaboration_items": [
+              {
+                "argument_keys": [
+                  "message",
+                  "task_name"
+                ],
+                "arguments_json_type": "object",
+                "field_types": {
+                  "arguments": "string",
+                  "call_id": "string",
+                  "id": "string",
+                  "name": "string",
+                  "namespace": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "arguments",
+                  "call_id",
+                  "id",
+                  "name",
+                  "namespace",
+                  "type"
+                ],
+                "name": "spawn_agent",
+                "namespace": "collaboration",
+                "type": "function_call"
+              },
+              {
+                "decoded_output_keys": [
+                  "task_name"
+                ],
+                "decoded_output_type": "object",
+                "field_types": {
+                  "call_id": "string",
+                  "id": "string",
+                  "output": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "call_id",
+                  "id",
+                  "output",
+                  "type"
+                ],
+                "output_wire_type": "string",
+                "type": "function_call_output"
+              },
+              {
+                "argument_keys": [
+                  "timeout_ms"
+                ],
+                "arguments_json_type": "object",
+                "field_types": {
+                  "arguments": "string",
+                  "call_id": "string",
+                  "id": "string",
+                  "name": "string",
+                  "namespace": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "arguments",
+                  "call_id",
+                  "id",
+                  "name",
+                  "namespace",
+                  "type"
+                ],
+                "name": "wait_agent",
+                "namespace": "collaboration",
+                "type": "function_call"
+              },
+              {
+                "decoded_output_keys": [
+                  "message",
+                  "timed_out"
+                ],
+                "decoded_output_type": "object",
+                "field_types": {
+                  "call_id": "string",
+                  "id": "string",
+                  "output": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "call_id",
+                  "id",
+                  "output",
+                  "type"
+                ],
+                "output_wire_type": "string",
+                "type": "function_call_output"
+              },
+              {
+                "content_variants": [
+                  {
+                    "field_types": {
+                      "text": "string",
+                      "type": "string"
+                    },
+                    "fields": [
+                      "text",
+                      "type"
+                    ],
+                    "type": "input_text"
+                  }
+                ],
+                "field_types": {
+                  "author": "string",
+                  "content": "array",
+                  "id": "string",
+                  "recipient": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "author",
+                  "content",
+                  "id",
+                  "recipient",
+                  "type"
+                ],
+                "type": "agent_message"
+              }
+            ],
+            "field_types": {
+              "client_metadata": "object",
+              "include": "array",
+              "input": "array",
+              "instructions": "string",
+              "model": "string",
+              "parallel_tool_calls": "boolean",
+              "prompt_cache_key": "string",
+              "reasoning": "object",
+              "store": "boolean",
+              "stream": "boolean",
+              "tool_choice": "string",
+              "tools": "array"
+            },
+            "fields": [
+              "client_metadata",
+              "include",
+              "input",
+              "instructions",
+              "model",
+              "parallel_tool_calls",
+              "prompt_cache_key",
+              "reasoning",
+              "store",
+              "stream",
+              "tool_choice",
+              "tools"
+            ],
+            "input_type_order": [
+              "message",
+              "message",
+              "message",
+              "message",
+              "message",
+              "function_call",
+              "function_call_output",
+              "function_call",
+              "function_call_output",
+              "agent_message",
+              "message",
+              "message"
+            ],
+            "multi_agent_version_locations": [],
+            "tool_choice": "auto"
+          },
+          "root_after_spawn": {
+            "collaboration_items": [
+              {
+                "argument_keys": [
+                  "message",
+                  "task_name"
+                ],
+                "arguments_json_type": "object",
+                "field_types": {
+                  "arguments": "string",
+                  "call_id": "string",
+                  "id": "string",
+                  "name": "string",
+                  "namespace": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "arguments",
+                  "call_id",
+                  "id",
+                  "name",
+                  "namespace",
+                  "type"
+                ],
+                "name": "spawn_agent",
+                "namespace": "collaboration",
+                "type": "function_call"
+              },
+              {
+                "decoded_output_keys": [
+                  "task_name"
+                ],
+                "decoded_output_type": "object",
+                "field_types": {
+                  "call_id": "string",
+                  "id": "string",
+                  "output": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "call_id",
+                  "id",
+                  "output",
+                  "type"
+                ],
+                "output_wire_type": "string",
+                "type": "function_call_output"
+              }
+            ],
+            "field_types": {
+              "client_metadata": "object",
+              "include": "array",
+              "input": "array",
+              "instructions": "string",
+              "model": "string",
+              "parallel_tool_calls": "boolean",
+              "prompt_cache_key": "string",
+              "reasoning": "object",
+              "store": "boolean",
+              "stream": "boolean",
+              "tool_choice": "string",
+              "tools": "array"
+            },
+            "fields": [
+              "client_metadata",
+              "include",
+              "input",
+              "instructions",
+              "model",
+              "parallel_tool_calls",
+              "prompt_cache_key",
+              "reasoning",
+              "store",
+              "stream",
+              "tool_choice",
+              "tools"
+            ],
+            "input_type_order": [
+              "message",
+              "message",
+              "message",
+              "message",
+              "message",
+              "function_call",
+              "function_call_output"
+            ],
+            "multi_agent_version_locations": [],
+            "tool_choice": "auto"
+          },
+          "root_after_wait": {
+            "collaboration_items": [
+              {
+                "argument_keys": [
+                  "message",
+                  "task_name"
+                ],
+                "arguments_json_type": "object",
+                "field_types": {
+                  "arguments": "string",
+                  "call_id": "string",
+                  "id": "string",
+                  "name": "string",
+                  "namespace": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "arguments",
+                  "call_id",
+                  "id",
+                  "name",
+                  "namespace",
+                  "type"
+                ],
+                "name": "spawn_agent",
+                "namespace": "collaboration",
+                "type": "function_call"
+              },
+              {
+                "decoded_output_keys": [
+                  "task_name"
+                ],
+                "decoded_output_type": "object",
+                "field_types": {
+                  "call_id": "string",
+                  "id": "string",
+                  "output": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "call_id",
+                  "id",
+                  "output",
+                  "type"
+                ],
+                "output_wire_type": "string",
+                "type": "function_call_output"
+              },
+              {
+                "argument_keys": [
+                  "timeout_ms"
+                ],
+                "arguments_json_type": "object",
+                "field_types": {
+                  "arguments": "string",
+                  "call_id": "string",
+                  "id": "string",
+                  "name": "string",
+                  "namespace": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "arguments",
+                  "call_id",
+                  "id",
+                  "name",
+                  "namespace",
+                  "type"
+                ],
+                "name": "wait_agent",
+                "namespace": "collaboration",
+                "type": "function_call"
+              },
+              {
+                "decoded_output_keys": [
+                  "message",
+                  "timed_out"
+                ],
+                "decoded_output_type": "object",
+                "field_types": {
+                  "call_id": "string",
+                  "id": "string",
+                  "output": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "call_id",
+                  "id",
+                  "output",
+                  "type"
+                ],
+                "output_wire_type": "string",
+                "type": "function_call_output"
+              },
+              {
+                "content_variants": [
+                  {
+                    "field_types": {
+                      "text": "string",
+                      "type": "string"
+                    },
+                    "fields": [
+                      "text",
+                      "type"
+                    ],
+                    "type": "input_text"
+                  }
+                ],
+                "field_types": {
+                  "author": "string",
+                  "content": "array",
+                  "id": "string",
+                  "recipient": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "author",
+                  "content",
+                  "id",
+                  "recipient",
+                  "type"
+                ],
+                "type": "agent_message"
+              }
+            ],
+            "field_types": {
+              "client_metadata": "object",
+              "include": "array",
+              "input": "array",
+              "instructions": "string",
+              "model": "string",
+              "parallel_tool_calls": "boolean",
+              "prompt_cache_key": "string",
+              "reasoning": "object",
+              "store": "boolean",
+              "stream": "boolean",
+              "tool_choice": "string",
+              "tools": "array"
+            },
+            "fields": [
+              "client_metadata",
+              "include",
+              "input",
+              "instructions",
+              "model",
+              "parallel_tool_calls",
+              "prompt_cache_key",
+              "reasoning",
+              "store",
+              "stream",
+              "tool_choice",
+              "tools"
+            ],
+            "input_type_order": [
+              "message",
+              "message",
+              "message",
+              "message",
+              "message",
+              "function_call",
+              "function_call_output",
+              "function_call",
+              "function_call_output",
+              "agent_message"
+            ],
+            "multi_agent_version_locations": [],
+            "tool_choice": "auto"
+          },
+          "root_initial": {
+            "collaboration_items": [],
+            "field_types": {
+              "client_metadata": "object",
+              "include": "array",
+              "input": "array",
+              "instructions": "string",
+              "model": "string",
+              "parallel_tool_calls": "boolean",
+              "prompt_cache_key": "string",
+              "reasoning": "object",
+              "store": "boolean",
+              "stream": "boolean",
+              "tool_choice": "string",
+              "tools": "array"
+            },
+            "fields": [
+              "client_metadata",
+              "include",
+              "input",
+              "instructions",
+              "model",
+              "parallel_tool_calls",
+              "prompt_cache_key",
+              "reasoning",
+              "store",
+              "stream",
+              "tool_choice",
+              "tools"
+            ],
+            "input_type_order": [
+              "message",
+              "message",
+              "message",
+              "message",
+              "message"
+            ],
+            "multi_agent_version_locations": [],
+            "tool_choice": "auto"
+          }
+        },
+        "rollout_readback": [
+          {
+            "collaboration_items": [
+              {
+                "argument_keys": [
+                  "message",
+                  "task_name"
+                ],
+                "arguments_json_type": "object",
+                "field_types": {
+                  "arguments": "string",
+                  "call_id": "string",
+                  "id": "string",
+                  "internal_chat_message_metadata_passthrough": "object",
+                  "name": "string",
+                  "namespace": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "arguments",
+                  "call_id",
+                  "id",
+                  "internal_chat_message_metadata_passthrough",
+                  "name",
+                  "namespace",
+                  "type"
+                ],
+                "name": "spawn_agent",
+                "namespace": "collaboration",
+                "type": "function_call"
+              },
+              {
+                "decoded_output_keys": [
+                  "task_name"
+                ],
+                "decoded_output_type": "object",
+                "field_types": {
+                  "call_id": "string",
+                  "id": "string",
+                  "internal_chat_message_metadata_passthrough": "object",
+                  "output": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "call_id",
+                  "id",
+                  "internal_chat_message_metadata_passthrough",
+                  "output",
+                  "type"
+                ],
+                "output_wire_type": "string",
+                "type": "function_call_output"
+              },
+              {
+                "argument_keys": [
+                  "timeout_ms"
+                ],
+                "arguments_json_type": "object",
+                "field_types": {
+                  "arguments": "string",
+                  "call_id": "string",
+                  "id": "string",
+                  "internal_chat_message_metadata_passthrough": "object",
+                  "name": "string",
+                  "namespace": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "arguments",
+                  "call_id",
+                  "id",
+                  "internal_chat_message_metadata_passthrough",
+                  "name",
+                  "namespace",
+                  "type"
+                ],
+                "name": "wait_agent",
+                "namespace": "collaboration",
+                "type": "function_call"
+              },
+              {
+                "decoded_output_keys": [
+                  "message",
+                  "timed_out"
+                ],
+                "decoded_output_type": "object",
+                "field_types": {
+                  "call_id": "string",
+                  "id": "string",
+                  "internal_chat_message_metadata_passthrough": "object",
+                  "output": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "call_id",
+                  "id",
+                  "internal_chat_message_metadata_passthrough",
+                  "output",
+                  "type"
+                ],
+                "output_wire_type": "string",
+                "type": "function_call_output"
+              },
+              {
+                "content_variants": [
+                  {
+                    "field_types": {
+                      "text": "string",
+                      "type": "string"
+                    },
+                    "fields": [
+                      "text",
+                      "type"
+                    ],
+                    "type": "input_text"
+                  }
+                ],
+                "field_types": {
+                  "author": "string",
+                  "content": "array",
+                  "id": "string",
+                  "internal_chat_message_metadata_passthrough": "object",
+                  "recipient": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "author",
+                  "content",
+                  "id",
+                  "internal_chat_message_metadata_passthrough",
+                  "recipient",
+                  "type"
+                ],
+                "type": "agent_message"
+              }
+            ],
+            "metadata_records": [
+              {
+                "multi_agent_version": "v2",
+                "payload_field_types": {
+                  "base_instructions": "object",
+                  "cli_version": "string",
+                  "context_window": "object",
+                  "cwd": "string",
+                  "git": "object",
+                  "history_mode": "string",
+                  "id": "string",
+                  "model_provider": "string",
+                  "multi_agent_version": "string",
+                  "originator": "string",
+                  "session_id": "string",
+                  "source": "string",
+                  "thread_source": "string",
+                  "timestamp": "string"
+                },
+                "payload_fields": [
+                  "base_instructions",
+                  "cli_version",
+                  "context_window",
+                  "cwd",
+                  "git",
+                  "history_mode",
+                  "id",
+                  "model_provider",
+                  "multi_agent_version",
+                  "originator",
+                  "session_id",
+                  "source",
+                  "thread_source",
+                  "timestamp"
+                ],
+                "record_field_types": {
+                  "payload": "object",
+                  "timestamp": "string",
+                  "type": "string"
+                },
+                "record_fields": [
+                  "payload",
+                  "timestamp",
+                  "type"
+                ],
+                "record_type": "session_meta"
+              },
+              {
+                "multi_agent_version": "v2",
+                "payload_field_types": {
+                  "approval_policy": "string",
+                  "approvals_reviewer": "string",
+                  "collaboration_mode": "object",
+                  "current_date": "string",
+                  "cwd": "string",
+                  "effort": "string",
+                  "model": "string",
+                  "multi_agent_version": "string",
+                  "permission_profile": "object",
+                  "personality": "string",
+                  "realtime_active": "boolean",
+                  "sandbox_policy": "object",
+                  "summary": "string",
+                  "timezone": "string",
+                  "turn_id": "string",
+                  "workspace_roots": "array"
+                },
+                "payload_fields": [
+                  "approval_policy",
+                  "approvals_reviewer",
+                  "collaboration_mode",
+                  "current_date",
+                  "cwd",
+                  "effort",
+                  "model",
+                  "multi_agent_version",
+                  "permission_profile",
+                  "personality",
+                  "realtime_active",
+                  "sandbox_policy",
+                  "summary",
+                  "timezone",
+                  "turn_id",
+                  "workspace_roots"
+                ],
+                "record_field_types": {
+                  "payload": "object",
+                  "timestamp": "string",
+                  "type": "string"
+                },
+                "record_fields": [
+                  "payload",
+                  "timestamp",
+                  "type"
+                ],
+                "record_type": "turn_context"
+              },
+              {
+                "multi_agent_version": "v2",
+                "payload_field_types": {
+                  "approval_policy": "string",
+                  "approvals_reviewer": "string",
+                  "collaboration_mode": "object",
+                  "current_date": "string",
+                  "cwd": "string",
+                  "effort": "string",
+                  "model": "string",
+                  "multi_agent_version": "string",
+                  "permission_profile": "object",
+                  "personality": "string",
+                  "realtime_active": "boolean",
+                  "sandbox_policy": "object",
+                  "summary": "string",
+                  "timezone": "string",
+                  "turn_id": "string",
+                  "workspace_roots": "array"
+                },
+                "payload_fields": [
+                  "approval_policy",
+                  "approvals_reviewer",
+                  "collaboration_mode",
+                  "current_date",
+                  "cwd",
+                  "effort",
+                  "model",
+                  "multi_agent_version",
+                  "permission_profile",
+                  "personality",
+                  "realtime_active",
+                  "sandbox_policy",
+                  "summary",
+                  "timezone",
+                  "turn_id",
+                  "workspace_roots"
+                ],
+                "record_field_types": {
+                  "payload": "object",
+                  "timestamp": "string",
+                  "type": "string"
+                },
+                "record_fields": [
+                  "payload",
+                  "timestamp",
+                  "type"
+                ],
+                "record_type": "turn_context"
+              }
+            ],
+            "relevant_record_type_order": [
+              "session_meta",
+              "response_item",
+              "response_item",
+              "response_item",
+              "response_item",
+              "turn_context",
+              "response_item",
+              "response_item",
+              "response_item",
+              "response_item",
+              "response_item",
+              "response_item",
+              "response_item",
+              "turn_context",
+              "response_item",
+              "response_item"
+            ],
+            "role": "root"
+          },
+          {
+            "collaboration_items": [
+              {
+                "content_variants": [
+                  {
+                    "field_types": {
+                      "text": "string",
+                      "type": "string"
+                    },
+                    "fields": [
+                      "text",
+                      "type"
+                    ],
+                    "type": "input_text"
+                  },
+                  {
+                    "field_types": {
+                      "encrypted_content": "string",
+                      "type": "string"
+                    },
+                    "fields": [
+                      "encrypted_content",
+                      "type"
+                    ],
+                    "type": "encrypted_content"
+                  }
+                ],
+                "field_types": {
+                  "author": "string",
+                  "content": "array",
+                  "id": "string",
+                  "internal_chat_message_metadata_passthrough": "object",
+                  "recipient": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "author",
+                  "content",
+                  "id",
+                  "internal_chat_message_metadata_passthrough",
+                  "recipient",
+                  "type"
+                ],
+                "type": "agent_message"
+              }
+            ],
+            "metadata_records": [
+              {
+                "multi_agent_version": "v2",
+                "payload_field_types": {
+                  "agent_nickname": "string",
+                  "agent_path": "string",
+                  "base_instructions": "object",
+                  "cli_version": "string",
+                  "context_window": "object",
+                  "cwd": "string",
+                  "forked_from_id": "string",
+                  "git": "object",
+                  "history_mode": "string",
+                  "id": "string",
+                  "model_provider": "string",
+                  "multi_agent_version": "string",
+                  "originator": "string",
+                  "parent_thread_id": "string",
+                  "session_id": "string",
+                  "source": "object",
+                  "thread_source": "string",
+                  "timestamp": "string"
+                },
+                "payload_fields": [
+                  "agent_nickname",
+                  "agent_path",
+                  "base_instructions",
+                  "cli_version",
+                  "context_window",
+                  "cwd",
+                  "forked_from_id",
+                  "git",
+                  "history_mode",
+                  "id",
+                  "model_provider",
+                  "multi_agent_version",
+                  "originator",
+                  "parent_thread_id",
+                  "session_id",
+                  "source",
+                  "thread_source",
+                  "timestamp"
+                ],
+                "record_field_types": {
+                  "payload": "object",
+                  "timestamp": "string",
+                  "type": "string"
+                },
+                "record_fields": [
+                  "payload",
+                  "timestamp",
+                  "type"
+                ],
+                "record_type": "session_meta"
+              },
+              {
+                "multi_agent_version": "v2",
+                "payload_field_types": {
+                  "base_instructions": "object",
+                  "cli_version": "string",
+                  "context_window": "object",
+                  "cwd": "string",
+                  "git": "object",
+                  "history_mode": "string",
+                  "id": "string",
+                  "model_provider": "string",
+                  "multi_agent_version": "string",
+                  "originator": "string",
+                  "session_id": "string",
+                  "source": "string",
+                  "thread_source": "string",
+                  "timestamp": "string"
+                },
+                "payload_fields": [
+                  "base_instructions",
+                  "cli_version",
+                  "context_window",
+                  "cwd",
+                  "git",
+                  "history_mode",
+                  "id",
+                  "model_provider",
+                  "multi_agent_version",
+                  "originator",
+                  "session_id",
+                  "source",
+                  "thread_source",
+                  "timestamp"
+                ],
+                "record_field_types": {
+                  "payload": "object",
+                  "timestamp": "string",
+                  "type": "string"
+                },
+                "record_fields": [
+                  "payload",
+                  "timestamp",
+                  "type"
+                ],
+                "record_type": "session_meta"
+              },
+              {
+                "multi_agent_version": "v2",
+                "payload_field_types": {
+                  "approval_policy": "string",
+                  "approvals_reviewer": "string",
+                  "collaboration_mode": "object",
+                  "current_date": "string",
+                  "cwd": "string",
+                  "effort": "string",
+                  "model": "string",
+                  "multi_agent_version": "string",
+                  "permission_profile": "object",
+                  "personality": "string",
+                  "realtime_active": "boolean",
+                  "sandbox_policy": "object",
+                  "summary": "string",
+                  "timezone": "string",
+                  "turn_id": "string",
+                  "workspace_roots": "array"
+                },
+                "payload_fields": [
+                  "approval_policy",
+                  "approvals_reviewer",
+                  "collaboration_mode",
+                  "current_date",
+                  "cwd",
+                  "effort",
+                  "model",
+                  "multi_agent_version",
+                  "permission_profile",
+                  "personality",
+                  "realtime_active",
+                  "sandbox_policy",
+                  "summary",
+                  "timezone",
+                  "turn_id",
+                  "workspace_roots"
+                ],
+                "record_field_types": {
+                  "payload": "object",
+                  "timestamp": "string",
+                  "type": "string"
+                },
+                "record_fields": [
+                  "payload",
+                  "timestamp",
+                  "type"
+                ],
+                "record_type": "turn_context"
+              },
+              {
+                "multi_agent_version": "v2",
+                "payload_field_types": {
+                  "approval_policy": "string",
+                  "approvals_reviewer": "string",
+                  "collaboration_mode": "object",
+                  "current_date": "string",
+                  "cwd": "string",
+                  "effort": "string",
+                  "model": "string",
+                  "multi_agent_version": "string",
+                  "permission_profile": "object",
+                  "personality": "string",
+                  "realtime_active": "boolean",
+                  "sandbox_policy": "object",
+                  "summary": "string",
+                  "timezone": "string",
+                  "turn_id": "string",
+                  "workspace_roots": "array"
+                },
+                "payload_fields": [
+                  "approval_policy",
+                  "approvals_reviewer",
+                  "collaboration_mode",
+                  "current_date",
+                  "cwd",
+                  "effort",
+                  "model",
+                  "multi_agent_version",
+                  "permission_profile",
+                  "personality",
+                  "realtime_active",
+                  "sandbox_policy",
+                  "summary",
+                  "timezone",
+                  "turn_id",
+                  "workspace_roots"
+                ],
+                "record_field_types": {
+                  "payload": "object",
+                  "timestamp": "string",
+                  "type": "string"
+                },
+                "record_fields": [
+                  "payload",
+                  "timestamp",
+                  "type"
+                ],
+                "record_type": "turn_context"
+              }
+            ],
+            "relevant_record_type_order": [
+              "session_meta",
+              "session_meta",
+              "response_item",
+              "response_item",
+              "response_item",
+              "turn_context",
+              "response_item",
+              "response_item",
+              "turn_context",
+              "response_item",
+              "response_item"
+            ],
+            "role": "child"
+          }
+        ],
+        "served_function_call_event_order": [
+          "response.output_item.added",
+          "response.function_call_arguments.delta",
+          "response.function_call_arguments.done",
+          "response.output_item.done",
+          "response.completed"
+        ],
+        "served_function_names": [
+          "spawn_agent",
+          "wait_agent"
+        ]
+      },
+      "process_runs": 2,
+      "workspace_created_under_home": true
+    }
+  },
+  "schema": "codexhub.issue392.collaboration-runtime-observations.v1"
+}

--- a/docs/evidence/issue-392/collaboration-runtime-observations.json
+++ b/docs/evidence/issue-392/collaboration-runtime-observations.json
@@ -1,11 +1,14 @@
 {
   "candidate_revision": "be10f62f44b22fa8c84510238250ae11fb3ecab4",
-  "capture_run_binding_sha256": "beb7668c5330c396e38457446d7985ae0c126a7a690d964b682744a6609c52c1",
+  "capture_run_binding_sha256": "5dcc331df5a1be35dce1ffe9a10f9902416d954e9c4c1321bd66c9675d24fdfe",
   "captured_on": "2026-08-10",
   "controls": {
     "existing_user_home_read": false,
     "existing_user_task_read": false,
     "explicit_runtime_capture": true,
+    "external_config_environment_removed": [
+      "CODEX_CONFIG"
+    ],
     "fresh_empty_home_per_scenario": true,
     "known_crash_task_read": false,
     "plugin_services_disabled": [
@@ -17,7 +20,8 @@
     "raw_content_or_credentials_retained": false,
     "raw_paths_or_opaque_identifiers_retained": false,
     "sensitive_environment_credentials_removed": true,
-    "workspace_under_isolated_home": true
+    "workspace_under_isolated_home": true,
+    "xdg_roots_under_isolated_home": true
   },
   "runtimes": {
     "codex_cli": {
@@ -164,10 +168,1018 @@
     }
   },
   "scenarios": {
+    "cli_terminal_failed": {
+      "client": "codex_cli",
+      "fresh_empty_home_before_marker": true,
+      "home_binding_sha256": "a058ffe406e7af055b87f98bff09077031ffd72c21389c4e89f1ffa265b15fb9",
+      "loopback_request_count": 1,
+      "observed": {
+        "client_disposition": "rejected_nonzero_exit",
+        "completed_event_present": false,
+        "declaration": {
+          "children": [
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "followup_task",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "message": {
+                    "encrypted": true,
+                    "type": "string"
+                  },
+                  "target": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "message",
+                  "target"
+                ],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "interrupt_agent",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "target": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "target"
+                ],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "list_agents",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "path_prefix": {
+                    "type": "string"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "send_message",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "message": {
+                    "encrypted": true,
+                    "type": "string"
+                  },
+                  "target": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "message",
+                  "target"
+                ],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "spawn_agent",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "agent_type": {
+                    "type": "string"
+                  },
+                  "fork_turns": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "encrypted": true,
+                    "type": "string"
+                  },
+                  "model": {
+                    "type": "string"
+                  },
+                  "reasoning_effort": {
+                    "type": "string"
+                  },
+                  "task_name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "message",
+                  "task_name"
+                ],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "wait_agent",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "timeout_ms": {
+                    "type": "number"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            }
+          ],
+          "description_type": "string",
+          "fields": [
+            "description",
+            "name",
+            "tools",
+            "type"
+          ],
+          "name": "collaboration",
+          "type": "namespace"
+        },
+        "request": {
+          "collaboration_items": [],
+          "field_types": {
+            "client_metadata": "object",
+            "include": "array",
+            "input": "array",
+            "instructions": "string",
+            "model": "string",
+            "parallel_tool_calls": "boolean",
+            "prompt_cache_key": "string",
+            "reasoning": "object",
+            "store": "boolean",
+            "stream": "boolean",
+            "tool_choice": "string",
+            "tools": "array"
+          },
+          "fields": [
+            "client_metadata",
+            "include",
+            "input",
+            "instructions",
+            "model",
+            "parallel_tool_calls",
+            "prompt_cache_key",
+            "reasoning",
+            "store",
+            "stream",
+            "tool_choice",
+            "tools"
+          ],
+          "input_type_order": [
+            "message",
+            "message",
+            "message",
+            "message",
+            "message"
+          ],
+          "multi_agent_version_locations": [],
+          "tool_choice": "auto"
+        },
+        "served_event_envelopes": [
+          {
+            "field_types": {
+              "response": "object",
+              "type": "string"
+            },
+            "fields": [
+              "response",
+              "type"
+            ],
+            "response_field_types": {
+              "id": "string",
+              "model": "string",
+              "object": "string",
+              "output": "array",
+              "status": "string"
+            },
+            "response_fields": [
+              "id",
+              "model",
+              "object",
+              "output",
+              "status"
+            ],
+            "response_output_item_types": [],
+            "response_status": "in_progress",
+            "type": "response.created"
+          },
+          {
+            "field_types": {
+              "response": "object",
+              "type": "string"
+            },
+            "fields": [
+              "response",
+              "type"
+            ],
+            "response_error_field_types": {
+              "code": "string",
+              "message": "string"
+            },
+            "response_error_fields": [
+              "code",
+              "message"
+            ],
+            "response_field_types": {
+              "error": "object",
+              "id": "string"
+            },
+            "response_fields": [
+              "error",
+              "id"
+            ],
+            "type": "response.failed"
+          }
+        ],
+        "terminal_control": "failed",
+        "terminal_event_present": true
+      },
+      "process_runs": 1,
+      "workspace_created_under_home": true
+    },
+    "cli_terminal_incomplete": {
+      "client": "codex_cli",
+      "fresh_empty_home_before_marker": true,
+      "home_binding_sha256": "17c8b4e96cc0744441c00a314e6ae14bc49454d0128559b35d2a00db7b4c7a50",
+      "loopback_request_count": 1,
+      "observed": {
+        "client_disposition": "rejected_nonzero_exit",
+        "completed_event_present": false,
+        "declaration": {
+          "children": [
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "followup_task",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "message": {
+                    "encrypted": true,
+                    "type": "string"
+                  },
+                  "target": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "message",
+                  "target"
+                ],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "interrupt_agent",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "target": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "target"
+                ],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "list_agents",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "path_prefix": {
+                    "type": "string"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "send_message",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "message": {
+                    "encrypted": true,
+                    "type": "string"
+                  },
+                  "target": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "message",
+                  "target"
+                ],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "spawn_agent",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "agent_type": {
+                    "type": "string"
+                  },
+                  "fork_turns": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "encrypted": true,
+                    "type": "string"
+                  },
+                  "model": {
+                    "type": "string"
+                  },
+                  "reasoning_effort": {
+                    "type": "string"
+                  },
+                  "task_name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "message",
+                  "task_name"
+                ],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "wait_agent",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "timeout_ms": {
+                    "type": "number"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            }
+          ],
+          "description_type": "string",
+          "fields": [
+            "description",
+            "name",
+            "tools",
+            "type"
+          ],
+          "name": "collaboration",
+          "type": "namespace"
+        },
+        "request": {
+          "collaboration_items": [],
+          "field_types": {
+            "client_metadata": "object",
+            "include": "array",
+            "input": "array",
+            "instructions": "string",
+            "model": "string",
+            "parallel_tool_calls": "boolean",
+            "prompt_cache_key": "string",
+            "reasoning": "object",
+            "store": "boolean",
+            "stream": "boolean",
+            "tool_choice": "string",
+            "tools": "array"
+          },
+          "fields": [
+            "client_metadata",
+            "include",
+            "input",
+            "instructions",
+            "model",
+            "parallel_tool_calls",
+            "prompt_cache_key",
+            "reasoning",
+            "store",
+            "stream",
+            "tool_choice",
+            "tools"
+          ],
+          "input_type_order": [
+            "message",
+            "message",
+            "message",
+            "message",
+            "message"
+          ],
+          "multi_agent_version_locations": [],
+          "tool_choice": "auto"
+        },
+        "served_event_envelopes": [
+          {
+            "field_types": {
+              "response": "object",
+              "type": "string"
+            },
+            "fields": [
+              "response",
+              "type"
+            ],
+            "response_field_types": {
+              "id": "string",
+              "model": "string",
+              "object": "string",
+              "output": "array",
+              "status": "string"
+            },
+            "response_fields": [
+              "id",
+              "model",
+              "object",
+              "output",
+              "status"
+            ],
+            "response_output_item_types": [],
+            "response_status": "in_progress",
+            "type": "response.created"
+          },
+          {
+            "field_types": {
+              "item": "object",
+              "output_index": "number",
+              "type": "string"
+            },
+            "fields": [
+              "item",
+              "output_index",
+              "type"
+            ],
+            "item_field_types": {
+              "content": "array",
+              "id": "string",
+              "role": "string",
+              "type": "string"
+            },
+            "item_fields": [
+              "content",
+              "id",
+              "role",
+              "type"
+            ],
+            "item_type": "message",
+            "type": "response.output_item.added"
+          },
+          {
+            "field_types": {
+              "content_index": "number",
+              "item_id": "string",
+              "output_index": "number",
+              "part": "object",
+              "type": "string"
+            },
+            "fields": [
+              "content_index",
+              "item_id",
+              "output_index",
+              "part",
+              "type"
+            ],
+            "part_field_types": {
+              "annotations": "array",
+              "text": "string",
+              "type": "string"
+            },
+            "part_fields": [
+              "annotations",
+              "text",
+              "type"
+            ],
+            "part_type": "output_text",
+            "type": "response.content_part.added"
+          },
+          {
+            "field_types": {
+              "content_index": "number",
+              "delta": "string",
+              "item_id": "string",
+              "output_index": "number",
+              "type": "string"
+            },
+            "fields": [
+              "content_index",
+              "delta",
+              "item_id",
+              "output_index",
+              "type"
+            ],
+            "type": "response.output_text.delta"
+          },
+          {
+            "field_types": {
+              "response": "object",
+              "type": "string"
+            },
+            "fields": [
+              "response",
+              "type"
+            ],
+            "response_field_types": {
+              "error": "null",
+              "id": "string",
+              "incomplete_details": "object",
+              "object": "string",
+              "status": "string"
+            },
+            "response_fields": [
+              "error",
+              "id",
+              "incomplete_details",
+              "object",
+              "status"
+            ],
+            "response_incomplete_details_field_types": {
+              "reason": "string"
+            },
+            "response_incomplete_details_fields": [
+              "reason"
+            ],
+            "response_status": "incomplete",
+            "type": "response.incomplete"
+          }
+        ],
+        "terminal_control": "incomplete",
+        "terminal_event_present": true
+      },
+      "process_runs": 1,
+      "workspace_created_under_home": true
+    },
+    "cli_terminal_truncated": {
+      "client": "codex_cli",
+      "fresh_empty_home_before_marker": true,
+      "home_binding_sha256": "f930beb2814989e633629ccc809f7f78b297e8e19ec3766f8cbcb813d7ac47ef",
+      "loopback_request_count": 1,
+      "observed": {
+        "client_disposition": "rejected_nonzero_exit",
+        "completed_event_present": false,
+        "declaration": {
+          "children": [
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "followup_task",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "message": {
+                    "encrypted": true,
+                    "type": "string"
+                  },
+                  "target": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "message",
+                  "target"
+                ],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "interrupt_agent",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "target": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "target"
+                ],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "list_agents",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "path_prefix": {
+                    "type": "string"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "send_message",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "message": {
+                    "encrypted": true,
+                    "type": "string"
+                  },
+                  "target": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "message",
+                  "target"
+                ],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "spawn_agent",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "agent_type": {
+                    "type": "string"
+                  },
+                  "fork_turns": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "encrypted": true,
+                    "type": "string"
+                  },
+                  "model": {
+                    "type": "string"
+                  },
+                  "reasoning_effort": {
+                    "type": "string"
+                  },
+                  "task_name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "message",
+                  "task_name"
+                ],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "wait_agent",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "timeout_ms": {
+                    "type": "number"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            }
+          ],
+          "description_type": "string",
+          "fields": [
+            "description",
+            "name",
+            "tools",
+            "type"
+          ],
+          "name": "collaboration",
+          "type": "namespace"
+        },
+        "request": {
+          "collaboration_items": [],
+          "field_types": {
+            "client_metadata": "object",
+            "include": "array",
+            "input": "array",
+            "instructions": "string",
+            "model": "string",
+            "parallel_tool_calls": "boolean",
+            "prompt_cache_key": "string",
+            "reasoning": "object",
+            "store": "boolean",
+            "stream": "boolean",
+            "tool_choice": "string",
+            "tools": "array"
+          },
+          "fields": [
+            "client_metadata",
+            "include",
+            "input",
+            "instructions",
+            "model",
+            "parallel_tool_calls",
+            "prompt_cache_key",
+            "reasoning",
+            "store",
+            "stream",
+            "tool_choice",
+            "tools"
+          ],
+          "input_type_order": [
+            "message",
+            "message",
+            "message",
+            "message",
+            "message"
+          ],
+          "multi_agent_version_locations": [],
+          "tool_choice": "auto"
+        },
+        "served_event_envelopes": [
+          {
+            "field_types": {
+              "response": "object",
+              "type": "string"
+            },
+            "fields": [
+              "response",
+              "type"
+            ],
+            "response_field_types": {
+              "id": "string",
+              "model": "string",
+              "object": "string",
+              "output": "array",
+              "status": "string"
+            },
+            "response_fields": [
+              "id",
+              "model",
+              "object",
+              "output",
+              "status"
+            ],
+            "response_output_item_types": [],
+            "response_status": "in_progress",
+            "type": "response.created"
+          },
+          {
+            "field_types": {
+              "item": "object",
+              "output_index": "number",
+              "type": "string"
+            },
+            "fields": [
+              "item",
+              "output_index",
+              "type"
+            ],
+            "item_field_types": {
+              "content": "array",
+              "id": "string",
+              "role": "string",
+              "type": "string"
+            },
+            "item_fields": [
+              "content",
+              "id",
+              "role",
+              "type"
+            ],
+            "item_type": "message",
+            "type": "response.output_item.added"
+          },
+          {
+            "field_types": {
+              "content_index": "number",
+              "item_id": "string",
+              "output_index": "number",
+              "part": "object",
+              "type": "string"
+            },
+            "fields": [
+              "content_index",
+              "item_id",
+              "output_index",
+              "part",
+              "type"
+            ],
+            "part_field_types": {
+              "annotations": "array",
+              "text": "string",
+              "type": "string"
+            },
+            "part_fields": [
+              "annotations",
+              "text",
+              "type"
+            ],
+            "part_type": "output_text",
+            "type": "response.content_part.added"
+          },
+          {
+            "field_types": {
+              "content_index": "number",
+              "delta": "string",
+              "item_id": "string",
+              "output_index": "number",
+              "type": "string"
+            },
+            "fields": [
+              "content_index",
+              "delta",
+              "item_id",
+              "output_index",
+              "type"
+            ],
+            "type": "response.output_text.delta"
+          }
+        ],
+        "terminal_control": "truncated",
+        "terminal_event_present": false
+      },
+      "process_runs": 1,
+      "workspace_created_under_home": true
+    },
     "cli_v1_request": {
       "client": "codex_cli",
       "fresh_empty_home_before_marker": true,
-      "home_binding_sha256": "b7da348dba582272740fa1392545e7b468a5fbe50f08d257de451631fc8490a8",
+      "home_binding_sha256": "feb22d28648102219916510e7dfee43d38c2dd3a1fed7620ac8bd0b3d53e1733",
       "loopback_request_count": 1,
       "observed": {
         "declaration": {
@@ -434,7 +1446,7 @@
     "cli_v2_lifecycle": {
       "client": "codex_cli",
       "fresh_empty_home_before_marker": true,
-      "home_binding_sha256": "1d36f56fcb0744f35ade8cdc621e9588f24c55ad5efcf556c69f12ff1a9f8b28",
+      "home_binding_sha256": "8fe4b7034c95a910bfa3b42c5d6fc8f8e8422e50581405ba0d01871219f38836",
       "loopback_request_count": 5,
       "observed": {
         "declaration": {
@@ -624,7 +1636,10 @@
           "type": "namespace"
         },
         "identity_relationships": {
+          "agent_message_addresses_nonempty": true,
           "agent_message_author_recipient_and_content_preserved": true,
+          "agent_message_item_ids_preserved": true,
+          "all_identity_fields_nonempty": true,
           "collaboration_item_order_preserved": true,
           "function_call_call_ids_preserved": true,
           "function_call_item_ids_preserved": true,
@@ -1759,6 +2774,865 @@
             "role": "child"
           }
         ],
+        "served_event_sequences": [
+          {
+            "events": [
+              {
+                "field_types": {
+                  "response": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "response",
+                  "type"
+                ],
+                "response_field_types": {
+                  "id": "string",
+                  "model": "string",
+                  "object": "string",
+                  "output": "array",
+                  "status": "string"
+                },
+                "response_fields": [
+                  "id",
+                  "model",
+                  "object",
+                  "output",
+                  "status"
+                ],
+                "response_output_item_types": [],
+                "response_status": "in_progress",
+                "type": "response.created"
+              },
+              {
+                "field_types": {
+                  "item": "object",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "item",
+                  "output_index",
+                  "type"
+                ],
+                "item_field_types": {
+                  "arguments": "string",
+                  "call_id": "string",
+                  "id": "string",
+                  "name": "string",
+                  "namespace": "string",
+                  "status": "string",
+                  "type": "string"
+                },
+                "item_fields": [
+                  "arguments",
+                  "call_id",
+                  "id",
+                  "name",
+                  "namespace",
+                  "status",
+                  "type"
+                ],
+                "item_name": "spawn_agent",
+                "item_namespace": "collaboration",
+                "item_status": "in_progress",
+                "item_type": "function_call",
+                "type": "response.output_item.added"
+              },
+              {
+                "field_types": {
+                  "delta": "string",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "delta",
+                  "item_id",
+                  "output_index",
+                  "type"
+                ],
+                "type": "response.function_call_arguments.delta"
+              },
+              {
+                "field_types": {
+                  "arguments": "string",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "arguments",
+                  "item_id",
+                  "output_index",
+                  "type"
+                ],
+                "type": "response.function_call_arguments.done"
+              },
+              {
+                "field_types": {
+                  "item": "object",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "item",
+                  "output_index",
+                  "type"
+                ],
+                "item_field_types": {
+                  "arguments": "string",
+                  "call_id": "string",
+                  "id": "string",
+                  "name": "string",
+                  "namespace": "string",
+                  "status": "string",
+                  "type": "string"
+                },
+                "item_fields": [
+                  "arguments",
+                  "call_id",
+                  "id",
+                  "name",
+                  "namespace",
+                  "status",
+                  "type"
+                ],
+                "item_name": "spawn_agent",
+                "item_namespace": "collaboration",
+                "item_status": "completed",
+                "item_type": "function_call",
+                "type": "response.output_item.done"
+              },
+              {
+                "field_types": {
+                  "response": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "response",
+                  "type"
+                ],
+                "response_field_types": {
+                  "id": "string",
+                  "model": "string",
+                  "object": "string",
+                  "output": "array",
+                  "status": "string",
+                  "usage": "object"
+                },
+                "response_fields": [
+                  "id",
+                  "model",
+                  "object",
+                  "output",
+                  "status",
+                  "usage"
+                ],
+                "response_output_item_types": [
+                  "function_call"
+                ],
+                "response_status": "completed",
+                "type": "response.completed"
+              }
+            ],
+            "request_index": 1
+          },
+          {
+            "events": [
+              {
+                "field_types": {
+                  "response": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "response",
+                  "type"
+                ],
+                "response_field_types": {
+                  "id": "string",
+                  "model": "string",
+                  "object": "string",
+                  "output": "array",
+                  "status": "string"
+                },
+                "response_fields": [
+                  "id",
+                  "model",
+                  "object",
+                  "output",
+                  "status"
+                ],
+                "response_output_item_types": [],
+                "response_status": "in_progress",
+                "type": "response.created"
+              },
+              {
+                "field_types": {
+                  "item": "object",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "item",
+                  "output_index",
+                  "type"
+                ],
+                "item_field_types": {
+                  "arguments": "string",
+                  "call_id": "string",
+                  "id": "string",
+                  "name": "string",
+                  "namespace": "string",
+                  "status": "string",
+                  "type": "string"
+                },
+                "item_fields": [
+                  "arguments",
+                  "call_id",
+                  "id",
+                  "name",
+                  "namespace",
+                  "status",
+                  "type"
+                ],
+                "item_name": "wait_agent",
+                "item_namespace": "collaboration",
+                "item_status": "in_progress",
+                "item_type": "function_call",
+                "type": "response.output_item.added"
+              },
+              {
+                "field_types": {
+                  "delta": "string",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "delta",
+                  "item_id",
+                  "output_index",
+                  "type"
+                ],
+                "type": "response.function_call_arguments.delta"
+              },
+              {
+                "field_types": {
+                  "arguments": "string",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "arguments",
+                  "item_id",
+                  "output_index",
+                  "type"
+                ],
+                "type": "response.function_call_arguments.done"
+              },
+              {
+                "field_types": {
+                  "item": "object",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "item",
+                  "output_index",
+                  "type"
+                ],
+                "item_field_types": {
+                  "arguments": "string",
+                  "call_id": "string",
+                  "id": "string",
+                  "name": "string",
+                  "namespace": "string",
+                  "status": "string",
+                  "type": "string"
+                },
+                "item_fields": [
+                  "arguments",
+                  "call_id",
+                  "id",
+                  "name",
+                  "namespace",
+                  "status",
+                  "type"
+                ],
+                "item_name": "wait_agent",
+                "item_namespace": "collaboration",
+                "item_status": "completed",
+                "item_type": "function_call",
+                "type": "response.output_item.done"
+              },
+              {
+                "field_types": {
+                  "response": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "response",
+                  "type"
+                ],
+                "response_field_types": {
+                  "id": "string",
+                  "model": "string",
+                  "object": "string",
+                  "output": "array",
+                  "status": "string",
+                  "usage": "object"
+                },
+                "response_fields": [
+                  "id",
+                  "model",
+                  "object",
+                  "output",
+                  "status",
+                  "usage"
+                ],
+                "response_output_item_types": [
+                  "function_call"
+                ],
+                "response_status": "completed",
+                "type": "response.completed"
+              }
+            ],
+            "request_index": 2
+          },
+          {
+            "events": [
+              {
+                "field_types": {
+                  "response": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "response",
+                  "type"
+                ],
+                "response_field_types": {
+                  "id": "string",
+                  "model": "string",
+                  "object": "string",
+                  "output": "array",
+                  "status": "string"
+                },
+                "response_fields": [
+                  "id",
+                  "model",
+                  "object",
+                  "output",
+                  "status"
+                ],
+                "response_output_item_types": [],
+                "response_status": "in_progress",
+                "type": "response.created"
+              },
+              {
+                "field_types": {
+                  "item": "object",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "item",
+                  "output_index",
+                  "type"
+                ],
+                "item_field_types": {
+                  "content": "array",
+                  "id": "string",
+                  "role": "string",
+                  "type": "string"
+                },
+                "item_fields": [
+                  "content",
+                  "id",
+                  "role",
+                  "type"
+                ],
+                "item_type": "message",
+                "type": "response.output_item.added"
+              },
+              {
+                "field_types": {
+                  "content_index": "number",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "part": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "content_index",
+                  "item_id",
+                  "output_index",
+                  "part",
+                  "type"
+                ],
+                "part_field_types": {
+                  "annotations": "array",
+                  "text": "string",
+                  "type": "string"
+                },
+                "part_fields": [
+                  "annotations",
+                  "text",
+                  "type"
+                ],
+                "part_type": "output_text",
+                "type": "response.content_part.added"
+              },
+              {
+                "field_types": {
+                  "content_index": "number",
+                  "delta": "string",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "content_index",
+                  "delta",
+                  "item_id",
+                  "output_index",
+                  "type"
+                ],
+                "type": "response.output_text.delta"
+              },
+              {
+                "field_types": {
+                  "content_index": "number",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "text": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "content_index",
+                  "item_id",
+                  "output_index",
+                  "text",
+                  "type"
+                ],
+                "type": "response.output_text.done"
+              },
+              {
+                "field_types": {
+                  "item": "object",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "item",
+                  "output_index",
+                  "type"
+                ],
+                "item_field_types": {
+                  "content": "array",
+                  "id": "string",
+                  "role": "string",
+                  "type": "string"
+                },
+                "item_fields": [
+                  "content",
+                  "id",
+                  "role",
+                  "type"
+                ],
+                "item_type": "message",
+                "type": "response.output_item.done"
+              },
+              {
+                "field_types": {
+                  "response": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "response",
+                  "type"
+                ],
+                "response_field_types": {
+                  "id": "string",
+                  "model": "string",
+                  "object": "string",
+                  "output": "array",
+                  "status": "string",
+                  "usage": "object"
+                },
+                "response_fields": [
+                  "id",
+                  "model",
+                  "object",
+                  "output",
+                  "status",
+                  "usage"
+                ],
+                "response_output_item_types": [
+                  "message"
+                ],
+                "response_status": "completed",
+                "type": "response.completed"
+              }
+            ],
+            "request_index": 3
+          },
+          {
+            "events": [
+              {
+                "field_types": {
+                  "response": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "response",
+                  "type"
+                ],
+                "response_field_types": {
+                  "id": "string",
+                  "model": "string",
+                  "object": "string",
+                  "output": "array",
+                  "status": "string"
+                },
+                "response_fields": [
+                  "id",
+                  "model",
+                  "object",
+                  "output",
+                  "status"
+                ],
+                "response_output_item_types": [],
+                "response_status": "in_progress",
+                "type": "response.created"
+              },
+              {
+                "field_types": {
+                  "item": "object",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "item",
+                  "output_index",
+                  "type"
+                ],
+                "item_field_types": {
+                  "content": "array",
+                  "id": "string",
+                  "role": "string",
+                  "type": "string"
+                },
+                "item_fields": [
+                  "content",
+                  "id",
+                  "role",
+                  "type"
+                ],
+                "item_type": "message",
+                "type": "response.output_item.added"
+              },
+              {
+                "field_types": {
+                  "content_index": "number",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "part": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "content_index",
+                  "item_id",
+                  "output_index",
+                  "part",
+                  "type"
+                ],
+                "part_field_types": {
+                  "annotations": "array",
+                  "text": "string",
+                  "type": "string"
+                },
+                "part_fields": [
+                  "annotations",
+                  "text",
+                  "type"
+                ],
+                "part_type": "output_text",
+                "type": "response.content_part.added"
+              },
+              {
+                "field_types": {
+                  "content_index": "number",
+                  "delta": "string",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "content_index",
+                  "delta",
+                  "item_id",
+                  "output_index",
+                  "type"
+                ],
+                "type": "response.output_text.delta"
+              },
+              {
+                "field_types": {
+                  "content_index": "number",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "text": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "content_index",
+                  "item_id",
+                  "output_index",
+                  "text",
+                  "type"
+                ],
+                "type": "response.output_text.done"
+              },
+              {
+                "field_types": {
+                  "item": "object",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "item",
+                  "output_index",
+                  "type"
+                ],
+                "item_field_types": {
+                  "content": "array",
+                  "id": "string",
+                  "role": "string",
+                  "type": "string"
+                },
+                "item_fields": [
+                  "content",
+                  "id",
+                  "role",
+                  "type"
+                ],
+                "item_type": "message",
+                "type": "response.output_item.done"
+              },
+              {
+                "field_types": {
+                  "response": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "response",
+                  "type"
+                ],
+                "response_field_types": {
+                  "id": "string",
+                  "model": "string",
+                  "object": "string",
+                  "output": "array",
+                  "status": "string",
+                  "usage": "object"
+                },
+                "response_fields": [
+                  "id",
+                  "model",
+                  "object",
+                  "output",
+                  "status",
+                  "usage"
+                ],
+                "response_output_item_types": [
+                  "message"
+                ],
+                "response_status": "completed",
+                "type": "response.completed"
+              }
+            ],
+            "request_index": 4
+          },
+          {
+            "events": [
+              {
+                "field_types": {
+                  "response": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "response",
+                  "type"
+                ],
+                "response_field_types": {
+                  "id": "string",
+                  "model": "string",
+                  "object": "string",
+                  "output": "array",
+                  "status": "string"
+                },
+                "response_fields": [
+                  "id",
+                  "model",
+                  "object",
+                  "output",
+                  "status"
+                ],
+                "response_output_item_types": [],
+                "response_status": "in_progress",
+                "type": "response.created"
+              },
+              {
+                "field_types": {
+                  "item": "object",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "item",
+                  "output_index",
+                  "type"
+                ],
+                "item_field_types": {
+                  "content": "array",
+                  "id": "string",
+                  "role": "string",
+                  "type": "string"
+                },
+                "item_fields": [
+                  "content",
+                  "id",
+                  "role",
+                  "type"
+                ],
+                "item_type": "message",
+                "type": "response.output_item.added"
+              },
+              {
+                "field_types": {
+                  "content_index": "number",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "part": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "content_index",
+                  "item_id",
+                  "output_index",
+                  "part",
+                  "type"
+                ],
+                "part_field_types": {
+                  "annotations": "array",
+                  "text": "string",
+                  "type": "string"
+                },
+                "part_fields": [
+                  "annotations",
+                  "text",
+                  "type"
+                ],
+                "part_type": "output_text",
+                "type": "response.content_part.added"
+              },
+              {
+                "field_types": {
+                  "content_index": "number",
+                  "delta": "string",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "content_index",
+                  "delta",
+                  "item_id",
+                  "output_index",
+                  "type"
+                ],
+                "type": "response.output_text.delta"
+              },
+              {
+                "field_types": {
+                  "content_index": "number",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "text": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "content_index",
+                  "item_id",
+                  "output_index",
+                  "text",
+                  "type"
+                ],
+                "type": "response.output_text.done"
+              },
+              {
+                "field_types": {
+                  "item": "object",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "item",
+                  "output_index",
+                  "type"
+                ],
+                "item_field_types": {
+                  "content": "array",
+                  "id": "string",
+                  "role": "string",
+                  "type": "string"
+                },
+                "item_fields": [
+                  "content",
+                  "id",
+                  "role",
+                  "type"
+                ],
+                "item_type": "message",
+                "type": "response.output_item.done"
+              },
+              {
+                "field_types": {
+                  "response": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "response",
+                  "type"
+                ],
+                "response_field_types": {
+                  "id": "string",
+                  "model": "string",
+                  "object": "string",
+                  "output": "array",
+                  "status": "string",
+                  "usage": "object"
+                },
+                "response_fields": [
+                  "id",
+                  "model",
+                  "object",
+                  "output",
+                  "status",
+                  "usage"
+                ],
+                "response_output_item_types": [
+                  "message"
+                ],
+                "response_status": "completed",
+                "type": "response.completed"
+              }
+            ],
+            "request_index": 5
+          }
+        ],
         "served_function_call_event_order": [
           "response.output_item.added",
           "response.function_call_arguments.delta",
@@ -1777,7 +3651,7 @@
     "desktop_app_v2_lifecycle": {
       "client": "codex_desktop",
       "fresh_empty_home_before_marker": true,
-      "home_binding_sha256": "8da0a0440f5dba6de038e2343dcf0a90aad1e9df7107f5f734031243fd50d551",
+      "home_binding_sha256": "8c77bace3858ed27914840ef6a7927f19b8effc9614b2af55279ad47fa82663d",
       "loopback_request_count": 4,
       "observed": {
         "declaration": {
@@ -1967,6 +3841,7 @@
           "type": "namespace"
         },
         "identity_relationships": {
+          "all_identity_fields_nonempty": true,
           "item_ids_preserved": true,
           "item_order_preserved": true,
           "structural_readback_preserved": true,
@@ -2975,10 +4850,1018 @@
       "process_runs": 2,
       "workspace_created_under_home": true
     },
+    "desktop_terminal_failed": {
+      "client": "codex_desktop",
+      "fresh_empty_home_before_marker": true,
+      "home_binding_sha256": "772155b18d258cc15cd032c7b9a86423969968125802e9871214767a1479b4cb",
+      "loopback_request_count": 1,
+      "observed": {
+        "client_disposition": "rejected_nonzero_exit",
+        "completed_event_present": false,
+        "declaration": {
+          "children": [
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "followup_task",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "message": {
+                    "encrypted": true,
+                    "type": "string"
+                  },
+                  "target": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "message",
+                  "target"
+                ],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "interrupt_agent",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "target": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "target"
+                ],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "list_agents",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "path_prefix": {
+                    "type": "string"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "send_message",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "message": {
+                    "encrypted": true,
+                    "type": "string"
+                  },
+                  "target": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "message",
+                  "target"
+                ],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "spawn_agent",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "agent_type": {
+                    "type": "string"
+                  },
+                  "fork_turns": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "encrypted": true,
+                    "type": "string"
+                  },
+                  "model": {
+                    "type": "string"
+                  },
+                  "reasoning_effort": {
+                    "type": "string"
+                  },
+                  "task_name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "message",
+                  "task_name"
+                ],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "wait_agent",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "timeout_ms": {
+                    "type": "number"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            }
+          ],
+          "description_type": "string",
+          "fields": [
+            "description",
+            "name",
+            "tools",
+            "type"
+          ],
+          "name": "collaboration",
+          "type": "namespace"
+        },
+        "request": {
+          "collaboration_items": [],
+          "field_types": {
+            "client_metadata": "object",
+            "include": "array",
+            "input": "array",
+            "instructions": "string",
+            "model": "string",
+            "parallel_tool_calls": "boolean",
+            "prompt_cache_key": "string",
+            "reasoning": "object",
+            "store": "boolean",
+            "stream": "boolean",
+            "tool_choice": "string",
+            "tools": "array"
+          },
+          "fields": [
+            "client_metadata",
+            "include",
+            "input",
+            "instructions",
+            "model",
+            "parallel_tool_calls",
+            "prompt_cache_key",
+            "reasoning",
+            "store",
+            "stream",
+            "tool_choice",
+            "tools"
+          ],
+          "input_type_order": [
+            "message",
+            "message",
+            "message",
+            "message",
+            "message"
+          ],
+          "multi_agent_version_locations": [],
+          "tool_choice": "auto"
+        },
+        "served_event_envelopes": [
+          {
+            "field_types": {
+              "response": "object",
+              "type": "string"
+            },
+            "fields": [
+              "response",
+              "type"
+            ],
+            "response_field_types": {
+              "id": "string",
+              "model": "string",
+              "object": "string",
+              "output": "array",
+              "status": "string"
+            },
+            "response_fields": [
+              "id",
+              "model",
+              "object",
+              "output",
+              "status"
+            ],
+            "response_output_item_types": [],
+            "response_status": "in_progress",
+            "type": "response.created"
+          },
+          {
+            "field_types": {
+              "response": "object",
+              "type": "string"
+            },
+            "fields": [
+              "response",
+              "type"
+            ],
+            "response_error_field_types": {
+              "code": "string",
+              "message": "string"
+            },
+            "response_error_fields": [
+              "code",
+              "message"
+            ],
+            "response_field_types": {
+              "error": "object",
+              "id": "string"
+            },
+            "response_fields": [
+              "error",
+              "id"
+            ],
+            "type": "response.failed"
+          }
+        ],
+        "terminal_control": "failed",
+        "terminal_event_present": true
+      },
+      "process_runs": 1,
+      "workspace_created_under_home": true
+    },
+    "desktop_terminal_incomplete": {
+      "client": "codex_desktop",
+      "fresh_empty_home_before_marker": true,
+      "home_binding_sha256": "824b4e8ff0667006a27c27c8b8b1668e574409585406da559d7e5f238234cfe0",
+      "loopback_request_count": 1,
+      "observed": {
+        "client_disposition": "rejected_nonzero_exit",
+        "completed_event_present": false,
+        "declaration": {
+          "children": [
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "followup_task",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "message": {
+                    "encrypted": true,
+                    "type": "string"
+                  },
+                  "target": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "message",
+                  "target"
+                ],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "interrupt_agent",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "target": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "target"
+                ],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "list_agents",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "path_prefix": {
+                    "type": "string"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "send_message",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "message": {
+                    "encrypted": true,
+                    "type": "string"
+                  },
+                  "target": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "message",
+                  "target"
+                ],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "spawn_agent",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "agent_type": {
+                    "type": "string"
+                  },
+                  "fork_turns": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "encrypted": true,
+                    "type": "string"
+                  },
+                  "model": {
+                    "type": "string"
+                  },
+                  "reasoning_effort": {
+                    "type": "string"
+                  },
+                  "task_name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "message",
+                  "task_name"
+                ],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "wait_agent",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "timeout_ms": {
+                    "type": "number"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            }
+          ],
+          "description_type": "string",
+          "fields": [
+            "description",
+            "name",
+            "tools",
+            "type"
+          ],
+          "name": "collaboration",
+          "type": "namespace"
+        },
+        "request": {
+          "collaboration_items": [],
+          "field_types": {
+            "client_metadata": "object",
+            "include": "array",
+            "input": "array",
+            "instructions": "string",
+            "model": "string",
+            "parallel_tool_calls": "boolean",
+            "prompt_cache_key": "string",
+            "reasoning": "object",
+            "store": "boolean",
+            "stream": "boolean",
+            "tool_choice": "string",
+            "tools": "array"
+          },
+          "fields": [
+            "client_metadata",
+            "include",
+            "input",
+            "instructions",
+            "model",
+            "parallel_tool_calls",
+            "prompt_cache_key",
+            "reasoning",
+            "store",
+            "stream",
+            "tool_choice",
+            "tools"
+          ],
+          "input_type_order": [
+            "message",
+            "message",
+            "message",
+            "message",
+            "message"
+          ],
+          "multi_agent_version_locations": [],
+          "tool_choice": "auto"
+        },
+        "served_event_envelopes": [
+          {
+            "field_types": {
+              "response": "object",
+              "type": "string"
+            },
+            "fields": [
+              "response",
+              "type"
+            ],
+            "response_field_types": {
+              "id": "string",
+              "model": "string",
+              "object": "string",
+              "output": "array",
+              "status": "string"
+            },
+            "response_fields": [
+              "id",
+              "model",
+              "object",
+              "output",
+              "status"
+            ],
+            "response_output_item_types": [],
+            "response_status": "in_progress",
+            "type": "response.created"
+          },
+          {
+            "field_types": {
+              "item": "object",
+              "output_index": "number",
+              "type": "string"
+            },
+            "fields": [
+              "item",
+              "output_index",
+              "type"
+            ],
+            "item_field_types": {
+              "content": "array",
+              "id": "string",
+              "role": "string",
+              "type": "string"
+            },
+            "item_fields": [
+              "content",
+              "id",
+              "role",
+              "type"
+            ],
+            "item_type": "message",
+            "type": "response.output_item.added"
+          },
+          {
+            "field_types": {
+              "content_index": "number",
+              "item_id": "string",
+              "output_index": "number",
+              "part": "object",
+              "type": "string"
+            },
+            "fields": [
+              "content_index",
+              "item_id",
+              "output_index",
+              "part",
+              "type"
+            ],
+            "part_field_types": {
+              "annotations": "array",
+              "text": "string",
+              "type": "string"
+            },
+            "part_fields": [
+              "annotations",
+              "text",
+              "type"
+            ],
+            "part_type": "output_text",
+            "type": "response.content_part.added"
+          },
+          {
+            "field_types": {
+              "content_index": "number",
+              "delta": "string",
+              "item_id": "string",
+              "output_index": "number",
+              "type": "string"
+            },
+            "fields": [
+              "content_index",
+              "delta",
+              "item_id",
+              "output_index",
+              "type"
+            ],
+            "type": "response.output_text.delta"
+          },
+          {
+            "field_types": {
+              "response": "object",
+              "type": "string"
+            },
+            "fields": [
+              "response",
+              "type"
+            ],
+            "response_field_types": {
+              "error": "null",
+              "id": "string",
+              "incomplete_details": "object",
+              "object": "string",
+              "status": "string"
+            },
+            "response_fields": [
+              "error",
+              "id",
+              "incomplete_details",
+              "object",
+              "status"
+            ],
+            "response_incomplete_details_field_types": {
+              "reason": "string"
+            },
+            "response_incomplete_details_fields": [
+              "reason"
+            ],
+            "response_status": "incomplete",
+            "type": "response.incomplete"
+          }
+        ],
+        "terminal_control": "incomplete",
+        "terminal_event_present": true
+      },
+      "process_runs": 1,
+      "workspace_created_under_home": true
+    },
+    "desktop_terminal_truncated": {
+      "client": "codex_desktop",
+      "fresh_empty_home_before_marker": true,
+      "home_binding_sha256": "6a5cbbb31fff06d91ebac181d783c6b569b7450e2212b6212ee75d3b5f2a7d14",
+      "loopback_request_count": 1,
+      "observed": {
+        "client_disposition": "rejected_nonzero_exit",
+        "completed_event_present": false,
+        "declaration": {
+          "children": [
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "followup_task",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "message": {
+                    "encrypted": true,
+                    "type": "string"
+                  },
+                  "target": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "message",
+                  "target"
+                ],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "interrupt_agent",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "target": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "target"
+                ],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "list_agents",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "path_prefix": {
+                    "type": "string"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "send_message",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "message": {
+                    "encrypted": true,
+                    "type": "string"
+                  },
+                  "target": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "message",
+                  "target"
+                ],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "spawn_agent",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "agent_type": {
+                    "type": "string"
+                  },
+                  "fork_turns": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "encrypted": true,
+                    "type": "string"
+                  },
+                  "model": {
+                    "type": "string"
+                  },
+                  "reasoning_effort": {
+                    "type": "string"
+                  },
+                  "task_name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "message",
+                  "task_name"
+                ],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            },
+            {
+              "description_type": "string",
+              "fields": [
+                "description",
+                "name",
+                "parameters",
+                "strict",
+                "type"
+              ],
+              "name": "wait_agent",
+              "parameters": {
+                "additionalProperties": false,
+                "properties": {
+                  "timeout_ms": {
+                    "type": "number"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              "strict": false,
+              "type": "function"
+            }
+          ],
+          "description_type": "string",
+          "fields": [
+            "description",
+            "name",
+            "tools",
+            "type"
+          ],
+          "name": "collaboration",
+          "type": "namespace"
+        },
+        "request": {
+          "collaboration_items": [],
+          "field_types": {
+            "client_metadata": "object",
+            "include": "array",
+            "input": "array",
+            "instructions": "string",
+            "model": "string",
+            "parallel_tool_calls": "boolean",
+            "prompt_cache_key": "string",
+            "reasoning": "object",
+            "store": "boolean",
+            "stream": "boolean",
+            "tool_choice": "string",
+            "tools": "array"
+          },
+          "fields": [
+            "client_metadata",
+            "include",
+            "input",
+            "instructions",
+            "model",
+            "parallel_tool_calls",
+            "prompt_cache_key",
+            "reasoning",
+            "store",
+            "stream",
+            "tool_choice",
+            "tools"
+          ],
+          "input_type_order": [
+            "message",
+            "message",
+            "message",
+            "message",
+            "message"
+          ],
+          "multi_agent_version_locations": [],
+          "tool_choice": "auto"
+        },
+        "served_event_envelopes": [
+          {
+            "field_types": {
+              "response": "object",
+              "type": "string"
+            },
+            "fields": [
+              "response",
+              "type"
+            ],
+            "response_field_types": {
+              "id": "string",
+              "model": "string",
+              "object": "string",
+              "output": "array",
+              "status": "string"
+            },
+            "response_fields": [
+              "id",
+              "model",
+              "object",
+              "output",
+              "status"
+            ],
+            "response_output_item_types": [],
+            "response_status": "in_progress",
+            "type": "response.created"
+          },
+          {
+            "field_types": {
+              "item": "object",
+              "output_index": "number",
+              "type": "string"
+            },
+            "fields": [
+              "item",
+              "output_index",
+              "type"
+            ],
+            "item_field_types": {
+              "content": "array",
+              "id": "string",
+              "role": "string",
+              "type": "string"
+            },
+            "item_fields": [
+              "content",
+              "id",
+              "role",
+              "type"
+            ],
+            "item_type": "message",
+            "type": "response.output_item.added"
+          },
+          {
+            "field_types": {
+              "content_index": "number",
+              "item_id": "string",
+              "output_index": "number",
+              "part": "object",
+              "type": "string"
+            },
+            "fields": [
+              "content_index",
+              "item_id",
+              "output_index",
+              "part",
+              "type"
+            ],
+            "part_field_types": {
+              "annotations": "array",
+              "text": "string",
+              "type": "string"
+            },
+            "part_fields": [
+              "annotations",
+              "text",
+              "type"
+            ],
+            "part_type": "output_text",
+            "type": "response.content_part.added"
+          },
+          {
+            "field_types": {
+              "content_index": "number",
+              "delta": "string",
+              "item_id": "string",
+              "output_index": "number",
+              "type": "string"
+            },
+            "fields": [
+              "content_index",
+              "delta",
+              "item_id",
+              "output_index",
+              "type"
+            ],
+            "type": "response.output_text.delta"
+          }
+        ],
+        "terminal_control": "truncated",
+        "terminal_event_present": false
+      },
+      "process_runs": 1,
+      "workspace_created_under_home": true
+    },
     "desktop_v1_request": {
       "client": "codex_desktop",
       "fresh_empty_home_before_marker": true,
-      "home_binding_sha256": "c99dd6202b2a2fddc017c522c869e619b72803c8ec1393209ab3bb8c66528007",
+      "home_binding_sha256": "15cf38a729af04feca92e316512bdfc7592fbc23704a0b524ef256718f2f2ea8",
       "loopback_request_count": 1,
       "observed": {
         "declaration": {
@@ -3245,7 +6128,7 @@
     "desktop_v2_lifecycle": {
       "client": "codex_desktop",
       "fresh_empty_home_before_marker": true,
-      "home_binding_sha256": "9ff014546ee3d0495ea5d21413bd8cc5e7ecf23f1e09bf0023e2b218526b7e04",
+      "home_binding_sha256": "dee87876f539a243364378b32892cecb50ac21524d1262f96328247091cc57ab",
       "loopback_request_count": 5,
       "observed": {
         "declaration": {
@@ -3435,7 +6318,10 @@
           "type": "namespace"
         },
         "identity_relationships": {
+          "agent_message_addresses_nonempty": true,
           "agent_message_author_recipient_and_content_preserved": true,
+          "agent_message_item_ids_preserved": true,
+          "all_identity_fields_nonempty": true,
           "collaboration_item_order_preserved": true,
           "function_call_call_ids_preserved": true,
           "function_call_item_ids_preserved": true,
@@ -4568,6 +7454,865 @@
               "response_item"
             ],
             "role": "child"
+          }
+        ],
+        "served_event_sequences": [
+          {
+            "events": [
+              {
+                "field_types": {
+                  "response": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "response",
+                  "type"
+                ],
+                "response_field_types": {
+                  "id": "string",
+                  "model": "string",
+                  "object": "string",
+                  "output": "array",
+                  "status": "string"
+                },
+                "response_fields": [
+                  "id",
+                  "model",
+                  "object",
+                  "output",
+                  "status"
+                ],
+                "response_output_item_types": [],
+                "response_status": "in_progress",
+                "type": "response.created"
+              },
+              {
+                "field_types": {
+                  "item": "object",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "item",
+                  "output_index",
+                  "type"
+                ],
+                "item_field_types": {
+                  "arguments": "string",
+                  "call_id": "string",
+                  "id": "string",
+                  "name": "string",
+                  "namespace": "string",
+                  "status": "string",
+                  "type": "string"
+                },
+                "item_fields": [
+                  "arguments",
+                  "call_id",
+                  "id",
+                  "name",
+                  "namespace",
+                  "status",
+                  "type"
+                ],
+                "item_name": "spawn_agent",
+                "item_namespace": "collaboration",
+                "item_status": "in_progress",
+                "item_type": "function_call",
+                "type": "response.output_item.added"
+              },
+              {
+                "field_types": {
+                  "delta": "string",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "delta",
+                  "item_id",
+                  "output_index",
+                  "type"
+                ],
+                "type": "response.function_call_arguments.delta"
+              },
+              {
+                "field_types": {
+                  "arguments": "string",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "arguments",
+                  "item_id",
+                  "output_index",
+                  "type"
+                ],
+                "type": "response.function_call_arguments.done"
+              },
+              {
+                "field_types": {
+                  "item": "object",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "item",
+                  "output_index",
+                  "type"
+                ],
+                "item_field_types": {
+                  "arguments": "string",
+                  "call_id": "string",
+                  "id": "string",
+                  "name": "string",
+                  "namespace": "string",
+                  "status": "string",
+                  "type": "string"
+                },
+                "item_fields": [
+                  "arguments",
+                  "call_id",
+                  "id",
+                  "name",
+                  "namespace",
+                  "status",
+                  "type"
+                ],
+                "item_name": "spawn_agent",
+                "item_namespace": "collaboration",
+                "item_status": "completed",
+                "item_type": "function_call",
+                "type": "response.output_item.done"
+              },
+              {
+                "field_types": {
+                  "response": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "response",
+                  "type"
+                ],
+                "response_field_types": {
+                  "id": "string",
+                  "model": "string",
+                  "object": "string",
+                  "output": "array",
+                  "status": "string",
+                  "usage": "object"
+                },
+                "response_fields": [
+                  "id",
+                  "model",
+                  "object",
+                  "output",
+                  "status",
+                  "usage"
+                ],
+                "response_output_item_types": [
+                  "function_call"
+                ],
+                "response_status": "completed",
+                "type": "response.completed"
+              }
+            ],
+            "request_index": 1
+          },
+          {
+            "events": [
+              {
+                "field_types": {
+                  "response": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "response",
+                  "type"
+                ],
+                "response_field_types": {
+                  "id": "string",
+                  "model": "string",
+                  "object": "string",
+                  "output": "array",
+                  "status": "string"
+                },
+                "response_fields": [
+                  "id",
+                  "model",
+                  "object",
+                  "output",
+                  "status"
+                ],
+                "response_output_item_types": [],
+                "response_status": "in_progress",
+                "type": "response.created"
+              },
+              {
+                "field_types": {
+                  "item": "object",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "item",
+                  "output_index",
+                  "type"
+                ],
+                "item_field_types": {
+                  "arguments": "string",
+                  "call_id": "string",
+                  "id": "string",
+                  "name": "string",
+                  "namespace": "string",
+                  "status": "string",
+                  "type": "string"
+                },
+                "item_fields": [
+                  "arguments",
+                  "call_id",
+                  "id",
+                  "name",
+                  "namespace",
+                  "status",
+                  "type"
+                ],
+                "item_name": "wait_agent",
+                "item_namespace": "collaboration",
+                "item_status": "in_progress",
+                "item_type": "function_call",
+                "type": "response.output_item.added"
+              },
+              {
+                "field_types": {
+                  "delta": "string",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "delta",
+                  "item_id",
+                  "output_index",
+                  "type"
+                ],
+                "type": "response.function_call_arguments.delta"
+              },
+              {
+                "field_types": {
+                  "arguments": "string",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "arguments",
+                  "item_id",
+                  "output_index",
+                  "type"
+                ],
+                "type": "response.function_call_arguments.done"
+              },
+              {
+                "field_types": {
+                  "item": "object",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "item",
+                  "output_index",
+                  "type"
+                ],
+                "item_field_types": {
+                  "arguments": "string",
+                  "call_id": "string",
+                  "id": "string",
+                  "name": "string",
+                  "namespace": "string",
+                  "status": "string",
+                  "type": "string"
+                },
+                "item_fields": [
+                  "arguments",
+                  "call_id",
+                  "id",
+                  "name",
+                  "namespace",
+                  "status",
+                  "type"
+                ],
+                "item_name": "wait_agent",
+                "item_namespace": "collaboration",
+                "item_status": "completed",
+                "item_type": "function_call",
+                "type": "response.output_item.done"
+              },
+              {
+                "field_types": {
+                  "response": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "response",
+                  "type"
+                ],
+                "response_field_types": {
+                  "id": "string",
+                  "model": "string",
+                  "object": "string",
+                  "output": "array",
+                  "status": "string",
+                  "usage": "object"
+                },
+                "response_fields": [
+                  "id",
+                  "model",
+                  "object",
+                  "output",
+                  "status",
+                  "usage"
+                ],
+                "response_output_item_types": [
+                  "function_call"
+                ],
+                "response_status": "completed",
+                "type": "response.completed"
+              }
+            ],
+            "request_index": 2
+          },
+          {
+            "events": [
+              {
+                "field_types": {
+                  "response": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "response",
+                  "type"
+                ],
+                "response_field_types": {
+                  "id": "string",
+                  "model": "string",
+                  "object": "string",
+                  "output": "array",
+                  "status": "string"
+                },
+                "response_fields": [
+                  "id",
+                  "model",
+                  "object",
+                  "output",
+                  "status"
+                ],
+                "response_output_item_types": [],
+                "response_status": "in_progress",
+                "type": "response.created"
+              },
+              {
+                "field_types": {
+                  "item": "object",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "item",
+                  "output_index",
+                  "type"
+                ],
+                "item_field_types": {
+                  "content": "array",
+                  "id": "string",
+                  "role": "string",
+                  "type": "string"
+                },
+                "item_fields": [
+                  "content",
+                  "id",
+                  "role",
+                  "type"
+                ],
+                "item_type": "message",
+                "type": "response.output_item.added"
+              },
+              {
+                "field_types": {
+                  "content_index": "number",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "part": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "content_index",
+                  "item_id",
+                  "output_index",
+                  "part",
+                  "type"
+                ],
+                "part_field_types": {
+                  "annotations": "array",
+                  "text": "string",
+                  "type": "string"
+                },
+                "part_fields": [
+                  "annotations",
+                  "text",
+                  "type"
+                ],
+                "part_type": "output_text",
+                "type": "response.content_part.added"
+              },
+              {
+                "field_types": {
+                  "content_index": "number",
+                  "delta": "string",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "content_index",
+                  "delta",
+                  "item_id",
+                  "output_index",
+                  "type"
+                ],
+                "type": "response.output_text.delta"
+              },
+              {
+                "field_types": {
+                  "content_index": "number",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "text": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "content_index",
+                  "item_id",
+                  "output_index",
+                  "text",
+                  "type"
+                ],
+                "type": "response.output_text.done"
+              },
+              {
+                "field_types": {
+                  "item": "object",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "item",
+                  "output_index",
+                  "type"
+                ],
+                "item_field_types": {
+                  "content": "array",
+                  "id": "string",
+                  "role": "string",
+                  "type": "string"
+                },
+                "item_fields": [
+                  "content",
+                  "id",
+                  "role",
+                  "type"
+                ],
+                "item_type": "message",
+                "type": "response.output_item.done"
+              },
+              {
+                "field_types": {
+                  "response": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "response",
+                  "type"
+                ],
+                "response_field_types": {
+                  "id": "string",
+                  "model": "string",
+                  "object": "string",
+                  "output": "array",
+                  "status": "string",
+                  "usage": "object"
+                },
+                "response_fields": [
+                  "id",
+                  "model",
+                  "object",
+                  "output",
+                  "status",
+                  "usage"
+                ],
+                "response_output_item_types": [
+                  "message"
+                ],
+                "response_status": "completed",
+                "type": "response.completed"
+              }
+            ],
+            "request_index": 3
+          },
+          {
+            "events": [
+              {
+                "field_types": {
+                  "response": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "response",
+                  "type"
+                ],
+                "response_field_types": {
+                  "id": "string",
+                  "model": "string",
+                  "object": "string",
+                  "output": "array",
+                  "status": "string"
+                },
+                "response_fields": [
+                  "id",
+                  "model",
+                  "object",
+                  "output",
+                  "status"
+                ],
+                "response_output_item_types": [],
+                "response_status": "in_progress",
+                "type": "response.created"
+              },
+              {
+                "field_types": {
+                  "item": "object",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "item",
+                  "output_index",
+                  "type"
+                ],
+                "item_field_types": {
+                  "content": "array",
+                  "id": "string",
+                  "role": "string",
+                  "type": "string"
+                },
+                "item_fields": [
+                  "content",
+                  "id",
+                  "role",
+                  "type"
+                ],
+                "item_type": "message",
+                "type": "response.output_item.added"
+              },
+              {
+                "field_types": {
+                  "content_index": "number",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "part": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "content_index",
+                  "item_id",
+                  "output_index",
+                  "part",
+                  "type"
+                ],
+                "part_field_types": {
+                  "annotations": "array",
+                  "text": "string",
+                  "type": "string"
+                },
+                "part_fields": [
+                  "annotations",
+                  "text",
+                  "type"
+                ],
+                "part_type": "output_text",
+                "type": "response.content_part.added"
+              },
+              {
+                "field_types": {
+                  "content_index": "number",
+                  "delta": "string",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "content_index",
+                  "delta",
+                  "item_id",
+                  "output_index",
+                  "type"
+                ],
+                "type": "response.output_text.delta"
+              },
+              {
+                "field_types": {
+                  "content_index": "number",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "text": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "content_index",
+                  "item_id",
+                  "output_index",
+                  "text",
+                  "type"
+                ],
+                "type": "response.output_text.done"
+              },
+              {
+                "field_types": {
+                  "item": "object",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "item",
+                  "output_index",
+                  "type"
+                ],
+                "item_field_types": {
+                  "content": "array",
+                  "id": "string",
+                  "role": "string",
+                  "type": "string"
+                },
+                "item_fields": [
+                  "content",
+                  "id",
+                  "role",
+                  "type"
+                ],
+                "item_type": "message",
+                "type": "response.output_item.done"
+              },
+              {
+                "field_types": {
+                  "response": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "response",
+                  "type"
+                ],
+                "response_field_types": {
+                  "id": "string",
+                  "model": "string",
+                  "object": "string",
+                  "output": "array",
+                  "status": "string",
+                  "usage": "object"
+                },
+                "response_fields": [
+                  "id",
+                  "model",
+                  "object",
+                  "output",
+                  "status",
+                  "usage"
+                ],
+                "response_output_item_types": [
+                  "message"
+                ],
+                "response_status": "completed",
+                "type": "response.completed"
+              }
+            ],
+            "request_index": 4
+          },
+          {
+            "events": [
+              {
+                "field_types": {
+                  "response": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "response",
+                  "type"
+                ],
+                "response_field_types": {
+                  "id": "string",
+                  "model": "string",
+                  "object": "string",
+                  "output": "array",
+                  "status": "string"
+                },
+                "response_fields": [
+                  "id",
+                  "model",
+                  "object",
+                  "output",
+                  "status"
+                ],
+                "response_output_item_types": [],
+                "response_status": "in_progress",
+                "type": "response.created"
+              },
+              {
+                "field_types": {
+                  "item": "object",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "item",
+                  "output_index",
+                  "type"
+                ],
+                "item_field_types": {
+                  "content": "array",
+                  "id": "string",
+                  "role": "string",
+                  "type": "string"
+                },
+                "item_fields": [
+                  "content",
+                  "id",
+                  "role",
+                  "type"
+                ],
+                "item_type": "message",
+                "type": "response.output_item.added"
+              },
+              {
+                "field_types": {
+                  "content_index": "number",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "part": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "content_index",
+                  "item_id",
+                  "output_index",
+                  "part",
+                  "type"
+                ],
+                "part_field_types": {
+                  "annotations": "array",
+                  "text": "string",
+                  "type": "string"
+                },
+                "part_fields": [
+                  "annotations",
+                  "text",
+                  "type"
+                ],
+                "part_type": "output_text",
+                "type": "response.content_part.added"
+              },
+              {
+                "field_types": {
+                  "content_index": "number",
+                  "delta": "string",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "content_index",
+                  "delta",
+                  "item_id",
+                  "output_index",
+                  "type"
+                ],
+                "type": "response.output_text.delta"
+              },
+              {
+                "field_types": {
+                  "content_index": "number",
+                  "item_id": "string",
+                  "output_index": "number",
+                  "text": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "content_index",
+                  "item_id",
+                  "output_index",
+                  "text",
+                  "type"
+                ],
+                "type": "response.output_text.done"
+              },
+              {
+                "field_types": {
+                  "item": "object",
+                  "output_index": "number",
+                  "type": "string"
+                },
+                "fields": [
+                  "item",
+                  "output_index",
+                  "type"
+                ],
+                "item_field_types": {
+                  "content": "array",
+                  "id": "string",
+                  "role": "string",
+                  "type": "string"
+                },
+                "item_fields": [
+                  "content",
+                  "id",
+                  "role",
+                  "type"
+                ],
+                "item_type": "message",
+                "type": "response.output_item.done"
+              },
+              {
+                "field_types": {
+                  "response": "object",
+                  "type": "string"
+                },
+                "fields": [
+                  "response",
+                  "type"
+                ],
+                "response_field_types": {
+                  "id": "string",
+                  "model": "string",
+                  "object": "string",
+                  "output": "array",
+                  "status": "string",
+                  "usage": "object"
+                },
+                "response_fields": [
+                  "id",
+                  "model",
+                  "object",
+                  "output",
+                  "status",
+                  "usage"
+                ],
+                "response_output_item_types": [
+                  "message"
+                ],
+                "response_status": "completed",
+                "type": "response.completed"
+              }
+            ],
+            "request_index": 5
           }
         ],
         "served_function_call_event_order": [

--- a/docs/evidence/issue-64/collaboration-v1-v2-inventory.json
+++ b/docs/evidence/issue-64/collaboration-v1-v2-inventory.json
@@ -79,7 +79,7 @@
     "basis": "accepted_issue392_exact_runtime_contract",
     "source_contract": {
       "file": "collaboration-runtime-contract.json",
-      "sha256": "5688d0730e6c0270a74b512fd43b4b96094e131481fb5847bd82b6149179e6a9"
+      "sha256": "7ed254a4171eabf59e9d8f0ab8c0133ccf13cfad6c83b0b57b122c244c71d2e2"
     }
   },
   "protocol_layers": {
@@ -1322,54 +1322,104 @@
         ],
         "event_shapes": {
           "response.function_call_arguments.delta": {
+            "field_types": {
+              "delta": "string",
+              "item_id": "string",
+              "output_index": "number",
+              "type": "string"
+            },
             "fields": [
-              "type",
+              "delta",
               "item_id",
               "output_index",
-              "delta"
-            ]
+              "type"
+            ],
+            "type": "response.function_call_arguments.delta"
           },
           "response.function_call_arguments.done": {
+            "field_types": {
+              "arguments": "string",
+              "item_id": "string",
+              "output_index": "number",
+              "type": "string"
+            },
             "fields": [
-              "type",
+              "arguments",
               "item_id",
               "output_index",
-              "arguments"
-            ]
+              "type"
+            ],
+            "type": "response.function_call_arguments.done"
           },
           "response.output_item.added": {
+            "field_types": {
+              "item": "object",
+              "output_index": "number",
+              "type": "string"
+            },
             "fields": [
-              "type",
+              "item",
               "output_index",
-              "item"
+              "type"
             ],
+            "item_field_types": {
+              "arguments": "string",
+              "call_id": "string",
+              "id": "string",
+              "name": "string",
+              "namespace": "string",
+              "status": "string",
+              "type": "string"
+            },
             "item_fields": [
-              "type",
+              "arguments",
+              "call_id",
               "id",
-              "status",
               "name",
               "namespace",
-              "arguments",
-              "call_id"
+              "status",
+              "type"
             ],
-            "status": "in_progress"
+            "item_name": "spawn_agent",
+            "item_namespace": "collaboration",
+            "item_status": "in_progress",
+            "item_type": "function_call",
+            "type": "response.output_item.added"
           },
           "response.output_item.done": {
+            "field_types": {
+              "item": "object",
+              "output_index": "number",
+              "type": "string"
+            },
             "fields": [
-              "type",
+              "item",
               "output_index",
-              "item"
+              "type"
             ],
+            "item_field_types": {
+              "arguments": "string",
+              "call_id": "string",
+              "id": "string",
+              "name": "string",
+              "namespace": "string",
+              "status": "string",
+              "type": "string"
+            },
             "item_fields": [
-              "type",
+              "arguments",
+              "call_id",
               "id",
-              "status",
               "name",
               "namespace",
-              "arguments",
-              "call_id"
+              "status",
+              "type"
             ],
-            "status": "completed"
+            "item_name": "spawn_agent",
+            "item_namespace": "collaboration",
+            "item_status": "completed",
+            "item_type": "function_call",
+            "type": "response.output_item.done"
           }
         },
         "terminal_events": [
@@ -1379,41 +1429,94 @@
         ],
         "terminal_shapes": {
           "response.completed": {
+            "field_types": {
+              "response": "object",
+              "type": "string"
+            },
             "fields": [
-              "type",
-              "response"
+              "response",
+              "type"
             ],
+            "response_field_types": {
+              "id": "string",
+              "model": "string",
+              "object": "string",
+              "output": "array",
+              "status": "string",
+              "usage": "object"
+            },
             "response_fields": [
               "id",
-              "status",
+              "model",
+              "object",
               "output",
+              "status",
               "usage"
             ],
-            "status": "completed"
+            "response_output_item_types": [
+              "function_call"
+            ],
+            "response_status": "completed",
+            "type": "response.completed"
           },
           "response.failed": {
+            "field_types": {
+              "response": "object",
+              "type": "string"
+            },
             "fields": [
-              "type",
-              "response"
+              "response",
+              "type"
             ],
-            "response_required_fields": [
-              "id",
-              "status",
-              "error"
+            "response_error_field_types": {
+              "code": "string",
+              "message": "string"
+            },
+            "response_error_fields": [
+              "code",
+              "message"
             ],
-            "status": "failed"
+            "response_field_types": {
+              "error": "object",
+              "id": "string"
+            },
+            "response_fields": [
+              "error",
+              "id"
+            ],
+            "type": "response.failed"
           },
           "response.incomplete": {
+            "field_types": {
+              "response": "object",
+              "type": "string"
+            },
             "fields": [
-              "type",
-              "response"
+              "response",
+              "type"
             ],
-            "response_required_fields": [
+            "response_field_types": {
+              "error": "null",
+              "id": "string",
+              "incomplete_details": "object",
+              "object": "string",
+              "status": "string"
+            },
+            "response_fields": [
+              "error",
               "id",
-              "status",
-              "incomplete_details"
+              "incomplete_details",
+              "object",
+              "status"
             ],
-            "status": "incomplete"
+            "response_incomplete_details_field_types": {
+              "reason": "string"
+            },
+            "response_incomplete_details_fields": [
+              "reason"
+            ],
+            "response_status": "incomplete",
+            "type": "response.incomplete"
           }
         }
       }
@@ -1973,54 +2076,104 @@
         ],
         "event_shapes": {
           "response.function_call_arguments.delta": {
+            "field_types": {
+              "delta": "string",
+              "item_id": "string",
+              "output_index": "number",
+              "type": "string"
+            },
             "fields": [
-              "type",
+              "delta",
               "item_id",
               "output_index",
-              "delta"
-            ]
+              "type"
+            ],
+            "type": "response.function_call_arguments.delta"
           },
           "response.function_call_arguments.done": {
+            "field_types": {
+              "arguments": "string",
+              "item_id": "string",
+              "output_index": "number",
+              "type": "string"
+            },
             "fields": [
-              "type",
+              "arguments",
               "item_id",
               "output_index",
-              "arguments"
-            ]
+              "type"
+            ],
+            "type": "response.function_call_arguments.done"
           },
           "response.output_item.added": {
+            "field_types": {
+              "item": "object",
+              "output_index": "number",
+              "type": "string"
+            },
             "fields": [
-              "type",
+              "item",
               "output_index",
-              "item"
+              "type"
             ],
+            "item_field_types": {
+              "arguments": "string",
+              "call_id": "string",
+              "id": "string",
+              "name": "string",
+              "namespace": "string",
+              "status": "string",
+              "type": "string"
+            },
             "item_fields": [
-              "type",
+              "arguments",
+              "call_id",
               "id",
-              "status",
               "name",
               "namespace",
-              "arguments",
-              "call_id"
+              "status",
+              "type"
             ],
-            "status": "in_progress"
+            "item_name": "spawn_agent",
+            "item_namespace": "collaboration",
+            "item_status": "in_progress",
+            "item_type": "function_call",
+            "type": "response.output_item.added"
           },
           "response.output_item.done": {
+            "field_types": {
+              "item": "object",
+              "output_index": "number",
+              "type": "string"
+            },
             "fields": [
-              "type",
+              "item",
               "output_index",
-              "item"
+              "type"
             ],
+            "item_field_types": {
+              "arguments": "string",
+              "call_id": "string",
+              "id": "string",
+              "name": "string",
+              "namespace": "string",
+              "status": "string",
+              "type": "string"
+            },
             "item_fields": [
-              "type",
+              "arguments",
+              "call_id",
               "id",
-              "status",
               "name",
               "namespace",
-              "arguments",
-              "call_id"
+              "status",
+              "type"
             ],
-            "status": "completed"
+            "item_name": "spawn_agent",
+            "item_namespace": "collaboration",
+            "item_status": "completed",
+            "item_type": "function_call",
+            "type": "response.output_item.done"
           }
         },
         "terminal_events": [
@@ -2030,41 +2183,94 @@
         ],
         "terminal_shapes": {
           "response.completed": {
+            "field_types": {
+              "response": "object",
+              "type": "string"
+            },
             "fields": [
-              "type",
-              "response"
+              "response",
+              "type"
             ],
+            "response_field_types": {
+              "id": "string",
+              "model": "string",
+              "object": "string",
+              "output": "array",
+              "status": "string",
+              "usage": "object"
+            },
             "response_fields": [
               "id",
-              "status",
+              "model",
+              "object",
               "output",
+              "status",
               "usage"
             ],
-            "status": "completed"
+            "response_output_item_types": [
+              "function_call"
+            ],
+            "response_status": "completed",
+            "type": "response.completed"
           },
           "response.failed": {
+            "field_types": {
+              "response": "object",
+              "type": "string"
+            },
             "fields": [
-              "type",
-              "response"
+              "response",
+              "type"
             ],
-            "response_required_fields": [
-              "id",
-              "status",
-              "error"
+            "response_error_field_types": {
+              "code": "string",
+              "message": "string"
+            },
+            "response_error_fields": [
+              "code",
+              "message"
             ],
-            "status": "failed"
+            "response_field_types": {
+              "error": "object",
+              "id": "string"
+            },
+            "response_fields": [
+              "error",
+              "id"
+            ],
+            "type": "response.failed"
           },
           "response.incomplete": {
+            "field_types": {
+              "response": "object",
+              "type": "string"
+            },
             "fields": [
-              "type",
-              "response"
+              "response",
+              "type"
             ],
-            "response_required_fields": [
+            "response_field_types": {
+              "error": "null",
+              "id": "string",
+              "incomplete_details": "object",
+              "object": "string",
+              "status": "string"
+            },
+            "response_fields": [
+              "error",
               "id",
-              "status",
-              "incomplete_details"
+              "incomplete_details",
+              "object",
+              "status"
             ],
-            "status": "incomplete"
+            "response_incomplete_details_field_types": {
+              "reason": "string"
+            },
+            "response_incomplete_details_fields": [
+              "reason"
+            ],
+            "response_status": "incomplete",
+            "type": "response.incomplete"
           }
         }
       }

--- a/docs/evidence/issue-64/collaboration-v1-v2-inventory.json
+++ b/docs/evidence/issue-64/collaboration-v1-v2-inventory.json
@@ -1,212 +1,620 @@
 {
   "adapter_requirements": {
+    "adapt_only_when": "complete_lifecycle_inverse_is_proven",
     "adaptation_owner": "codexhub_gateway",
     "forbidden_gateway_actions": [
       "execute_tools",
       "schedule_agents",
-      "forge_results",
-      "downgrade_v2_to_v1"
+      "forge_results_or_identity",
+      "downgrade_v2_to_v1",
+      "rewrite_history"
     ],
+    "native_namespace": "pass_without_semantic_mutation",
     "owner": "codex_client",
-    "protocol_shape_decisions": {
-      "collaboration_v1": {
-        "inverse_mapping": "request_scoped_and_lossless",
-        "namespace_to_function": "required_when_selected_protocol_lacks_namespace",
-        "official_cli_capture_status": "not_observed",
-        "shape_kind": "current_gateway_compatibility_surface"
-      },
-      "collaboration_v2": {
-        "inverse_mapping": "request_scoped_and_lossless",
-        "namespace_to_function": "optional_only_when_selected_protocol_lacks_namespace",
-        "native_namespace": "may_pass_when_selected_protocol_supports_namespace",
-        "official_cli_capture_status": "not_observed",
-        "preserved_fields": [
-          "task_path",
-          "continuation_id",
-          "task_name",
-          "fork_turns"
-        ],
-        "shape_kind": "accepted_structural_contract"
-      }
-    },
     "requirements": [
-      "namespace_to_function",
       "injective_request_scoped_aliases",
-      "preserve_task_path_identity",
-      "preserve_continuation_id_and_fork_turns",
-      "preserve_call_result_history_links",
-      "preserve_inverse_declaration_call_result_history_mapping",
-      "assemble_stream_before_validation",
-      "reject_unknown_or_ambiguous_boundary",
+      "preserve_namespace_and_child_name",
+      "preserve_call_and_item_identity",
+      "preserve_order_and_stream_boundaries",
+      "preserve_task_name_and_agent_path_identity",
+      "preserve_agent_message_author_and_recipient",
+      "preserve_same_home_history_replay",
+      "reject_unknown_missing_duplicate_conflicting_or_mixed_boundary",
       "keep_v1_and_v2_isolated"
-    ],
-    "scope": "requirements_only_for_198_and_58"
+    ]
   },
   "artifact_kind": "collaboration_v1_v2_inventory",
   "boundary": {
-    "ambiguous_action": "fail_closed",
-    "discriminator_fields": [
-      "namespace",
-      "name"
-    ],
-    "flattened_name_policy": "not_decidable_without_namespace",
+    "conflicting_action": "fail_closed",
+    "direct_function_policy": "not_a_frozen_runtime_collaboration_marker",
+    "duplicate_action": "fail_closed",
+    "matching_policy": "complete_namespace_and_child_schema",
+    "missing_action": "fail_closed",
     "mixed_v1_v2_action": "fail_closed",
-    "pre_exposure_stage": "before_tool_exposure_or_semantic_repair",
+    "pre_exposure_stage": "before_schema_repair_state_or_scheduler",
     "protocol_markers": {
       "collaboration_v1": {
         "namespace": "multi_agent_v1",
         "tool_names": [
-          "spawn_agent",
-          "send_input",
-          "wait_agent",
           "close_agent",
-          "resume_agent"
+          "resume_agent",
+          "send_input",
+          "spawn_agent",
+          "wait_agent"
         ]
       },
       "collaboration_v2": {
         "namespace": "collaboration",
         "tool_names": [
-          "spawn_agent",
-          "send_message",
           "followup_task",
-          "wait_agent",
           "interrupt_agent",
-          "list_agents"
+          "list_agents",
+          "send_message",
+          "spawn_agent",
+          "wait_agent"
         ]
       }
     },
+    "request_metadata_version_field": "absent_in_both_frozen_runtimes",
+    "shared_tool_name_policy": "never_classify_from_child_name_alone",
+    "tool_choice": "auto",
     "unknown_action": "fail_closed"
   },
   "candidate_identity": {
-    "cli_version": "0.146.0",
-    "source_capture_status": "not_observed",
-    "source_commit": "e363b08c9175ac1cbe5893615dd2cb9ddf95043b",
-    "source_commit_status": "published_attested",
-    "source_contract_file": "codex-0.146-source-contract.json",
-    "source_tag": "rust-v0.146.0"
+    "candidate_revision": "be10f62f44b22fa8c84510238250ae11fb3ecab4",
+    "cli_source_commit": "79b4f03d35962b005b007a015113b38930711665",
+    "cli_version": "0.146.1",
+    "desktop_runtime_version": "0.147.0-alpha.6.5",
+    "desktop_source_commit": "618b8e9111da9f57fe380b09d0f6516e3f343536",
+    "desktop_version": "26.803.5235.0",
+    "source_capture_status": "observed",
+    "source_contract_file": "collaboration-runtime-contract.json"
   },
   "deferred_qualification": [
-    "full_spawn_message_followup_wait_interrupt_list_lifecycle",
-    "restart_and_cold_root_resume",
-    "cross_home_topology_and_history"
+    "full_six_tool_two_child_lifecycle",
+    "cross_home_negative_cases",
+    "malformed_agent_message_and_identity_negative_cases"
   ],
   "evidence_binding": {
-    "basis": "accepted_issue_62_source_contract_and_repository_evidence",
+    "basis": "accepted_issue392_exact_runtime_contract",
     "source_contract": {
-      "file": "codex-0.146-source-contract.json",
-      "sha256": "6f38b8b07b98c6f28edd7418b63449242ee41d6396694392a70c0d7fb2b70f2c"
+      "file": "collaboration-runtime-contract.json",
+      "sha256": "fd093c72294cda2b48ca87f7e9d71502ba3d7ecb076d709c0daffe47818bd981"
+    }
+  },
+  "protocol_layers": {
+    "client_dispatch": {
+      "meaning": "client_tool_dispatch_group",
+      "recipient_namespace": "collaboration",
+      "wire_discriminator_by_itself": false
+    },
+    "desktop_app": {
+      "item_notifications": {
+        "agentMessage": [
+          "item/started",
+          "item/agentMessage/delta",
+          "item/completed"
+        ],
+        "collabAgentToolCall": [
+          "item/started",
+          "item/completed"
+        ],
+        "subAgentActivity": [
+          "item/started",
+          "item/completed"
+        ]
+      },
+      "same_home_thread_resume_and_read": "observed",
+      "thread_items": {
+        "agentMessage": [
+          "type",
+          "id",
+          "text",
+          "phase",
+          "memoryCitation"
+        ],
+        "collabAgentToolCall": [
+          "type",
+          "id",
+          "tool",
+          "status",
+          "senderThreadId",
+          "receiverThreadIds",
+          "prompt",
+          "model",
+          "reasoningEffort",
+          "agentsStates"
+        ],
+        "subAgentActivity": [
+          "type",
+          "id",
+          "kind",
+          "agentThreadId",
+          "agentPath"
+        ]
+      },
+      "turn_terminal_notification": "turn/completed",
+      "wire_item_equivalent": false
+    },
+    "model_input_agent_message": {
+      "content_variants": {
+        "encrypted_content": [
+          "type",
+          "encrypted_content"
+        ],
+        "input_text": [
+          "type",
+          "text"
+        ]
+      },
+      "fields": [
+        "type",
+        "id",
+        "author",
+        "recipient",
+        "content"
+      ],
+      "function_result": false,
+      "source_optional_field": "internal_chat_message_metadata_passthrough",
+      "task_identity_fields": [
+        "author",
+        "recipient"
+      ],
+      "type": "agent_message"
+    },
+    "responses_declaration_and_call": {
+      "call_namespace_field": true,
+      "call_type": "function_call",
+      "declaration_type": "namespace",
+      "namespace": "collaboration",
+      "tool_choice": "auto"
+    },
+    "rollout_metadata": {
+      "sent_as_request_metadata": false,
+      "session_meta_field": "multi_agent_version",
+      "turn_context_field": "multi_agent_version",
+      "values": [
+        "v1",
+        "v2"
+      ]
     }
   },
   "protocols": [
     {
       "call": {
+        "fields": [
+          "type",
+          "id",
+          "name",
+          "namespace",
+          "arguments",
+          "call_id"
+        ],
+        "identity_fields": [
+          "id",
+          "call_id"
+        ],
+        "wire_type": "function_call"
+      },
+      "declaration": {
         "argument_fields": {
           "close_agent": {
+            "additional_properties": false,
+            "client_result_schema": {
+              "additionalProperties": false,
+              "properties": {
+                "previous_status": {
+                  "oneOf": [
+                    {
+                      "enum": [
+                        "pending_init",
+                        "running",
+                        "interrupted",
+                        "shutdown",
+                        "not_found"
+                      ],
+                      "type": "string"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "completed": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "completed"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "errored": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "errored"
+                      ],
+                      "type": "object"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "previous_status"
+              ],
+              "type": "object"
+            },
+            "normalized_parameter_schema": {
+              "additionalProperties": false,
+              "properties": {
+                "target": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "target"
+              ],
+              "type": "object"
+            },
             "optional": [],
+            "request_output_schema_field": "absent",
             "required": [
               "target"
             ]
           },
           "resume_agent": {
+            "additional_properties": false,
+            "client_result_schema": {
+              "additionalProperties": false,
+              "properties": {
+                "status": {
+                  "oneOf": [
+                    {
+                      "enum": [
+                        "pending_init",
+                        "running",
+                        "interrupted",
+                        "shutdown",
+                        "not_found"
+                      ],
+                      "type": "string"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "completed": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "completed"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "errored": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "errored"
+                      ],
+                      "type": "object"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "status"
+              ],
+              "type": "object"
+            },
+            "normalized_parameter_schema": {
+              "additionalProperties": false,
+              "properties": {
+                "id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id"
+              ],
+              "type": "object"
+            },
             "optional": [],
+            "request_output_schema_field": "absent",
             "required": [
               "id"
             ]
           },
           "send_input": {
+            "additional_properties": false,
+            "client_result_schema": {
+              "additionalProperties": false,
+              "properties": {
+                "submission_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "submission_id"
+              ],
+              "type": "object"
+            },
+            "normalized_parameter_schema": {
+              "additionalProperties": false,
+              "properties": {
+                "interrupt": {
+                  "type": "boolean"
+                },
+                "items": {
+                  "items": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "audio_url": {
+                        "type": "string"
+                      },
+                      "image_url": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "path": {
+                        "type": "string"
+                      },
+                      "text": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [],
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "message": {
+                  "type": "string"
+                },
+                "target": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "target"
+              ],
+              "type": "object"
+            },
             "optional": [
               "interrupt",
+              "items",
               "message"
             ],
+            "request_output_schema_field": "absent",
             "required": [
               "target"
             ]
           },
           "spawn_agent": {
+            "additional_properties": false,
+            "client_result_schema": {
+              "additionalProperties": false,
+              "properties": {
+                "agent_id": {
+                  "type": "string"
+                },
+                "nickname": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "required": [
+                "agent_id",
+                "nickname"
+              ],
+              "type": "object"
+            },
+            "normalized_parameter_schema": {
+              "additionalProperties": false,
+              "properties": {
+                "agent_type": {
+                  "type": "string"
+                },
+                "fork_context": {
+                  "type": "boolean"
+                },
+                "items": {
+                  "items": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "audio_url": {
+                        "type": "string"
+                      },
+                      "image_url": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "path": {
+                        "type": "string"
+                      },
+                      "text": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [],
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "message": {
+                  "type": "string"
+                },
+                "model": {
+                  "type": "string"
+                },
+                "reasoning_effort": {
+                  "type": "string"
+                },
+                "service_tier": {
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "type": "object"
+            },
             "optional": [
+              "agent_type",
               "fork_context",
-              "message"
+              "items",
+              "message",
+              "model",
+              "reasoning_effort",
+              "service_tier"
             ],
-            "required": [
-              "agent_type"
-            ]
+            "request_output_schema_field": "absent",
+            "required": []
           },
           "wait_agent": {
+            "additional_properties": false,
+            "client_result_schema": {
+              "additionalProperties": false,
+              "properties": {
+                "status": {
+                  "additionalProperties": {
+                    "oneOf": [
+                      {
+                        "enum": [
+                          "pending_init",
+                          "running",
+                          "interrupted",
+                          "shutdown",
+                          "not_found"
+                        ],
+                        "type": "string"
+                      },
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "completed": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "completed"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "additionalProperties": false,
+                        "properties": {
+                          "errored": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "errored"
+                        ],
+                        "type": "object"
+                      }
+                    ]
+                  },
+                  "type": "object"
+                },
+                "timed_out": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "status",
+                "timed_out"
+              ],
+              "type": "object"
+            },
+            "normalized_parameter_schema": {
+              "additionalProperties": false,
+              "properties": {
+                "targets": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "timeout_ms": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "targets"
+              ],
+              "type": "object"
+            },
             "optional": [
               "timeout_ms"
             ],
+            "request_output_schema_field": "absent",
             "required": [
               "targets"
             ]
           }
         },
-        "fields": [
-          "type",
-          "namespace",
-          "name",
-          "item_id",
-          "call_id",
-          "arguments"
-        ],
-        "identity_fields": [
-          "call_id",
-          "item_id"
-        ],
-        "wire_type": "function_call"
-      },
-      "declaration": {
         "child_wire_type": "function",
-        "discriminator": {
-          "namespace": "multi_agent_v1",
-          "tool_field": "name"
-        },
         "fields": [
           "type",
           "name",
+          "description",
           "tools"
         ],
-        "flattened_name_prefixes": [
-          "multi_agent_v1__",
-          "multi_agent_v1."
-        ],
         "tool_names": [
-          "spawn_agent",
-          "send_input",
-          "wait_agent",
           "close_agent",
-          "resume_agent"
+          "resume_agent",
+          "send_input",
+          "spawn_agent",
+          "wait_agent"
         ],
         "wire_type": "namespace"
       },
       "executor": "codex_client",
       "history": {
-        "continuation_identity": "agent_id",
         "identity_fields": [
-          "agent_id",
+          "id",
           "call_id",
-          "call_item_id",
-          "output_item_id"
+          "agent_id"
         ],
         "items": [
           "function_call",
           "function_call_output"
         ],
-        "transcript_markers": [
-          "Previous real Codex native multi_agent_v1.<tool> call transcript",
-          "Codex native multi_agent_v1.<tool> result"
-        ]
+        "rollout_version_field": "multi_agent_version"
       },
       "id": "collaboration_v1",
       "isolation": {
         "forbidden_v2_fields": [
-          "continuation_id",
           "fork_turns",
-          "task_name",
-          "task_path"
-        ],
-        "forbidden_v2_semantics": [
-          "task_path_continuation",
-          "fork_turns"
+          "path_prefix",
+          "task_name"
         ],
         "forbidden_v2_tools": [
           "followup_task",
@@ -220,197 +628,676 @@
       "result": {
         "fields": [
           "type",
+          "id",
           "call_id",
-          "item_id",
           "output"
         ],
         "identity_fields": [
-          "call_id",
-          "item_id"
+          "id",
+          "call_id"
         ],
-        "result_fields_by_tool": {
-          "close_agent": [
-            "previous_status"
-          ],
-          "resume_agent": [
-            "status"
-          ],
-          "send_input": [
-            "status"
-          ],
-          "spawn_agent": [
-            "agent_id",
-            "nickname"
-          ],
-          "wait_agent": [
-            "timed_out",
-            "status"
-          ]
+        "output_wire_encoding": "json_text_string",
+        "spawn_identity": "agent_id",
+        "tool_output_schemas": {
+          "close_agent": {
+            "additionalProperties": false,
+            "properties": {
+              "previous_status": {
+                "oneOf": [
+                  {
+                    "enum": [
+                      "pending_init",
+                      "running",
+                      "interrupted",
+                      "shutdown",
+                      "not_found"
+                    ],
+                    "type": "string"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "completed": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "completed"
+                    ],
+                    "type": "object"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "errored": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "errored"
+                    ],
+                    "type": "object"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "previous_status"
+            ],
+            "type": "object"
+          },
+          "resume_agent": {
+            "additionalProperties": false,
+            "properties": {
+              "status": {
+                "oneOf": [
+                  {
+                    "enum": [
+                      "pending_init",
+                      "running",
+                      "interrupted",
+                      "shutdown",
+                      "not_found"
+                    ],
+                    "type": "string"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "completed": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "completed"
+                    ],
+                    "type": "object"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "errored": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "errored"
+                    ],
+                    "type": "object"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "status"
+            ],
+            "type": "object"
+          },
+          "send_input": {
+            "additionalProperties": false,
+            "properties": {
+              "submission_id": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "submission_id"
+            ],
+            "type": "object"
+          },
+          "spawn_agent": {
+            "additionalProperties": false,
+            "properties": {
+              "agent_id": {
+                "type": "string"
+              },
+              "nickname": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "agent_id",
+              "nickname"
+            ],
+            "type": "object"
+          },
+          "wait_agent": {
+            "additionalProperties": false,
+            "properties": {
+              "status": {
+                "additionalProperties": {
+                  "oneOf": [
+                    {
+                      "enum": [
+                        "pending_init",
+                        "running",
+                        "interrupted",
+                        "shutdown",
+                        "not_found"
+                      ],
+                      "type": "string"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "completed": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "completed"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "errored": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "errored"
+                      ],
+                      "type": "object"
+                    }
+                  ]
+                },
+                "type": "object"
+              },
+              "timed_out": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "status",
+              "timed_out"
+            ],
+            "type": "object"
+          }
         },
-        "result_identity": "agent_id",
         "wire_type": "function_call_output"
       },
       "shape_provenance": {
-        "official_cli_capture_status": "not_observed",
-        "shape_kind": "current_gateway_compatibility_surface",
-        "source": "src-python/codex_proxy.py#MULTI_AGENT_DISCOVERY_TOOLS"
+        "cli_capture_status": "observed",
+        "desktop_capture_status": "observed",
+        "source": "issue392_exact_cli_and_desktop_runtime_contract"
       },
-      "status": "legacy_structural_contract",
+      "status": "runtime_observed",
       "stream": {
-        "error_event": "response.failed",
         "event_order": [
           "response.output_item.added",
           "response.function_call_arguments.delta",
           "response.function_call_arguments.done",
           "response.output_item.done"
         ],
-        "qualification": "not_observed",
+        "event_shapes": {
+          "response.function_call_arguments.delta": {
+            "fields": [
+              "type",
+              "item_id",
+              "output_index",
+              "delta"
+            ]
+          },
+          "response.function_call_arguments.done": {
+            "fields": [
+              "type",
+              "item_id",
+              "output_index",
+              "arguments"
+            ]
+          },
+          "response.output_item.added": {
+            "fields": [
+              "type",
+              "output_index",
+              "item"
+            ],
+            "item_fields": [
+              "type",
+              "id",
+              "status",
+              "name",
+              "namespace",
+              "arguments",
+              "call_id"
+            ],
+            "status": "in_progress"
+          },
+          "response.output_item.done": {
+            "fields": [
+              "type",
+              "output_index",
+              "item"
+            ],
+            "item_fields": [
+              "type",
+              "id",
+              "status",
+              "name",
+              "namespace",
+              "arguments",
+              "call_id"
+            ],
+            "status": "completed"
+          }
+        },
         "terminal_events": [
           "response.completed",
           "response.incomplete",
           "response.failed"
-        ]
-      },
-      "terminal_error": {
-        "error_event": "response.failed",
-        "error_fields": [
-          "id",
-          "status",
-          "error"
         ],
-        "qualification": "not_observed",
-        "terminal_events": [
-          "response.completed",
-          "response.incomplete",
-          "response.failed"
-        ]
+        "terminal_shapes": {
+          "response.completed": {
+            "fields": [
+              "type",
+              "response"
+            ],
+            "response_fields": [
+              "id",
+              "status",
+              "output",
+              "usage"
+            ],
+            "status": "completed"
+          },
+          "response.failed": {
+            "fields": [
+              "type",
+              "response"
+            ],
+            "response_required_fields": [
+              "id",
+              "status",
+              "error"
+            ],
+            "status": "failed"
+          },
+          "response.incomplete": {
+            "fields": [
+              "type",
+              "response"
+            ],
+            "response_required_fields": [
+              "id",
+              "status",
+              "incomplete_details"
+            ],
+            "status": "incomplete"
+          }
+        }
       }
     },
     {
       "call": {
+        "fields": [
+          "type",
+          "id",
+          "name",
+          "namespace",
+          "arguments",
+          "call_id"
+        ],
+        "identity_fields": [
+          "id",
+          "call_id"
+        ],
+        "wire_type": "function_call"
+      },
+      "declaration": {
         "argument_fields": {
           "followup_task": {
+            "additional_properties": false,
+            "client_result_schema": null,
+            "normalized_parameter_schema": {
+              "additionalProperties": false,
+              "properties": {
+                "message": {
+                  "encrypted": true,
+                  "type": "string"
+                },
+                "target": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "target",
+                "message"
+              ],
+              "type": "object"
+            },
             "optional": [],
+            "request_output_schema_field": "absent",
             "required": [
-              "target",
-              "message"
+              "message",
+              "target"
             ]
           },
           "interrupt_agent": {
+            "additional_properties": false,
+            "client_result_schema": {
+              "additionalProperties": false,
+              "properties": {
+                "previous_status": {
+                  "oneOf": [
+                    {
+                      "enum": [
+                        "pending_init",
+                        "running",
+                        "interrupted",
+                        "shutdown",
+                        "not_found"
+                      ],
+                      "type": "string"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "completed": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "completed"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "properties": {
+                        "errored": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "errored"
+                      ],
+                      "type": "object"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "previous_status"
+              ],
+              "type": "object"
+            },
+            "normalized_parameter_schema": {
+              "additionalProperties": false,
+              "properties": {
+                "target": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "target"
+              ],
+              "type": "object"
+            },
             "optional": [],
+            "request_output_schema_field": "absent",
             "required": [
               "target"
             ]
           },
           "list_agents": {
+            "additional_properties": false,
+            "client_result_schema": {
+              "additionalProperties": false,
+              "properties": {
+                "agents": {
+                  "items": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "agent_name": {
+                        "type": "string"
+                      },
+                      "agent_status": {
+                        "oneOf": [
+                          {
+                            "enum": [
+                              "pending_init",
+                              "running",
+                              "interrupted",
+                              "shutdown",
+                              "not_found"
+                            ],
+                            "type": "string"
+                          },
+                          {
+                            "additionalProperties": false,
+                            "properties": {
+                              "completed": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "completed"
+                            ],
+                            "type": "object"
+                          },
+                          {
+                            "additionalProperties": false,
+                            "properties": {
+                              "errored": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "errored"
+                            ],
+                            "type": "object"
+                          }
+                        ]
+                      }
+                    },
+                    "required": [
+                      "agent_name",
+                      "agent_status"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "agents"
+              ],
+              "type": "object"
+            },
+            "normalized_parameter_schema": {
+              "additionalProperties": false,
+              "properties": {
+                "path_prefix": {
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "type": "object"
+            },
             "optional": [
               "path_prefix"
             ],
+            "request_output_schema_field": "absent",
             "required": []
           },
           "send_message": {
+            "additional_properties": false,
+            "client_result_schema": null,
+            "normalized_parameter_schema": {
+              "additionalProperties": false,
+              "properties": {
+                "message": {
+                  "encrypted": true,
+                  "type": "string"
+                },
+                "target": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "target",
+                "message"
+              ],
+              "type": "object"
+            },
             "optional": [],
+            "request_output_schema_field": "absent",
             "required": [
-              "target",
-              "message"
+              "message",
+              "target"
             ]
           },
           "spawn_agent": {
+            "additional_properties": false,
+            "client_result_schema": {
+              "additionalProperties": false,
+              "properties": {
+                "task_name": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "task_name"
+              ],
+              "type": "object"
+            },
+            "normalized_parameter_schema": {
+              "additionalProperties": false,
+              "properties": {
+                "agent_type": {
+                  "type": "string"
+                },
+                "fork_turns": {
+                  "type": "string"
+                },
+                "message": {
+                  "encrypted": true,
+                  "type": "string"
+                },
+                "model": {
+                  "type": "string"
+                },
+                "reasoning_effort": {
+                  "type": "string"
+                },
+                "task_name": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "task_name",
+                "message"
+              ],
+              "type": "object"
+            },
             "optional": [
-              "fork_turns",
               "agent_type",
+              "fork_turns",
               "model",
               "reasoning_effort"
             ],
+            "request_output_schema_field": "absent",
             "required": [
-              "task_name",
-              "message"
+              "message",
+              "task_name"
             ]
           },
           "wait_agent": {
+            "additional_properties": false,
+            "client_result_schema": {
+              "additionalProperties": false,
+              "properties": {
+                "message": {
+                  "type": "string"
+                },
+                "timed_out": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "message",
+                "timed_out"
+              ],
+              "type": "object"
+            },
+            "normalized_parameter_schema": {
+              "additionalProperties": false,
+              "properties": {
+                "timeout_ms": {
+                  "type": "number"
+                }
+              },
+              "required": [],
+              "type": "object"
+            },
             "optional": [
               "timeout_ms"
             ],
+            "request_output_schema_field": "absent",
             "required": []
           }
         },
-        "fields": [
-          "type",
-          "namespace",
-          "name",
-          "item_id",
-          "call_id",
-          "arguments"
-        ],
-        "fork_turns": {
-          "field": "fork_turns",
-          "values": [
-            "all",
-            "none",
-            "positive_decimal_string"
-          ]
-        },
-        "identity_fields": [
-          "call_id",
-          "item_id",
-          "task_path",
-          "continuation_id"
-        ],
-        "wire_type": "function_call"
-      },
-      "declaration": {
         "child_wire_type": "function",
-        "discriminator": {
-          "namespace": "collaboration",
-          "tool_field": "name"
-        },
         "fields": [
           "type",
           "name",
+          "description",
           "tools"
         ],
         "tool_names": [
-          "spawn_agent",
-          "send_message",
           "followup_task",
-          "wait_agent",
           "interrupt_agent",
-          "list_agents"
+          "list_agents",
+          "send_message",
+          "spawn_agent",
+          "wait_agent"
         ],
         "wire_type": "namespace"
       },
       "executor": "codex_client",
       "history": {
-        "continuation_fields": [
-          "task_path",
-          "continuation_id",
-          "task_name",
-          "fork_turns"
-        ],
-        "continuation_identity": "task_path",
+        "canonical_task_identity": "agent_path_serialized_as_task_name",
         "identity_fields": [
-          "task_path",
-          "continuation_id",
+          "id",
           "call_id",
-          "call_item_id",
-          "output_item_id"
+          "author",
+          "recipient"
         ],
-        "inherited_prefix": "deferred_qualification",
         "items": [
           "function_call",
-          "function_call_output"
+          "function_call_output",
+          "agent_message"
         ],
-        "pagination": "deferred_qualification"
+        "rollout_version_field": "multi_agent_version",
+        "same_home_restart_readback": "observed"
       },
       "id": "collaboration_v2",
       "isolation": {
         "forbidden_v1_fields": [
           "agent_id",
-          "fork_context"
-        ],
-        "forbidden_v1_semantics": [
-          "agent_id_close_resume",
-          "fork_context"
+          "fork_context",
+          "items",
+          "targets"
         ],
         "forbidden_v1_tools": [
           "close_agent",
@@ -421,65 +1308,292 @@
       "namespace": "collaboration",
       "owner": "codex_client",
       "result": {
+        "continuation_id_field": "not_present",
         "fields": [
           "type",
+          "id",
           "call_id",
-          "item_id",
           "output"
         ],
         "identity_fields": [
-          "call_id",
-          "item_id",
-          "task_path",
-          "continuation_id"
+          "id",
+          "call_id"
         ],
-        "result_fields": [
-          "task_path",
-          "continuation_id",
-          "status"
+        "output_wire_encoding": {
+          "followup_task": "plain_text",
+          "interrupt_agent": "json_text_string",
+          "list_agents": "json_text_string",
+          "send_message": "plain_text",
+          "spawn_agent": "json_text_string",
+          "wait_agent": "json_text_string"
+        },
+        "spawn_identity": "task_name",
+        "spawn_output_fields_default": [
+          "task_name"
         ],
-        "result_identity": "task_path",
+        "tool_output_schemas": {
+          "followup_task": null,
+          "interrupt_agent": {
+            "additionalProperties": false,
+            "properties": {
+              "previous_status": {
+                "oneOf": [
+                  {
+                    "enum": [
+                      "pending_init",
+                      "running",
+                      "interrupted",
+                      "shutdown",
+                      "not_found"
+                    ],
+                    "type": "string"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "completed": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "completed"
+                    ],
+                    "type": "object"
+                  },
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "errored": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "errored"
+                    ],
+                    "type": "object"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "previous_status"
+            ],
+            "type": "object"
+          },
+          "list_agents": {
+            "additionalProperties": false,
+            "properties": {
+              "agents": {
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "agent_name": {
+                      "type": "string"
+                    },
+                    "agent_status": {
+                      "oneOf": [
+                        {
+                          "enum": [
+                            "pending_init",
+                            "running",
+                            "interrupted",
+                            "shutdown",
+                            "not_found"
+                          ],
+                          "type": "string"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "completed": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "completed"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "errored": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "errored"
+                          ],
+                          "type": "object"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "agent_name",
+                    "agent_status"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "agents"
+            ],
+            "type": "object"
+          },
+          "send_message": null,
+          "spawn_agent": {
+            "additionalProperties": false,
+            "properties": {
+              "task_name": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "task_name"
+            ],
+            "type": "object"
+          },
+          "wait_agent": {
+            "additionalProperties": false,
+            "properties": {
+              "message": {
+                "type": "string"
+              },
+              "timed_out": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "message",
+              "timed_out"
+            ],
+            "type": "object"
+          }
+        },
         "wire_type": "function_call_output"
       },
       "shape_provenance": {
-        "official_cli_capture_status": "not_observed",
-        "shape_kind": "accepted_structural_contract",
-        "source": "accepted_issue_62_source_contract_and_repository_evidence"
+        "cli_capture_status": "observed",
+        "desktop_capture_status": "observed",
+        "source": "issue392_exact_cli_and_desktop_runtime_contract"
       },
-      "status": "stable_surface_not_lifecycle_qualified",
+      "status": "runtime_observed_request_shape_and_readback",
       "stream": {
-        "call_semantics": "namespace_child_function_uses_function_call_lifecycle",
-        "error_event": "response.failed",
         "event_order": [
           "response.output_item.added",
           "response.function_call_arguments.delta",
           "response.function_call_arguments.done",
           "response.output_item.done"
         ],
-        "qualification": "not_observed",
+        "event_shapes": {
+          "response.function_call_arguments.delta": {
+            "fields": [
+              "type",
+              "item_id",
+              "output_index",
+              "delta"
+            ]
+          },
+          "response.function_call_arguments.done": {
+            "fields": [
+              "type",
+              "item_id",
+              "output_index",
+              "arguments"
+            ]
+          },
+          "response.output_item.added": {
+            "fields": [
+              "type",
+              "output_index",
+              "item"
+            ],
+            "item_fields": [
+              "type",
+              "id",
+              "status",
+              "name",
+              "namespace",
+              "arguments",
+              "call_id"
+            ],
+            "status": "in_progress"
+          },
+          "response.output_item.done": {
+            "fields": [
+              "type",
+              "output_index",
+              "item"
+            ],
+            "item_fields": [
+              "type",
+              "id",
+              "status",
+              "name",
+              "namespace",
+              "arguments",
+              "call_id"
+            ],
+            "status": "completed"
+          }
+        },
         "terminal_events": [
           "response.completed",
           "response.incomplete",
           "response.failed"
-        ]
-      },
-      "terminal_error": {
-        "error_event": "response.failed",
-        "error_fields": [
-          "id",
-          "status",
-          "error"
         ],
-        "qualification": "not_observed",
-        "terminal_events": [
-          "response.completed",
-          "response.incomplete",
-          "response.failed"
-        ]
+        "terminal_shapes": {
+          "response.completed": {
+            "fields": [
+              "type",
+              "response"
+            ],
+            "response_fields": [
+              "id",
+              "status",
+              "output",
+              "usage"
+            ],
+            "status": "completed"
+          },
+          "response.failed": {
+            "fields": [
+              "type",
+              "response"
+            ],
+            "response_required_fields": [
+              "id",
+              "status",
+              "error"
+            ],
+            "status": "failed"
+          },
+          "response.incomplete": {
+            "fields": [
+              "type",
+              "response"
+            ],
+            "response_required_fields": [
+              "id",
+              "status",
+              "incomplete_details"
+            ],
+            "status": "incomplete"
+          }
+        }
       }
     }
   ],
-  "qualification_status": "structural_boundary_only",
+  "qualification_status": "superseded_by_issue392_exact_runtime_contract",
   "schema": "codexhub.issue64.collaboration-v1-v2.v1",
-  "verification_scope": "structural_contract_only"
+  "verification_scope": "runtime_observed_structural_contract"
 }

--- a/docs/evidence/issue-64/collaboration-v1-v2-inventory.json
+++ b/docs/evidence/issue-64/collaboration-v1-v2-inventory.json
@@ -79,7 +79,7 @@
     "basis": "accepted_issue392_exact_runtime_contract",
     "source_contract": {
       "file": "collaboration-runtime-contract.json",
-      "sha256": "7ed254a4171eabf59e9d8f0ab8c0133ccf13cfad6c83b0b57b122c244c71d2e2"
+      "sha256": "f4de10e5898ed1bfe8381f825e7bd0e157057acc35e176f0662ef4aa1e6b3fb7"
     }
   },
   "protocol_layers": {

--- a/docs/evidence/issue-64/collaboration-v1-v2-inventory.json
+++ b/docs/evidence/issue-64/collaboration-v1-v2-inventory.json
@@ -79,7 +79,7 @@
     "basis": "accepted_issue392_exact_runtime_contract",
     "source_contract": {
       "file": "collaboration-runtime-contract.json",
-      "sha256": "fd093c72294cda2b48ca87f7e9d71502ba3d7ecb076d709c0daffe47818bd981"
+      "sha256": "5688d0730e6c0270a74b512fd43b4b96094e131481fb5847bd82b6149179e6a9"
     }
   },
   "protocol_layers": {
@@ -104,6 +104,304 @@
           "item/completed"
         ]
       },
+      "notification_envelopes": [
+        {
+          "item_field_types": {
+            "agentPath": "string",
+            "agentThreadId": "string",
+            "id": "string",
+            "kind": "string",
+            "type": "string"
+          },
+          "item_fields": [
+            "agentPath",
+            "agentThreadId",
+            "id",
+            "kind",
+            "type"
+          ],
+          "item_kind": "started",
+          "item_type": "subAgentActivity",
+          "method": "item/started",
+          "params_field_types": {
+            "item": "object",
+            "startedAtMs": "number",
+            "threadId": "string",
+            "turnId": "string"
+          },
+          "params_fields": [
+            "item",
+            "startedAtMs",
+            "threadId",
+            "turnId"
+          ]
+        },
+        {
+          "item_field_types": {
+            "agentPath": "string",
+            "agentThreadId": "string",
+            "id": "string",
+            "kind": "string",
+            "type": "string"
+          },
+          "item_fields": [
+            "agentPath",
+            "agentThreadId",
+            "id",
+            "kind",
+            "type"
+          ],
+          "item_kind": "started",
+          "item_type": "subAgentActivity",
+          "method": "item/completed",
+          "params_field_types": {
+            "completedAtMs": "number",
+            "item": "object",
+            "threadId": "string",
+            "turnId": "string"
+          },
+          "params_fields": [
+            "completedAtMs",
+            "item",
+            "threadId",
+            "turnId"
+          ]
+        },
+        {
+          "item_field_types": {
+            "agentsStates": "object",
+            "id": "string",
+            "model": "null",
+            "prompt": "null",
+            "reasoningEffort": "null",
+            "receiverThreadIds": "array",
+            "senderThreadId": "string",
+            "status": "string",
+            "tool": "string",
+            "type": "string"
+          },
+          "item_fields": [
+            "agentsStates",
+            "id",
+            "model",
+            "prompt",
+            "reasoningEffort",
+            "receiverThreadIds",
+            "senderThreadId",
+            "status",
+            "tool",
+            "type"
+          ],
+          "item_status": "inProgress",
+          "item_tool": "wait",
+          "item_type": "collabAgentToolCall",
+          "method": "item/started",
+          "params_field_types": {
+            "item": "object",
+            "startedAtMs": "number",
+            "threadId": "string",
+            "turnId": "string"
+          },
+          "params_fields": [
+            "item",
+            "startedAtMs",
+            "threadId",
+            "turnId"
+          ]
+        },
+        {
+          "item_field_types": {
+            "id": "string",
+            "memoryCitation": "null",
+            "phase": "null",
+            "text": "string",
+            "type": "string"
+          },
+          "item_fields": [
+            "id",
+            "memoryCitation",
+            "phase",
+            "text",
+            "type"
+          ],
+          "item_type": "agentMessage",
+          "method": "item/started",
+          "params_field_types": {
+            "item": "object",
+            "startedAtMs": "number",
+            "threadId": "string",
+            "turnId": "string"
+          },
+          "params_fields": [
+            "item",
+            "startedAtMs",
+            "threadId",
+            "turnId"
+          ]
+        },
+        {
+          "method": "item/agentMessage/delta",
+          "params_field_types": {
+            "delta": "string",
+            "itemId": "string",
+            "threadId": "string",
+            "turnId": "string"
+          },
+          "params_fields": [
+            "delta",
+            "itemId",
+            "threadId",
+            "turnId"
+          ]
+        },
+        {
+          "item_field_types": {
+            "id": "string",
+            "memoryCitation": "null",
+            "phase": "null",
+            "text": "string",
+            "type": "string"
+          },
+          "item_fields": [
+            "id",
+            "memoryCitation",
+            "phase",
+            "text",
+            "type"
+          ],
+          "item_type": "agentMessage",
+          "method": "item/completed",
+          "params_field_types": {
+            "completedAtMs": "number",
+            "item": "object",
+            "threadId": "string",
+            "turnId": "string"
+          },
+          "params_fields": [
+            "completedAtMs",
+            "item",
+            "threadId",
+            "turnId"
+          ]
+        },
+        {
+          "item_field_types": {
+            "agentsStates": "object",
+            "id": "string",
+            "model": "null",
+            "prompt": "null",
+            "reasoningEffort": "null",
+            "receiverThreadIds": "array",
+            "senderThreadId": "string",
+            "status": "string",
+            "tool": "string",
+            "type": "string"
+          },
+          "item_fields": [
+            "agentsStates",
+            "id",
+            "model",
+            "prompt",
+            "reasoningEffort",
+            "receiverThreadIds",
+            "senderThreadId",
+            "status",
+            "tool",
+            "type"
+          ],
+          "item_status": "completed",
+          "item_tool": "wait",
+          "item_type": "collabAgentToolCall",
+          "method": "item/completed",
+          "params_field_types": {
+            "completedAtMs": "number",
+            "item": "object",
+            "threadId": "string",
+            "turnId": "string"
+          },
+          "params_fields": [
+            "completedAtMs",
+            "item",
+            "threadId",
+            "turnId"
+          ]
+        },
+        {
+          "item_field_types": {
+            "id": "string",
+            "memoryCitation": "null",
+            "phase": "null",
+            "text": "string",
+            "type": "string"
+          },
+          "item_fields": [
+            "id",
+            "memoryCitation",
+            "phase",
+            "text",
+            "type"
+          ],
+          "item_type": "agentMessage",
+          "method": "item/started",
+          "params_field_types": {
+            "item": "object",
+            "startedAtMs": "number",
+            "threadId": "string",
+            "turnId": "string"
+          },
+          "params_fields": [
+            "item",
+            "startedAtMs",
+            "threadId",
+            "turnId"
+          ]
+        },
+        {
+          "method": "item/agentMessage/delta",
+          "params_field_types": {
+            "delta": "string",
+            "itemId": "string",
+            "threadId": "string",
+            "turnId": "string"
+          },
+          "params_fields": [
+            "delta",
+            "itemId",
+            "threadId",
+            "turnId"
+          ]
+        },
+        {
+          "item_field_types": {
+            "id": "string",
+            "memoryCitation": "null",
+            "phase": "null",
+            "text": "string",
+            "type": "string"
+          },
+          "item_fields": [
+            "id",
+            "memoryCitation",
+            "phase",
+            "text",
+            "type"
+          ],
+          "item_type": "agentMessage",
+          "method": "item/completed",
+          "params_field_types": {
+            "completedAtMs": "number",
+            "item": "object",
+            "threadId": "string",
+            "turnId": "string"
+          },
+          "params_fields": [
+            "completedAtMs",
+            "item",
+            "threadId",
+            "turnId"
+          ]
+        }
+      ],
       "same_home_thread_resume_and_read": "observed",
       "thread_items": {
         "agentMessage": [
@@ -131,6 +429,185 @@
           "kind",
           "agentThreadId",
           "agentPath"
+        ]
+      },
+      "thread_read_envelope": {
+        "field_types": {
+          "agentNickname": "null",
+          "agentRole": "null",
+          "canAcceptDirectInput": "boolean",
+          "cliVersion": "string",
+          "createdAt": "number",
+          "cwd": "string",
+          "ephemeral": "boolean",
+          "extra": "null",
+          "forkedFromId": "null",
+          "gitInfo": "object",
+          "historyMode": "string",
+          "id": "string",
+          "modelProvider": "string",
+          "name": "null",
+          "parentThreadId": "null",
+          "path": "string",
+          "preview": "string",
+          "recencyAt": "number",
+          "section": "null",
+          "sectionEnteredAt": "null",
+          "sessionId": "string",
+          "source": "string",
+          "status": "object",
+          "threadSource": "null",
+          "turns": "array",
+          "updatedAt": "number"
+        },
+        "fields": [
+          "agentNickname",
+          "agentRole",
+          "canAcceptDirectInput",
+          "cliVersion",
+          "createdAt",
+          "cwd",
+          "ephemeral",
+          "extra",
+          "forkedFromId",
+          "gitInfo",
+          "historyMode",
+          "id",
+          "modelProvider",
+          "name",
+          "parentThreadId",
+          "path",
+          "preview",
+          "recencyAt",
+          "section",
+          "sectionEnteredAt",
+          "sessionId",
+          "source",
+          "status",
+          "threadSource",
+          "turns",
+          "updatedAt"
+        ],
+        "status_field_types": {
+          "type": "string"
+        },
+        "status_fields": [
+          "type"
+        ],
+        "turns": [
+          {
+            "field_types": {
+              "completedAt": "number",
+              "durationMs": "number",
+              "error": "null",
+              "id": "string",
+              "items": "array",
+              "itemsView": "string",
+              "startedAt": "number",
+              "status": "string"
+            },
+            "fields": [
+              "completedAt",
+              "durationMs",
+              "error",
+              "id",
+              "items",
+              "itemsView",
+              "startedAt",
+              "status"
+            ],
+            "items": [
+              {
+                "field_types": {
+                  "clientId": "null",
+                  "content": "array",
+                  "id": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "clientId",
+                  "content",
+                  "id",
+                  "type"
+                ],
+                "type": "userMessage"
+              },
+              {
+                "field_types": {
+                  "agentPath": "string",
+                  "agentThreadId": "string",
+                  "id": "string",
+                  "kind": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "agentPath",
+                  "agentThreadId",
+                  "id",
+                  "kind",
+                  "type"
+                ],
+                "kind": "started",
+                "type": "subAgentActivity"
+              },
+              {
+                "field_types": {
+                  "id": "string",
+                  "memoryCitation": "null",
+                  "phase": "null",
+                  "text": "string",
+                  "type": "string"
+                },
+                "fields": [
+                  "id",
+                  "memoryCitation",
+                  "phase",
+                  "text",
+                  "type"
+                ],
+                "type": "agentMessage"
+              }
+            ],
+            "status": "completed"
+          }
+        ]
+      },
+      "thread_resume_result": {
+        "field_types": {
+          "activePermissionProfile": "object",
+          "approvalPolicy": "string",
+          "approvalsReviewer": "string",
+          "cwd": "string",
+          "initialTurnsPage": "null",
+          "instructionSources": "array",
+          "itemsBackwardsCursor": "null",
+          "model": "string",
+          "modelProvider": "string",
+          "multiAgentMode": "string",
+          "reasoningEffort": "string",
+          "runtimeWorkspaceRoots": "array",
+          "sandbox": "object",
+          "serviceTier": "null",
+          "thread": "object",
+          "turnsBackwardsCursor": "null"
+        },
+        "fields": [
+          "activePermissionProfile",
+          "approvalPolicy",
+          "approvalsReviewer",
+          "cwd",
+          "initialTurnsPage",
+          "instructionSources",
+          "itemsBackwardsCursor",
+          "model",
+          "modelProvider",
+          "multiAgentMode",
+          "reasoningEffort",
+          "runtimeWorkspaceRoots",
+          "sandbox",
+          "serviceTier",
+          "thread",
+          "turnsBackwardsCursor"
         ]
       },
       "turn_terminal_notification": "turn/completed",

--- a/scripts/build_issue_392_collaboration_contract.py
+++ b/scripts/build_issue_392_collaboration_contract.py
@@ -1264,6 +1264,16 @@ def validate_runtime_observations(payload: Mapping[str, Any]) -> None:
                 observed["completed_event_present"] is False,
                 "observation_terminal_completed_invalid",
             )
+    for terminal in ("incomplete", "failed", "truncated"):
+        _require(
+            scenarios[f"cli_terminal_{terminal}"]["observed"][
+                "served_event_envelopes"
+            ]
+            == scenarios[f"desktop_terminal_{terminal}"]["observed"][
+                "served_event_envelopes"
+            ],
+            "observation_terminal_client_shape_mismatch",
+        )
 
     app_observed = scenarios["desktop_app_v2_lifecycle"]["observed"]
     _require(isinstance(app_observed, Mapping), "observation_desktop_app_invalid")
@@ -1466,6 +1476,25 @@ def build_contract(observations: Mapping[str, Any] | None = None) -> dict[str, A
     failed_event = copy.deepcopy(
         terminal_controls["cli"]["failed"]["served_event_envelopes"][-1]
     )
+    incomplete_events = terminal_controls["cli"]["incomplete"][
+        "served_event_envelopes"
+    ]
+    failed_events = terminal_controls["cli"]["failed"]["served_event_envelopes"]
+    truncated_events = terminal_controls["cli"]["truncated"][
+        "served_event_envelopes"
+    ]
+    terminal_event_boundaries = {
+        "response.completed": {
+            "previous_event": cli_function_sequence[-2]["type"]
+        },
+        "response.incomplete": {
+            "previous_event": incomplete_events[-2]["type"]
+        },
+        "response.failed": {"previous_event": failed_events[-2]["type"]},
+        "stream_close_without_terminal": {
+            "last_observed_event": truncated_events[-1]["type"]
+        },
+    }
     return {
         "schema": SCHEMA,
         "qualification_status": "accepted_request_call_result_agent_message_and_readback",
@@ -1637,7 +1666,7 @@ def build_contract(observations: Mapping[str, Any] | None = None) -> dict[str, A
                 "assembly_rule": "ordered_delta_assembly_must_equal_done_arguments",
             },
             "terminal": {
-                "event_order_boundary": "after_output_item_done",
+                "event_boundaries": terminal_event_boundaries,
                 "events": [
                     "response.completed",
                     "response.incomplete",

--- a/scripts/build_issue_392_collaboration_contract.py
+++ b/scripts/build_issue_392_collaboration_contract.py
@@ -450,6 +450,18 @@ def _validate_safe_request(value: Any) -> None:
                 item.get("arguments_json_type") == "object",
                 "observation_function_arguments_invalid",
             )
+            required_types = {
+                "type": "string",
+                "id": "string",
+                "name": "string",
+                "namespace": "string",
+                "arguments": "string",
+                "call_id": "string",
+            }
+            _require(
+                all(item["field_types"].get(key) == value for key, value in required_types.items()),
+                "observation_function_call_identity_invalid",
+            )
         elif item_type == "function_call_output":
             _require_exact_fields(
                 item,
@@ -467,6 +479,16 @@ def _validate_safe_request(value: Any) -> None:
                 item.get("output_wire_type") == "string",
                 "observation_function_output_wire_invalid",
             )
+            required_types = {
+                "type": "string",
+                "id": "string",
+                "call_id": "string",
+                "output": "string",
+            }
+            _require(
+                all(item["field_types"].get(key) == value for key, value in required_types.items()),
+                "observation_function_output_identity_invalid",
+            )
         elif item_type == "agent_message":
             _require_exact_fields(
                 item,
@@ -474,6 +496,17 @@ def _validate_safe_request(value: Any) -> None:
                 "observation_agent_message_fields_invalid",
             )
             variants = item.get("content_variants")
+            required_types = {
+                "type": "string",
+                "id": "string",
+                "author": "string",
+                "recipient": "string",
+                "content": "array",
+            }
+            _require(
+                all(item["field_types"].get(key) == value for key, value in required_types.items()),
+                "observation_agent_message_identity_invalid",
+            )
             _require(isinstance(variants, list), "observation_agent_message_invalid")
             for variant in variants:
                 _require(
@@ -492,6 +525,14 @@ def _validate_safe_request(value: Any) -> None:
                 _require(
                     variant.get("fields") == sorted(variant.get("field_types", {})),
                     "observation_agent_message_variant_type_keys_invalid",
+                )
+                content_field = (
+                    "text" if variant.get("type") == "input_text" else "encrypted_content"
+                )
+                _require(
+                    variant["field_types"].get("type") == "string"
+                    and variant["field_types"].get(content_field) == "string",
+                    "observation_agent_message_variant_content_invalid",
                 )
         else:
             raise ContractValidationError("observation_collaboration_item_type_invalid")
@@ -517,6 +558,256 @@ def _collaboration_signature(request: Mapping[str, Any]) -> list[Any]:
                 ]
             )
     return result
+
+
+def _validate_event_envelope(value: Any) -> None:
+    _require(isinstance(value, Mapping), "observation_event_envelope_invalid")
+    base_fields = {"type", "fields", "field_types"}
+    optional_groups = {
+        "item_fields": {"item_fields", "item_field_types"},
+        "part_fields": {"part_fields", "part_field_types"},
+        "response_fields": {"response_fields", "response_field_types"},
+        "response_error_fields": {
+            "response_error_fields",
+            "response_error_field_types",
+        },
+        "response_incomplete_details_fields": {
+            "response_incomplete_details_fields",
+            "response_incomplete_details_field_types",
+        },
+    }
+    allowed = base_fields | {
+        child for group in optional_groups.values() for child in group
+    } | {
+        "item_type",
+        "item_status",
+        "item_name",
+        "item_namespace",
+        "part_type",
+        "response_status",
+        "response_output_item_types",
+    }
+    _require(base_fields <= set(value) <= allowed, "observation_event_envelope_fields_invalid")
+    event_type = value.get("type")
+    _require(
+        event_type
+        in {
+            "response.created",
+            "response.output_item.added",
+            "response.content_part.added",
+            "response.output_text.delta",
+            "response.output_text.done",
+            "response.function_call_arguments.delta",
+            "response.function_call_arguments.done",
+            "response.output_item.done",
+            "response.completed",
+            "response.incomplete",
+            "response.failed",
+        },
+        "observation_event_type_invalid",
+    )
+    _require(
+        value.get("fields") == sorted(value.get("field_types", {})),
+        "observation_event_field_type_keys_invalid",
+    )
+    expected_event_field_types = {
+        "response.created": {"response": "object", "type": "string"},
+        "response.output_item.added": {
+            "item": "object",
+            "output_index": "number",
+            "type": "string",
+        },
+        "response.content_part.added": {
+            "content_index": "number",
+            "item_id": "string",
+            "output_index": "number",
+            "part": "object",
+            "type": "string",
+        },
+        "response.output_text.delta": {
+            "content_index": "number",
+            "delta": "string",
+            "item_id": "string",
+            "output_index": "number",
+            "type": "string",
+        },
+        "response.output_text.done": {
+            "content_index": "number",
+            "item_id": "string",
+            "output_index": "number",
+            "text": "string",
+            "type": "string",
+        },
+        "response.function_call_arguments.delta": {
+            "delta": "string",
+            "item_id": "string",
+            "output_index": "number",
+            "type": "string",
+        },
+        "response.function_call_arguments.done": {
+            "arguments": "string",
+            "item_id": "string",
+            "output_index": "number",
+            "type": "string",
+        },
+        "response.output_item.done": {
+            "item": "object",
+            "output_index": "number",
+            "type": "string",
+        },
+        "response.completed": {"response": "object", "type": "string"},
+        "response.incomplete": {"response": "object", "type": "string"},
+        "response.failed": {"response": "object", "type": "string"},
+    }
+    _require(
+        value.get("field_types") == expected_event_field_types[event_type],
+        "observation_event_field_types_invalid",
+    )
+    for field_name, group in optional_groups.items():
+        present = group & set(value)
+        _require(not present or present == group, "observation_event_nested_pair_invalid")
+        if present:
+            type_field = next(name for name in group if name.endswith("_field_types"))
+            _require(
+                value[field_name] == sorted(value[type_field]),
+                "observation_event_nested_type_keys_invalid",
+            )
+    if "item_type" in value:
+        _require(
+            value["item_type"] in {"function_call", "message"},
+            "observation_event_item_type_invalid",
+        )
+    if "item_status" in value:
+        _require(
+            value["item_status"] in {"in_progress", "completed"},
+            "observation_event_item_status_invalid",
+        )
+    if "item_name" in value:
+        _require(value["item_name"] in V2_TOOLS, "observation_event_item_name_invalid")
+    if "item_namespace" in value:
+        _require(
+            value["item_namespace"] == V2_NAMESPACE,
+            "observation_event_item_namespace_invalid",
+        )
+    if "part_type" in value:
+        _require(value["part_type"] == "output_text", "observation_event_part_type_invalid")
+    if "response_status" in value:
+        _require(
+            value["response_status"] in {"in_progress", "completed", "incomplete"},
+            "observation_event_response_status_invalid",
+        )
+    if "response_output_item_types" in value:
+        _require(
+            isinstance(value["response_output_item_types"], list)
+            and all(
+                item_type in {"function_call", "message"}
+                for item_type in value["response_output_item_types"]
+            ),
+            "observation_event_response_output_invalid",
+        )
+    if value.get("item_type") == "function_call":
+        item_types = value.get("item_field_types")
+        _require(isinstance(item_types, Mapping), "observation_event_function_item_invalid")
+        required_types = {
+            "type": "string",
+            "id": "string",
+            "status": "string",
+            "name": "string",
+            "namespace": "string",
+            "arguments": "string",
+            "call_id": "string",
+        }
+        _require(
+            dict(item_types) == required_types,
+            "observation_event_function_identity_invalid",
+        )
+    elif value.get("item_type") == "message":
+        _require(
+            value.get("item_field_types")
+            == {
+                "content": "array",
+                "id": "string",
+                "role": "string",
+                "type": "string",
+            },
+            "observation_event_message_item_invalid",
+        )
+    if "part_field_types" in value:
+        _require(
+            value["part_field_types"]
+            == {"annotations": "array", "text": "string", "type": "string"},
+            "observation_event_part_fields_invalid",
+        )
+    expected_response_types = {
+        "response.created": {
+            "id": "string",
+            "model": "string",
+            "object": "string",
+            "output": "array",
+            "status": "string",
+        },
+        "response.completed": {
+            "id": "string",
+            "model": "string",
+            "object": "string",
+            "output": "array",
+            "status": "string",
+            "usage": "object",
+        },
+        "response.incomplete": {
+            "error": "null",
+            "id": "string",
+            "incomplete_details": "object",
+            "object": "string",
+            "status": "string",
+        },
+        "response.failed": {"error": "object", "id": "string"},
+    }
+    if event_type in expected_response_types:
+        _require(
+            value.get("response_field_types") == expected_response_types[event_type],
+            "observation_event_response_fields_invalid",
+        )
+    if event_type == "response.failed":
+        _require(
+            value.get("response_error_field_types")
+            == {"code": "string", "message": "string"},
+            "observation_event_response_error_invalid",
+        )
+    if event_type == "response.incomplete":
+        _require(
+            value.get("response_incomplete_details_field_types")
+            == {"reason": "string"},
+            "observation_event_incomplete_details_invalid",
+        )
+
+
+def _validate_event_sequences(value: Any) -> None:
+    _require(isinstance(value, list) and value, "observation_event_sequences_invalid")
+    request_indices: list[int] = []
+    for sequence in value:
+        _require(isinstance(sequence, Mapping), "observation_event_sequence_invalid")
+        _require_exact_fields(
+            sequence,
+            {"request_index", "events"},
+            "observation_event_sequence_fields_invalid",
+        )
+        request_index = sequence.get("request_index")
+        _require(
+            isinstance(request_index, int)
+            and not isinstance(request_index, bool)
+            and request_index >= 1,
+            "observation_event_sequence_index_invalid",
+        )
+        request_indices.append(request_index)
+        events = sequence.get("events")
+        _require(isinstance(events, list) and events, "observation_event_sequence_empty")
+        for event in events:
+            _validate_event_envelope(event)
+    _require(
+        sorted(request_indices) == list(range(1, len(request_indices) + 1)),
+        "observation_event_sequence_indices_invalid",
+    )
 
 
 def _validate_v2_phase_requests(
@@ -735,6 +1026,8 @@ def validate_runtime_observations(payload: Mapping[str, Any]) -> None:
         "protocol_upstream_loopback": True,
         "plugin_services_disabled": ["plugins", "remote_plugin", "plugin_sharing"],
         "sensitive_environment_credentials_removed": True,
+        "external_config_environment_removed": ["CODEX_CONFIG"],
+        "xdg_roots_under_isolated_home": True,
         "existing_user_home_read": False,
         "existing_user_task_read": False,
         "known_crash_task_read": False,
@@ -773,6 +1066,12 @@ def validate_runtime_observations(payload: Mapping[str, Any]) -> None:
         "desktop_v1_request": ("codex_desktop", 1, 1),
         "cli_v2_lifecycle": ("codex_cli", 5, 2),
         "desktop_v2_lifecycle": ("codex_desktop", 5, 2),
+        "cli_terminal_incomplete": ("codex_cli", 1, 1),
+        "cli_terminal_failed": ("codex_cli", 1, 1),
+        "cli_terminal_truncated": ("codex_cli", 1, 1),
+        "desktop_terminal_incomplete": ("codex_desktop", 1, 1),
+        "desktop_terminal_failed": ("codex_desktop", 1, 1),
+        "desktop_terminal_truncated": ("codex_desktop", 1, 1),
         "desktop_app_v2_lifecycle": ("codex_desktop", 4, 2),
     }
     _require(set(scenarios) == set(scenario_contract), "observations_scenario_set_invalid")
@@ -841,6 +1140,7 @@ def validate_runtime_observations(payload: Mapping[str, Any]) -> None:
                 "requests_by_phase",
                 "served_function_call_event_order",
                 "served_function_names",
+                "served_event_sequences",
                 "identity_relationships",
                 "rollout_readback",
             },
@@ -871,11 +1171,99 @@ def validate_runtime_observations(payload: Mapping[str, Any]) -> None:
             observed["served_function_names"] == ["spawn_agent", "wait_agent"],
             "observation_served_functions_invalid",
         )
+        _validate_event_sequences(observed["served_event_sequences"])
+        _require(
+            len(observed["served_event_sequences"])
+            == scenarios[name]["loopback_request_count"],
+            "observation_event_sequence_count_invalid",
+        )
+        function_sequences = [
+            sequence["events"]
+            for sequence in observed["served_event_sequences"]
+            if any(
+                event["type"] == "response.function_call_arguments.delta"
+                for event in sequence["events"]
+            )
+        ]
+        _require(len(function_sequences) == 2, "observation_function_stream_count_invalid")
+        expected_function_stream = [
+            "response.created",
+            "response.output_item.added",
+            "response.function_call_arguments.delta",
+            "response.function_call_arguments.done",
+            "response.output_item.done",
+            "response.completed",
+        ]
+        _require(
+            all(
+                [event["type"] for event in sequence] == expected_function_stream
+                for sequence in function_sequences
+            ),
+            "observation_function_stream_invalid",
+        )
         _require_all_true(
             observed["identity_relationships"],
             "observation_identity_relationship_invalid",
         )
         _validate_rollout_readback(observed["rollout_readback"])
+
+    for client_prefix in ("cli", "desktop"):
+        for terminal in ("incomplete", "failed", "truncated"):
+            name = f"{client_prefix}_terminal_{terminal}"
+            observed = scenarios[name]["observed"]
+            _require(isinstance(observed, Mapping), "observation_terminal_control_invalid")
+            _require_exact_fields(
+                observed,
+                {
+                    "terminal_control",
+                    "client_disposition",
+                    "request",
+                    "declaration",
+                    "served_event_envelopes",
+                    "terminal_event_present",
+                    "completed_event_present",
+                },
+                "observation_terminal_control_fields_invalid",
+            )
+            _require(
+                observed["terminal_control"] == terminal,
+                "observation_terminal_control_kind_invalid",
+            )
+            _require(
+                observed["client_disposition"] == "rejected_nonzero_exit",
+                "observation_terminal_disposition_invalid",
+            )
+            _validate_safe_request(observed["request"])
+            _require(
+                observed["declaration"] == _expected_observed_declaration(V2),
+                "observation_terminal_declaration_invalid",
+            )
+            events = observed["served_event_envelopes"]
+            _require(isinstance(events, list) and events, "observation_terminal_events_invalid")
+            for event in events:
+                _validate_event_envelope(event)
+            event_types = [event["type"] for event in events]
+            expected_terminal_type = f"response.{terminal}"
+            if terminal == "truncated":
+                _require(
+                    observed["terminal_event_present"] is False
+                    and not any(
+                        event_type
+                        in {"response.completed", "response.incomplete", "response.failed"}
+                        for event_type in event_types
+                    ),
+                    "observation_truncated_terminal_invalid",
+                )
+            else:
+                _require(
+                    observed["terminal_event_present"] is True
+                    and event_types[-1] == expected_terminal_type,
+                    "observation_terminal_event_invalid",
+                )
+            _require(
+                observed["completed_event_present"] is False,
+                "observation_terminal_completed_invalid",
+            )
 
     app_observed = scenarios["desktop_app_v2_lifecycle"]["observed"]
     _require(isinstance(app_observed, Mapping), "observation_desktop_app_invalid")
@@ -1013,10 +1401,16 @@ def build_contract(observations: Mapping[str, Any] | None = None) -> dict[str, A
     cli_scenarios = [
         "cli_v1_request",
         "cli_v2_lifecycle",
+        "cli_terminal_incomplete",
+        "cli_terminal_failed",
+        "cli_terminal_truncated",
     ]
     desktop_scenarios = [
         "desktop_v1_request",
         "desktop_v2_lifecycle",
+        "desktop_terminal_incomplete",
+        "desktop_terminal_failed",
+        "desktop_terminal_truncated",
         "desktop_app_v2_lifecycle",
     ]
     cli_home_bindings = [
@@ -1028,6 +1422,50 @@ def build_contract(observations: Mapping[str, Any] | None = None) -> dict[str, A
     cli_lifecycle = scenarios["cli_v2_lifecycle"]["observed"]
     desktop_lifecycle = scenarios["desktop_v2_lifecycle"]["observed"]
     desktop_app = scenarios["desktop_app_v2_lifecycle"]["observed"]
+    cli_function_sequence = next(
+        sequence["events"]
+        for sequence in cli_lifecycle["served_event_sequences"]
+        if any(
+            event["type"] == "response.function_call_arguments.delta"
+            for event in sequence["events"]
+        )
+    )
+    function_core_types = {
+        "response.output_item.added",
+        "response.function_call_arguments.delta",
+        "response.function_call_arguments.done",
+        "response.output_item.done",
+    }
+    function_event_order = [
+        event["type"]
+        for event in cli_function_sequence
+        if event["type"] in function_core_types
+    ]
+    function_event_shapes = {
+        event["type"]: copy.deepcopy(event)
+        for event in cli_function_sequence
+        if event["type"] in function_core_types
+    }
+    terminal_controls = {
+        client: {
+            terminal: copy.deepcopy(
+                scenarios[f"{client}_terminal_{terminal}"]["observed"]
+            )
+            for terminal in ("incomplete", "failed", "truncated")
+        }
+        for client in ("cli", "desktop")
+    }
+    completed_event = next(
+        copy.deepcopy(event)
+        for event in cli_function_sequence
+        if event["type"] == "response.completed"
+    )
+    incomplete_event = copy.deepcopy(
+        terminal_controls["cli"]["incomplete"]["served_event_envelopes"][-1]
+    )
+    failed_event = copy.deepcopy(
+        terminal_controls["cli"]["failed"]["served_event_envelopes"][-1]
+    )
     return {
         "schema": SCHEMA,
         "qualification_status": "accepted_request_call_result_agent_message_and_readback",
@@ -1190,45 +1628,11 @@ def build_contract(observations: Mapping[str, Any] | None = None) -> dict[str, A
         },
         "wire_lifecycle": {
             "function_call_stream": {
-                "event_order": [
-                    "response.output_item.added",
-                    "response.function_call_arguments.delta",
-                    "response.function_call_arguments.done",
-                    "response.output_item.done",
-                ],
-                "event_shapes": {
-                    "response.output_item.added": {
-                        "fields": ["type", "output_index", "item"],
-                        "item_fields": [
-                            "type",
-                            "id",
-                            "status",
-                            "name",
-                            "namespace",
-                            "arguments",
-                            "call_id",
-                        ],
-                        "status": "in_progress",
-                    },
-                    "response.function_call_arguments.delta": {
-                        "fields": ["type", "item_id", "output_index", "delta"]
-                    },
-                    "response.function_call_arguments.done": {
-                        "fields": ["type", "item_id", "output_index", "arguments"]
-                    },
-                    "response.output_item.done": {
-                        "fields": ["type", "output_index", "item"],
-                        "item_fields": [
-                            "type",
-                            "id",
-                            "status",
-                            "name",
-                            "namespace",
-                            "arguments",
-                            "call_id",
-                        ],
-                        "status": "completed",
-                    },
+                "event_order": function_event_order,
+                "event_shapes": function_event_shapes,
+                "captured_event_sequences": {
+                    "codex_cli": cli_lifecycle["served_event_sequences"],
+                    "codex_desktop": desktop_lifecycle["served_event_sequences"],
                 },
                 "assembly_rule": "ordered_delta_assembly_must_equal_done_arguments",
             },
@@ -1240,23 +1644,12 @@ def build_contract(observations: Mapping[str, Any] | None = None) -> dict[str, A
                     "response.failed",
                 ],
                 "event_shapes": {
-                    "response.completed": {
-                        "fields": ["type", "response"],
-                        "response_fields": ["id", "status", "output", "usage"],
-                        "status": "completed",
-                    },
-                    "response.incomplete": {
-                        "fields": ["type", "response"],
-                        "response_required_fields": ["id", "status", "incomplete_details"],
-                        "status": "incomplete",
-                    },
-                    "response.failed": {
-                        "fields": ["type", "response"],
-                        "response_required_fields": ["id", "status", "error"],
-                        "status": "failed",
-                    },
+                    "response.completed": completed_event,
+                    "response.incomplete": incomplete_event,
+                    "response.failed": failed_event,
                 },
-                "stream_close_without_completed": "terminal_error",
+                "controls_by_client": terminal_controls,
+                "stream_close_without_completed": "rejected_nonzero_exit",
             },
             "history_items": ["function_call", "function_call_output", "agent_message"],
             "request_replay_envelopes": {

--- a/scripts/build_issue_392_collaboration_contract.py
+++ b/scripts/build_issue_392_collaboration_contract.py
@@ -10,13 +10,21 @@ from __future__ import annotations
 
 import argparse
 import copy
+import hashlib
 import json
 from pathlib import Path
+import re
 from typing import Any, Mapping, Sequence
 
 
 SCHEMA = "codexhub.issue392.collaboration-runtime-contract.v1"
 DEFAULT_OUTPUT = Path("docs/evidence/issue-392/collaboration-runtime-contract.json")
+OBSERVATION_SCHEMA = "codexhub.issue392.collaboration-runtime-observations.v1"
+DEFAULT_OBSERVATIONS = Path(
+    "docs/evidence/issue-392/collaboration-runtime-observations.json"
+)
+_DIGEST = re.compile(r"[0-9a-f]{64}\Z")
+_CAPTURE_DATE = re.compile(r"20[0-9]{2}-[0-9]{2}-[0-9]{2}\Z")
 
 V1 = "collaboration_v1"
 V2 = "collaboration_v2"
@@ -278,26 +286,19 @@ def _argument_contract(version: str) -> dict[str, Any]:
 
 def _runtime(
     *,
-    client: str,
-    client_version: str,
-    runtime_version: str,
-    binary_sha256: str,
-    source_tag: str,
-    source_commit: str,
-    source_blobs: Mapping[str, str],
+    runtime_observation: Mapping[str, Any],
     desktop_app: bool,
+    scenario_names: Sequence[str],
+    home_bindings: Sequence[str],
 ) -> dict[str, Any]:
     return {
-        "client": client,
-        "client_version": client_version,
-        "runtime_version": runtime_version,
-        "binary_sha256": binary_sha256,
-        "source_tag": source_tag,
-        "source_commit": source_commit,
-        "source_files": {
-            key: {"path": SOURCE_FILES[key], "git_blob": source_blobs[key]}
-            for key in SOURCE_FILES
-        },
+        "client": runtime_observation["client"],
+        "client_version": runtime_observation["client_version"],
+        "runtime_version": runtime_observation["runtime_version"],
+        "binary_sha256": runtime_observation["binary_sha256"],
+        "source_tag": runtime_observation["source_tag"],
+        "source_commit": runtime_observation["source_commit"],
+        "source_files": copy.deepcopy(runtime_observation["source_files"]),
         "observations": {
             "v1_namespace_declaration": "observed",
             "v2_namespace_declaration": "observed",
@@ -310,15 +311,736 @@ def _runtime(
                 "observed" if desktop_app else "not_applicable"
             ),
         },
+        "observation_scenarios": list(scenario_names),
+        "isolated_home_bindings_sha256": list(home_bindings),
     }
 
 
-def build_contract() -> dict[str, Any]:
+def _canonical_digest(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(
+        payload, ensure_ascii=True, separators=(",", ":"), sort_keys=True
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _capture_run_binding(payload: Mapping[str, Any]) -> str:
+    clone = copy.deepcopy(dict(payload))
+    clone.pop("capture_run_binding_sha256", None)
+    return _canonical_digest(clone)
+
+
+def _expected_runtime_observation(
+    *,
+    client: str,
+    client_version: str,
+    runtime_version: str,
+    binary_sha256: str,
+    source_tag: str,
+    source_commit: str,
+    source_blobs: Mapping[str, str],
+) -> dict[str, Any]:
+    return {
+        "client": client,
+        "client_version": client_version,
+        "runtime_version": runtime_version,
+        "version_output": f"codex-cli {runtime_version}",
+        "binary_sha256": binary_sha256,
+        "source_tag": source_tag,
+        "source_commit": source_commit,
+        "source_files": {
+            key: {"path": SOURCE_FILES[key], "git_blob": source_blobs[key]}
+            for key in SOURCE_FILES
+        },
+    }
+
+
+def _expected_observed_declaration(version: str) -> dict[str, Any]:
+    namespace = V1_NAMESPACE if version == V1 else V2_NAMESPACE
+    children = [
+        {
+            "type": "function",
+            "name": name,
+            "description_type": "string",
+            "strict": False,
+            "fields": ["description", "name", "parameters", "strict", "type"],
+            "parameters": _normalize_schema(schema),
+        }
+        for name, schema in EXPECTED_PARAMETER_SCHEMAS[version].items()
+    ]
+    children.sort(key=lambda value: value["name"])
+    return {
+        "type": "namespace",
+        "name": namespace,
+        "description_type": "string",
+        "fields": ["description", "name", "tools", "type"],
+        "children": children,
+    }
+
+
+def _require_exact_fields(
+    value: Mapping[str, Any], expected: set[str], code: str
+) -> None:
+    _require(set(value) == expected, code)
+
+
+def _require_digest(value: Any, code: str) -> None:
+    _require(isinstance(value, str) and _DIGEST.fullmatch(value) is not None, code)
+
+
+def _validate_safe_request(value: Any) -> None:
+    _require(isinstance(value, Mapping), "observation_request_invalid")
+    _require_exact_fields(
+        value,
+        {
+            "fields",
+            "field_types",
+            "tool_choice",
+            "multi_agent_version_locations",
+            "input_type_order",
+            "collaboration_items",
+        },
+        "observation_request_fields_invalid",
+    )
+    _require(value.get("tool_choice") == "auto", "observation_tool_choice_invalid")
+    _require(
+        value.get("multi_agent_version_locations") == [],
+        "observation_version_location_invalid",
+    )
+    _require(isinstance(value.get("fields"), list), "observation_request_fields_invalid")
+    _require(
+        isinstance(value.get("field_types"), Mapping),
+        "observation_request_field_types_invalid",
+    )
+    _require(
+        value["fields"] == sorted(value["field_types"]),
+        "observation_request_field_type_keys_invalid",
+    )
+    _require(
+        isinstance(value.get("input_type_order"), list),
+        "observation_input_order_invalid",
+    )
+    items = value.get("collaboration_items")
+    _require(isinstance(items, list), "observation_collaboration_items_invalid")
+    for item in items:
+        _require(isinstance(item, Mapping), "observation_collaboration_item_invalid")
+        item_type = item.get("type")
+        if item_type == "function_call":
+            _require_exact_fields(
+                item,
+                {
+                    "type",
+                    "fields",
+                    "field_types",
+                    "name",
+                    "namespace",
+                    "arguments_json_type",
+                    "argument_keys",
+                },
+                "observation_function_call_fields_invalid",
+            )
+            _require(
+                item.get("namespace") == V2_NAMESPACE,
+                "observation_function_call_namespace_invalid",
+            )
+            _require(
+                item.get("name") in V2_TOOLS,
+                "observation_function_call_name_invalid",
+            )
+            _require(
+                item.get("arguments_json_type") == "object",
+                "observation_function_arguments_invalid",
+            )
+        elif item_type == "function_call_output":
+            _require_exact_fields(
+                item,
+                {
+                    "type",
+                    "fields",
+                    "field_types",
+                    "output_wire_type",
+                    "decoded_output_type",
+                    "decoded_output_keys",
+                },
+                "observation_function_output_fields_invalid",
+            )
+            _require(
+                item.get("output_wire_type") == "string",
+                "observation_function_output_wire_invalid",
+            )
+        elif item_type == "agent_message":
+            _require_exact_fields(
+                item,
+                {"type", "fields", "field_types", "content_variants"},
+                "observation_agent_message_fields_invalid",
+            )
+            variants = item.get("content_variants")
+            _require(isinstance(variants, list), "observation_agent_message_invalid")
+            for variant in variants:
+                _require(
+                    isinstance(variant, Mapping),
+                    "observation_agent_message_variant_invalid",
+                )
+                _require_exact_fields(
+                    variant,
+                    {"type", "fields", "field_types"},
+                    "observation_agent_message_variant_fields_invalid",
+                )
+                _require(
+                    variant.get("type") in {"input_text", "encrypted_content"},
+                    "observation_agent_message_variant_invalid",
+                )
+                _require(
+                    variant.get("fields") == sorted(variant.get("field_types", {})),
+                    "observation_agent_message_variant_type_keys_invalid",
+                )
+        else:
+            raise ContractValidationError("observation_collaboration_item_type_invalid")
+        _require(
+            item.get("fields") == sorted(item.get("field_types", {})),
+            "observation_collaboration_item_field_type_keys_invalid",
+        )
+
+
+def _collaboration_signature(request: Mapping[str, Any]) -> list[Any]:
+    result: list[Any] = []
+    for item in request["collaboration_items"]:
+        item_type = item["type"]
+        if item_type == "function_call":
+            result.append([item_type, item["name"]])
+        elif item_type == "function_call_output":
+            result.append([item_type, item["decoded_output_keys"]])
+        else:
+            result.append(
+                [
+                    item_type,
+                    [variant["type"] for variant in item["content_variants"]],
+                ]
+            )
+    return result
+
+
+def _validate_v2_phase_requests(
+    phases: Any, *, includes_restart: bool
+) -> None:
+    _require(isinstance(phases, Mapping), "observation_phase_requests_invalid")
+    expected = {
+        "root_initial",
+        "root_after_spawn",
+        "child_initial",
+        "root_after_wait",
+    }
+    if includes_restart:
+        expected.add("restart_replay")
+    _require(set(phases) == expected, "observation_phase_set_invalid")
+    for request in phases.values():
+        _validate_safe_request(request)
+    signatures = {
+        phase: _collaboration_signature(request) for phase, request in phases.items()
+    }
+    _require(signatures["root_initial"] == [], "observation_root_initial_invalid")
+    _require(
+        signatures["root_after_spawn"]
+        == [
+            ["function_call", "spawn_agent"],
+            ["function_call_output", ["task_name"]],
+        ],
+        "observation_after_spawn_invalid",
+    )
+    _require(
+        signatures["child_initial"]
+        == [["agent_message", ["input_text", "encrypted_content"]]],
+        "observation_child_initial_invalid",
+    )
+    expected_after_wait = [
+        ["function_call", "spawn_agent"],
+        ["function_call_output", ["task_name"]],
+        ["function_call", "wait_agent"],
+        ["function_call_output", ["message", "timed_out"]],
+        ["agent_message", ["input_text"]],
+    ]
+    _require(
+        signatures["root_after_wait"] == expected_after_wait,
+        "observation_after_wait_invalid",
+    )
+    if includes_restart:
+        _require(
+            signatures["restart_replay"] == expected_after_wait,
+            "observation_restart_replay_invalid",
+        )
+
+
+def _require_all_true(value: Any, code: str) -> None:
+    _require(isinstance(value, Mapping) and value, code)
+    _require(all(child is True for child in value.values()), code)
+
+
+def _validate_rollout_readback(value: Any) -> None:
+    _require(isinstance(value, list) and value, "observation_rollout_invalid")
+    roles = {entry.get("role") for entry in value if isinstance(entry, Mapping)}
+    _require(roles == {"root", "child"}, "observation_rollout_roles_invalid")
+    for entry in value:
+        _require(isinstance(entry, Mapping), "observation_rollout_entry_invalid")
+        _require_exact_fields(
+            entry,
+            {
+                "role",
+                "relevant_record_type_order",
+                "metadata_records",
+                "collaboration_items",
+            },
+            "observation_rollout_fields_invalid",
+        )
+        metadata = entry.get("metadata_records")
+        _require(isinstance(metadata, list) and metadata, "observation_metadata_invalid")
+        record_order = entry.get("relevant_record_type_order")
+        _require(
+            isinstance(record_order, list)
+            and all(
+                record_type in {"session_meta", "turn_context", "response_item"}
+                for record_type in record_order
+            ),
+            "observation_rollout_record_order_invalid",
+        )
+        for record in metadata:
+            _require(isinstance(record, Mapping), "observation_metadata_record_invalid")
+            _require_exact_fields(
+                record,
+                {
+                    "record_type",
+                    "record_fields",
+                    "record_field_types",
+                    "payload_fields",
+                    "payload_field_types",
+                    "multi_agent_version",
+                },
+                "observation_metadata_record_fields_invalid",
+            )
+            _require(
+                record.get("record_fields")
+                == sorted(record.get("record_field_types", {})),
+                "observation_metadata_record_type_keys_invalid",
+            )
+            _require(
+                record.get("payload_fields")
+                == sorted(record.get("payload_field_types", {})),
+                "observation_metadata_payload_type_keys_invalid",
+            )
+        versions = [
+            record.get("multi_agent_version")
+            for record in metadata
+            if isinstance(record, Mapping)
+            and record.get("record_type") in {"session_meta", "turn_context"}
+        ]
+        _require(versions and set(versions) == {"v2"}, "observation_rollout_version_invalid")
+        for item in entry.get("collaboration_items", []):
+            _validate_safe_request(
+                {
+                    "fields": [],
+                    "field_types": {},
+                    "tool_choice": "auto",
+                    "multi_agent_version_locations": [],
+                    "input_type_order": [],
+                    "collaboration_items": [item],
+                }
+            )
+
+
+def _validate_thread_structure(value: Any) -> None:
+    _require(isinstance(value, Mapping), "observation_thread_structure_invalid")
+    _require_exact_fields(
+        value,
+        {
+            "fields",
+            "field_types",
+            "status_fields",
+            "status_field_types",
+            "turns",
+        },
+        "observation_thread_structure_fields_invalid",
+    )
+    turns = value.get("turns")
+    _require(
+        value.get("fields") == sorted(value.get("field_types", {})),
+        "observation_thread_structure_type_keys_invalid",
+    )
+    _require(
+        value.get("status_fields") == sorted(value.get("status_field_types", {})),
+        "observation_thread_status_type_keys_invalid",
+    )
+    _require(isinstance(turns, list) and turns, "observation_thread_turns_invalid")
+    for turn in turns:
+        _require(isinstance(turn, Mapping), "observation_thread_turn_invalid")
+        _require_exact_fields(
+            turn,
+            {"fields", "field_types", "status", "items"},
+            "observation_thread_turn_fields_invalid",
+        )
+        _require(
+            turn.get("fields") == sorted(turn.get("field_types", {})),
+            "observation_thread_turn_type_keys_invalid",
+        )
+        items = turn.get("items")
+        _require(isinstance(items, list), "observation_thread_items_invalid")
+        for item in items:
+            _require(isinstance(item, Mapping), "observation_thread_item_invalid")
+            _require(
+                {"type", "fields", "field_types"}.issubset(item),
+                "observation_thread_item_fields_invalid",
+            )
+            _require(
+                set(item).issubset(
+                    {"type", "fields", "field_types", "kind", "status", "tool", "phase"}
+                ),
+                "observation_thread_item_fields_invalid",
+            )
+            _require(
+                item.get("fields") == sorted(item.get("field_types", {})),
+                "observation_thread_item_type_keys_invalid",
+            )
+
+
+def validate_runtime_observations(payload: Mapping[str, Any]) -> None:
+    _require(isinstance(payload, Mapping), "observations_invalid")
+    _require_exact_fields(
+        payload,
+        {
+            "schema",
+            "candidate_revision",
+            "captured_on",
+            "capture_run_binding_sha256",
+            "controls",
+            "runtimes",
+            "scenarios",
+        },
+        "observations_fields_invalid",
+    )
+    _require(payload.get("schema") == OBSERVATION_SCHEMA, "observations_schema_invalid")
+    _require(
+        payload.get("candidate_revision")
+        == "be10f62f44b22fa8c84510238250ae11fb3ecab4",
+        "observations_candidate_invalid",
+    )
+    captured_on = payload.get("captured_on")
+    _require(
+        isinstance(captured_on, str) and _CAPTURE_DATE.fullmatch(captured_on) is not None,
+        "observations_capture_date_invalid",
+    )
+    binding = payload.get("capture_run_binding_sha256")
+    _require_digest(binding, "observations_binding_invalid")
+    _require(binding == _capture_run_binding(payload), "observations_binding_mismatch")
+    expected_controls = {
+        "explicit_runtime_capture": True,
+        "fresh_empty_home_per_scenario": True,
+        "workspace_under_isolated_home": True,
+        "protocol_upstream_loopback": True,
+        "plugin_services_disabled": ["plugins", "remote_plugin", "plugin_sharing"],
+        "sensitive_environment_credentials_removed": True,
+        "existing_user_home_read": False,
+        "existing_user_task_read": False,
+        "known_crash_task_read": False,
+        "raw_content_or_credentials_retained": False,
+        "raw_paths_or_opaque_identifiers_retained": False,
+    }
+    _require(payload.get("controls") == expected_controls, "observations_controls_invalid")
+    runtimes = payload.get("runtimes")
+    _require(isinstance(runtimes, Mapping), "observations_runtimes_invalid")
+    expected_runtimes = {
+        "codex_cli": _expected_runtime_observation(
+            client="codex_cli",
+            client_version="0.146.1",
+            runtime_version="0.146.1",
+            binary_sha256="ae9d865f3d346a1a2a60c4e84775622d74e3e7ef53e0dede9c68b81eab306cca",
+            source_tag="rust-v0.146.1",
+            source_commit="79b4f03d35962b005b007a015113b38930711665",
+            source_blobs=CLI_SOURCE_BLOBS,
+        ),
+        "codex_desktop": _expected_runtime_observation(
+            client="codex_desktop",
+            client_version="26.803.5235.0",
+            runtime_version="0.147.0-alpha.6.5",
+            binary_sha256="fb5c760e14cf8fe86e12e49e8a3e7f237af06082d6b9fe1e411e463b7229c916",
+            source_tag="rust-v0.147.0-alpha.6.5",
+            source_commit="618b8e9111da9f57fe380b09d0f6516e3f343536",
+            source_blobs=DESKTOP_SOURCE_BLOBS,
+        ),
+    }
+    _require(dict(runtimes) == expected_runtimes, "observations_runtime_inputs_invalid")
+
+    scenarios = payload.get("scenarios")
+    _require(isinstance(scenarios, Mapping), "observations_scenarios_invalid")
+    scenario_contract = {
+        "cli_v1_request": ("codex_cli", 1, 1),
+        "desktop_v1_request": ("codex_desktop", 1, 1),
+        "cli_v2_lifecycle": ("codex_cli", 5, 2),
+        "desktop_v2_lifecycle": ("codex_desktop", 5, 2),
+        "desktop_app_v2_lifecycle": ("codex_desktop", 4, 2),
+    }
+    _require(set(scenarios) == set(scenario_contract), "observations_scenario_set_invalid")
+    home_bindings: list[str] = []
+    for name, (client, request_count, process_runs) in scenario_contract.items():
+        scenario = scenarios[name]
+        _require(isinstance(scenario, Mapping), "observation_scenario_invalid")
+        _require_exact_fields(
+            scenario,
+            {
+                "client",
+                "home_binding_sha256",
+                "fresh_empty_home_before_marker",
+                "workspace_created_under_home",
+                "loopback_request_count",
+                "process_runs",
+                "observed",
+            },
+            "observation_scenario_fields_invalid",
+        )
+        _require(scenario.get("client") == client, "observation_scenario_client_invalid")
+        _require_digest(scenario.get("home_binding_sha256"), "observation_home_binding_invalid")
+        home_bindings.append(scenario["home_binding_sha256"])
+        _require(
+            scenario.get("fresh_empty_home_before_marker") is True,
+            "observation_home_not_fresh",
+        )
+        _require(
+            scenario.get("workspace_created_under_home") is True,
+            "observation_workspace_scope_invalid",
+        )
+        _require(
+            scenario.get("loopback_request_count") == request_count,
+            "observation_request_count_invalid",
+        )
+        _require(
+            scenario.get("process_runs") == process_runs,
+            "observation_process_runs_invalid",
+        )
+    _require(len(set(home_bindings)) == len(home_bindings), "observation_home_binding_duplicate")
+
+    for name in ("cli_v1_request", "desktop_v1_request"):
+        observed = scenarios[name]["observed"]
+        _require(isinstance(observed, Mapping), "observation_v1_invalid")
+        _require_exact_fields(
+            observed, {"request", "declaration"}, "observation_v1_fields_invalid"
+        )
+        _validate_safe_request(observed["request"])
+        _require(
+            observed["request"]["collaboration_items"] == [],
+            "observation_v1_history_invalid",
+        )
+        _require(
+            observed["declaration"] == _expected_observed_declaration(V1),
+            "observation_v1_declaration_invalid",
+        )
+
+    for name in ("cli_v2_lifecycle", "desktop_v2_lifecycle"):
+        observed = scenarios[name]["observed"]
+        _require(isinstance(observed, Mapping), "observation_v2_invalid")
+        _require_exact_fields(
+            observed,
+            {
+                "declaration",
+                "request_arrival_order",
+                "requests_by_phase",
+                "served_function_call_event_order",
+                "served_function_names",
+                "identity_relationships",
+                "rollout_readback",
+            },
+            "observation_v2_fields_invalid",
+        )
+        _require(
+            observed["declaration"] == _expected_observed_declaration(V2),
+            "observation_v2_declaration_invalid",
+        )
+        _validate_v2_phase_requests(observed["requests_by_phase"], includes_restart=True)
+        _require(
+            sorted(observed["request_arrival_order"])
+            == sorted(observed["requests_by_phase"]),
+            "observation_request_arrival_invalid",
+        )
+        _require(
+            observed["served_function_call_event_order"]
+            == [
+                "response.output_item.added",
+                "response.function_call_arguments.delta",
+                "response.function_call_arguments.done",
+                "response.output_item.done",
+                "response.completed",
+            ],
+            "observation_stream_order_invalid",
+        )
+        _require(
+            observed["served_function_names"] == ["spawn_agent", "wait_agent"],
+            "observation_served_functions_invalid",
+        )
+        _require_all_true(
+            observed["identity_relationships"],
+            "observation_identity_relationship_invalid",
+        )
+        _validate_rollout_readback(observed["rollout_readback"])
+
+    app_observed = scenarios["desktop_app_v2_lifecycle"]["observed"]
+    _require(isinstance(app_observed, Mapping), "observation_desktop_app_invalid")
+    _require_exact_fields(
+        app_observed,
+        {
+            "declaration",
+            "requests_by_phase",
+            "notifications",
+            "thread_read_before_restart",
+            "thread_read_after_restart",
+            "resume_result_fields",
+            "resume_result_field_types",
+            "identity_relationships",
+        },
+        "observation_desktop_app_fields_invalid",
+    )
+    _require(
+        app_observed["declaration"] == _expected_observed_declaration(V2),
+        "observation_desktop_app_declaration_invalid",
+    )
+    _validate_v2_phase_requests(app_observed["requests_by_phase"], includes_restart=False)
+    notifications = app_observed["notifications"]
+    _require(isinstance(notifications, list) and notifications, "observation_notifications_invalid")
+    observed_notification_pairs = {
+        (entry.get("method"), entry.get("item_type"))
+        for entry in notifications
+        if isinstance(entry, Mapping)
+    }
+    required_notification_pairs = {
+        ("item/started", "agentMessage"),
+        ("item/completed", "agentMessage"),
+        ("item/started", "collabAgentToolCall"),
+        ("item/completed", "collabAgentToolCall"),
+        ("item/started", "subAgentActivity"),
+        ("item/completed", "subAgentActivity"),
+        ("item/agentMessage/delta", None),
+    }
+    _require(
+        required_notification_pairs.issubset(observed_notification_pairs),
+        "observation_notification_lifecycle_invalid",
+    )
+    notification_enum_values = {
+        "item_kind": {"started", "completed"},
+        "item_status": {"inProgress", "completed", "failed"},
+        "item_tool": {
+            "spawnAgent",
+            "sendMessage",
+            "followupTask",
+            "wait",
+            "interruptAgent",
+            "listAgents",
+        },
+        "item_phase": {"commentary", "final"},
+    }
+    for entry in notifications:
+        _require(isinstance(entry, Mapping), "observation_notification_invalid")
+        base_fields = {"method", "params_fields", "params_field_types"}
+        if "item_type" in entry:
+            allowed_fields = base_fields | {
+                "item_type",
+                "item_fields",
+                "item_field_types",
+                "item_kind",
+                "item_status",
+                "item_tool",
+                "item_phase",
+            }
+            _require(
+                base_fields
+                | {"item_type", "item_fields", "item_field_types"}
+                <= set(entry)
+                <= allowed_fields,
+                "observation_notification_fields_invalid",
+            )
+            _require(
+                entry.get("item_fields")
+                == sorted(entry.get("item_field_types", {})),
+                "observation_notification_item_type_keys_invalid",
+            )
+            _require(
+                entry.get("item_type")
+                in {"agentMessage", "collabAgentToolCall", "subAgentActivity"},
+                "observation_notification_item_type_invalid",
+            )
+        else:
+            _require(set(entry) == base_fields, "observation_notification_fields_invalid")
+            _require(
+                entry.get("method") == "item/agentMessage/delta",
+                "observation_notification_method_invalid",
+            )
+        _require(
+            entry.get("params_fields")
+            == sorted(entry.get("params_field_types", {})),
+            "observation_notification_param_type_keys_invalid",
+        )
+        for field, allowed in notification_enum_values.items():
+            if field in entry:
+                _require(entry[field] in allowed, "observation_notification_enum_invalid")
+    _validate_thread_structure(app_observed["thread_read_before_restart"])
+    _validate_thread_structure(app_observed["thread_read_after_restart"])
+    _require(
+        app_observed["thread_read_before_restart"]
+        == app_observed["thread_read_after_restart"],
+        "observation_thread_readback_mismatch",
+    )
+    _require_all_true(
+        app_observed["identity_relationships"],
+        "observation_desktop_identity_relationship_invalid",
+    )
+
+    serialized = json.dumps(payload, ensure_ascii=True, sort_keys=True)
+    _require(
+        re.search(
+            r"\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b",
+            serialized,
+            re.IGNORECASE,
+        )
+        is None,
+        "observations_opaque_identifier_retained",
+    )
+
+
+def _load_runtime_observations(path: Path) -> dict[str, Any]:
+    payload = _load(path, code="observations_file_invalid")
+    validate_runtime_observations(payload)
+    return payload
+
+
+def build_contract(observations: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    if observations is None:
+        observations = _load_runtime_observations(DEFAULT_OBSERVATIONS)
+    validate_runtime_observations(observations)
+    scenarios = observations["scenarios"]
+    cli_scenarios = [
+        "cli_v1_request",
+        "cli_v2_lifecycle",
+    ]
+    desktop_scenarios = [
+        "desktop_v1_request",
+        "desktop_v2_lifecycle",
+        "desktop_app_v2_lifecycle",
+    ]
+    cli_home_bindings = [
+        scenarios[name]["home_binding_sha256"] for name in cli_scenarios
+    ]
+    desktop_home_bindings = [
+        scenarios[name]["home_binding_sha256"] for name in desktop_scenarios
+    ]
+    cli_lifecycle = scenarios["cli_v2_lifecycle"]["observed"]
+    desktop_lifecycle = scenarios["desktop_v2_lifecycle"]["observed"]
+    desktop_app = scenarios["desktop_app_v2_lifecycle"]["observed"]
     return {
         "schema": SCHEMA,
         "qualification_status": "accepted_request_call_result_agent_message_and_readback",
         "candidate_revision": "be10f62f44b22fa8c84510238250ae11fb3ecab4",
-        "captured_on": "2026-08-10",
+        "captured_on": observations["captured_on"],
+        "source_observations": {
+            "schema": observations["schema"],
+            "canonical_sha256": _canonical_digest(observations),
+            "capture_run_binding_sha256": observations[
+                "capture_run_binding_sha256"
+            ],
+            "path": str(DEFAULT_OBSERVATIONS).replace("\\", "/"),
+        },
         "capture_scope": {
             "home": "new_isolated_home_per_runtime",
             "upstream": "loopback_protocol_controlled_responses",
@@ -334,27 +1056,22 @@ def build_contract() -> dict[str, Any]:
                 "desktop_v2_request_call_result_agent_message_and_restart",
                 "desktop_app_thread_items_notifications_and_restart",
             ],
+            "isolated_home_bindings_sha256": [
+                scenarios[name]["home_binding_sha256"] for name in sorted(scenarios)
+            ],
         },
         "runtimes": [
             _runtime(
-                client="codex_cli",
-                client_version="0.146.1",
-                runtime_version="0.146.1",
-                binary_sha256="ae9d865f3d346a1a2a60c4e84775622d74e3e7ef53e0dede9c68b81eab306cca",
-                source_tag="rust-v0.146.1",
-                source_commit="79b4f03d35962b005b007a015113b38930711665",
-                source_blobs=CLI_SOURCE_BLOBS,
+                runtime_observation=observations["runtimes"]["codex_cli"],
                 desktop_app=False,
+                scenario_names=cli_scenarios,
+                home_bindings=cli_home_bindings,
             ),
             _runtime(
-                client="codex_desktop",
-                client_version="26.803.5235.0",
-                runtime_version="0.147.0-alpha.6.5",
-                binary_sha256="fb5c760e14cf8fe86e12e49e8a3e7f237af06082d6b9fe1e411e463b7229c916",
-                source_tag="rust-v0.147.0-alpha.6.5",
-                source_commit="618b8e9111da9f57fe380b09d0f6516e3f343536",
-                source_blobs=DESKTOP_SOURCE_BLOBS,
+                runtime_observation=observations["runtimes"]["codex_desktop"],
                 desktop_app=True,
+                scenario_names=desktop_scenarios,
+                home_bindings=desktop_home_bindings,
             ),
         ],
         "selection_contract": {
@@ -542,6 +1259,14 @@ def build_contract() -> dict[str, Any]:
                 "stream_close_without_completed": "terminal_error",
             },
             "history_items": ["function_call", "function_call_output", "agent_message"],
+            "request_replay_envelopes": {
+                "codex_cli": cli_lifecycle["requests_by_phase"],
+                "codex_desktop": desktop_lifecycle["requests_by_phase"],
+            },
+            "rollout_readback_envelopes": {
+                "codex_cli": cli_lifecycle["rollout_readback"],
+                "codex_desktop": desktop_lifecycle["rollout_readback"],
+            },
             "same_home_readback": {
                 "clients": ["codex_cli", "codex_desktop"],
                 "call_namespace_preserved": True,
@@ -551,6 +1276,15 @@ def build_contract() -> dict[str, Any]:
                 "session_meta_multi_agent_version": "v2",
                 "turn_context_multi_agent_version": "v2",
                 "desktop_thread_resume_and_read": "observed",
+                "cli_identity_relationships": cli_lifecycle[
+                    "identity_relationships"
+                ],
+                "desktop_identity_relationships": desktop_lifecycle[
+                    "identity_relationships"
+                ],
+                "desktop_app_identity_relationships": desktop_app[
+                    "identity_relationships"
+                ],
             },
         },
         "protocol_layers": {
@@ -615,6 +1349,14 @@ def build_contract() -> dict[str, Any]:
                     "collabAgentToolCall": ["item/started", "item/completed"],
                     "subAgentActivity": ["item/started", "item/completed"],
                 },
+                "notification_envelopes": desktop_app["notifications"],
+                "thread_read_envelope": desktop_app[
+                    "thread_read_before_restart"
+                ],
+                "thread_resume_result": {
+                    "fields": desktop_app["resume_result_fields"],
+                    "field_types": desktop_app["resume_result_field_types"],
+                },
                 "turn_terminal_notification": "turn/completed",
                 "same_home_thread_resume_and_read": "observed",
                 "wire_item_equivalent": False,
@@ -661,15 +1403,44 @@ def _namespace_candidates(tools: Sequence[Any]) -> list[Mapping[str, Any]]:
     return candidates
 
 
+def _conflicting_collaboration_markers(
+    tools: Sequence[Any], candidates: Sequence[Mapping[str, Any]]
+) -> list[Mapping[str, Any]]:
+    candidate_ids = {id(candidate) for candidate in candidates}
+    collaboration_names = {V1_NAMESPACE, V2_NAMESPACE}
+    child_names = set(V1_TOOLS) | set(V2_TOOLS)
+    conflicts: list[Mapping[str, Any]] = []
+    for tool in tools:
+        if not isinstance(tool, Mapping) or id(tool) in candidate_ids:
+            continue
+        name = tool.get("name")
+        if name in collaboration_names or (
+            tool.get("type") == "function" and name in child_names
+        ):
+            conflicts.append(tool)
+    return conflicts
+
+
 def _normalize_schema(value: Any) -> Any:
     if isinstance(value, Mapping):
-        normalized = {
-            key: _normalize_schema(child)
-            for key, child in value.items()
-            if key != "description"
-        }
+        normalized: dict[str, Any] = {}
+        for key, child in value.items():
+            if key == "description":
+                continue
+            if key == "properties" and isinstance(child, Mapping):
+                normalized[key] = {
+                    property_name: _normalize_schema(property_schema)
+                    for property_name, property_schema in child.items()
+                }
+            else:
+                normalized[key] = _normalize_schema(child)
         if normalized.get("type") == "object":
             normalized.setdefault("required", [])
+            required = normalized["required"]
+            if isinstance(required, list) and all(
+                isinstance(field, str) for field in required
+            ):
+                normalized["required"] = sorted(required)
         return normalized
     if isinstance(value, list):
         return [_normalize_schema(child) for child in value]
@@ -682,6 +1453,8 @@ def classify_tools(tools: Sequence[Any]) -> str:
     _require(isinstance(tools, Sequence) and not isinstance(tools, (str, bytes)), "tools_invalid")
     candidates = _namespace_candidates(tools)
     _require(candidates, "collaboration_marker_missing")
+    conflicts = _conflicting_collaboration_markers(tools, candidates)
+    _require(not conflicts, "collaboration_marker_duplicate_or_mixed")
     namespaces = [candidate.get("name") for candidate in candidates]
     _require(len(candidates) == 1, "collaboration_marker_duplicate_or_mixed")
     candidate = candidates[0]
@@ -713,7 +1486,7 @@ def classify_tools(tools: Sequence[Any]) -> str:
         _require(isinstance(parameters, Mapping), "namespace_child_parameters_invalid")
         normalized = _normalize_schema(parameters)
         _require(
-            normalized == EXPECTED_PARAMETER_SCHEMAS[version][name],
+            normalized == _normalize_schema(EXPECTED_PARAMETER_SCHEMAS[version][name]),
             "namespace_child_parameter_schema_mismatch",
         )
     return version
@@ -735,16 +1508,20 @@ def classify_request(request: Mapping[str, Any]) -> str:
     return version
 
 
-def validate_contract(payload: Mapping[str, Any]) -> None:
-    expected = build_contract()
+def validate_contract(
+    payload: Mapping[str, Any], observations: Mapping[str, Any] | None = None
+) -> None:
+    expected = build_contract(observations)
     _require(isinstance(payload, Mapping), "contract_invalid")
     _require(payload.get("schema") == SCHEMA, "contract_schema_invalid")
     _require(dict(payload) == expected, "contract_content_invalid")
 
 
-def reconcile_contract(payload: Mapping[str, Any]) -> dict[str, Any]:
+def reconcile_contract(
+    payload: Mapping[str, Any], observations: Mapping[str, Any] | None = None
+) -> dict[str, Any]:
     try:
-        validate_contract(payload)
+        validate_contract(payload, observations)
     except ContractValidationError as error:
         return {"reconciled": False, "mismatches": [str(error)]}
     return {"reconciled": True, "mismatches": []}
@@ -762,18 +1539,21 @@ def replay_contract(payload: Mapping[str, Any], case: str) -> dict[str, Any]:
     return clone
 
 
-def _load(path: Path) -> dict[str, Any]:
+def _load(path: Path, *, code: str = "contract_file_invalid") -> dict[str, Any]:
     try:
         value = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, UnicodeError, json.JSONDecodeError) as error:
-        raise ContractValidationError("contract_file_invalid") from error
-    _require(isinstance(value, dict), "contract_file_invalid")
+        raise ContractValidationError(code) from error
+    _require(isinstance(value, dict), code)
     return value
 
 
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--out", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument(
+        "--source-observations", type=Path, default=DEFAULT_OBSERVATIONS
+    )
     parser.add_argument("--check", action="store_true")
     return parser
 
@@ -781,10 +1561,11 @@ def _parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> int:
     args = _parser().parse_args(argv)
     try:
-        expected = build_contract()
-        validate_contract(expected)
+        observations = _load_runtime_observations(args.source_observations)
+        expected = build_contract(observations)
+        validate_contract(expected, observations)
         if args.check:
-            report = reconcile_contract(_load(args.out))
+            report = reconcile_contract(_load(args.out), observations)
             print(json.dumps(report, sort_keys=True))
             return 0 if report["reconciled"] else 1
         args.out.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/build_issue_392_collaboration_contract.py
+++ b/scripts/build_issue_392_collaboration_contract.py
@@ -1,0 +1,804 @@
+#!/usr/bin/env python3
+"""Build and validate the frozen Beta4 Collaboration runtime contract.
+
+The artifact is deliberately bounded.  It records source- and runtime-derived
+wire shapes, but never stores prompts, credentials, paths, task identifiers,
+call identifiers, or message content.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+
+SCHEMA = "codexhub.issue392.collaboration-runtime-contract.v1"
+DEFAULT_OUTPUT = Path("docs/evidence/issue-392/collaboration-runtime-contract.json")
+
+V1 = "collaboration_v1"
+V2 = "collaboration_v2"
+V1_NAMESPACE = "multi_agent_v1"
+V2_NAMESPACE = "collaboration"
+V1_TOOLS = ("close_agent", "resume_agent", "send_input", "spawn_agent", "wait_agent")
+V2_TOOLS = (
+    "followup_task",
+    "interrupt_agent",
+    "list_agents",
+    "send_message",
+    "spawn_agent",
+    "wait_agent",
+)
+
+def _object_schema(
+    properties: Mapping[str, Any], required: Sequence[str] = ()
+) -> dict[str, Any]:
+    return {
+        "type": "object",
+        "properties": dict(properties),
+        "required": list(required),
+        "additionalProperties": False,
+    }
+
+
+STRING = {"type": "string"}
+NUMBER = {"type": "number"}
+BOOLEAN = {"type": "boolean"}
+NULLABLE_STRING = {"type": ["string", "null"]}
+ENCRYPTED_STRING = {"type": "string", "encrypted": True}
+
+COLLAB_INPUT_ITEM_SCHEMA = _object_schema(
+    {
+        "audio_url": STRING,
+        "image_url": STRING,
+        "name": STRING,
+        "path": STRING,
+        "text": STRING,
+        "type": STRING,
+    }
+)
+
+# Descriptions are deliberately excluded because user roles and runtime wording
+# can change them without changing the wire contract.  Types, encryption flags,
+# required fields, nesting, and additionalProperties are exact normalized
+# captures from both frozen clients.
+EXPECTED_PARAMETER_SCHEMAS: dict[str, dict[str, dict[str, Any]]] = {
+    V1: {
+        "close_agent": _object_schema({"target": STRING}, ["target"]),
+        "resume_agent": _object_schema({"id": STRING}, ["id"]),
+        "send_input": _object_schema(
+            {
+                "interrupt": BOOLEAN,
+                "items": {"type": "array", "items": COLLAB_INPUT_ITEM_SCHEMA},
+                "message": STRING,
+                "target": STRING,
+            },
+            ["target"],
+        ),
+        "spawn_agent": _object_schema(
+            {
+                "agent_type": STRING,
+                "fork_context": BOOLEAN,
+                "items": {"type": "array", "items": COLLAB_INPUT_ITEM_SCHEMA},
+                "message": STRING,
+                "model": STRING,
+                "reasoning_effort": STRING,
+                "service_tier": STRING,
+            }
+        ),
+        "wait_agent": _object_schema(
+            {
+                "targets": {"type": "array", "items": STRING},
+                "timeout_ms": NUMBER,
+            },
+            ["targets"],
+        ),
+    },
+    V2: {
+        "followup_task": _object_schema(
+            {"message": ENCRYPTED_STRING, "target": STRING},
+            ["target", "message"],
+        ),
+        "interrupt_agent": _object_schema({"target": STRING}, ["target"]),
+        "list_agents": _object_schema({"path_prefix": STRING}),
+        "send_message": _object_schema(
+            {"message": ENCRYPTED_STRING, "target": STRING},
+            ["target", "message"],
+        ),
+        "spawn_agent": _object_schema(
+            {
+                "agent_type": STRING,
+                "fork_turns": STRING,
+                "message": ENCRYPTED_STRING,
+                "model": STRING,
+                "reasoning_effort": STRING,
+                "task_name": STRING,
+            },
+            ["task_name", "message"],
+        ),
+        "wait_agent": _object_schema({"timeout_ms": NUMBER}),
+    },
+}
+
+
+def _argument_sets(
+    schema: Mapping[str, Any],
+) -> tuple[frozenset[str], frozenset[str]]:
+    properties = frozenset(schema["properties"])
+    required = frozenset(schema.get("required", []))
+    return required, properties - required
+
+
+EXPECTED_ARGUMENTS: dict[
+    str, dict[str, tuple[frozenset[str], frozenset[str]]]
+] = {
+    version: {
+        name: _argument_sets(schema) for name, schema in tool_schemas.items()
+    }
+    for version, tool_schemas in EXPECTED_PARAMETER_SCHEMAS.items()
+}
+
+
+AGENT_STATUS_SCHEMA = {
+    "oneOf": [
+        {
+            "type": "string",
+            "enum": ["pending_init", "running", "interrupted", "shutdown", "not_found"],
+        },
+        _object_schema({"completed": NULLABLE_STRING}, ["completed"]),
+        _object_schema({"errored": STRING}, ["errored"]),
+    ]
+}
+
+EXPECTED_OUTPUT_SCHEMAS: dict[str, dict[str, dict[str, Any] | None]] = {
+    V1: {
+        "close_agent": _object_schema(
+            {"previous_status": AGENT_STATUS_SCHEMA}, ["previous_status"]
+        ),
+        "resume_agent": _object_schema({"status": AGENT_STATUS_SCHEMA}, ["status"]),
+        "send_input": _object_schema({"submission_id": STRING}, ["submission_id"]),
+        "spawn_agent": _object_schema(
+            {"agent_id": STRING, "nickname": NULLABLE_STRING},
+            ["agent_id", "nickname"],
+        ),
+        "wait_agent": _object_schema(
+            {
+                "status": {"type": "object", "additionalProperties": AGENT_STATUS_SCHEMA},
+                "timed_out": BOOLEAN,
+            },
+            ["status", "timed_out"],
+        ),
+    },
+    V2: {
+        "followup_task": None,
+        "interrupt_agent": _object_schema(
+            {"previous_status": AGENT_STATUS_SCHEMA}, ["previous_status"]
+        ),
+        "list_agents": _object_schema(
+            {
+                "agents": {
+                    "type": "array",
+                    "items": _object_schema(
+                        {"agent_name": STRING, "agent_status": AGENT_STATUS_SCHEMA},
+                        ["agent_name", "agent_status"],
+                    ),
+                }
+            },
+            ["agents"],
+        ),
+        "send_message": None,
+        "spawn_agent": _object_schema({"task_name": STRING}, ["task_name"]),
+        "wait_agent": _object_schema(
+            {"message": STRING, "timed_out": BOOLEAN}, ["message", "timed_out"]
+        ),
+    },
+}
+
+SOURCE_FILES = {
+    "multi_agent_tool_schemas": "codex-rs/core/src/tools/handlers/multi_agents_spec.rs",
+    "multi_agent_output_serialization": "codex-rs/core/src/tools/handlers/multi_agents_common.rs",
+    "v2_spawn_handler": "codex-rs/core/src/tools/handlers/multi_agents_v2/spawn.rs",
+    "v2_message_handler": "codex-rs/core/src/tools/handlers/multi_agents_v2/message_tool.rs",
+    "v2_wait_handler": "codex-rs/core/src/tools/handlers/multi_agents_v2/wait.rs",
+    "v2_interrupt_handler": "codex-rs/core/src/tools/handlers/multi_agents_v2/interrupt_agent.rs",
+    "v2_list_handler": "codex-rs/core/src/tools/handlers/multi_agents_v2/list_agents.rs",
+    "tool_planning_and_namespace_override": "codex-rs/core/src/tools/spec_plan.rs",
+    "version_selection_and_namespace_default": "codex-rs/core/src/config/mod.rs",
+    "responses_request_and_tool_choice": "codex-rs/core/src/client.rs",
+    "responses_stream_parser": "codex-rs/codex-api/src/sse/responses.rs",
+    "responses_items": "codex-rs/protocol/src/models.rs",
+    "agent_message_and_rollout": "codex-rs/protocol/src/protocol.rs",
+    "desktop_thread_items": "codex-rs/app-server-protocol/src/protocol/v2/item.rs",
+    "desktop_event_mapping": "codex-rs/app-server-protocol/src/protocol/event_mapping.rs",
+}
+
+CLI_SOURCE_BLOBS = {
+    "multi_agent_tool_schemas": "2eb82e175b454db0fc8fb8bba61b37d07ab69d30",
+    "multi_agent_output_serialization": "9bb7f76f9de0d799766d050c5811e33d3a7635ea",
+    "v2_spawn_handler": "67f8057e435b8522a82825f055c75ed420401975",
+    "v2_message_handler": "62defe65c4114ffcdc661b98836d9964f09a7c64",
+    "v2_wait_handler": "4e2eced26037d4c876a8b9fcd28912fb4344953b",
+    "v2_interrupt_handler": "a418dec4a86550715080b95a3191ce3c72836e8f",
+    "v2_list_handler": "99e54e1ce91cbd0f182f52fd8ff16f9268f96233",
+    "tool_planning_and_namespace_override": "5ff9e392f3ebec0a510efd11305752133944ceda",
+    "version_selection_and_namespace_default": "216af994bc03e136c4797453525df473f579adf5",
+    "responses_request_and_tool_choice": "b13242062022d9d37302a060dd493977d9c0c1f1",
+    "responses_stream_parser": "441d7bb3bfa743f2fc3fe089cfdb88ddec887aac",
+    "responses_items": "51e22d10fd57af6bffd7a11b60dc2d422a7ad607",
+    "agent_message_and_rollout": "c692d040d292cf223777cae42dd577b03e85aab5",
+    "desktop_thread_items": "f3a3a65d20516ac9dc99ef0c981eaf399e151cfa",
+    "desktop_event_mapping": "b32b15272ba4791db5a253ecc50555bf29b4ef14",
+}
+
+DESKTOP_SOURCE_BLOBS = {
+    "multi_agent_tool_schemas": "757e111cc2d060f84b2618896426001225bba4ef",
+    "multi_agent_output_serialization": "f8569c441ed24a01760a51674687787014dfde28",
+    "v2_spawn_handler": "a6b5c46eec06931354fdc3109909fd574865611d",
+    "v2_message_handler": "eb1790480eeeb5d524cfb132846812ce073c674f",
+    "v2_wait_handler": "4e2eced26037d4c876a8b9fcd28912fb4344953b",
+    "v2_interrupt_handler": "a418dec4a86550715080b95a3191ce3c72836e8f",
+    "v2_list_handler": "99e54e1ce91cbd0f182f52fd8ff16f9268f96233",
+    "tool_planning_and_namespace_override": "1047190cc37f34ec4cfcae348af170da2bacc4c7",
+    "version_selection_and_namespace_default": "844184314f2fa3a2fe2f8238e8d351aaa1050a5e",
+    "responses_request_and_tool_choice": "d6b25864dfa4620682d163cf9b65a4747d8fcfa9",
+    "responses_stream_parser": "44ed78737ba4ecf9e777c9d38199005ea4e2c2cc",
+    "responses_items": "2c2a6d6b7aa49eee6309e5a9ba9e7587a1047d4e",
+    "agent_message_and_rollout": "93313c63c2dd185e02d20fff9eff31d43b461277",
+    "desktop_thread_items": "a98ec3f3b2e19f4fef57ae7a5451a54dc471fb9b",
+    "desktop_event_mapping": "b32b15272ba4791db5a253ecc50555bf29b4ef14",
+}
+
+
+class ContractValidationError(ValueError):
+    """Stable bounded failure; values from a request are never included."""
+
+
+def _require(condition: bool, code: str) -> None:
+    if not condition:
+        raise ContractValidationError(code)
+
+
+def _argument_contract(version: str) -> dict[str, Any]:
+    return {
+        name: {
+            "required": sorted(required),
+            "optional": sorted(optional),
+            "additional_properties": False,
+            "normalized_parameter_schema": copy.deepcopy(
+                EXPECTED_PARAMETER_SCHEMAS[version][name]
+            ),
+            "request_output_schema_field": "absent",
+            "client_result_schema": copy.deepcopy(EXPECTED_OUTPUT_SCHEMAS[version][name]),
+        }
+        for name, (required, optional) in EXPECTED_ARGUMENTS[version].items()
+    }
+
+
+def _runtime(
+    *,
+    client: str,
+    client_version: str,
+    runtime_version: str,
+    binary_sha256: str,
+    source_tag: str,
+    source_commit: str,
+    source_blobs: Mapping[str, str],
+    desktop_app: bool,
+) -> dict[str, Any]:
+    return {
+        "client": client,
+        "client_version": client_version,
+        "runtime_version": runtime_version,
+        "binary_sha256": binary_sha256,
+        "source_tag": source_tag,
+        "source_commit": source_commit,
+        "source_files": {
+            key: {"path": SOURCE_FILES[key], "git_blob": source_blobs[key]}
+            for key in SOURCE_FILES
+        },
+        "observations": {
+            "v1_namespace_declaration": "observed",
+            "v2_namespace_declaration": "observed",
+            "tool_choice_auto": "observed",
+            "v2_function_call_and_output": "observed",
+            "v2_agent_message_input": "observed",
+            "v2_same_home_restart_readback": "observed",
+            "v2_rollout_version_metadata": "observed",
+            "desktop_thread_items_and_notifications": (
+                "observed" if desktop_app else "not_applicable"
+            ),
+        },
+    }
+
+
+def build_contract() -> dict[str, Any]:
+    return {
+        "schema": SCHEMA,
+        "qualification_status": "accepted_request_call_result_agent_message_and_readback",
+        "candidate_revision": "be10f62f44b22fa8c84510238250ae11fb3ecab4",
+        "captured_on": "2026-08-10",
+        "capture_scope": {
+            "home": "new_isolated_home_per_runtime",
+            "upstream": "loopback_protocol_controlled_responses",
+            "existing_user_home_read": False,
+            "existing_user_task_read": False,
+            "known_crash_task_read": False,
+            "content_or_credentials_retained": False,
+            "opaque_identity_retained": False,
+            "isolated_observations": [
+                "cli_v1_request",
+                "cli_v2_request_call_result_agent_message_and_restart",
+                "desktop_v1_request",
+                "desktop_v2_request_call_result_agent_message_and_restart",
+                "desktop_app_thread_items_notifications_and_restart",
+            ],
+        },
+        "runtimes": [
+            _runtime(
+                client="codex_cli",
+                client_version="0.146.1",
+                runtime_version="0.146.1",
+                binary_sha256="ae9d865f3d346a1a2a60c4e84775622d74e3e7ef53e0dede9c68b81eab306cca",
+                source_tag="rust-v0.146.1",
+                source_commit="79b4f03d35962b005b007a015113b38930711665",
+                source_blobs=CLI_SOURCE_BLOBS,
+                desktop_app=False,
+            ),
+            _runtime(
+                client="codex_desktop",
+                client_version="26.803.5235.0",
+                runtime_version="0.147.0-alpha.6.5",
+                binary_sha256="fb5c760e14cf8fe86e12e49e8a3e7f237af06082d6b9fe1e411e463b7229c916",
+                source_tag="rust-v0.147.0-alpha.6.5",
+                source_commit="618b8e9111da9f57fe380b09d0f6516e3f343536",
+                source_blobs=DESKTOP_SOURCE_BLOBS,
+                desktop_app=True,
+            ),
+        ],
+        "selection_contract": {
+            "stage": "before_schema_repair_state_or_scheduler",
+            "request_metadata_version_field": "absent_in_both_frozen_runtimes",
+            "tool_choice": {
+                "observed_value": "auto",
+                "included_in_version_discriminator": False,
+                "unexpected_value": "fail_closed_for_frozen_runtime_contract",
+            },
+            "markers": {
+                V1: {
+                    "wire_type": "namespace",
+                    "namespace": V1_NAMESPACE,
+                    "tool_names": list(V1_TOOLS),
+                    "argument_contract": _argument_contract(V1),
+                },
+                V2: {
+                    "wire_type": "namespace",
+                    "namespace": V2_NAMESPACE,
+                    "tool_names": list(V2_TOOLS),
+                    "argument_contract": _argument_contract(V2),
+                },
+            },
+            "shared_tool_name_policy": "never_classify_from_child_name_alone",
+            "direct_function_policy": "not_a_frozen_runtime_collaboration_marker",
+            "matching_policy": "complete_namespace_and_child_schema",
+            "description_policy": "require_string_but_exclude_dynamic_text_from_matching",
+            "child_policy": "exact_type_name_strict_parameter_shape_and_no_output_schema",
+            "unknown_missing_duplicate_conflicting_or_mixed": "fail_closed",
+            "unexpected_multi_agent_version_field": "fail_closed",
+        },
+        "protocols": {
+            V1: {
+                "namespace": V1_NAMESPACE,
+                "owner": "codex_client",
+                "declaration": {
+                    "type": "namespace",
+                    "fields": ["type", "name", "description", "tools"],
+                    "child_type": "function",
+                    "child_fields": [
+                        "type",
+                        "name",
+                        "description",
+                        "strict",
+                        "parameters",
+                    ],
+                    "child_strict": False,
+                    "child_output_schema_field": "absent",
+                    "tool_names": list(V1_TOOLS),
+                    "normalized_parameter_schemas": copy.deepcopy(
+                        EXPECTED_PARAMETER_SCHEMAS[V1]
+                    ),
+                },
+                "call": {
+                    "type": "function_call",
+                    "fields": ["type", "id", "name", "namespace", "arguments", "call_id"],
+                    "identity_fields": ["id", "call_id"],
+                },
+                "result": {
+                    "type": "function_call_output",
+                    "fields": ["type", "id", "call_id", "output"],
+                    "identity_fields": ["id", "call_id"],
+                    "output_wire_encoding": "json_text_string",
+                    "tool_output_schemas": copy.deepcopy(EXPECTED_OUTPUT_SCHEMAS[V1]),
+                    "spawn_identity": "agent_id",
+                },
+                "target_identity": "agent_id",
+            },
+            V2: {
+                "namespace": V2_NAMESPACE,
+                "owner": "codex_client",
+                "declaration": {
+                    "type": "namespace",
+                    "fields": ["type", "name", "description", "tools"],
+                    "child_type": "function",
+                    "child_fields": [
+                        "type",
+                        "name",
+                        "description",
+                        "strict",
+                        "parameters",
+                    ],
+                    "child_strict": False,
+                    "child_output_schema_field": "absent",
+                    "tool_names": list(V2_TOOLS),
+                    "normalized_parameter_schemas": copy.deepcopy(
+                        EXPECTED_PARAMETER_SCHEMAS[V2]
+                    ),
+                },
+                "call": {
+                    "type": "function_call",
+                    "fields": ["type", "id", "name", "namespace", "arguments", "call_id"],
+                    "identity_fields": ["id", "call_id"],
+                },
+                "result": {
+                    "type": "function_call_output",
+                    "fields": ["type", "id", "call_id", "output"],
+                    "identity_fields": ["id", "call_id"],
+                    "output_wire_encoding": {
+                        "followup_task": "plain_text",
+                        "interrupt_agent": "json_text_string",
+                        "list_agents": "json_text_string",
+                        "send_message": "plain_text",
+                        "spawn_agent": "json_text_string",
+                        "wait_agent": "json_text_string",
+                    },
+                    "tool_output_schemas": copy.deepcopy(EXPECTED_OUTPUT_SCHEMAS[V2]),
+                    "spawn_identity": "task_name",
+                    "spawn_output_fields_default": ["task_name"],
+                },
+                "target_identity": "relative_or_canonical_task_name",
+                "canonical_task_identity": "agent_path_serialized_as_task_name",
+                "continuation_id_field": "not_present",
+            },
+        },
+        "wire_lifecycle": {
+            "function_call_stream": {
+                "event_order": [
+                    "response.output_item.added",
+                    "response.function_call_arguments.delta",
+                    "response.function_call_arguments.done",
+                    "response.output_item.done",
+                ],
+                "event_shapes": {
+                    "response.output_item.added": {
+                        "fields": ["type", "output_index", "item"],
+                        "item_fields": [
+                            "type",
+                            "id",
+                            "status",
+                            "name",
+                            "namespace",
+                            "arguments",
+                            "call_id",
+                        ],
+                        "status": "in_progress",
+                    },
+                    "response.function_call_arguments.delta": {
+                        "fields": ["type", "item_id", "output_index", "delta"]
+                    },
+                    "response.function_call_arguments.done": {
+                        "fields": ["type", "item_id", "output_index", "arguments"]
+                    },
+                    "response.output_item.done": {
+                        "fields": ["type", "output_index", "item"],
+                        "item_fields": [
+                            "type",
+                            "id",
+                            "status",
+                            "name",
+                            "namespace",
+                            "arguments",
+                            "call_id",
+                        ],
+                        "status": "completed",
+                    },
+                },
+                "assembly_rule": "ordered_delta_assembly_must_equal_done_arguments",
+            },
+            "terminal": {
+                "event_order_boundary": "after_output_item_done",
+                "events": [
+                    "response.completed",
+                    "response.incomplete",
+                    "response.failed",
+                ],
+                "event_shapes": {
+                    "response.completed": {
+                        "fields": ["type", "response"],
+                        "response_fields": ["id", "status", "output", "usage"],
+                        "status": "completed",
+                    },
+                    "response.incomplete": {
+                        "fields": ["type", "response"],
+                        "response_required_fields": ["id", "status", "incomplete_details"],
+                        "status": "incomplete",
+                    },
+                    "response.failed": {
+                        "fields": ["type", "response"],
+                        "response_required_fields": ["id", "status", "error"],
+                        "status": "failed",
+                    },
+                },
+                "stream_close_without_completed": "terminal_error",
+            },
+            "history_items": ["function_call", "function_call_output", "agent_message"],
+            "same_home_readback": {
+                "clients": ["codex_cli", "codex_desktop"],
+                "call_namespace_preserved": True,
+                "call_and_output_ids_preserved": True,
+                "call_output_order_preserved": True,
+                "agent_message_author_recipient_and_content_kind_preserved": True,
+                "session_meta_multi_agent_version": "v2",
+                "turn_context_multi_agent_version": "v2",
+                "desktop_thread_resume_and_read": "observed",
+            },
+        },
+        "protocol_layers": {
+            "client_dispatch": {
+                "recipient_namespace": "collaboration",
+                "meaning": "client_tool_dispatch_group",
+                "wire_discriminator_by_itself": False,
+            },
+            "responses_declaration_and_call": {
+                "namespace": V2_NAMESPACE,
+                "declaration_type": "namespace",
+                "call_type": "function_call",
+                "call_namespace_field": True,
+                "tool_choice": "auto",
+            },
+            "model_input_agent_message": {
+                "type": "agent_message",
+                "fields": ["type", "id", "author", "recipient", "content"],
+                "task_identity_fields": ["author", "recipient"],
+                "content_variants": {
+                    "input_text": ["type", "text"],
+                    "encrypted_content": ["type", "encrypted_content"],
+                },
+                "source_optional_field": "internal_chat_message_metadata_passthrough",
+                "function_result": False,
+            },
+            "rollout_metadata": {
+                "session_meta_field": "multi_agent_version",
+                "turn_context_field": "multi_agent_version",
+                "values": ["v1", "v2"],
+                "sent_as_request_metadata": False,
+            },
+            "desktop_app": {
+                "thread_items": {
+                    "agentMessage": ["type", "id", "text", "phase", "memoryCitation"],
+                    "collabAgentToolCall": [
+                        "type",
+                        "id",
+                        "tool",
+                        "status",
+                        "senderThreadId",
+                        "receiverThreadIds",
+                        "prompt",
+                        "model",
+                        "reasoningEffort",
+                        "agentsStates",
+                    ],
+                    "subAgentActivity": [
+                        "type",
+                        "id",
+                        "kind",
+                        "agentThreadId",
+                        "agentPath",
+                    ],
+                },
+                "item_notifications": {
+                    "agentMessage": [
+                        "item/started",
+                        "item/agentMessage/delta",
+                        "item/completed",
+                    ],
+                    "collabAgentToolCall": ["item/started", "item/completed"],
+                    "subAgentActivity": ["item/started", "item/completed"],
+                },
+                "turn_terminal_notification": "turn/completed",
+                "same_home_thread_resume_and_read": "observed",
+                "wire_item_equivalent": False,
+            },
+        },
+        "gateway_boundary": {
+            "allowed": "reversible_wire_adaptation_only",
+            "native_namespace": "pass_without_semantic_mutation",
+            "adaptation_requirements": [
+                "injective_request_scoped_aliases",
+                "preserve_namespace_and_child_name",
+                "preserve_call_and_item_identity",
+                "preserve_order_and_stream_boundaries",
+                "preserve_agent_message_author_and_recipient",
+                "preserve_rollout_and_same_home_replay_semantics",
+            ],
+            "forbidden": [
+                "agent_execution",
+                "agent_scheduling",
+                "identity_fabrication",
+                "v2_to_v1_downgrade",
+                "model_or_provider_fallback",
+                "history_rewrite",
+            ],
+        },
+        "deferred_to_issue_283": [
+            "full_six_tool_two_child_lifecycle",
+            "cross_home_negative_cases",
+            "malformed_agent_message_and_identity_negative_cases",
+        ],
+    }
+
+
+def _namespace_candidates(tools: Sequence[Any]) -> list[Mapping[str, Any]]:
+    candidates: list[Mapping[str, Any]] = []
+    for tool in tools:
+        if not isinstance(tool, Mapping):
+            continue
+        if tool.get("type") == "namespace" and tool.get("name") in {
+            V1_NAMESPACE,
+            V2_NAMESPACE,
+        }:
+            candidates.append(tool)
+    return candidates
+
+
+def _normalize_schema(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        normalized = {
+            key: _normalize_schema(child)
+            for key, child in value.items()
+            if key != "description"
+        }
+        if normalized.get("type") == "object":
+            normalized.setdefault("required", [])
+        return normalized
+    if isinstance(value, list):
+        return [_normalize_schema(child) for child in value]
+    return value
+
+
+def classify_tools(tools: Sequence[Any]) -> str:
+    """Classify the exact frozen request declaration surface, or fail closed."""
+
+    _require(isinstance(tools, Sequence) and not isinstance(tools, (str, bytes)), "tools_invalid")
+    candidates = _namespace_candidates(tools)
+    _require(candidates, "collaboration_marker_missing")
+    namespaces = [candidate.get("name") for candidate in candidates]
+    _require(len(candidates) == 1, "collaboration_marker_duplicate_or_mixed")
+    candidate = candidates[0]
+    namespace = namespaces[0]
+    version = V1 if namespace == V1_NAMESPACE else V2
+    expected_names = set(V1_TOOLS if version == V1 else V2_TOOLS)
+    _require(
+        set(candidate) == {"type", "name", "description", "tools"},
+        "namespace_fields_invalid",
+    )
+    _require(isinstance(candidate.get("description"), str), "namespace_description_invalid")
+    children = candidate.get("tools")
+    _require(isinstance(children, list), "namespace_children_invalid")
+    _require(all(isinstance(child, Mapping) for child in children), "namespace_child_invalid")
+    names = [child.get("name") for child in children]
+    _require(all(child.get("type") == "function" for child in children), "namespace_child_type_invalid")
+    _require(all(isinstance(child.get("name"), str) for child in children), "namespace_child_name_invalid")
+    _require(len(names) == len(set(names)), "namespace_child_duplicate")
+    _require(set(names) == expected_names, "namespace_child_set_invalid")
+    for child in children:
+        name = child["name"]
+        _require(
+            set(child) == {"type", "name", "description", "strict", "parameters"},
+            "namespace_child_fields_invalid",
+        )
+        _require(isinstance(child.get("description"), str), "namespace_child_description_invalid")
+        _require(child.get("strict") is False, "namespace_child_strict_invalid")
+        parameters = child.get("parameters")
+        _require(isinstance(parameters, Mapping), "namespace_child_parameters_invalid")
+        normalized = _normalize_schema(parameters)
+        _require(
+            normalized == EXPECTED_PARAMETER_SCHEMAS[version][name],
+            "namespace_child_parameter_schema_mismatch",
+        )
+    return version
+
+
+def classify_request(request: Mapping[str, Any]) -> str:
+    _require(isinstance(request, Mapping), "request_invalid")
+    _require(request.get("tool_choice") == "auto", "tool_choice_invalid")
+    tools = request.get("tools")
+    version = classify_tools(tools)  # type: ignore[arg-type]
+    markers: list[Any] = []
+    if "multi_agent_version" in request:
+        markers.append(request.get("multi_agent_version"))
+    for parent_name in ("metadata", "features", "client_metadata"):
+        parent = request.get(parent_name)
+        if isinstance(parent, Mapping) and "multi_agent_version" in parent:
+            markers.append(parent.get("multi_agent_version"))
+    _require(not markers, "collaboration_version_signal_unexpected")
+    return version
+
+
+def validate_contract(payload: Mapping[str, Any]) -> None:
+    expected = build_contract()
+    _require(isinstance(payload, Mapping), "contract_invalid")
+    _require(payload.get("schema") == SCHEMA, "contract_schema_invalid")
+    _require(dict(payload) == expected, "contract_content_invalid")
+
+
+def reconcile_contract(payload: Mapping[str, Any]) -> dict[str, Any]:
+    try:
+        validate_contract(payload)
+    except ContractValidationError as error:
+        return {"reconciled": False, "mismatches": [str(error)]}
+    return {"reconciled": True, "mismatches": []}
+
+
+def replay_contract(payload: Mapping[str, Any], case: str) -> dict[str, Any]:
+    _require(case in {"mutation", "deletion", "loss"}, "replay_case_invalid")
+    clone = copy.deepcopy(dict(payload))
+    if case == "mutation":
+        clone["selection_contract"]["markers"][V2]["namespace"] = V1_NAMESPACE
+    elif case == "deletion":
+        del clone["protocol_layers"]["model_input_agent_message"]
+    else:
+        clone["runtimes"][1]["source_files"] = {}
+    return clone
+
+
+def _load(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise ContractValidationError("contract_file_invalid") from error
+    _require(isinstance(value, dict), "contract_file_invalid")
+    return value
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument("--check", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        expected = build_contract()
+        validate_contract(expected)
+        if args.check:
+            report = reconcile_contract(_load(args.out))
+            print(json.dumps(report, sort_keys=True))
+            return 0 if report["reconciled"] else 1
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(
+            json.dumps(expected, ensure_ascii=True, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+        print(json.dumps({"schema": SCHEMA, "reconciled": True}, sort_keys=True))
+        return 0
+    except ContractValidationError as error:
+        print(f"CONTRACT_INVALID:{error}")
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_issue_64_collaboration_inventory.py
+++ b/scripts/build_issue_64_collaboration_inventory.py
@@ -1,18 +1,12 @@
 #!/usr/bin/env python3
-"""Build and reconcile the bounded Issue #64 Collaboration V1/V2 contract.
-
-This is a structural inventory only.  It binds the accepted Codex CLI 0.146
-source contract, records the pre-exposure discriminator and the two small
-schema families, and states the namespace adapter requirements needed by #198
-and #58.  It does not inspect a live client, execute tools, schedule agents,
-or implement a protocol adapter.
-"""
+"""Build the #64 inventory from the exact runtime contract accepted by #392."""
 
 from __future__ import annotations
 
 import argparse
 import copy
 import hashlib
+import importlib.util
 import json
 from pathlib import Path
 from typing import Any, Mapping
@@ -20,155 +14,39 @@ from typing import Any, Mapping
 
 SCHEMA = "codexhub.issue64.collaboration-v1-v2.v1"
 ARTIFACT_KIND = "collaboration_v1_v2_inventory"
-DEFAULT_SOURCE_CONTRACT = Path("docs/evidence/issue-62/codex-0.146-source-contract.json")
+DEFAULT_SOURCE_CONTRACT = Path(
+    "docs/evidence/issue-392/collaboration-runtime-contract.json"
+)
 DEFAULT_OUTPUT = Path("docs/evidence/issue-64/collaboration-v1-v2-inventory.json")
-EXPECTED_SOURCE_CONTRACT_SHA256 = "6f38b8b07b98c6f28edd7418b63449242ee41d6396694392a70c0d7fb2b70f2c"
-EXPECTED_SOURCE_RUNTIME_SURFACE_DIGEST = "53ad2ec352b7ad558fefdb265f01d3f28da0f410f022ffdf0cc231a488f5d318"
 
 V1_ID = "collaboration_v1"
 V2_ID = "collaboration_v2"
 V1_NAMESPACE = "multi_agent_v1"
 V2_NAMESPACE = "collaboration"
-V1_TOOLS = ("spawn_agent", "send_input", "wait_agent", "close_agent", "resume_agent")
+V1_TOOLS = ("close_agent", "resume_agent", "send_input", "spawn_agent", "wait_agent")
 V2_TOOLS = (
-    "spawn_agent",
-    "send_message",
     "followup_task",
-    "wait_agent",
     "interrupt_agent",
     "list_agents",
+    "send_message",
+    "spawn_agent",
+    "wait_agent",
 )
-V1_ONLY_FIELDS = frozenset({"agent_id", "fork_context"})
-V2_ONLY_FIELDS = frozenset({"task_name", "task_path", "fork_turns", "continuation_id"})
+V1_ONLY_FIELDS = frozenset({"agent_id", "fork_context", "items", "targets"})
+V2_ONLY_FIELDS = frozenset({"task_name", "fork_turns", "path_prefix"})
 V1_ONLY_TOOLS = frozenset({"send_input", "close_agent", "resume_agent"})
-V2_ONLY_TOOLS = frozenset({"send_message", "followup_task", "interrupt_agent", "list_agents"})
-BOUNDARY_ARGUMENT_FIELDS = {
-    V1_NAMESPACE: {
-        "spawn_agent": frozenset({"agent_type", "fork_context", "message"}),
-        "send_input": frozenset({"target", "message", "interrupt"}),
-        "wait_agent": frozenset({"targets", "timeout_ms"}),
-        "close_agent": frozenset({"target"}),
-        "resume_agent": frozenset({"id"}),
-    },
-    V2_NAMESPACE: {
-        "spawn_agent": frozenset({"task_name", "message", "fork_turns", "agent_type", "model", "reasoning_effort"}),
-        "send_message": frozenset({"target", "message"}),
-        "followup_task": frozenset({"target", "message"}),
-        "wait_agent": frozenset({"timeout_ms"}),
-        "interrupt_agent": frozenset({"target"}),
-        "list_agents": frozenset({"path_prefix"}),
-    },
-}
-BOUNDARY_INPUT_FIELDS = frozenset({
-    "namespace",
-    "name",
-    "tool_name",
-    "arguments",
-    "type",
-    "item_id",
-    "call_id",
-    "parameters",
-    "tools",
-})
+V2_ONLY_TOOLS = frozenset(
+    {"send_message", "followup_task", "interrupt_agent", "list_agents"}
+)
 DEFERRED_QUALIFICATION = [
-    "full_spawn_message_followup_wait_interrupt_list_lifecycle",
-    "restart_and_cold_root_resume",
-    "cross_home_topology_and_history",
+    "full_six_tool_two_child_lifecycle",
+    "cross_home_negative_cases",
+    "malformed_agent_message_and_identity_negative_cases",
 ]
-
-SOURCE_CONTRACT_TOP_LEVEL_FIELDS = {
-    "schema_version",
-    "fixture_kind",
-    "capture_status",
-    "qualification_status",
-    "captured_at",
-    "provenance",
-    "runtime_wire_surface",
-}
-SOURCE_CONTRACT_PROVENANCE = {
-    "cli_version": "0.146.0",
-    "source_commit": "e363b08c9175ac1cbe5893615dd2cb9ddf95043b",
-    "cli_source_tag": "rust-v0.146.0",
-    "cli_source_commit_status": "published_attested",
-    "cli_binary_sha256": "bc343ba420dc2e2e9f59e6fc5e5bf0aae1cd8c771fc319665241fc9c0271fddb",
-    "candidate_revision": "accab8ff6eb4d6ebd93cda84585fb5f6cb89da82",
-}
-SOURCE_DECLARATION_FAMILY_ORDER = [
-    "plain_function",
-    "custom_freeform",
-    "namespace",
-    "client_executed_tool_discovery",
-    "selected_provider_hosted",
-    "unknown_future_kind",
-]
-SOURCE_DECLARATION_FAMILIES = [
-    {
-        "family": "plain_function",
-        "runtime_type": "function",
-        "wire_declaration_type": "function",
-        "observed": False,
-        "observation": "not_observed_source_contract_only",
-        "executor": "codex_client",
-        "loss_boundary": "preserve declaration and inverse call/result/history IDs",
-    },
-    {
-        "family": "custom_freeform",
-        "runtime_type": "custom",
-        "wire_declaration_type": "custom",
-        "observed": False,
-        "observation": "not_observed_source_contract_only",
-        "executor": "codex_client",
-        "loss_boundary": "preserve declaration and inverse call/result/history IDs",
-    },
-    {
-        "family": "namespace",
-        "runtime_type": "namespace",
-        "wire_declaration_type": "namespace",
-        "observed": False,
-        "observation": "not_observed_source_contract_only",
-        "executor": "codex_client",
-        "loss_boundary": "preserve declaration and inverse call/result/history IDs",
-    },
-    {
-        "family": "client_executed_tool_discovery",
-        "runtime_type": "tool_search",
-        "wire_declaration_type": "tool_search",
-        "observed": False,
-        "observation": "not_observed_source_contract_only",
-        "executor": "codex_client",
-        "loss_boundary": "discovery request/result stays client-executed",
-    },
-    {
-        "family": "selected_provider_hosted",
-        "runtime_type": "web_search",
-        "wire_declaration_type": "web_search",
-        "observed": False,
-        "observation": "not_observed_selected_provider_control_required",
-        "executor": "selected_provider",
-        "loss_boundary": "optional unsupported hosted capability is omitted; required capability fails visibly",
-    },
-    {
-        "family": "unknown_future_kind",
-        "runtime_type": "unknown",
-        "wire_declaration_type": "<unknown>",
-        "observed": False,
-        "observation": "opaque_sentinel_only",
-        "executor": "unknown",
-        "loss_boundary": "retain tag and opaque payload; do not normalize",
-    },
-]
-SOURCE_RUNTIME_SURFACE_FIELDS = {
-    "source",
-    "declaration_family_order",
-    "declaration_families",
-    "request_shape",
-    "response_shape",
-    "declaration_family_examples",
-}
 
 
 class InventoryValidationError(ValueError):
-    """A deliberately bounded, non-sensitive contract failure."""
+    """Bounded inventory failure; never includes request content."""
 
 
 def _require(condition: bool, code: str) -> None:
@@ -176,472 +54,292 @@ def _require(condition: bool, code: str) -> None:
         raise InventoryValidationError(code)
 
 
-def _exact(value: Any, fields: set[str], code: str) -> Mapping[str, Any]:
-    _require(isinstance(value, Mapping), code)
-    _require(set(value) == fields, code)
-    return value
-
-
-def _sha256_file(path: Path) -> str:
-    try:
-        # Evidence files are text.  Bind their canonical LF bytes so Windows
-        # CRLF and Linux LF checkouts reconcile to the same source digest.
-        canonical = path.read_bytes().replace(b"\r\n", b"\n")
-        return hashlib.sha256(canonical).hexdigest()
-    except OSError as error:
-        raise InventoryValidationError("source_contract_unavailable") from error
-
-
 def _load_json(path: Path) -> dict[str, Any]:
     try:
         value = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, UnicodeError, json.JSONDecodeError) as error:
         raise InventoryValidationError("source_contract_invalid") from error
-    _require(isinstance(value, dict), "source_contract_root_invalid")
+    _require(isinstance(value, dict), "source_contract_invalid")
     return value
 
 
-def _validate_source_contract(source_contract: Mapping[str, Any]) -> None:
-    _require(set(source_contract) == SOURCE_CONTRACT_TOP_LEVEL_FIELDS, "source_contract_fields_invalid")
-    _require(source_contract.get("schema_version") == 1, "source_contract_schema_invalid")
-    _require(source_contract.get("fixture_kind") == "codex_cli_source_contract", "source_contract_kind_invalid")
-    _require(source_contract.get("capture_status") == "not_observed", "source_contract_capture_status_invalid")
-    _require(source_contract.get("qualification_status") == "unqualified", "source_contract_qualification_invalid")
-    _require(source_contract.get("captured_at") is None, "source_contract_captured_at_invalid")
-    provenance = source_contract.get("provenance")
-    _require(isinstance(provenance, Mapping), "source_contract_provenance_invalid")
-    _require(dict(provenance) == SOURCE_CONTRACT_PROVENANCE, "source_contract_provenance_invalid")
-    surface = source_contract.get("runtime_wire_surface")
-    _require(isinstance(surface, Mapping), "source_contract_surface_invalid")
-    _require(set(surface) == SOURCE_RUNTIME_SURFACE_FIELDS, "source_contract_surface_fields_invalid")
-    _require(surface.get("source") == "Codex CLI 0.146.0 ToolSpec and ResponseItem source contract", "source_contract_surface_source_invalid")
-    _require(surface.get("declaration_family_order") == SOURCE_DECLARATION_FAMILY_ORDER, "source_contract_family_order_invalid")
-    _require(surface.get("declaration_families") == SOURCE_DECLARATION_FAMILIES, "source_contract_families_invalid")
-    surface_digest = hashlib.sha256(
-        json.dumps(surface, ensure_ascii=True, sort_keys=True, separators=(",", ":")).encode("utf-8")
-    ).hexdigest()
-    _require(surface_digest == EXPECTED_SOURCE_RUNTIME_SURFACE_DIGEST, "source_contract_surface_digest_invalid")
+def _sha256_file(path: Path) -> str:
+    try:
+        canonical = path.read_bytes().replace(b"\r\n", b"\n")
+    except OSError as error:
+        raise InventoryValidationError("source_contract_unavailable") from error
+    return hashlib.sha256(canonical).hexdigest()
 
 
-def _boundary_arguments(value: Mapping[str, Any]) -> Mapping[str, Any]:
-    if "arguments" not in value:
-        return {}
-    arguments = value.get("arguments")
-    _require(isinstance(arguments, Mapping), "boundary_arguments_invalid")
-    return arguments
+def _issue392_module():
+    path = Path(__file__).with_name("build_issue_392_collaboration_contract.py")
+    spec = importlib.util.spec_from_file_location("issue392_contract", path)
+    _require(spec is not None and spec.loader is not None, "source_validator_unavailable")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
-def classify_boundary(value: Mapping[str, Any]) -> str:
-    """Classify a declaration/call before exposure or semantic repair.
-
-    The namespace and child tool name are both required.  A bare or flattened
-    name is intentionally not enough to choose a repair path.
-    """
-
-    _require(isinstance(value, Mapping), "boundary_input_invalid")
-    _require(set(value).issubset(BOUNDARY_INPUT_FIELDS), "boundary_fields_unknown")
-    if "name" in value and "tool_name" in value:
-        _require(value["name"] == value["tool_name"], "boundary_discriminator_conflict")
-    namespace = value.get("namespace")
-    name = value.get("name", value.get("tool_name"))
-    _require(isinstance(namespace, str) and namespace, "boundary_discriminator_missing")
-    _require(isinstance(name, str) and name, "boundary_discriminator_missing")
-    arguments = _boundary_arguments(value)
-    fields = set(arguments)
-    if (namespace == V1_NAMESPACE and "tools" in value) or (namespace == V2_NAMESPACE and "parameters" in value):
-        raise InventoryValidationError("boundary_v1_v2_field_mixed")
-    if (namespace == V1_NAMESPACE and fields & V2_ONLY_FIELDS) or (namespace == V2_NAMESPACE and fields & V1_ONLY_FIELDS):
-        raise InventoryValidationError("boundary_v1_v2_field_mixed")
-    allowed_fields = BOUNDARY_ARGUMENT_FIELDS.get(namespace, {}).get(name)
-    if allowed_fields is not None:
-        _require(fields.issubset(allowed_fields), "boundary_arguments_unknown")
-    if namespace == V1_NAMESPACE:
-        if name in V2_ONLY_TOOLS:
-            raise InventoryValidationError("boundary_v1_v2_field_mixed")
-        if name not in V1_TOOLS:
-            raise InventoryValidationError("boundary_tool_unknown")
-        return V1_ID
-    if namespace == V2_NAMESPACE:
-        if name in V1_ONLY_TOOLS:
-            raise InventoryValidationError("boundary_v1_v2_field_mixed")
-        if name not in V2_TOOLS:
-            raise InventoryValidationError("boundary_tool_unknown")
-        return V2_ID
-    raise InventoryValidationError("boundary_namespace_unknown")
+def _validate_source_contract(source: Mapping[str, Any]) -> None:
+    module = _issue392_module()
+    try:
+        module.validate_contract(source)
+    except module.ContractValidationError as error:
+        raise InventoryValidationError("source_contract_content_invalid") from error
 
 
-def _stream_shape() -> dict[str, Any]:
-    return {
-        "event_order": [
-            "response.output_item.added",
-            "response.function_call_arguments.delta",
-            "response.function_call_arguments.done",
-            "response.output_item.done",
-        ],
-        "terminal_events": ["response.completed", "response.incomplete", "response.failed"],
-        "error_event": "response.failed",
-        "qualification": "not_observed",
-    }
+def _argument_fields(source: Mapping[str, Any], version: str) -> dict[str, Any]:
+    return copy.deepcopy(
+        source["selection_contract"]["markers"][version]["argument_contract"]
+    )
 
 
-def _protocol_v1() -> dict[str, Any]:
+def _protocol_v1(source: Mapping[str, Any]) -> dict[str, Any]:
     return {
         "id": V1_ID,
         "namespace": V1_NAMESPACE,
         "owner": "codex_client",
         "executor": "codex_client",
-        "status": "legacy_structural_contract",
+        "status": "runtime_observed",
         "shape_provenance": {
-            "shape_kind": "current_gateway_compatibility_surface",
-            "source": "src-python/codex_proxy.py#MULTI_AGENT_DISCOVERY_TOOLS",
-            "official_cli_capture_status": "not_observed",
+            "source": "issue392_exact_cli_and_desktop_runtime_contract",
+            "cli_capture_status": "observed",
+            "desktop_capture_status": "observed",
         },
         "declaration": {
-            "discriminator": {"namespace": V1_NAMESPACE, "tool_field": "name"},
             "wire_type": "namespace",
-            "fields": ["type", "name", "tools"],
+            "fields": ["type", "name", "description", "tools"],
             "child_wire_type": "function",
             "tool_names": list(V1_TOOLS),
-            "flattened_name_prefixes": ["multi_agent_v1__", "multi_agent_v1."],
+            "argument_fields": _argument_fields(source, V1_ID),
         },
         "call": {
             "wire_type": "function_call",
-            "fields": ["type", "namespace", "name", "item_id", "call_id", "arguments"],
-            "identity_fields": ["call_id", "item_id"],
-            "argument_fields": {
-                "spawn_agent": {"required": ["agent_type"], "optional": ["fork_context", "message"]},
-                "send_input": {"required": ["target"], "optional": ["interrupt", "message"]},
-                "wait_agent": {"required": ["targets"], "optional": ["timeout_ms"]},
-                "close_agent": {"required": ["target"], "optional": []},
-                "resume_agent": {"required": ["id"], "optional": []},
-            },
+            "fields": ["type", "id", "name", "namespace", "arguments", "call_id"],
+            "identity_fields": ["id", "call_id"],
         },
         "result": {
             "wire_type": "function_call_output",
-            "fields": ["type", "call_id", "item_id", "output"],
-            "identity_fields": ["call_id", "item_id"],
-            "result_identity": "agent_id",
-            "result_fields_by_tool": {
-                "spawn_agent": ["agent_id", "nickname"],
-                "wait_agent": ["timed_out", "status"],
-                "close_agent": ["previous_status"],
-                "send_input": ["status"],
-                "resume_agent": ["status"],
-            },
+            "fields": ["type", "id", "call_id", "output"],
+            "identity_fields": ["id", "call_id"],
+            "spawn_identity": "agent_id",
+            "output_wire_encoding": source["protocols"][V1_ID]["result"][
+                "output_wire_encoding"
+            ],
+            "tool_output_schemas": copy.deepcopy(
+                source["protocols"][V1_ID]["result"]["tool_output_schemas"]
+            ),
         },
         "history": {
             "items": ["function_call", "function_call_output"],
-            "identity_fields": ["agent_id", "call_id", "call_item_id", "output_item_id"],
-            "continuation_identity": "agent_id",
-            "transcript_markers": [
-                "Previous real Codex native multi_agent_v1.<tool> call transcript",
-                "Codex native multi_agent_v1.<tool> result",
-            ],
+            "identity_fields": ["id", "call_id", "agent_id"],
+            "rollout_version_field": "multi_agent_version",
         },
-        "stream": _stream_shape(),
-        "terminal_error": {
-            "terminal_events": ["response.completed", "response.incomplete", "response.failed"],
-            "error_event": "response.failed",
-            "error_fields": ["id", "status", "error"],
-            "qualification": "not_observed",
+        "stream": {
+            "event_order": list(
+                source["wire_lifecycle"]["function_call_stream"]["event_order"]
+            ),
+            "event_shapes": copy.deepcopy(
+                source["wire_lifecycle"]["function_call_stream"]["event_shapes"]
+            ),
+            "terminal_events": list(source["wire_lifecycle"]["terminal"]["events"]),
+            "terminal_shapes": copy.deepcopy(
+                source["wire_lifecycle"]["terminal"]["event_shapes"]
+            ),
         },
         "isolation": {
             "forbidden_v2_fields": sorted(V2_ONLY_FIELDS),
             "forbidden_v2_tools": sorted(V2_ONLY_TOOLS),
-            "forbidden_v2_semantics": ["task_path_continuation", "fork_turns"],
         },
     }
 
 
-def _protocol_v2() -> dict[str, Any]:
+def _protocol_v2(source: Mapping[str, Any]) -> dict[str, Any]:
     return {
         "id": V2_ID,
         "namespace": V2_NAMESPACE,
         "owner": "codex_client",
         "executor": "codex_client",
-        "status": "stable_surface_not_lifecycle_qualified",
+        "status": "runtime_observed_request_shape_and_readback",
         "shape_provenance": {
-            "shape_kind": "accepted_structural_contract",
-            "source": "accepted_issue_62_source_contract_and_repository_evidence",
-            "official_cli_capture_status": "not_observed",
+            "source": "issue392_exact_cli_and_desktop_runtime_contract",
+            "cli_capture_status": "observed",
+            "desktop_capture_status": "observed",
         },
         "declaration": {
-            "discriminator": {"namespace": V2_NAMESPACE, "tool_field": "name"},
             "wire_type": "namespace",
-            "fields": ["type", "name", "tools"],
+            "fields": ["type", "name", "description", "tools"],
             "child_wire_type": "function",
             "tool_names": list(V2_TOOLS),
+            "argument_fields": _argument_fields(source, V2_ID),
         },
         "call": {
             "wire_type": "function_call",
-            "fields": ["type", "namespace", "name", "item_id", "call_id", "arguments"],
-            "identity_fields": ["call_id", "item_id", "task_path", "continuation_id"],
-            "argument_fields": {
-                "spawn_agent": {"required": ["task_name", "message"], "optional": ["fork_turns", "agent_type", "model", "reasoning_effort"]},
-                "send_message": {"required": ["target", "message"], "optional": []},
-                "followup_task": {"required": ["target", "message"], "optional": []},
-                "wait_agent": {"required": [], "optional": ["timeout_ms"]},
-                "interrupt_agent": {"required": ["target"], "optional": []},
-                "list_agents": {"required": [], "optional": ["path_prefix"]},
-            },
-            "fork_turns": {"field": "fork_turns", "values": ["all", "none", "positive_decimal_string"]},
+            "fields": ["type", "id", "name", "namespace", "arguments", "call_id"],
+            "identity_fields": ["id", "call_id"],
         },
         "result": {
             "wire_type": "function_call_output",
-            "fields": ["type", "call_id", "item_id", "output"],
-            "identity_fields": ["call_id", "item_id", "task_path", "continuation_id"],
-            "result_identity": "task_path",
-            "result_fields": ["task_path", "continuation_id", "status"],
+            "fields": ["type", "id", "call_id", "output"],
+            "identity_fields": ["id", "call_id"],
+            "spawn_identity": "task_name",
+            "spawn_output_fields_default": ["task_name"],
+            "continuation_id_field": "not_present",
+            "output_wire_encoding": copy.deepcopy(
+                source["protocols"][V2_ID]["result"]["output_wire_encoding"]
+            ),
+            "tool_output_schemas": copy.deepcopy(
+                source["protocols"][V2_ID]["result"]["tool_output_schemas"]
+            ),
         },
         "history": {
-            "items": ["function_call", "function_call_output"],
-            "identity_fields": ["task_path", "continuation_id", "call_id", "call_item_id", "output_item_id"],
-            "continuation_identity": "task_path",
-            "continuation_fields": ["task_path", "continuation_id", "task_name", "fork_turns"],
-            "pagination": "deferred_qualification",
-            "inherited_prefix": "deferred_qualification",
+            "items": ["function_call", "function_call_output", "agent_message"],
+            "identity_fields": ["id", "call_id", "author", "recipient"],
+            "canonical_task_identity": "agent_path_serialized_as_task_name",
+            "rollout_version_field": "multi_agent_version",
+            "same_home_restart_readback": "observed",
         },
         "stream": {
-            **_stream_shape(),
-            "call_semantics": "namespace_child_function_uses_function_call_lifecycle",
-        },
-        "terminal_error": {
-            "terminal_events": ["response.completed", "response.incomplete", "response.failed"],
-            "error_event": "response.failed",
-            "error_fields": ["id", "status", "error"],
-            "qualification": "not_observed",
+            "event_order": list(
+                source["wire_lifecycle"]["function_call_stream"]["event_order"]
+            ),
+            "event_shapes": copy.deepcopy(
+                source["wire_lifecycle"]["function_call_stream"]["event_shapes"]
+            ),
+            "terminal_events": list(source["wire_lifecycle"]["terminal"]["events"]),
+            "terminal_shapes": copy.deepcopy(
+                source["wire_lifecycle"]["terminal"]["event_shapes"]
+            ),
         },
         "isolation": {
             "forbidden_v1_fields": sorted(V1_ONLY_FIELDS),
             "forbidden_v1_tools": sorted(V1_ONLY_TOOLS),
-            "forbidden_v1_semantics": ["agent_id_close_resume", "fork_context"],
         },
     }
 
 
-def _build_inventory(source_contract_path: Path) -> dict[str, Any]:
-    source_contract = _load_json(source_contract_path)
-    _validate_source_contract(source_contract)
-    _require(_sha256_file(source_contract_path) == EXPECTED_SOURCE_CONTRACT_SHA256, "source_contract_digest_invalid")
+def build_inventory(source_contract_path: Path = DEFAULT_SOURCE_CONTRACT) -> dict[str, Any]:
+    source = _load_json(source_contract_path)
+    _validate_source_contract(source)
+    runtimes = source["runtimes"]
     return {
         "schema": SCHEMA,
         "artifact_kind": ARTIFACT_KIND,
-        "verification_scope": "structural_contract_only",
-        "qualification_status": "structural_boundary_only",
+        "verification_scope": "runtime_observed_structural_contract",
+        "qualification_status": "superseded_by_issue392_exact_runtime_contract",
         "candidate_identity": {
-            "cli_version": "0.146.0",
-            "source_commit": "e363b08c9175ac1cbe5893615dd2cb9ddf95043b",
-            "source_tag": "rust-v0.146.0",
-            "source_commit_status": "published_attested",
-            "source_capture_status": "not_observed",
+            "candidate_revision": source["candidate_revision"],
+            "cli_version": runtimes[0]["client_version"],
+            "cli_source_commit": runtimes[0]["source_commit"],
+            "desktop_version": runtimes[1]["client_version"],
+            "desktop_runtime_version": runtimes[1]["runtime_version"],
+            "desktop_source_commit": runtimes[1]["source_commit"],
+            "source_capture_status": "observed",
             "source_contract_file": source_contract_path.name,
         },
         "evidence_binding": {
-            "source_contract": {"file": source_contract_path.name, "sha256": _sha256_file(source_contract_path)},
-            "basis": "accepted_issue_62_source_contract_and_repository_evidence",
+            "source_contract": {
+                "file": source_contract_path.name,
+                "sha256": _sha256_file(source_contract_path),
+            },
+            "basis": "accepted_issue392_exact_runtime_contract",
         },
         "boundary": {
-            "pre_exposure_stage": "before_tool_exposure_or_semantic_repair",
-            "discriminator_fields": ["namespace", "name"],
+            "pre_exposure_stage": "before_schema_repair_state_or_scheduler",
             "protocol_markers": {
                 V1_ID: {"namespace": V1_NAMESPACE, "tool_names": list(V1_TOOLS)},
                 V2_ID: {"namespace": V2_NAMESPACE, "tool_names": list(V2_TOOLS)},
             },
-            "flattened_name_policy": "not_decidable_without_namespace",
+            "matching_policy": "complete_namespace_and_child_schema",
+            "shared_tool_name_policy": "never_classify_from_child_name_alone",
+            "direct_function_policy": "not_a_frozen_runtime_collaboration_marker",
+            "request_metadata_version_field": "absent_in_both_frozen_runtimes",
+            "tool_choice": "auto",
             "unknown_action": "fail_closed",
-            "ambiguous_action": "fail_closed",
+            "missing_action": "fail_closed",
+            "duplicate_action": "fail_closed",
+            "conflicting_action": "fail_closed",
             "mixed_v1_v2_action": "fail_closed",
         },
-        "protocols": [_protocol_v1(), _protocol_v2()],
+        "protocols": [_protocol_v1(source), _protocol_v2(source)],
+        "protocol_layers": copy.deepcopy(source["protocol_layers"]),
         "adapter_requirements": {
             "owner": "codex_client",
             "adaptation_owner": "codexhub_gateway",
-            "protocol_shape_decisions": {
-                V1_ID: {
-                    "shape_kind": "current_gateway_compatibility_surface",
-                    "namespace_to_function": "required_when_selected_protocol_lacks_namespace",
-                    "official_cli_capture_status": "not_observed",
-                    "inverse_mapping": "request_scoped_and_lossless",
-                },
-                V2_ID: {
-                    "shape_kind": "accepted_structural_contract",
-                    "namespace_to_function": "optional_only_when_selected_protocol_lacks_namespace",
-                    "native_namespace": "may_pass_when_selected_protocol_supports_namespace",
-                    "official_cli_capture_status": "not_observed",
-                    "inverse_mapping": "request_scoped_and_lossless",
-                    "preserved_fields": ["task_path", "continuation_id", "task_name", "fork_turns"],
-                },
-            },
+            "native_namespace": "pass_without_semantic_mutation",
+            "adapt_only_when": "complete_lifecycle_inverse_is_proven",
             "requirements": [
-                "namespace_to_function",
                 "injective_request_scoped_aliases",
-                "preserve_task_path_identity",
-                "preserve_continuation_id_and_fork_turns",
-                "preserve_call_result_history_links",
-                "preserve_inverse_declaration_call_result_history_mapping",
-                "assemble_stream_before_validation",
-                "reject_unknown_or_ambiguous_boundary",
+                "preserve_namespace_and_child_name",
+                "preserve_call_and_item_identity",
+                "preserve_order_and_stream_boundaries",
+                "preserve_task_name_and_agent_path_identity",
+                "preserve_agent_message_author_and_recipient",
+                "preserve_same_home_history_replay",
+                "reject_unknown_missing_duplicate_conflicting_or_mixed_boundary",
                 "keep_v1_and_v2_isolated",
             ],
-            "forbidden_gateway_actions": ["execute_tools", "schedule_agents", "forge_results", "downgrade_v2_to_v1"],
-            "scope": "requirements_only_for_198_and_58",
+            "forbidden_gateway_actions": [
+                "execute_tools",
+                "schedule_agents",
+                "forge_results_or_identity",
+                "downgrade_v2_to_v1",
+                "rewrite_history",
+            ],
         },
-        "deferred_qualification": list(DEFERRED_QUALIFICATION),
+        "deferred_qualification": DEFERRED_QUALIFICATION,
     }
 
 
-def _validate_protocol(protocol: Any, expected_id: str, expected_namespace: str) -> None:
-    expected_fields = {
-        "id",
-        "namespace",
-        "owner",
-        "executor",
-        "status",
-        "shape_provenance",
-        "declaration",
-        "call",
-        "result",
-        "history",
-        "stream",
-        "terminal_error",
-        "isolation",
-    }
-    _exact(protocol, expected_fields, "protocol_fields_invalid")
-    expected = _protocol_v1() if expected_id == V1_ID else _protocol_v2()
-    _require(protocol == expected, "protocol_schema_invalid")
-    _require(protocol["id"] == expected_id and protocol["namespace"] == expected_namespace, "protocol_identity_invalid")
+def classify_boundary(value: Mapping[str, Any]) -> str:
+    """Classify an already-selected namespaced call without using name alone."""
+
+    _require(isinstance(value, Mapping), "boundary_input_invalid")
+    allowed = {"type", "id", "item_id", "call_id", "namespace", "name", "tool_name", "arguments"}
+    _require(set(value).issubset(allowed), "boundary_fields_unknown")
+    namespace = value.get("namespace")
+    name = value.get("name", value.get("tool_name"))
+    if "name" in value and "tool_name" in value:
+        _require(value["name"] == value["tool_name"], "boundary_discriminator_conflict")
+    _require(isinstance(namespace, str) and isinstance(name, str), "boundary_discriminator_missing")
+    arguments = value.get("arguments", {})
+    _require(isinstance(arguments, Mapping), "boundary_arguments_invalid")
+    fields = set(arguments)
+    if namespace == V1_NAMESPACE:
+        _require(name in V1_TOOLS, "boundary_tool_unknown")
+        _require(not fields.intersection(V2_ONLY_FIELDS), "boundary_v1_v2_field_mixed")
+        version = V1_ID
+    elif namespace == V2_NAMESPACE:
+        _require(name in V2_TOOLS, "boundary_tool_unknown")
+        _require(not fields.intersection(V1_ONLY_FIELDS), "boundary_v1_v2_field_mixed")
+        version = V2_ID
+    else:
+        raise InventoryValidationError("boundary_namespace_unknown")
+    source = _load_json(DEFAULT_SOURCE_CONTRACT)
+    argument_contract = source["selection_contract"]["markers"][version][
+        "argument_contract"
+    ][name]
+    required = argument_contract["required"]
+    optional = argument_contract["optional"]
+    _require(fields.issubset(set(required) | set(optional)), "boundary_arguments_unknown")
+    return version
 
 
 def validate_inventory(payload: Mapping[str, Any], source_contract_path: Path) -> None:
-    _exact(
-        payload,
-        {
-            "schema",
-            "artifact_kind",
-            "verification_scope",
-            "qualification_status",
-            "candidate_identity",
-            "evidence_binding",
-            "boundary",
-            "protocols",
-            "adapter_requirements",
-            "deferred_qualification",
-        },
-        "inventory_fields_invalid",
-    )
-    _require(payload["schema"] == SCHEMA, "inventory_schema_invalid")
-    _require(payload["artifact_kind"] == ARTIFACT_KIND, "inventory_kind_invalid")
-    _require(payload["verification_scope"] == "structural_contract_only", "inventory_scope_invalid")
-    _require(payload["qualification_status"] == "structural_boundary_only", "inventory_qualification_invalid")
-    _validate_source_contract(_load_json(source_contract_path))
-    _require(_sha256_file(source_contract_path) == EXPECTED_SOURCE_CONTRACT_SHA256, "source_contract_digest_invalid")
-
-    candidate = _exact(
-        payload["candidate_identity"],
-        {
-            "cli_version",
-            "source_commit",
-            "source_tag",
-            "source_commit_status",
-            "source_capture_status",
-            "source_contract_file",
-        },
-        "candidate_fields_invalid",
-    )
-    _require(
-        dict(candidate)
-        == {
-            "cli_version": "0.146.0",
-            "source_commit": "e363b08c9175ac1cbe5893615dd2cb9ddf95043b",
-            "source_tag": "rust-v0.146.0",
-            "source_commit_status": "published_attested",
-            "source_capture_status": "not_observed",
-            "source_contract_file": source_contract_path.name,
-        },
-        "candidate_identity_invalid",
-    )
-    binding = _exact(payload["evidence_binding"], {"source_contract", "basis"}, "evidence_binding_invalid")
-    source_binding = _exact(binding["source_contract"], {"file", "sha256"}, "evidence_binding_source_invalid")
-    _require(source_binding["file"] == source_contract_path.name, "evidence_binding_source_file_invalid")
-    _require(source_binding["sha256"] == EXPECTED_SOURCE_CONTRACT_SHA256, "evidence_binding_source_digest_invalid")
-    _require(binding["basis"] == "accepted_issue_62_source_contract_and_repository_evidence", "evidence_binding_basis_invalid")
-
-    boundary = _exact(
-        payload["boundary"],
-        {
-            "pre_exposure_stage",
-            "discriminator_fields",
-            "protocol_markers",
-            "flattened_name_policy",
-            "unknown_action",
-            "ambiguous_action",
-            "mixed_v1_v2_action",
-        },
-        "boundary_fields_invalid",
-    )
-    _require(
-        boundary["pre_exposure_stage"] == "before_tool_exposure_or_semantic_repair",
-        "boundary_pre_exposure_stage_invalid",
-    )
-    _require(boundary["discriminator_fields"] == ["namespace", "name"], "boundary_discriminator_fields_invalid")
-    _require(boundary["unknown_action"] == "fail_closed" and boundary["ambiguous_action"] == "fail_closed", "boundary_fail_closed_invalid")
-    _require(boundary["mixed_v1_v2_action"] == "fail_closed", "boundary_mixed_action_invalid")
-    markers = _exact(boundary["protocol_markers"], {V1_ID, V2_ID}, "boundary_markers_invalid")
-    _require(markers[V1_ID] == {"namespace": V1_NAMESPACE, "tool_names": list(V1_TOOLS)}, "boundary_v1_marker_invalid")
-    _require(markers[V2_ID] == {"namespace": V2_NAMESPACE, "tool_names": list(V2_TOOLS)}, "boundary_v2_marker_invalid")
-    _require(boundary["flattened_name_policy"] == "not_decidable_without_namespace", "boundary_flattened_policy_invalid")
-
-    protocols = payload["protocols"]
-    _require(isinstance(protocols, list) and len(protocols) == 2, "protocols_invalid")
-    _validate_protocol(protocols[0], V1_ID, V1_NAMESPACE)
-    _validate_protocol(protocols[1], V2_ID, V2_NAMESPACE)
-    _require(classify_boundary({"namespace": V1_NAMESPACE, "name": "spawn_agent"}) == V1_ID, "boundary_v1_not_decidable")
-    _require(classify_boundary({"namespace": V2_NAMESPACE, "name": "spawn_agent"}) == V2_ID, "boundary_v2_not_decidable")
-
-    adapter = _exact(payload["adapter_requirements"], {"owner", "adaptation_owner", "protocol_shape_decisions", "requirements", "forbidden_gateway_actions", "scope"}, "adapter_requirements_invalid")
-    _require(adapter["owner"] == "codex_client" and adapter["adaptation_owner"] == "codexhub_gateway", "adapter_owner_invalid")
-    _require(adapter["scope"] == "requirements_only_for_198_and_58", "adapter_scope_invalid")
-    _require(adapter["protocol_shape_decisions"] == {
-        V1_ID: {
-            "shape_kind": "current_gateway_compatibility_surface",
-            "namespace_to_function": "required_when_selected_protocol_lacks_namespace",
-            "official_cli_capture_status": "not_observed",
-            "inverse_mapping": "request_scoped_and_lossless",
-        },
-        V2_ID: {
-            "shape_kind": "accepted_structural_contract",
-            "namespace_to_function": "optional_only_when_selected_protocol_lacks_namespace",
-            "native_namespace": "may_pass_when_selected_protocol_supports_namespace",
-            "official_cli_capture_status": "not_observed",
-            "inverse_mapping": "request_scoped_and_lossless",
-            "preserved_fields": ["task_path", "continuation_id", "task_name", "fork_turns"],
-        },
-    }, "adapter_shape_decisions_invalid")
-    _require(adapter["requirements"] == [
-        "namespace_to_function",
-        "injective_request_scoped_aliases",
-        "preserve_task_path_identity",
-        "preserve_continuation_id_and_fork_turns",
-        "preserve_call_result_history_links",
-        "preserve_inverse_declaration_call_result_history_mapping",
-        "assemble_stream_before_validation",
-        "reject_unknown_or_ambiguous_boundary",
-        "keep_v1_and_v2_isolated",
-    ], "adapter_requirements_list_invalid")
-    _require(
-        adapter["forbidden_gateway_actions"] == ["execute_tools", "schedule_agents", "forge_results", "downgrade_v2_to_v1"],
-        "adapter_forbidden_actions_invalid",
-    )
-    _require(payload["deferred_qualification"] == DEFERRED_QUALIFICATION, "deferred_qualification_invalid")
+    expected = build_inventory(source_contract_path)
+    _require(isinstance(payload, Mapping), "inventory_invalid")
+    _require(payload.get("schema") == SCHEMA, "inventory_schema_invalid")
+    _require(dict(payload) == expected, "inventory_content_invalid")
 
 
-def reconcile_inventory(payload: Mapping[str, Any], *, source_contract_path: Path) -> dict[str, Any]:
-    mismatches: list[str] = []
+def reconcile_inventory(
+    payload: Mapping[str, Any], *, source_contract_path: Path
+) -> dict[str, Any]:
     try:
         validate_inventory(payload, source_contract_path)
     except InventoryValidationError as error:
-        mismatches.append(str(error))
-    return {"reconciled": not mismatches, "mismatches": mismatches}
+        return {"reconciled": False, "mismatches": [str(error)]}
+    return {"reconciled": True, "mismatches": []}
 
 
 def replay_inventory(payload: Mapping[str, Any], case: str) -> dict[str, Any]:
@@ -652,7 +350,7 @@ def replay_inventory(payload: Mapping[str, Any], case: str) -> dict[str, Any]:
     elif case == "deletion":
         clone["protocols"] = clone["protocols"][:1]
     else:
-        clone["candidate_identity"].pop("source_commit", None)
+        clone["candidate_identity"].pop("desktop_source_commit", None)
     return clone
 
 
@@ -661,28 +359,38 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--source-contract", type=Path, default=DEFAULT_SOURCE_CONTRACT)
     parser.add_argument("--out", type=Path, default=DEFAULT_OUTPUT)
     parser.add_argument("--check", action="store_true")
-    parser.add_argument("--replay-case", choices=("identity", "mutation", "deletion", "loss"), default="identity")
+    parser.add_argument(
+        "--replay-case",
+        choices=("identity", "mutation", "deletion", "loss"),
+        default="identity",
+    )
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     args = _parser().parse_args(argv)
     try:
-        inventory = _build_inventory(args.source_contract)
+        inventory = build_inventory(args.source_contract)
         validate_inventory(inventory, args.source_contract)
         if args.replay_case != "identity":
-            report = reconcile_inventory(replay_inventory(inventory, args.replay_case), source_contract_path=args.source_contract)
+            report = reconcile_inventory(
+                replay_inventory(inventory, args.replay_case),
+                source_contract_path=args.source_contract,
+            )
             print(json.dumps(report, sort_keys=True))
             return 0 if not report["reconciled"] else 1
         if args.check:
-            existing = _load_json(args.out)
-            report = reconcile_inventory(existing, source_contract_path=args.source_contract)
-            if not report["reconciled"]:
-                print(json.dumps(report, sort_keys=True))
-                return 1
-            return 0
+            report = reconcile_inventory(
+                _load_json(args.out), source_contract_path=args.source_contract
+            )
+            print(json.dumps(report, sort_keys=True))
+            return 0 if report["reconciled"] else 1
         args.out.parent.mkdir(parents=True, exist_ok=True)
-        args.out.write_text(json.dumps(inventory, ensure_ascii=True, indent=2, sort_keys=True) + "\n", encoding="utf-8", newline="\n")
+        args.out.write_text(
+            json.dumps(inventory, ensure_ascii=True, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
         print(json.dumps({"schema": SCHEMA, "reconciled": True}, sort_keys=True))
         return 0
     except InventoryValidationError as error:

--- a/scripts/capture_issue_392_collaboration_runtime.py
+++ b/scripts/capture_issue_392_collaboration_runtime.py
@@ -346,6 +346,107 @@ def _response_completed(output: list[dict[str, Any]], index: int) -> dict[str, A
     }
 
 
+def _response_incomplete(index: int) -> dict[str, Any]:
+    return {
+        "type": "response.incomplete",
+        "response": {
+            "id": f"response_{index}",
+            "object": "response",
+            "status": "incomplete",
+            "error": None,
+            "incomplete_details": {"reason": "content_filter"},
+        },
+    }
+
+
+def _response_failed(index: int) -> dict[str, Any]:
+    return {
+        "type": "response.failed",
+        "response": {
+            "id": f"response_{index}",
+            "error": {
+                "code": "invalid_prompt",
+                "message": "bounded fixture failure",
+            },
+        },
+    }
+
+
+def _partial_message_events(index: int) -> list[dict[str, Any]]:
+    item_id = f"message_{index}"
+    return [
+        _response_created(index),
+        {
+            "type": "response.output_item.added",
+            "output_index": 0,
+            "item": {
+                "id": item_id,
+                "type": "message",
+                "role": "assistant",
+                "content": [],
+            },
+        },
+        {
+            "type": "response.content_part.added",
+            "item_id": item_id,
+            "output_index": 0,
+            "content_index": 0,
+            "part": {"type": "output_text", "text": "", "annotations": []},
+        },
+        {
+            "type": "response.output_text.delta",
+            "item_id": item_id,
+            "output_index": 0,
+            "content_index": 0,
+            "delta": "partial",
+        },
+    ]
+
+
+def _event_envelope(event: Mapping[str, Any]) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "type": event.get("type"),
+        "fields": sorted(event),
+        "field_types": _field_types(event),
+    }
+    item = event.get("item")
+    if isinstance(item, Mapping):
+        result["item_fields"] = sorted(item)
+        result["item_field_types"] = _field_types(item)
+        for field in ("type", "status", "name", "namespace"):
+            value = item.get(field)
+            if isinstance(value, str):
+                result[f"item_{field}"] = value
+    part = event.get("part")
+    if isinstance(part, Mapping):
+        result["part_fields"] = sorted(part)
+        result["part_field_types"] = _field_types(part)
+        if isinstance(part.get("type"), str):
+            result["part_type"] = part["type"]
+    response = event.get("response")
+    if isinstance(response, Mapping):
+        result["response_fields"] = sorted(response)
+        result["response_field_types"] = _field_types(response)
+        if isinstance(response.get("status"), str):
+            result["response_status"] = response["status"]
+        output = response.get("output")
+        if isinstance(output, list):
+            result["response_output_item_types"] = [
+                child.get("type")
+                for child in output
+                if isinstance(child, Mapping) and isinstance(child.get("type"), str)
+            ]
+        error = response.get("error")
+        if isinstance(error, Mapping):
+            result["response_error_fields"] = sorted(error)
+            result["response_error_field_types"] = _field_types(error)
+        incomplete = response.get("incomplete_details")
+        if isinstance(incomplete, Mapping):
+            result["response_incomplete_details_fields"] = sorted(incomplete)
+            result["response_incomplete_details_field_types"] = _field_types(incomplete)
+    return result
+
+
 def _message_events(index: int) -> list[dict[str, Any]]:
     item_id = f"message_{index}"
     done = {
@@ -431,10 +532,15 @@ def _function_events(
 class _FixtureServer(ThreadingHTTPServer):
     daemon_threads = True
 
-    def __init__(self, lifecycle: bool) -> None:
+    def __init__(self, mode: str) -> None:
         super().__init__(("127.0.0.1", 0), _FixtureHandler)
-        self.lifecycle = lifecycle
+        _require(
+            mode in {"message", "lifecycle", "incomplete", "failed", "truncated"},
+            "fixture_mode_invalid",
+        )
+        self.mode = mode
         self.requests: list[dict[str, Any]] = []
+        self.served_event_sequences: list[dict[str, Any]] = []
         self.lock = threading.Lock()
         self.root_thread: str | None = None
         self.root_request_count = 0
@@ -453,17 +559,32 @@ class _FixtureServer(ThreadingHTTPServer):
                 root_stage = self.root_request_count
             else:
                 root_stage = 0
-        if not self.lifecycle:
-            return _message_events(index)
-        if is_root and root_stage == 1:
-            return _function_events(
+        if self.mode == "message":
+            events = _message_events(index)
+        elif self.mode == "incomplete":
+            events = [*_partial_message_events(index), _response_incomplete(index)]
+        elif self.mode == "failed":
+            events = [_response_created(index), _response_failed(index)]
+        elif self.mode == "truncated":
+            events = _partial_message_events(index)
+        elif is_root and root_stage == 1:
+            events = _function_events(
                 "spawn_agent",
                 {"task_name": "worker", "message": "bounded child task"},
                 index,
             )
-        if is_root and root_stage == 2:
-            return _function_events("wait_agent", {"timeout_ms": 10000}, index)
-        return _message_events(index)
+        elif is_root and root_stage == 2:
+            events = _function_events("wait_agent", {"timeout_ms": 10000}, index)
+        else:
+            events = _message_events(index)
+        with self.lock:
+            self.served_event_sequences.append(
+                {
+                    "request_index": index,
+                    "events": [_event_envelope(event) for event in events],
+                }
+            )
+        return events
 
 
 class _FixtureHandler(BaseHTTPRequestHandler):
@@ -495,8 +616,8 @@ class _FixtureHandler(BaseHTTPRequestHandler):
 
 
 class FixtureServer:
-    def __init__(self, *, lifecycle: bool) -> None:
-        self._server = _FixtureServer(lifecycle)
+    def __init__(self, *, mode: str) -> None:
+        self._server = _FixtureServer(mode)
         self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
 
     def __enter__(self) -> _FixtureServer:
@@ -545,8 +666,12 @@ class IsolatedHome:
 
 def _isolated_environment(home: Path) -> dict[str, str]:
     environment = os.environ.copy()
+    environment.pop("CODEX_CONFIG", None)
     for name in SENSITIVE_ENVIRONMENT_NAMES:
         environment.pop(name, None)
+    xdg_config = home / "Xdg/Config"
+    xdg_data = home / "Xdg/Data"
+    xdg_cache = home / "Xdg/Cache"
     environment.update(
         CODEX_HOME=str(home),
         HOME=str(home),
@@ -558,9 +683,18 @@ def _isolated_environment(home: Path) -> dict[str, str]:
         HTTP_PROXY="",
         HTTPS_PROXY="",
         ALL_PROXY="",
+        XDG_CONFIG_HOME=str(xdg_config),
+        XDG_DATA_HOME=str(xdg_data),
+        XDG_CACHE_HOME=str(xdg_cache),
     )
-    Path(environment["APPDATA"]).mkdir(parents=True)
-    Path(environment["LOCALAPPDATA"]).mkdir(parents=True)
+    for path in (
+        Path(environment["APPDATA"]),
+        Path(environment["LOCALAPPDATA"]),
+        xdg_config,
+        xdg_data,
+        xdg_cache,
+    ):
+        path.mkdir(parents=True)
     return environment
 
 
@@ -585,6 +719,8 @@ base_url="http://127.0.0.1:{port}/v1"
 wire_api="responses"
 requires_openai_auth=false
 experimental_bearer_token="fixture-key"
+request_max_retries=0
+stream_max_retries=0
 {feature_config}''',
         encoding="utf-8",
         newline="\n",
@@ -621,8 +757,13 @@ def _resume_options(session_id: str) -> list[str]:
 
 
 def _run_codex(
-    command: Sequence[str], *, prompt: str, cwd: Path, environment: Mapping[str, str]
-) -> None:
+    command: Sequence[str],
+    *,
+    prompt: str,
+    cwd: Path,
+    environment: Mapping[str, str],
+    expect_success: bool = True,
+) -> int:
     try:
         completed = subprocess.run(
             list(command),
@@ -638,7 +779,11 @@ def _run_codex(
         )
     except (OSError, subprocess.TimeoutExpired) as error:
         raise CaptureFailure("frozen_runtime_execution_failed") from error
-    _require(completed.returncode == 0, "frozen_runtime_execution_failed")
+    if expect_success:
+        _require(completed.returncode == 0, "frozen_runtime_execution_failed")
+    else:
+        _require(completed.returncode != 0, "terminal_control_was_not_rejected")
+    return completed.returncode
 
 
 def _base_scenario(
@@ -665,7 +810,7 @@ def _capture_request_scenario(
         home = isolated.path
         workspace = home / "workspace"
         workspace.mkdir()
-        with FixtureServer(lifecycle=False) as server:
+        with FixtureServer(mode="message") as server:
             _write_config(home, server.server_port, v2=version == contract.V2, app_server=False)
             environment = _isolated_environment(home)
             _run_codex(
@@ -770,25 +915,49 @@ def _identity_relationships(
     ]
     before_agents = [item for item in before if item.get("type") == "agent_message"]
     replay_agents = [item for item in replay if item.get("type") == "agent_message"]
+    before_call_item_ids = [item.get("id") for item in before_calls]
+    replay_call_item_ids = [item.get("id") for item in replay_calls]
+    before_call_ids = [item.get("call_id") for item in before_calls]
+    replay_call_ids = [item.get("call_id") for item in replay_calls]
+    before_output_item_ids = [item.get("id") for item in before_outputs]
+    replay_output_item_ids = [item.get("id") for item in replay_outputs]
+    before_output_call_ids = [item.get("call_id") for item in before_outputs]
+    replay_output_call_ids = [item.get("call_id") for item in replay_outputs]
+    before_agent_item_ids = [item.get("id") for item in before_agents]
+    replay_agent_item_ids = [item.get("id") for item in replay_agents]
+    all_identity_values = (
+        before_call_item_ids
+        + replay_call_item_ids
+        + before_call_ids
+        + replay_call_ids
+        + before_output_item_ids
+        + replay_output_item_ids
+        + before_output_call_ids
+        + replay_output_call_ids
+        + before_agent_item_ids
+        + replay_agent_item_ids
+    )
+    identities_nonempty = bool(all_identity_values) and all(
+        isinstance(value, str) and bool(value) for value in all_identity_values
+    )
+    agent_addresses_nonempty = all(
+        isinstance(item.get(field), str) and bool(item.get(field))
+        for item in before_agents + replay_agents
+        for field in ("author", "recipient")
+    )
     call_output_links = all(
         any(output.get("call_id") == call.get("call_id") for output in before_outputs)
         for call in before_calls
     )
     return {
-        "function_call_item_ids_preserved": [item.get("id") for item in before_calls]
-        == [item.get("id") for item in replay_calls],
-        "function_call_call_ids_preserved": [
-            item.get("call_id") for item in before_calls
-        ]
-        == [item.get("call_id") for item in replay_calls],
-        "function_output_item_ids_preserved": [
-            item.get("id") for item in before_outputs
-        ]
-        == [item.get("id") for item in replay_outputs],
-        "function_output_call_ids_preserved": [
-            item.get("call_id") for item in before_outputs
-        ]
-        == [item.get("call_id") for item in replay_outputs],
+        "all_identity_fields_nonempty": identities_nonempty,
+        "function_call_item_ids_preserved": before_call_item_ids
+        == replay_call_item_ids,
+        "function_call_call_ids_preserved": before_call_ids == replay_call_ids,
+        "function_output_item_ids_preserved": before_output_item_ids
+        == replay_output_item_ids,
+        "function_output_call_ids_preserved": before_output_call_ids
+        == replay_output_call_ids,
         "function_outputs_link_to_calls": call_output_links,
         "collaboration_item_order_preserved": [
             _item_signature(item) for item in before
@@ -818,6 +987,9 @@ def _identity_relationships(
             )
             for item in replay_agents
         ],
+        "agent_message_item_ids_preserved": before_agent_item_ids
+        == replay_agent_item_ids,
+        "agent_message_addresses_nonempty": agent_addresses_nonempty,
     }
 
 
@@ -888,7 +1060,7 @@ def _capture_v2_lifecycle(
         home = isolated.path
         workspace = home / "workspace"
         workspace.mkdir()
-        with FixtureServer(lifecycle=True) as server:
+        with FixtureServer(mode="lifecycle") as server:
             _write_config(home, server.server_port, v2=True, app_server=False)
             environment = _isolated_environment(home)
             _run_codex(
@@ -907,6 +1079,7 @@ def _capture_v2_lifecycle(
                 environment=environment,
             )
             requests = copy.deepcopy(server.requests)
+            served_event_sequences = copy.deepcopy(server.served_event_sequences)
         phases = _phase_requests(requests, root_thread, restart_offset)
         declaration = _declaration(phases["root_initial"], contract.V2_NAMESPACE)
         rollout = _rollout_summary(home, root_thread)
@@ -935,8 +1108,63 @@ def _capture_v2_lifecycle(
                 "response.completed",
             ],
             "served_function_names": ["spawn_agent", "wait_agent"],
+            "served_event_sequences": served_event_sequences,
             "identity_relationships": _identity_relationships(phases),
             "rollout_readback": rollout,
+        }
+        return result
+
+
+def _capture_terminal_control(
+    *, client: str, executable: Path, terminal: str
+) -> dict[str, Any]:
+    _require(
+        terminal in {"incomplete", "failed", "truncated"},
+        "terminal_control_invalid",
+    )
+    scenario_name = f"{client}_terminal_{terminal}"
+    with IsolatedHome(scenario_name) as isolated:
+        _require(isolated.path is not None, "isolated_home_missing")
+        home = isolated.path
+        workspace = home / "workspace"
+        workspace.mkdir()
+        with FixtureServer(mode=terminal) as server:
+            _write_config(home, server.server_port, v2=True, app_server=False)
+            environment = _isolated_environment(home)
+            _run_codex(
+                (str(executable), "exec", *_exec_options(workspace)),
+                prompt="Reject the controlled terminal stream.",
+                cwd=workspace,
+                environment=environment,
+                expect_success=False,
+            )
+            requests = copy.deepcopy(server.requests)
+            served_event_sequences = copy.deepcopy(server.served_event_sequences)
+        _require(len(requests) == 1, "terminal_control_request_count_invalid")
+        _require(
+            len(served_event_sequences) == 1,
+            "terminal_control_event_sequence_invalid",
+        )
+        event_types = [
+            event["type"] for event in served_event_sequences[0]["events"]
+        ]
+        terminal_event = f"response.{terminal}"
+        result = _base_scenario(
+            client=client,
+            home=isolated,
+            request_count=len(requests),
+            process_runs=1,
+        )
+        result["observed"] = {
+            "terminal_control": terminal,
+            "client_disposition": "rejected_nonzero_exit",
+            "request": _safe_request_shape(requests[0]),
+            "declaration": _declaration(requests[0], contract.V2_NAMESPACE),
+            "served_event_envelopes": served_event_sequences[0]["events"],
+            "terminal_event_present": (
+                terminal_event in event_types if terminal != "truncated" else False
+            ),
+            "completed_event_present": "response.completed" in event_types,
         }
         return result
 
@@ -1040,12 +1268,23 @@ def _desktop_identity_relationships(
         for turn in after_turns
         if isinstance(turn, Mapping)
     ]
+    before_turn_ids = [
+        turn.get("id") for turn in before_turns if isinstance(turn, Mapping)
+    ]
+    after_turn_ids = [
+        turn.get("id") for turn in after_turns if isinstance(turn, Mapping)
+    ]
+    identity_values = (
+        [before.get("id"), after.get("id")]
+        + before_turn_ids
+        + after_turn_ids
+        + [value for values in before_item_ids + after_item_ids for value in values]
+    )
     return {
+        "all_identity_fields_nonempty": bool(identity_values)
+        and all(isinstance(value, str) and bool(value) for value in identity_values),
         "thread_id_preserved": before.get("id") == after.get("id"),
-        "turn_ids_preserved": [
-            turn.get("id") for turn in before_turns if isinstance(turn, Mapping)
-        ]
-        == [turn.get("id") for turn in after_turns if isinstance(turn, Mapping)],
+        "turn_ids_preserved": before_turn_ids == after_turn_ids,
         "item_ids_preserved": before_item_ids == after_item_ids,
         "item_order_preserved": before_types == after_types,
         "structural_readback_preserved": _thread_structure(before)
@@ -1073,7 +1312,7 @@ def _capture_desktop_app_lifecycle(executable: Path) -> dict[str, Any]:
         home = isolated.path
         workspace = home / "workspace"
         workspace.mkdir()
-        with FixtureServer(lifecycle=True) as server:
+        with FixtureServer(mode="lifecycle") as server:
             _write_config(home, server.server_port, v2=True, app_server=True)
             environment = _isolated_environment(home)
             app = start_issue106_app_server(executable, home, environment)
@@ -1223,6 +1462,32 @@ def capture(
         "desktop_v2_lifecycle": _capture_v2_lifecycle(
             client="codex_desktop", executable=desktop_executable
         ),
+        "cli_terminal_incomplete": _capture_terminal_control(
+            client="codex_cli",
+            executable=cli_executable,
+            terminal="incomplete",
+        ),
+        "cli_terminal_failed": _capture_terminal_control(
+            client="codex_cli", executable=cli_executable, terminal="failed"
+        ),
+        "cli_terminal_truncated": _capture_terminal_control(
+            client="codex_cli", executable=cli_executable, terminal="truncated"
+        ),
+        "desktop_terminal_incomplete": _capture_terminal_control(
+            client="codex_desktop",
+            executable=desktop_executable,
+            terminal="incomplete",
+        ),
+        "desktop_terminal_failed": _capture_terminal_control(
+            client="codex_desktop",
+            executable=desktop_executable,
+            terminal="failed",
+        ),
+        "desktop_terminal_truncated": _capture_terminal_control(
+            client="codex_desktop",
+            executable=desktop_executable,
+            terminal="truncated",
+        ),
         "desktop_app_v2_lifecycle": _capture_desktop_app_lifecycle(
             desktop_executable
         ),
@@ -1238,6 +1503,8 @@ def capture(
             "protocol_upstream_loopback": True,
             "plugin_services_disabled": list(DISABLED_FEATURES),
             "sensitive_environment_credentials_removed": True,
+            "external_config_environment_removed": ["CODEX_CONFIG"],
+            "xdg_roots_under_isolated_home": True,
             "existing_user_home_read": False,
             "existing_user_task_read": False,
             "known_crash_task_read": False,

--- a/scripts/capture_issue_392_collaboration_runtime.py
+++ b/scripts/capture_issue_392_collaboration_runtime.py
@@ -1,0 +1,1305 @@
+#!/usr/bin/env python3
+"""Capture the frozen #392 Collaboration contract from isolated runtimes.
+
+This is an explicit evidence runner.  It accepts only the frozen CLI/Desktop
+binaries and source commits, creates a new empty Codex Home for every
+scenario, and talks only to a loopback protocol-controlled Responses server.
+The emitted artifact contains structural types and relationship assertions;
+it never retains prompts, credentials, paths, or opaque runtime identifiers.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+from datetime import date
+import hashlib
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import json
+import os
+from pathlib import Path
+import secrets
+import shutil
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from typing import Any, Mapping, Sequence
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import build_issue_392_collaboration_contract as contract
+from run_issue_106_task_lifecycle import (
+    JsonRpcClient,
+    initialize,
+    response_result,
+    start_issue106_app_server,
+    start_issue106_custom_thread,
+    stop_issue106_app_server,
+    turn_started,
+    wait_for_turn,
+)
+
+
+SCHEMA = "codexhub.issue392.collaboration-runtime-observations.v1"
+DEFAULT_OUTPUT = Path(
+    "docs/evidence/issue-392/collaboration-runtime-observations.json"
+)
+HOME_PREFIX = "codexhub-issue392-runtime-"
+MODEL = "fixture-v2"
+CANDIDATE_REVISION = "be10f62f44b22fa8c84510238250ae11fb3ecab4"
+SENSITIVE_ENVIRONMENT_NAMES = (
+    "ANTHROPIC_API_KEY",
+    "OLLAMA_API_KEY",
+    "OPENAI_API_KEY",
+)
+DISABLED_FEATURES = ("plugins", "remote_plugin", "plugin_sharing")
+
+
+class CaptureFailure(RuntimeError):
+    """A fixed-code capture failure that never includes captured content."""
+
+
+def _require(condition: bool, code: str) -> None:
+    if not condition:
+        raise CaptureFailure(code)
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _run_text(command: Sequence[str], *, cwd: Path | None = None) -> str:
+    try:
+        completed = subprocess.run(
+            list(command),
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired) as error:
+        raise CaptureFailure("frozen_input_command_failed") from error
+    _require(completed.returncode == 0, "frozen_input_command_failed")
+    return completed.stdout.strip()
+
+
+def _git_value(source_root: Path, *arguments: str) -> str:
+    return _run_text(("git", "-C", str(source_root), *arguments))
+
+
+def _verify_runtime(
+    *,
+    client: str,
+    executable: Path,
+    source_root: Path,
+    expected_binary_sha256: str,
+    expected_runtime_version: str,
+    expected_source_commit: str,
+    expected_source_blobs: Mapping[str, str],
+    client_version: str,
+    source_tag: str,
+) -> dict[str, Any]:
+    _require(executable.is_file(), "frozen_binary_missing")
+    _require(source_root.is_dir(), "frozen_source_missing")
+    binary_sha256 = _sha256_file(executable)
+    _require(binary_sha256 == expected_binary_sha256, "frozen_binary_hash_mismatch")
+    version_output = _run_text((str(executable), "--version"))
+    _require(
+        version_output == f"codex-cli {expected_runtime_version}",
+        "frozen_runtime_version_mismatch",
+    )
+    source_commit = _git_value(source_root, "rev-parse", "HEAD")
+    _require(source_commit == expected_source_commit, "frozen_source_commit_mismatch")
+    source_files: dict[str, dict[str, str]] = {}
+    for key, relative_path in contract.SOURCE_FILES.items():
+        blob = _git_value(
+            source_root, "rev-parse", f"{expected_source_commit}:{relative_path}"
+        )
+        _require(blob == expected_source_blobs[key], "frozen_source_blob_mismatch")
+        source_files[key] = {"path": relative_path, "git_blob": blob}
+    return {
+        "client": client,
+        "client_version": client_version,
+        "runtime_version": expected_runtime_version,
+        "version_output": version_output,
+        "binary_sha256": binary_sha256,
+        "source_tag": source_tag,
+        "source_commit": source_commit,
+        "source_files": source_files,
+    }
+
+
+def _value_type(value: Any) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, str):
+        return "string"
+    if isinstance(value, (int, float)):
+        return "number"
+    if isinstance(value, list):
+        return "array"
+    if isinstance(value, Mapping):
+        return "object"
+    return "unknown"
+
+
+def _field_types(value: Mapping[str, Any]) -> dict[str, str]:
+    return {key: _value_type(child) for key, child in sorted(value.items())}
+
+
+def _json_object_keys(value: Any) -> tuple[str, list[str]]:
+    if not isinstance(value, str):
+        return "not_string", []
+    try:
+        decoded = json.loads(value)
+    except json.JSONDecodeError:
+        return "plain_text", []
+    if isinstance(decoded, Mapping):
+        return "object", sorted(str(key) for key in decoded)
+    return _value_type(decoded), []
+
+
+def _declaration(body: Mapping[str, Any], namespace: str) -> dict[str, Any]:
+    tools = body.get("tools")
+    _require(isinstance(tools, list), "request_tools_invalid")
+    matches = [
+        tool
+        for tool in tools
+        if isinstance(tool, Mapping)
+        and tool.get("type") == "namespace"
+        and tool.get("name") == namespace
+    ]
+    _require(len(matches) == 1, "request_namespace_invalid")
+    marker = matches[0]
+    children = marker.get("tools")
+    _require(isinstance(children, list), "request_namespace_children_invalid")
+    normalized_children: list[dict[str, Any]] = []
+    for child in children:
+        _require(isinstance(child, Mapping), "request_namespace_child_invalid")
+        parameters = child.get("parameters")
+        _require(isinstance(parameters, Mapping), "request_namespace_schema_invalid")
+        normalized_children.append(
+            {
+                "type": child.get("type"),
+                "name": child.get("name"),
+                "description_type": _value_type(child.get("description")),
+                "strict": child.get("strict"),
+                "fields": sorted(child),
+                "parameters": contract._normalize_schema(parameters),
+            }
+        )
+    normalized_children.sort(key=lambda value: str(value["name"]))
+    return {
+        "type": marker.get("type"),
+        "name": marker.get("name"),
+        "description_type": _value_type(marker.get("description")),
+        "fields": sorted(marker),
+        "children": normalized_children,
+    }
+
+
+def _version_locations(body: Mapping[str, Any]) -> list[str]:
+    locations: list[str] = []
+    if "multi_agent_version" in body:
+        locations.append("request")
+    for parent_name in ("metadata", "features", "client_metadata"):
+        parent = body.get(parent_name)
+        if isinstance(parent, Mapping) and "multi_agent_version" in parent:
+            locations.append(parent_name)
+    return locations
+
+
+def _interesting_item(item: Mapping[str, Any]) -> dict[str, Any] | None:
+    item_type = item.get("type")
+    if item_type == "function_call":
+        argument_kind, argument_keys = _json_object_keys(item.get("arguments"))
+        return {
+            "type": item_type,
+            "fields": sorted(item),
+            "field_types": _field_types(item),
+            "name": item.get("name"),
+            "namespace": item.get("namespace"),
+            "arguments_json_type": argument_kind,
+            "argument_keys": argument_keys,
+        }
+    if item_type == "function_call_output":
+        output_kind, output_keys = _json_object_keys(item.get("output"))
+        return {
+            "type": item_type,
+            "fields": sorted(item),
+            "field_types": _field_types(item),
+            "output_wire_type": _value_type(item.get("output")),
+            "decoded_output_type": output_kind,
+            "decoded_output_keys": output_keys,
+        }
+    if item_type == "agent_message":
+        content = item.get("content")
+        _require(isinstance(content, list), "agent_message_content_invalid")
+        variants = []
+        for part in content:
+            _require(isinstance(part, Mapping), "agent_message_part_invalid")
+            variants.append(
+                {
+                    "type": part.get("type"),
+                    "fields": sorted(part),
+                    "field_types": _field_types(part),
+                }
+            )
+        return {
+            "type": item_type,
+            "fields": sorted(item),
+            "field_types": _field_types(item),
+            "content_variants": variants,
+        }
+    return None
+
+
+def _collaboration_items(body: Mapping[str, Any]) -> list[dict[str, Any]]:
+    items = body.get("input")
+    _require(isinstance(items, list), "request_input_invalid")
+    result: list[dict[str, Any]] = []
+    for item in items:
+        if isinstance(item, Mapping):
+            summary = _interesting_item(item)
+            if summary is not None:
+                result.append(summary)
+    return result
+
+
+def _input_type_order(body: Mapping[str, Any]) -> list[str]:
+    items = body.get("input")
+    _require(isinstance(items, list), "request_input_invalid")
+    return [
+        str(item.get("type"))
+        for item in items
+        if isinstance(item, Mapping) and isinstance(item.get("type"), str)
+    ]
+
+
+def _safe_request_shape(body: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "fields": sorted(body),
+        "field_types": _field_types(body),
+        "tool_choice": body.get("tool_choice"),
+        "multi_agent_version_locations": _version_locations(body),
+        "input_type_order": _input_type_order(body),
+        "collaboration_items": _collaboration_items(body),
+    }
+
+
+def _sse(event: Mapping[str, Any]) -> bytes:
+    body = json.dumps(event, separators=(",", ":")).encode("utf-8")
+    return (
+        b"event: "
+        + str(event["type"]).encode("utf-8")
+        + b"\n"
+        + b"data: "
+        + body
+        + b"\n\n"
+    )
+
+
+def _response_created(index: int) -> dict[str, Any]:
+    return {
+        "type": "response.created",
+        "response": {
+            "id": f"response_{index}",
+            "object": "response",
+            "status": "in_progress",
+            "model": MODEL,
+            "output": [],
+        },
+    }
+
+
+def _response_completed(output: list[dict[str, Any]], index: int) -> dict[str, Any]:
+    return {
+        "type": "response.completed",
+        "response": {
+            "id": f"response_{index}",
+            "object": "response",
+            "status": "completed",
+            "model": MODEL,
+            "output": output,
+            "usage": {
+                "input_tokens": 1,
+                "output_tokens": 1,
+                "total_tokens": 2,
+                "input_tokens_details": {"cached_tokens": 0},
+                "output_tokens_details": {"reasoning_tokens": 0},
+            },
+        },
+    }
+
+
+def _message_events(index: int) -> list[dict[str, Any]]:
+    item_id = f"message_{index}"
+    done = {
+        "id": item_id,
+        "type": "message",
+        "role": "assistant",
+        "content": [{"type": "output_text", "text": "done", "annotations": []}],
+    }
+    return [
+        _response_created(index),
+        {
+            "type": "response.output_item.added",
+            "output_index": 0,
+            "item": {
+                "id": item_id,
+                "type": "message",
+                "role": "assistant",
+                "content": [],
+            },
+        },
+        {
+            "type": "response.content_part.added",
+            "item_id": item_id,
+            "output_index": 0,
+            "content_index": 0,
+            "part": {"type": "output_text", "text": "", "annotations": []},
+        },
+        {
+            "type": "response.output_text.delta",
+            "item_id": item_id,
+            "output_index": 0,
+            "content_index": 0,
+            "delta": "done",
+        },
+        {
+            "type": "response.output_text.done",
+            "item_id": item_id,
+            "output_index": 0,
+            "content_index": 0,
+            "text": "done",
+        },
+        {"type": "response.output_item.done", "output_index": 0, "item": done},
+        _response_completed([done], index),
+    ]
+
+
+def _function_events(
+    name: str, arguments: Mapping[str, Any], index: int
+) -> list[dict[str, Any]]:
+    item_id = f"function_{index}"
+    call_id = f"call_{index}"
+    arguments_text = json.dumps(arguments, separators=(",", ":"))
+    done = {
+        "id": item_id,
+        "type": "function_call",
+        "status": "completed",
+        "name": name,
+        "namespace": contract.V2_NAMESPACE,
+        "call_id": call_id,
+        "arguments": arguments_text,
+    }
+    added = {**done, "status": "in_progress", "arguments": ""}
+    return [
+        _response_created(index),
+        {"type": "response.output_item.added", "output_index": 0, "item": added},
+        {
+            "type": "response.function_call_arguments.delta",
+            "item_id": item_id,
+            "output_index": 0,
+            "delta": arguments_text,
+        },
+        {
+            "type": "response.function_call_arguments.done",
+            "item_id": item_id,
+            "output_index": 0,
+            "arguments": arguments_text,
+        },
+        {"type": "response.output_item.done", "output_index": 0, "item": done},
+        _response_completed([done], index),
+    ]
+
+
+class _FixtureServer(ThreadingHTTPServer):
+    daemon_threads = True
+
+    def __init__(self, lifecycle: bool) -> None:
+        super().__init__(("127.0.0.1", 0), _FixtureHandler)
+        self.lifecycle = lifecycle
+        self.requests: list[dict[str, Any]] = []
+        self.lock = threading.Lock()
+        self.root_thread: str | None = None
+        self.root_request_count = 0
+
+    def events_for(self, body: dict[str, Any]) -> list[dict[str, Any]]:
+        thread_id_value = (body.get("client_metadata") or {}).get("thread_id")
+        thread_id = thread_id_value if isinstance(thread_id_value, str) else None
+        with self.lock:
+            self.requests.append(body)
+            index = len(self.requests)
+            if self.root_thread is None:
+                self.root_thread = thread_id
+            is_root = thread_id == self.root_thread
+            if is_root:
+                self.root_request_count += 1
+                root_stage = self.root_request_count
+            else:
+                root_stage = 0
+        if not self.lifecycle:
+            return _message_events(index)
+        if is_root and root_stage == 1:
+            return _function_events(
+                "spawn_agent",
+                {"task_name": "worker", "message": "bounded child task"},
+                index,
+            )
+        if is_root and root_stage == 2:
+            return _function_events("wait_agent", {"timeout_ms": 10000}, index)
+        return _message_events(index)
+
+
+class _FixtureHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, *_args: Any) -> None:
+        return
+
+    def do_POST(self) -> None:  # noqa: N802 - stdlib callback name
+        server = self.server
+        _require(isinstance(server, _FixtureServer), "fixture_server_invalid")
+        try:
+            size = int(self.headers.get("Content-Length", "0"))
+            body = json.loads(self.rfile.read(size))
+        except (ValueError, json.JSONDecodeError):
+            self.send_error(400)
+            return
+        if not isinstance(body, dict):
+            self.send_error(400)
+            return
+        events = server.events_for(body)
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Connection", "close")
+        self.end_headers()
+        for event in events:
+            self.wfile.write(_sse(event))
+            self.wfile.flush()
+
+
+class FixtureServer:
+    def __init__(self, *, lifecycle: bool) -> None:
+        self._server = _FixtureServer(lifecycle)
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+
+    def __enter__(self) -> _FixtureServer:
+        self._thread.start()
+        return self._server
+
+    def __exit__(self, *_args: Any) -> None:
+        self._server.shutdown()
+        self._server.server_close()
+        self._thread.join(timeout=5)
+
+
+class IsolatedHome:
+    def __init__(self, scenario: str) -> None:
+        self.scenario = scenario
+        self.path: Path | None = None
+        self.marker_sha256: str | None = None
+        self.fresh_empty = False
+
+    def __enter__(self) -> "IsolatedHome":
+        path = Path(tempfile.mkdtemp(prefix=HOME_PREFIX))
+        self.path = path
+        self.fresh_empty = not any(path.iterdir())
+        _require(self.fresh_empty, "isolated_home_not_empty")
+        marker = self.scenario.encode("utf-8") + b"\0" + secrets.token_bytes(32)
+        marker_path = path / ".codexhub-issue392-home-marker"
+        marker_path.write_bytes(marker)
+        self.marker_sha256 = hashlib.sha256(marker).hexdigest()
+        return self
+
+    def __exit__(self, *_args: Any) -> None:
+        if self.path is None:
+            return
+        last_error: OSError | None = None
+        for _ in range(10):
+            try:
+                shutil.rmtree(self.path)
+                return
+            except FileNotFoundError:
+                return
+            except OSError as error:
+                last_error = error
+                time.sleep(0.25)
+        raise CaptureFailure("isolated_home_cleanup_failed") from last_error
+
+
+def _isolated_environment(home: Path) -> dict[str, str]:
+    environment = os.environ.copy()
+    for name in SENSITIVE_ENVIRONMENT_NAMES:
+        environment.pop(name, None)
+    environment.update(
+        CODEX_HOME=str(home),
+        HOME=str(home),
+        USERPROFILE=str(home),
+        APPDATA=str(home / "AppData/Roaming"),
+        LOCALAPPDATA=str(home / "AppData/Local"),
+        NO_PROXY="127.0.0.1,localhost",
+        no_proxy="127.0.0.1,localhost",
+        HTTP_PROXY="",
+        HTTPS_PROXY="",
+        ALL_PROXY="",
+    )
+    Path(environment["APPDATA"]).mkdir(parents=True)
+    Path(environment["LOCALAPPDATA"]).mkdir(parents=True)
+    return environment
+
+
+def _write_config(home: Path, port: int, *, v2: bool, app_server: bool) -> None:
+    provider = "custom" if app_server else "fixture"
+    if v2:
+        feature_config = """[features.multi_agent_v2]
+enabled=true
+non_code_mode_only=false
+"""
+    else:
+        feature_config = """[features]
+multi_agent=true
+multi_agent_v2=false
+"""
+    (home / "config.toml").write_text(
+        f'''model="{MODEL}"
+model_provider="{provider}"
+[model_providers.{provider}]
+name="fixture"
+base_url="http://127.0.0.1:{port}/v1"
+wire_api="responses"
+requires_openai_auth=false
+experimental_bearer_token="fixture-key"
+{feature_config}''',
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def _exec_options(workspace: Path) -> list[str]:
+    options = [
+        "--json",
+        "--skip-git-repo-check",
+        "--strict-config",
+        "--dangerously-bypass-approvals-and-sandbox",
+    ]
+    for feature in DISABLED_FEATURES:
+        options.extend(("--disable", feature))
+    options.extend(("-C", str(workspace), "-m", MODEL, "-"))
+    return options
+
+
+def _resume_options(session_id: str) -> list[str]:
+    options = [session_id, "--json", "--strict-config"]
+    for feature in DISABLED_FEATURES:
+        options.extend(("--disable", feature))
+    options.extend(
+        (
+            "--skip-git-repo-check",
+            "--dangerously-bypass-approvals-and-sandbox",
+            "-m",
+            MODEL,
+            "-",
+        )
+    )
+    return options
+
+
+def _run_codex(
+    command: Sequence[str], *, prompt: str, cwd: Path, environment: Mapping[str, str]
+) -> None:
+    try:
+        completed = subprocess.run(
+            list(command),
+            input=prompt,
+            cwd=cwd,
+            env=dict(environment),
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+            timeout=180,
+        )
+    except (OSError, subprocess.TimeoutExpired) as error:
+        raise CaptureFailure("frozen_runtime_execution_failed") from error
+    _require(completed.returncode == 0, "frozen_runtime_execution_failed")
+
+
+def _base_scenario(
+    *, client: str, home: IsolatedHome, request_count: int, process_runs: int
+) -> dict[str, Any]:
+    _require(home.marker_sha256 is not None, "isolated_home_marker_missing")
+    return {
+        "client": client,
+        "home_binding_sha256": home.marker_sha256,
+        "fresh_empty_home_before_marker": home.fresh_empty,
+        "workspace_created_under_home": True,
+        "loopback_request_count": request_count,
+        "process_runs": process_runs,
+    }
+
+
+def _capture_request_scenario(
+    *, client: str, executable: Path, version: str
+) -> dict[str, Any]:
+    namespace = contract.V1_NAMESPACE if version == contract.V1 else contract.V2_NAMESPACE
+    scenario_name = f"{client}_{version}_request"
+    with IsolatedHome(scenario_name) as isolated:
+        _require(isolated.path is not None, "isolated_home_missing")
+        home = isolated.path
+        workspace = home / "workspace"
+        workspace.mkdir()
+        with FixtureServer(lifecycle=False) as server:
+            _write_config(home, server.server_port, v2=version == contract.V2, app_server=False)
+            environment = _isolated_environment(home)
+            _run_codex(
+                (str(executable), "exec", *_exec_options(workspace)),
+                prompt="Reply exactly done without using tools.",
+                cwd=workspace,
+                environment=environment,
+            )
+            requests = copy.deepcopy(server.requests)
+        _require(len(requests) == 1, "request_scenario_count_invalid")
+        request = requests[0]
+        result = _base_scenario(
+            client=client,
+            home=isolated,
+            request_count=len(requests),
+            process_runs=1,
+        )
+        result["observed"] = {
+            "request": _safe_request_shape(request),
+            "declaration": _declaration(request, namespace),
+        }
+        return result
+
+
+def _raw_collaboration_items(body: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    inputs = body.get("input")
+    _require(isinstance(inputs, list), "request_input_invalid")
+    return [
+        item
+        for item in inputs
+        if isinstance(item, Mapping)
+        and item.get("type")
+        in {"function_call", "function_call_output", "agent_message"}
+    ]
+
+
+def _phase_requests(
+    requests: Sequence[Mapping[str, Any]], root_thread: str, restart_offset: int
+) -> dict[str, Mapping[str, Any]]:
+    phases: dict[str, Mapping[str, Any]] = {}
+    child_count = 0
+    root_count = 0
+    for index, body in enumerate(requests):
+        thread_id = (body.get("client_metadata") or {}).get("thread_id")
+        if thread_id == root_thread:
+            root_count += 1
+            if index >= restart_offset:
+                phase = "restart_replay"
+            elif root_count == 1:
+                phase = "root_initial"
+            elif root_count == 2:
+                phase = "root_after_spawn"
+            else:
+                phase = "root_after_wait"
+        else:
+            child_count += 1
+            phase = "child_initial" if child_count == 1 else f"child_{child_count}"
+        _require(phase not in phases, "lifecycle_phase_duplicate")
+        phases[phase] = body
+    _require(
+        set(phases)
+        == {
+            "root_initial",
+            "root_after_spawn",
+            "child_initial",
+            "root_after_wait",
+            "restart_replay",
+        },
+        "lifecycle_phase_set_invalid",
+    )
+    return phases
+
+
+def _item_signature(item: Mapping[str, Any]) -> tuple[Any, ...]:
+    item_type = item.get("type")
+    if item_type == "function_call":
+        return (item_type, item.get("name"), item.get("namespace"))
+    if item_type == "agent_message":
+        content = item.get("content")
+        _require(isinstance(content, list), "agent_message_content_invalid")
+        kinds = tuple(
+            part.get("type")
+            for part in content
+            if isinstance(part, Mapping)
+        )
+        return (item_type, kinds)
+    return (item_type,)
+
+
+def _identity_relationships(
+    phases: Mapping[str, Mapping[str, Any]]
+) -> dict[str, bool]:
+    before = _raw_collaboration_items(phases["root_after_wait"])
+    replay = _raw_collaboration_items(phases["restart_replay"])
+    before_calls = [item for item in before if item.get("type") == "function_call"]
+    replay_calls = [item for item in replay if item.get("type") == "function_call"]
+    before_outputs = [
+        item for item in before if item.get("type") == "function_call_output"
+    ]
+    replay_outputs = [
+        item for item in replay if item.get("type") == "function_call_output"
+    ]
+    before_agents = [item for item in before if item.get("type") == "agent_message"]
+    replay_agents = [item for item in replay if item.get("type") == "agent_message"]
+    call_output_links = all(
+        any(output.get("call_id") == call.get("call_id") for output in before_outputs)
+        for call in before_calls
+    )
+    return {
+        "function_call_item_ids_preserved": [item.get("id") for item in before_calls]
+        == [item.get("id") for item in replay_calls],
+        "function_call_call_ids_preserved": [
+            item.get("call_id") for item in before_calls
+        ]
+        == [item.get("call_id") for item in replay_calls],
+        "function_output_item_ids_preserved": [
+            item.get("id") for item in before_outputs
+        ]
+        == [item.get("id") for item in replay_outputs],
+        "function_output_call_ids_preserved": [
+            item.get("call_id") for item in before_outputs
+        ]
+        == [item.get("call_id") for item in replay_outputs],
+        "function_outputs_link_to_calls": call_output_links,
+        "collaboration_item_order_preserved": [
+            _item_signature(item) for item in before
+        ]
+        == [_item_signature(item) for item in replay],
+        "agent_message_author_recipient_and_content_preserved": [
+            (
+                item.get("author"),
+                item.get("recipient"),
+                [
+                    part.get("type")
+                    for part in item.get("content", [])
+                    if isinstance(part, Mapping)
+                ],
+            )
+            for item in before_agents
+        ]
+        == [
+            (
+                item.get("author"),
+                item.get("recipient"),
+                [
+                    part.get("type")
+                    for part in item.get("content", [])
+                    if isinstance(part, Mapping)
+                ],
+            )
+            for item in replay_agents
+        ],
+    }
+
+
+def _rollout_summary(home: Path, root_thread: str) -> list[dict[str, Any]]:
+    summaries: list[dict[str, Any]] = []
+    for path in sorted(home.rglob("*.jsonl")):
+        records: list[dict[str, Any]] = []
+        for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+            try:
+                value = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(value, dict):
+                records.append(value)
+        session_id = None
+        for record in records:
+            if record.get("type") == "session_meta" and isinstance(
+                record.get("payload"), Mapping
+            ):
+                session_id = record["payload"].get("id")
+                break
+        role = "root" if session_id == root_thread else "child"
+        relevant = [
+            record
+            for record in records
+            if record.get("type") in {"session_meta", "turn_context", "response_item"}
+        ]
+        metadata: list[dict[str, Any]] = []
+        collaboration_items: list[dict[str, Any]] = []
+        for record in relevant:
+            payload = record.get("payload")
+            if not isinstance(payload, Mapping):
+                continue
+            record_type = record.get("type")
+            if record_type in {"session_meta", "turn_context"}:
+                metadata.append(
+                    {
+                        "record_type": record_type,
+                        "record_fields": sorted(record),
+                        "record_field_types": _field_types(record),
+                        "payload_fields": sorted(payload),
+                        "payload_field_types": _field_types(payload),
+                        "multi_agent_version": payload.get("multi_agent_version"),
+                    }
+                )
+            elif record_type == "response_item":
+                item = _interesting_item(payload)
+                if item is not None:
+                    collaboration_items.append(item)
+        summaries.append(
+            {
+                "role": role,
+                "relevant_record_type_order": [record.get("type") for record in relevant],
+                "metadata_records": metadata,
+                "collaboration_items": collaboration_items,
+            }
+        )
+    summaries.sort(key=lambda value: (value["role"] != "root", value["role"]))
+    return summaries
+
+
+def _capture_v2_lifecycle(
+    *, client: str, executable: Path
+) -> dict[str, Any]:
+    scenario_name = f"{client}_collaboration_v2_lifecycle"
+    with IsolatedHome(scenario_name) as isolated:
+        _require(isolated.path is not None, "isolated_home_missing")
+        home = isolated.path
+        workspace = home / "workspace"
+        workspace.mkdir()
+        with FixtureServer(lifecycle=True) as server:
+            _write_config(home, server.server_port, v2=True, app_server=False)
+            environment = _isolated_environment(home)
+            _run_codex(
+                (str(executable), "exec", *_exec_options(workspace)),
+                prompt="Spawn worker, wait for completion, then finish.",
+                cwd=workspace,
+                environment=environment,
+            )
+            _require(isinstance(server.root_thread, str), "root_thread_missing")
+            root_thread = server.root_thread
+            restart_offset = len(server.requests)
+            _run_codex(
+                (str(executable), "exec", "resume", *_resume_options(root_thread)),
+                prompt="Reply exactly done again without using tools.",
+                cwd=workspace,
+                environment=environment,
+            )
+            requests = copy.deepcopy(server.requests)
+        phases = _phase_requests(requests, root_thread, restart_offset)
+        declaration = _declaration(phases["root_initial"], contract.V2_NAMESPACE)
+        rollout = _rollout_summary(home, root_thread)
+        result = _base_scenario(
+            client=client,
+            home=isolated,
+            request_count=len(requests),
+            process_runs=2,
+        )
+        result["observed"] = {
+            "declaration": declaration,
+            "request_arrival_order": [
+                phase
+                for body in requests
+                for phase, phase_body in phases.items()
+                if phase_body is body
+            ],
+            "requests_by_phase": {
+                phase: _safe_request_shape(body) for phase, body in sorted(phases.items())
+            },
+            "served_function_call_event_order": [
+                "response.output_item.added",
+                "response.function_call_arguments.delta",
+                "response.function_call_arguments.done",
+                "response.output_item.done",
+                "response.completed",
+            ],
+            "served_function_names": ["spawn_agent", "wait_agent"],
+            "identity_relationships": _identity_relationships(phases),
+            "rollout_readback": rollout,
+        }
+        return result
+
+
+def _notification_summary(notification: Mapping[str, Any]) -> dict[str, Any] | None:
+    method = notification.get("method")
+    params = notification.get("params")
+    if not isinstance(method, str) or not isinstance(params, Mapping):
+        return None
+    item = params.get("item")
+    if isinstance(item, Mapping) and item.get("type") in {
+        "agentMessage",
+        "collabAgentToolCall",
+        "subAgentActivity",
+    }:
+        result: dict[str, Any] = {
+            "method": method,
+            "params_fields": sorted(params),
+            "params_field_types": _field_types(params),
+            "item_type": item.get("type"),
+            "item_fields": sorted(item),
+            "item_field_types": _field_types(item),
+        }
+        for field in ("kind", "status", "tool", "phase"):
+            value = item.get(field)
+            if isinstance(value, str):
+                result[f"item_{field}"] = value
+        return result
+    if method == "item/agentMessage/delta":
+        return {
+            "method": method,
+            "params_fields": sorted(params),
+            "params_field_types": _field_types(params),
+        }
+    return None
+
+
+def _thread_structure(thread: Mapping[str, Any]) -> dict[str, Any]:
+    turns = thread.get("turns")
+    _require(isinstance(turns, list), "desktop_thread_turns_invalid")
+    turn_summaries: list[dict[str, Any]] = []
+    for turn in turns:
+        _require(isinstance(turn, Mapping), "desktop_turn_invalid")
+        items = turn.get("items")
+        _require(isinstance(items, list), "desktop_turn_items_invalid")
+        item_summaries: list[dict[str, Any]] = []
+        for item in items:
+            _require(isinstance(item, Mapping), "desktop_thread_item_invalid")
+            summary: dict[str, Any] = {
+                "type": item.get("type"),
+                "fields": sorted(item),
+                "field_types": _field_types(item),
+            }
+            for field in ("kind", "status", "tool", "phase"):
+                value = item.get(field)
+                if isinstance(value, str):
+                    summary[field] = value
+            item_summaries.append(summary)
+        turn_summaries.append(
+            {
+                "fields": sorted(turn),
+                "field_types": _field_types(turn),
+                "status": turn.get("status"),
+                "items": item_summaries,
+            }
+        )
+    status = thread.get("status")
+    return {
+        "fields": sorted(thread),
+        "field_types": _field_types(thread),
+        "status_fields": sorted(status) if isinstance(status, Mapping) else [],
+        "status_field_types": _field_types(status) if isinstance(status, Mapping) else {},
+        "turns": turn_summaries,
+    }
+
+
+def _desktop_identity_relationships(
+    before: Mapping[str, Any], after: Mapping[str, Any]
+) -> dict[str, bool]:
+    before_turns = before.get("turns")
+    after_turns = after.get("turns")
+    _require(isinstance(before_turns, list), "desktop_thread_turns_invalid")
+    _require(isinstance(after_turns, list), "desktop_thread_turns_invalid")
+    before_item_ids = [
+        [item.get("id") for item in turn.get("items", []) if isinstance(item, Mapping)]
+        for turn in before_turns
+        if isinstance(turn, Mapping)
+    ]
+    after_item_ids = [
+        [item.get("id") for item in turn.get("items", []) if isinstance(item, Mapping)]
+        for turn in after_turns
+        if isinstance(turn, Mapping)
+    ]
+    before_types = [
+        [item.get("type") for item in turn.get("items", []) if isinstance(item, Mapping)]
+        for turn in before_turns
+        if isinstance(turn, Mapping)
+    ]
+    after_types = [
+        [item.get("type") for item in turn.get("items", []) if isinstance(item, Mapping)]
+        for turn in after_turns
+        if isinstance(turn, Mapping)
+    ]
+    return {
+        "thread_id_preserved": before.get("id") == after.get("id"),
+        "turn_ids_preserved": [
+            turn.get("id") for turn in before_turns if isinstance(turn, Mapping)
+        ]
+        == [turn.get("id") for turn in after_turns if isinstance(turn, Mapping)],
+        "item_ids_preserved": before_item_ids == after_item_ids,
+        "item_order_preserved": before_types == after_types,
+        "structural_readback_preserved": _thread_structure(before)
+        == _thread_structure(after),
+    }
+
+
+def _read_thread(client: JsonRpcClient, thread_id: str) -> dict[str, Any]:
+    result = response_result(
+        client.request(
+            "thread/read", {"threadId": thread_id, "includeTurns": True}, 30
+        ),
+        "issue392_thread_read",
+    )
+    thread = result.get("thread")
+    _require(isinstance(thread, dict), "desktop_thread_read_invalid")
+    return thread
+
+
+def _capture_desktop_app_lifecycle(executable: Path) -> dict[str, Any]:
+    client_name = "codex_desktop"
+    scenario_name = "desktop_app_collaboration_v2_lifecycle"
+    with IsolatedHome(scenario_name) as isolated:
+        _require(isolated.path is not None, "isolated_home_missing")
+        home = isolated.path
+        workspace = home / "workspace"
+        workspace.mkdir()
+        with FixtureServer(lifecycle=True) as server:
+            _write_config(home, server.server_port, v2=True, app_server=True)
+            environment = _isolated_environment(home)
+            app = start_issue106_app_server(executable, home, environment)
+            client = JsonRpcClient(app)
+            try:
+                initialize(client, 30)
+                thread_id = start_issue106_custom_thread(
+                    client, workspace, MODEL, 30, "issue392_thread_start"
+                )
+                turn_id = turn_started(
+                    client,
+                    thread_id,
+                    "Spawn worker, wait for completion, then finish.",
+                    60,
+                    model=MODEL,
+                )
+                wait_for_turn(client, thread_id, turn_id, 180)
+                before = _read_thread(client, thread_id)
+                notifications = list(client._notifications)
+            finally:
+                client.close()
+                stop_issue106_app_server(app)
+
+            app_restart = start_issue106_app_server(executable, home, environment)
+            restart_client = JsonRpcClient(app_restart)
+            try:
+                initialize(restart_client, 30)
+                resumed = response_result(
+                    restart_client.request(
+                        "thread/resume", {"threadId": thread_id}, 30
+                    ),
+                    "issue392_thread_resume",
+                )
+                resumed_thread = resumed.get("thread")
+                _require(
+                    isinstance(resumed_thread, Mapping),
+                    "desktop_thread_resume_invalid",
+                )
+                after = _read_thread(restart_client, thread_id)
+            finally:
+                restart_client.close()
+                stop_issue106_app_server(app_restart)
+            requests = copy.deepcopy(server.requests)
+
+        _require(isinstance(server.root_thread, str), "root_thread_missing")
+        phases: dict[str, Mapping[str, Any]] = {}
+        root_count = 0
+        child_count = 0
+        for body in requests:
+            thread = (body.get("client_metadata") or {}).get("thread_id")
+            if thread == server.root_thread:
+                root_count += 1
+                phase = (
+                    "root_initial"
+                    if root_count == 1
+                    else "root_after_spawn"
+                    if root_count == 2
+                    else "root_after_wait"
+                )
+            else:
+                child_count += 1
+                phase = "child_initial" if child_count == 1 else f"child_{child_count}"
+            phases[phase] = body
+        _require(
+            set(phases)
+            == {"root_initial", "root_after_spawn", "child_initial", "root_after_wait"},
+            "desktop_app_lifecycle_phase_set_invalid",
+        )
+        relevant_notifications = [
+            summary
+            for notification in notifications
+            if (summary := _notification_summary(notification)) is not None
+        ]
+        result = _base_scenario(
+            client=client_name,
+            home=isolated,
+            request_count=len(requests),
+            process_runs=2,
+        )
+        result["observed"] = {
+            "declaration": _declaration(
+                phases["root_initial"], contract.V2_NAMESPACE
+            ),
+            "requests_by_phase": {
+                phase: _safe_request_shape(body) for phase, body in sorted(phases.items())
+            },
+            "notifications": relevant_notifications,
+            "thread_read_before_restart": _thread_structure(before),
+            "thread_read_after_restart": _thread_structure(after),
+            "resume_result_fields": sorted(resumed),
+            "resume_result_field_types": _field_types(resumed),
+            "identity_relationships": _desktop_identity_relationships(before, after),
+        }
+        return result
+
+
+def _capture_binding(payload: Mapping[str, Any]) -> str:
+    clone = copy.deepcopy(dict(payload))
+    clone.pop("capture_run_binding_sha256", None)
+    encoded = json.dumps(
+        clone, ensure_ascii=True, separators=(",", ":"), sort_keys=True
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def capture(
+    *,
+    cli_executable: Path,
+    desktop_executable: Path,
+    cli_source_root: Path,
+    desktop_source_root: Path,
+) -> dict[str, Any]:
+    runtimes = {
+        "codex_cli": _verify_runtime(
+            client="codex_cli",
+            executable=cli_executable,
+            source_root=cli_source_root,
+            expected_binary_sha256="ae9d865f3d346a1a2a60c4e84775622d74e3e7ef53e0dede9c68b81eab306cca",
+            expected_runtime_version="0.146.1",
+            expected_source_commit="79b4f03d35962b005b007a015113b38930711665",
+            expected_source_blobs=contract.CLI_SOURCE_BLOBS,
+            client_version="0.146.1",
+            source_tag="rust-v0.146.1",
+        ),
+        "codex_desktop": _verify_runtime(
+            client="codex_desktop",
+            executable=desktop_executable,
+            source_root=desktop_source_root,
+            expected_binary_sha256="fb5c760e14cf8fe86e12e49e8a3e7f237af06082d6b9fe1e411e463b7229c916",
+            expected_runtime_version="0.147.0-alpha.6.5",
+            expected_source_commit="618b8e9111da9f57fe380b09d0f6516e3f343536",
+            expected_source_blobs=contract.DESKTOP_SOURCE_BLOBS,
+            client_version="26.803.5235.0",
+            source_tag="rust-v0.147.0-alpha.6.5",
+        ),
+    }
+    scenarios = {
+        "cli_v1_request": _capture_request_scenario(
+            client="codex_cli", executable=cli_executable, version=contract.V1
+        ),
+        "desktop_v1_request": _capture_request_scenario(
+            client="codex_desktop", executable=desktop_executable, version=contract.V1
+        ),
+        "cli_v2_lifecycle": _capture_v2_lifecycle(
+            client="codex_cli", executable=cli_executable
+        ),
+        "desktop_v2_lifecycle": _capture_v2_lifecycle(
+            client="codex_desktop", executable=desktop_executable
+        ),
+        "desktop_app_v2_lifecycle": _capture_desktop_app_lifecycle(
+            desktop_executable
+        ),
+    }
+    payload: dict[str, Any] = {
+        "schema": SCHEMA,
+        "candidate_revision": CANDIDATE_REVISION,
+        "captured_on": date.today().isoformat(),
+        "controls": {
+            "explicit_runtime_capture": True,
+            "fresh_empty_home_per_scenario": True,
+            "workspace_under_isolated_home": True,
+            "protocol_upstream_loopback": True,
+            "plugin_services_disabled": list(DISABLED_FEATURES),
+            "sensitive_environment_credentials_removed": True,
+            "existing_user_home_read": False,
+            "existing_user_task_read": False,
+            "known_crash_task_read": False,
+            "raw_content_or_credentials_retained": False,
+            "raw_paths_or_opaque_identifiers_retained": False,
+        },
+        "runtimes": runtimes,
+        "scenarios": scenarios,
+    }
+    payload["capture_run_binding_sha256"] = _capture_binding(payload)
+    contract.validate_runtime_observations(payload)
+    return payload
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--enable-runtime-capture", action="store_true")
+    parser.add_argument("--cli-exe", type=Path, required=True)
+    parser.add_argument("--desktop-exe", type=Path, required=True)
+    parser.add_argument("--cli-source-root", type=Path, required=True)
+    parser.add_argument("--desktop-source-root", type=Path, required=True)
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUTPUT)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if not args.enable_runtime_capture:
+        print("CAPTURE_DISABLED:enable_runtime_capture_required")
+        return 2
+    try:
+        payload = capture(
+            cli_executable=args.cli_exe.resolve(),
+            desktop_executable=args.desktop_exe.resolve(),
+            cli_source_root=args.cli_source_root.resolve(),
+            desktop_source_root=args.desktop_source_root.resolve(),
+        )
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(
+            json.dumps(payload, ensure_ascii=True, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
+        print(
+            json.dumps(
+                {
+                    "schema": SCHEMA,
+                    "capture_run_binding_sha256": payload[
+                        "capture_run_binding_sha256"
+                    ],
+                },
+                sort_keys=True,
+            )
+        )
+        return 0
+    except CaptureFailure as error:
+        print(f"CAPTURE_FAILED:{error}")
+        return 2
+    except contract.ContractValidationError as error:
+        print(f"CAPTURE_INVALID:{error}")
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -14498,6 +14498,7 @@ def _tool_exposure_policy_for_route(
     request_kind: str,
     raw_provider_probe: bool,
 ) -> ToolExposurePolicy:
+    tool_protocol = _external_tool_protocol(upstream)
     raw_requested_mode = upstream.get("tool_exposure_mode")
     if raw_requested_mode is None:
         if behavior_profile == BEHAVIOR_OFFICIAL_CODEX_APP_HTTP_PASSTHROUGH:
@@ -14536,6 +14537,8 @@ def _tool_exposure_policy_for_route(
         capability_state = CapabilityState.UNQUALIFIED
     elif requested_mode == ToolExposureMode.UNSUPPORTED:
         capability_state = CapabilityState.UNSUPPORTED
+    if tool_protocol == "none":
+        capability_state = CapabilityState.UNSUPPORTED
 
     raw_subset = upstream.get("proven_tool_subset")
     proven_tool_subset = (
@@ -14556,6 +14559,8 @@ def _tool_exposure_policy_for_route(
         # evidence visible while executing the compatibility mode is the
         # behavior-preserving fail-closed boundary.
         effective_mode = ToolExposureMode.CURRENT_COMPATIBILITY
+    if tool_protocol == "none":
+        effective_mode = ToolExposureMode.UNSUPPORTED
     gateway_schema_injection = (
         upstream_name != "official"
         and effective_mode == ToolExposureMode.CURRENT_COMPATIBILITY

--- a/src-python/probe_upstream_format.py
+++ b/src-python/probe_upstream_format.py
@@ -163,7 +163,6 @@ def chat_tool_payload(model: str, *, stream: bool) -> dict[str, Any]:
                 },
             }
         ],
-        "tool_choice": {"type": "function", "function": {"name": "get_weather"}},
     }
 
 
@@ -201,7 +200,6 @@ def chat_tool_history_payload(model: str) -> dict[str, Any]:
                 },
             }
         ],
-        "tool_choice": {"type": "function", "function": {"name": "get_weather"}},
     }
 
 

--- a/tests/test_issue_392_collaboration_contract.py
+++ b/tests/test_issue_392_collaboration_contract.py
@@ -387,6 +387,14 @@ def test_outputs_stream_terminal_and_same_home_shapes_are_complete() -> None:
     assert lifecycle["terminal"]["stream_close_without_completed"] == (
         "rejected_nonzero_exit"
     )
+    assert lifecycle["terminal"]["event_boundaries"] == {
+        "response.completed": {"previous_event": "response.output_item.done"},
+        "response.incomplete": {"previous_event": "response.output_text.delta"},
+        "response.failed": {"previous_event": "response.created"},
+        "stream_close_without_terminal": {
+            "last_observed_event": "response.output_text.delta"
+        },
+    }
     for controls in lifecycle["terminal"]["controls_by_client"].values():
         assert set(controls) == {"incomplete", "failed", "truncated"}
         assert all(

--- a/tests/test_issue_392_collaboration_contract.py
+++ b/tests/test_issue_392_collaboration_contract.py
@@ -13,7 +13,15 @@ import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "build_issue_392_collaboration_contract.py"
+CAPTURE_SCRIPT = ROOT / "scripts" / "capture_issue_392_collaboration_runtime.py"
 ARTIFACT = ROOT / "docs" / "evidence" / "issue-392" / "collaboration-runtime-contract.json"
+OBSERVATIONS = (
+    ROOT
+    / "docs"
+    / "evidence"
+    / "issue-392"
+    / "collaboration-runtime-observations.json"
+)
 
 
 def load_module():
@@ -59,6 +67,13 @@ def test_artifact_binds_both_frozen_runtime_binaries_and_sources() -> None:
         "accepted_request_call_result_agent_message_and_readback"
     )
     assert payload["candidate_revision"] == "be10f62f44b22fa8c84510238250ae11fb3ecab4"
+    observations = json.loads(OBSERVATIONS.read_text(encoding="utf-8"))
+    assert payload["source_observations"] == {
+        "schema": "codexhub.issue392.collaboration-runtime-observations.v1",
+        "canonical_sha256": load_module()._canonical_digest(observations),
+        "capture_run_binding_sha256": observations["capture_run_binding_sha256"],
+        "path": "docs/evidence/issue-392/collaboration-runtime-observations.json",
+    }
 
     by_client = {entry["client"]: entry for entry in payload["runtimes"]}
     assert by_client["codex_cli"] | {
@@ -198,6 +213,9 @@ def test_selection_matches_exact_types_encryption_and_frozen_v2_spawn_fields() -
         lambda: by_name["wait_agent"]["parameters"]["properties"]["timeout_ms"].__setitem__(
             "type", "string"
         ),
+        lambda: by_name["list_agents"]["parameters"]["properties"].__setitem__(
+            "description", {"type": "number"}
+        ),
     ):
         candidate = copy.deepcopy(value)
         candidate_by_name = {child["name"]: child for child in candidate["tools"]}
@@ -208,6 +226,16 @@ def test_selection_matches_exact_types_encryption_and_frozen_v2_spawn_fields() -
             match="namespace_child_parameter_schema_mismatch",
         ):
             module.classify_request({"tool_choice": "auto", "tools": [candidate]})
+
+    annotated = declaration(module, module.V2)
+    annotated_by_name = {child["name"]: child for child in annotated["tools"]}
+    annotated_by_name["list_agents"]["parameters"]["properties"]["path_prefix"][
+        "description"
+    ] = "dynamic annotation"
+    assert (
+        module.classify_request({"tool_choice": "auto", "tools": [annotated]})
+        == module.V2
+    )
 
 
 def test_selection_fails_closed_on_mixed_duplicate_and_conflicting_signals() -> None:
@@ -224,6 +252,31 @@ def test_selection_fails_closed_on_mixed_duplicate_and_conflicting_signals() -> 
     ):
         module.classify_request(
             {"tool_choice": "auto", "tools": [v2, copy.deepcopy(v2)]}
+        )
+    with pytest.raises(
+        module.ContractValidationError, match="collaboration_marker_duplicate_or_mixed"
+    ):
+        module.classify_request(
+            {
+                "tool_choice": "auto",
+                "tools": [
+                    v2,
+                    {
+                        "type": "function",
+                        "name": "spawn_agent",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                ],
+            }
+        )
+    with pytest.raises(
+        module.ContractValidationError, match="collaboration_marker_duplicate_or_mixed"
+    ):
+        module.classify_request(
+            {
+                "tool_choice": "auto",
+                "tools": [v2, {"type": "function", "name": "collaboration"}],
+            }
         )
     with pytest.raises(
         module.ContractValidationError, match="collaboration_version_signal_unexpected"
@@ -306,20 +359,174 @@ def test_outputs_stream_terminal_and_same_home_shapes_are_complete() -> None:
     assert readback["clients"] == ["codex_cli", "codex_desktop"]
     assert readback["call_output_order_preserved"] is True
     assert readback["agent_message_author_recipient_and_content_kind_preserved"] is True
+    assert all(readback["cli_identity_relationships"].values())
+    assert all(readback["desktop_identity_relationships"].values())
+    assert all(readback["desktop_app_identity_relationships"].values())
+
+    replay = lifecycle["request_replay_envelopes"]["codex_cli"]
+    root_after_wait = replay["root_after_wait"]["collaboration_items"]
+    assert [item["type"] for item in root_after_wait] == [
+        "function_call",
+        "function_call_output",
+        "function_call",
+        "function_call_output",
+        "agent_message",
+    ]
+    assert root_after_wait[0]["fields"] == [
+        "arguments",
+        "call_id",
+        "id",
+        "name",
+        "namespace",
+        "type",
+    ]
+    assert root_after_wait[1]["fields"] == ["call_id", "id", "output", "type"]
+    assert root_after_wait[-1]["fields"] == [
+        "author",
+        "content",
+        "id",
+        "recipient",
+        "type",
+    ]
+
+
+def test_runtime_observations_bind_unique_homes_and_exact_readback_envelopes() -> None:
+    module = load_module()
+    observations = json.loads(OBSERVATIONS.read_text(encoding="utf-8"))
+    module.validate_runtime_observations(observations)
+    assert observations["capture_run_binding_sha256"] == module._capture_run_binding(
+        observations
+    )
+
+    scenarios = observations["scenarios"]
+    bindings = [scenario["home_binding_sha256"] for scenario in scenarios.values()]
+    assert len(bindings) == 5
+    assert len(set(bindings)) == 5
+    assert all(re.fullmatch(r"[0-9a-f]{64}", binding) for binding in bindings)
+    assert all(
+        scenario["fresh_empty_home_before_marker"] is True
+        and scenario["workspace_created_under_home"] is True
+        for scenario in scenarios.values()
+    )
+
+    cli = scenarios["cli_v2_lifecycle"]["observed"]
+    assert set(cli["requests_by_phase"]) == {
+        "root_initial",
+        "root_after_spawn",
+        "child_initial",
+        "root_after_wait",
+        "restart_replay",
+    }
+    assert cli["requests_by_phase"]["restart_replay"]["collaboration_items"] == (
+        cli["requests_by_phase"]["root_after_wait"]["collaboration_items"]
+    )
+    root_rollout = next(
+        entry for entry in cli["rollout_readback"] if entry["role"] == "root"
+    )
+    assert {record["record_type"] for record in root_rollout["metadata_records"]} == {
+        "session_meta",
+        "turn_context",
+    }
+    assert all(
+        record["multi_agent_version"] == "v2"
+        for record in root_rollout["metadata_records"]
+    )
+
+    desktop_app = scenarios["desktop_app_v2_lifecycle"]["observed"]
+    assert desktop_app["thread_read_before_restart"] == desktop_app[
+        "thread_read_after_restart"
+    ]
+    pairs = {
+        (entry["method"], entry.get("item_type"))
+        for entry in desktop_app["notifications"]
+    }
+    assert {
+        ("item/started", "agentMessage"),
+        ("item/agentMessage/delta", None),
+        ("item/completed", "agentMessage"),
+        ("item/started", "collabAgentToolCall"),
+        ("item/completed", "collabAgentToolCall"),
+        ("item/started", "subAgentActivity"),
+        ("item/completed", "subAgentActivity"),
+    }.issubset(pairs)
+
+
+@pytest.mark.parametrize("case", ["mutation", "deletion", "loss", "home", "replay"])
+def test_runtime_observation_mutation_deletion_loss_and_replay_fail_closed(
+    case: str,
+) -> None:
+    module = load_module()
+    observations = json.loads(OBSERVATIONS.read_text(encoding="utf-8"))
+    candidate = copy.deepcopy(observations)
+    if case == "mutation":
+        candidate["scenarios"]["cli_v2_lifecycle"]["observed"][
+            "requests_by_phase"
+        ]["root_after_spawn"]["collaboration_items"][0]["namespace"] = (
+            "multi_agent_v1"
+        )
+    elif case == "deletion":
+        del candidate["scenarios"]["desktop_v1_request"]
+    elif case == "loss":
+        candidate["scenarios"]["desktop_v2_lifecycle"]["observed"][
+            "identity_relationships"
+        ]["function_call_item_ids_preserved"] = False
+    elif case == "home":
+        candidate["scenarios"]["desktop_v1_request"]["home_binding_sha256"] = (
+            candidate["scenarios"]["cli_v1_request"]["home_binding_sha256"]
+        )
+    else:
+        replay = candidate["scenarios"]["cli_v2_lifecycle"]["observed"][
+            "requests_by_phase"
+        ]["restart_replay"]["collaboration_items"]
+        replay[0], replay[1] = replay[1], replay[0]
+    candidate["capture_run_binding_sha256"] = module._capture_run_binding(candidate)
+    with pytest.raises(module.ContractValidationError):
+        module.validate_runtime_observations(candidate)
+
+
+def test_capture_runner_requires_explicit_enable_switch(tmp_path: Path) -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(CAPTURE_SCRIPT),
+            "--cli-exe",
+            str(tmp_path / "cli"),
+            "--desktop-exe",
+            str(tmp_path / "desktop"),
+            "--cli-source-root",
+            str(tmp_path / "cli-source"),
+            "--desktop-source-root",
+            str(tmp_path / "desktop-source"),
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 2
+    assert result.stdout.strip() == "CAPTURE_DISABLED:enable_runtime_capture_required"
 
 
 def test_contract_is_sanitized_and_never_references_existing_tasks() -> None:
-    text = ARTIFACT.read_text(encoding="utf-8")
-    assert "019fb82d-f601-7812-a339-e9c5f675e2e8" not in text
-    assert not re.search(
-        r"\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b",
-        text,
-        re.IGNORECASE,
-    )
-    lowered = text.lower()
-    for forbidden in ("api_key", "bearer ", "prompt_text", "task_path_value", "call_fixture"):
-        assert forbidden not in lowered
-    scope = json.loads(text)["capture_scope"]
+    contract_text = ARTIFACT.read_text(encoding="utf-8")
+    observation_text = OBSERVATIONS.read_text(encoding="utf-8")
+    for text in (contract_text, observation_text):
+        assert "019fb82d-f601-7812-a339-e9c5f675e2e8" not in text
+        assert not re.search(
+            r"\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b",
+            text,
+            re.IGNORECASE,
+        )
+        lowered = text.lower()
+        for forbidden in (
+            "api_key",
+            "bearer ",
+            "prompt_text",
+            "task_path_value",
+            "call_fixture",
+        ):
+            assert forbidden not in lowered
+    scope = json.loads(contract_text)["capture_scope"]
     assert scope["existing_user_home_read"] is False
     assert scope["existing_user_task_read"] is False
     assert scope["known_crash_task_read"] is False

--- a/tests/test_issue_392_collaboration_contract.py
+++ b/tests/test_issue_392_collaboration_contract.py
@@ -355,6 +355,48 @@ def test_outputs_stream_terminal_and_same_home_shapes_are_complete() -> None:
         "response.incomplete",
         "response.failed",
     ]
+    event_shapes = lifecycle["function_call_stream"]["event_shapes"]
+    assert event_shapes["response.output_item.added"]["field_types"] == {
+        "item": "object",
+        "output_index": "number",
+        "type": "string",
+    }
+    assert event_shapes["response.function_call_arguments.delta"]["field_types"] == {
+        "delta": "string",
+        "item_id": "string",
+        "output_index": "number",
+        "type": "string",
+    }
+    terminal_shapes = lifecycle["terminal"]["event_shapes"]
+    assert terminal_shapes["response.completed"]["response_fields"] == [
+        "id",
+        "model",
+        "object",
+        "output",
+        "status",
+        "usage",
+    ]
+    assert terminal_shapes["response.incomplete"]["response_fields"] == [
+        "error",
+        "id",
+        "incomplete_details",
+        "object",
+        "status",
+    ]
+    assert terminal_shapes["response.failed"]["response_fields"] == ["error", "id"]
+    assert lifecycle["terminal"]["stream_close_without_completed"] == (
+        "rejected_nonzero_exit"
+    )
+    for controls in lifecycle["terminal"]["controls_by_client"].values():
+        assert set(controls) == {"incomplete", "failed", "truncated"}
+        assert all(
+            control["client_disposition"] == "rejected_nonzero_exit"
+            and control["completed_event_present"] is False
+            for control in controls.values()
+        )
+        assert controls["incomplete"]["terminal_event_present"] is True
+        assert controls["failed"]["terminal_event_present"] is True
+        assert controls["truncated"]["terminal_event_present"] is False
     readback = lifecycle["same_home_readback"]
     assert readback["clients"] == ["codex_cli", "codex_desktop"]
     assert readback["call_output_order_preserved"] is True
@@ -400,14 +442,17 @@ def test_runtime_observations_bind_unique_homes_and_exact_readback_envelopes() -
 
     scenarios = observations["scenarios"]
     bindings = [scenario["home_binding_sha256"] for scenario in scenarios.values()]
-    assert len(bindings) == 5
-    assert len(set(bindings)) == 5
+    assert len(bindings) == 11
+    assert len(set(bindings)) == 11
     assert all(re.fullmatch(r"[0-9a-f]{64}", binding) for binding in bindings)
     assert all(
         scenario["fresh_empty_home_before_marker"] is True
         and scenario["workspace_created_under_home"] is True
         for scenario in scenarios.values()
     )
+    controls = observations["controls"]
+    assert controls["external_config_environment_removed"] == ["CODEX_CONFIG"]
+    assert controls["xdg_roots_under_isolated_home"] is True
 
     cli = scenarios["cli_v2_lifecycle"]["observed"]
     assert set(cli["requests_by_phase"]) == {
@@ -451,7 +496,10 @@ def test_runtime_observations_bind_unique_homes_and_exact_readback_envelopes() -
     }.issubset(pairs)
 
 
-@pytest.mark.parametrize("case", ["mutation", "deletion", "loss", "home", "replay"])
+@pytest.mark.parametrize(
+    "case",
+    ["mutation", "deletion", "loss", "home", "replay", "identity", "stream"],
+)
 def test_runtime_observation_mutation_deletion_loss_and_replay_fail_closed(
     case: str,
 ) -> None:
@@ -474,11 +522,29 @@ def test_runtime_observation_mutation_deletion_loss_and_replay_fail_closed(
         candidate["scenarios"]["desktop_v1_request"]["home_binding_sha256"] = (
             candidate["scenarios"]["cli_v1_request"]["home_binding_sha256"]
         )
-    else:
+    elif case == "replay":
         replay = candidate["scenarios"]["cli_v2_lifecycle"]["observed"][
             "requests_by_phase"
         ]["restart_replay"]["collaboration_items"]
         replay[0], replay[1] = replay[1], replay[0]
+    elif case == "identity":
+        call = candidate["scenarios"]["cli_v2_lifecycle"]["observed"][
+            "requests_by_phase"
+        ]["root_after_spawn"]["collaboration_items"][0]
+        call["fields"].remove("id")
+        del call["field_types"]["id"]
+    else:
+        sequences = candidate["scenarios"]["cli_v2_lifecycle"]["observed"][
+            "served_event_sequences"
+        ]
+        delta = next(
+            event
+            for sequence in sequences
+            for event in sequence["events"]
+            if event["type"] == "response.function_call_arguments.delta"
+        )
+        delta["fields"].remove("item_id")
+        del delta["field_types"]["item_id"]
     candidate["capture_run_binding_sha256"] = module._capture_run_binding(candidate)
     with pytest.raises(module.ContractValidationError):
         module.validate_runtime_observations(candidate)

--- a/tests/test_issue_392_collaboration_contract.py
+++ b/tests/test_issue_392_collaboration_contract.py
@@ -1,0 +1,344 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+from pathlib import Path
+import re
+import subprocess
+import sys
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "build_issue_392_collaboration_contract.py"
+ARTIFACT = ROOT / "docs" / "evidence" / "issue-392" / "collaboration-runtime-contract.json"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("issue392_contract", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def declaration(module, version: str) -> dict[str, object]:
+    namespace = module.V1_NAMESPACE if version == module.V1 else module.V2_NAMESPACE
+    children = []
+    for name, parameter_schema in module.EXPECTED_PARAMETER_SCHEMAS[version].items():
+        parameters = copy.deepcopy(parameter_schema)
+        if not parameters["required"]:
+            del parameters["required"]
+        children.append(
+            {
+                "type": "function",
+                "name": name,
+                "description": "sanitized",
+                "strict": False,
+                "parameters": parameters,
+            }
+        )
+    return {
+        "type": "namespace",
+        "name": namespace,
+        "description": "sanitized",
+        "tools": children,
+    }
+
+
+def request(module, version: str) -> dict[str, object]:
+    return {"tool_choice": "auto", "tools": [declaration(module, version)]}
+
+
+def test_artifact_binds_both_frozen_runtime_binaries_and_sources() -> None:
+    payload = json.loads(ARTIFACT.read_text(encoding="utf-8"))
+    assert payload["schema"] == "codexhub.issue392.collaboration-runtime-contract.v1"
+    assert payload["qualification_status"] == (
+        "accepted_request_call_result_agent_message_and_readback"
+    )
+    assert payload["candidate_revision"] == "be10f62f44b22fa8c84510238250ae11fb3ecab4"
+
+    by_client = {entry["client"]: entry for entry in payload["runtimes"]}
+    assert by_client["codex_cli"] | {
+        "source_files": by_client["codex_cli"]["source_files"],
+        "observations": by_client["codex_cli"]["observations"],
+    } == by_client["codex_cli"]
+    assert by_client["codex_cli"]["client_version"] == "0.146.1"
+    assert by_client["codex_cli"]["source_commit"] == "79b4f03d35962b005b007a015113b38930711665"
+    assert by_client["codex_cli"]["binary_sha256"] == (
+        "ae9d865f3d346a1a2a60c4e84775622d74e3e7ef53e0dede9c68b81eab306cca"
+    )
+    assert by_client["codex_desktop"]["client_version"] == "26.803.5235.0"
+    assert by_client["codex_desktop"]["runtime_version"] == "0.147.0-alpha.6.5"
+    assert by_client["codex_desktop"]["source_commit"] == "618b8e9111da9f57fe380b09d0f6516e3f343536"
+    assert by_client["codex_desktop"]["binary_sha256"] == (
+        "fb5c760e14cf8fe86e12e49e8a3e7f237af06082d6b9fe1e411e463b7229c916"
+    )
+    for runtime in by_client.values():
+        assert set(runtime["source_files"]) == {
+            "multi_agent_tool_schemas",
+            "multi_agent_output_serialization",
+            "v2_spawn_handler",
+            "v2_message_handler",
+            "v2_wait_handler",
+            "v2_interrupt_handler",
+            "v2_list_handler",
+            "tool_planning_and_namespace_override",
+            "version_selection_and_namespace_default",
+            "responses_request_and_tool_choice",
+            "responses_stream_parser",
+            "responses_items",
+            "agent_message_and_rollout",
+            "desktop_thread_items",
+            "desktop_event_mapping",
+        }
+        assert set(runtime["observations"].values()).issubset(
+            {"observed", "not_applicable"}
+        )
+    assert by_client["codex_cli"]["observations"][
+        "desktop_thread_items_and_notifications"
+    ] == "not_applicable"
+    assert by_client["codex_desktop"]["observations"][
+        "desktop_thread_items_and_notifications"
+    ] == "observed"
+
+
+def test_selection_uses_complete_namespace_schema_not_shared_names() -> None:
+    module = load_module()
+    v1 = declaration(module, module.V1)
+    v2 = declaration(module, module.V2)
+
+    assert module.classify_request({"tool_choice": "auto", "tools": [v1]}) == module.V1
+    assert module.classify_request({"tool_choice": "auto", "tools": [v2]}) == module.V2
+
+    direct_functions = [
+        child for child in copy.deepcopy(v2["tools"]) if isinstance(child, dict)
+    ]
+    with pytest.raises(module.ContractValidationError, match="collaboration_marker_missing"):
+        module.classify_request({"tool_choice": "auto", "tools": direct_functions})
+    with pytest.raises(module.ContractValidationError, match="collaboration_marker_missing"):
+        module.classify_request(
+            {
+                "tool_choice": "auto",
+                "tools": [
+                    {
+                        "type": "function",
+                        "name": "spawn_agent",
+                        "parameters": {"type": "object", "properties": {}},
+                    }
+                ]
+            }
+        )
+
+
+@pytest.mark.parametrize(
+    ("mutate", "code"),
+    [
+        (lambda module, value: value["tools"].pop(), "namespace_child_set_invalid"),
+        (
+            lambda module, value: value["tools"].append(copy.deepcopy(value["tools"][0])),
+            "namespace_child_duplicate",
+        ),
+        (
+            lambda module, value: value["tools"][0].__setitem__("type", "custom"),
+            "namespace_child_type_invalid",
+        ),
+        (
+            lambda module, value: value["tools"][0]["parameters"].__setitem__(
+                "required", ["unknown"]
+            ),
+            "namespace_child_parameter_schema_mismatch",
+        ),
+        (
+            lambda module, value: value["tools"][0]["parameters"].__setitem__(
+                "additionalProperties", True
+            ),
+            "namespace_child_parameter_schema_mismatch",
+        ),
+        (
+            lambda module, value: value["tools"][0].__setitem__("strict", True),
+            "namespace_child_strict_invalid",
+        ),
+        (
+            lambda module, value: value["tools"][0].__setitem__(
+                "output_schema", {"type": "object"}
+            ),
+            "namespace_child_fields_invalid",
+        ),
+    ],
+)
+def test_selection_fails_closed_on_incomplete_or_mutated_schema(mutate, code: str) -> None:
+    module = load_module()
+    value = declaration(module, module.V2)
+    mutate(module, value)
+    with pytest.raises(module.ContractValidationError, match=code):
+        module.classify_request({"tool_choice": "auto", "tools": [value]})
+
+
+def test_selection_matches_exact_types_encryption_and_frozen_v2_spawn_fields() -> None:
+    module = load_module()
+    value = declaration(module, module.V2)
+    by_name = {child["name"]: child for child in value["tools"]}
+
+    assert "service_tier" not in by_name["spawn_agent"]["parameters"]["properties"]
+    assert by_name["spawn_agent"]["parameters"]["properties"]["message"] == {
+        "type": "string",
+        "encrypted": True,
+    }
+
+    for mutate in (
+        lambda: by_name["spawn_agent"]["parameters"]["properties"].__setitem__(
+            "service_tier", {"type": "string"}
+        ),
+        lambda: by_name["spawn_agent"]["parameters"]["properties"]["message"].pop(
+            "encrypted"
+        ),
+        lambda: by_name["wait_agent"]["parameters"]["properties"]["timeout_ms"].__setitem__(
+            "type", "string"
+        ),
+    ):
+        candidate = copy.deepcopy(value)
+        candidate_by_name = {child["name"]: child for child in candidate["tools"]}
+        by_name = candidate_by_name
+        mutate()
+        with pytest.raises(
+            module.ContractValidationError,
+            match="namespace_child_parameter_schema_mismatch",
+        ):
+            module.classify_request({"tool_choice": "auto", "tools": [candidate]})
+
+
+def test_selection_fails_closed_on_mixed_duplicate_and_conflicting_signals() -> None:
+    module = load_module()
+    v1 = declaration(module, module.V1)
+    v2 = declaration(module, module.V2)
+
+    with pytest.raises(
+        module.ContractValidationError, match="collaboration_marker_duplicate_or_mixed"
+    ):
+        module.classify_request({"tool_choice": "auto", "tools": [v1, v2]})
+    with pytest.raises(
+        module.ContractValidationError, match="collaboration_marker_duplicate_or_mixed"
+    ):
+        module.classify_request(
+            {"tool_choice": "auto", "tools": [v2, copy.deepcopy(v2)]}
+        )
+    with pytest.raises(
+        module.ContractValidationError, match="collaboration_version_signal_unexpected"
+    ):
+        module.classify_request(
+            {
+                "tool_choice": "auto",
+                "tools": [v2],
+                "features": {"multi_agent_version": "v1"},
+            }
+        )
+    with pytest.raises(
+        module.ContractValidationError, match="collaboration_version_signal_unexpected"
+    ):
+        module.classify_request(
+            {
+                "tool_choice": "auto",
+                "tools": [v1],
+                "metadata": {"multi_agent_version": "v1"},
+            }
+        )
+    with pytest.raises(module.ContractValidationError, match="tool_choice_invalid"):
+        module.classify_request({"tool_choice": "required", "tools": [v2]})
+
+
+def test_task_identity_and_protocol_layers_are_assigned_to_exact_layers() -> None:
+    payload = json.loads(ARTIFACT.read_text(encoding="utf-8"))
+    v2 = payload["protocols"]["collaboration_v2"]
+    assert v2["result"]["spawn_identity"] == "task_name"
+    assert v2["canonical_task_identity"] == "agent_path_serialized_as_task_name"
+    assert v2["continuation_id_field"] == "not_present"
+    assert v2["call"]["identity_fields"] == ["id", "call_id"]
+
+    layers = payload["protocol_layers"]
+    assert layers["client_dispatch"]["recipient_namespace"] == "collaboration"
+    assert layers["client_dispatch"]["wire_discriminator_by_itself"] is False
+    assert layers["responses_declaration_and_call"]["namespace"] == "collaboration"
+    assert layers["model_input_agent_message"] == {
+        "type": "agent_message",
+        "fields": ["type", "id", "author", "recipient", "content"],
+        "task_identity_fields": ["author", "recipient"],
+        "content_variants": {
+            "input_text": ["type", "text"],
+            "encrypted_content": ["type", "encrypted_content"],
+        },
+        "source_optional_field": "internal_chat_message_metadata_passthrough",
+        "function_result": False,
+    }
+    assert layers["rollout_metadata"]["sent_as_request_metadata"] is False
+    assert set(layers["desktop_app"]["thread_items"]) == {
+        "agentMessage",
+        "collabAgentToolCall",
+        "subAgentActivity",
+    }
+    assert layers["desktop_app"]["wire_item_equivalent"] is False
+
+
+def test_outputs_stream_terminal_and_same_home_shapes_are_complete() -> None:
+    payload = json.loads(ARTIFACT.read_text(encoding="utf-8"))
+    v2 = payload["protocols"]["collaboration_v2"]
+    output_schemas = v2["result"]["tool_output_schemas"]
+    assert output_schemas["spawn_agent"]["required"] == ["task_name"]
+    assert output_schemas["wait_agent"]["required"] == ["message", "timed_out"]
+    assert output_schemas["send_message"] is None
+    assert output_schemas["followup_task"] is None
+
+    lifecycle = payload["wire_lifecycle"]
+    assert lifecycle["function_call_stream"]["event_order"] == [
+        "response.output_item.added",
+        "response.function_call_arguments.delta",
+        "response.function_call_arguments.done",
+        "response.output_item.done",
+    ]
+    assert lifecycle["terminal"]["events"] == [
+        "response.completed",
+        "response.incomplete",
+        "response.failed",
+    ]
+    readback = lifecycle["same_home_readback"]
+    assert readback["clients"] == ["codex_cli", "codex_desktop"]
+    assert readback["call_output_order_preserved"] is True
+    assert readback["agent_message_author_recipient_and_content_kind_preserved"] is True
+
+
+def test_contract_is_sanitized_and_never_references_existing_tasks() -> None:
+    text = ARTIFACT.read_text(encoding="utf-8")
+    assert "019fb82d-f601-7812-a339-e9c5f675e2e8" not in text
+    assert not re.search(
+        r"\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b",
+        text,
+        re.IGNORECASE,
+    )
+    lowered = text.lower()
+    for forbidden in ("api_key", "bearer ", "prompt_text", "task_path_value", "call_fixture"):
+        assert forbidden not in lowered
+    scope = json.loads(text)["capture_scope"]
+    assert scope["existing_user_home_read"] is False
+    assert scope["existing_user_task_read"] is False
+    assert scope["known_crash_task_read"] is False
+
+
+def test_builder_check_and_negative_reconciliation() -> None:
+    module = load_module()
+    payload = json.loads(ARTIFACT.read_text(encoding="utf-8"))
+    assert module.reconcile_contract(payload) == {"reconciled": True, "mismatches": []}
+    for case in ("mutation", "deletion", "loss"):
+        report = module.reconcile_contract(module.replay_contract(payload, case))
+        assert report["reconciled"] is False
+        assert report["mismatches"] == ["contract_content_invalid"]
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--check"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/test_issue_64_collaboration_inventory.py
+++ b/tests/test_issue_64_collaboration_inventory.py
@@ -4,6 +4,8 @@ import copy
 import importlib.util
 import json
 from pathlib import Path
+import subprocess
+import sys
 
 import pytest
 
@@ -11,7 +13,9 @@ import pytest
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "build_issue_64_collaboration_inventory.py"
 INVENTORY = ROOT / "docs" / "evidence" / "issue-64" / "collaboration-v1-v2-inventory.json"
-SOURCE_CONTRACT = ROOT / "docs" / "evidence" / "issue-62" / "codex-0.146-source-contract.json"
+SOURCE_CONTRACT = (
+    ROOT / "docs" / "evidence" / "issue-392" / "collaboration-runtime-contract.json"
+)
 
 
 def load_inventory_module():
@@ -22,294 +26,250 @@ def load_inventory_module():
     return module
 
 
-def test_inventory_is_bound_to_the_accepted_0146_source_contract() -> None:
+def test_inventory_is_bound_to_the_accepted_issue392_runtime_contract() -> None:
     payload = json.loads(INVENTORY.read_text(encoding="utf-8"))
 
     assert payload["schema"] == "codexhub.issue64.collaboration-v1-v2.v1"
     assert payload["artifact_kind"] == "collaboration_v1_v2_inventory"
-    assert payload["qualification_status"] == "structural_boundary_only"
+    assert payload["qualification_status"] == "superseded_by_issue392_exact_runtime_contract"
     assert payload["candidate_identity"] == {
-        "cli_version": "0.146.0",
-        "source_commit": "e363b08c9175ac1cbe5893615dd2cb9ddf95043b",
-        "source_tag": "rust-v0.146.0",
-        "source_commit_status": "published_attested",
-        "source_capture_status": "not_observed",
-        "source_contract_file": "codex-0.146-source-contract.json",
+        "candidate_revision": "be10f62f44b22fa8c84510238250ae11fb3ecab4",
+        "cli_version": "0.146.1",
+        "cli_source_commit": "79b4f03d35962b005b007a015113b38930711665",
+        "desktop_version": "26.803.5235.0",
+        "desktop_runtime_version": "0.147.0-alpha.6.5",
+        "desktop_source_commit": "618b8e9111da9f57fe380b09d0f6516e3f343536",
+        "source_capture_status": "observed",
+        "source_contract_file": "collaboration-runtime-contract.json",
     }
+    assert payload["evidence_binding"]["basis"] == (
+        "accepted_issue392_exact_runtime_contract"
+    )
+    assert len(payload["evidence_binding"]["source_contract"]["sha256"]) == 64
 
 
-def test_inventory_covers_bounded_v1_and_v2_shapes() -> None:
+def test_inventory_covers_exact_v1_and_v2_shapes() -> None:
     payload = json.loads(INVENTORY.read_text(encoding="utf-8"))
     protocols = {entry["id"]: entry for entry in payload["protocols"]}
 
     assert set(protocols) == {"collaboration_v1", "collaboration_v2"}
     for protocol in protocols.values():
-        assert set(protocol) == {
-            "id",
-            "namespace",
-            "owner",
-            "executor",
-            "status",
-            "shape_provenance",
-            "declaration",
-            "call",
-            "result",
-            "history",
-            "stream",
-            "terminal_error",
-            "isolation",
-        }
         assert protocol["owner"] == protocol["executor"] == "codex_client"
-        assert protocol["declaration"]["fields"]
-        assert protocol["call"]["fields"]
-        assert protocol["result"]["fields"]
-        assert protocol["history"]["identity_fields"]
-        assert protocol["stream"]["event_order"]
-        assert protocol["terminal_error"]["terminal_events"]
+        assert protocol["declaration"]["wire_type"] == "namespace"
+        assert protocol["declaration"]["child_wire_type"] == "function"
+        assert protocol["call"]["wire_type"] == "function_call"
+        assert protocol["result"]["wire_type"] == "function_call_output"
+        assert protocol["stream"]["event_order"] == [
+            "response.output_item.added",
+            "response.function_call_arguments.delta",
+            "response.function_call_arguments.done",
+            "response.output_item.done",
+        ]
+        assert protocol["stream"]["terminal_events"] == [
+            "response.completed",
+            "response.incomplete",
+            "response.failed",
+        ]
 
     v1 = protocols["collaboration_v1"]
     assert v1["namespace"] == "multi_agent_v1"
-    assert v1["shape_provenance"] == {
-        "shape_kind": "current_gateway_compatibility_surface",
-        "source": "src-python/codex_proxy.py#MULTI_AGENT_DISCOVERY_TOOLS",
-        "official_cli_capture_status": "not_observed",
-    }
-    assert v1["declaration"]["wire_type"] == "namespace"
-    assert v1["declaration"]["child_wire_type"] == "function"
     assert v1["declaration"]["tool_names"] == [
-        "spawn_agent",
-        "send_input",
-        "wait_agent",
         "close_agent",
         "resume_agent",
+        "send_input",
+        "spawn_agent",
+        "wait_agent",
     ]
-    assert v1["history"]["continuation_identity"] == "agent_id"
-    assert v1["call"]["argument_fields"]["spawn_agent"] == {
-        "required": ["agent_type"],
-        "optional": ["fork_context", "message"],
-    }
-    assert v1["call"]["argument_fields"]["resume_agent"] == {
-        "required": ["id"],
-        "optional": [],
-    }
-    assert "task_path" in v1["isolation"]["forbidden_v2_fields"]
-    assert "fork_turns" in v1["isolation"]["forbidden_v2_fields"]
+    assert v1["result"]["spawn_identity"] == "agent_id"
+    assert v1["result"]["tool_output_schemas"]["spawn_agent"]["required"] == [
+        "agent_id",
+        "nickname",
+    ]
 
     v2 = protocols["collaboration_v2"]
     assert v2["namespace"] == "collaboration"
-    assert v2["shape_provenance"] == {
-        "shape_kind": "accepted_structural_contract",
-        "source": "accepted_issue_62_source_contract_and_repository_evidence",
-        "official_cli_capture_status": "not_observed",
-    }
     assert v2["declaration"]["tool_names"] == [
-        "spawn_agent",
-        "send_message",
         "followup_task",
-        "wait_agent",
         "interrupt_agent",
         "list_agents",
+        "send_message",
+        "spawn_agent",
+        "wait_agent",
     ]
-    assert v2["history"]["continuation_identity"] == "task_path"
-    assert v2["call"]["argument_fields"]["spawn_agent"]["optional"] == [
-        "fork_turns",
+    spawn = v2["declaration"]["argument_fields"]["spawn_agent"]
+    assert spawn["required"] == ["message", "task_name"]
+    assert spawn["optional"] == [
         "agent_type",
+        "fork_turns",
         "model",
         "reasoning_effort",
     ]
-    assert "agent_id" in v2["isolation"]["forbidden_v1_fields"]
-    assert "close_agent" in v2["isolation"]["forbidden_v1_tools"]
+    assert "service_tier" not in spawn["normalized_parameter_schema"]["properties"]
+    assert v2["result"]["spawn_identity"] == "task_name"
+    assert v2["history"]["same_home_restart_readback"] == "observed"
 
 
-def test_boundary_requires_exact_namespace_and_tool_discriminator() -> None:
+def test_boundary_requires_namespace_and_known_tool_before_argument_checks() -> None:
     module = load_inventory_module()
 
-    assert module.classify_boundary({"namespace": "multi_agent_v1", "name": "spawn_agent"}) == "collaboration_v1"
-    assert module.classify_boundary({"namespace": "collaboration", "name": "followup_task"}) == "collaboration_v2"
-    assert module.classify_boundary({
-        "type": "function_call",
-        "namespace": "collaboration",
-        "name": "spawn_agent",
-        "item_id": "<opaque>",
-        "call_id": "<opaque>",
-        "arguments": {"task_name": "<opaque>", "message": "<redacted>"},
-    }) == "collaboration_v2"
+    assert (
+        module.classify_boundary(
+            {"namespace": "multi_agent_v1", "name": "spawn_agent"}
+        )
+        == "collaboration_v1"
+    )
+    assert (
+        module.classify_boundary(
+            {"namespace": "collaboration", "name": "followup_task"}
+        )
+        == "collaboration_v2"
+    )
+    assert (
+        module.classify_boundary(
+            {
+                "type": "function_call",
+                "namespace": "collaboration",
+                "name": "spawn_agent",
+                "item_id": "<opaque>",
+                "call_id": "<opaque>",
+                "arguments": {"task_name": "<opaque>", "message": "<redacted>"},
+            }
+        )
+        == "collaboration_v2"
+    )
 
-    for value, code in (
+    cases = (
         ({"name": "spawn_agent"}, "boundary_discriminator_missing"),
         ({"namespace": "unknown", "name": "spawn_agent"}, "boundary_namespace_unknown"),
-        ({"namespace": "collaboration", "name": "unknown_tool"}, "boundary_tool_unknown"),
-        ({"namespace": "multi_agent_v1", "name": "spawn_agent", "arguments": "{}"}, "boundary_arguments_invalid"),
-        ({"namespace": "multi_agent_v1", "name": "spawn_agent", "arguments": []}, "boundary_arguments_invalid"),
-        ({"namespace": "multi_agent_v1", "name": "spawn_agent", "arguments": None}, "boundary_arguments_invalid"),
-        ({"namespace": "multi_agent_v1", "name": "spawn_agent", "tool_name": "wait_agent"}, "boundary_discriminator_conflict"),
-        ({"namespace": "multi_agent_v1", "name": "spawn_agent", "unexpected": True}, "boundary_fields_unknown"),
-        ({"namespace": "multi_agent_v1", "name": "spawn_agent", "arguments": {"random": True}}, "boundary_arguments_unknown"),
-        ({"namespace": "collaboration", "name": "wait_agent", "arguments": {"random": True}}, "boundary_arguments_unknown"),
-        ({"namespace": "multi_agent_v1", "name": "spawn_agent", "tools": []}, "boundary_v1_v2_field_mixed"),
-        ({"namespace": "collaboration", "name": "spawn_agent", "parameters": {}}, "boundary_v1_v2_field_mixed"),
-    ):
+        ({"namespace": "collaboration", "name": "unknown"}, "boundary_tool_unknown"),
+        (
+            {"namespace": "collaboration", "name": "spawn_agent", "arguments": "{}"},
+            "boundary_arguments_invalid",
+        ),
+        (
+            {
+                "namespace": "multi_agent_v1",
+                "name": "spawn_agent",
+                "tool_name": "wait_agent",
+            },
+            "boundary_discriminator_conflict",
+        ),
+        (
+            {"namespace": "multi_agent_v1", "name": "spawn_agent", "unexpected": True},
+            "boundary_fields_unknown",
+        ),
+        (
+            {
+                "namespace": "collaboration",
+                "name": "wait_agent",
+                "arguments": {"random": True},
+            },
+            "boundary_arguments_unknown",
+        ),
+    )
+    for value, code in cases:
         with pytest.raises(module.InventoryValidationError, match=code):
             module.classify_boundary(value)
 
 
-def test_boundary_rejects_v1_v2_mixed_fields_before_repair() -> None:
+def test_boundary_rejects_v1_v2_mixed_fields() -> None:
     module = load_inventory_module()
-
-    mixed_v1 = {
-        "namespace": "multi_agent_v1",
-        "name": "spawn_agent",
-        "arguments": {"message": "<redacted>", "task_path": "<opaque>"},
-    }
-    mixed_v2 = {
-        "namespace": "collaboration",
-        "name": "spawn_agent",
-        "arguments": {"message": "<redacted>", "fork_context": False, "agent_id": "<opaque>"},
-    }
-
-    for value, code in ((mixed_v1, "boundary_v1_v2_field_mixed"), (mixed_v2, "boundary_v1_v2_field_mixed")):
-        with pytest.raises(module.InventoryValidationError, match=code):
+    for value in (
+        {
+            "namespace": "multi_agent_v1",
+            "name": "spawn_agent",
+            "arguments": {"message": "<redacted>", "task_name": "child"},
+        },
+        {
+            "namespace": "collaboration",
+            "name": "spawn_agent",
+            "arguments": {"message": "<redacted>", "fork_context": False},
+        },
+    ):
+        with pytest.raises(
+            module.InventoryValidationError, match="boundary_v1_v2_field_mixed"
+        ):
             module.classify_boundary(value)
 
 
-def test_inventory_declares_adapter_requirements_without_implementing_lifecycle() -> None:
+def test_inventory_declares_exact_boundary_and_adapter_requirements() -> None:
     payload = json.loads(INVENTORY.read_text(encoding="utf-8"))
-    requirements = payload["adapter_requirements"]
+    boundary = payload["boundary"]
+    assert boundary["matching_policy"] == "complete_namespace_and_child_schema"
+    assert boundary["shared_tool_name_policy"] == "never_classify_from_child_name_alone"
+    assert boundary["request_metadata_version_field"] == (
+        "absent_in_both_frozen_runtimes"
+    )
+    assert boundary["tool_choice"] == "auto"
+    for field in (
+        "unknown_action",
+        "missing_action",
+        "duplicate_action",
+        "conflicting_action",
+        "mixed_v1_v2_action",
+    ):
+        assert boundary[field] == "fail_closed"
 
+    requirements = payload["adapter_requirements"]
     assert requirements["owner"] == "codex_client"
     assert requirements["adaptation_owner"] == "codexhub_gateway"
-    assert "namespace_to_function" in requirements["requirements"]
-    assert "injective_request_scoped_aliases" in requirements["requirements"]
-    assert "preserve_task_path_identity" in requirements["requirements"]
-    assert "preserve_continuation_id_and_fork_turns" in requirements["requirements"]
-    assert "preserve_inverse_declaration_call_result_history_mapping" in requirements["requirements"]
-    assert requirements["protocol_shape_decisions"]["collaboration_v2"] == {
-        "shape_kind": "accepted_structural_contract",
-        "namespace_to_function": "optional_only_when_selected_protocol_lacks_namespace",
-        "native_namespace": "may_pass_when_selected_protocol_supports_namespace",
-        "official_cli_capture_status": "not_observed",
-        "inverse_mapping": "request_scoped_and_lossless",
-        "preserved_fields": ["task_path", "continuation_id", "task_name", "fork_turns"],
-    }
+    assert requirements["native_namespace"] == "pass_without_semantic_mutation"
+    assert "preserve_call_and_item_identity" in requirements["requirements"]
+    assert "preserve_agent_message_author_and_recipient" in requirements["requirements"]
     assert "execute_tools" in requirements["forbidden_gateway_actions"]
     assert "schedule_agents" in requirements["forbidden_gateway_actions"]
-    assert "forge_results" in requirements["forbidden_gateway_actions"]
-    assert payload["deferred_qualification"] == [
-        "full_spawn_message_followup_wait_interrupt_list_lifecycle",
-        "restart_and_cold_root_resume",
-        "cross_home_topology_and_history",
-    ]
+    assert "rewrite_history" in requirements["forbidden_gateway_actions"]
 
 
-def test_inventory_reconciliation_fails_closed_on_unknown_or_mutated_shape() -> None:
+def test_inventory_reconciliation_and_replay_fail_closed() -> None:
     module = load_inventory_module()
     payload = json.loads(INVENTORY.read_text(encoding="utf-8"))
 
-    assert module.reconcile_inventory(payload, source_contract_path=SOURCE_CONTRACT) == {
-        "reconciled": True,
-        "mismatches": [],
-    }
-
-    unknown = copy.deepcopy(payload)
-    unknown["protocols"][0]["new_field"] = "must-fail"
-    report = module.reconcile_inventory(unknown, source_contract_path=SOURCE_CONTRACT)
-    assert report["reconciled"] is False
-    assert any("protocol_fields_invalid" in item for item in report["mismatches"])
-
-    ambiguous = copy.deepcopy(payload)
-    ambiguous["boundary"]["discriminator_fields"] = ["name"]
-    report = module.reconcile_inventory(ambiguous, source_contract_path=SOURCE_CONTRACT)
-    assert report["reconciled"] is False
-    assert any("boundary_discriminator_fields_invalid" in item for item in report["mismatches"])
-
-    for field, value, code in (
-        ("pre_exposure_stage", "after_repair", "boundary_pre_exposure_stage_invalid"),
-        ("mixed_v1_v2_action", "guess", "boundary_mixed_action_invalid"),
-    ):
-        mutated = copy.deepcopy(payload)
-        mutated["boundary"][field] = value
-        report = module.reconcile_inventory(mutated, source_contract_path=SOURCE_CONTRACT)
-        assert report["reconciled"] is False
-        assert any(code in item for item in report["mismatches"])
-
-
-def test_inventory_replay_controls_are_negative() -> None:
-    module = load_inventory_module()
-    payload = json.loads(INVENTORY.read_text(encoding="utf-8"))
+    assert module.reconcile_inventory(
+        payload, source_contract_path=SOURCE_CONTRACT
+    ) == {"reconciled": True, "mismatches": []}
 
     for case in ("mutation", "deletion", "loss"):
-        replay = module.replay_inventory(payload, case)
-        report = module.reconcile_inventory(replay, source_contract_path=SOURCE_CONTRACT)
-        assert report["reconciled"] is False, case
-        assert report["mismatches"], case
+        report = module.reconcile_inventory(
+            module.replay_inventory(payload, case), source_contract_path=SOURCE_CONTRACT
+        )
+        assert report == {"reconciled": False, "mismatches": ["inventory_content_invalid"]}
+
+    mutated = copy.deepcopy(payload)
+    mutated["protocols"][1]["stream"]["event_order"] = []
+    assert module.reconcile_inventory(
+        mutated, source_contract_path=SOURCE_CONTRACT
+    ) == {"reconciled": False, "mismatches": ["inventory_content_invalid"]}
 
 
-def test_source_contract_validator_rejects_provenance_and_family_mutations() -> None:
+def test_source_contract_validation_and_digest_are_reproducible(tmp_path: Path) -> None:
     module = load_inventory_module()
     source = json.loads(SOURCE_CONTRACT.read_text(encoding="utf-8"))
+    module._validate_source_contract(source)
 
-    for key, value, code in (
-        ("schema_version", 2, "source_contract_schema_invalid"),
-        ("qualification_status", "observed", "source_contract_qualification_invalid"),
+    mutated = copy.deepcopy(source)
+    mutated["selection_contract"]["markers"]["collaboration_v2"]["namespace"] = (
+        "wrong"
+    )
+    with pytest.raises(
+        module.InventoryValidationError, match="source_contract_content_invalid"
     ):
-        mutated = copy.deepcopy(source)
-        mutated[key] = value
-        with pytest.raises(module.InventoryValidationError, match=code):
-            module._validate_source_contract(mutated)
-
-    mutated = copy.deepcopy(source)
-    mutated["runtime_wire_surface"]["declaration_family_order"] = ["namespace"]
-    with pytest.raises(module.InventoryValidationError, match="source_contract_family_order_invalid"):
         module._validate_source_contract(mutated)
 
-    mutated = copy.deepcopy(source)
-    mutated["runtime_wire_surface"]["declaration_families"][0]["observed"] = True
-    with pytest.raises(module.InventoryValidationError, match="source_contract_families_invalid"):
-        module._validate_source_contract(mutated)
-
-    mutated = copy.deepcopy(source)
-    mutated["runtime_wire_surface"]["response_shape"]["terminal_events"] = ["response.completed"]
-    with pytest.raises(module.InventoryValidationError, match="source_contract_surface_digest_invalid"):
-        module._validate_source_contract(mutated)
-
-
-def test_source_contract_digest_normalizes_lf_and_crlf(tmp_path: Path) -> None:
-    module = load_inventory_module()
     canonical = SOURCE_CONTRACT.read_bytes().replace(b"\r\n", b"\n")
     lf_path = tmp_path / "source-lf.json"
     crlf_path = tmp_path / "source-crlf.json"
     lf_path.write_bytes(canonical)
     crlf_path.write_bytes(canonical.replace(b"\n", b"\r\n"))
-
     assert module._sha256_file(lf_path) == module._sha256_file(crlf_path)
-    assert module._sha256_file(lf_path) == module.EXPECTED_SOURCE_CONTRACT_SHA256
-
-    mutated = copy.deepcopy(json.loads(SOURCE_CONTRACT.read_text(encoding="utf-8")))
-    mutated["qualification_status"] = "observed"
-    mutated_path = tmp_path / "codex-0.146-source-contract.json"
-    mutated_path.write_text(json.dumps(mutated), encoding="utf-8", newline="\n")
-    with pytest.raises(module.InventoryValidationError, match="source_contract_qualification_invalid"):
-        module._build_inventory(mutated_path)
-
-    reformatted_path = tmp_path / "reformatted-source-contract.json"
-    reformatted_path.write_text(json.dumps(json.loads(SOURCE_CONTRACT.read_text(encoding="utf-8"))), encoding="utf-8", newline="\n")
-    with pytest.raises(module.InventoryValidationError, match="source_contract_digest_invalid"):
-        module._build_inventory(reformatted_path)
 
 
-def test_nested_protocol_schema_mutations_fail_closed() -> None:
-    module = load_inventory_module()
-    payload = json.loads(INVENTORY.read_text(encoding="utf-8"))
-
-    mutations = (
-        ("stream_terminal_events", lambda value: value["protocols"][0]["stream"].__setitem__("terminal_events", [])),
-        ("call_wire_type", lambda value: value["protocols"][0]["call"].__setitem__("wire_type", "unknown")),
-        ("declaration_discriminator", lambda value: value["protocols"][0]["declaration"].__setitem__("discriminator", {"namespace": "wrong", "tool_field": "name"})),
-        ("history_identity_fields", lambda value: value["protocols"][1]["history"].__setitem__("identity_fields", ["task_path"])),
+def test_builder_check_succeeds() -> None:
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--check"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
     )
-    for case, mutate in mutations:
-        replay = copy.deepcopy(payload)
-        mutate(replay)
-        report = module.reconcile_inventory(replay, source_contract_path=SOURCE_CONTRACT)
-        assert report["reconciled"] is False, case
-        assert any("protocol_schema_invalid" in item for item in report["mismatches"]), case
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/test_probe_upstream_format.py
+++ b/tests/test_probe_upstream_format.py
@@ -249,6 +249,67 @@ class ProbeUpstreamFormatTests(unittest.TestCase):
             ],
         )
 
+    def test_probe_detects_chat_tools_when_named_choice_conflicts_with_thinking(self) -> None:
+        def fake_request_json(
+            base_url: str,
+            api_key: str,
+            path: str,
+            *,
+            method: str = "GET",
+            payload: dict | None = None,
+            timeout: int,
+        ):
+            if path == "/models":
+                return True, 200, {"data": [{"id": "k3"}]}, None
+            if path == "/responses":
+                return False, 404, None, "not found"
+            if path == "/messages":
+                return True, 200, {"id": "msg_1", "type": "message", "content": []}, None
+            if path == "/chat/completions" and payload and payload.get("tools"):
+                if isinstance(payload.get("tool_choice"), dict):
+                    return (
+                        False,
+                        400,
+                        None,
+                        "tool_choice 'specified' is incompatible with thinking enabled",
+                    )
+                return (
+                    True,
+                    200,
+                    {
+                        "choices": [
+                            {
+                                "finish_reason": "tool_calls",
+                                "message": {
+                                    "content": None,
+                                    "tool_calls": [
+                                        {
+                                            "id": "call_weather",
+                                            "type": "function",
+                                            "function": {
+                                                "name": "get_weather",
+                                                "arguments": '{"location":"Paris"}',
+                                            },
+                                        }
+                                    ],
+                                },
+                            }
+                        ]
+                    },
+                    None,
+                )
+            if path == "/chat/completions":
+                return True, 200, {"choices": [{"message": {"content": "OK"}}]}, None
+            raise AssertionError(f"unexpected probe path: {path}")
+
+        with patch("probe_upstream_format.request_json", side_effect=fake_request_json):
+            result = probe("https://api.example.test/coding", "test-key", "k3", 2)
+
+        self.assertTrue(result["chat_tool_ok"])
+        self.assertTrue(result["chat_tool_history_ok"])
+        self.assertEqual(result["recommended_format"], UPSTREAM_FORMAT_CHAT)
+        self.assertEqual(result["recommended_tool_protocol"], "chat_tools")
+
     def test_anthropic_message_shape_detection_is_lightweight(self) -> None:
         self.assertTrue(anthropic_text_ok({"id": "msg_1", "type": "message", "content": []}))
         self.assertTrue(anthropic_text_ok({"content": [{"type": "text", "text": "OK"}]}))

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1247,6 +1247,35 @@ class RoutingTests(unittest.TestCase):
                 self.assertFalse(plan.official_http_passthrough)
                 self.assertFalse(plan.transparent_metered)
 
+    def test_route_plan_reports_disabled_tool_protocol_without_schema_injection(self):
+        plan = codex_proxy.route_plan_for_request(
+            {
+                "name": "custom_endpoint",
+                "auth": "api_key",
+                "upstream_model": "thinking-model",
+                "upstream_format": "chat_completions",
+                "tool_protocol": "none",
+            },
+            {"client_id": "codex-app"},
+            inbound_format="responses",
+            model_requested="custom-endpoint/thinking-model",
+        )
+
+        self.assertEqual(plan.primary_attempt.tool_protocol, "none")
+        self.assertEqual(
+            plan.tool_exposure.capability_state,
+            codex_proxy.CapabilityState.UNSUPPORTED,
+        )
+        self.assertEqual(
+            plan.tool_exposure.effective_mode,
+            codex_proxy.ToolExposureMode.UNSUPPORTED,
+        )
+        self.assertFalse(plan.tool_exposure.gateway_schema_injection)
+        self.assertNotIn(
+            codex_proxy.RouteMutation.HARD_CODED_SCHEMA_INJECTION,
+            plan.named_mutations,
+        )
+
     def test_route_plan_and_nested_tool_policy_are_immutable(self):
         plan = codex_proxy.route_plan_for_request(
             {


### PR DESCRIPTION
## What changed

- stop Chat tool probes from forcing a specified tool choice, so thinking-enabled providers such as Kimi can expose their native tool protocol
- freeze the Codex CLI 0.146.1 and Desktop 26.803.5235.0 Collaboration V1/V2 request-visible contract
- add isolated runtime capture evidence for request, function stream, terminal controls, history/replay, agent_message, and Desktop restart/readback
- make the contract builder consume and fail closed on the committed runtime observations
- update the #64 inventory and ADR evidence

## Why

The previous Chat probe could persist `tool_protocol=none` after a thinking model rejected forced tool choice. The initial #392 artifact also encoded runtime observations as builder constants rather than reproducible, Home-bound captures.

## Impact

Beta4 now includes the Kimi probe fix and a reviewed Collaboration contract baseline for #282. Gateway production routing/adaptation is unchanged by #392.

## Validation

- runtime capture: frozen CLI/Desktop binaries, source commits/blobs, 11 fresh isolated Homes
- focused: 32 passed
- Python core: 2250 passed, 1 skipped, 484 subtests passed
- contract and inventory reconciliation: passed
- Standards review: passed
- Spec review: passed
- git diff --check: passed

Closes #392

