### PR TITLE
fix(gateway): allow activation without safe Official snapshot (#403)

### DIFF
--- a/src-tauri/src/gateway.rs
+++ b/src-tauri/src/gateway.rs
@@ -1993,12 +1993,10 @@ fn official_models_from_metadata(
     subscription_models: Option<Vec<crate::Model>>,
     published_context_windows: &BTreeMap<String, u32>,
 ) -> Vec<GatewayModel> {
-    // When the Official cost guard is enabled, a missing publication fence
-    // must not expose an Official model with an unbounded context window. The
-    // activation path also refuses to start Official routing without this
-    // fence. With the optional guard disabled, preserve the legacy metadata
-    // surface and leave an unknown window unset rather than inventing one.
-    if settings.openai_context_guard_enabled && published_context_windows.is_empty() {
+    // A missing publication fence means no safe Official snapshot is available.
+    // Official models must not be listed or routed until a safe snapshot has
+    // been published, regardless of whether the optional cost guard is enabled.
+    if published_context_windows.is_empty() {
         return Vec::new();
     }
     let mut models: Vec<GatewayModel> =
@@ -8113,8 +8111,7 @@ mod tests {
             &BTreeMap::new(),
         );
 
-        assert_eq!(models.len(), 1);
-        assert_eq!(models[0].context_window, None);
+        assert!(models.is_empty());
 
         let guarded = official_models_from_metadata(
             &Settings {
@@ -8129,6 +8126,63 @@ mod tests {
             &BTreeMap::new(),
         );
         assert!(guarded.is_empty());
+    }
+
+    #[test]
+    fn official_gateway_models_are_available_with_guard_disabled_when_safe_snapshot_exists() {
+        let settings = Settings::default();
+        let published_contexts = published_context_windows(&[("gpt-5.6-terra", 272_000)]);
+        let models = official_models_from_metadata(
+            &settings,
+            Some(vec![Model {
+                id: "openai/gpt-5.6-terra".to_string(),
+                context_window: Some(353_400),
+                ..Model::default()
+            }]),
+            &published_contexts,
+        );
+
+        assert_eq!(models.len(), 1);
+        assert_eq!(models[0].id, "gpt-5.6-terra");
+        assert_eq!(models[0].context_window, Some(272_000));
+    }
+
+    #[test]
+    fn gateway_models_exclude_official_and_include_external_when_safe_snapshot_is_unavailable() {
+        let settings = Settings {
+            include_official_models: true,
+            ..Settings::default()
+        };
+        let providers = vec![Provider {
+            id: "test-provider".to_string(),
+            name: "Test Provider".to_string(),
+            base_url: "https://api.test.example/v1".to_string(),
+            api_key: None,
+            upstream_format: Some(UpstreamFormat::Responses),
+            available_upstream_formats: None,
+            tool_protocol: None,
+            tool_surface_strategy: None,
+            reports_cached_input_tokens: None,
+            supports_developer_role: None,
+            display_prefix: None,
+            sort_order: None,
+            enabled: true,
+            locked: false,
+            models: vec![Model {
+                id: "test-model".to_string(),
+                display_name: Some("Test Model".to_string()),
+                gateway_exported: true,
+                context_window: Some(128_000),
+                ..Model::default()
+            }],
+        }];
+
+        let models = gateway_models_from_sources(&settings, &providers, Vec::new());
+
+        assert_eq!(models.len(), 1);
+        assert_eq!(models[0].id, "test-provider/test-model");
+        assert_eq!(models[0].source, "Test Provider");
+        assert_eq!(models[0].source_kind, "external");
     }
 
     #[test]

--- a/src-tauri/src/official_refresh.rs
+++ b/src-tauri/src/official_refresh.rs
@@ -172,13 +172,17 @@ pub(crate) fn refresh_before_official_activation() -> Result<(), String> {
         return Ok(());
     }
     let outcome = refresh(RefreshTrigger::Activation)?;
+    allow_activation_without_official_snapshot(outcome)
+}
+
+fn allow_activation_without_official_snapshot(outcome: RefreshOutcome) -> Result<(), String> {
     if outcome.snapshot_available {
         Ok(())
     } else {
-        Err(
-            "current Official context snapshot is unavailable; refuse to activate CodexHub Official without a safe budget"
-                .to_string(),
-        )
+        log::warn!(
+            "CodexHub Official snapshot is unavailable; activating Gateway without Official models until a safe snapshot is published"
+        );
+        Ok(())
     }
 }
 
@@ -709,13 +713,12 @@ fn unix_timestamp() -> u64 {
 #[cfg(test)]
 mod tests {
     use super::{
-        automatic_refresh_due, finalize_published_snapshot, manual_refresh_models, read_state,
-        record_attempt, published_context_budgets_from_catalog_payload,
-        published_official_models_from_catalog, refresh_with_flight, should_attempt,
-        direct_official_refresh_failure_message, update_published_context_budgets, write_state,
-        OfficialRefreshState,
-        PublishedOfficialBudget, RefreshOutcome, RefreshTrigger, SingleFlight,
-        OFFICIAL_REFRESH_INTERVAL_SECONDS,
+        allow_activation_without_official_snapshot, automatic_refresh_due,
+        finalize_published_snapshot, manual_refresh_models, read_state, record_attempt,
+        published_context_budgets_from_catalog_payload, published_official_models_from_catalog,
+        refresh_with_flight, should_attempt, direct_official_refresh_failure_message,
+        update_published_context_budgets, write_state, OfficialRefreshState, PublishedOfficialBudget,
+        RefreshOutcome, RefreshTrigger, SingleFlight, OFFICIAL_REFRESH_INTERVAL_SECONDS,
     };
     use crate::Model;
     use serde_json::json;
@@ -794,6 +797,20 @@ mod tests {
         assert!(!should_attempt(RefreshTrigger::Scheduled, &state, 1_001));
         assert!(!should_attempt(RefreshTrigger::Resume, &state, 1_001));
         assert!(should_attempt(RefreshTrigger::Activation, &state, 1_001));
+    }
+
+    #[test]
+    fn activation_succeeds_without_official_models_when_safe_snapshot_is_unavailable() {
+        assert!(allow_activation_without_official_snapshot(outcome(
+            RefreshTrigger::Activation,
+            false,
+        ))
+        .is_ok());
+        assert!(allow_activation_without_official_snapshot(outcome(
+            RefreshTrigger::Activation,
+            true,
+        ))
+        .is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Gateway activation no longer fails when there is no Codex sign-in and no safe Official snapshot; external Provider models remain served (Closes #403)
- Official models are hard-gated on `published_context_windows` regardless of the context-guard toggle, so they are neither listed nor routable until a safe snapshot exists

## Verification
- cargo test --bin codexhub official_refresh: 17 passed
- cargo test --bin codexhub gateway: 217 passed
- cargo clippy --locked --all-targets -- -D warnings: pass
- Full cargo test --locked: 537 passed, 5 failed (pre-existing env issue: system python 3.11 vs PEP 695 syntax in spawned gateway, unrelated)