### PR TITLE
fix(frontend): sync provider editor draft after discovery and merge against persisted models (#405)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "vite --host 127.0.0.1",
     "build": "tsc && vite build",
-    "test:ui-contract": "node --test scripts/ui-contract.test.mjs scripts/official-models-visibility.test.mjs",
+    "test:ui-contract": "node --test scripts/ui-contract.test.mjs scripts/official-models-visibility.test.mjs scripts/provider-discovery-draft.test.mjs",
     "test:provider-comparison": "node --test scripts/provider-comparison.test.mjs",
     "preview": "vite preview --host 127.0.0.1"
   },

--- a/frontend/scripts/provider-discovery-draft.test.mjs
+++ b/frontend/scripts/provider-discovery-draft.test.mjs
@@ -1,0 +1,149 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+import ts from "typescript";
+
+const actionsPath = new URL("../src/hooks/useProviderCatalogActions.ts", import.meta.url);
+const editorPath = new URL("../src/components/providers/ProviderEditor.tsx", import.meta.url);
+const formatPath = new URL("../src/lib/format.ts", import.meta.url);
+const typesPath = new URL("../src/lib/types.ts", import.meta.url);
+
+async function readFormatModule() {
+  const [formatSource, typesSource] = await Promise.all([
+    readFile(formatPath, "utf8"),
+    readFile(typesPath, "utf8"),
+  ]);
+
+  const combinedSource = [
+    typesSource
+      .replace(/export (interface|type) /g, "declare $1 ")
+      .replace(/export function/g, "function"),
+    formatSource
+      .replace(/^\s*import[\s\S]*?;\s*$/gm, "")
+      .replace(/export function/g, "function"),
+  ].join("\n\n");
+
+  const jsOutput = ts.transpileModule(combinedSource, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2022,
+      strict: false,
+    },
+  }).outputText;
+
+  const moduleExports = {};
+  const wrappedModule = new Function(
+    "exports",
+    jsOutput + "\nexports.mergeDiscoveredModels = mergeDiscoveredModels; exports.renumberModels = renumberModels;",
+  );
+  wrappedModule(moduleExports);
+  return moduleExports;
+}
+
+function makeModel(overrides = {}) {
+  return {
+    id: "model-a",
+    display_name: "Model A",
+    upstream_model: "model-a",
+    context_window: null,
+    max_output_tokens: null,
+    input_modalities: ["text"],
+    supported_reasoning_levels: [],
+    default_reasoning_level: null,
+    source_kind: "manual",
+    locked: false,
+    codex_enabled: true,
+    gateway_exported: true,
+    sort_order: 1,
+    enabled: true,
+    ...overrides,
+  };
+}
+
+test("mergeDiscoveredModels preserves manual models absent from discovery", async () => {
+  const { mergeDiscoveredModels } = await readFormatModule();
+  const manual = makeModel({ id: "manual", display_name: "Manual Model" });
+  const discovered = makeModel({ id: "discovered", display_name: "Discovered Model", source_kind: "discovered" });
+  const merged = mergeDiscoveredModels([manual], [discovered]);
+  const ids = merged.map((model) => model.id);
+  assert.ok(ids.includes("manual"), "manual model should be retained");
+  assert.ok(ids.includes("discovered"), "discovered model should be added");
+});
+
+test("mergeDiscoveredModels preserves existing per-model settings when a model is rediscovered", async () => {
+  const { mergeDiscoveredModels } = await readFormatModule();
+  const existing = makeModel({
+    id: "shared",
+    display_name: "Custom Display",
+    upstream_model: "custom-upstream",
+    input_modalities: ["text", "image"],
+    supported_reasoning_levels: ["low", "medium"],
+    default_reasoning_level: "low",
+    codex_enabled: false,
+    gateway_exported: false,
+    enabled: false,
+  });
+  const discovered = makeModel({
+    id: "shared",
+    display_name: "Discovered Display",
+    upstream_model: "discovered-upstream",
+    input_modalities: ["text"],
+    supported_reasoning_levels: [],
+    default_reasoning_level: null,
+    codex_enabled: true,
+    gateway_exported: true,
+    enabled: true,
+  });
+  const merged = mergeDiscoveredModels([existing], [discovered]);
+  const result = merged.find((model) => model.id === "shared");
+  assert.ok(result, "rediscovered model should be present");
+  assert.equal(result.display_name, "Custom Display", "display_name should be preserved");
+  assert.equal(result.upstream_model, "custom-upstream", "upstream_model should be preserved");
+  assert.deepEqual(result.input_modalities, ["text", "image"], "input_modalities should be preserved");
+  assert.deepEqual(result.supported_reasoning_levels, ["low", "medium"], "reasoning levels should be preserved");
+  assert.equal(result.default_reasoning_level, "low", "default reasoning level should be preserved");
+  assert.equal(result.codex_enabled, false, "codex_enabled should be preserved");
+  assert.equal(result.gateway_exported, false, "gateway_exported should be preserved");
+  assert.equal(result.enabled, false, "enabled should be preserved");
+});
+
+test("mergeDiscoveredModels leaves existing models unchanged on empty discovery", async () => {
+  const { mergeDiscoveredModels } = await readFormatModule();
+  const existing = [makeModel({ id: "manual" })];
+  const merged = mergeDiscoveredModels(existing, []);
+  assert.equal(merged.length, 1, "existing model should remain");
+  assert.equal(merged[0].id, "manual", "existing model id should be unchanged");
+});
+
+test("refreshProviderModels merges against persisted provider models, not the stale draft", async () => {
+  const source = await readFile(actionsPath, "utf8");
+  assert.match(
+    source,
+    /const\s+persistedProvider\s*=\s*providers\.find\(\(item\)\s*=>\s*item\.id\s*===\s*provider\.id\)\s*\?\?\s*provider;/,
+    "should look up the persisted provider by id",
+  );
+  assert.match(
+    source,
+    /mergeDiscoveredModels\(persistedProvider\.models,\s*models\)/,
+    "should merge discovered models against the persisted provider's models",
+  );
+  assert.match(
+    source,
+    /const\s+previousModelIds\s*=\s*new\s+Set\(persistedProvider\.models\.map\(\(model\)\s*=>\s*model\.id\)\);/,
+    "should compute previous model ids from the persisted provider's models",
+  );
+});
+
+test("ProviderDetail keeps draft models in sync with persisted provider models", async () => {
+  const source = await readFile(editorPath, "utf8");
+  assert.match(
+    source,
+    /setDraft\(\(current\)\s*=>\s*\{\s*if\s*\(\s*current\.id\s*!==\s*normalizedProvider\.id\s*\|\|\s*current\.models\s*===\s*normalizedProvider\.models\s*\)\s*\{\s*return\s*current;\s*\}\s*return\s*\{\s*\.\.\.current,\s*models:\s*normalizedProvider\.models\s*\};\s*\}\);/,
+    "should sync draft models from normalizedProvider.models",
+  );
+  assert.match(
+    source,
+    /useEffect\(\(\)\s*=>\s*\{\s*setDraft\(\(current\)\s*=>\s*\{/,
+    "should use an effect to update the draft",
+  );
+});

--- a/frontend/scripts/ui-contract.test.mjs
+++ b/frontend/scripts/ui-contract.test.mjs
@@ -2713,7 +2713,8 @@ test("provider discovery updates the selected provider and reports progress", as
   const providersSource = await readProviderContractSource();
 
   assert.match(providersSource, /showToast\(t\("providers\.discoveringProviderModels", \{ name: provider\.name \}\), "loading"\)/);
-  assert.match(providersSource, /const nextProvider = \{\s*\.\.\.provider,\s*models: mergeDiscoveredModels\(provider\.models, models\),\s*\}/s);
+  assert.match(providersSource, /const\s+persistedProvider\s*=\s*providers\.find\(\(item\)\s*=>\s*item\.id\s*===\s*provider\.id\)\s*\?\?\s*provider;/);
+  assert.match(providersSource, /const nextProvider = \{\s*\.\.\.persistedProvider,\s*models: mergeDiscoveredModels\(persistedProvider\.models, models\),\s*\}/s);
   assert.match(providersSource, /setProviders\(nextProviders\)/);
   assert.match(providersSource, /t\("providers\.discoveredProviderModels", \{/);
 });

--- a/frontend/src/components/providers/ProviderEditor.tsx
+++ b/frontend/src/components/providers/ProviderEditor.tsx
@@ -74,6 +74,18 @@ export function ProviderDetail({
     setEndpointTestState(availableFormats.length ? "success" : "idle");
   }, [provider.id, provider.available_upstream_formats]);
 
+  // Keep the editor model list in sync with the persisted provider so that
+  // successful discovery is reflected immediately and a stale draft cannot be
+  // saved back over the discovered models.
+  useEffect(() => {
+    setDraft((current) => {
+      if (current.id !== normalizedProvider.id || current.models === normalizedProvider.models) {
+        return current;
+      }
+      return { ...current, models: normalizedProvider.models };
+    });
+  }, [normalizedProvider.id, normalizedProvider.models]);
+
   useEffect(() => {
     if (probeResult) {
       setEndpointTestState("success");

--- a/frontend/src/hooks/useProviderCatalogActions.ts
+++ b/frontend/src/hooks/useProviderCatalogActions.ts
@@ -237,10 +237,13 @@ export function useProviderCatalogActions({
     const toastId = showToast(t("providers.discoveringProviderModels", { name: provider.name }), "loading");
     try {
       const models = await api.discoverProviderModels(provider.base_url, provider.api_key ?? "");
-      const previousModelIds = new Set(provider.models.map((model) => model.id));
+      // Merge against the persisted provider so discovery never drops manual
+      // models that are present in saved state but absent from a stale draft.
+      const persistedProvider = providers.find((item) => item.id === provider.id) ?? provider;
+      const previousModelIds = new Set(persistedProvider.models.map((model) => model.id));
       const nextProvider = {
-        ...provider,
-        models: mergeDiscoveredModels(provider.models, models),
+        ...persistedProvider,
+        models: mergeDiscoveredModels(persistedProvider.models, models),
       };
       const nextProviders = providers.map((item) =>
         item.id === provider.id ? nextProvider : item,


### PR DESCRIPTION
## Summary
- Discover models now merges against the persisted provider instead of a possibly stale zero-model draft, and the open editor draft syncs to discovered models so a later Save can no longer clobber them (Closes #405)

## Verification
- node --test scripts/provider-discovery-draft.test.mjs: 5/5
- npm run test:ui-contract: 151/151
- npm run build (tsc + vite): pass