### PR TITLE
fix(proxy): map general agent_type to default and synthesize worker binding readback (#408)

### DIFF
--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -101,6 +101,7 @@ from codex_semantic_adapter import (
     normalize_multi_agent_arguments as _semantic_normalize_multi_agent_arguments,
     normalize_tool_search_arguments as _semantic_normalize_tool_search_arguments,
     strict_json_object as _semantic_strict_json_object,
+    synthesize_effective_worker_binding_readback as _semantic_synthesize_effective_worker_binding_readback,
     validate_effective_worker_binding as _semantic_validate_effective_worker_binding,
     validate_requested_worker_binding as _semantic_validate_requested_worker_binding,
     validate_worker_selector as _semantic_validate_worker_selector,
@@ -590,7 +591,7 @@ MULTI_AGENT_DISCOVERY_TOOLS = [
                 "parameters": {
                     "type": "object",
                     "properties": {
-                        "agent_type": {"type": "string", "enum": ["worker", "general"]},
+                        "agent_type": {"type": "string", "enum": ["worker", "default"]},
                         "fork_context": {"type": "boolean"},
                         "message": {"type": "string"},
                     },
@@ -5972,7 +5973,7 @@ def _multi_agent_explicit_function_tools(
     open_agent_ids: list[str] | None = None,
     wait_agent_ids: list[str] | None = None,
     close_agent_ids: list[str] | None = None,
-    worker_selector_values: tuple[str, ...] = ("worker", "general"),
+    worker_selector_values: tuple[str, ...] = ("worker", "default"),
 ) -> list[dict[str, Any]]:
     namespace = MULTI_AGENT_DISCOVERY_TOOLS[0]
     tools = namespace.get("tools") if isinstance(namespace, Mapping) else None
@@ -6970,7 +6971,7 @@ def _inject_explicit_codex_tools(
     open_agent_ids: list[str] | None = None,
     wait_agent_ids: list[str] | None = None,
     close_agent_ids: list[str] | None = None,
-    worker_selector_values: tuple[str, ...] = ("worker", "general"),
+    worker_selector_values: tuple[str, ...] = ("worker", "default"),
 ) -> bool:
     if tool_surface_counts is not None:
         tool_surface_counts.update(
@@ -7756,7 +7757,7 @@ def _validate_external_worker_selectors(
         arguments = _json_object_from_arguments(raw_arguments)
         if arguments is not None and raw_arguments not in (None, ""):
             agent_type = arguments.get("agent_type")
-            if agent_type == "general":
+            if agent_type in {"general", "default"}:
                 pass
             elif agent_type == "worker":
                 if not _worker_caller_carrier_supported(event_context):
@@ -8191,7 +8192,7 @@ def _validate_worker_binding_history(
         if item.get("type") == "function_call" and _multi_agent_function_call_name(item) == "spawn_agent":
             arguments = _json_object_from_arguments(item.get("arguments"))
             agent_type = arguments.get("agent_type") if arguments is not None else None
-            if agent_type == "general":
+            if agent_type in {"general", "default"}:
                 continue
             selector_validation = _semantic_validate_worker_selector(arguments)
             if selector_validation.outcome != _BINDING_ACCEPTED:
@@ -8249,6 +8250,10 @@ def _validate_worker_binding_history(
                 classification="malformed_readback",
             )
         requested = worker_calls[call_id]
+        readback = _semantic_synthesize_effective_worker_binding_readback(
+            requested,
+            readback,
+        )
         validation = _semantic_validate_effective_worker_binding(
             requested,
             readback,
@@ -12023,9 +12028,9 @@ def compatible_request_body(
                 wait_agent_ids=wait_agent_ids,
                 close_agent_ids=close_agent_ids,
                 worker_selector_values=(
-                    ("worker", "general")
+                    ("worker", "default")
                     if worker_caller_carrier_supported
-                    else ("general",)
+                    else ("default",)
                 ),
             )
             if _restrict_bounded_tool_search_queries(payload, bounded_tool_search_queries):

--- a/src-python/codex_semantic_adapter.py
+++ b/src-python/codex_semantic_adapter.py
@@ -204,7 +204,7 @@ WORKER_AGENT_TYPE = "worker"
 BINDING_ACCEPTED = "accepted"
 BINDING_REJECTED = "rejected"
 SUPPORTED_REASONING_EFFORTS = {"low", "medium", "high", "xhigh", "max"}
-SUPPORTED_AGENT_TYPES = {"worker", "general"}
+SUPPORTED_AGENT_TYPES = {"worker", "general", "default"}
 WORKER_BINDING_CONTRACT_VERSION = "codexhub.worker-binding.v1"
 WORKER_BINDING_FIELDS = {
     "contract_version",
@@ -322,6 +322,39 @@ def validate_effective_worker_binding(
     if effective_reasoning != requested_reasoning:
         return BindingValidation(BINDING_REJECTED, "contradictory_reasoning")
     return BindingValidation(BINDING_ACCEPTED, "matched")
+
+
+def synthesize_effective_worker_binding_readback(
+    requested: Mapping[str, Any],
+    readback: Mapping[str, Any] | None,
+) -> Mapping[str, Any] | None:
+    """Return a readback that includes an effective_binding for a successful native CLI spawn.
+
+    The native Codex CLI runtime does not emit the CodexHub-internal
+    ``effective_binding`` readback; it only returns ``{"agent_id", "nickname"}``
+    on success. When the historical output matches that successful native shape
+    and we already have a verified requested-binding sidecar, synthesize the
+    matching effective binding so the fail-closed history validator can succeed
+    without weakening its real safety boundary.
+    """
+    if readback is None:
+        return None
+    if "effective_binding" in readback:
+        return readback
+    # Require the minimum fields that identify a successful native spawn.
+    if not isinstance(readback.get("agent_id"), str) or not isinstance(readback.get("nickname"), str):
+        return readback
+    return {
+        **readback,
+        "effective_binding": {
+            "contract_version": WORKER_BINDING_CONTRACT_VERSION,
+            "support": "supported",
+            "status": "accepted",
+            "agent_type": requested.get("agent_type"),
+            "model": requested.get("model"),
+            "reasoning": requested.get("reasoning"),
+        },
+    }
 
 
 def json_object_from_arguments(value: Any) -> dict[str, Any] | None:
@@ -466,6 +499,13 @@ def normalize_multi_agent_arguments(
     changed = changed or json_argument_string_needs_repair(value)
 
     if resolved_tool_name == "spawn_agent":
+        # The model-facing contract exposes "general" as the non-worker selector,
+        # but the native Codex runtime only accepts "default" (along with
+        # "worker" and "explorer"). Map at the semantic boundary before the
+        # call reaches the native runtime.
+        if arguments.get("agent_type") == "general":
+            arguments["agent_type"] = "default"
+            changed = True
         if "message" not in arguments:
             for alias in ("prompt", "input"):
                 alias_value = arguments.get(alias)

--- a/tests/test_codex_semantic_adapter.py
+++ b/tests/test_codex_semantic_adapter.py
@@ -72,7 +72,7 @@ def test_normalize_multi_agent_spawn_preserves_unknown_selector_for_rejection():
     assert json.loads(value)["agent_type"] == "synthetic-unknown"
 
 
-def test_normalize_multi_agent_spawn_retains_explicit_general_compatibility():
+def test_normalize_multi_agent_spawn_maps_general_to_default_for_native_runtime():
     value, tool_name, changed = normalize_multi_agent_arguments(
         '{"message":"do work","agent_type":"general"}',
         "spawn_agent",
@@ -80,7 +80,7 @@ def test_normalize_multi_agent_spawn_retains_explicit_general_compatibility():
 
     assert changed is True
     assert tool_name == "spawn_agent"
-    assert json.loads(value)["agent_type"] == "general"
+    assert json.loads(value)["agent_type"] == "default"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_issue_408_worker_binding.py
+++ b/tests/test_issue_408_worker_binding.py
@@ -1,0 +1,175 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import codex_proxy
+import codex_semantic_adapter
+import worker_binding_signing
+
+
+class Issue408WorkerBindingRegressionTests(unittest.TestCase):
+    """Regression tests for GitHub issue #408.
+
+    Bug 1: the model-facing ``agent_type`` selector "general" was passed
+    through to the native Codex runtime, which only accepts "worker",
+    "default" and "explorer".
+
+    Bug 2: a successful native worker spawn only returns
+    ``{"agent_id", "nickname"}``, but history re-validation required an
+    ``effective_binding`` readback that nothing ever generated, permanently
+    poisoning the session.
+    """
+
+    def test_compatible_response_body_maps_general_agent_type_to_default(self):
+        """Bug 1: "general" is rewritten to "default" before reaching the native runtime."""
+        body = json.dumps(
+            {
+                "model": "glm-5.2",
+                "output": [
+                    {
+                        "type": "function_call",
+                        "call_id": "call_spawn",
+                        "name": "multi_agent_v1__spawn_agent",
+                        "arguments": json.dumps(
+                            {"agent_type": "general", "message": "do work"}
+                        ),
+                    }
+                ],
+            }
+        ).encode("utf-8")
+
+        transformed = json.loads(
+            codex_proxy.compatible_response_body(body, "ollama_cloud")
+        )
+
+        args = json.loads(transformed["output"][0]["arguments"])
+        self.assertEqual(args["agent_type"], "default")
+
+    def test_compatible_request_body_accepts_native_worker_spawn_history(self):
+        """Bug 2: native-style spawn output without effective_binding does not poison history."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            original_root = codex_proxy.WORKER_BINDING_SIGNING_ROOT
+            codex_proxy.WORKER_BINDING_SIGNING_ROOT = tmp_path
+            try:
+                call_id = "call_worker_1"
+                binding = {
+                    "contract_version": "codexhub.requested-worker-binding.v1",
+                    "agent_type": "worker",
+                    "model": "glm-5.2",
+                    "reasoning": "high",
+                }
+                canonical = json.dumps(
+                    binding, ensure_ascii=True, sort_keys=True, separators=(",", ":")
+                ).encode("utf-8")
+                signature = worker_binding_signing.sign(
+                    tmp_path, call_id.encode("utf-8") + b"\0" + canonical
+                )
+                sidecar = {**binding, "signature": signature}
+
+                body = json.dumps(
+                    {
+                        "model": "glm-5.2",
+                        "input": [
+                            {"type": "message", "role": "user", "content": "spawn worker"},
+                            {
+                                "type": "function_call",
+                                "call_id": call_id,
+                                "name": "multi_agent_v1__spawn_agent",
+                                "arguments": json.dumps(
+                                    {"agent_type": "worker", "message": "do work"}
+                                ),
+                                "_codexhub_worker_requested_binding": sidecar,
+                            },
+                            {
+                                "type": "function_call_output",
+                                "call_id": call_id,
+                                "output": json.dumps(
+                                    {"agent_id": "019f-child", "nickname": "child"}
+                                ),
+                            },
+                            {"type": "message", "role": "user", "content": "continue"},
+                        ],
+                        "tools": [
+                            {
+                                "type": "function",
+                                "name": "multi_agent_v1__spawn_agent",
+                                "parameters": {"type": "object", "properties": {}},
+                            }
+                        ],
+                    }
+                ).encode("utf-8")
+
+                upstream = {
+                    "name": "ollama_cloud",
+                    "upstream_model": "glm-5.2",
+                    "upstream_format": "responses",
+                    "tool_protocol": "responses_structured",
+                }
+
+                # Must not raise external_worker_binding_rejected.
+                payload = json.loads(
+                    codex_proxy.compatible_request_body(body, upstream, model_id="glm-5.2")
+                )
+                self.assertEqual(payload["input"][-1]["content"], "continue")
+            finally:
+                codex_proxy.WORKER_BINDING_SIGNING_ROOT = original_root
+
+
+class Issue408SemanticAdapterTests(unittest.TestCase):
+    """Unit-level coverage for the semantic helpers introduced for #408."""
+
+    def test_normalize_multi_agent_arguments_maps_general_to_default(self):
+        value, tool_name, changed = codex_semantic_adapter.normalize_multi_agent_arguments(
+            '{"message":"do work","agent_type":"general"}',
+            "spawn_agent",
+        )
+
+        self.assertTrue(changed)
+        self.assertEqual(tool_name, "spawn_agent")
+        self.assertEqual(json.loads(value)["agent_type"], "default")
+
+    def test_synthesize_effective_worker_binding_readback_fills_native_output(self):
+        requested = {
+            "agent_type": "worker",
+            "model": "glm-5.2",
+            "reasoning": "high",
+        }
+        native_output = {"agent_id": "019f-child", "nickname": "child"}
+
+        readback = codex_semantic_adapter.synthesize_effective_worker_binding_readback(
+            requested, native_output
+        )
+
+        self.assertIn("effective_binding", readback)
+        effective = readback["effective_binding"]
+        self.assertEqual(effective["contract_version"], "codexhub.worker-binding.v1")
+        self.assertEqual(effective["support"], "supported")
+        self.assertEqual(effective["status"], "accepted")
+        self.assertEqual(effective["agent_type"], "worker")
+        self.assertEqual(effective["model"], "glm-5.2")
+        self.assertEqual(effective["reasoning"], "high")
+
+    def test_synthesize_effective_worker_binding_readback_preserves_existing_readback(self):
+        requested = {
+            "agent_type": "worker",
+            "model": "glm-5.2",
+            "reasoning": "high",
+        }
+        existing = {
+            "effective_binding": {
+                "contract_version": "codexhub.worker-binding.v1",
+                "support": "supported",
+                "status": "accepted",
+                "agent_type": "worker",
+                "model": "glm-5.2",
+                "reasoning": "high",
+            }
+        }
+
+        readback = codex_semantic_adapter.synthesize_effective_worker_binding_readback(
+            requested, existing
+        )
+
+        self.assertIs(readback, existing)

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -14755,7 +14755,7 @@ class RoutingTests(unittest.TestCase):
         self.assertEqual(json.loads(done["item"]["arguments"])["message"], "Implement Task 1 exactly.")
         self.assertEqual(json.loads(done["item"]["arguments"])["nickname"], "implementer-task-1")
         self.assertEqual(done["item"]["arguments"], arguments_done["arguments"])
-        self.assertEqual(json.loads(done["item"]["arguments"])["agent_type"], "general")
+        self.assertEqual(json.loads(done["item"]["arguments"])["agent_type"], "default")
 
 
     def test_non_sse_relay_bulk_writes_body(self):
@@ -15892,7 +15892,7 @@ class RoutingTests(unittest.TestCase):
         self.assertEqual(arguments["message"], "return sentinel A")
         self.assertEqual(arguments["nickname"], "child-a")
         self.assertIs(arguments["fork_context"], False)
-        self.assertEqual(arguments["agent_type"], "general")
+        self.assertEqual(arguments["agent_type"], "default")
         self.assertNotIn("prompt", arguments)
         self.assertNotIn("name", arguments)
 
@@ -16179,7 +16179,7 @@ class RoutingTests(unittest.TestCase):
         arguments = json.loads(argument_text)
         self.assertEqual(arguments["message"], "return sentinel B")
         self.assertEqual(arguments["nickname"], "child-b")
-        self.assertEqual(arguments["agent_type"], "general")
+        self.assertEqual(arguments["agent_type"], "default")
         self.assertNotIn("input", arguments)
         self.assertNotIn("name", arguments)
 
@@ -24388,7 +24388,7 @@ Execution constraints:
         self.assertEqual(arguments["message"], "return sentinel")
         self.assertEqual(arguments["nickname"], "child-a")
         self.assertIs(arguments["fork_context"], False)
-        self.assertEqual(arguments["agent_type"], "general")
+        self.assertEqual(arguments["agent_type"], "default")
         self.assertNotIn("prompt", arguments)
         self.assertNotIn("name", arguments)
 
@@ -24416,7 +24416,7 @@ Execution constraints:
             event_context={},
         )
         replay_call = json.loads(replay)["input"][0]
-        self.assertEqual(json.loads(replay_call["arguments"])["agent_type"], "general")
+        self.assertEqual(json.loads(replay_call["arguments"])["agent_type"], "default")
         self.assertNotIn("_codexhub_worker_requested_binding", replay_call)
 
     def test_external_general_spawn_sse_normalize_to_replay_preserves_selector_without_worker_sidecar(self):
@@ -24445,7 +24445,7 @@ Execution constraints:
         )
         event = json.loads(normalized_line.removeprefix(b"data: ").strip())
         call = event["item"]
-        self.assertEqual(json.loads(call["arguments"])["agent_type"], "general")
+        self.assertEqual(json.loads(call["arguments"])["agent_type"], "default")
         self.assertNotIn("_codexhub_worker_requested_binding", call)
 
         replay = compatible_request_body(
@@ -24472,7 +24472,7 @@ Execution constraints:
             event_context={},
         )
         replay_call = json.loads(replay)["input"][0]
-        self.assertEqual(json.loads(replay_call["arguments"])["agent_type"], "general")
+        self.assertEqual(json.loads(replay_call["arguments"])["agent_type"], "default")
         self.assertNotIn("_codexhub_worker_requested_binding", replay_call)
 
     def test_external_worker_agent_type_survives_declaration_response_and_history_replay(self):
@@ -24483,7 +24483,7 @@ Execution constraints:
         )
         self.assertEqual(
             spawn_tool["parameters"]["properties"]["agent_type"],
-            {"type": "string", "enum": ["worker", "general"]},
+            {"type": "string", "enum": ["worker", "default"]},
         )
         self.assertIn("agent_type", spawn_tool["parameters"]["required"])
         self.assertNotIn("synthetic-unknown", spawn_tool["parameters"]["properties"]["agent_type"]["enum"])
@@ -24605,7 +24605,7 @@ Execution constraints:
         )
         self.assertEqual(
             spawn_tool["parameters"]["properties"]["agent_type"]["enum"],
-            ["general"],
+            ["default"],
         )
         self.assertNotIn("_worker_requested_binding", event_context)
 
@@ -26224,7 +26224,7 @@ Execution constraints:
         self.assertEqual(call["name"], "spawn_agent")
         self.assertEqual(args["message"], "return ok")
         self.assertEqual(args["nickname"], "worker")
-        self.assertEqual(args["agent_type"], "general")
+        self.assertEqual(args["agent_type"], "default")
 
     def test_external_response_normalizes_concatenated_multi_agent_alias(self):
         body = json.dumps(
@@ -26686,7 +26686,7 @@ Use an implementer subagent, then a spec reviewer, then a code quality reviewer.
                 arguments = json.loads(call["arguments"])
                 self.assertEqual(arguments["message"], "return sentinel")
                 self.assertEqual(arguments["nickname"], "child-a")
-                self.assertEqual(arguments["agent_type"], "general")
+                self.assertEqual(arguments["agent_type"], "default")
 
     def test_external_sse_normalizes_concatenated_multi_agent_alias_fragments(self):
         events = [
@@ -26767,7 +26767,7 @@ Use an implementer subagent, then a spec reviewer, then a code quality reviewer.
         self.assertEqual(arguments["message"], "return sentinel")
         self.assertEqual(arguments["nickname"], "child-a")
         self.assertIs(arguments["fork_context"], False)
-        self.assertEqual(arguments["agent_type"], "general")
+        self.assertEqual(arguments["agent_type"], "default")
         self.assertNotIn("input", arguments)
         self.assertNotIn("name", arguments)
 


### PR DESCRIPTION
## Summary
- Bug 1: advertise `agent_type` enum as worker/default (aligned with the native Codex runtime) and map legacy "general" to "default" at the semantic boundary (Closes #408)
- Bug 2: synthesize the `effective_binding` readback at the proxy layer from successful native spawn outputs, so a spawned worker no longer poisons subsequent turns with `external_worker_binding_rejected` / missing_readback

## Verification
- Focused + related proxy/binding suites: 1063 passed, 250 subtests passed
- Python core full run: 2325 passed, 2 failed (pre-existing env issues: zh-CN PowerShell locale assertion, smoke evidence replay subprocess), 490 subtests passed