### PR TITLE
test: preserve agents config through overlay lifecycle

### DIFF
--- a/tests/test_config_overlay.py
+++ b/tests/test_config_overlay.py
@@ -76,6 +76,8 @@ class ConfigOverlayTests(unittest.TestCase):
         concurrency_key: str = "max_concurrent_threads_per_session",
         feature_mode: str = "structured_v2",
         include_defaults: bool = True,
+        agents_enabled: bool = True,
+        structured_v2_enabled: bool = True,
     ) -> str:
         lines = [
             'model = "volc/glm-5.2"',
@@ -88,31 +90,32 @@ class ConfigOverlayTests(unittest.TestCase):
             "hooks = true",
         ]
         if feature_mode == "scalar_v1":
-            lines.append("multi_agent_v2 = false")
+            lines.append("multi_agent_v2 = false # explicit user-owned V1 choice")
         elif feature_mode not in {"missing", "structured_v2"}:
             raise ValueError(f"unsupported feature mode: {feature_mode}")
         lines.extend(
             [
                 "",
-                "[agents]",
-                "enabled = true",
-                f"{concurrency_key} = 7",
-                'future_scheduler_policy = "preserve-me"',
+                "[agents] # user-owned collaboration settings",
+                f"enabled  = {'true' if agents_enabled else 'false'} # preserve spacing and comment",
+                f"{concurrency_key} = 7  # preserve canonical or legacy spelling",
+                "",
+                "future_scheduler_policy = 'preserve-me'",
             ]
         )
         if include_defaults:
             lines.extend(
                 [
-                    'default_subagent_model = "openai/gpt-5.6-terra"',
-                    'default_subagent_reasoning_effort = "xhigh"',
+                    "default_subagent_model = 'openai/gpt-5.6-terra'",
+                    'default_subagent_reasoning_effort = "xhigh" # user choice',
                 ]
             )
         lines.extend(
             [
                 "",
-                "[agents.reviewer]",
+                "[agents.reviewer] # nested user role",
                 'description = "Reviews lifecycle changes"',
-                'config_file = "agents/reviewer.toml"',
+                "config_file = 'agents/reviewer.toml' # keep relative text",
                 'future_role_key = "preserve-me-too"',
                 "",
                 "[agents.reviewer.runtime]",
@@ -123,12 +126,27 @@ class ConfigOverlayTests(unittest.TestCase):
             lines.extend(
                 [
                     "",
-                    "[features.multi_agent_v2]",
-                    "enabled = true",
+                    "[features.multi_agent_v2] # structured user choice",
+                    f"enabled = {'true' if structured_v2_enabled else 'false'}",
                     "non_code_mode_only = false",
                 ]
             )
         return "\n".join([*lines, ""])
+
+    def _table_family_text(self, text: str, root: str) -> str:
+        headers = list(re.finditer(r"(?m)^\s*\[([^\]]+)\]", text))
+        start_position = next(
+            match.start()
+            for match in headers
+            if match.group(1).strip() == root
+        )
+        end_position = len(text)
+        for match in headers:
+            section = match.group(1).strip()
+            if match.start() > start_position and section != root and not section.startswith(f"{root}."):
+                end_position = match.start()
+                break
+        return text[start_position:end_position].rstrip("\r\n")
 
     def _assert_agents_semantics_preserved(self, original: str, active: str) -> None:
         original_config = tomllib.loads(original)
@@ -151,6 +169,20 @@ class ConfigOverlayTests(unittest.TestCase):
         original_v2 = original_config["features"].get("multi_agent_v2")
         active_v2 = active_config["features"].get("multi_agent_v2")
         self.assertEqual(active_v2, original_v2)
+        self.assertEqual(
+            self._table_family_text(active, "agents"),
+            self._table_family_text(original, "agents"),
+        )
+        if isinstance(original_v2, dict):
+            self.assertEqual(
+                self._table_family_text(active, "features.multi_agent_v2"),
+                self._table_family_text(original, "features.multi_agent_v2"),
+            )
+        elif original_v2 is not None:
+            original_v2_line = next(
+                line for line in original.splitlines() if line.lstrip().startswith("multi_agent_v2")
+            )
+            self.assertIn(original_v2_line, active.splitlines())
         self.assertEqual(active.count("[agents]"), 1)
         self.assertEqual(active.count("[agents.reviewer]"), 1)
         self.assertEqual(active.count("[agents.reviewer.runtime]"), 1)
@@ -312,12 +344,34 @@ class ConfigOverlayTests(unittest.TestCase):
 
     def test_agents_config_survives_apply_restart_readback_and_restore(self):
         cases = (
-            ("canonical_missing_v2", "max_concurrent_threads_per_session", "missing", False),
-            ("legacy_alias_v1", "max_threads", "scalar_v1", True),
-            ("canonical_structured_v2", "max_concurrent_threads_per_session", "structured_v2", True),
+            ("canonical_missing_v2", "max_concurrent_threads_per_session", "missing", False, False, False),
+            ("legacy_alias_v1", "max_threads", "scalar_v1", True, True, False),
+            (
+                "canonical_structured_v2_enabled",
+                "max_concurrent_threads_per_session",
+                "structured_v2",
+                True,
+                True,
+                True,
+            ),
+            (
+                "canonical_structured_v2_disabled",
+                "max_concurrent_threads_per_session",
+                "structured_v2",
+                True,
+                False,
+                False,
+            ),
         )
 
-        for name, concurrency_key, feature_mode, include_defaults in cases:
+        for (
+            name,
+            concurrency_key,
+            feature_mode,
+            include_defaults,
+            agents_enabled,
+            structured_v2_enabled,
+        ) in cases:
             with self.subTest(name=name), tempfile.TemporaryDirectory() as tmpdir:
                 tmp = Path(tmpdir)
                 config_path = tmp / "config.toml"
@@ -327,6 +381,8 @@ class ConfigOverlayTests(unittest.TestCase):
                     concurrency_key=concurrency_key,
                     feature_mode=feature_mode,
                     include_defaults=include_defaults,
+                    agents_enabled=agents_enabled,
+                    structured_v2_enabled=structured_v2_enabled,
                 )
                 config_path.write_text(original, encoding="utf-8", newline="")
 

--- a/tests/test_config_overlay.py
+++ b/tests/test_config_overlay.py
@@ -5,11 +5,15 @@ import hashlib
 import io
 import re
 import json
+import subprocess
+import sys
 import tempfile
+import tomllib
 from pathlib import Path
 import unittest
 from unittest.mock import patch
 
+import config_overlay
 from config_overlay import (
     MARKER_BEGIN,
     MARKER_END,
@@ -66,6 +70,91 @@ class DeterministicCompactionReplay:
 
 
 class ConfigOverlayTests(unittest.TestCase):
+    def _agents_config(
+        self,
+        *,
+        concurrency_key: str = "max_concurrent_threads_per_session",
+        feature_mode: str = "structured_v2",
+        include_defaults: bool = True,
+    ) -> str:
+        lines = [
+            'model = "volc/glm-5.2"',
+            'model_provider = "openai"',
+            'model_reasoning_effort = "high"',
+            "model_context_window = 1000000",
+            "model_auto_compact_token_limit = 900000",
+            "",
+            "[features]",
+            "hooks = true",
+        ]
+        if feature_mode == "scalar_v1":
+            lines.append("multi_agent_v2 = false")
+        elif feature_mode not in {"missing", "structured_v2"}:
+            raise ValueError(f"unsupported feature mode: {feature_mode}")
+        lines.extend(
+            [
+                "",
+                "[agents]",
+                "enabled = true",
+                f"{concurrency_key} = 7",
+                'future_scheduler_policy = "preserve-me"',
+            ]
+        )
+        if include_defaults:
+            lines.extend(
+                [
+                    'default_subagent_model = "openai/gpt-5.6-terra"',
+                    'default_subagent_reasoning_effort = "xhigh"',
+                ]
+            )
+        lines.extend(
+            [
+                "",
+                "[agents.reviewer]",
+                'description = "Reviews lifecycle changes"',
+                'config_file = "agents/reviewer.toml"',
+                'future_role_key = "preserve-me-too"',
+                "",
+                "[agents.reviewer.runtime]",
+                "future_nested_flag = true",
+            ]
+        )
+        if feature_mode == "structured_v2":
+            lines.extend(
+                [
+                    "",
+                    "[features.multi_agent_v2]",
+                    "enabled = true",
+                    "non_code_mode_only = false",
+                ]
+            )
+        return "\n".join([*lines, ""])
+
+    def _assert_agents_semantics_preserved(self, original: str, active: str) -> None:
+        original_config = tomllib.loads(original)
+        active_config = tomllib.loads(active)
+
+        self.assertEqual(active_config["agents"], original_config["agents"])
+        self.assertEqual(active_config["model"], original_config["model"])
+        self.assertEqual(
+            active_config["model_reasoning_effort"],
+            original_config["model_reasoning_effort"],
+        )
+        self.assertEqual(
+            active_config["model_context_window"],
+            original_config["model_context_window"],
+        )
+        self.assertEqual(
+            active_config["model_auto_compact_token_limit"],
+            original_config["model_auto_compact_token_limit"],
+        )
+        original_v2 = original_config["features"].get("multi_agent_v2")
+        active_v2 = active_config["features"].get("multi_agent_v2")
+        self.assertEqual(active_v2, original_v2)
+        self.assertEqual(active.count("[agents]"), 1)
+        self.assertEqual(active.count("[agents.reviewer]"), 1)
+        self.assertEqual(active.count("[agents.reviewer.runtime]"), 1)
+
     def _official_budget_catalog(
         self,
         root: Path,
@@ -220,6 +309,190 @@ class ConfigOverlayTests(unittest.TestCase):
 
             self.assertEqual(config_path.read_text(encoding="utf-8"), original)
             self.assertFalse(backup_path.exists())
+
+    def test_agents_config_survives_apply_restart_readback_and_restore(self):
+        cases = (
+            ("canonical_missing_v2", "max_concurrent_threads_per_session", "missing", False),
+            ("legacy_alias_v1", "max_threads", "scalar_v1", True),
+            ("canonical_structured_v2", "max_concurrent_threads_per_session", "structured_v2", True),
+        )
+
+        for name, concurrency_key, feature_mode, include_defaults in cases:
+            with self.subTest(name=name), tempfile.TemporaryDirectory() as tmpdir:
+                tmp = Path(tmpdir)
+                config_path = tmp / "config.toml"
+                backup_path = tmp / "config.backup.toml"
+                catalog_path = tmp / "catalog.json"
+                original = self._agents_config(
+                    concurrency_key=concurrency_key,
+                    feature_mode=feature_mode,
+                    include_defaults=include_defaults,
+                )
+                config_path.write_text(original, encoding="utf-8", newline="")
+
+                apply_overlay(config_path, backup_path, catalog_path, "http://127.0.0.1:9099")
+                first_readback = config_path.read_text(encoding="utf-8")
+                self._assert_agents_semantics_preserved(original, first_readback)
+                self.assertEqual(backup_path.read_text(encoding="utf-8"), original)
+                if feature_mode == "missing":
+                    self.assertNotIn("multi_agent_v2", first_readback)
+                    self.assertNotIn("default_subagent_model", first_readback)
+                    self.assertNotIn("default_subagent_reasoning_effort", first_readback)
+
+                apply_overlay(config_path, backup_path, catalog_path, "http://127.0.0.1:9099")
+                restarted_readback = config_path.read_text(encoding="utf-8")
+                self._assert_agents_semantics_preserved(original, restarted_readback)
+                self.assertEqual(backup_path.read_text(encoding="utf-8"), original)
+                if feature_mode == "missing":
+                    self.assertNotIn("multi_agent_v2", restarted_readback)
+
+                restore_overlay(config_path, backup_path)
+                self.assertEqual(config_path.read_text(encoding="utf-8"), original)
+                self.assertFalse(backup_path.exists())
+
+    def test_agents_config_survives_stable_developer_takeover_in_both_directions(self):
+        original = self._agents_config()
+
+        for first_owner, takeover_owner in (("release", "beta"), ("beta", "release")):
+            with self.subTest(first_owner=first_owner), tempfile.TemporaryDirectory() as tmpdir:
+                tmp = Path(tmpdir)
+                config_path = tmp / "config.toml"
+                first_backup = tmp / f"{first_owner}.backup.toml"
+                takeover_backup = tmp / f"{takeover_owner}.backup.toml"
+                catalog_path = tmp / "catalog.json"
+                config_path.write_text(original, encoding="utf-8", newline="")
+
+                apply_overlay(
+                    config_path,
+                    first_backup,
+                    catalog_path,
+                    "http://127.0.0.1:9099",
+                    owner=first_owner,
+                )
+                first_active = config_path.read_text(encoding="utf-8")
+                self._assert_agents_semantics_preserved(original, first_active)
+
+                apply_overlay(
+                    config_path,
+                    takeover_backup,
+                    catalog_path,
+                    "http://127.0.0.1:9109",
+                    owner=takeover_owner,
+                    takeover=True,
+                )
+                self._assert_agents_semantics_preserved(
+                    original,
+                    config_path.read_text(encoding="utf-8"),
+                )
+
+                restore_overlay(config_path, takeover_backup)
+                self.assertEqual(config_path.read_text(encoding="utf-8"), first_active)
+                restore_overlay(config_path, first_backup)
+                self.assertEqual(config_path.read_text(encoding="utf-8"), original)
+
+    def test_agents_config_recovers_after_interrupted_takeover_publication(self):
+        original = self._agents_config(feature_mode="scalar_v1")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path = tmp / "config.toml"
+            release_backup = tmp / "release.backup.toml"
+            beta_backup = tmp / "beta.backup.toml"
+            catalog_path = tmp / "catalog.json"
+            config_path.write_text(original, encoding="utf-8", newline="")
+
+            apply_overlay(
+                config_path,
+                release_backup,
+                catalog_path,
+                "http://127.0.0.1:9099",
+                owner="release",
+            )
+            release_active = config_path.read_text(encoding="utf-8")
+
+            real_atomic_write = config_overlay.atomic_write_text
+
+            def interrupt_live_publication(path: Path, text: str, *, encoding: str = "utf-8") -> None:
+                if path == config_path:
+                    raise OSError("simulated interrupted takeover publication")
+                real_atomic_write(path, text, encoding=encoding)
+
+            with patch("config_overlay.atomic_write_text", interrupt_live_publication):
+                with self.assertRaisesRegex(OSError, "interrupted takeover publication"):
+                    apply_overlay(
+                        config_path,
+                        beta_backup,
+                        catalog_path,
+                        "http://127.0.0.1:9109",
+                        owner="beta",
+                        takeover=True,
+                    )
+
+            self.assertEqual(config_path.read_text(encoding="utf-8"), release_active)
+            self.assertEqual(beta_backup.read_text(encoding="utf-8"), release_active)
+
+            apply_overlay(
+                config_path,
+                beta_backup,
+                catalog_path,
+                "http://127.0.0.1:9109",
+                owner="beta",
+                takeover=True,
+            )
+            self._assert_agents_semantics_preserved(original, config_path.read_text(encoding="utf-8"))
+            restore_overlay(config_path, beta_backup)
+            self.assertEqual(config_path.read_text(encoding="utf-8"), release_active)
+            restore_overlay(config_path, release_backup)
+            self.assertEqual(config_path.read_text(encoding="utf-8"), original)
+
+    def test_agents_config_survives_fresh_process_apply_and_restore(self):
+        original = self._agents_config()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config_path = tmp / "config.toml"
+            backup_path = tmp / "config.backup.toml"
+            catalog_path = tmp / "catalog.json"
+            script_path = Path(__file__).parents[1] / "src-python" / "config_overlay.py"
+            config_path.write_text(original, encoding="utf-8", newline="")
+
+            apply_command = [
+                sys.executable,
+                str(script_path),
+                "apply",
+                "--config",
+                str(config_path),
+                "--backup",
+                str(backup_path),
+                "--catalog",
+                str(catalog_path),
+                "--base-url",
+                "http://127.0.0.1:9099",
+            ]
+            subprocess.run(apply_command, check=True, capture_output=True, text=True)
+            first_readback = config_path.read_text(encoding="utf-8")
+            self._assert_agents_semantics_preserved(original, first_readback)
+
+            subprocess.run(apply_command, check=True, capture_output=True, text=True)
+            restarted_readback = config_path.read_text(encoding="utf-8")
+            self._assert_agents_semantics_preserved(original, restarted_readback)
+            self.assertEqual(backup_path.read_text(encoding="utf-8"), original)
+
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(script_path),
+                    "restore",
+                    "--config",
+                    str(config_path),
+                    "--backup",
+                    str(backup_path),
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(config_path.read_text(encoding="utf-8"), original)
 
     def test_apply_and_restore_overlay_preserves_user_owned_catalog_path(self):
         original = (


### PR DESCRIPTION
## Summary
- add a representative user-owned `[agents]` fixture with nested roles, `config_file`, default subagent model/reasoning, canonical concurrency and `max_threads` alias, and unknown future keys
- prove scalar V1, structured V2 enabled/disabled, and missing V2 choices survive without CodexHub choosing or enabling them
- cover apply/reapply, fresh-process restart/readback, Stable↔Developer takeover, interrupted takeover recovery, and exact restore
- keep production overlay code unchanged because the focused regression matrix proves the current implementation already preserves the contract

## Verification
- `C:\Users\noirb\AppData\Local\Programs\Python\Python313\python.exe -m pytest -q tests/test_config_overlay.py` — 69 passed, 11 subtests passed
- Python core — 2254 passed, 1 skipped, 490 subtests passed
- `python scripts/report_quality_gates.py` — report-only, exit 0, parse errors 0
- `git diff --check origin/dev...HEAD` — passed
- independent Standards review — PASS
- independent Spec review — PASS

Closes #199