### PR TITLE
fix(probe): distinguish missing model from unsupported endpoint in provider test (#404)

### DIFF
--- a/frontend/src/components/providers/ProviderEditor.tsx
+++ b/frontend/src/components/providers/ProviderEditor.tsx
@@ -76,7 +76,7 @@ export function ProviderDetail({
 
   useEffect(() => {
     if (probeResult) {
-      setEndpointTestState("success");
+      setEndpointTestState(probeResult.model_required ? "error" : "success");
     }
   }, [probeResult]);
 
@@ -268,7 +268,7 @@ export function AddProviderPanel({
 
   useEffect(() => {
     if (probeResult) {
-      setEndpointTestState("success");
+      setEndpointTestState(probeResult.model_required ? "error" : "success");
     }
   }, [probeResult]);
 

--- a/frontend/src/hooks/useProviderCatalogActions.ts
+++ b/frontend/src/hooks/useProviderCatalogActions.ts
@@ -86,6 +86,14 @@ export function useProviderCatalogActions({
   const { showToast, updateToast } = toast;
 
   function updateProbeToast(toastId: string, result: UpstreamFormatProbeResult) {
+    if (result.model_required) {
+      updateToast(toastId, {
+        action: null,
+        text: t("providers.probeModelRequired"),
+        tone: "error",
+      });
+      return;
+    }
     const detectedFormat = probeDetectedEndpointFormat(result);
     updateToast(toastId, {
       action: null,

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -469,6 +469,7 @@ const enUS = {
     providerOrderSaved: "Provider order saved",
     providerSaved: "{{name}} saved",
     probeCompleted: "Probe completed: {{format}}",
+    probeModelRequired: "A model is required to test endpoint compatibility",
     probeNoSupportedEndpoint: "Probe completed: no supported endpoint detected",
     reasoningLevels: "Reasoning levels",
     recommendedFormat: "recommended {{format}}",

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -468,6 +468,7 @@ const zhCN = {
     providerOrderSaved: "供应商顺序已保存",
     providerSaved: "{{name}} 已保存",
     probeCompleted: "探测完成：{{format}}",
+    probeModelRequired: "需要模型才能测试端点兼容性",
     probeNoSupportedEndpoint: "探测完成：未检测到可用端点",
     reasoningLevels: "推理级别",
     recommendedFormat: "推荐 {{format}}",

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -74,6 +74,7 @@ export interface Provider {
 export interface UpstreamFormatProbeResult {
   base_url: string;
   model: string | null;
+  model_required: boolean;
   models_ok: boolean;
   responses_text_ok: boolean;
   responses_tool_ok: boolean;

--- a/src-python/probe_upstream_format.py
+++ b/src-python/probe_upstream_format.py
@@ -474,6 +474,7 @@ def probe(base_url: str, api_key: str, requested_model: str | None, timeout: int
     result: dict[str, Any] = {
         "base_url": base_url,
         "model": requested_model.strip() if requested_model and requested_model.strip() else None,
+        "model_required": False,
         "models_ok": False,
         "responses_text_ok": False,
         "responses_tool_ok": False,
@@ -501,6 +502,7 @@ def probe(base_url: str, api_key: str, requested_model: str | None, timeout: int
     model = result["model"]
     if not isinstance(model, str) or not model.strip():
         notes.append("No model is available for POST probes.")
+        result["model_required"] = True
         result["duration_ms"] = int((time.monotonic() - started) * 1000)
         return result
 

--- a/tests/test_probe_upstream_format.py
+++ b/tests/test_probe_upstream_format.py
@@ -315,6 +315,107 @@ class ProbeUpstreamFormatTests(unittest.TestCase):
         self.assertTrue(anthropic_text_ok({"content": [{"type": "text", "text": "OK"}]}))
         self.assertFalse(anthropic_text_ok({"choices": []}))
 
+    def test_probe_reports_model_required_when_no_model_and_discovery_fails(self) -> None:
+        def fake_request_json(
+            base_url: str,
+            api_key: str,
+            path: str,
+            *,
+            method: str = "GET",
+            payload: dict | None = None,
+            timeout: int,
+        ):
+            if path == "/models":
+                return False, 404, None, "not found"
+            raise AssertionError(f"unexpected probe path: {path}")
+
+        with patch("probe_upstream_format.request_json", side_effect=fake_request_json):
+            result = probe("https://example.test/v1", "test-key", None, 2)
+
+        self.assertTrue(result["model_required"])
+        self.assertIsNone(result["model"])
+        self.assertFalse(result["models_ok"])
+        self.assertEqual(result["recommended_format"], UPSTREAM_FORMAT_AUTO)
+        self.assertIn("No model is available for POST probes.", result["notes"])
+
+    def test_probe_reports_model_required_when_discovery_returns_no_models(self) -> None:
+        def fake_request_json(
+            base_url: str,
+            api_key: str,
+            path: str,
+            *,
+            method: str = "GET",
+            payload: dict | None = None,
+            timeout: int,
+        ):
+            if path == "/models":
+                return True, 200, {"data": []}, None
+            raise AssertionError(f"unexpected probe path: {path}")
+
+        with patch("probe_upstream_format.request_json", side_effect=fake_request_json):
+            result = probe("https://example.test/v1", "test-key", None, 2)
+
+        self.assertTrue(result["model_required"])
+        self.assertIsNone(result["model"])
+        self.assertTrue(result["models_ok"])
+        self.assertEqual(result["recommended_format"], UPSTREAM_FORMAT_AUTO)
+
+    def test_probe_uses_discovered_model_when_none_configured(self) -> None:
+        def fake_request_json(
+            base_url: str,
+            api_key: str,
+            path: str,
+            *,
+            method: str = "GET",
+            payload: dict | None = None,
+            timeout: int,
+        ):
+            if path == "/models":
+                return True, 200, {"data": [{"id": "discovered-model"}]}, None
+            if path == "/responses":
+                return True, 200, {"id": "resp_1"}, None
+            if path == "/chat/completions":
+                return False, 404, None, "not found"
+            if path == "/messages":
+                return False, 404, None, "not found"
+            raise AssertionError(f"unexpected probe path: {path}")
+
+        with patch("probe_upstream_format.request_json", side_effect=fake_request_json):
+            result = probe("https://example.test/v1", "test-key", None, 2)
+
+        self.assertFalse(result["model_required"])
+        self.assertEqual(result["model"], "discovered-model")
+        self.assertTrue(result["responses_text_ok"])
+        self.assertEqual(result["recommended_format"], UPSTREAM_FORMAT_RESPONSES)
+
+    def test_probe_uses_configured_model_when_provided(self) -> None:
+        def fake_request_json(
+            base_url: str,
+            api_key: str,
+            path: str,
+            *,
+            method: str = "GET",
+            payload: dict | None = None,
+            timeout: int,
+        ):
+            if path == "/models":
+                return False, 404, None, "not found"
+            if path == "/responses":
+                return True, 200, {"id": "resp_1"}, None
+            if path == "/chat/completions":
+                return False, 404, None, "not found"
+            if path == "/messages":
+                return False, 404, None, "not found"
+            raise AssertionError(f"unexpected probe path: {path}")
+
+        with patch("probe_upstream_format.request_json", side_effect=fake_request_json):
+            result = probe("https://example.test/v1", "test-key", "configured-model", 2)
+
+        self.assertFalse(result["model_required"])
+        self.assertEqual(result["model"], "configured-model")
+        self.assertTrue(result["responses_text_ok"])
+        self.assertEqual(result["recommended_format"], UPSTREAM_FORMAT_RESPONSES)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Provider Test no longer reports "Probe completed: no supported endpoint detected" when the real problem is an empty model list with discovery unavailable; a dedicated model_required signal and message are surfaced instead (Closes #404)

## Verification
- Focused: tests/test_probe_upstream_format.py + tests/test_provider_registry.py: 20 passed
- Python core full run: 2325 passed, 1 failed (pre-existing zh-CN PowerShell locale assertion, unrelated)
- Frontend: npm run test:ui-contract 146 passed, npm run build pass