### PR TITLE
fix(gateway): forward official ImageGen and drain rejected POST bodies

### DIFF
--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -18592,6 +18592,11 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
         request_id = uuid.uuid4().hex[:12]
         started_at = time.monotonic()
         request_context = request_context_from_headers(self.headers)
+
+        def send_user_requested_shutdown() -> None:
+            _record_user_requested_shutdown()
+            self._send_json_and_close(503, user_requested_shutdown_payload("responses"))
+
         if not _local_request_authorized(self.headers, request_context):
             write_proxy_event(
                 "request_error",
@@ -18613,14 +18618,15 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
         shutdown_controller = _gateway_shutdown_controller_for_handler(self)
         admission = shutdown_controller.admit()
         if admission is None:
-            self._send_json_and_close(503, user_requested_shutdown_payload("responses"))
+            send_user_requested_shutdown()
             return
         previous_admission = _activate_gateway_request(admission)
-        upstream = official_upstream()
-        upstream_name = str(upstream["name"])
+        upstream_name = "official"
         status = 500
         try:
             admission.raise_if_cancelled()
+            upstream = official_upstream()
+            upstream_name = str(upstream["name"])
             try:
                 content_length = int(self.headers.get("Content-Length", "0"))
             except (TypeError, ValueError):
@@ -18707,8 +18713,11 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 **request_context,
             )
         except GatewayUserRequestedShutdown:
-            self._send_json_and_close(503, user_requested_shutdown_payload("responses"))
+            send_user_requested_shutdown()
         except (IncompleteRead, OSError, URLError) as exc:
+            if admission.cancelled:
+                send_user_requested_shutdown()
+                return
             detail = safe_upstream_error_detail(exc)
             write_proxy_event(
                 "request_error",
@@ -18728,6 +18737,9 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
                 {"error": type(exc).__name__, "detail": detail},
             )
         except Exception as exc:
+            if admission.cancelled:
+                send_user_requested_shutdown()
+                return
             detail = safe_upstream_error_detail(exc)
             logger.error(
                 "unexpected image generation proxy error request_id=%s detail=%s",
@@ -20756,6 +20768,9 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
     def _relay_raw_upstream_response(self, response: Any, upstream_name: str) -> int:
         status = getattr(response, "status", None) or getattr(response, "code", 502)
         body = response.read()
+        admission = _active_gateway_request()
+        if admission is not None:
+            admission.raise_if_cancelled()
         self.send_response(status)
         for key, value in _filtered_response_headers(
             response.headers,

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -18582,7 +18582,165 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
             self._proxy_post_request(inbound_format="chat_completions", provider_hint=provider_hint)
             return
 
-        self._send_json(404, {"error": "not found"})
+        if parsed.path == "/v1/images/generations":
+            self._proxy_official_image_generation()
+            return
+
+        self._send_json_and_close(404, {"error": "not found"})
+
+    def _proxy_official_image_generation(self) -> None:
+        request_id = uuid.uuid4().hex[:12]
+        started_at = time.monotonic()
+        request_context = request_context_from_headers(self.headers)
+        if not _local_request_authorized(self.headers, request_context):
+            write_proxy_event(
+                "request_error",
+                request_id=request_id,
+                path=self.path,
+                method="POST",
+                model=None,
+                upstream="local",
+                route_reason="official_image_generation",
+                status=401,
+                error="UnauthorizedLocalClient",
+                detail="missing or invalid local Gateway client key",
+                duration_ms=int((time.monotonic() - started_at) * 1000),
+                **request_context,
+            )
+            self._send_json_and_close(401, _local_gateway_auth_error_payload())
+            return
+
+        shutdown_controller = _gateway_shutdown_controller_for_handler(self)
+        admission = shutdown_controller.admit()
+        if admission is None:
+            self._send_json_and_close(503, user_requested_shutdown_payload("responses"))
+            return
+        previous_admission = _activate_gateway_request(admission)
+        upstream = official_upstream()
+        upstream_name = str(upstream["name"])
+        status = 500
+        try:
+            admission.raise_if_cancelled()
+            try:
+                content_length = int(self.headers.get("Content-Length", "0"))
+            except (TypeError, ValueError):
+                self._send_json_and_close(400, {"error": "invalid Content-Length"})
+                return
+            if content_length < 0:
+                self._send_json_and_close(400, {"error": "invalid Content-Length"})
+                return
+            max_body_bytes = max_request_body_bytes()
+            if content_length > max_body_bytes:
+                self._send_json_and_close(
+                    413,
+                    {
+                        "error": "request body too large",
+                        "max_request_body_bytes": max_body_bytes,
+                    },
+                )
+                return
+
+            body = self.rfile.read(content_length)
+            admission.raise_if_cancelled()
+            operational_authentication = materialize_operational_authentication(
+                self.headers,
+                upstream,
+            )
+            headers = upstream_headers(
+                self.headers,
+                upstream,
+                request_mutation_policy=MutationPolicy.OFFICIAL_PASSTHROUGH,
+                operational_authentication=operational_authentication,
+            )
+            request = Request(
+                _upstream_endpoint_url(upstream, "/images/generations"),
+                data=body,
+                headers=headers,
+                method="POST",
+            )
+            event_context = {
+                "request_id": request_id,
+                "model": None,
+                **_event_context_with_request_kind(
+                    request_context,
+                    RETRY_REQUEST_MAIN_GENERATION,
+                ),
+            }
+            write_proxy_event(
+                "request_start",
+                request_id=request_id,
+                path=self.path,
+                method="POST",
+                model=None,
+                upstream=upstream_name,
+                route_reason="official_image_generation",
+                content_length=content_length,
+                **request_context,
+            )
+            try:
+                with _open_upstream_response(
+                    request,
+                    upstream_name=upstream_name,
+                    upstream_format="images",
+                    timeout=upstream_timeout_seconds(),
+                    event_context=event_context,
+                    request_kind=RETRY_REQUEST_MAIN_GENERATION,
+                    max_attempts=1,
+                    retry_http_errors=False,
+                    transport_policy=TransportPolicy.OFFICIAL_KEEPALIVE,
+                ) as response:
+                    status = self._relay_raw_upstream_response(response, upstream_name)
+            except HTTPError as exc:
+                try:
+                    status = self._relay_raw_upstream_response(exc, upstream_name)
+                finally:
+                    exc.close()
+            write_proxy_event(
+                "request_complete",
+                request_id=request_id,
+                method="POST",
+                model=None,
+                upstream=upstream_name,
+                route_reason="official_image_generation",
+                status=status,
+                duration_ms=int((time.monotonic() - started_at) * 1000),
+                **request_context,
+            )
+        except GatewayUserRequestedShutdown:
+            self._send_json_and_close(503, user_requested_shutdown_payload("responses"))
+        except (IncompleteRead, OSError, URLError) as exc:
+            detail = safe_upstream_error_detail(exc)
+            write_proxy_event(
+                "request_error",
+                request_id=request_id,
+                method="POST",
+                model=None,
+                upstream=upstream_name,
+                route_reason="official_image_generation",
+                status=502,
+                error=type(exc).__name__,
+                detail=detail,
+                duration_ms=int((time.monotonic() - started_at) * 1000),
+                **request_context,
+            )
+            self._send_json_and_close(
+                502,
+                {"error": type(exc).__name__, "detail": detail},
+            )
+        except Exception as exc:
+            detail = safe_upstream_error_detail(exc)
+            logger.error(
+                "unexpected image generation proxy error request_id=%s detail=%s",
+                request_id,
+                detail,
+            )
+            self._send_json_and_close(
+                500,
+                {"error": type(exc).__name__, "detail": detail},
+            )
+        finally:
+            _restore_gateway_request(previous_admission)
+            shutdown_controller.complete(admission)
 
     def _proxy_post_request(self, *, inbound_format: str, provider_hint: str | None = None) -> None:
         """Shared POST handler for inbound Responses and Chat Completions requests.
@@ -20584,6 +20742,34 @@ class CodexProxyHandler(BaseHTTPRequestHandler):
         self.send_header("Content-Length", str(len(body)))
         self.end_headers()
         self.wfile.write(body)
+
+    def _send_json_and_close(self, status: int, payload: dict[str, Any]) -> None:
+        body = _json_response_bytes(payload)
+        self.close_connection = True
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Connection", "close")
+        self.end_headers()
+        self._write_non_streaming_body_relay(body)
+
+    def _relay_raw_upstream_response(self, response: Any, upstream_name: str) -> int:
+        status = getattr(response, "status", None) or getattr(response, "code", 502)
+        body = response.read()
+        self.send_response(status)
+        for key, value in _filtered_response_headers(
+            response.headers,
+            False,
+            content_length=len(body),
+        ):
+            self.send_header(key, value)
+        self.send_header("X-Codex-Proxy-Upstream", upstream_name)
+        self.send_header("Connection", "close")
+        self.end_headers()
+        if not self._write_non_streaming_body_relay(body):
+            return 499
+        self.close_connection = True
+        return status
 
     def _send_sse_headers(self, status: int, upstream_name: str) -> bool:
         seam = _handler_downstream_stream_commit(self)

--- a/tests/test_chat_completions_gateway.py
+++ b/tests/test_chat_completions_gateway.py
@@ -4619,7 +4619,7 @@ class ChatCompletionsEndpointTests(unittest.TestCase):
     def test_post_chat_completions_404_for_unknown_path(self):
         handler = self._make_handler(b'{}', path="/v1/unknown")
         sent = []
-        handler._send_json = lambda status, payload: sent.append((status, payload))
+        handler._send_json_and_close = lambda status, payload: sent.append((status, payload))
         CodexProxyHandler.do_POST(handler)
         self.assertEqual(sent[0][0], 404)
 

--- a/tests/test_image_generation_gateway.py
+++ b/tests/test_image_generation_gateway.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import http.client
+import json
 import socket
 import threading
 from contextlib import contextmanager
@@ -38,6 +39,43 @@ class _ImageUpstreamHandler(BaseHTTPRequestHandler):
 
     def log_message(self, format: str, *args: object) -> None:
         return
+
+
+class _CancellationResponse:
+    status = 200
+    headers = {
+        "Content-Type": "application/json",
+        "Content-Length": "30",
+    }
+
+    def __init__(self, read_outcome: str) -> None:
+        self.read_outcome = read_outcome
+        self.read_started = threading.Event()
+        self.closed = threading.Event()
+
+    def __enter__(self) -> "_CancellationResponse":
+        admission = codex_proxy._active_gateway_request()
+        assert admission is not None
+        admission.attach_upstream_transport(self)
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> bool:
+        self.close()
+        return False
+
+    def read(self) -> bytes:
+        self.read_started.set()
+        assert self.closed.wait(timeout=2)
+        if self.read_outcome == "incomplete":
+            raise http.client.IncompleteRead(b'{"partial":', 20)
+        if self.read_outcome == "oserror":
+            raise OSError("fixture cancellation closed upstream")
+        if self.read_outcome == "generic":
+            raise RuntimeError("fixture cancellation closed upstream")
+        return b'{"partial":"must-not-relay"}'
+
+    def close(self) -> None:
+        self.closed.set()
 
 
 @contextmanager
@@ -143,6 +181,76 @@ def test_image_generation_relays_official_raw_contract(
     assert "local-client-key" not in str(captured)
     assert "session-id" not in captured["headers"]
     assert "x-client-request-id" not in captured["headers"]
+
+
+@pytest.mark.parametrize("read_outcome", ["partial", "incomplete", "oserror", "generic"])
+def test_image_generation_cancellation_during_upstream_body_read_uses_shutdown_outcome(
+    read_outcome: str,
+) -> None:
+    upstream_response = _CancellationResponse(read_outcome)
+    result: dict[str, object] = {}
+
+    with (
+        patch.object(
+            codex_proxy,
+            "official_upstream",
+            return_value={
+                "name": "official",
+                "base_url": "https://controlled.invalid/v1",
+                "auth": "codex_auth",
+            },
+        ),
+        patch.object(codex_proxy, "gateway_client_key", return_value="local-client-key"),
+        patch.object(codex_proxy, "codex_access_token", return_value="synthetic-official-token"),
+        patch.object(codex_proxy, "codex_account_id", return_value="synthetic-account-id"),
+        patch.object(codex_proxy, "_open_upstream_response", return_value=upstream_response),
+        _http_server(codex_proxy.CodexProxyHandler) as gateway,
+    ):
+        request_thread = threading.Thread(
+            target=lambda: result.update(
+                zip(
+                    ("status", "headers", "body"),
+                    _request_image_generation(gateway, b'{"fixture":"cancel"}'),
+                )
+            ),
+            daemon=True,
+        )
+        request_thread.start()
+        assert upstream_response.read_started.wait(timeout=2)
+        gateway.gateway_shutdown_controller.close_admission()  # type: ignore[attr-defined]
+        request_thread.join(timeout=3)
+
+    assert request_thread.is_alive() is False
+    assert result["status"] == 503
+    assert result["headers"]["connection"] == "close"  # type: ignore[index]
+    payload = json.loads(result["body"])  # type: ignore[arg-type]
+    assert payload["type"] == codex_proxy.USER_REQUESTED_SHUTDOWN_OUTCOME
+    assert payload["error"] == codex_proxy.USER_REQUESTED_SHUTDOWN_OUTCOME
+    assert b"must-not-relay" not in result["body"]  # type: ignore[operator]
+
+
+def test_image_generation_official_lookup_failure_completes_admission_and_returns_error() -> None:
+    with (
+        patch.object(codex_proxy, "gateway_client_key", return_value="local-client-key"),
+        patch.object(
+            codex_proxy,
+            "official_upstream",
+            side_effect=RuntimeError("controlled routing config failure"),
+        ),
+        _http_server(codex_proxy.CodexProxyHandler) as gateway,
+    ):
+        status, headers, body = _request_image_generation(
+            gateway,
+            b'{"fixture":"lookup-failure"}',
+        )
+        admission_drained = gateway.gateway_shutdown_controller.wait_for_active_requests()  # type: ignore[attr-defined]
+
+    assert status == 500
+    assert headers["connection"] == "close"
+    payload = json.loads(body)
+    assert payload["error"] == "RuntimeError"
+    assert "controlled routing config failure" in payload["detail"]
+    assert admission_drained is True
 
 
 def test_unsupported_keepalive_post_returns_one_404_closes_and_does_not_log_body() -> None:

--- a/tests/test_image_generation_gateway.py
+++ b/tests/test_image_generation_gateway.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import http.client
+import socket
+import threading
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Iterator
+from unittest.mock import patch
+
+import codex_proxy
+import pytest
+
+
+class _ImageUpstreamHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def do_POST(self) -> None:  # noqa: N802 - stdlib callback name
+        content_length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(content_length)
+        self.server.captures.append(  # type: ignore[attr-defined]
+            {
+                "path": self.path,
+                "headers": {key.lower(): value for key, value in self.headers.items()},
+                "body": body,
+            }
+        )
+        response_body = self.server.response_body  # type: ignore[attr-defined]
+        self.send_response(self.server.response_status)  # type: ignore[attr-defined]
+        self.send_header(
+            "Content-Type",
+            self.server.response_content_type,  # type: ignore[attr-defined]
+        )
+        self.send_header("Content-Length", str(len(response_body)))
+        self.send_header("X-Image-Fixture", "preserved")
+        self.end_headers()
+        self.wfile.write(response_body)
+
+    def log_message(self, format: str, *args: object) -> None:
+        return
+
+
+@contextmanager
+def _http_server(
+    handler: type[BaseHTTPRequestHandler],
+) -> Iterator[ThreadingHTTPServer]:
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    server.gateway_shutdown_controller = codex_proxy.GatewayShutdownController()  # type: ignore[attr-defined]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def _request_image_generation(
+    gateway: ThreadingHTTPServer,
+    body: bytes,
+) -> tuple[int, dict[str, str], bytes]:
+    connection = http.client.HTTPConnection(
+        "127.0.0.1",
+        gateway.server_port,
+        timeout=3,
+    )
+    connection.request(
+        "POST",
+        "/v1/images/generations",
+        body=body,
+        headers={
+            "Authorization": "Bearer local-client-key",
+            "Content-Type": "application/json; charset=utf-8",
+            "Originator": "codex-cli",
+            "X-Codex-Image-Turn-Id": "fixture-turn-id",
+            "X-Image-Fixture": "request-preserved",
+            "Connection": "close",
+        },
+    )
+    response = connection.getresponse()
+    status = response.status
+    headers = {key.lower(): value for key, value in response.getheaders()}
+    response_body = response.read()
+    connection.close()
+    return status, headers, response_body
+
+
+@pytest.mark.parametrize(
+    ("upstream_status", "upstream_content_type", "upstream_body"),
+    [
+        (
+            200,
+            "application/json; charset=utf-8",
+            b'{"created":123,"data":[{"b64_json":"AAECAw=="}],"size":"1024x1024"}',
+        ),
+        (
+            429,
+            "application/problem+json",
+            b'{ "opaque_error" : { "code" : "fixture_limit" } }',
+        ),
+    ],
+)
+def test_image_generation_relays_official_raw_contract(
+    upstream_status: int,
+    upstream_content_type: str,
+    upstream_body: bytes,
+) -> None:
+    request_body = (
+        b'{ "prompt" : "non-secret-image-fixture", "model" : "gpt-image-2", '
+        b'"background" : "opaque", "quality" : "high", "size" : "1024x1024" }'
+    )
+    with _http_server(_ImageUpstreamHandler) as upstream:
+        upstream.captures = []  # type: ignore[attr-defined]
+        upstream.response_status = upstream_status  # type: ignore[attr-defined]
+        upstream.response_content_type = upstream_content_type  # type: ignore[attr-defined]
+        upstream.response_body = upstream_body  # type: ignore[attr-defined]
+        controlled_base = f"http://127.0.0.1:{upstream.server_port}/custom/v1"
+        with (
+            patch.object(codex_proxy, "official_base_url", return_value=controlled_base),
+            patch.object(codex_proxy, "gateway_client_key", return_value="local-client-key"),
+            patch.object(codex_proxy, "codex_access_token", return_value="synthetic-official-token"),
+            patch.object(codex_proxy, "codex_account_id", return_value="synthetic-account-id"),
+            patch.object(codex_proxy, "OFFICIAL_HTTP_POOLS", {}),
+            _http_server(codex_proxy.CodexProxyHandler) as gateway,
+        ):
+            status, headers, response_body = _request_image_generation(gateway, request_body)
+
+    assert status == upstream_status
+    assert headers["content-type"] == upstream_content_type
+    assert headers["x-image-fixture"] == "preserved"
+    assert response_body == upstream_body
+    assert len(upstream.captures) == 1  # type: ignore[attr-defined]
+    captured = upstream.captures[0]  # type: ignore[attr-defined]
+    assert captured["path"] == "/custom/v1/images/generations"
+    assert captured["body"] == request_body
+    assert captured["headers"]["authorization"] == "Bearer synthetic-official-token"
+    assert captured["headers"]["chatgpt-account-id"] == "synthetic-account-id"
+    assert captured["headers"]["content-type"] == "application/json; charset=utf-8"
+    assert captured["headers"]["originator"] == "codex-cli"
+    assert captured["headers"]["x-codex-image-turn-id"] == "fixture-turn-id"
+    assert captured["headers"]["x-image-fixture"] == "request-preserved"
+    assert "local-client-key" not in str(captured)
+    assert "session-id" not in captured["headers"]
+    assert "x-client-request-id" not in captured["headers"]
+
+
+def test_unsupported_keepalive_post_returns_one_404_closes_and_does_not_log_body() -> None:
+    sentinel = b"NON_SECRET_REJECTED_BODY_SENTINEL_401_402"
+    body = b'{"fixture":"' + sentinel + b'"}\r\n'
+    request = (
+        b"POST /v1/unsupported-fixture HTTP/1.1\r\n"
+        b"Host: 127.0.0.1\r\n"
+        b"Content-Type: application/json\r\n"
+        + f"Content-Length: {len(body)}\r\n".encode("ascii")
+        + b"Connection: keep-alive\r\n\r\n"
+        + body
+    )
+
+    with (
+        patch.object(codex_proxy.logger, "info") as info_log,
+        patch.object(codex_proxy.logger, "error") as error_log,
+        _http_server(codex_proxy.CodexProxyHandler) as gateway,
+    ):
+        client = socket.create_connection(("127.0.0.1", gateway.server_port), timeout=2)
+        client.settimeout(2)
+        client.sendall(request)
+        chunks: list[bytes] = []
+        socket_closed = False
+        try:
+            while True:
+                chunk = client.recv(65536)
+                if not chunk:
+                    socket_closed = True
+                    break
+                chunks.append(chunk)
+        finally:
+            client.close()
+
+    response = b"".join(chunks)
+    logged = repr(info_log.call_args_list) + repr(error_log.call_args_list)
+    assert response.count(b"HTTP/1.1 ") == 1
+    assert response.startswith(b"HTTP/1.1 404 ")
+    assert b"\r\nConnection: close\r\n" in response
+    assert sentinel not in response
+    assert sentinel.decode("ascii") not in logged
+    assert socket_closed is True


### PR DESCRIPTION
Closes #401, #402.

- POST /v1/images/generations now relays to the Official image-generation upstream with required auth, preserving the built-in Codex ImageGen contract.
- Rejected POST paths drain/close the connection so HTTP/1.1 keep-alive cannot parse the unread body as a second request or log raw prompt content.
- Shutdown/cancellation during upstream body read returns the standard user-requested-shutdown outcome instead of relaying partial content.

Focused: tests/test_image_generation_gateway.py 8 passed (py3.13).
Python core full suite: 2322 passed, 1 skipped, 490 subtests (run on this exact tree in the originating session).
git diff --check: clean.