### PR TITLE
Beta4: implement exact runtime-derived Collaboration V2 Responses lifecycle

### DIFF
--- a/scripts/build_issue_392_collaboration_contract.py
+++ b/scripts/build_issue_392_collaboration_contract.py
@@ -14,7 +14,19 @@ import hashlib
 import json
 from pathlib import Path
 import re
+import sys
 from typing import Any, Mapping, Sequence
+
+
+_SRC_PYTHON = Path(__file__).resolve().parents[1] / "src-python"
+if str(_SRC_PYTHON) not in sys.path:
+    sys.path.insert(0, str(_SRC_PYTHON))
+
+from collaboration_runtime_contract import (  # noqa: E402
+    CollaborationContractError as _ProductionContractError,
+    classify_collaboration_request as _classify_production_request,
+    classify_collaboration_tools as _classify_production_tools,
+)
 
 
 SCHEMA = "codexhub.issue392.collaboration-runtime-contract.v1"
@@ -1870,63 +1882,20 @@ def _normalize_schema(value: Any) -> Any:
 
 
 def classify_tools(tools: Sequence[Any]) -> str:
-    """Classify the exact frozen request declaration surface, or fail closed."""
+    """Delegate declaration classification to the production #392 contract."""
 
-    _require(isinstance(tools, Sequence) and not isinstance(tools, (str, bytes)), "tools_invalid")
-    candidates = _namespace_candidates(tools)
-    _require(candidates, "collaboration_marker_missing")
-    conflicts = _conflicting_collaboration_markers(tools, candidates)
-    _require(not conflicts, "collaboration_marker_duplicate_or_mixed")
-    namespaces = [candidate.get("name") for candidate in candidates]
-    _require(len(candidates) == 1, "collaboration_marker_duplicate_or_mixed")
-    candidate = candidates[0]
-    namespace = namespaces[0]
-    version = V1 if namespace == V1_NAMESPACE else V2
-    expected_names = set(V1_TOOLS if version == V1 else V2_TOOLS)
-    _require(
-        set(candidate) == {"type", "name", "description", "tools"},
-        "namespace_fields_invalid",
-    )
-    _require(isinstance(candidate.get("description"), str), "namespace_description_invalid")
-    children = candidate.get("tools")
-    _require(isinstance(children, list), "namespace_children_invalid")
-    _require(all(isinstance(child, Mapping) for child in children), "namespace_child_invalid")
-    names = [child.get("name") for child in children]
-    _require(all(child.get("type") == "function" for child in children), "namespace_child_type_invalid")
-    _require(all(isinstance(child.get("name"), str) for child in children), "namespace_child_name_invalid")
-    _require(len(names) == len(set(names)), "namespace_child_duplicate")
-    _require(set(names) == expected_names, "namespace_child_set_invalid")
-    for child in children:
-        name = child["name"]
-        _require(
-            set(child) == {"type", "name", "description", "strict", "parameters"},
-            "namespace_child_fields_invalid",
-        )
-        _require(isinstance(child.get("description"), str), "namespace_child_description_invalid")
-        _require(child.get("strict") is False, "namespace_child_strict_invalid")
-        parameters = child.get("parameters")
-        _require(isinstance(parameters, Mapping), "namespace_child_parameters_invalid")
-        normalized = _normalize_schema(parameters)
-        _require(
-            normalized == _normalize_schema(EXPECTED_PARAMETER_SCHEMAS[version][name]),
-            "namespace_child_parameter_schema_mismatch",
-        )
-    return version
+    try:
+        return _classify_production_tools(tools)
+    except _ProductionContractError as exc:
+        raise ContractValidationError(exc.classification) from exc
 
 
 def classify_request(request: Mapping[str, Any]) -> str:
-    _require(isinstance(request, Mapping), "request_invalid")
-    _require(request.get("tool_choice") == "auto", "tool_choice_invalid")
-    tools = request.get("tools")
-    version = classify_tools(tools)  # type: ignore[arg-type]
-    markers: list[Any] = []
-    if "multi_agent_version" in request:
-        markers.append(request.get("multi_agent_version"))
-    for parent_name in ("metadata", "features", "client_metadata"):
-        parent = request.get(parent_name)
-        if isinstance(parent, Mapping) and "multi_agent_version" in parent:
-            markers.append(parent.get("multi_agent_version"))
-    _require(not markers, "collaboration_version_signal_unexpected")
+    try:
+        version = _classify_production_request(request)
+    except _ProductionContractError as exc:
+        raise ContractValidationError(exc.classification) from exc
+    _require(version is not None, "collaboration_marker_missing")
     return version
 
 

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -2513,12 +2513,14 @@ def _raise_collaboration_boundary_error(
     *,
     classification: str,
     message: str,
+    surface: str = "request",
     cause: BaseException | None = None,
 ) -> NoReturn:
-    _write_adapter_event(
-        event_context,
+    write_proxy_event(
         "collaboration_boundary_rejected",
-        classification=classification,
+        surface=surface,
+        outcome="rejected",
+        count=1,
     )
     error = UpstreamProtocolTranslationError(
         UnsupportedProtocolTranslationError(
@@ -2545,6 +2547,7 @@ def _resolve_collaboration_boundary(
                 event_context,
                 classification=exc.classification,
                 message="Collaboration protocol boundary is malformed or ambiguous.",
+                surface=surface,
                 cause=exc,
             )
         context_protocol = (
@@ -2560,6 +2563,7 @@ def _resolve_collaboration_boundary(
                 event_context,
                 classification="unknown_state",
                 message="Collaboration protocol selection is unknown.",
+                surface=surface,
             )
         if (
             context_protocol is not None
@@ -2570,38 +2574,19 @@ def _resolve_collaboration_boundary(
                 event_context,
                 classification="conflicting_selection",
                 message="Collaboration protocol selection conflicts with the response.",
+                surface=surface,
             )
     else:
         try:
-            tool_protocols = _collaboration_protocols(
-                {"tools": payload.get("tools", [])}
-                if isinstance(payload, Mapping)
-                else {"tools": []}
-            )
-            if len(tool_protocols) > 1:
-                _raise_collaboration_boundary_error(
-                    event_context,
-                    classification="mixed_current_tool_surface",
-                    message="Current Collaboration tools contain multiple protocol families.",
-                )
-            current_protocol = next(iter(tool_protocols), None)
-
-            metadata = {
-                key: event_context[key]
-                for key in (
-                    "multi_agent_version",
-                    "metadata",
-                    "model_metadata",
-                    "capabilities",
-                    "features",
-                )
-                if isinstance(event_context, Mapping) and key in event_context
-            }
-            metadata_protocol = (
-                _classify_collaboration_payload({"metadata": metadata})
-                if metadata
-                else None
-            )
+            request_boundary = {
+                "tools": payload.get("tools", []),
+                "tool_choice": payload.get("tool_choice"),
+            } if isinstance(payload, Mapping) else {"tools": [], "tool_choice": None}
+            if isinstance(payload, Mapping):
+                for key in ("multi_agent_version", "metadata", "features", "client_metadata"):
+                    if key in payload:
+                        request_boundary[key] = payload[key]
+            current_protocol = _classify_collaboration_payload(request_boundary)
 
             raw_context_protocol = (
                 event_context.get("collaboration_protocol")
@@ -2612,23 +2597,6 @@ def _resolve_collaboration_boundary(
                 _COLLABORATION_V1,
                 _COLLABORATION_V2,
             } else None
-            request_metadata = {
-                key: payload[key]
-                for key in (
-                    "collaboration_protocol",
-                    "multi_agent_version",
-                    "metadata",
-                    "model_metadata",
-                    "capabilities",
-                    "features",
-                )
-                if isinstance(payload, Mapping) and key in payload
-            }
-            request_metadata_protocol = (
-                _classify_collaboration_payload(request_metadata)
-                if request_metadata
-                else None
-            )
             history_protocols = _collaboration_protocols(
                 {"input": payload.get("input", [])}
                 if isinstance(payload, Mapping)
@@ -2636,10 +2604,19 @@ def _resolve_collaboration_boundary(
             )
             protocol = (
                 current_protocol
-                or request_metadata_protocol
-                or metadata_protocol
                 or context_protocol
             )
+            if (
+                current_protocol is not None
+                and context_protocol is not None
+                and current_protocol != context_protocol
+            ):
+                _raise_collaboration_boundary_error(
+                    event_context,
+                    classification="conflicting_selection",
+                    message="Collaboration protocol selection conflicts with the request.",
+                    surface=surface,
+                )
             if (
                 raw_context_protocol is not None
                 and context_protocol is None
@@ -2649,12 +2626,14 @@ def _resolve_collaboration_boundary(
                     event_context,
                     classification="unknown_state",
                     message="Collaboration protocol selection is unknown.",
+                    surface=surface,
                 )
         except _CollaborationBoundaryError as exc:
             _raise_collaboration_boundary_error(
                 event_context,
                 classification=exc.classification,
                 message="Collaboration protocol boundary is malformed or ambiguous.",
+                surface=surface,
                 cause=exc,
             )
 
@@ -6418,8 +6397,9 @@ def _prepare_runtime_tool_compatibility(
     except RuntimeToolCompatibilityError as exc:
         write_proxy_event(
             "runtime_tool_compatibility_rejected",
-            classification=exc.classification,
             surface=exc.surface,
+            outcome="rejected",
+            count=1,
         )
         _raise_runtime_tool_compatibility_error(exc)
     event_context[_RUNTIME_TOOL_COMPATIBILITY_PLAN_KEY] = plan

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -12965,13 +12965,18 @@ def compatible_sse_line(
     except (UnicodeDecodeError, json.JSONDecodeError):
         return line
 
-    _remember_worker_stream_event(payload, event_context)
     collaboration_protocol = _resolve_collaboration_boundary(
         payload,
         event_context,
         surface="stream",
     )
+    if collaboration_protocol is None and isinstance(event_context, Mapping):
+        selected_protocol = event_context.get("collaboration_protocol")
+        if selected_protocol in {_COLLABORATION_V1, _COLLABORATION_V2}:
+            collaboration_protocol = selected_protocol
     event_context = _collaboration_context_with_protocol(event_context, collaboration_protocol)
+    if collaboration_protocol != _COLLABORATION_V2:
+        _remember_worker_stream_event(payload, event_context)
     _raise_on_invalid_worker_stream_event(
         payload,
         event_context,

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -2617,6 +2617,25 @@ def _resolve_collaboration_boundary(
                     message="Collaboration protocol selection conflicts with the request.",
                     surface=surface,
                 )
+            if len(history_protocols) > 1:
+                _raise_collaboration_boundary_error(
+                    event_context,
+                    classification="mixed_v1_v2",
+                    message="Collaboration history contains multiple protocol families.",
+                    surface=surface,
+                )
+            history_protocol = next(iter(history_protocols), None)
+            if (
+                protocol is not None
+                and history_protocol is not None
+                and protocol != history_protocol
+            ):
+                _raise_collaboration_boundary_error(
+                    event_context,
+                    classification="conflicting_selection",
+                    message="Collaboration protocol selection conflicts with history.",
+                    surface=surface,
+                )
             if (
                 raw_context_protocol is not None
                 and context_protocol is None
@@ -2637,14 +2656,8 @@ def _resolve_collaboration_boundary(
                 cause=exc,
             )
 
-        if len(history_protocols) > 1:
-            _write_adapter_event(
-                event_context,
-                "collaboration_history_mixed",
-                protocol_count=len(history_protocols),
-            )
-        if protocol is None and len(history_protocols) == 1:
-            protocol = next(iter(history_protocols))
+        if protocol is None:
+            protocol = history_protocol
 
     if isinstance(event_context, dict) and protocol is not None:
         event_context["collaboration_protocol"] = protocol

--- a/src-python/codex_semantic_adapter.py
+++ b/src-python/codex_semantic_adapter.py
@@ -14,6 +14,11 @@ import re
 from dataclasses import dataclass
 from typing import Any, Mapping
 
+from collaboration_runtime_contract import (
+    CollaborationContractError,
+    classify_collaboration_request,
+)
+
 MULTI_AGENT_TOOL_NAMES = {
     "spawn_agent",
     "send_input",
@@ -34,11 +39,6 @@ COLLABORATION_V2_TOOL_NAMES = frozenset(
 )
 COLLABORATION_V1_ONLY_FIELDS = frozenset({"agent_id", "fork_context"})
 COLLABORATION_V2_ONLY_FIELDS = frozenset({"task_name", "task_path", "fork_turns", "continuation_id"})
-COLLABORATION_PROTOCOL_METADATA_KEYS = frozenset(
-    {"collaboration_protocol", "multi_agent_version"}
-)
-
-
 class CollaborationBoundaryError(ValueError):
     """A malformed or ambiguous Collaboration boundary that must fail closed."""
 
@@ -127,34 +127,9 @@ def _classify_collaboration_item(value: Mapping[str, Any], inherited_namespace: 
 
 
 def _metadata_protocol(value: Mapping[str, Any]) -> str | None:
-    """Resolve an explicit model/feature selection marker when present."""
+    """Metadata never selects the frozen Responses Collaboration version."""
 
-    candidates: list[Any] = [value]
-    for key in ("metadata", "model_metadata", "capabilities", "features"):
-        nested = value.get(key)
-        if isinstance(nested, Mapping):
-            candidates.append(nested)
-    protocols: set[str] = set()
-    for candidate in candidates:
-        for key in COLLABORATION_PROTOCOL_METADATA_KEYS:
-            if key not in candidate:
-                continue
-            marker = candidate.get(key)
-            if marker is None:
-                continue
-            if key == "multi_agent_version":
-                marker = {
-                    "v1": COLLABORATION_V1,
-                    "v2": COLLABORATION_V2,
-                }.get(marker)
-            elif marker in {"v1", "v2"}:
-                marker = f"collaboration_{marker}"
-            if marker not in {COLLABORATION_V1, COLLABORATION_V2}:
-                raise CollaborationBoundaryError("unknown_state")
-            protocols.add(marker)
-    if len(protocols) > 1:
-        raise CollaborationBoundaryError("mixed_v1_v2")
-    return next(iter(protocols), None)
+    return None
 
 
 def collaboration_protocols(value: Any) -> frozenset[str]:
@@ -166,12 +141,18 @@ def collaboration_protocols(value: Any) -> frozenset[str]:
     """
 
     protocols: set[str] = set()
+    exact_request_root: Mapping[str, Any] | None = None
+    if isinstance(value, Mapping):
+        try:
+            exact_protocol = classify_collaboration_request(value)
+        except CollaborationContractError as exc:
+            raise CollaborationBoundaryError(exc.classification) from exc
+        if exact_protocol is not None:
+            protocols.add(exact_protocol)
+            exact_request_root = value
 
     def visit(item: Any, inherited_namespace: str | None = None) -> None:
         if isinstance(item, Mapping):
-            metadata_protocol = _metadata_protocol(item)
-            if metadata_protocol is not None:
-                protocols.add(metadata_protocol)
             protocol = _classify_collaboration_item(item, inherited_namespace)
             if protocol is not None:
                 protocols.add(protocol)
@@ -190,6 +171,8 @@ def collaboration_protocols(value: Any) -> frozenset[str]:
             }:
                 child_namespace = item["name"]
             for key, child in item.items():
+                if item is exact_request_root and key == "tools":
+                    continue
                 if key == "tools" and child_namespace is not None:
                     visit(child, child_namespace)
                 elif key not in {"arguments", "parameters", "properties"}:

--- a/src-python/collaboration_runtime_contract.py
+++ b/src-python/collaboration_runtime_contract.py
@@ -1,0 +1,487 @@
+"""Frozen Codex Collaboration Responses declaration contract.
+
+The schemas below are generated from the accepted issue #392 runtime capture
+for Codex CLI 0.146.1 and Codex Desktop 26.803.5235.0.  Production never reads
+the evidence artifact: request classification is a pure, local structural
+check and dynamic description text is deliberately excluded from matching.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping, Sequence
+
+
+COLLABORATION_V1 = "collaboration_v1"
+COLLABORATION_V2 = "collaboration_v2"
+V1_NAMESPACE = "multi_agent_v1"
+V2_NAMESPACE = "collaboration"
+V1_TOOLS = ("close_agent", "resume_agent", "send_input", "spawn_agent", "wait_agent")
+V2_TOOLS = (
+    "followup_task",
+    "interrupt_agent",
+    "list_agents",
+    "send_message",
+    "spawn_agent",
+    "wait_agent",
+)
+
+
+class CollaborationContractError(ValueError):
+    """Stable bounded failure; request values are never included."""
+
+    def __init__(self, classification: str) -> None:
+        self.classification = classification
+        super().__init__(classification)
+
+
+def _require(condition: bool, classification: str) -> None:
+    if not condition:
+        raise CollaborationContractError(classification)
+
+
+def _object_schema(
+    properties: Mapping[str, Any], required: Sequence[str] = ()
+) -> dict[str, Any]:
+    return {
+        "type": "object",
+        "properties": dict(properties),
+        "required": list(required),
+        "additionalProperties": False,
+    }
+
+
+STRING = {"type": "string"}
+NUMBER = {"type": "number"}
+BOOLEAN = {"type": "boolean"}
+ENCRYPTED_STRING = {"type": "string", "encrypted": True}
+NULLABLE_STRING = {"type": ["string", "null"]}
+COLLAB_INPUT_ITEM_SCHEMA = _object_schema(
+    {
+        "audio_url": STRING,
+        "image_url": STRING,
+        "name": STRING,
+        "path": STRING,
+        "text": STRING,
+        "type": STRING,
+    }
+)
+
+
+# Exact normalized schemas emitted by both frozen clients.  Only description
+# annotations are dynamic and ignored by ``_normalize_schema``.
+EXPECTED_PARAMETER_SCHEMAS: dict[str, dict[str, dict[str, Any]]] = {
+    COLLABORATION_V1: {
+        "close_agent": _object_schema({"target": STRING}, ["target"]),
+        "resume_agent": _object_schema({"id": STRING}, ["id"]),
+        "send_input": _object_schema(
+            {
+                "interrupt": BOOLEAN,
+                "items": {"type": "array", "items": COLLAB_INPUT_ITEM_SCHEMA},
+                "message": STRING,
+                "target": STRING,
+            },
+            ["target"],
+        ),
+        "spawn_agent": _object_schema(
+            {
+                "agent_type": STRING,
+                "fork_context": BOOLEAN,
+                "items": {"type": "array", "items": COLLAB_INPUT_ITEM_SCHEMA},
+                "message": STRING,
+                "model": STRING,
+                "reasoning_effort": STRING,
+                "service_tier": STRING,
+            }
+        ),
+        "wait_agent": _object_schema(
+            {
+                "targets": {"type": "array", "items": STRING},
+                "timeout_ms": NUMBER,
+            },
+            ["targets"],
+        ),
+    },
+    COLLABORATION_V2: {
+        "followup_task": _object_schema(
+            {"message": ENCRYPTED_STRING, "target": STRING},
+            ["target", "message"],
+        ),
+        "interrupt_agent": _object_schema({"target": STRING}, ["target"]),
+        "list_agents": _object_schema({"path_prefix": STRING}),
+        "send_message": _object_schema(
+            {"message": ENCRYPTED_STRING, "target": STRING},
+            ["target", "message"],
+        ),
+        "spawn_agent": _object_schema(
+            {
+                "agent_type": STRING,
+                "fork_turns": STRING,
+                "message": ENCRYPTED_STRING,
+                "model": STRING,
+                "reasoning_effort": STRING,
+                "task_name": STRING,
+            },
+            ["task_name", "message"],
+        ),
+        "wait_agent": _object_schema({"timeout_ms": NUMBER}),
+    },
+}
+
+
+AGENT_STATUS_SCHEMA = {
+    "oneOf": [
+        {
+            "type": "string",
+            "enum": ["pending_init", "running", "interrupted", "shutdown", "not_found"],
+        },
+        _object_schema({"completed": NULLABLE_STRING}, ["completed"]),
+        _object_schema({"errored": STRING}, ["errored"]),
+    ]
+}
+EXPECTED_OUTPUT_SCHEMAS: dict[str, dict[str, dict[str, Any] | None]] = {
+    COLLABORATION_V1: {
+        "close_agent": _object_schema(
+            {"previous_status": AGENT_STATUS_SCHEMA}, ["previous_status"]
+        ),
+        "resume_agent": _object_schema({"status": AGENT_STATUS_SCHEMA}, ["status"]),
+        "send_input": _object_schema({"submission_id": STRING}, ["submission_id"]),
+        "spawn_agent": _object_schema(
+            {"agent_id": STRING, "nickname": NULLABLE_STRING},
+            ["agent_id", "nickname"],
+        ),
+        "wait_agent": _object_schema(
+            {
+                "status": {"type": "object", "additionalProperties": AGENT_STATUS_SCHEMA},
+                "timed_out": BOOLEAN,
+            },
+            ["status", "timed_out"],
+        ),
+    },
+    COLLABORATION_V2: {
+        "followup_task": None,
+        "interrupt_agent": _object_schema(
+            {"previous_status": AGENT_STATUS_SCHEMA}, ["previous_status"]
+        ),
+        "list_agents": _object_schema(
+            {
+                "agents": {
+                    "type": "array",
+                    "items": _object_schema(
+                        {"agent_name": STRING, "agent_status": AGENT_STATUS_SCHEMA},
+                        ["agent_name", "agent_status"],
+                    ),
+                }
+            },
+            ["agents"],
+        ),
+        "send_message": None,
+        "spawn_agent": _object_schema({"task_name": STRING}, ["task_name"]),
+        "wait_agent": _object_schema(
+            {"message": STRING, "timed_out": BOOLEAN}, ["message", "timed_out"]
+        ),
+    },
+}
+
+
+def _normalize_schema(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        normalized: dict[str, Any] = {}
+        for key, child in value.items():
+            if key == "description":
+                continue
+            if key == "properties" and isinstance(child, Mapping):
+                normalized[key] = {
+                    property_name: _normalize_schema(property_schema)
+                    for property_name, property_schema in child.items()
+                }
+            else:
+                normalized[key] = _normalize_schema(child)
+        if normalized.get("type") == "object":
+            normalized.setdefault("required", [])
+            required = normalized["required"]
+            if isinstance(required, list) and all(
+                isinstance(field, str) for field in required
+            ):
+                normalized["required"] = sorted(required)
+        return normalized
+    if isinstance(value, list):
+        return [_normalize_schema(child) for child in value]
+    return value
+
+
+def _namespace_candidates(tools: Sequence[Any]) -> list[Mapping[str, Any]]:
+    return [
+        tool
+        for tool in tools
+        if isinstance(tool, Mapping)
+        and tool.get("type") == "namespace"
+        and tool.get("name") in {V1_NAMESPACE, V2_NAMESPACE}
+    ]
+
+
+def _has_collaboration_marker(tools: Any) -> bool:
+    if not isinstance(tools, Sequence) or isinstance(tools, (str, bytes, bytearray)):
+        return False
+    collaboration_names = {V1_NAMESPACE, V2_NAMESPACE}
+    child_names = set(V1_TOOLS) | set(V2_TOOLS)
+    return any(
+        isinstance(tool, Mapping)
+        and (
+            tool.get("name") in collaboration_names
+            or (tool.get("type") == "function" and tool.get("name") in child_names)
+        )
+        for tool in tools
+    )
+
+
+def classify_collaboration_tools(tools: Sequence[Any]) -> str:
+    """Classify the exact frozen declaration surface, or fail closed."""
+
+    _require(
+        isinstance(tools, Sequence) and not isinstance(tools, (str, bytes, bytearray)),
+        "tools_invalid",
+    )
+    candidates = _namespace_candidates(tools)
+    _require(bool(candidates), "collaboration_marker_missing")
+    candidate_ids = {id(candidate) for candidate in candidates}
+    collaboration_names = {V1_NAMESPACE, V2_NAMESPACE}
+    child_names = set(V1_TOOLS) | set(V2_TOOLS)
+    conflicts = [
+        tool
+        for tool in tools
+        if isinstance(tool, Mapping)
+        and id(tool) not in candidate_ids
+        and (
+            tool.get("name") in collaboration_names
+            or (tool.get("type") == "function" and tool.get("name") in child_names)
+        )
+    ]
+    _require(
+        len(candidates) == 1 and not conflicts,
+        "collaboration_marker_duplicate_or_mixed",
+    )
+    candidate = candidates[0]
+    version = (
+        COLLABORATION_V1
+        if candidate.get("name") == V1_NAMESPACE
+        else COLLABORATION_V2
+    )
+    expected_names = set(V1_TOOLS if version == COLLABORATION_V1 else V2_TOOLS)
+    _require(
+        set(candidate) == {"type", "name", "description", "tools"},
+        "namespace_fields_invalid",
+    )
+    _require(
+        isinstance(candidate.get("description"), str),
+        "namespace_description_invalid",
+    )
+    children = candidate.get("tools")
+    _require(isinstance(children, list), "namespace_children_invalid")
+    _require(
+        all(isinstance(child, Mapping) for child in children),
+        "namespace_child_invalid",
+    )
+    names = [child.get("name") for child in children]
+    _require(
+        all(child.get("type") == "function" for child in children),
+        "namespace_child_type_invalid",
+    )
+    _require(
+        all(isinstance(child.get("name"), str) for child in children),
+        "namespace_child_name_invalid",
+    )
+    _require(len(names) == len(set(names)), "namespace_child_duplicate")
+    _require(set(names) == expected_names, "namespace_child_set_invalid")
+    for child in children:
+        name = child["name"]
+        _require(
+            set(child) == {"type", "name", "description", "strict", "parameters"},
+            "namespace_child_fields_invalid",
+        )
+        _require(
+            isinstance(child.get("description"), str),
+            "namespace_child_description_invalid",
+        )
+        _require(child.get("strict") is False, "namespace_child_strict_invalid")
+        parameters = child.get("parameters")
+        _require(
+            isinstance(parameters, Mapping),
+            "namespace_child_parameters_invalid",
+        )
+        _require(
+            _normalize_schema(parameters)
+            == _normalize_schema(EXPECTED_PARAMETER_SCHEMAS[version][name]),
+            "namespace_child_parameter_schema_mismatch",
+        )
+    return version
+
+
+def _has_unexpected_version_signal(request: Mapping[str, Any]) -> bool:
+    if "multi_agent_version" in request:
+        return True
+    for parent_name in ("metadata", "features", "client_metadata"):
+        parent = request.get(parent_name)
+        if isinstance(parent, Mapping) and "multi_agent_version" in parent:
+            return True
+    return False
+
+
+def classify_collaboration_request(request: Mapping[str, Any]) -> str | None:
+    """Return the exact request version or ``None`` when no marker exists."""
+
+    _require(isinstance(request, Mapping), "request_invalid")
+    _require(
+        not _has_unexpected_version_signal(request),
+        "collaboration_version_signal_unexpected",
+    )
+    tools = request.get("tools")
+    if not _has_collaboration_marker(tools):
+        return None
+    _require(request.get("tool_choice") == "auto", "tool_choice_invalid")
+    return classify_collaboration_tools(tools)  # type: ignore[arg-type]
+
+
+def _json_object_or_value(value: Any, malformed: str) -> Any:
+    if not isinstance(value, str):
+        return value
+
+    def unique_object(items: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, child in items:
+            if key in result:
+                raise CollaborationContractError(malformed)
+            result[key] = child
+        return result
+
+    try:
+        return json.loads(value, object_pairs_hook=unique_object)
+    except CollaborationContractError:
+        raise
+    except (TypeError, ValueError):
+        raise CollaborationContractError(malformed) from None
+
+
+def _matches_schema(value: Any, schema: Mapping[str, Any]) -> bool:
+    alternatives = schema.get("oneOf")
+    if isinstance(alternatives, list):
+        return sum(
+            1
+            for alternative in alternatives
+            if isinstance(alternative, Mapping) and _matches_schema(value, alternative)
+        ) == 1
+    expected_type = schema.get("type")
+    if isinstance(expected_type, list):
+        return any(_matches_schema(value, {**schema, "type": item}) for item in expected_type)
+    if expected_type == "null":
+        if value is not None:
+            return False
+    elif expected_type == "string":
+        if not isinstance(value, str):
+            return False
+    elif expected_type == "boolean":
+        if type(value) is not bool:
+            return False
+    elif expected_type == "number":
+        if type(value) not in {int, float}:
+            return False
+    elif expected_type == "array":
+        if not isinstance(value, list):
+            return False
+        item_schema = schema.get("items")
+        if isinstance(item_schema, Mapping) and not all(
+            _matches_schema(item, item_schema) for item in value
+        ):
+            return False
+    elif expected_type == "object":
+        if not isinstance(value, Mapping):
+            return False
+        properties = schema.get("properties", {})
+        if not isinstance(properties, Mapping):
+            return False
+        required = schema.get("required", [])
+        if not isinstance(required, list) or not set(required).issubset(value):
+            return False
+        extras = set(value) - set(properties)
+        additional = schema.get("additionalProperties", True)
+        if additional is False and extras:
+            return False
+        if isinstance(additional, Mapping) and not all(
+            _matches_schema(value[key], additional) for key in extras
+        ):
+            return False
+        for key, child in value.items():
+            child_schema = properties.get(key)
+            if isinstance(child_schema, Mapping) and not _matches_schema(child, child_schema):
+                return False
+    if "enum" in schema and value not in schema["enum"]:
+        return False
+    return True
+
+
+def validate_collaboration_arguments(version: str, name: str, value: Any) -> None:
+    schemas = EXPECTED_PARAMETER_SCHEMAS.get(version)
+    if schemas is None or name not in schemas:
+        raise CollaborationContractError("unknown_collaboration_function")
+    parsed = _json_object_or_value(value, "malformed_collaboration_arguments")
+    if not _matches_schema(parsed, schemas[name]):
+        raise CollaborationContractError("collaboration_arguments_schema_mismatch")
+
+
+def validate_collaboration_result(version: str, name: str, value: Any) -> None:
+    schemas = EXPECTED_OUTPUT_SCHEMAS.get(version)
+    if schemas is None or name not in schemas:
+        raise CollaborationContractError("unknown_collaboration_function")
+    parsed = _json_object_or_value(value, "malformed_collaboration_result")
+    schema = schemas[name]
+    if (schema is None and parsed is not None) or (
+        isinstance(schema, Mapping) and not _matches_schema(parsed, schema)
+    ):
+        raise CollaborationContractError("collaboration_result_schema_mismatch")
+
+
+def validate_agent_message(value: Mapping[str, Any]) -> None:
+    if set(value) != {"type", "id", "author", "recipient", "content"}:
+        raise CollaborationContractError("agent_message_fields_invalid")
+    if value.get("type") != "agent_message":
+        raise CollaborationContractError("agent_message_fields_invalid")
+    if not all(
+        isinstance(value.get(field), str) and bool(value[field])
+        for field in ("id", "author", "recipient")
+    ):
+        raise CollaborationContractError("agent_message_identity_invalid")
+    content = value.get("content")
+    if not isinstance(content, list):
+        raise CollaborationContractError("agent_message_content_invalid")
+    for part in content:
+        if not isinstance(part, Mapping):
+            raise CollaborationContractError("agent_message_content_invalid")
+        part_type = part.get("type")
+        if part_type == "input_text":
+            valid = set(part) == {"type", "text"} and isinstance(part.get("text"), str)
+        elif part_type == "encrypted_content":
+            valid = set(part) == {"type", "encrypted_content"} and isinstance(
+                part.get("encrypted_content"), str
+            )
+        else:
+            valid = False
+        if not valid:
+            raise CollaborationContractError("agent_message_content_invalid")
+
+
+__all__ = [
+    "COLLABORATION_V1",
+    "COLLABORATION_V2",
+    "CollaborationContractError",
+    "EXPECTED_PARAMETER_SCHEMAS",
+    "EXPECTED_OUTPUT_SCHEMAS",
+    "V1_NAMESPACE",
+    "V1_TOOLS",
+    "V2_NAMESPACE",
+    "V2_TOOLS",
+    "classify_collaboration_request",
+    "classify_collaboration_tools",
+    "validate_agent_message",
+    "validate_collaboration_arguments",
+    "validate_collaboration_result",
+]

--- a/src-python/collaboration_runtime_contract.py
+++ b/src-python/collaboration_runtime_contract.py
@@ -423,6 +423,8 @@ def validate_collaboration_arguments(version: str, name: str, value: Any) -> Non
     schemas = EXPECTED_PARAMETER_SCHEMAS.get(version)
     if schemas is None or name not in schemas:
         raise CollaborationContractError("unknown_collaboration_function")
+    if not isinstance(value, str):
+        raise CollaborationContractError("collaboration_arguments_wire_type_invalid")
     parsed = _json_object_or_value(value, "malformed_collaboration_arguments")
     if not _matches_schema(parsed, schemas[name]):
         raise CollaborationContractError("collaboration_arguments_schema_mismatch")
@@ -432,6 +434,8 @@ def validate_collaboration_result(version: str, name: str, value: Any) -> None:
     schemas = EXPECTED_OUTPUT_SCHEMAS.get(version)
     if schemas is None or name not in schemas:
         raise CollaborationContractError("unknown_collaboration_function")
+    if not isinstance(value, str):
+        raise CollaborationContractError("collaboration_result_wire_type_invalid")
     parsed = _json_object_or_value(value, "malformed_collaboration_result")
     schema = schemas[name]
     if (schema is None and parsed is not None) or (

--- a/src-python/runtime_tool_compatibility.py
+++ b/src-python/runtime_tool_compatibility.py
@@ -15,6 +15,15 @@ import json
 from types import MappingProxyType
 from typing import Any, Iterable, Mapping
 
+from collaboration_runtime_contract import (
+    COLLABORATION_V2,
+    CollaborationContractError,
+    classify_collaboration_request,
+    validate_agent_message,
+    validate_collaboration_arguments,
+    validate_collaboration_result,
+)
+
 
 NATIVE = "native"
 ADAPT = "adapt"
@@ -767,6 +776,21 @@ def build_tool_compatibility_plan(
         if not isinstance(item, Mapping):
             raise _MalformedDeclaration()
         declarations.append(item)
+    try:
+        collaboration_version = classify_collaboration_request(
+            {"tools": declarations, "tool_choice": tool_choice}
+        )
+    except CollaborationContractError as exc:
+        raise ToolCompatibilityError(
+            "tool_compatibility_boundary",
+            exc.classification,
+            surface="request",
+        ) from exc
+    if (
+        collaboration_version == COLLABORATION_V2
+        and selected_protocol != "responses_structured"
+    ):
+        raise RequiredToolUnavailableError(family=NAMESPACE)
     capabilities = _protocol_capabilities(selected_protocol, protocol_capabilities)
     hosted = _provider_hosted(provider_hosted_capabilities)
 
@@ -803,6 +827,12 @@ def build_tool_compatibility_plan(
         if not valid:
             raise _MalformedDeclaration()
         namespace, children, version, namespace_valid = _namespace_details(declaration)
+        if (
+            collaboration_version == COLLABORATION_V2
+            and family == NAMESPACE
+            and namespace == "collaboration"
+        ):
+            is_required = True
         reason = "native_lifecycle"
         disposition = OMIT
         aliases: list[str] = []
@@ -1140,6 +1170,140 @@ class ToolCompatibilityPlan:
             tool_choice=self.tool_choice,
             provider_hosted_kinds=self.provider_hosted_kinds,
         )
+
+    def _collaboration_v2_entry(self) -> ToolCompatibilityEntry | None:
+        matches = [
+            entry
+            for entry in self.entries
+            if entry.family == NAMESPACE
+            and entry.version == "v2"
+            and entry.namespace == "collaboration"
+        ]
+        return matches[0] if len(matches) == 1 else None
+
+    @staticmethod
+    def _raise_collaboration_contract(
+        error: CollaborationContractError,
+        *,
+        surface: str,
+    ) -> None:
+        raise ToolCompatibilityError(
+            "tool_compatibility_boundary",
+            error.classification,
+            surface=surface,
+        ) from error
+
+    def _validate_collaboration_v2_items(
+        self,
+        items: Any,
+        *,
+        surface: str,
+    ) -> None:
+        if self._collaboration_v2_entry() is None or not isinstance(items, list):
+            return
+        calls: dict[str, str] = {}
+        seen_item_ids: set[str] = set()
+        for item in items:
+            if not isinstance(item, Mapping):
+                continue
+            item_type = item.get("type")
+            if item_type == "agent_message":
+                try:
+                    validate_agent_message(item)
+                except CollaborationContractError as exc:
+                    self._raise_collaboration_contract(exc, surface=surface)
+                item_id = item.get("id")
+            elif (
+                item_type == "function_call"
+                and item.get("namespace") == "collaboration"
+                and item.get("name") in _V2_NAMES
+            ):
+                item_id = item.get("id")
+                if not isinstance(item_id, str) or not item_id:
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "missing_item_identity",
+                        surface=surface,
+                    )
+                allowed_fields = {
+                    "type",
+                    "id",
+                    "call_id",
+                    "namespace",
+                    "name",
+                    "arguments",
+                }
+                if surface in {"response", "stream"}:
+                    allowed_fields.add("status")
+                valid_field_sets = [allowed_fields]
+                if "status" in allowed_fields:
+                    valid_field_sets.append(allowed_fields - {"status"})
+                if set(item) not in valid_field_sets:
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "collaboration_call_fields_invalid",
+                        surface=surface,
+                    )
+                call_id = item.get("call_id")
+                if not isinstance(call_id, str) or not call_id:
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "missing_call_identity",
+                        surface=surface,
+                    )
+                if call_id in calls:
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "duplicate_call_identity",
+                        surface=surface,
+                    )
+                name = str(item["name"])
+                try:
+                    validate_collaboration_arguments(
+                        COLLABORATION_V2,
+                        name,
+                        item.get("arguments"),
+                    )
+                except CollaborationContractError as exc:
+                    self._raise_collaboration_contract(exc, surface=surface)
+                calls[call_id] = name
+            elif item_type == "function_call_output" and item.get("call_id") in calls:
+                item_id = item.get("id")
+                if not isinstance(item_id, str) or not item_id:
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "missing_item_identity",
+                        surface=surface,
+                    )
+                if set(item) != {"type", "id", "call_id", "output"}:
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "collaboration_result_fields_invalid",
+                        surface=surface,
+                    )
+                try:
+                    validate_collaboration_result(
+                        COLLABORATION_V2,
+                        calls[str(item["call_id"])],
+                        item.get("output"),
+                    )
+                except CollaborationContractError as exc:
+                    self._raise_collaboration_contract(exc, surface=surface)
+            else:
+                continue
+            if not isinstance(item_id, str) or not item_id:
+                raise ToolCompatibilityError(
+                    "tool_compatibility_boundary",
+                    "missing_item_identity",
+                    surface=surface,
+                )
+            if item_id in seen_item_ids:
+                raise ToolCompatibilityError(
+                    "tool_compatibility_boundary",
+                    "duplicate_item_identity",
+                    surface=surface,
+                )
+            seen_item_ids.add(item_id)
 
     def with_final_declarations(
         self,
@@ -2200,6 +2364,7 @@ class ToolCompatibilityPlan:
         call_aliases: dict[str, str] = {}
         raw_input = result.get("input")
         if isinstance(raw_input, list):
+            self._validate_collaboration_v2_items(raw_input, surface="history")
             encoded_input: list[Any] = []
             changed = tools_changed or choice_changed
             history_call_owners: dict[str, ToolCompatibilityEntry] = {}
@@ -2687,6 +2852,7 @@ class ToolCompatibilityPlan:
         entry: ToolCompatibilityEntry,
         *,
         require_completed: bool = False,
+        surface: str = "history",
     ) -> None:
         if entry.version is not None:
             _validate_version_fields(
@@ -2702,6 +2868,24 @@ class ToolCompatibilityPlan:
                     version=entry.version,
                 ),
             )
+        if (
+            entry.version == "v2"
+            and entry.family == NAMESPACE
+            and item.get("arguments") is not None
+            and item.get("arguments") != ""
+        ):
+            try:
+                validate_collaboration_arguments(
+                    COLLABORATION_V2,
+                    str(item.get("name")),
+                    item.get("arguments"),
+                )
+            except CollaborationContractError as exc:
+                raise ToolCompatibilityError(
+                    "tool_compatibility_boundary",
+                    exc.classification,
+                    surface=surface,
+                ) from exc
         item_type = item.get("type")
         if entry.family == PLAIN_FUNCTION:
             namespace = item.get("namespace")
@@ -2714,30 +2898,30 @@ class ToolCompatibilityPlan:
                 and f"{namespace}__{item.get('name')}" == entry.original_name
             )
             if item_type != "function_call" or not (plain_shape or flattened_shape):
-                raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_native_identity", surface="history")
+                raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_native_identity", surface=surface)
         elif entry.family == NAMESPACE:
             if (
                 item_type != "function_call"
                 or item.get("namespace") != entry.namespace
                 or item.get("name") not in entry.child_names
             ):
-                raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_native_identity", surface="history")
+                raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_native_identity", surface=surface)
         elif entry.family == CUSTOM_FREEFORM:
             if item_type != "custom_tool_call" or item.get("name") != entry.original_name:
-                raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_native_identity", surface="history")
+                raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_native_identity", surface=surface)
         elif entry.family == TOOL_SEARCH:
             if item_type not in {"tool_search_call", "tool_search_output"}:
-                raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_native_identity", surface="history")
+                raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_native_identity", surface=surface)
             if item.get("execution") != "client":
-                raise ToolCompatibilityError("tool_compatibility_boundary", "invalid_tool_search_execution", surface="history")
+                raise ToolCompatibilityError("tool_compatibility_boundary", "invalid_tool_search_execution", surface=surface)
         elif entry.family == SELECTED_PROVIDER_HOSTED:
             hosted_spec = _hosted_event_spec_for_declaration_kind(entry.declaration.get("type"))
             if hosted_spec is None or item_type != hosted_spec[0]:
-                raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_native_identity", surface="history")
+                raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_native_identity", surface=surface)
             if _item_identity(item) is None:
-                raise ToolCompatibilityError("tool_compatibility_boundary", "missing_item_identity", surface="history")
+                raise ToolCompatibilityError("tool_compatibility_boundary", "missing_item_identity", surface=surface)
             if require_completed and item.get("status") not in {None, "completed"}:
-                raise ToolCompatibilityError("tool_compatibility_boundary", "incomplete_hosted_lifecycle", surface="history")
+                raise ToolCompatibilityError("tool_compatibility_boundary", "incomplete_hosted_lifecycle", surface=surface)
 
     def _decode_items(self, items: Any, *, reject_omitted_response: bool = False) -> tuple[Any, bool]:
         if not isinstance(items, list):
@@ -2926,6 +3110,7 @@ class ToolCompatibilityPlan:
                     raise ToolCompatibilityError("tool_compatibility_boundary", "unknown_alias", surface="history")
             result.append(decoded)
             changed = changed or item_changed
+        self._validate_collaboration_v2_items(result, surface=surface)
         return result, changed
 
     def decode_payload(self, payload: Mapping[str, Any]) -> dict[str, Any]:
@@ -3153,7 +3338,7 @@ class CompatibilityStreamState:
                 "duplicate_call_identity",
                 surface="stream",
             )
-        self.plan._validate_native_item(item, entry)
+        self.plan._validate_native_item(item, entry, surface="stream")
         self._seen_item_ids.add(item_id)
         self._seen_call_ids.add(call_id)
         self._native_done.add(item_id)
@@ -3358,6 +3543,20 @@ class CompatibilityStreamState:
     def _check_alias_in_item(self, item: Mapping[str, Any], *, allow_incomplete: bool = True) -> tuple[dict[str, Any], AliasRecord | None, bool]:
         if item.get("type") == "function_call":
             decoded, record, changed = self.plan._decode_call_compat(item, allow_incomplete=allow_incomplete)
+            if (
+                record is not None
+                and record.version == "v2"
+                and record.family == NAMESPACE
+                and not allow_incomplete
+            ):
+                try:
+                    validate_collaboration_arguments(
+                        COLLABORATION_V2,
+                        str(record.child_name),
+                        decoded.get("arguments"),
+                    )
+                except CollaborationContractError as exc:
+                    self.plan._raise_collaboration_contract(exc, surface="stream")
             if record is not None and record.family == NAMESPACE:
                 supplied_namespace = item.get("namespace")
                 if supplied_namespace is not None and supplied_namespace != record.namespace:
@@ -3503,7 +3702,7 @@ class CompatibilityStreamState:
                             "ambiguous_native_identity",
                             surface="stream",
                         )
-                    self.plan._validate_native_item(item, expected_entry)
+                    self.plan._validate_native_item(item, expected_entry, surface="stream")
                     if self._semantic_wire_payload(item, expected_entry) != expected_payload:
                         raise ToolCompatibilityError(
                             "tool_compatibility_boundary",
@@ -3660,7 +3859,7 @@ class CompatibilityStreamState:
                     surface="stream",
                 )
             if expected_entry.family == TOOL_SEARCH:
-                self.plan._validate_native_item(item, expected_entry)
+                self.plan._validate_native_item(item, expected_entry, surface="stream")
             if self._native_wire_identities.get(item_id) != self._native_wire_identity(item):
                 raise ToolCompatibilityError(
                     "tool_compatibility_boundary",
@@ -3698,6 +3897,9 @@ class CompatibilityStreamState:
         hosted_event_spec = _hosted_event_spec(event_type)
         if hosted_event_spec is not None:
             return self._decode_hosted_event(result, hosted_event_spec)
+        item = result.get("item")
+        if isinstance(item, Mapping) and item.get("type") == "agent_message":
+            self.plan._validate_collaboration_v2_items([item], surface="stream")
         if event_type in {"response.completed", "response.incomplete", "response.failed"}:
             response = result.get("response")
             if isinstance(response, Mapping):
@@ -3713,7 +3915,6 @@ class CompatibilityStreamState:
                     response["output"] = decoded_output
                     result["response"] = response
             return result
-        item = result.get("item")
         if event_type == "response.output_item.added" and isinstance(item, Mapping):
             self.plan._validate_registered_item_identity(item, surface="stream")
             self._validate_output_item_added(item)
@@ -3749,7 +3950,7 @@ class CompatibilityStreamState:
                 if item_id is None:
                     raise ToolCompatibilityError("tool_compatibility_boundary", "missing_item_identity", surface="stream")
                 if native_entry.family == SELECTED_PROVIDER_HOSTED:
-                    self.plan._validate_native_item(item, native_entry)
+                    self.plan._validate_native_item(item, native_entry, surface="stream")
                     if item_id in self._seen_item_ids:
                         raise ToolCompatibilityError("tool_compatibility_boundary", "duplicate_item_identity", surface="stream")
                     self._seen_item_ids.add(item_id)
@@ -3772,7 +3973,7 @@ class CompatibilityStreamState:
                     return result
                 if not isinstance(call_id, str) or not call_id:
                     raise ToolCompatibilityError("tool_compatibility_boundary", "missing_call_identity", surface="stream")
-                self.plan._validate_native_item(item, native_entry)
+                self.plan._validate_native_item(item, native_entry, surface="stream")
                 if item_id in self._seen_item_ids:
                     raise ToolCompatibilityError("tool_compatibility_boundary", "duplicate_item_identity", surface="stream")
                 if call_id in self._seen_call_ids:
@@ -4108,9 +4309,14 @@ class CompatibilityStreamState:
                                 "incomplete_hosted_lifecycle",
                                 surface="stream",
                             )
-                        self.plan._validate_native_item(item, hosted_entry, require_completed=True)
+                        self.plan._validate_native_item(
+                            item,
+                            hosted_entry,
+                            require_completed=True,
+                            surface="stream",
+                        )
                     elif expected_entry.family == TOOL_SEARCH:
-                        self.plan._validate_native_item(item, expected_entry)
+                        self.plan._validate_native_item(item, expected_entry, surface="stream")
                     elif expected_entry.family != TOOL_SEARCH and native_item_id not in self._native_delta_done:
                         self._complete_native_arguments_from_item(
                             native_item_id,
@@ -4211,7 +4417,7 @@ class CompatibilityStreamState:
             if pending.record.family == CUSTOM_FREEFORM:
                 decoded_item, _record, _changed = self.plan._decode_call(item, allow_incomplete=False)
             else:
-                decoded_item, _record, _changed = self._check_alias_in_item(item, allow_incomplete=True)
+                decoded_item, _record, _changed = self._check_alias_in_item(item, allow_incomplete=False)
             pending.item_done = True
             payload = self._semantic_wire_payload(item, pending.record)
             if pending.item_id in self._wire_payloads and self._wire_payloads[pending.item_id] != payload:

--- a/src-python/runtime_tool_compatibility.py
+++ b/src-python/runtime_tool_compatibility.py
@@ -1193,15 +1193,90 @@ class ToolCompatibilityPlan:
             surface=surface,
         ) from error
 
+    def _validate_collaboration_v2_call_item(
+        self,
+        item: Mapping[str, Any],
+        *,
+        surface: str,
+        allow_incomplete_arguments: bool = False,
+    ) -> tuple[str, str]:
+        if (
+            item.get("type") != "function_call"
+            or item.get("namespace") != "collaboration"
+            or item.get("name") not in _V2_NAMES
+        ):
+            raise ToolCompatibilityError(
+                "tool_compatibility_boundary",
+                "unknown_native_identity",
+                surface=surface,
+            )
+        item_id = item.get("id")
+        if not isinstance(item_id, str) or not item_id:
+            raise ToolCompatibilityError(
+                "tool_compatibility_boundary",
+                "missing_item_identity",
+                surface=surface,
+            )
+        allowed_fields = {
+            "type",
+            "id",
+            "call_id",
+            "namespace",
+            "name",
+            "arguments",
+        }
+        if surface in {"response", "stream"}:
+            allowed_fields.add("status")
+        valid_field_sets = [allowed_fields]
+        if "status" in allowed_fields:
+            valid_field_sets.append(allowed_fields - {"status"})
+        if set(item) not in valid_field_sets:
+            raise ToolCompatibilityError(
+                "tool_compatibility_boundary",
+                "collaboration_call_fields_invalid",
+                surface=surface,
+            )
+        call_id = item.get("call_id")
+        if not isinstance(call_id, str) or not call_id:
+            raise ToolCompatibilityError(
+                "tool_compatibility_boundary",
+                "missing_call_identity",
+                surface=surface,
+            )
+        arguments = item.get("arguments")
+        if allow_incomplete_arguments and arguments in {None, ""}:
+            return item_id, call_id
+        try:
+            validate_collaboration_arguments(
+                COLLABORATION_V2,
+                str(item["name"]),
+                arguments,
+            )
+        except CollaborationContractError as exc:
+            self._raise_collaboration_contract(exc, surface=surface)
+        return item_id, call_id
+
     def _validate_collaboration_v2_items(
         self,
         items: Any,
         *,
         surface: str,
     ) -> None:
-        if self._collaboration_v2_entry() is None or not isinstance(items, list):
+        if not isinstance(items, list):
+            return
+        if self._collaboration_v2_entry() is None:
+            if any(
+                isinstance(item, Mapping) and item.get("type") == "agent_message"
+                for item in items
+            ):
+                raise ToolCompatibilityError(
+                    "tool_compatibility_boundary",
+                    "unknown_native_identity",
+                    surface=surface,
+                )
             return
         calls: dict[str, str] = {}
+        seen_result_call_ids: set[str] = set()
         seen_item_ids: set[str] = set()
         for item in items:
             if not isinstance(item, Mapping):
@@ -1218,32 +1293,18 @@ class ToolCompatibilityPlan:
                 and item.get("namespace") == "collaboration"
                 and item.get("name") in _V2_NAMES
             ):
-                item_id = item.get("id")
-                if not isinstance(item_id, str) or not item_id:
+                item_id, call_id = self._validate_collaboration_v2_call_item(
+                    item,
+                    surface=surface,
+                )
+                if call_id in calls:
                     raise ToolCompatibilityError(
                         "tool_compatibility_boundary",
-                        "missing_item_identity",
+                        "duplicate_call_identity",
                         surface=surface,
                     )
-                allowed_fields = {
-                    "type",
-                    "id",
-                    "call_id",
-                    "namespace",
-                    "name",
-                    "arguments",
-                }
-                if surface in {"response", "stream"}:
-                    allowed_fields.add("status")
-                valid_field_sets = [allowed_fields]
-                if "status" in allowed_fields:
-                    valid_field_sets.append(allowed_fields - {"status"})
-                if set(item) not in valid_field_sets:
-                    raise ToolCompatibilityError(
-                        "tool_compatibility_boundary",
-                        "collaboration_call_fields_invalid",
-                        surface=surface,
-                    )
+                calls[call_id] = str(item["name"])
+            elif item_type == "function_call_output":
                 call_id = item.get("call_id")
                 if not isinstance(call_id, str) or not call_id:
                     raise ToolCompatibilityError(
@@ -1251,23 +1312,12 @@ class ToolCompatibilityPlan:
                         "missing_call_identity",
                         surface=surface,
                     )
-                if call_id in calls:
+                if call_id not in calls:
                     raise ToolCompatibilityError(
                         "tool_compatibility_boundary",
-                        "duplicate_call_identity",
+                        "unknown_call_identity",
                         surface=surface,
                     )
-                name = str(item["name"])
-                try:
-                    validate_collaboration_arguments(
-                        COLLABORATION_V2,
-                        name,
-                        item.get("arguments"),
-                    )
-                except CollaborationContractError as exc:
-                    self._raise_collaboration_contract(exc, surface=surface)
-                calls[call_id] = name
-            elif item_type == "function_call_output" and item.get("call_id") in calls:
                 item_id = item.get("id")
                 if not isinstance(item_id, str) or not item_id:
                     raise ToolCompatibilityError(
@@ -1281,14 +1331,21 @@ class ToolCompatibilityPlan:
                         "collaboration_result_fields_invalid",
                         surface=surface,
                     )
+                if call_id in seen_result_call_ids:
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "duplicate_call_identity",
+                        surface=surface,
+                    )
                 try:
                     validate_collaboration_result(
                         COLLABORATION_V2,
-                        calls[str(item["call_id"])],
+                        calls[call_id],
                         item.get("output"),
                     )
                 except CollaborationContractError as exc:
                     self._raise_collaboration_contract(exc, surface=surface)
+                seen_result_call_ids.add(call_id)
             else:
                 continue
             if not isinstance(item_id, str) or not item_id:
@@ -3234,6 +3291,11 @@ class CompatibilityStreamState:
         self._agent_message_added_order: list[str] = []
         self._agent_message_done: set[str] = set()
         self._agent_message_done_order: list[str] = []
+        self._collaboration_v2_calls: dict[str, dict[str, Any]] = {}
+        self._collaboration_v2_output_indices: dict[str, int] = {}
+        self._collaboration_v2_added_order: list[str] = []
+        self._collaboration_v2_done: set[str] = set()
+        self._collaboration_v2_done_order: list[str] = []
         self._terminal = False
 
     @property
@@ -3656,12 +3718,16 @@ class CompatibilityStreamState:
         agent_message_incomplete = (
             set(self._agent_message_pending) - self._agent_message_done
         )
+        collaboration_v2_incomplete = (
+            set(self._collaboration_v2_calls) - self._collaboration_v2_done
+        )
         if (
             incomplete
             or native_incomplete
             or opaque_incomplete
             or search_incomplete
             or agent_message_incomplete
+            or collaboration_v2_incomplete
         ):
             raise ToolCompatibilityError("tool_compatibility_boundary", "incomplete_stream", surface="stream")
         self._terminal = True
@@ -3677,12 +3743,104 @@ class CompatibilityStreamState:
             )
         return output_index
 
+    @staticmethod
+    def _collaboration_v2_output_index(event: Mapping[str, Any]) -> int:
+        output_index = event.get("output_index")
+        if type(output_index) is not int or output_index < 0:
+            raise ToolCompatibilityError(
+                "tool_compatibility_boundary",
+                "ambiguous_native_identity",
+                surface="stream",
+            )
+        return output_index
+
+    def _record_collaboration_v2_added(
+        self,
+        item_id: str,
+        item: Mapping[str, Any],
+        event: Mapping[str, Any],
+    ) -> None:
+        if item_id in self._collaboration_v2_calls:
+            raise ToolCompatibilityError(
+                "tool_compatibility_boundary",
+                "duplicate_item_identity",
+                surface="stream",
+            )
+        output_index = self._collaboration_v2_output_index(event)
+        if (
+            output_index in self._collaboration_v2_output_indices.values()
+            or (
+                self._collaboration_v2_added_order
+                and output_index
+                <= self._collaboration_v2_output_indices[
+                    self._collaboration_v2_added_order[-1]
+                ]
+            )
+        ):
+            raise ToolCompatibilityError(
+                "tool_compatibility_boundary",
+                "ambiguous_native_identity",
+                surface="stream",
+            )
+        self._collaboration_v2_calls[item_id] = _copy_mapping(item)
+        self._collaboration_v2_output_indices[item_id] = output_index
+        self._collaboration_v2_added_order.append(item_id)
+
+    def _validate_collaboration_v2_stream_call(
+        self,
+        item_id: str,
+        item: Mapping[str, Any],
+        *,
+        surface: str = "stream",
+    ) -> dict[str, Any]:
+        canonical = _copy_mapping(item)
+        record = self.plan.registry.record_for_alias(canonical.get("name"))
+        if record is not None and record.version == "v2" and record.family == NAMESPACE:
+            canonical, _record, _changed = self._check_alias_in_item(
+                canonical,
+                allow_incomplete=False,
+            )
+        self.plan._validate_collaboration_v2_call_item(
+            canonical,
+            surface=surface,
+        )
+        expected = self._collaboration_v2_calls.get(item_id)
+        if expected is None:
+            raise ToolCompatibilityError(
+                "tool_compatibility_boundary",
+                "missing_stream_identity",
+                surface=surface,
+            )
+        for key in ("id", "call_id", "namespace", "name"):
+            if canonical.get(key) != expected.get(key):
+                raise ToolCompatibilityError(
+                    "tool_compatibility_boundary",
+                    "ambiguous_native_identity",
+                    surface=surface,
+                )
+        return canonical
+
+    def _validate_collaboration_v2_event_index(
+        self,
+        item_id: str,
+        event: Mapping[str, Any],
+    ) -> None:
+        output_index = self._collaboration_v2_output_index(event)
+        expected_output_index = self._collaboration_v2_output_indices.get(item_id)
+        if expected_output_index is None or output_index != expected_output_index:
+            raise ToolCompatibilityError(
+                "tool_compatibility_boundary",
+                "ambiguous_native_identity",
+                surface="stream",
+            )
+
     def _validate_terminal_native_output(self, response: Mapping[str, Any]) -> None:
         output = response.get("output")
         required_native_ids = {
             item_id
             for item_id in self._native_pending
         }
+        required_collaboration_v2_ids = set(self._collaboration_v2_calls)
         required_adapter_ids = set(self._pending) | set(self._adapter_wire_identities)
         required_agent_message_ids = set(self._agent_message_pending)
         if output is None:
@@ -3697,13 +3855,19 @@ class CompatibilityStreamState:
                 )
             return
         if output == []:
-            if required_native_ids or required_adapter_ids or required_agent_message_ids:
+            if (
+                required_native_ids
+                or required_collaboration_v2_ids
+                or required_adapter_ids
+                or required_agent_message_ids
+            ):
                 raise ToolCompatibilityError("tool_compatibility_boundary", "incomplete_stream", surface="stream")
             return
         if not isinstance(output, list):
             raise ToolCompatibilityError("tool_compatibility_boundary", "malformed_stream_event", surface="stream")
         seen_output_ids: set[str] = set()
         terminal_agent_message_order: list[str] = []
+        terminal_collaboration_v2_order: list[str] = []
         for output_index, item in enumerate(output):
             if not isinstance(item, Mapping):
                 continue
@@ -3740,6 +3904,86 @@ class CompatibilityStreamState:
                         surface="stream",
                     )
                 terminal_agent_message_order.append(item_id)
+                continue
+            collaboration_v2_record = None
+            if item_id is not None:
+                collaboration_v2_record = self._collaboration_v2_calls.get(item_id)
+            alias_record = self.plan.registry.record_for_alias(item.get("name"))
+            is_collaboration_v2_item = (
+                collaboration_v2_record is not None
+                or (
+                    item.get("type") == "function_call"
+                    and (
+                        (
+                            item.get("namespace") == "collaboration"
+                            and item.get("name") in _V2_NAMES
+                        )
+                        or (
+                            alias_record is not None
+                            and alias_record.version == "v2"
+                            and alias_record.family == NAMESPACE
+                        )
+                    )
+                )
+            )
+            if is_collaboration_v2_item:
+                # Terminal output is not allowed to establish a new V2 call.
+                # The call must have been established by ``output_item.added``
+                # and completed by ``output_item.done`` first.
+                canonical = self._validate_collaboration_v2_stream_call(
+                    item_id or "",
+                    item,
+                )
+                if item_id is None or collaboration_v2_record is None:
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "missing_stream_identity",
+                        surface="stream",
+                    )
+                expected_output_index = self._collaboration_v2_output_indices.get(item_id)
+                if expected_output_index is None or output_index != expected_output_index:
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "ambiguous_native_identity",
+                        surface="stream",
+                    )
+                if item_id not in self._collaboration_v2_done:
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "incomplete_stream",
+                        surface="stream",
+                    )
+                if (
+                    terminal_collaboration_v2_order
+                    and self._collaboration_v2_output_indices[
+                        terminal_collaboration_v2_order[-1]
+                    ]
+                    >= expected_output_index
+                ):
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "ambiguous_native_identity",
+                        surface="stream",
+                )
+                expected_payload = self._wire_payloads.get(item_id)
+                payload_owner = alias_record
+                if payload_owner is None:
+                    payload_owner = self._native_entry_for_item(canonical)
+                if payload_owner is None:
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "ambiguous_native_identity",
+                        surface="stream",
+                    )
+                if expected_payload is not None and self._semantic_wire_payload(
+                    canonical, payload_owner
+                ) != expected_payload:
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "ambiguous_native_identity",
+                        surface="stream",
+                    )
+                terminal_collaboration_v2_order.append(item_id)
                 continue
             pending = self._native_pending.get(item_id) if item_id is not None else None
             if pending is None:
@@ -3941,11 +4185,20 @@ class CompatibilityStreamState:
                     surface="stream",
                 )
         missing = (
-            required_native_ids | required_adapter_ids | required_agent_message_ids
+            required_native_ids
+            | required_collaboration_v2_ids
+            | required_adapter_ids
+            | required_agent_message_ids
         ) - seen_output_ids
         if missing:
             raise ToolCompatibilityError("tool_compatibility_boundary", "incomplete_stream", surface="stream")
         if terminal_agent_message_order != self._agent_message_added_order:
+            raise ToolCompatibilityError(
+                "tool_compatibility_boundary",
+                "ambiguous_native_identity",
+                surface="stream",
+            )
+        if terminal_collaboration_v2_order != self._collaboration_v2_added_order:
             raise ToolCompatibilityError(
                 "tool_compatibility_boundary",
                 "ambiguous_native_identity",
@@ -3969,6 +4222,12 @@ class CompatibilityStreamState:
             return self._decode_hosted_event(result, hosted_event_spec)
         item = result.get("item")
         if isinstance(item, Mapping) and item.get("type") == "agent_message":
+            if self.plan._collaboration_v2_entry() is None:
+                raise ToolCompatibilityError(
+                    "tool_compatibility_boundary",
+                    "unknown_native_identity",
+                    surface="stream",
+                )
             self.plan._validate_collaboration_v2_items([item], surface="stream")
             item_id = self._item_id(item)
             if item_id is None:
@@ -4098,6 +4357,17 @@ class CompatibilityStreamState:
                     record,
                     self._native_wire_identity(item),
                 )
+                if record.version == "v2" and record.family == NAMESPACE:
+                    self.plan._validate_collaboration_v2_call_item(
+                        decoded_item,
+                        surface="stream",
+                        allow_incomplete_arguments=True,
+                    )
+                    self._record_collaboration_v2_added(
+                        item_id,
+                        decoded_item,
+                        result,
+                    )
                 result["item"] = decoded_item
                 return result
             native_entry = self._native_entry_for_item(item)
@@ -4135,10 +4405,18 @@ class CompatibilityStreamState:
                     raise ToolCompatibilityError("tool_compatibility_boundary", "duplicate_item_identity", surface="stream")
                 if call_id in self._seen_call_ids:
                     raise ToolCompatibilityError("tool_compatibility_boundary", "duplicate_call_identity", surface="stream")
+                if native_entry.version == "v2" and native_entry.family == NAMESPACE:
+                    self.plan._validate_collaboration_v2_call_item(
+                        item,
+                        surface="stream",
+                        allow_incomplete_arguments=True,
+                    )
                 self._seen_item_ids.add(item_id)
                 self._seen_call_ids.add(call_id)
                 self._native_pending[item_id] = (call_id, native_entry)
                 self._native_wire_identities[item_id] = self._native_wire_identity(item)
+                if native_entry.version == "v2" and native_entry.family == NAMESPACE:
+                    self._record_collaboration_v2_added(item_id, item, result)
                 result["item"] = decoded_item
             elif item.get("type") == "custom_tool_call":
                 if self.plan._omitted_response_entry_for_item(item) is not None:
@@ -4210,6 +4488,8 @@ class CompatibilityStreamState:
                         "ambiguous_call_identity",
                         surface="stream",
                     )
+                if expected_entry.version == "v2" and expected_entry.family == NAMESPACE:
+                    self._validate_collaboration_v2_event_index(item_id, result)
                 delta = result.get("delta")
                 if not isinstance(delta, str):
                     raise ToolCompatibilityError("tool_compatibility_boundary", "malformed_stream_delta", surface="stream")
@@ -4246,6 +4526,8 @@ class CompatibilityStreamState:
             pending = self._pending_for(result)
             if isinstance(result.get("call_id"), str) and result.get("call_id") != pending.call_id:
                 raise ToolCompatibilityError("tool_compatibility_boundary", "ambiguous_call_identity", surface="stream")
+            if pending.record.version == "v2" and pending.record.family == NAMESPACE:
+                self._validate_collaboration_v2_event_index(item_id, result)
             delta = result.get("delta")
             if not isinstance(delta, str):
                 raise ToolCompatibilityError("tool_compatibility_boundary", "malformed_stream_delta", surface="stream")
@@ -4270,6 +4552,8 @@ class CompatibilityStreamState:
                         "ambiguous_call_identity",
                         surface="stream",
                     )
+                if expected_entry.version == "v2" and expected_entry.family == NAMESPACE:
+                    self._validate_collaboration_v2_event_index(item_id, result)
                 if item_id in self._native_delta_done:
                     raise ToolCompatibilityError("tool_compatibility_boundary", "duplicate_stream_done", surface="stream")
                 arguments = result.get("arguments", result.get("input"))
@@ -4278,6 +4562,15 @@ class CompatibilityStreamState:
                 fragments = self._native_fragments.get(item_id, [])
                 if fragments and "".join(fragments) != arguments:
                     raise ToolCompatibilityError("tool_compatibility_boundary", "incomplete_stream_delta", surface="stream")
+                if expected_entry.version == "v2" and expected_entry.family == NAMESPACE:
+                    complete_item = _copy_mapping(
+                        self._collaboration_v2_calls.get(item_id, {})
+                    )
+                    complete_item["arguments"] = arguments
+                    self._validate_collaboration_v2_stream_call(
+                        item_id,
+                        complete_item,
+                    )
                 payload_item = (
                     {"type": "custom_tool_call", "input": result.get("input", arguments)}
                     if expected_entry.family == CUSTOM_FREEFORM
@@ -4326,6 +4619,8 @@ class CompatibilityStreamState:
             pending = self._pending_for(result)
             if isinstance(result.get("call_id"), str) and result.get("call_id") != pending.call_id:
                 raise ToolCompatibilityError("tool_compatibility_boundary", "ambiguous_call_identity", surface="stream")
+            if pending.record.version == "v2" and pending.record.family == NAMESPACE:
+                self._validate_collaboration_v2_event_index(item_id, result)
             if pending.delta_done:
                 raise ToolCompatibilityError("tool_compatibility_boundary", "duplicate_stream_done", surface="stream")
             arguments = result.get("arguments", result.get("input"))
@@ -4335,6 +4630,18 @@ class CompatibilityStreamState:
                 raise ToolCompatibilityError("tool_compatibility_boundary", "incomplete_stream_delta", surface="stream")
             if not arguments:
                 raise ToolCompatibilityError("tool_compatibility_boundary", "incomplete_stream_delta", surface="stream")
+            if pending.record.version == "v2" and pending.record.family == NAMESPACE:
+                complete_item = {
+                    "type": "function_call",
+                    "id": item_id,
+                    "call_id": pending.call_id,
+                    "name": pending.record.alias,
+                    "arguments": arguments,
+                }
+                self._validate_collaboration_v2_stream_call(
+                    item_id,
+                    complete_item,
+                )
             pending.delta_done = True
             if pending.record.family == CUSTOM_FREEFORM:
                 envelope = _json_object_exact(arguments)
@@ -4455,6 +4762,36 @@ class CompatibilityStreamState:
                             "ambiguous_native_identity",
                             surface="stream",
                         )
+                    is_v2_call = (
+                        expected_entry.version == "v2"
+                        and expected_entry.family == NAMESPACE
+                    )
+                    if is_v2_call:
+                        output_index = self._collaboration_v2_output_index(result)
+                        expected_output_index = self._collaboration_v2_output_indices.get(
+                            native_item_id
+                        )
+                        if (
+                            expected_output_index is None
+                            or output_index != expected_output_index
+                            or native_item_id in self._collaboration_v2_done
+                            or (
+                                self._collaboration_v2_done_order
+                                and output_index
+                                <= self._collaboration_v2_output_indices[
+                                    self._collaboration_v2_done_order[-1]
+                                ]
+                            )
+                        ):
+                            raise ToolCompatibilityError(
+                                "tool_compatibility_boundary",
+                                "ambiguous_native_identity",
+                                surface="stream",
+                            )
+                        self._validate_collaboration_v2_stream_call(
+                            native_item_id,
+                            item,
+                        )
                     if expected_entry.family == SELECTED_PROVIDER_HOSTED:
                         hosted_entry = self._native_entry_for_item(item)
                         if hosted_entry is None or hosted_entry is not expected_entry:
@@ -4487,6 +4824,9 @@ class CompatibilityStreamState:
                         raise ToolCompatibilityError("tool_compatibility_boundary", "ambiguous_native_identity", surface="stream")
                     self._wire_payloads[native_item_id] = payload
                     self._native_done.add(native_item_id)
+                    if is_v2_call:
+                        self._collaboration_v2_done.add(native_item_id)
+                        self._collaboration_v2_done_order.append(native_item_id)
                     return result
                 native_entry = self._native_entry_for_item(item)
                 if native_entry is not None:
@@ -4575,11 +4915,41 @@ class CompatibilityStreamState:
                 decoded_item, _record, _changed = self.plan._decode_call(item, allow_incomplete=False)
             else:
                 decoded_item, _record, _changed = self._check_alias_in_item(item, allow_incomplete=False)
+            is_v2_call = pending.record.version == "v2" and pending.record.family == NAMESPACE
+            if is_v2_call:
+                output_index = self._collaboration_v2_output_index(result)
+                expected_output_index = self._collaboration_v2_output_indices.get(
+                    pending.item_id
+                )
+                if (
+                    expected_output_index is None
+                    or output_index != expected_output_index
+                    or pending.item_id in self._collaboration_v2_done
+                    or (
+                        self._collaboration_v2_done_order
+                        and output_index
+                        <= self._collaboration_v2_output_indices[
+                            self._collaboration_v2_done_order[-1]
+                        ]
+                    )
+                ):
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "ambiguous_native_identity",
+                        surface="stream",
+                    )
+                decoded_item = self._validate_collaboration_v2_stream_call(
+                    pending.item_id,
+                    decoded_item,
+                )
             pending.item_done = True
             payload = self._semantic_wire_payload(item, pending.record)
             if pending.item_id in self._wire_payloads and self._wire_payloads[pending.item_id] != payload:
                 raise ToolCompatibilityError("tool_compatibility_boundary", "ambiguous_native_identity", surface="stream")
             self._wire_payloads[pending.item_id] = payload
+            if is_v2_call:
+                self._collaboration_v2_done.add(pending.item_id)
+                self._collaboration_v2_done_order.append(pending.item_id)
             result["item"] = decoded_item
             return result
         if isinstance(item, Mapping) and self.plan.registry.looks_like_alias(item.get("name")):

--- a/src-python/runtime_tool_compatibility.py
+++ b/src-python/runtime_tool_compatibility.py
@@ -3230,7 +3230,10 @@ class CompatibilityStreamState:
         # later deltas and terminal events cannot borrow an arbitrary id.
         self._opaque_pending: dict[str, _OpaqueStreamItem] = {}
         self._agent_message_pending: dict[str, Any] = {}
+        self._agent_message_output_indices: dict[str, int] = {}
+        self._agent_message_added_order: list[str] = []
         self._agent_message_done: set[str] = set()
+        self._agent_message_done_order: list[str] = []
         self._terminal = False
 
     @property
@@ -3663,6 +3666,17 @@ class CompatibilityStreamState:
             raise ToolCompatibilityError("tool_compatibility_boundary", "incomplete_stream", surface="stream")
         self._terminal = True
 
+    @staticmethod
+    def _agent_message_output_index(event: Mapping[str, Any]) -> int:
+        output_index = event.get("output_index")
+        if type(output_index) is not int or output_index < 0:
+            raise ToolCompatibilityError(
+                "tool_compatibility_boundary",
+                "ambiguous_native_identity",
+                surface="stream",
+            )
+        return output_index
+
     def _validate_terminal_native_output(self, response: Mapping[str, Any]) -> None:
         output = response.get("output")
         required_native_ids = {
@@ -3675,6 +3689,12 @@ class CompatibilityStreamState:
             # Some upstream terminal envelopes omit ``output`` after the SSE
             # lifecycle has already delivered the completed item.  _finish_terminal
             # below still rejects an actually incomplete lifecycle.
+            if required_agent_message_ids:
+                raise ToolCompatibilityError(
+                    "tool_compatibility_boundary",
+                    "incomplete_stream",
+                    surface="stream",
+                )
             return
         if output == []:
             if required_native_ids or required_adapter_ids or required_agent_message_ids:
@@ -3683,7 +3703,8 @@ class CompatibilityStreamState:
         if not isinstance(output, list):
             raise ToolCompatibilityError("tool_compatibility_boundary", "malformed_stream_event", surface="stream")
         seen_output_ids: set[str] = set()
-        for item in output:
+        terminal_agent_message_order: list[str] = []
+        for output_index, item in enumerate(output):
             if not isinstance(item, Mapping):
                 continue
             item_id = _item_identity(item)
@@ -3693,19 +3714,32 @@ class CompatibilityStreamState:
                 seen_output_ids.add(item_id)
             if item.get("type") == "agent_message":
                 self.plan._validate_collaboration_v2_items([item], surface="stream")
-                if item_id in self._agent_message_pending:
-                    if item_id not in self._agent_message_done:
-                        raise ToolCompatibilityError(
-                            "tool_compatibility_boundary",
-                            "incomplete_stream",
-                            surface="stream",
-                        )
-                    if _freeze(item) != self._agent_message_pending[item_id]:
-                        raise ToolCompatibilityError(
-                            "tool_compatibility_boundary",
-                            "ambiguous_native_identity",
-                            surface="stream",
-                        )
+                if item_id not in self._agent_message_pending:
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "missing_stream_identity",
+                        surface="stream",
+                    )
+                expected_output_index = self._agent_message_output_indices[item_id]
+                if output_index != expected_output_index:
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "ambiguous_native_identity",
+                        surface="stream",
+                    )
+                if item_id not in self._agent_message_done:
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "incomplete_stream",
+                        surface="stream",
+                    )
+                if _freeze(item) != self._agent_message_pending[item_id]:
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "ambiguous_native_identity",
+                        surface="stream",
+                    )
+                terminal_agent_message_order.append(item_id)
                 continue
             pending = self._native_pending.get(item_id) if item_id is not None else None
             if pending is None:
@@ -3911,6 +3945,12 @@ class CompatibilityStreamState:
         ) - seen_output_ids
         if missing:
             raise ToolCompatibilityError("tool_compatibility_boundary", "incomplete_stream", surface="stream")
+        if terminal_agent_message_order != self._agent_message_added_order:
+            raise ToolCompatibilityError(
+                "tool_compatibility_boundary",
+                "ambiguous_native_identity",
+                surface="stream",
+            )
 
     def decode_event(self, event: Mapping[str, Any]) -> dict[str, Any]:
         if not isinstance(event, Mapping):
@@ -3944,8 +3984,26 @@ class CompatibilityStreamState:
                         "duplicate_item_identity",
                         surface="stream",
                     )
+                output_index = self._agent_message_output_index(result)
+                if (
+                    output_index in self._agent_message_output_indices.values()
+                    or (
+                        self._agent_message_added_order
+                        and output_index
+                        <= self._agent_message_output_indices[
+                            self._agent_message_added_order[-1]
+                        ]
+                    )
+                ):
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "ambiguous_native_identity",
+                        surface="stream",
+                    )
                 self._seen_item_ids.add(item_id)
                 self._agent_message_pending[item_id] = _freeze(item)
+                self._agent_message_output_indices[item_id] = output_index
+                self._agent_message_added_order.append(item_id)
                 return result
             if event_type == "response.output_item.done":
                 if item_id not in self._agent_message_pending:
@@ -3960,6 +4018,25 @@ class CompatibilityStreamState:
                         "duplicate_item_identity",
                         surface="stream",
                     )
+                output_index = self._agent_message_output_index(result)
+                if output_index != self._agent_message_output_indices[item_id]:
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "ambiguous_native_identity",
+                        surface="stream",
+                    )
+                if (
+                    self._agent_message_done_order
+                    and output_index
+                    <= self._agent_message_output_indices[
+                        self._agent_message_done_order[-1]
+                    ]
+                ):
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "ambiguous_native_identity",
+                        surface="stream",
+                    )
                 if _freeze(item) != self._agent_message_pending[item_id]:
                     raise ToolCompatibilityError(
                         "tool_compatibility_boundary",
@@ -3967,6 +4044,7 @@ class CompatibilityStreamState:
                         surface="stream",
                     )
                 self._agent_message_done.add(item_id)
+                self._agent_message_done_order.append(item_id)
                 return result
             raise ToolCompatibilityError(
                 "tool_compatibility_boundary",
@@ -3977,6 +4055,12 @@ class CompatibilityStreamState:
             response = result.get("response")
             if isinstance(response, Mapping):
                 self._validate_terminal_native_output(response)
+            elif self._agent_message_pending:
+                raise ToolCompatibilityError(
+                    "tool_compatibility_boundary",
+                    "incomplete_stream",
+                    surface="stream",
+                )
             self._finish_terminal()
             if isinstance(response, Mapping):
                 decoded_output, output_changed = self.plan._decode_items(

--- a/src-python/runtime_tool_compatibility.py
+++ b/src-python/runtime_tool_compatibility.py
@@ -1275,6 +1275,36 @@ class ToolCompatibilityPlan:
                     surface=surface,
                 )
             return
+
+        def claims_collaboration_v2_identity(item: Mapping[str, Any]) -> bool:
+            if item.get("namespace") == "collaboration":
+                return True
+            record = self.registry.record_for_alias(item.get("name"))
+            return bool(
+                record is not None
+                and record.family == NAMESPACE
+                and record.version == "v2"
+                and record.namespace == "collaboration"
+            )
+
+        # Results do not repeat the function identity.  Preclassify local call
+        # ownership so only results paired with an unrelated call bypass V2
+        # validation; result identities without a local owner remain closed.
+        collaboration_call_ids: set[str] = set()
+        unrelated_call_ids: set[str] = set()
+        for item in items:
+            if not isinstance(item, Mapping) or item.get("type") != "function_call":
+                continue
+            call_id = item.get("call_id")
+            if not isinstance(call_id, str) or not call_id:
+                continue
+            target = (
+                collaboration_call_ids
+                if claims_collaboration_v2_identity(item)
+                else unrelated_call_ids
+            )
+            target.add(call_id)
+
         calls: dict[str, str] = {}
         seen_result_call_ids: set[str] = set()
         seen_item_ids: set[str] = set()
@@ -1288,11 +1318,7 @@ class ToolCompatibilityPlan:
                 except CollaborationContractError as exc:
                     self._raise_collaboration_contract(exc, surface=surface)
                 item_id = item.get("id")
-            elif (
-                item_type == "function_call"
-                and item.get("namespace") == "collaboration"
-                and item.get("name") in _V2_NAMES
-            ):
+            elif item_type == "function_call" and claims_collaboration_v2_identity(item):
                 item_id, call_id = self._validate_collaboration_v2_call_item(
                     item,
                     surface=surface,
@@ -1312,6 +1338,22 @@ class ToolCompatibilityPlan:
                         "missing_call_identity",
                         surface=surface,
                     )
+                record = self.registry.record_for_call(call_id)
+                result_claims_collaboration_v2 = (
+                    claims_collaboration_v2_identity(item)
+                    or (
+                        record is not None
+                        and record.family == NAMESPACE
+                        and record.version == "v2"
+                        and record.namespace == "collaboration"
+                    )
+                )
+                if (
+                    call_id in unrelated_call_ids
+                    and call_id not in collaboration_call_ids
+                    and not result_claims_collaboration_v2
+                ):
+                    continue
                 if call_id not in calls:
                     raise ToolCompatibilityError(
                         "tool_compatibility_boundary",

--- a/src-python/runtime_tool_compatibility.py
+++ b/src-python/runtime_tool_compatibility.py
@@ -3229,6 +3229,8 @@ class CompatibilityStreamState:
         # an opaque stream owner once ``output_item.added`` establishes it so
         # later deltas and terminal events cannot borrow an arbitrary id.
         self._opaque_pending: dict[str, _OpaqueStreamItem] = {}
+        self._agent_message_pending: dict[str, Any] = {}
+        self._agent_message_done: set[str] = set()
         self._terminal = False
 
     @property
@@ -3648,7 +3650,16 @@ class CompatibilityStreamState:
             pending.arguments_done_event is None
             for pending in self._buffered_tool_search.values()
         )
-        if incomplete or native_incomplete or opaque_incomplete or search_incomplete:
+        agent_message_incomplete = (
+            set(self._agent_message_pending) - self._agent_message_done
+        )
+        if (
+            incomplete
+            or native_incomplete
+            or opaque_incomplete
+            or search_incomplete
+            or agent_message_incomplete
+        ):
             raise ToolCompatibilityError("tool_compatibility_boundary", "incomplete_stream", surface="stream")
         self._terminal = True
 
@@ -3659,13 +3670,14 @@ class CompatibilityStreamState:
             for item_id in self._native_pending
         }
         required_adapter_ids = set(self._pending) | set(self._adapter_wire_identities)
+        required_agent_message_ids = set(self._agent_message_pending)
         if output is None:
             # Some upstream terminal envelopes omit ``output`` after the SSE
             # lifecycle has already delivered the completed item.  _finish_terminal
             # below still rejects an actually incomplete lifecycle.
             return
         if output == []:
-            if required_native_ids or required_adapter_ids:
+            if required_native_ids or required_adapter_ids or required_agent_message_ids:
                 raise ToolCompatibilityError("tool_compatibility_boundary", "incomplete_stream", surface="stream")
             return
         if not isinstance(output, list):
@@ -3679,6 +3691,22 @@ class CompatibilityStreamState:
                 if item_id in seen_output_ids:
                     raise ToolCompatibilityError("tool_compatibility_boundary", "duplicate_item_identity", surface="stream")
                 seen_output_ids.add(item_id)
+            if item.get("type") == "agent_message":
+                self.plan._validate_collaboration_v2_items([item], surface="stream")
+                if item_id in self._agent_message_pending:
+                    if item_id not in self._agent_message_done:
+                        raise ToolCompatibilityError(
+                            "tool_compatibility_boundary",
+                            "incomplete_stream",
+                            surface="stream",
+                        )
+                    if _freeze(item) != self._agent_message_pending[item_id]:
+                        raise ToolCompatibilityError(
+                            "tool_compatibility_boundary",
+                            "ambiguous_native_identity",
+                            surface="stream",
+                        )
+                continue
             pending = self._native_pending.get(item_id) if item_id is not None else None
             if pending is None:
                 legacy_done = self._legacy_unowned_done.get(item_id) if item_id is not None else None
@@ -3878,7 +3906,9 @@ class CompatibilityStreamState:
                     "ambiguous_call_identity",
                     surface="stream",
                 )
-        missing = (required_native_ids | required_adapter_ids) - seen_output_ids
+        missing = (
+            required_native_ids | required_adapter_ids | required_agent_message_ids
+        ) - seen_output_ids
         if missing:
             raise ToolCompatibilityError("tool_compatibility_boundary", "incomplete_stream", surface="stream")
 
@@ -3900,6 +3930,49 @@ class CompatibilityStreamState:
         item = result.get("item")
         if isinstance(item, Mapping) and item.get("type") == "agent_message":
             self.plan._validate_collaboration_v2_items([item], surface="stream")
+            item_id = self._item_id(item)
+            if item_id is None:
+                raise ToolCompatibilityError(
+                    "tool_compatibility_boundary",
+                    "missing_item_identity",
+                    surface="stream",
+                )
+            if event_type == "response.output_item.added":
+                if item_id in self._seen_item_ids:
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "duplicate_item_identity",
+                        surface="stream",
+                    )
+                self._seen_item_ids.add(item_id)
+                self._agent_message_pending[item_id] = _freeze(item)
+                return result
+            if event_type == "response.output_item.done":
+                if item_id not in self._agent_message_pending:
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "missing_stream_identity",
+                        surface="stream",
+                    )
+                if item_id in self._agent_message_done:
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "duplicate_item_identity",
+                        surface="stream",
+                    )
+                if _freeze(item) != self._agent_message_pending[item_id]:
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "ambiguous_native_identity",
+                        surface="stream",
+                    )
+                self._agent_message_done.add(item_id)
+                return result
+            raise ToolCompatibilityError(
+                "tool_compatibility_boundary",
+                "invalid_agent_message_lifecycle",
+                surface="stream",
+            )
         if event_type in {"response.completed", "response.incomplete", "response.failed"}:
             response = result.get("response")
             if isinstance(response, Mapping):

--- a/tests/test_issue_198_v1_v2_isolation.py
+++ b/tests/test_issue_198_v1_v2_isolation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import hashlib
 import json
 from unittest.mock import patch
@@ -7,6 +8,7 @@ from unittest.mock import patch
 import pytest
 
 import codex_proxy
+from collaboration_runtime_contract import EXPECTED_PARAMETER_SCHEMAS
 from codex_semantic_adapter import (
     COLLABORATION_V1,
     COLLABORATION_V2,
@@ -33,6 +35,7 @@ def _v2_spawn_call() -> dict[str, object]:
         "type": "function_call",
         "namespace": "collaboration",
         "name": "spawn_agent",
+        "id": "item_v2_spawn",
         "call_id": "call_v2_spawn",
         "arguments": {
             "task_name": "worker-task",
@@ -47,8 +50,42 @@ def _v1_spawn_call() -> dict[str, object]:
         "type": "function_call",
         "namespace": "multi_agent_v1",
         "name": "spawn_agent",
+        "id": "item_v1_spawn",
         "call_id": "call_v1_spawn",
         "arguments": {"agent_type": "general", "message": "return the bounded result"},
+    }
+
+
+def _collaboration_namespace(version: str) -> dict[str, object]:
+    namespace = "multi_agent_v1" if version == COLLABORATION_V1 else "collaboration"
+    children = []
+    for name, schema in EXPECTED_PARAMETER_SCHEMAS[version].items():
+        parameters = copy.deepcopy(schema)
+        if not parameters["required"]:
+            del parameters["required"]
+        children.append(
+            {
+                "type": "function",
+                "name": name,
+                "description": "dynamic",
+                "strict": False,
+                "parameters": parameters,
+            }
+        )
+    return {
+        "type": "namespace",
+        "name": namespace,
+        "description": "dynamic",
+        "tools": children,
+    }
+
+
+def _v2_spawn_output() -> dict[str, object]:
+    return {
+        "type": "function_call_output",
+        "id": "item_v2_spawn_output",
+        "call_id": "call_v2_spawn",
+        "output": '{"task_name":"/root/worker-task"}',
     }
 
 
@@ -57,13 +94,8 @@ def test_collaboration_boundary_classifies_explicit_protocols_and_rejects_mixed_
     assert classify_collaboration_payload({"input": [_v2_spawn_call()]}) == COLLABORATION_V2
     assert classify_collaboration_payload(
         {
-            "tools": [
-                {
-                    "type": "namespace",
-                    "name": "collaboration",
-                    "tools": [{"type": "function", "name": "spawn_agent"}],
-                }
-            ]
+            "tool_choice": "auto",
+            "tools": [_collaboration_namespace(COLLABORATION_V2)],
         }
     ) == COLLABORATION_V2
 
@@ -82,8 +114,9 @@ def test_collaboration_boundary_classifies_explicit_protocols_and_rejects_mixed_
                 ]
             }
         )
-    assert classify_collaboration_payload({"metadata": {"multi_agent_version": "v2"}}) == COLLABORATION_V2
-    with pytest.raises(CollaborationBoundaryError, match="unknown_state"):
+    with pytest.raises(CollaborationBoundaryError, match="collaboration_version_signal_unexpected"):
+        classify_collaboration_payload({"metadata": {"multi_agent_version": "v2"}})
+    with pytest.raises(CollaborationBoundaryError, match="collaboration_version_signal_unexpected"):
         classify_collaboration_payload({"metadata": {"multi_agent_version": "v3"}})
     with pytest.raises(CollaborationBoundaryError, match="missing_namespace"):
         classify_collaboration_payload({"namespace": "collaboration", "type": "function_call"})
@@ -91,26 +124,8 @@ def test_collaboration_boundary_classifies_explicit_protocols_and_rejects_mixed_
 
 def test_v2_namespace_function_declaration_accepts_parameters_schema() -> None:
     body = {
-        "tools": [
-            {
-                "type": "namespace",
-                "name": "collaboration",
-                "tools": [
-                    {
-                        "type": "function",
-                        "name": "followup_task",
-                        "description": "Continue work in a child task.",
-                        "parameters": {
-                            "type": "object",
-                            "properties": {
-                                "task_name": {"type": "string"},
-                                "message": {"type": "string"},
-                            },
-                        },
-                    }
-                ],
-            }
-        ]
+        "tool_choice": "auto",
+        "tools": [_collaboration_namespace(COLLABORATION_V2)],
     }
 
     assert classify_collaboration_payload(body) == COLLABORATION_V2
@@ -185,13 +200,8 @@ def test_current_v2_tools_reject_malformed_collaboration_history(
     body = {
         "model": "gpt-5.6-luna",
         "input": [history_item],
-        "tools": [
-            {
-                "type": "namespace",
-                "name": "collaboration",
-                "tools": [{"type": "function", "name": "followup_task"}],
-            }
-        ],
+        "tool_choice": "auto",
+        "tools": [_collaboration_namespace(COLLABORATION_V2)],
     }
 
     with pytest.raises(codex_proxy.UpstreamProtocolTranslationError) as exc_info:
@@ -211,15 +221,10 @@ def test_current_v2_tools_allow_completed_mixed_collaboration_history() -> None:
             _v1_spawn_call(),
             {"type": "function_call_output", "call_id": "call_v1_spawn", "output": "done"},
             _v2_spawn_call(),
-            {"type": "function_call_output", "call_id": "call_v2_spawn", "output": "done"},
+            _v2_spawn_output(),
         ],
-        "tools": [
-            {
-                "type": "namespace",
-                "name": "collaboration",
-                "tools": [{"type": "function", "name": "followup_task"}],
-            }
-        ],
+        "tool_choice": "auto",
+        "tools": [_collaboration_namespace(COLLABORATION_V2)],
     }
     context = {"request_id": "mixed-history-v2-current"}
 
@@ -261,13 +266,8 @@ def test_v2_request_preserves_native_namespace_and_does_not_inject_v1_tools() ->
     body = {
         "model": "glm-5.2",
         "input": [_v2_spawn_call()],
-        "tools": [
-            {
-                "type": "namespace",
-                "name": "collaboration",
-                "tools": [{"type": "function", "name": "spawn_agent"}],
-            }
-        ],
+        "tool_choice": "auto",
+        "tools": [_collaboration_namespace(COLLABORATION_V2)],
     }
 
     transformed = codex_proxy.compatible_request_body(
@@ -304,18 +304,13 @@ def test_v2_preserves_collaboration_calls_but_rewrites_unsupported_custom_tool_h
         "model": "glm-5.2",
         "input": [
             _v2_spawn_call(),
-            {"type": "function_call_output", "call_id": "call_v2_spawn", "output": "done"},
+            _v2_spawn_output(),
             custom_call,
             custom_output,
             {"type": "message", "role": "user", "content": "continue"},
         ],
-        "tools": [
-            {
-                "type": "namespace",
-                "name": "collaboration",
-                "tools": [{"type": "function", "name": "spawn_agent"}],
-            }
-        ],
+        "tool_choice": "auto",
+        "tools": [_collaboration_namespace(COLLABORATION_V2)],
     }
 
     transformed = codex_proxy.compatible_request_body(
@@ -355,12 +350,9 @@ def test_v2_does_not_preserve_custom_history_that_only_matches_a_plain_function(
                 "output": "completed",
             },
         ],
+        "tool_choice": "auto",
         "tools": [
-            {
-                "type": "namespace",
-                "name": "collaboration",
-                "tools": [{"type": "function", "name": "spawn_agent"}],
-            },
+            _collaboration_namespace(COLLABORATION_V2),
             {"type": "function", "name": "exec"},
         ],
     }
@@ -405,12 +397,9 @@ def test_v2_does_not_preserve_undeclared_custom_history_when_capability_is_expli
                 "output": "completed",
             },
         ],
+        "tool_choice": "auto",
         "tools": [
-            {
-                "type": "namespace",
-                "name": "collaboration",
-                "tools": [{"type": "function", "name": "spawn_agent"}],
-            },
+            _collaboration_namespace(COLLABORATION_V2),
             {"type": "function", "name": "exec"},
         ],
     }
@@ -450,12 +439,9 @@ def test_v2_does_not_preserve_unknown_custom_alias_history() -> None:
                 "output": "completed",
             },
         ],
+        "tool_choice": "auto",
         "tools": [
-            {
-                "type": "namespace",
-                "name": "collaboration",
-                "tools": [{"type": "function", "name": "spawn_agent"}],
-            },
+            _collaboration_namespace(COLLABORATION_V2),
         ],
     }
 
@@ -497,12 +483,9 @@ def test_v2_does_not_treat_namespace_alias_as_custom_history_owner() -> None:
                 "output": "completed",
             },
         ],
+        "tool_choice": "auto",
         "tools": [
-            {
-                "type": "namespace",
-                "name": "collaboration",
-                "tools": [{"type": "function", "name": "spawn_agent"}],
-            },
+            _collaboration_namespace(COLLABORATION_V2),
             {
                 "type": "namespace",
                 "name": "other",
@@ -601,12 +584,9 @@ def test_v2_preserves_custom_history_when_upstream_explicitly_supports_custom_li
                 "output": "completed",
             },
         ],
+        "tool_choice": "auto",
         "tools": [
-            {
-                "type": "namespace",
-                "name": "collaboration",
-                "tools": [{"type": "function", "name": "spawn_agent"}],
-            },
+            _collaboration_namespace(COLLABORATION_V2),
             {
                 "type": "custom",
                 "name": "exec",
@@ -643,12 +623,9 @@ def test_v2_preserves_declared_custom_history_without_event_context() -> None:
                 "output": "completed",
             },
         ],
+        "tool_choice": "auto",
         "tools": [
-            {
-                "type": "namespace",
-                "name": "collaboration",
-                "tools": [{"type": "function", "name": "spawn_agent"}],
-            },
+            _collaboration_namespace(COLLABORATION_V2),
             {
                 "type": "custom",
                 "name": "exec",
@@ -761,7 +738,7 @@ def test_selected_v2_metadata_skips_v1_injection_without_a_call_marker() -> None
     }
 
 
-def test_selected_v2_model_metadata_in_context_skips_v1_injection() -> None:
+def test_context_multi_agent_version_does_not_select_a_runtime_protocol() -> None:
     context = {
         "repair_policy": REPAIR_CODEX_SUBAGENT,
         "multi_agent_version": "v2",
@@ -774,13 +751,11 @@ def test_selected_v2_model_metadata_in_context_skips_v1_injection() -> None:
     )
     payload = json.loads(transformed)
 
-    assert context["collaboration_protocol"] == COLLABORATION_V2
-    assert "multi_agent_v1__spawn_agent" not in {
-        tool.get("name") for tool in payload.get("tools", []) if isinstance(tool, dict)
-    }
+    assert "collaboration_protocol" not in context
+    assert payload["input"]
 
 
-def test_selected_v2_model_metadata_in_request_skips_v1_injection() -> None:
+def test_request_multi_agent_version_is_rejected() -> None:
     context = {
         "repair_policy": REPAIR_CODEX_SUBAGENT,
         "request_id": "issue198-request-v2",
@@ -791,17 +766,13 @@ def test_selected_v2_model_metadata_in_request_skips_v1_injection() -> None:
         "metadata": {"multi_agent_version": "v2"},
     }
 
-    transformed = codex_proxy.compatible_request_body(
-        json.dumps(body).encode(),
-        _upstream(),
-        event_context=context,
-    )
-    payload = json.loads(transformed)
-
-    assert context["collaboration_protocol"] == COLLABORATION_V2
-    assert "multi_agent_v1__spawn_agent" not in {
-        tool.get("name") for tool in payload.get("tools", []) if isinstance(tool, dict)
-    }
+    with pytest.raises(codex_proxy.UpstreamProtocolTranslationError) as caught:
+        codex_proxy.compatible_request_body(
+            json.dumps(body).encode(),
+            _upstream(),
+            event_context=context,
+        )
+    assert caught.value.cause.code == codex_proxy.COLLABORATION_BOUNDARY_ERROR_CODE
 
 
 @pytest.mark.parametrize(
@@ -809,8 +780,6 @@ def test_selected_v2_model_metadata_in_request_skips_v1_injection() -> None:
     [
         ({"collaboration_protocol": "collaboration_v1"}, COLLABORATION_V1),
         ({"collaboration_protocol": "collaboration_v2"}, COLLABORATION_V2),
-        ({"metadata": {"multi_agent_version": "v2"}}, COLLABORATION_V2),
-        ({"features": {"multi_agent_version": "v2"}}, COLLABORATION_V2),
     ],
 )
 def test_context_feature_selection_is_table_driven(
@@ -888,12 +857,16 @@ def test_selected_v2_context_overrides_v1_history() -> None:
 def test_conflicting_current_target_metadata_fails_closed() -> None:
     with pytest.raises(codex_proxy.UpstreamProtocolTranslationError) as exc_info:
         codex_proxy.compatible_request_body(
-            json.dumps({"model": "glm-5.2", "input": "continue"}).encode(),
+            json.dumps(
+                {
+                    "model": "glm-5.2",
+                    "input": "continue",
+                    "metadata": {"multi_agent_version": "v1"},
+                    "features": {"multi_agent_version": "v2"},
+                }
+            ).encode(),
             _upstream(),
-            event_context={
-                "multi_agent_version": "v1",
-                "features": {"multi_agent_version": "v2"},
-            },
+            event_context={},
         )
 
     assert exc_info.value.cause.code == codex_proxy.COLLABORATION_BOUNDARY_ERROR_CODE
@@ -945,12 +918,9 @@ def test_model_switch_v2_history_to_v1_current_surface_is_allowed() -> None:
     context = {"repair_policy": REPAIR_CODEX_SUBAGENT, "request_id": "switch-v2-v1"}
     body = {
         "model": "deepseek-v4-flash:0731",
-        "input": [_v2_spawn_call(), {"type": "function_call_output", "call_id": "call_v2_spawn", "output": "done"}],
-        "tools": [{
-            "type": "namespace",
-            "name": "multi_agent_v1",
-            "tools": [{"type": "function", "name": "spawn_agent"}],
-        }],
+        "input": [_v2_spawn_call(), _v2_spawn_output()],
+        "tool_choice": "auto",
+        "tools": [_collaboration_namespace(COLLABORATION_V1)],
     }
     upstream = _upstream()
     upstream["upstream_model"] = body["model"]
@@ -970,11 +940,8 @@ def test_model_switch_v1_history_to_v2_current_surface_is_allowed() -> None:
     body = {
         "model": "gpt-5.6-luna",
         "input": [_v1_spawn_call(), {"type": "function_call_output", "call_id": "call_v1_spawn", "output": "done"}],
-        "tools": [{
-            "type": "namespace",
-            "name": "collaboration",
-            "tools": [{"type": "function", "name": "followup_task"}],
-        }],
+        "tool_choice": "auto",
+        "tools": [_collaboration_namespace(COLLABORATION_V2)],
     }
     upstream = _upstream()
     upstream["upstream_model"] = body["model"]
@@ -989,7 +956,7 @@ def test_model_switch_v1_history_to_v2_current_surface_is_allowed() -> None:
     assert payload["tools"][0]["name"] == "collaboration"
 
 
-def test_current_tool_surface_overrides_previous_turn_protocol_context() -> None:
+def test_current_tool_surface_conflicting_with_context_fails_closed() -> None:
     context = {
         "repair_policy": REPAIR_CODEX_SUBAGENT,
         "collaboration_protocol": COLLABORATION_V2,
@@ -998,27 +965,25 @@ def test_current_tool_surface_overrides_previous_turn_protocol_context() -> None
     body = {
         "model": "deepseek-v4-flash:0731",
         "input": [{"type": "message", "role": "user", "content": "continue"}],
-        "tools": [{
-            "type": "namespace",
-            "name": "multi_agent_v1",
-            "tools": [{"type": "function", "name": "spawn_agent"}],
-        }],
+        "tool_choice": "auto",
+        "tools": [_collaboration_namespace(COLLABORATION_V1)],
     }
 
-    codex_proxy.compatible_request_body(
-        json.dumps(body).encode(), _upstream(), event_context=context,
-    )
-
-    assert context["collaboration_protocol"] == COLLABORATION_V1
+    with pytest.raises(codex_proxy.UpstreamProtocolTranslationError) as caught:
+        codex_proxy.compatible_request_body(
+            json.dumps(body).encode(), _upstream(), event_context=context,
+        )
+    assert caught.value.cause.code == codex_proxy.COLLABORATION_BOUNDARY_ERROR_CODE
 
 
 def test_current_tool_surface_containing_both_protocols_still_fails_closed() -> None:
     body = {
         "model": "deepseek-v4-flash:0731",
         "input": [{"type": "message", "role": "user", "content": "continue"}],
+        "tool_choice": "auto",
         "tools": [
-            {"type": "namespace", "name": "multi_agent_v1", "tools": [{"type": "function", "name": "spawn_agent"}]},
-            {"type": "namespace", "name": "collaboration", "tools": [{"type": "function", "name": "followup_task"}]},
+            _collaboration_namespace(COLLABORATION_V1),
+            _collaboration_namespace(COLLABORATION_V2),
         ],
     }
 
@@ -1031,13 +996,8 @@ def test_current_tool_surface_containing_both_protocols_still_fails_closed() -> 
 def test_current_target_boundary_precedence_handles_mixed_history() -> None:
     current_v1_tools_body = {
         "input": [_v1_spawn_call(), _v2_spawn_call()],
-        "tools": [
-            {
-                "type": "namespace",
-                "name": "multi_agent_v1",
-                "tools": [{"type": "function", "name": "spawn_agent"}],
-            }
-        ],
+        "tool_choice": "auto",
+        "tools": [_collaboration_namespace(COLLABORATION_V1)],
     }
     context = {}
 
@@ -1050,7 +1010,7 @@ def test_current_target_boundary_precedence_handles_mixed_history() -> None:
     assert codex_proxy._resolve_collaboration_boundary(
         {"input": [_v1_spawn_call(), _v2_spawn_call()]},
         {"multi_agent_version": "v2"},
-    ) == COLLABORATION_V2
+    ) is None
 
     with patch.object(codex_proxy, "write_proxy_event") as write_event:
         history_context = {}
@@ -1070,17 +1030,10 @@ def test_current_target_boundary_precedence_handles_mixed_history() -> None:
             json.dumps(
                 {
                     "input": [{"type": "message", "role": "user", "content": "continue"}],
+                    "tool_choice": "auto",
                     "tools": [
-                        {
-                            "type": "namespace",
-                            "name": "multi_agent_v1",
-                            "tools": [{"type": "function", "name": "spawn_agent"}],
-                        },
-                        {
-                            "type": "namespace",
-                            "name": "collaboration",
-                            "tools": [{"type": "function", "name": "followup_task"}],
-                        },
+                        _collaboration_namespace(COLLABORATION_V1),
+                        _collaboration_namespace(COLLABORATION_V2),
                     ],
                 }
             ).encode(),

--- a/tests/test_issue_198_v1_v2_isolation.py
+++ b/tests/test_issue_198_v1_v2_isolation.py
@@ -37,11 +37,14 @@ def _v2_spawn_call() -> dict[str, object]:
         "name": "spawn_agent",
         "id": "item_v2_spawn",
         "call_id": "call_v2_spawn",
-        "arguments": {
-            "task_name": "worker-task",
-            "message": "return the bounded result",
-            "fork_turns": "all",
-        },
+        "arguments": json.dumps(
+            {
+                "task_name": "worker-task",
+                "message": "return the bounded result",
+                "fork_turns": "all",
+            },
+            separators=(",", ":"),
+        ),
     }
 
 
@@ -214,7 +217,7 @@ def test_current_v2_tools_reject_malformed_collaboration_history(
     assert exc_info.value.cause.code == codex_proxy.COLLABORATION_BOUNDARY_ERROR_CODE
 
 
-def test_current_v2_tools_allow_completed_mixed_collaboration_history() -> None:
+def test_current_v2_tools_reject_completed_mixed_collaboration_history() -> None:
     body = {
         "model": "gpt-5.6-luna",
         "input": [
@@ -228,24 +231,16 @@ def test_current_v2_tools_allow_completed_mixed_collaboration_history() -> None:
     }
     context = {"request_id": "mixed-history-v2-current"}
 
-    with patch.object(codex_proxy, "write_proxy_event") as write_event:
-        transformed = codex_proxy.compatible_request_body(
-            json.dumps(body).encode(),
-            _upstream(),
-            event_context=context,
-        )
+    with patch.object(codex_proxy, "_prepare_runtime_tool_compatibility") as prepare:
+        with pytest.raises(codex_proxy.UpstreamProtocolTranslationError) as caught:
+            codex_proxy.compatible_request_body(
+                json.dumps(body).encode(),
+                _upstream(),
+                event_context=context,
+            )
 
-    transformed_payload = json.loads(transformed)
-    assert transformed_payload["input"] == body["input"]
-    assert transformed_payload["tools"][0]["name"] == "collaboration"
-    assert context["collaboration_protocol"] == COLLABORATION_V2
-    mixed_events = [
-        call for call in write_event.call_args_list
-        if call.args and call.args[0] == "collaboration_history_mixed"
-    ]
-    assert len(mixed_events) == 1
-    assert mixed_events[0].kwargs["protocol_count"] == 2
-    assert set(mixed_events[0].kwargs) <= {"request_id", "protocol_count"}
+    assert caught.value.cause.code == codex_proxy.COLLABORATION_BOUNDARY_ERROR_CODE
+    prepare.assert_not_called()
 
 
 def test_collaboration_protocols_collects_mixed_history_protocols() -> None:
@@ -814,7 +809,7 @@ def test_unknown_context_state_fails_closed() -> None:
     assert exc_info.value.cause.code == codex_proxy.COLLABORATION_BOUNDARY_ERROR_CODE
 
 
-def test_mixed_history_diagnostic_is_bounded_and_does_not_include_payload() -> None:
+def test_mixed_history_rejection_is_bounded_and_does_not_include_payload() -> None:
     context = {"request_id": "safe-request", "repair_policy": REPAIR_CODEX_SUBAGENT}
     body = {
         "model": "glm-5.2",
@@ -828,30 +823,36 @@ def test_mixed_history_diagnostic_is_bounded_and_does_not_include_payload() -> N
     }
 
     with patch.object(codex_proxy, "write_proxy_event") as write_event:
-        assert codex_proxy._resolve_collaboration_boundary(body, context) is None
+        with pytest.raises(codex_proxy.UpstreamProtocolTranslationError):
+            codex_proxy._resolve_collaboration_boundary(body, context)
 
-    event = next(call for call in write_event.call_args_list if call.args[0] == "collaboration_history_mixed")
+    event = next(
+        call
+        for call in write_event.call_args_list
+        if call.args[0] == "collaboration_boundary_rejected"
+    )
     fields = event.kwargs
-    assert fields["protocol_count"] == 2
+    assert fields == {"surface": "request", "outcome": "rejected", "count": 1}
     assert "SECRET_PROMPT" not in repr(fields)
     assert "SECRET_TASK" not in repr(fields)
     assert "call_v1_spawn" not in repr(fields)
 
 
-def test_selected_v2_context_overrides_v1_history() -> None:
+def test_selected_v2_context_conflicting_with_v1_history_fails_closed() -> None:
     context = {
         "repair_policy": REPAIR_CODEX_SUBAGENT,
         "collaboration_protocol": COLLABORATION_V2,
         "request_id": "issue198-conflict",
     }
 
-    codex_proxy.compatible_request_body(
-        json.dumps({"model": "glm-5.2", "input": [_v1_spawn_call()]}).encode(),
-        _upstream(),
-        event_context=context,
-    )
+    with pytest.raises(codex_proxy.UpstreamProtocolTranslationError) as caught:
+        codex_proxy.compatible_request_body(
+            json.dumps({"model": "glm-5.2", "input": [_v1_spawn_call()]}).encode(),
+            _upstream(),
+            event_context=context,
+        )
 
-    assert context["collaboration_protocol"] == COLLABORATION_V2
+    assert caught.value.cause.code == codex_proxy.COLLABORATION_BOUNDARY_ERROR_CODE
 
 
 def test_conflicting_current_target_metadata_fails_closed() -> None:
@@ -891,7 +892,7 @@ def test_official_passthrough_does_not_interpret_collaboration_metadata() -> Non
     assert payload["input"] == body_payload["input"]
 
 
-def test_v1_request_keeps_existing_repair_path_and_mixed_history_is_tolerated() -> None:
+def test_v1_request_keeps_existing_repair_path_and_rejects_mixed_history() -> None:
     context = {"repair_policy": REPAIR_CODEX_SUBAGENT, "request_id": "issue198-v1"}
     transformed = codex_proxy.compatible_request_body(
         json.dumps({"model": "glm-5.2", "input": [_v1_spawn_call()]}).encode(),
@@ -907,14 +908,16 @@ def test_v1_request_keeps_existing_repair_path_and_mixed_history_is_tolerated() 
     )
 
     mixed_context = {"request_id": "issue198-mixed"}
-    codex_proxy.compatible_request_body(
-        json.dumps({"model": "glm-5.2", "input": [_v1_spawn_call(), _v2_spawn_call()]}).encode(),
-        _upstream(),
-        event_context=mixed_context,
-    )
+    with pytest.raises(codex_proxy.UpstreamProtocolTranslationError) as caught:
+        codex_proxy.compatible_request_body(
+            json.dumps({"model": "glm-5.2", "input": [_v1_spawn_call(), _v2_spawn_call()]}).encode(),
+            _upstream(),
+            event_context=mixed_context,
+        )
+    assert caught.value.cause.code == codex_proxy.COLLABORATION_BOUNDARY_ERROR_CODE
 
 
-def test_model_switch_v2_history_to_v1_current_surface_is_allowed() -> None:
+def test_model_switch_v2_history_to_v1_current_surface_fails_closed() -> None:
     context = {"repair_policy": REPAIR_CODEX_SUBAGENT, "request_id": "switch-v2-v1"}
     body = {
         "model": "deepseek-v4-flash:0731",
@@ -925,17 +928,15 @@ def test_model_switch_v2_history_to_v1_current_surface_is_allowed() -> None:
     upstream = _upstream()
     upstream["upstream_model"] = body["model"]
 
-    payload = json.loads(codex_proxy.compatible_request_body(
-        json.dumps(body).encode(), upstream, event_context=context,
-    ))
+    with pytest.raises(codex_proxy.UpstreamProtocolTranslationError) as caught:
+        codex_proxy.compatible_request_body(
+            json.dumps(body).encode(), upstream, event_context=context,
+        )
 
-    assert context["collaboration_protocol"] == COLLABORATION_V1
-    assert payload["model"] == upstream["upstream_model"]
-    assert payload["input"][0]["namespace"] == "collaboration"
-    assert payload["tools"][0]["name"] == "multi_agent_v1"
+    assert caught.value.cause.code == codex_proxy.COLLABORATION_BOUNDARY_ERROR_CODE
 
 
-def test_model_switch_v1_history_to_v2_current_surface_is_allowed() -> None:
+def test_model_switch_v1_history_to_v2_current_surface_fails_closed() -> None:
     context = {"repair_policy": REPAIR_CODEX_SUBAGENT, "request_id": "switch-v1-v2"}
     body = {
         "model": "gpt-5.6-luna",
@@ -946,14 +947,12 @@ def test_model_switch_v1_history_to_v2_current_surface_is_allowed() -> None:
     upstream = _upstream()
     upstream["upstream_model"] = body["model"]
 
-    payload = json.loads(codex_proxy.compatible_request_body(
-        json.dumps(body).encode(), upstream, event_context=context,
-    ))
+    with pytest.raises(codex_proxy.UpstreamProtocolTranslationError) as caught:
+        codex_proxy.compatible_request_body(
+            json.dumps(body).encode(), upstream, event_context=context,
+        )
 
-    assert context["collaboration_protocol"] == COLLABORATION_V2
-    assert payload["model"] == upstream["upstream_model"]
-    assert payload["input"][0]["namespace"] == "multi_agent_v1"
-    assert payload["tools"][0]["name"] == "collaboration"
+    assert caught.value.cause.code == codex_proxy.COLLABORATION_BOUNDARY_ERROR_CODE
 
 
 def test_current_tool_surface_conflicting_with_context_fails_closed() -> None:
@@ -993,37 +992,22 @@ def test_current_tool_surface_containing_both_protocols_still_fails_closed() -> 
     assert exc_info.value.cause.code == codex_proxy.COLLABORATION_BOUNDARY_ERROR_CODE
 
 
-def test_current_target_boundary_precedence_handles_mixed_history() -> None:
+def test_current_target_boundary_rejects_mixed_history() -> None:
     current_v1_tools_body = {
         "input": [_v1_spawn_call(), _v2_spawn_call()],
         "tool_choice": "auto",
         "tools": [_collaboration_namespace(COLLABORATION_V1)],
     }
-    context = {}
-
-    assert codex_proxy._resolve_collaboration_boundary(
-        current_v1_tools_body,
-        context,
-    ) == COLLABORATION_V1
-    assert context["collaboration_protocol"] == COLLABORATION_V1
-
-    assert codex_proxy._resolve_collaboration_boundary(
-        {"input": [_v1_spawn_call(), _v2_spawn_call()]},
-        {"multi_agent_version": "v2"},
-    ) is None
-
-    with patch.object(codex_proxy, "write_proxy_event") as write_event:
-        history_context = {}
-        assert codex_proxy._resolve_collaboration_boundary(
+    for payload, context in (
+        (current_v1_tools_body, {}),
+        (
             {"input": [_v1_spawn_call(), _v2_spawn_call()]},
-            history_context,
-        ) is None
-
-    history_event = next(
-        call for call in write_event.call_args_list
-        if call.args[0] == "collaboration_history_mixed"
-    )
-    assert history_event.kwargs == {"protocol_count": 2}
+            {"multi_agent_version": "v2"},
+        ),
+        ({"input": [_v1_spawn_call(), _v2_spawn_call()]}, {}),
+    ):
+        with pytest.raises(codex_proxy.UpstreamProtocolTranslationError):
+            codex_proxy._resolve_collaboration_boundary(payload, context)
 
     with pytest.raises(codex_proxy.UpstreamProtocolTranslationError):
         codex_proxy.compatible_request_body(

--- a/tests/test_issue_282_collaboration_v2.py
+++ b/tests/test_issue_282_collaboration_v2.py
@@ -1,0 +1,557 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import codex_proxy
+from codex_semantic_adapter import (
+    COLLABORATION_V1,
+    COLLABORATION_V2,
+    CollaborationBoundaryError,
+    classify_collaboration_payload,
+)
+from runtime_tool_compatibility import (
+    ProtocolCapabilities,
+    ToolCompatibilityError,
+    build_tool_compatibility_plan,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTRACT_GENERATOR = ROOT / "scripts" / "build_issue_392_collaboration_contract.py"
+
+
+def _load_contract_generator():
+    spec = importlib.util.spec_from_file_location("issue392_runtime_contract", CONTRACT_GENERATOR)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _declaration(version: str) -> dict[str, object]:
+    module = _load_contract_generator()
+    namespace = module.V1_NAMESPACE if version == COLLABORATION_V1 else module.V2_NAMESPACE
+    children = []
+    for name, parameter_schema in module.EXPECTED_PARAMETER_SCHEMAS[version].items():
+        parameters = copy.deepcopy(parameter_schema)
+        if not parameters["required"]:
+            del parameters["required"]
+        children.append(
+            {
+                "type": "function",
+                "name": name,
+                "description": f"dynamic child description for {name}",
+                "strict": False,
+                "parameters": parameters,
+            }
+        )
+    return {
+        "type": "namespace",
+        "name": namespace,
+        "description": "dynamic namespace description",
+        "tools": children,
+    }
+
+
+def _request(version: str) -> dict[str, object]:
+    return {
+        "model": "model-a",
+        "tool_choice": "auto",
+        "tools": [_declaration(version)],
+        "input": [],
+    }
+
+
+def _responses_upstream(*, native_namespace: bool) -> dict[str, object]:
+    return {
+        "name": "responses_endpoint",
+        "upstream_model": "model-a",
+        "upstream_format": "responses",
+        "tool_protocol": "responses_structured",
+        "tool_surface_strategy": "eager",
+        "tool_protocol_capabilities": {
+            "function_lifecycle": True,
+            "namespace_lifecycle": native_namespace,
+            "accepts_namespace_adapter": True,
+        },
+    }
+
+
+V2_ARGUMENTS = {
+    "followup_task": {"target": "/root/worker", "message": "continue"},
+    "interrupt_agent": {"target": "/root/worker"},
+    "list_agents": {},
+    "send_message": {"target": "/root/worker", "message": "status"},
+    "spawn_agent": {"task_name": "worker", "message": "do work", "fork_turns": "all"},
+    "wait_agent": {"timeout_ms": 1000},
+}
+V2_RESULTS = {
+    "followup_task": None,
+    "interrupt_agent": {"previous_status": "running"},
+    "list_agents": {
+        "agents": [{"agent_name": "/root/worker", "agent_status": "running"}]
+    },
+    "send_message": None,
+    "spawn_agent": {"task_name": "/root/worker"},
+    "wait_agent": {"message": "done", "timed_out": False},
+}
+
+
+def _v2_history() -> list[dict[str, object]]:
+    history: list[dict[str, object]] = []
+    for index, name in enumerate(V2_ARGUMENTS):
+        call_id = f"call-{index}"
+        history.extend(
+            [
+                {
+                    "type": "function_call",
+                    "id": f"item-call-{index}",
+                    "call_id": call_id,
+                    "namespace": "collaboration",
+                    "name": name,
+                    "arguments": json.dumps(V2_ARGUMENTS[name], separators=(",", ":")),
+                },
+                {
+                    "type": "function_call_output",
+                    "id": f"item-result-{index}",
+                    "call_id": call_id,
+                    "output": json.dumps(V2_RESULTS[name], separators=(",", ":")),
+                },
+            ]
+        )
+    history.append(
+        {
+            "type": "agent_message",
+            "id": "agent-message-1",
+            "author": "/root/worker",
+            "recipient": "/root",
+            "content": [
+                {"type": "input_text", "text": "done"},
+                {"type": "encrypted_content", "encrypted_content": "opaque"},
+            ],
+        }
+    )
+    return history
+
+
+def _v2_plan(*, native: bool = False):
+    capabilities = ProtocolCapabilities.responses_structured(
+        namespace_lifecycle=native,
+        function_lifecycle=True,
+        accepts_namespace_adapter=True,
+    )
+    return build_tool_compatibility_plan(
+        [_declaration(COLLABORATION_V2)],
+        selected_protocol="responses_structured",
+        tool_choice="auto",
+        protocol_capabilities=capabilities,
+        request_token="issue-282",
+    )
+
+
+def test_exact_runtime_namespaces_classify_and_descriptions_are_dynamic() -> None:
+    for version in (COLLABORATION_V1, COLLABORATION_V2):
+        body = _request(version)
+        assert classify_collaboration_payload(body) == version
+        body["tools"][0]["description"] = "changed at runtime"
+        for child in body["tools"][0]["tools"]:
+            child["description"] = "also dynamic"
+        assert classify_collaboration_payload(body) == version
+
+
+@pytest.mark.parametrize(
+    ("mutate", "classification"),
+    [
+        (lambda body: body["tools"][0]["tools"].pop(), "namespace_child_set_invalid"),
+        (
+            lambda body: body["tools"][0]["tools"].append(
+                copy.deepcopy(body["tools"][0]["tools"][0])
+            ),
+            "namespace_child_duplicate",
+        ),
+        (
+            lambda body: body["tools"][0]["tools"][0].__setitem__("strict", True),
+            "namespace_child_strict_invalid",
+        ),
+        (
+            lambda body: body["tools"][0]["tools"][0]["parameters"].__setitem__(
+                "additionalProperties", True
+            ),
+            "namespace_child_parameter_schema_mismatch",
+        ),
+        (
+            lambda body: body["tools"][0]["tools"][0].__setitem__(
+                "output_schema", {"type": "object"}
+            ),
+            "namespace_child_fields_invalid",
+        ),
+        (lambda body: body.__setitem__("tool_choice", "required"), "tool_choice_invalid"),
+        (
+            lambda body: body.__setitem__("metadata", {"multi_agent_version": "v2"}),
+            "collaboration_version_signal_unexpected",
+        ),
+        (
+            lambda body: body.__setitem__("features", {"multi_agent_version": "v2"}),
+            "collaboration_version_signal_unexpected",
+        ),
+        (
+            lambda body: body.__setitem__("client_metadata", {"multi_agent_version": "v2"}),
+            "collaboration_version_signal_unexpected",
+        ),
+    ],
+)
+def test_exact_runtime_namespace_request_fails_closed(
+    mutate,
+    classification: str,
+) -> None:
+    body = _request(COLLABORATION_V2)
+    mutate(body)
+    with pytest.raises(CollaborationBoundaryError) as caught:
+        classify_collaboration_payload(body)
+    assert caught.value.classification == classification
+
+
+def test_direct_duplicate_and_mixed_runtime_markers_fail_closed() -> None:
+    direct = copy.deepcopy(_declaration(COLLABORATION_V2)["tools"])
+    with pytest.raises(CollaborationBoundaryError) as caught:
+        classify_collaboration_payload({"tool_choice": "auto", "tools": direct})
+    assert caught.value.classification == "collaboration_marker_missing"
+
+    duplicate = _request(COLLABORATION_V2)
+    duplicate["tools"].append(copy.deepcopy(duplicate["tools"][0]))
+    with pytest.raises(CollaborationBoundaryError) as caught:
+        classify_collaboration_payload(duplicate)
+    assert caught.value.classification == "collaboration_marker_duplicate_or_mixed"
+
+    mixed = _request(COLLABORATION_V2)
+    mixed["tools"].append(_declaration(COLLABORATION_V1))
+    with pytest.raises(CollaborationBoundaryError) as caught:
+        classify_collaboration_payload(mixed)
+    assert caught.value.classification == "collaboration_marker_duplicate_or_mixed"
+
+
+def test_invalid_request_is_rejected_before_runtime_planning() -> None:
+    body = _request(COLLABORATION_V2)
+    body["tools"][0]["tools"].pop()
+
+    with patch.object(codex_proxy, "_prepare_runtime_tool_compatibility") as prepare:
+        with pytest.raises(codex_proxy.UpstreamProtocolTranslationError) as caught:
+            codex_proxy.compatible_request_body(
+                json.dumps(body).encode(),
+                _responses_upstream(native_namespace=False),
+                event_context={"request_id": "bounded-request"},
+                inject_codex_tools=False,
+            )
+
+    assert caught.value.cause.code == codex_proxy.COLLABORATION_BOUNDARY_ERROR_CODE
+    prepare.assert_not_called()
+
+
+def test_collaboration_rejection_diagnostic_is_count_only_and_content_safe() -> None:
+    body = _request(COLLABORATION_V2)
+    body["tools"][0]["tools"].pop()
+    body["input"] = [
+        {
+            "type": "function_call",
+            "id": "SECRET_ITEM",
+            "call_id": "SECRET_CALL",
+            "namespace": "collaboration",
+            "name": "spawn_agent",
+            "arguments": '{"task_name":"SECRET_TASK","message":"SECRET_MESSAGE"}',
+        }
+    ]
+
+    with patch.object(codex_proxy, "write_proxy_event") as write_event:
+        with pytest.raises(codex_proxy.UpstreamProtocolTranslationError):
+            codex_proxy.compatible_request_body(
+                json.dumps(body).encode(),
+                _responses_upstream(native_namespace=False),
+                event_context={"request_id": "SECRET_REQUEST"},
+                inject_codex_tools=False,
+            )
+
+    rejected = next(
+        call for call in write_event.call_args_list
+        if call.args[0] == "collaboration_boundary_rejected"
+    )
+    assert rejected.kwargs == {"surface": "request", "outcome": "rejected", "count": 1}
+    assert "SECRET" not in repr(rejected.kwargs)
+
+
+def test_native_responses_namespace_is_validated_and_preserved_unchanged() -> None:
+    body = _request(COLLABORATION_V2)
+    raw = json.dumps(body, separators=(",", ":")).encode()
+    context: dict[str, object] = {}
+
+    transformed = codex_proxy.compatible_request_body(
+        raw,
+        _responses_upstream(native_namespace=True),
+        event_context=context,
+        inject_codex_tools=False,
+    )
+
+    assert transformed == raw
+    assert context["collaboration_protocol"] == COLLABORATION_V2
+    plan = context["_runtime_tool_compatibility_plan"]
+    assert plan.entries[0].disposition == "native"
+    assert plan.entries[0].version == "v2"
+
+
+def test_conservative_responses_adapts_all_six_v2_children_without_v1_behavior() -> None:
+    body = _request(COLLABORATION_V2)
+    context: dict[str, object] = {
+        "repair_policy": codex_proxy.REPAIR_CODEX_SUBAGENT,
+        "request_id": "bounded-request",
+    }
+
+    transformed = json.loads(
+        codex_proxy.compatible_request_body(
+            json.dumps(body).encode(),
+            _responses_upstream(native_namespace=False),
+            event_context=context,
+            inject_codex_tools=True,
+        )
+    )
+
+    aliases = [tool["name"] for tool in transformed["tools"]]
+    assert len(aliases) == 6
+    assert len(set(aliases)) == 6
+    assert all(alias.startswith("__codexhub_ns_") for alias in aliases)
+    assert not any("multi_agent_v1" in alias for alias in aliases)
+    assert context["collaboration_protocol"] == COLLABORATION_V2
+    assert context["subagent_spawn_allowed"] is False
+    plan = context["_runtime_tool_compatibility_plan"]
+    assert plan.entries[0].disposition == "adapt"
+    assert plan.entries[0].child_names == (
+        "followup_task",
+        "interrupt_agent",
+        "list_agents",
+        "send_message",
+        "spawn_agent",
+        "wait_agent",
+    )
+
+
+def test_v2_chat_surface_fails_before_sampling_instead_of_downgrading() -> None:
+    body = _request(COLLABORATION_V2)
+    upstream = {
+        "name": "chat_endpoint",
+        "upstream_model": "model-a",
+        "upstream_format": "chat_completions",
+        "tool_protocol": "chat_tools",
+        "tool_surface_strategy": "eager",
+    }
+
+    with pytest.raises(codex_proxy.UpstreamProtocolTranslationError) as caught:
+        codex_proxy.compatible_request_body(
+            json.dumps(body).encode(),
+            upstream,
+            event_context={},
+            inject_codex_tools=False,
+        )
+
+    assert caught.value.cause.code == "tool_compatibility_required_unavailable"
+
+
+def test_v2_unrepresentable_responses_surface_fails_instead_of_omitting_lifecycle() -> None:
+    with pytest.raises(ToolCompatibilityError) as caught:
+        build_tool_compatibility_plan(
+            [_declaration(COLLABORATION_V2)],
+            selected_protocol="responses_structured",
+            tool_choice="auto",
+            protocol_capabilities=ProtocolCapabilities(),
+            request_token="unrepresentable",
+        )
+
+    assert caught.value.code == "tool_compatibility_required_unavailable"
+
+
+@pytest.mark.parametrize("native", [False, True], ids=["adapted", "native"])
+def test_v2_all_six_calls_results_and_agent_message_round_trip(native: bool) -> None:
+    plan = _v2_plan(native=native)
+    original = {
+        "tool_choice": "auto",
+        "tools": [_declaration(COLLABORATION_V2)],
+        "input": _v2_history(),
+    }
+
+    encoded = plan.encode_payload(original)
+    decoded = plan.decode_payload({"input": encoded["input"]})
+
+    assert decoded["input"] == original["input"]
+    assert [item["id"] for item in decoded["input"]] == [
+        item["id"] for item in original["input"]
+    ]
+    if native:
+        assert encoded == original
+    else:
+        calls = [item for item in encoded["input"] if item["type"] == "function_call"]
+        assert len(calls) == 6
+        assert all("namespace" not in item for item in calls)
+        assert len({item["name"] for item in calls}) == 6
+
+
+def test_v2_adapted_history_and_restart_replay_use_the_same_inverse() -> None:
+    plan = _v2_plan()
+    payload = {
+        "tool_choice": "auto",
+        "tools": [_declaration(COLLABORATION_V2)],
+        "input": _v2_history(),
+    }
+
+    first = plan.encode_payload(payload)
+    restart = plan.new_attempt().encode_payload(payload)
+
+    assert restart == first
+    assert plan.decode_payload({"input": first["input"]})["input"] == payload["input"]
+
+
+@pytest.mark.parametrize(
+    ("mutate", "classification"),
+    [
+        (lambda history: history[0].pop("id"), "missing_item_identity"),
+        (
+            lambda history: history[2].__setitem__("id", history[0]["id"]),
+            "duplicate_item_identity",
+        ),
+        (
+            lambda history: history[0].__setitem__("arguments", '{"task_name":'),
+            "malformed_collaboration_arguments",
+        ),
+        (
+            lambda history: history[0].__setitem__(
+                "arguments", json.dumps({"target": 7, "message": "continue"})
+            ),
+            "collaboration_arguments_schema_mismatch",
+        ),
+        (
+            lambda history: history[1].__setitem__("output", json.dumps({"unexpected": True})),
+            "collaboration_result_schema_mismatch",
+        ),
+        (
+            lambda history: history[-1].__setitem__("extra", "not-on-wire"),
+            "agent_message_fields_invalid",
+        ),
+        (
+            lambda history: history[-1]["content"].append(
+                {"type": "output_text", "text": "wrong variant"}
+            ),
+            "agent_message_content_invalid",
+        ),
+    ],
+)
+def test_v2_lifecycle_ambiguity_and_schema_drift_fail_closed(
+    mutate,
+    classification: str,
+) -> None:
+    history = _v2_history()
+    mutate(history)
+
+    with pytest.raises(ToolCompatibilityError) as caught:
+        _v2_plan().encode_payload(
+            {
+                "tool_choice": "auto",
+                "tools": [_declaration(COLLABORATION_V2)],
+                "input": history,
+            }
+        )
+
+    assert caught.value.classification == classification
+    assert caught.value.surface == "history"
+
+
+def test_v2_adapted_stream_restores_all_six_calls_and_preserves_boundaries() -> None:
+    plan = _v2_plan()
+    stream = plan.new_stream()
+    decoded_types: list[str] = []
+    decoded_names: list[str] = []
+    wire_output: list[dict[str, object]] = []
+
+    for index, name in enumerate(V2_ARGUMENTS):
+        alias = plan.entries[0].aliases[index]
+        item_id = f"stream-item-{index}"
+        call_id = f"stream-call-{index}"
+        arguments = json.dumps(V2_ARGUMENTS[name], separators=(",", ":"))
+        added_item = {
+            "type": "function_call",
+            "id": item_id,
+            "call_id": call_id,
+            "name": alias,
+            "arguments": "",
+            "status": "in_progress",
+        }
+        done_item = {**added_item, "arguments": arguments, "status": "completed"}
+        events = [
+            {"type": "response.output_item.added", "output_index": index, "item": added_item},
+            {
+                "type": "response.function_call_arguments.delta",
+                "output_index": index,
+                "item_id": item_id,
+                "delta": arguments,
+            },
+            {
+                "type": "response.function_call_arguments.done",
+                "output_index": index,
+                "item_id": item_id,
+                "arguments": arguments,
+            },
+            {"type": "response.output_item.done", "output_index": index, "item": done_item},
+        ]
+        for event in events:
+            decoded = stream.decode_events_for_event(event)
+            assert len(decoded) == 1
+            decoded_types.append(decoded[0]["type"])
+            if decoded[0]["type"] == "response.output_item.done":
+                decoded_names.append(decoded[0]["item"]["name"])
+                assert decoded[0]["item"]["namespace"] == "collaboration"
+                assert decoded[0]["item"]["id"] == item_id
+                assert decoded[0]["item"]["call_id"] == call_id
+        wire_output.append(done_item)
+
+    terminal = stream.decode_events_for_event(
+        {
+            "type": "response.completed",
+            "response": {
+                "id": "response-1",
+                "model": "model-a",
+                "object": "response",
+                "output": wire_output,
+                "status": "completed",
+                "usage": {},
+            },
+        }
+    )
+
+    assert decoded_names == list(V2_ARGUMENTS)
+    assert decoded_types == [
+        event_type
+        for _ in V2_ARGUMENTS
+        for event_type in (
+            "response.output_item.added",
+            "response.function_call_arguments.delta",
+            "response.function_call_arguments.done",
+            "response.output_item.done",
+        )
+    ]
+    assert terminal[0]["type"] == "response.completed"
+    assert [item["name"] for item in terminal[0]["response"]["output"]] == list(V2_ARGUMENTS)
+
+
+def test_v2_stream_rejects_malformed_agent_message_before_forwarding() -> None:
+    stream = _v2_plan().new_stream()
+    item = _v2_history()[-1]
+    item["content"] = [{"type": "output_text", "text": "wrong variant"}]
+
+    with pytest.raises(ToolCompatibilityError) as caught:
+        stream.decode_events_for_event(
+            {"type": "response.output_item.added", "output_index": 0, "item": item}
+        )
+
+    assert caught.value.classification == "agent_message_content_invalid"
+    assert caught.value.surface == "stream"

--- a/tests/test_issue_282_collaboration_v2.py
+++ b/tests/test_issue_282_collaboration_v2.py
@@ -155,6 +155,36 @@ def _v2_plan(*, native: bool = False):
     )
 
 
+def _ordinary_function_declaration() -> dict[str, object]:
+    return {
+        "type": "function",
+        "name": "ordinary_lookup",
+        "description": "An unrelated ordinary function.",
+        "strict": False,
+        "parameters": {
+            "type": "object",
+            "properties": {"query": {"type": "string"}},
+            "required": ["query"],
+            "additionalProperties": False,
+        },
+    }
+
+
+def _mixed_v2_plan(*, native: bool = False):
+    capabilities = ProtocolCapabilities.responses_structured(
+        namespace_lifecycle=native,
+        function_lifecycle=True,
+        accepts_namespace_adapter=True,
+    )
+    return build_tool_compatibility_plan(
+        [_declaration(COLLABORATION_V2), _ordinary_function_declaration()],
+        selected_protocol="responses_structured",
+        tool_choice="auto",
+        protocol_capabilities=capabilities,
+        request_token="issue-282-mixed",
+    )
+
+
 def test_exact_runtime_namespaces_classify_and_descriptions_are_dynamic() -> None:
     for version in (COLLABORATION_V1, COLLABORATION_V2):
         body = _request(version)
@@ -681,6 +711,92 @@ def test_v2_history_results_are_owned_and_validated_fail_closed(
 
     assert caught.value.classification == classification
     assert caught.value.surface == "history"
+
+
+@pytest.mark.parametrize("native", [False, True], ids=["adapted", "native"])
+def test_v2_history_preserves_unrelated_function_call_and_result(native: bool) -> None:
+    plan = _mixed_v2_plan(native=native)
+    collaboration_call, collaboration_result = _v2_history()[:2]
+    ordinary_call = {
+        "type": "function_call",
+        "id": "ordinary-call-item",
+        "call_id": "ordinary-call",
+        "name": "ordinary_lookup",
+        "arguments": '{"query":"opaque"}',
+    }
+    ordinary_result = {
+        "type": "function_call_output",
+        "id": "ordinary-result-item",
+        "call_id": "ordinary-call",
+        "output": '{"value":"opaque"}',
+    }
+    history = [
+        collaboration_call,
+        ordinary_call,
+        ordinary_result,
+        collaboration_result,
+    ]
+    payload = {
+        "tool_choice": "auto",
+        "tools": [_declaration(COLLABORATION_V2), _ordinary_function_declaration()],
+        "input": history,
+    }
+    ordinary_wire = [
+        json.dumps(item, separators=(",", ":")).encode()
+        for item in (ordinary_call, ordinary_result)
+    ]
+
+    encoded = plan.encode_payload(payload)
+
+    assert [
+        json.dumps(item, separators=(",", ":")).encode()
+        for item in encoded["input"][1:3]
+    ] == ordinary_wire
+    if native:
+        assert encoded == payload
+    else:
+        assert encoded["input"][0]["name"] == plan.entries[0].aliases[0]
+        assert "namespace" not in encoded["input"][0]
+
+    decoded = plan.decode_payload({"input": encoded["input"]})
+    assert decoded["input"] == history
+
+
+@pytest.mark.parametrize("native", [False, True], ids=["adapted-alias", "native-namespace"])
+def test_v2_unknown_result_claiming_collaboration_identity_fails_closed(native: bool) -> None:
+    plan = _mixed_v2_plan(native=native)
+    ordinary_call = {
+        "type": "function_call",
+        "id": "ordinary-call-item",
+        "call_id": "ordinary-call",
+        "name": "ordinary_lookup",
+        "arguments": '{"query":"opaque"}',
+    }
+    identity = (
+        {"namespace": "collaboration", "name": "followup_task"}
+        if native
+        else {"name": plan.entries[0].aliases[0]}
+    )
+    unknown_result = {
+        "type": "function_call_output",
+        "id": "SECRET_RESULT_ITEM",
+        "call_id": "ordinary-call",
+        "output": '{"secret":"SECRET_RESULT_CONTENT"}',
+        **identity,
+    }
+
+    with pytest.raises(ToolCompatibilityError) as caught:
+        plan.encode_payload(
+            {
+                "tool_choice": "auto",
+                "tools": [_declaration(COLLABORATION_V2), _ordinary_function_declaration()],
+                "input": [ordinary_call, unknown_result],
+            }
+        )
+
+    assert caught.value.classification == "unknown_call_identity"
+    assert caught.value.surface == "history"
+    assert "SECRET" not in str(caught.value)
 
 
 def _agent_message_stream_event(

--- a/tests/test_issue_282_collaboration_v2.py
+++ b/tests/test_issue_282_collaboration_v2.py
@@ -631,6 +631,58 @@ def test_v2_request_history_requires_string_call_and_result_payloads(
     assert caught.value.surface == "history"
 
 
+@pytest.mark.parametrize(
+    ("mutate", "classification"),
+    [
+        (
+            lambda history: history.insert(0, history.pop(1)),
+            "unknown_call_identity",
+        ),
+        (
+            lambda history: history[1].__setitem__("call_id", "orphan-call"),
+            "unknown_call_identity",
+        ),
+        (
+            lambda history: history.append(copy.deepcopy(history[1])),
+            "duplicate_call_identity",
+        ),
+        (
+            lambda history: history[1].__setitem__("output", "{}"),
+            "collaboration_result_schema_mismatch",
+        ),
+        (
+            lambda history: history[1].__setitem__("output", {}),
+            "collaboration_result_wire_type_invalid",
+        ),
+    ],
+    ids=[
+        "result-before-call",
+        "orphan-result",
+        "duplicate-result",
+        "invalid-result-schema",
+        "invalid-result-wire-type",
+    ],
+)
+def test_v2_history_results_are_owned_and_validated_fail_closed(
+    mutate,
+    classification: str,
+) -> None:
+    history = _v2_history()[:2]
+    mutate(history)
+
+    with pytest.raises(ToolCompatibilityError) as caught:
+        _v2_plan().encode_payload(
+            {
+                "tool_choice": "auto",
+                "tools": [_declaration(COLLABORATION_V2)],
+                "input": history,
+            }
+        )
+
+    assert caught.value.classification == classification
+    assert caught.value.surface == "history"
+
+
 def _agent_message_stream_event(
     event_type: str,
     item: dict[str, object],
@@ -879,4 +931,163 @@ def test_v2_agent_message_stream_rejects_broken_lifecycle(events, classification
             stream.decode_events_for_event(event)
 
     assert caught.value.classification == classification
+    assert caught.value.surface == "stream"
+
+
+@pytest.mark.parametrize("native", [False, True], ids=["adapted", "native"])
+def test_v2_stream_call_lifecycle_reconciles_terminal_identity_and_order(native: bool) -> None:
+    plan = _v2_plan(native=native)
+    stream = plan.new_stream()
+    arguments = json.dumps(V2_ARGUMENTS["followup_task"], separators=(",", ":"))
+    name = "followup_task" if native else plan.entries[0].aliases[0]
+    item = {
+        "type": "function_call",
+        "id": "v2-stream-item",
+        "call_id": "v2-stream-call",
+        "name": name,
+        "arguments": "",
+        "status": "in_progress",
+    }
+    if native:
+        item["namespace"] = "collaboration"
+    stream.decode_events_for_event(
+        {"type": "response.output_item.added", "output_index": 0, "item": item}
+    )
+    stream.decode_events_for_event(
+        {
+            "type": "response.function_call_arguments.done",
+            "item_id": item["id"],
+            "output_index": 0,
+            "arguments": arguments,
+        }
+    )
+    done_item = {**item, "arguments": arguments, "status": "completed"}
+    stream.decode_events_for_event(
+        {"type": "response.output_item.done", "output_index": 0, "item": done_item}
+    )
+
+    terminal = stream.decode_events_for_event(
+        {
+            "type": "response.completed",
+            "response": {"output": [done_item]},
+        }
+    )
+    assert terminal[0]["response"]["output"][0]["id"] == item["id"]
+
+
+@pytest.mark.parametrize("native", [False, True], ids=["adapted", "native"])
+def test_v2_stream_rejects_output_index_drift_and_terminal_shape_changes(native: bool) -> None:
+    def make_stream() -> tuple[object, dict[str, object], str]:
+        plan = _v2_plan(native=native)
+        stream = plan.new_stream()
+        arguments = json.dumps(V2_ARGUMENTS["followup_task"], separators=(",", ":"))
+        name = "followup_task" if native else plan.entries[0].aliases[0]
+        item = {
+            "type": "function_call",
+            "id": "v2-stream-item",
+            "call_id": "v2-stream-call",
+            "name": name,
+            "arguments": "",
+            "status": "in_progress",
+        }
+        if native:
+            item["namespace"] = "collaboration"
+        stream.decode_events_for_event(
+            {"type": "response.output_item.added", "output_index": 0, "item": item}
+        )
+        stream.decode_events_for_event(
+            {
+                "type": "response.function_call_arguments.done",
+                "item_id": item["id"],
+                "output_index": 0,
+                "arguments": arguments,
+            }
+        )
+        return stream, {**item, "arguments": arguments, "status": "completed"}, arguments
+
+    stream, done_item, _arguments = make_stream()
+    with pytest.raises(ToolCompatibilityError) as caught:
+        stream.decode_events_for_event(
+            {"type": "response.output_item.done", "output_index": 1, "item": done_item}
+        )
+    assert caught.value.classification == "ambiguous_native_identity"
+
+    stream, done_item, _arguments = make_stream()
+    stream.decode_events_for_event(
+        {"type": "response.output_item.done", "output_index": 0, "item": done_item}
+    )
+    with pytest.raises(ToolCompatibilityError) as caught:
+        stream.decode_events_for_event(
+            {
+                "type": "response.completed",
+                "response": {"output": [{**done_item, "extra": "invalid"}]},
+            }
+        )
+    assert caught.value.classification == "collaboration_call_fields_invalid"
+
+
+def test_v2_stream_does_not_create_v1_worker_binding_state() -> None:
+    context: dict[str, object] = {}
+    body = _request(COLLABORATION_V2)
+    codex_proxy.compatible_request_body(
+        json.dumps(body).encode(),
+        _responses_upstream(native_namespace=False),
+        event_context=context,
+        inject_codex_tools=False,
+    )
+    alias = context["_runtime_tool_compatibility_plan"].entries[0].aliases[0]
+    added = {
+        "type": "response.output_item.added",
+        "output_index": 0,
+        "item": {
+            "type": "function_call",
+            "id": "v2-delta-item",
+            "call_id": "v2-delta-call",
+            "name": alias,
+            "arguments": "",
+            "status": "in_progress",
+        },
+    }
+    codex_proxy.compatible_sse_line(
+        ("data: " + json.dumps(added) + "\n").encode(),
+        "custom_endpoint",
+        event_context=context,
+    )
+    event = {
+        "type": "response.function_call_arguments.delta",
+        "output_index": 0,
+        "item_id": "v2-delta-item",
+        "delta": "{",
+    }
+    # The argument delta is intentionally incomplete; it still must not
+    # initialize the V1 worker stream scheduler before V2 is resolved.
+    codex_proxy.compatible_sse_line(
+        ("data: " + json.dumps(event) + "\n").encode(),
+        "custom_endpoint",
+        event_context=context,
+    )
+    assert "_worker_stream_binding_state" not in context
+    assert "_subagent_state" not in context
+
+
+def test_agent_message_requires_an_exact_selected_v2_contract() -> None:
+    plain_plan = build_tool_compatibility_plan(
+        [{"type": "function", "name": "plain", "parameters": {}}],
+        selected_protocol="responses_structured",
+        tool_choice="auto",
+        protocol_capabilities=ProtocolCapabilities.responses_structured(),
+        request_token="agent-message-without-v2",
+    )
+    item = _v2_history()[-1]
+
+    with pytest.raises(ToolCompatibilityError) as caught:
+        plain_plan.decode_payload({"input": [item]})
+    assert caught.value.classification == "unknown_native_identity"
+    assert caught.value.surface == "history"
+
+    with pytest.raises(ToolCompatibilityError) as caught:
+        plain_plan.new_stream().decode_events_for_event(
+            {"type": "response.output_item.added", "output_index": 0, "item": item}
+        )
+    assert caught.value.classification == "unknown_native_identity"
     assert caught.value.surface == "stream"

--- a/tests/test_issue_282_collaboration_v2.py
+++ b/tests/test_issue_282_collaboration_v2.py
@@ -555,3 +555,162 @@ def test_v2_stream_rejects_malformed_agent_message_before_forwarding() -> None:
 
     assert caught.value.classification == "agent_message_content_invalid"
     assert caught.value.surface == "stream"
+
+
+def test_mixed_collaboration_history_fails_before_runtime_planning() -> None:
+    body = _request(COLLABORATION_V2)
+    body["input"] = [
+        {
+            "type": "function_call",
+            "id": "item-v1",
+            "call_id": "call-v1",
+            "namespace": "multi_agent_v1",
+            "name": "spawn_agent",
+            "arguments": '{"agent_type":"general","message":"work"}',
+        },
+        _v2_history()[0],
+    ]
+
+    with patch.object(codex_proxy, "_prepare_runtime_tool_compatibility") as prepare:
+        with pytest.raises(codex_proxy.UpstreamProtocolTranslationError) as caught:
+            codex_proxy.compatible_request_body(
+                json.dumps(body).encode(),
+                _responses_upstream(native_namespace=False),
+                event_context={},
+                inject_codex_tools=False,
+            )
+
+    assert caught.value.cause.code == codex_proxy.COLLABORATION_BOUNDARY_ERROR_CODE
+    prepare.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("item_index", "field", "value", "classification"),
+    [
+        (0, "arguments", V2_ARGUMENTS["followup_task"], "collaboration_arguments_wire_type_invalid"),
+        (1, "output", None, "collaboration_result_wire_type_invalid"),
+        (
+            8,
+            "arguments",
+            '{"task_name":"worker","task_name":"other","message":"work"}',
+            "malformed_collaboration_arguments",
+        ),
+        (
+            9,
+            "output",
+            '{"task_name":"/root/worker","task_name":"/root/other"}',
+            "malformed_collaboration_result",
+        ),
+    ],
+    ids=[
+        "raw-arguments-object",
+        "raw-output-null",
+        "duplicate-argument-key",
+        "duplicate-result-key",
+    ],
+)
+def test_v2_request_history_requires_string_call_and_result_payloads(
+    item_index: int,
+    field: str,
+    value,
+    classification: str,
+) -> None:
+    history = _v2_history()
+    history[item_index][field] = value
+
+    with pytest.raises(ToolCompatibilityError) as caught:
+        _v2_plan().encode_payload(
+            {
+                "tool_choice": "auto",
+                "tools": [_declaration(COLLABORATION_V2)],
+                "input": history,
+            }
+        )
+
+    assert caught.value.classification == classification
+    assert caught.value.surface == "history"
+
+
+def _agent_message_stream_event(event_type: str, item: dict[str, object]) -> dict[str, object]:
+    return {"type": event_type, "output_index": 0, "item": item}
+
+
+def test_v2_agent_message_stream_preserves_complete_lifecycle() -> None:
+    stream = _v2_plan().new_stream()
+    item = _v2_history()[-1]
+
+    added = stream.decode_events_for_event(
+        _agent_message_stream_event("response.output_item.added", item)
+    )
+    done = stream.decode_events_for_event(
+        _agent_message_stream_event("response.output_item.done", item)
+    )
+    terminal = stream.decode_events_for_event(
+        {
+            "type": "response.completed",
+            "response": {
+                "id": "response-agent-message",
+                "object": "response",
+                "status": "completed",
+                "output": [item],
+            },
+        }
+    )
+
+    assert added[0]["item"] == item
+    assert done[0]["item"] == item
+    assert terminal[0]["response"]["output"] == [item]
+
+
+@pytest.mark.parametrize(
+    ("events", "classification"),
+    [
+        (
+            lambda item: [
+                _agent_message_stream_event("response.output_item.added", item),
+                _agent_message_stream_event("response.output_item.added", item),
+            ],
+            "duplicate_item_identity",
+        ),
+        (
+            lambda item: [
+                _agent_message_stream_event("response.output_item.done", item),
+            ],
+            "missing_stream_identity",
+        ),
+        (
+            lambda item: [
+                _agent_message_stream_event("response.output_item.added", item),
+                {
+                    "type": "response.completed",
+                    "response": {"id": "response", "object": "response", "status": "completed"},
+                },
+            ],
+            "incomplete_stream",
+        ),
+        (
+            lambda item: [
+                _agent_message_stream_event("response.output_item.added", item),
+                _agent_message_stream_event(
+                    "response.output_item.done",
+                    {
+                        **item,
+                        "content": [{"type": "input_text", "text": "changed"}],
+                    },
+                ),
+            ],
+            "ambiguous_native_identity",
+        ),
+    ],
+    ids=["duplicate-id", "done-without-added", "missing-done", "changed-content"],
+)
+def test_v2_agent_message_stream_rejects_broken_lifecycle(events, classification: str) -> None:
+    stream = _v2_plan().new_stream()
+    item = _v2_history()[-1]
+
+    with pytest.raises(ToolCompatibilityError) as caught:
+        for event in events(item):
+            stream.decode_events_for_event(event)
+
+    assert caught.value.classification == classification
+    assert caught.value.surface == "stream"

--- a/tests/test_issue_282_collaboration_v2.py
+++ b/tests/test_issue_282_collaboration_v2.py
@@ -631,8 +631,13 @@ def test_v2_request_history_requires_string_call_and_result_payloads(
     assert caught.value.surface == "history"
 
 
-def _agent_message_stream_event(event_type: str, item: dict[str, object]) -> dict[str, object]:
-    return {"type": event_type, "output_index": 0, "item": item}
+def _agent_message_stream_event(
+    event_type: str,
+    item: dict[str, object],
+    *,
+    output_index: int = 0,
+) -> dict[str, object]:
+    return {"type": event_type, "output_index": output_index, "item": item}
 
 
 def test_v2_agent_message_stream_preserves_complete_lifecycle() -> None:
@@ -660,6 +665,167 @@ def test_v2_agent_message_stream_preserves_complete_lifecycle() -> None:
     assert added[0]["item"] == item
     assert done[0]["item"] == item
     assert terminal[0]["response"]["output"] == [item]
+
+
+def _agent_message_terminal_event(output: list[dict[str, object]] | None) -> dict[str, object]:
+    response: dict[str, object] = {
+        "id": "response-agent-message",
+        "object": "response",
+        "status": "completed",
+    }
+    if output is not None:
+        response["output"] = output
+    return {"type": "response.completed", "response": response}
+
+
+def _complete_agent_message_lifecycle(
+    stream,
+    item: dict[str, object],
+    *,
+    output_index: int = 0,
+) -> None:
+    stream.decode_events_for_event(
+        _agent_message_stream_event(
+            "response.output_item.added",
+            item,
+            output_index=output_index,
+        )
+    )
+    stream.decode_events_for_event(
+        _agent_message_stream_event(
+            "response.output_item.done",
+            item,
+            output_index=output_index,
+        )
+    )
+
+
+def test_v2_agent_message_stream_rejects_terminal_only_item() -> None:
+    stream = _v2_plan().new_stream()
+
+    with pytest.raises(ToolCompatibilityError) as caught:
+        stream.decode_events_for_event(
+            _agent_message_terminal_event([_v2_history()[-1]])
+        )
+
+    assert caught.value.classification == "missing_stream_identity"
+    assert caught.value.surface == "stream"
+
+
+@pytest.mark.parametrize(
+    ("terminal_output", "classification"),
+    [
+        (
+            lambda item: [item, item],
+            "duplicate_item_identity",
+        ),
+        (
+            lambda item: [
+                {
+                    **item,
+                    "id": "unknown-agent-message",
+                }
+            ],
+            "missing_stream_identity",
+        ),
+        (
+            lambda item: [],
+            "incomplete_stream",
+        ),
+        (
+            lambda item: [
+                {
+                    **item,
+                    "content": [{"type": "input_text", "text": "changed terminal"}],
+                }
+            ],
+            "ambiguous_native_identity",
+        ),
+    ],
+    ids=["duplicate-terminal-id", "unknown-terminal-id", "missing-terminal-item", "changed-terminal-content"],
+)
+def test_v2_agent_message_stream_reconciles_terminal_ownership(
+    terminal_output,
+    classification: str,
+) -> None:
+    stream = _v2_plan().new_stream()
+    item = _v2_history()[-1]
+    _complete_agent_message_lifecycle(stream, item)
+
+    with pytest.raises(ToolCompatibilityError) as caught:
+        stream.decode_events_for_event(
+            _agent_message_terminal_event(terminal_output(item))
+        )
+
+    assert caught.value.classification == classification
+    assert caught.value.surface == "stream"
+
+
+@pytest.mark.parametrize(
+    ("events", "classification"),
+    [
+        (
+            lambda item: [
+                _agent_message_stream_event(
+                    "response.output_item.added",
+                    item,
+                    output_index=0,
+                ),
+                _agent_message_stream_event(
+                    "response.output_item.done",
+                    item,
+                    output_index=1,
+                ),
+            ],
+            "ambiguous_native_identity",
+        ),
+        (
+            lambda item: [
+                _agent_message_stream_event(
+                    "response.output_item.added",
+                    item,
+                ),
+                _agent_message_stream_event(
+                    "response.output_item.done",
+                    item,
+                    output_index=0,
+                ),
+                _agent_message_terminal_event(None),
+            ],
+            "incomplete_stream",
+        ),
+    ],
+    ids=["output-index-drift", "terminal-output-index-required"],
+)
+def test_v2_agent_message_stream_rejects_index_boundary_drift(
+    events,
+    classification: str,
+) -> None:
+    stream = _v2_plan().new_stream()
+    item = _v2_history()[-1]
+
+    with pytest.raises(ToolCompatibilityError) as caught:
+        for event in events(item):
+            stream.decode_events_for_event(event)
+
+    assert caught.value.classification == classification
+    assert caught.value.surface == "stream"
+
+
+def test_v2_agent_message_stream_rejects_terminal_order_drift() -> None:
+    stream = _v2_plan().new_stream()
+    first = _v2_history()[-1]
+    second = {**first, "id": "agent-message-2"}
+    _complete_agent_message_lifecycle(stream, first, output_index=0)
+    _complete_agent_message_lifecycle(stream, second, output_index=1)
+
+    with pytest.raises(ToolCompatibilityError) as caught:
+        stream.decode_events_for_event(
+            _agent_message_terminal_event([second, first])
+        )
+
+    assert caught.value.classification == "ambiguous_native_identity"
+    assert caught.value.surface == "stream"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -3406,7 +3406,7 @@ class RoutingTests(unittest.TestCase):
             self.assertEqual(fields["transport_policy"], codex_proxy.TransportPolicy.OFFICIAL_KEEPALIVE.value)
             self.assertEqual(fields["mutation_summary"], [codex_proxy.RouteMutation.MODEL_ALIAS.value])
 
-    def test_model_switch_gateway_request_response_path_uses_selected_model_in_both_directions(self):
+    def test_model_switch_gateway_rejects_cross_protocol_history_before_sampling(self):
         versioned_slug = "deepseek-v4-flash:0731"
         versioned_catalog = catalog_sync.build_codex_catalog(
             [],
@@ -3430,12 +3430,6 @@ class RoutingTests(unittest.TestCase):
         }
         fixture = _load_model_switch_fixture()
         self.assertEqual(fixture["schema_version"], "codexhub.model-switch.v1")
-        self.assertEqual(fixture["expected"], {
-            "same_thread": True,
-            "fallback_model": None,
-            "boundary_error": None,
-            "reconnect_count": 0,
-        })
         turns = fixture["turns"]
         self.assertEqual(len(turns), 2)
         self.assertEqual(
@@ -3566,6 +3560,17 @@ class RoutingTests(unittest.TestCase):
                     ) as open_upstream,
                 ):
                     CodexProxyHandler.do_POST(handler)
+
+                if turn_index > 0:
+                    self.assertEqual(fake.status, 400, direction)
+                    open_upstream.assert_not_called()
+                    event_names = [
+                        event_call.args[0]
+                        for event_call in self.write_proxy_event.call_args_list[event_offset:]
+                        if event_call.args
+                    ]
+                    self.assertIn("collaboration_boundary_rejected", event_names)
+                    break
 
                 self.assertEqual(fake.status, 200, direction)
                 open_upstream.assert_called_once()

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1,3 +1,4 @@
+import copy
 import gc
 import os
 import gzip
@@ -20,6 +21,13 @@ from urllib.error import HTTPError, URLError
 
 import catalog_sync
 import codex_proxy
+from collaboration_runtime_contract import (
+    COLLABORATION_V1,
+    COLLABORATION_V2,
+    EXPECTED_PARAMETER_SCHEMAS,
+    V1_NAMESPACE,
+    V2_NAMESPACE,
+)
 from sse_events import DEFAULT_MAX_FRAME_BYTES, SseEventAssembler, SseFrameTooLargeError
 from subagent_state import build_subagent_state
 from codex_proxy import (
@@ -71,11 +79,27 @@ def _load_model_switch_fixture():
 
 
 def _model_switch_tool_surface(protocol: str) -> dict[str, Any]:
-    namespace = "collaboration" if protocol == "collaboration_v2" else "multi_agent_v1"
+    version = COLLABORATION_V2 if protocol == COLLABORATION_V2 else COLLABORATION_V1
+    namespace = V2_NAMESPACE if version == COLLABORATION_V2 else V1_NAMESPACE
+    children = []
+    for name, parameter_schema in EXPECTED_PARAMETER_SCHEMAS[version].items():
+        parameters = copy.deepcopy(parameter_schema)
+        if not parameters["required"]:
+            del parameters["required"]
+        children.append(
+            {
+                "type": "function",
+                "name": name,
+                "description": f"dynamic child description for {name}",
+                "strict": False,
+                "parameters": parameters,
+            }
+        )
     return {
         "type": "namespace",
         "name": namespace,
-        "tools": [{"type": "function", "name": "spawn_agent"}],
+        "description": "dynamic namespace description",
+        "tools": children,
     }
 
 
@@ -95,10 +119,25 @@ def _model_switch_call(protocol: str, call_id: str) -> dict[str, Any]:
     namespace = "collaboration" if protocol == "collaboration_v2" else "multi_agent_v1"
     return {
         "type": "function_call",
+        "id": f"item-{call_id}",
         "namespace": namespace,
         "name": "spawn_agent",
         "call_id": call_id,
-        "arguments": arguments,
+        "arguments": json.dumps(arguments, separators=(",", ":")),
+    }
+
+
+def _model_switch_result(protocol: str, call_id: str) -> dict[str, Any]:
+    output = (
+        {"task_name": "/root/bounded-model-switch-check"}
+        if protocol == COLLABORATION_V2
+        else {"agent_id": "019f-child", "nickname": None}
+    )
+    return {
+        "type": "function_call_output",
+        "id": f"item-result-{call_id}",
+        "call_id": call_id,
+        "output": json.dumps(output, separators=(",", ":")),
     }
 
 
@@ -3460,11 +3499,12 @@ class RoutingTests(unittest.TestCase):
                 call_item = _model_switch_call(protocol, call_id)
                 body = {
                     "model": model,
+                    "tool_choice": "auto",
                     "input": [
                         *history,
                         {"type": "message", "role": "user", "content": "continue with the selected model"},
                         call_item,
-                        {"type": "function_call_output", "call_id": call_id, "output": "done"},
+                        _model_switch_result(protocol, call_id),
                     ],
                     "tools": [_model_switch_tool_surface(protocol)],
                     "stream": False,
@@ -3564,7 +3604,7 @@ class RoutingTests(unittest.TestCase):
                 history.extend(
                     [
                         call_item,
-                        {"type": "function_call_output", "call_id": call_id, "output": "done"},
+                        _model_switch_result(protocol, call_id),
                     ]
                 )
 
@@ -18613,16 +18653,17 @@ class RoutingTests(unittest.TestCase):
         self.assertNotIn("encrypted_content", payload["input"][0])
         self.assertNotIn(encrypted_content, transformed.decode("utf-8"))
 
-    def test_collaboration_v2_chat_adapts_responses_only_history_before_translation(self):
+    def test_collaboration_v2_chat_fails_before_history_translation(self):
         summary_text = "PRIVATE_REASONING_SUMMARY"
         encrypted_content = "gAAAA-private-reasoning"
         event_context = {
             "request_id": "request-v2-chat-reasoning-history",
             "collaboration_protocol": "collaboration_v2",
         }
-        transformed = compatible_request_body(
-            json.dumps(
-                {
+        with self.assertRaises(codex_proxy.UpstreamProtocolTranslationError) as caught:
+            compatible_request_body(
+                json.dumps(
+                    {
                     "model": "kimi-k3",
                     "input": [
                         {
@@ -18641,65 +18682,31 @@ class RoutingTests(unittest.TestCase):
                         {"type": "message", "role": "user", "content": "continue"},
                     ],
                     "tools": [_model_switch_tool_surface("collaboration_v2")],
+                    "tool_choice": "auto",
                     "stream": True,
-                }
-            ).encode("utf-8"),
-            {
-                "name": "kimi",
-                "upstream_model": "kimi-k3",
-                "upstream_format": "chat_completions",
-                "tool_protocol": "none",
-            },
-            event_context=event_context,
-            inject_codex_tools=False,
-        )
-        payload = json.loads(transformed)
+                    }
+                ).encode("utf-8"),
+                {
+                    "name": "kimi",
+                    "upstream_model": "kimi-k3",
+                    "upstream_format": "chat_completions",
+                    "tool_protocol": "none",
+                },
+                event_context=event_context,
+                inject_codex_tools=False,
+            )
 
         self.assertEqual(
-            payload["input"],
-            [
-                {
-                    "id": "msg_final",
-                    "type": "message",
-                    "role": "assistant",
-                    "content": [{"type": "output_text", "text": "Earlier answer."}],
-                },
-                {"type": "message", "role": "user", "content": "continue"},
-            ],
+            caught.exception.cause.code,
+            "tool_compatibility_required_unavailable",
         )
-        chat_payload = json.loads(
-            _responses_request_to_chat_completion_body(
-                transformed,
-                drop_client_transport_fields=True,
-                drop_reasoning=True,
-            )
-        )
-        self.assertEqual(
-            chat_payload["messages"],
-            [
-                {"role": "assistant", "content": "Earlier answer."},
-                {"role": "user", "content": "continue"},
-            ],
-        )
-        serialized = json.dumps(chat_payload, ensure_ascii=False)
-        self.assertNotIn(summary_text, serialized)
-        self.assertNotIn(encrypted_content, serialized)
-        removal_event = next(
-            call.kwargs
+        event_names = [
+            call.args[0]
             for call in self.write_proxy_event.call_args_list
-            if call.args and call.args[0] == "v2_chat_reasoning_history_removed"
-        )
-        self.assertEqual(removal_event["count"], 1)
-        for forbidden in ("id", "summary", "content", "text", "encrypted_content"):
-            self.assertNotIn(forbidden, removal_event)
-        phase_event = next(
-            call.kwargs
-            for call in self.write_proxy_event.call_args_list
-            if call.args and call.args[0] == "chat_message_phase_removed"
-        )
-        self.assertEqual(phase_event["count"], 1)
-        for forbidden in ("id", "phase", "content", "text"):
-            self.assertNotIn(forbidden, phase_event)
+            if call.args
+        ]
+        self.assertNotIn("v2_chat_reasoning_history_removed", event_names)
+        self.assertNotIn("chat_message_phase_removed", event_names)
 
     def test_codex_app_chat_adapts_message_phase_without_collaboration_signal(self):
         summary_text = "PRIVATE_REASONING_SUMMARY"
@@ -23582,15 +23589,6 @@ Execution constraints:
                     },
                 ],
                 "tools": [
-                    {
-                        "type": "namespace",
-                        "name": "multi_agent_v1",
-                        "tools": [
-                            {"type": "function", "name": "spawn_agent", "parameters": {"type": "object"}},
-                            {"type": "function", "name": "wait_agent", "parameters": {"type": "object"}},
-                            {"type": "function", "name": "close_agent", "parameters": {"type": "object"}},
-                        ],
-                    },
                     {"type": "function", "name": "multi_agent_v1__spawn_agent", "parameters": {"type": "object"}},
                     {"type": "function", "name": "multi_agent_v1__wait_agent", "parameters": {"type": "object"}},
                     {"type": "function", "name": "multi_agent_v1__close_agent", "parameters": {"type": "object"}},

--- a/tests/test_runtime_tool_compatibility.py
+++ b/tests/test_runtime_tool_compatibility.py
@@ -17,7 +17,7 @@ from runtime_tool_compatibility import (
 )
 
 
-def _namespace(namespace: str = "collaboration", *, tool: str = "spawn_agent") -> dict:
+def _namespace(namespace: str = "vendor", *, tool: str = "run") -> dict:
     return {
         "type": "namespace",
         "name": namespace,
@@ -48,7 +48,7 @@ def test_issue65_table_classifies_every_family_without_implicit_fallback() -> No
             accepts_namespace_adapter=True,
             accepts_custom_adapter=True,
         ),
-        required={"plain": False, "collaboration": False, "freeform": False},
+        required={"plain": False, "vendor": False, "freeform": False},
         request_token="table",
     )
 
@@ -83,7 +83,7 @@ def test_required_unavailable_fails_before_request_encoding() -> None:
     assert "tool_search" not in str(raised.value)
 
 
-def test_namespace_alias_round_trip_preserves_version_fields_and_ids() -> None:
+def test_namespace_alias_round_trip_preserves_fields_and_ids() -> None:
     declaration = _namespace()
     plan = build_tool_compatibility_plan(
         [declaration],
@@ -97,11 +97,11 @@ def test_namespace_alias_round_trip_preserves_version_fields_and_ids() -> None:
         "input": [
             {
                 "type": "function_call",
-                "namespace": "collaboration",
-                "name": "spawn_agent",
+                "namespace": "vendor",
+                "name": "run",
                 "call_id": "call_v2",
                 "item_id": "item_v2",
-                "arguments": '{"task_name":"worker","task_path":"root/1","continuation_id":"cont","fork_turns":"all"}',
+                "arguments": '{"value":"opaque"}',
             },
             {
                 "type": "function_call_output",
@@ -112,8 +112,8 @@ def test_namespace_alias_round_trip_preserves_version_fields_and_ids() -> None:
         ],
         "tool_choice": {
             "type": "function",
-            "namespace": "collaboration",
-            "name": "spawn_agent",
+            "namespace": "vendor",
+            "name": "run",
         },
     }
 
@@ -126,8 +126,8 @@ def test_namespace_alias_round_trip_preserves_version_fields_and_ids() -> None:
     assert encoded["tool_choice"] == {"type": "function", "name": alias}
 
     decoded = plan.decode_payload({"output": [encoded["input"][0]]})
-    assert decoded["output"][0]["namespace"] == "collaboration"
-    assert decoded["output"][0]["name"] == "spawn_agent"
+    assert decoded["output"][0]["namespace"] == "vendor"
+    assert decoded["output"][0]["name"] == "run"
     assert decoded["output"][0]["call_id"] == "call_v2"
     assert plan.entries[0].aliases == (alias,)
 

--- a/tests/test_runtime_tool_compatibility_boundaries.py
+++ b/tests/test_runtime_tool_compatibility_boundaries.py
@@ -5,6 +5,12 @@ import json
 
 import pytest
 
+from collaboration_runtime_contract import (
+    COLLABORATION_V1,
+    COLLABORATION_V2,
+    CollaborationContractError,
+    validate_collaboration_arguments,
+)
 from codex_semantic_adapter import (
     CollaborationBoundaryError,
     classify_collaboration_payload,
@@ -1128,7 +1134,7 @@ def test_native_namespace_rejects_unqualified_child_without_plain_owner(surface)
 
 
 def test_foreign_collaboration_history_is_preserved_when_current_plan_is_different() -> None:
-    plan = _adapted_namespace_plan(_namespace("multi_agent_v1", child="spawn_agent"))
+    plan = _adapted_namespace_plan(_namespace("vendor", child="run"))
     history = [{
         "type": "function_call",
         "namespace": "collaboration",
@@ -2095,25 +2101,14 @@ def test_adapted_namespace_rejects_original_or_flattened_alias_without_exact_map
     ids=["v1-json-arguments", "v2-json-arguments"],
 )
 def test_v1_v2_forbidden_fields_inside_json_arguments_fail(namespace, forbidden):
-    declaration = _namespace(namespace, child="spawn_agent")
-    plan = _adapted_namespace_plan(declaration)
-    alias = plan.entries[0].aliases[0]
-    with pytest.raises(ToolCompatibilityError):
-        plan.encode_payload(
-            {
-                "input": [
-                    {
-                        "type": "function_call",
-                        "namespace": namespace,
-                        "name": "spawn_agent",
-                        "call_id": "call",
-                        "arguments": json.dumps({forbidden: "mixed"}),
-                    }
-                ],
-                "tools": [declaration],
-                "tool_choice": {"type": "function", "name": "spawn_agent"},
-            }
+    version = COLLABORATION_V1 if namespace == "multi_agent_v1" else COLLABORATION_V2
+    with pytest.raises(CollaborationContractError) as caught:
+        validate_collaboration_arguments(
+            version,
+            "spawn_agent",
+            json.dumps({forbidden: "mixed"}),
         )
+    assert caught.value.classification == "collaboration_arguments_schema_mismatch"
 
 
 def test_adapted_namespace_tool_choice_with_duplicate_child_name_fails_preflight():

--- a/tests/test_runtime_tool_compatibility_integration.py
+++ b/tests/test_runtime_tool_compatibility_integration.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import copy
 import json
 
 import pytest
 
 import codex_proxy
-from codex_semantic_adapter import COLLABORATION_V2
+from collaboration_runtime_contract import EXPECTED_PARAMETER_SCHEMAS
+from codex_semantic_adapter import COLLABORATION_V1, COLLABORATION_V2
 
 
 def _external_chat_upstream() -> dict:
@@ -26,6 +28,30 @@ def _request(tools: list[dict], *, model: str = "custom-model", tool_choice="aut
             "tool_choice": tool_choice,
         }
     ).encode("utf-8")
+
+
+def _collaboration_namespace(version: str) -> dict:
+    namespace = "multi_agent_v1" if version == COLLABORATION_V1 else "collaboration"
+    children = []
+    for name, schema in EXPECTED_PARAMETER_SCHEMAS[version].items():
+        parameters = copy.deepcopy(schema)
+        if not parameters["required"]:
+            del parameters["required"]
+        children.append(
+            {
+                "type": "function",
+                "name": name,
+                "description": "dynamic",
+                "strict": False,
+                "parameters": parameters,
+            }
+        )
+    return {
+        "type": "namespace",
+        "name": namespace,
+        "description": "dynamic",
+        "tools": children,
+    }
 
 
 def _decoded_sse(line: bytes) -> dict:
@@ -532,27 +558,22 @@ def test_collaboration_v2_is_adapted_without_v1_injection_or_repair():
         "request_id": "req",
         "repair_policy": codex_proxy.REPAIR_CODEX_SUBAGENT,
     }
-    tools = [
-        {
-            "type": "namespace",
-            "name": "collaboration",
-            "tools": [
-                {
-                    "type": "function",
-                    "name": "followup_task",
-                }
-            ],
-        }
-    ]
+    tools = [_collaboration_namespace(COLLABORATION_V2)]
     history = [
         {
             "type": "function_call",
+            "id": "item_v2",
             "namespace": "collaboration",
             "name": "followup_task",
             "call_id": "call_v2",
-            "arguments": '{"task_path":"/root/a","task_name":"a","fork_turns":"all"}',
+            "arguments": '{"target":"/root/a","message":"continue"}',
         },
-        {"type": "function_call_output", "call_id": "call_v2", "output": "queued"},
+        {
+            "type": "function_call_output",
+            "id": "item_v2_output",
+            "call_id": "call_v2",
+            "output": "null",
+        },
     ]
 
     payload = json.loads(
@@ -562,19 +583,20 @@ def test_collaboration_v2_is_adapted_without_v1_injection_or_repair():
                     "model": "custom-model",
                     "input": history,
                     "tools": tools,
+                    "tool_choice": "auto",
                 }
             ).encode("utf-8"),
-            _external_chat_upstream(),
+            _external_responses_upstream(),
             event_context=context,
         )
     )
 
     aliases = [tool["name"] for tool in payload["tools"] if tool.get("type") == "function"]
-    assert len(aliases) == 1
-    assert aliases[0].startswith("__codexhub_ns_")
-    assert payload["input"][0]["name"] == aliases[0]
+    assert len(aliases) == 6
+    assert all(alias.startswith("__codexhub_ns_") for alias in aliases)
+    assert payload["input"][0]["name"] in aliases
     assert "namespace" not in payload["input"][0]
-    assert json.loads(payload["input"][0]["arguments"])["task_path"] == "/root/a"
+    assert json.loads(payload["input"][0]["arguments"])["target"] == "/root/a"
     assert context["collaboration_protocol"] == COLLABORATION_V2
     assert not any(name.startswith("multi_agent_v1__") for name in aliases)
 
@@ -629,12 +651,13 @@ def test_gateway_plan_preserves_foreign_collaboration_history_in_both_directions
     body = {
         "model": "custom-model",
         "input": foreign_history,
+        "tool_choice": "auto",
         "tools": [
-            {
-                "type": "namespace",
-                "name": current_namespace,
-                "tools": [{"type": "function", "name": current_child}],
-            }
+            _collaboration_namespace(
+                COLLABORATION_V1
+                if current_namespace == "multi_agent_v1"
+                else COLLABORATION_V2
+            )
         ],
     }
 
@@ -642,7 +665,7 @@ def test_gateway_plan_preserves_foreign_collaboration_history_in_both_directions
     payload = json.loads(
         codex_proxy.compatible_request_body(
             json.dumps(body).encode("utf-8"),
-            _external_chat_upstream(),
+            _external_responses_upstream(),
             event_context=context,
             inject_codex_tools=False,
         )

--- a/tests/test_runtime_tool_compatibility_integration.py
+++ b/tests/test_runtime_tool_compatibility_integration.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 import json
+from unittest.mock import patch
 
 import pytest
 
@@ -602,11 +603,10 @@ def test_collaboration_v2_is_adapted_without_v1_injection_or_repair():
 
 
 @pytest.mark.parametrize(
-    ("current_namespace", "current_child", "foreign_history"),
+    ("current_namespace", "foreign_history"),
     [
         (
             "multi_agent_v1",
-            "spawn_agent",
             [
                 {
                     "type": "function_call",
@@ -624,7 +624,6 @@ def test_collaboration_v2_is_adapted_without_v1_injection_or_repair():
         ),
         (
             "collaboration",
-            "followup_task",
             [
                 {
                     "type": "function_call",
@@ -643,9 +642,8 @@ def test_collaboration_v2_is_adapted_without_v1_injection_or_repair():
     ],
     ids=["current-v1-foreign-v2", "current-v2-foreign-v1"],
 )
-def test_gateway_plan_preserves_foreign_collaboration_history_in_both_directions(
+def test_gateway_rejects_foreign_collaboration_history_before_planning(
     current_namespace: str,
-    current_child: str,
     foreign_history: list[dict],
 ) -> None:
     body = {
@@ -662,19 +660,17 @@ def test_gateway_plan_preserves_foreign_collaboration_history_in_both_directions
     }
 
     context: dict = {}
-    payload = json.loads(
-        codex_proxy.compatible_request_body(
-            json.dumps(body).encode("utf-8"),
-            _external_responses_upstream(),
-            event_context=context,
-            inject_codex_tools=False,
-        )
-    )
+    with patch.object(codex_proxy, "_prepare_runtime_tool_compatibility") as prepare:
+        with pytest.raises(codex_proxy.UpstreamProtocolTranslationError) as caught:
+            codex_proxy.compatible_request_body(
+                json.dumps(body).encode("utf-8"),
+                _external_responses_upstream(),
+                event_context=context,
+                inject_codex_tools=False,
+            )
 
-    assert payload["input"] == foreign_history
-    assert context["_runtime_tool_compatibility_plan"].entries[0].disposition == "adapt"
-    assert payload["tools"][0]["type"] == "function"
-    assert payload["tools"][0]["name"].startswith("__codexhub_ns_")
+    assert caught.value.cause.code == codex_proxy.COLLABORATION_BOUNDARY_ERROR_CODE
+    prepare.assert_not_called()
 
 
 def _external_responses_upstream() -> dict:


### PR DESCRIPTION
## Summary

- Implement the exact #392 runtime-derived Collaboration V1/V2 Responses contract.
- Keep complete native namespaces byte-semantic; use only request-scoped reversible adaptation when the full lifecycle is representable.
- Enforce call/result/agent_message identity, schema, SSE order/index, history/replay, and V2-before-V1 isolation with fail-closed behavior.

## Verification

- #282 focused: 58 passed; amended combined focused/routing: 341 passed.
- Python core: 2314 passed, 1 skipped, 490 subtests.
- `git diff --check`: passed.
- Report-only quality gate: 0 parse errors (non-blocking repository findings remain).

Closes #282
