### PR TITLE
fix: prepare Beta4.1 compatibility and Luna controls

### DIFF
--- a/docs/agents/beta4.1-cli-e2e-plan.md
+++ b/docs/agents/beta4.1-cli-e2e-plan.md
@@ -1,0 +1,129 @@
+# Beta4.1 CLI E2E plan
+
+This is the release qualification plan for the Beta4.1 Collaboration and
+session-compatibility fixes. It complements the general Windows gate in
+[`real-client-e2e.md`](real-client-e2e.md); it is intentionally CLI-only.
+
+## Scope
+
+The run must use the exact candidate Gateway build and the real Codex CLI
+`0.146.1`, with a fresh isolated `CODEX_HOME` for every run. The harness may
+record sanitized request/response metadata, but it must not rewrite the CLI's
+request schema, inject `agent_type`, add binding sidecars, or synthesize tool
+outputs. The existing `scripts/run_issue_283_cli_v2_lifecycle.py` remains
+synthetic-fixture evidence because its `_inject_collaboration_agent_type()`
+helper changes the request shape; it is not direct-schema evidence for this
+plan.
+
+The run requires a dedicated authenticated account and a disposable copy of
+the historical Session `019fe193-d396-7293-86ea-4bc2c204ca9f`. Never modify
+the user's original Session or shared Codex home.
+
+## Matrix
+
+| Case | Native path | Required coverage | Pass evidence |
+| --- | --- | --- | --- |
+| `v1-lifecycle` | `multi_agent_v1` | spawn worker, send input, wait, close; verify terminal result | Native V1 namespace and argument shape remain unchanged; one complete lifecycle |
+| `v2-lifecycle` | `collaboration` | spawn/list, send message, follow-up, wait, interrupt, and final readback | Native V2 lifecycle completes without a V1 rewrite or duplicate terminal event |
+| `model-switch-replay` | V1 then V2, and V2 then V1 | switch the selected Luna Collaboration version between turns; replay prior history | Each request uses the selected model/version and prior messages/call IDs remain ordered and readable |
+| `legacy-session-resume` | historical V1 Session | restore the supplied pre-Beta4 Session, continue it, wait, and close | Old worker calls with the exact native shape are accepted; continuation and history are preserved |
+| `new-binding-integrity` | Beta4.1 worker binding | create a new worker with model/reasoning binding, then replay unchanged and tampered histories | Signed binding/readback matches; model, reasoning, signature, missing, duplicate, and malformed cases fail closed |
+| `cli-restart-continuity` | real CLI process | stop and restart the CLI/Gateway while retaining the isolated home, then resume | Same Session identity, prior history, worker state, and selected version are read back after restart |
+
+The `legacy-session-resume` case is the regression gate for #418. The
+`new-binding-integrity` case must prove that the compatibility exception is
+limited to the exact old V1 shape; an extended or partially edited old call
+must still be rejected.
+
+## Execution phases
+
+1. **Preflight**
+   - Verify the candidate SHA, CLI version, Gateway health, loopback route,
+     catalog model, and dedicated auth.
+   - Create a new non-reparse isolated root and record only safe paths,
+     versions, protocol names, and hashes.
+   - Copy the historical Session into the isolated root with its identity
+     intact. Redact prompts, tokens, account data, and local paths before any
+     evidence leaves the machine.
+
+2. **Direct-schema capture**
+   - Run one request through the real CLI for each native path.
+   - Capture the sanitized top-level request/response shape, tool namespace,
+     call/output IDs, event order, model, reasoning, HTTP status, and Gateway
+     correlation IDs.
+   - Assert that the bytes/JSON emitted by the CLI reached the Gateway before
+     any CodexHub compatibility translation. The harness may hash the input;
+     it must not patch it.
+
+3. **Lifecycle and history**
+   - Execute the V1 and V2 cases in fresh Session roots.
+   - Assert exactly one successful terminal outcome per turn, paired call and
+     output IDs, preserved call order, and readable assistant/worker history.
+   - Run the model-switch case with at least one follow-up turn after each
+     switch; verify that old turns are replayed rather than dropped or
+     reclassified.
+
+4. **Historical recovery**
+   - Start from the copied Session `019fe193-d396-7293-86ea-4bc2c204ca9f`.
+   - Resume without rewriting its old `multi_agent_v1.spawn_agent` calls.
+   - Complete a new turn and verify that the old worker readbacks plus the new
+     turn are accepted by the same Gateway process.
+
+5. **Binding and tamper checks**
+   - Record a new worker call with its model/reasoning binding and effective
+     readback.
+   - Replay the unchanged history, then independently alter the model,
+     reasoning, signature, call identity, output, and call/output cardinality.
+   - Require a bounded, sanitized rejection classification for every altered
+     case. Do not log the prompt, model secrets, signatures, or raw payload.
+
+6. **Restart and readback**
+   - Stop the CLI after a completed worker turn and restart it against the same
+     isolated home; repeat once with a Gateway restart if the candidate runner
+     supports it.
+   - Query/read the existing Session before creating a new one. Verify the
+     Session ID, selected version, history, worker IDs, and next legal action.
+   - Finish with a new turn and confirm no duplicate spawn or terminal event.
+
+## Evidence contract
+
+The planned runner should emit one sanitized summary with schema
+`codexhub.beta41.cli-e2e.v1` and one record per matrix case. Each record may
+contain:
+
+- candidate SHA, CLI version, protocol (`v1`/`v2`), selected model, and
+  reasoning level;
+- lifecycle phase names and bounded counts for calls, outputs, stream events,
+  restarts, and Gateway correlations;
+- stable hashes for request/response bodies and the preserved Session history;
+- safe result codes such as `accepted`, `legacy_native_spawn`,
+  `binding_rejected`, `history_replayed`, or `restart_readback`.
+
+It must not contain prompts, assistant text, authorization headers, tokens,
+signatures, account identifiers, PIDs, absolute paths, or raw upstream
+payloads. A missing, contradictory, duplicated, or unparseable event is a
+failure, not an omitted field.
+
+## Local and release checks
+
+The implementation phase should add deterministic tests for the runner's
+schema parser and sanitized evidence validator, then execute the real matrix
+only on the dedicated Windows host. The release checklist is:
+
+- all six cases pass with the exact CLI version and candidate SHA;
+- the legacy Session continuation passes without changing its old call shape;
+- direct-schema hashes show no harness mutation;
+- restart readback passes for both selected versions;
+- no secret-bearing or raw Session artifact is written to the repository.
+
+## Manual confirmation still required
+
+- Real Codex CLI lifecycle, model switching, historical Session resume, and
+  process restart require the dedicated authenticated Windows environment and
+  cannot be proven by the local unit/UI checks alone.
+- Desktop #419 still needs a manual UI check: select Luna V1 and V2, save each,
+  restart CodexHub, and confirm the selected value and `(Default)` marker are
+  retained. The CLI plan does not replace this Desktop verification.
+- If the historical Session is unavailable in the isolated test fixture, stop
+  with `legacy_session_fixture_unavailable`; do not fall back to a newly
+  created Session and call #418 verified.

--- a/frontend/scripts/official-models-visibility.test.mjs
+++ b/frontend/scripts/official-models-visibility.test.mjs
@@ -21,11 +21,11 @@ const wrappedModule = new Function(
   "exports",
   "normalizeOfficialModelId",
   jsOutput +
-    "\nexports.mergeOfficialModelSources = mergeOfficialModelSources; exports.filterCodexVisibleOfficialModels = filterCodexVisibleOfficialModels;",
+    "\nexports.mergeOfficialModelSources = mergeOfficialModelSources; exports.filterCodexVisibleOfficialModels = filterCodexVisibleOfficialModels; exports.officialCollaborationVersionOptions = officialCollaborationVersionOptions;",
 );
 wrappedModule(moduleExports, (value) => value.trim().replace(/^openai\//, ""));
 
-const { mergeOfficialModelSources } = moduleExports;
+const { mergeOfficialModelSources, officialCollaborationVersionOptions } = moduleExports;
 
 function model(id, overrides = {}) {
   return { id, enabled: true, ...overrides };
@@ -65,4 +65,44 @@ test("metadata cannot create an Official model absent from the catalog", () => {
   );
 
   assert.deepEqual(combined, []);
+});
+
+test("Luna collaboration options expose the catalog baseline and effective selection separately", () => {
+  const luna = model("gpt-5.6-luna", {
+    upstream_model: "gpt-5.6-luna",
+    source_kind: "official",
+    visibility: "list",
+    multi_agent_version: "v1",
+  });
+
+  assert.deepEqual(
+    officialCollaborationVersionOptions(luna),
+    {
+      baseline: "v1",
+      effective: "v1",
+      explicit: null,
+      candidate: "7006542a773fc20c10e4bbcadd593393a259ceb2",
+    },
+  );
+  assert.equal(
+    officialCollaborationVersionOptions({ ...luna, multi_agent_version: "v2" }).baseline,
+    "v2",
+  );
+  assert.deepEqual(
+    officialCollaborationVersionOptions(luna, { "gpt-5.6-luna": "v2" }),
+    {
+      baseline: "v1",
+      effective: "v2",
+      explicit: "v2",
+      candidate: "7006542a773fc20c10e4bbcadd593393a259ceb2",
+    },
+  );
+  assert.equal(
+    officialCollaborationVersionOptions(
+      { ...luna, multi_agent_version: "v1" },
+      { "gpt-5.6-luna": "v1" },
+      { "gpt-5.6-luna": "v2" },
+    ).baseline,
+    "v2",
+  );
 });

--- a/frontend/scripts/provider-discovery-draft.test.mjs
+++ b/frontend/scripts/provider-discovery-draft.test.mjs
@@ -5,6 +5,7 @@ import ts from "typescript";
 
 const actionsPath = new URL("../src/hooks/useProviderCatalogActions.ts", import.meta.url);
 const editorPath = new URL("../src/components/providers/ProviderEditor.tsx", import.meta.url);
+const endpointPath = new URL("../src/lib/providerEndpoint.ts", import.meta.url);
 const formatPath = new URL("../src/lib/format.ts", import.meta.url);
 const typesPath = new URL("../src/lib/types.ts", import.meta.url);
 
@@ -58,6 +59,30 @@ function makeModel(overrides = {}) {
     enabled: true,
     ...overrides,
   };
+}
+
+async function readEndpointModule() {
+  const source = (await readFile(endpointPath, "utf8"))
+    .replace(/^import i18n from "\.\.\/i18n";\r?\n/m, "const i18n = { t: () => \"\" };\n")
+    .replace(/^import \{ messageFromError \} from "\.\/tauri";\r?\n/m, "const messageFromError = (error) => String(error);\n")
+    .replace(/export function/g, "function");
+  const jsOutput = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2022,
+      strict: false,
+    },
+  }).outputText;
+  const moduleExports = {};
+  const wrappedModule = new Function(
+    "exports",
+    jsOutput +
+      "\nexports.applyProviderProbeResult = applyProviderProbeResult;" +
+      " exports.applyAddProviderProbeResult = applyAddProviderProbeResult;" +
+      " exports.probeSucceeded = probeSucceeded;",
+  );
+  wrappedModule(moduleExports);
+  return moduleExports;
 }
 
 test("mergeDiscoveredModels preserves manual models absent from discovery", async () => {
@@ -145,5 +170,66 @@ test("ProviderDetail keeps draft models in sync with persisted provider models",
     source,
     /useEffect\(\(\)\s*=>\s*\{\s*setDraft\(\(current\)\s*=>\s*\{/,
     "should use an effect to update the draft",
+  );
+});
+
+test("model-required probe preserves existing endpoint capabilities", async () => {
+  const { applyAddProviderProbeResult, applyProviderProbeResult, probeSucceeded } = await readEndpointModule();
+  const provider = {
+    id: "provider-a",
+    name: "Provider A",
+    base_url: "https://example.test/v1",
+    api_key: "secret",
+    upstream_format: "chat_completions",
+    available_upstream_formats: ["chat_completions"],
+    tool_protocol: "chat_tools",
+    enabled: true,
+    models: [],
+  };
+  const form = { ...provider, id: "", name: "" };
+  const modelRequired = {
+    base_url: provider.base_url,
+    model: null,
+    model_required: true,
+    models_ok: false,
+    responses_text_ok: false,
+    responses_tool_ok: false,
+    responses_tool_stream_ok: false,
+    chat_text_ok: false,
+    chat_tool_ok: false,
+    chat_tool_stream_ok: false,
+    chat_tool_history_ok: false,
+    anthropic_text_ok: false,
+    recommended_format: "auto",
+    recommended_tool_protocol: "none",
+    notes: ["No model is available for POST probes."],
+  };
+
+  assert.equal(probeSucceeded(modelRequired), false);
+  assert.deepEqual(applyProviderProbeResult(provider, modelRequired), provider);
+  assert.deepEqual(applyAddProviderProbeResult(form, modelRequired), form);
+});
+
+test("model-required probe cannot be marked successful by a suggested format", async () => {
+  const { probeSucceeded } = await readEndpointModule();
+  assert.equal(
+    probeSucceeded({
+      base_url: "https://example.test/v1",
+      model: null,
+      model_required: true,
+      models_ok: false,
+      responses_text_ok: false,
+      responses_tool_ok: false,
+      responses_tool_stream_ok: false,
+      chat_text_ok: false,
+      chat_tool_ok: false,
+      chat_tool_stream_ok: false,
+      chat_tool_history_ok: false,
+      anthropic_text_ok: false,
+      recommended_format: "responses",
+      recommended_tool_protocol: "responses_structured",
+      notes: [],
+    }),
+    false,
   );
 });

--- a/frontend/scripts/ui-contract.test.mjs
+++ b/frontend/scripts/ui-contract.test.mjs
@@ -1196,13 +1196,24 @@ test("Codex app-server probes time out and avoid visible Windows consoles", asyn
   assert.match(modelsSource, /CODEX_APP_SERVER_MODEL_LIST_TIMEOUT/);
 });
 
-test("OpenAI primary and secondary quota names render as 5 hours and weekly", async () => {
+test("OpenAI quota labels use explicit windows and keep a weekly-only limit weekly", async () => {
   const providersSource = await readProviderContractSource();
   const fiveHour = providersSource.match(/function isFiveHourUsageLimit[\s\S]*?^}/m)?.[0] ?? "";
   const weekly = providersSource.match(/function isWeeklyUsageLimit[\s\S]*?^}/m)?.[0] ?? "";
+  const placeholders = providersSource.match(/const OPENAI_USAGE_LIMIT_PLACEHOLDERS[\s\S]*?;/)?.[0] ?? "";
 
-  assert.match(fiveHour, /\\bprimary\\b/);
+  assert.doesNotMatch(fiveHour, /\\bprimary\\b/);
+  assert.match(fiveHour, /hour/);
+  assert.match(weekly, /week/);
+  assert.match(weekly, /\\bprimary\\b/);
   assert.match(weekly, /\\bsecondary\\b/);
+  assert.match(providersSource, /const selected: OpenAIUsageLimit\[\] = \[\]/);
+  assert.match(providersSource, /for \(const limit of \[fiveHour, weekly\]\)/);
+  assert.match(providersSource, /!selected\.some\(\(item\) => item\.key === limit\.key\)/);
+  assert.match(providersSource, /name: "Weekly", period: "week"/);
+  assert.equal([...placeholders.matchAll(/\{ key:/g)].length, 1);
+  assert.doesNotMatch(placeholders, /five_hours|5 hours/);
+  assert.match(providersSource, /return selected\.slice\(0, 2\)/);
   assert.match(providersSource, /fiveHourLimit:|"providers\.fiveHourLimit"/);
   assert.match(providersSource, /weeklyLimit:|"providers\.weeklyLimit"/);
 });
@@ -1939,6 +1950,7 @@ test("provider endpoint probe persists detected formats and selects the recommen
   assert.doesNotMatch(providerDetail, /const upstreamFormat = normalizedEndpointFormat\(provider\.upstream_format\);/);
   assert.match(addProviderPanel, /onFormChange\(applyAddProviderProbeResult\(form, result\)\);/);
   assert.match(endpointSource, /function probeDetectedEndpointFormat\([\s\S]*?normalizedProbeEndpointFormat\(result\.recommended_format\) \?\? probeAvailableFormats\(result\)\[0\] \?\? null/);
+  assert.match(endpointSource, /function probeSucceeded\([\s\S]*?!result\.model_required[\s\S]*?probeDetectedEndpointFormat\(result\) !== null/);
   assert.match(endpointSource, /function normalizedProbeEndpointFormat\([\s\S]*?normalized === "responses" \|\| normalized === "response"/);
   assert.match(endpointSource, /function applyProviderProbeResult\([\s\S]*?const detectedFormat = probeDetectedEndpointFormat\(result\);[\s\S]*?upstream_format: detectedFormat \?\? provider\.upstream_format,[\s\S]*?available_upstream_formats: probeAvailableFormats\(result\),[\s\S]*?tool_protocol: result\.recommended_tool_protocol,/);
   assert.match(endpointSource, /function applyAddProviderProbeResult(?:<[^>]+>)?\([\s\S]*?const detectedFormat = probeDetectedEndpointFormat\(result\);[\s\S]*?upstream_format: detectedFormat \?\? form\.upstream_format,[\s\S]*?available_upstream_formats: probeAvailableFormats\(result\),[\s\S]*?tool_protocol: result\.recommended_tool_protocol,/);
@@ -2044,6 +2056,54 @@ test("official model rows only toggle from the switch while provider rows can st
   assert.match(modelSection, /role=\{rowInteractable \? "button" : undefined\}/);
   assert.match(modelSection, /tabIndex=\{rowInteractable \? 0 : undefined\}/);
   assert.match(modelSection, /onClick=\{rowInteractable \? activateModelRow : undefined\}/);
+});
+
+test("Luna Collaboration selector shows only V1/V2 and marks the live catalog default", async () => {
+  const [providersSource, enSource, zhSource] = await Promise.all([
+    readProviderContractSource(),
+    readFile(enLocalePath, "utf8"),
+    readFile(zhLocalePath, "utf8"),
+  ]);
+  const modelSection = providersSource.match(/function ModelSection[\s\S]*?function providerQualifiedModelId/)?.[0] ?? "";
+
+  assert.match(modelSection, /value=\{collaboration\.effective\}/);
+  assert.match(modelSection, /officialCollaborationVersionOptions\([\s\S]*officialCollaborationBaselines/);
+  assert.equal([...modelSection.matchAll(/<option value="v[12]">/g)].length, 2);
+  assert.doesNotMatch(modelSection, /<option value="">/);
+  assert.match(modelSection, /collaboration\.baseline === "v1"/);
+  assert.match(modelSection, /collaboration\.baseline === "v2"/);
+  assert.match(modelSection, /selected === collaboration\.baseline \? null : selected/);
+  assert.match(enSource, /collaborationVersionDefault: "\(Default\)"/);
+  assert.match(zhSource, /collaborationVersionDefault: "（默认）"/);
+});
+
+test("Luna Collaboration save uses the Tauri modelId contract and reloads persisted overrides", async () => {
+  const [tauriSource, bridgeSource, providersSource] = await Promise.all([
+    readFile(tauriSourcePath, "utf8"),
+    readFile(tauriWebBridgePath, "utf8"),
+    readFile(providersPagePath, "utf8"),
+  ]);
+  const saveApi = tauriSource.match(/saveOfficialMultiAgentVersion[\s\S]*?listOfficialMultiAgentOverrides/)?.[0] ?? "";
+
+  assert.match(saveApi, /call<Model>\("save_official_multi_agent_version"/);
+  assert.match(saveApi, /modelId,\s*version/);
+  assert.doesNotMatch(saveApi, /model_id/);
+  assert.match(tauriSource, /listOfficialMultiAgentBaselines:[\s\S]*list_official_multi_agent_baselines/);
+  assert.match(
+    bridgeSource,
+    /"save_official_multi_agent_version"[\s\S]*optional_string_arg\(&request\.args, &\["modelId", "model_id"\]\)/,
+  );
+  assert.match(providersSource, /api\.listOfficialMultiAgentOverrides\(\)/);
+  assert.match(providersSource, /api\.saveOfficialMultiAgentVersion\(modelId, version\)/);
+  assert.match(
+    providersSource,
+    /async function refreshOfficialModelsAndCollaborationState[\s\S]*api\.listOfficialMultiAgentBaselines\(\)/,
+  );
+  assert.match(
+    providersSource,
+    /async function primeOfficialModels\(\)[\s\S]*refreshOfficialModelsAndCollaborationState\(\{ quiet: true \}\)/,
+  );
+  assert.match(providersSource, /onRefresh\(\{ quiet: true, throwOnError: true \}\)/);
 });
 
 test("Gateway restart planning uses only the current Gateway running snapshot", async () => {

--- a/frontend/src/components/providers/OfficialOpenAIUsagePanel.tsx
+++ b/frontend/src/components/providers/OfficialOpenAIUsagePanel.tsx
@@ -22,8 +22,7 @@ const OFFICIAL_USAGE_CELL_SIZE = 8;
 const USAGE_MONTH_LABEL_MIN_GAP_PX = 36;
 const OFFICIAL_USAGE_COLOR_STOPS = ["#eff2f5", "#d8ebff", "#acd7ff", "#7cc1ff", "#48a7fb", "#1687e8"];
 const OPENAI_USAGE_LIMIT_PLACEHOLDERS: OpenAIUsageLimit[] = [
-  { key: "five_hours", name: "5 hours", period: "five_hours" },
-  { key: "week", name: "Week", period: "week" },
+  { key: "week", name: "Weekly", period: "week" },
 ];
 
 function useElementContentWidth<T extends HTMLElement>(dependencies: ReadonlyArray<unknown> = []) {
@@ -547,7 +546,12 @@ function preferredOpenAIUsageLimits(limits: OpenAIUsageLimit[]) {
   const usable = limits.filter(limitHasUsageData);
   const fiveHour = usable.find(isFiveHourUsageLimit);
   const weekly = usable.find(isWeeklyUsageLimit);
-  const selected = [fiveHour, weekly].filter((limit): limit is OpenAIUsageLimit => Boolean(limit));
+  const selected: OpenAIUsageLimit[] = [];
+  for (const limit of [fiveHour, weekly]) {
+    if (limit && !selected.some((item) => item.key === limit.key)) {
+      selected.push(limit);
+    }
+  }
   for (const limit of usable) {
     if (selected.length >= 2) {
       break;
@@ -573,14 +577,18 @@ function isFiveHourUsageLimit(limit: OpenAIUsageLimit) {
   return (
     /\b5\s*h(?:our)?s?\b/.test(value) ||
     /\bfive[-_\s]?h(?:our)?s?\b/.test(value) ||
-    ((value.includes("5") || value.includes("five")) && value.includes("hour")) ||
-    /\bprimary\b/.test(value)
+    ((value.includes("5") || value.includes("five")) && value.includes("hour"))
   );
 }
 
 function isWeeklyUsageLimit(limit: OpenAIUsageLimit) {
   const value = usageLimitSearchText(limit);
-  return value.includes("week") || value.includes("weekly") || /\bsecondary\b/.test(value);
+  return (
+    value.includes("week") ||
+    value.includes("weekly") ||
+    /\bsecondary\b/.test(value) ||
+    /\bprimary\b/.test(value)
+  );
 }
 
 function usageLimitSearchText(limit: OpenAIUsageLimit) {

--- a/frontend/src/components/providers/ProviderEditor.tsx
+++ b/frontend/src/components/providers/ProviderEditor.tsx
@@ -13,6 +13,7 @@ import {
   normalizedEndpointFormat,
   normalizeEndpointFormats,
   normalizeProviderEndpointSelection,
+  probeSucceeded,
   probeAvailableFormats,
   toolProtocolLabel,
   upstreamFormatLabel,
@@ -88,7 +89,7 @@ export function ProviderDetail({
 
   useEffect(() => {
     if (probeResult) {
-      setEndpointTestState(probeResult.model_required ? "error" : "success");
+      setEndpointTestState(probeSucceeded(probeResult) ? "success" : "error");
     }
   }, [probeResult]);
 
@@ -132,7 +133,7 @@ export function ProviderDetail({
     if (result) {
       setDraft((current) => applyProviderProbeResult(current, result));
     }
-    setEndpointTestState(result ? "success" : "error");
+    setEndpointTestState(result && probeSucceeded(result) ? "success" : "error");
   }
 
   async function testModel(model: Model) {
@@ -280,7 +281,7 @@ export function AddProviderPanel({
 
   useEffect(() => {
     if (probeResult) {
-      setEndpointTestState(probeResult.model_required ? "error" : "success");
+      setEndpointTestState(probeSucceeded(probeResult) ? "success" : "error");
     }
   }, [probeResult]);
 
@@ -308,7 +309,7 @@ export function AddProviderPanel({
     if (result) {
       onFormChange(applyAddProviderProbeResult(form, result));
     }
-    setEndpointTestState(result ? "success" : "error");
+    setEndpointTestState(result && probeSucceeded(result) ? "success" : "error");
   }
 
   async function testModel(model: Model) {

--- a/frontend/src/components/providers/ProviderModelSection.tsx
+++ b/frontend/src/components/providers/ProviderModelSection.tsx
@@ -35,6 +35,7 @@ export function ModelSection({
   onReorder,
   onTestModel,
   officialDisabledModels,
+  officialCollaborationBaselines = {},
   officialCollaborationOverrides = {},
   providerId,
   reorderable = true,
@@ -61,6 +62,7 @@ export function ModelSection({
   onReorder: (models: Model[]) => void;
   onTestModel?: (model: Model) => Promise<boolean>;
   officialDisabledModels?: string[];
+  officialCollaborationBaselines?: Readonly<Record<string, "v1" | "v2">>;
   officialCollaborationOverrides?: Readonly<Record<string, "v1" | "v2">>;
   providerId?: string;
   reorderable?: boolean;
@@ -146,7 +148,11 @@ export function ModelSection({
           title={modelLimitDetails(model, contextWindow)}
         />
         {disabled && onOfficialCollaborationVersionChange && (() => {
-          const collaboration = officialCollaborationVersionOptions(model, officialCollaborationOverrides);
+          const collaboration = officialCollaborationVersionOptions(
+            model,
+            officialCollaborationOverrides,
+            officialCollaborationBaselines,
+          );
           if (!collaboration) {
             return null;
           }
@@ -168,22 +174,22 @@ export function ModelSection({
               <span>{t("providers.collaborationVersion")}</span>
               <select
                 className="h-5 bg-transparent text-[11px] font-semibold outline-none"
-                value={collaboration.explicit ?? ""}
+                value={collaboration.effective}
                 disabled={interactionDisabled}
                 aria-label={t("providers.collaborationVersionForModel", { model: model.id })}
                 onChange={(event) => {
                   event.stopPropagation();
+                  const selected = event.target.value === "v1" || event.target.value === "v2"
+                    ? event.target.value
+                    : null;
                   onOfficialCollaborationVersionChange(
                     model.id,
-                    event.target.value === "v1" || event.target.value === "v2"
-                      ? event.target.value
-                      : null,
+                    selected === collaboration.baseline ? null : selected,
                   );
                 }}
               >
-                <option value="">{t("providers.catalogBaseline")} (V{collaboration.baseline})</option>
-                <option value="v1">V1</option>
-                <option value="v2">V2</option>
+                <option value="v1">V1{collaboration.baseline === "v1" ? ` ${t("providers.collaborationVersionDefault")}` : ""}</option>
+                <option value="v2">V2{collaboration.baseline === "v2" ? ` ${t("providers.collaborationVersionDefault")}` : ""}</option>
               </select>
             </label>
           );

--- a/frontend/src/i18n/locales/en-US.ts
+++ b/frontend/src/i18n/locales/en-US.ts
@@ -362,6 +362,7 @@ const enUS = {
     collaborationVersionForModel: "Collaboration version for {{model}}",
     collaborationVersionSaved: "Collaboration version saved",
     collaborationVersionSaveFailed: "Failed to save Collaboration version: {{message}}",
+    collaborationVersionDefault: "(Default)",
     savingCollaborationVersion: "Saving Collaboration {{version}}...",
     catalogBaseline: "catalog baseline",
     officialCatalogRestartRequired: "Restart Codex App after the catalog refresh.",

--- a/frontend/src/i18n/locales/zh-CN.ts
+++ b/frontend/src/i18n/locales/zh-CN.ts
@@ -362,6 +362,7 @@ const zhCN = {
     collaborationVersionForModel: "{{model}} 的 Collaboration 版本",
     collaborationVersionSaved: "Collaboration 版本已保存",
     collaborationVersionSaveFailed: "保存 Collaboration 版本失败：{{message}}",
+    collaborationVersionDefault: "（默认）",
     savingCollaborationVersion: "正在保存 Collaboration {{version}}...",
     catalogBaseline: "目录基线",
     officialCatalogRestartRequired: "目录刷新后请重启 Codex App。",

--- a/frontend/src/lib/officialModels.ts
+++ b/frontend/src/lib/officialModels.ts
@@ -169,6 +169,7 @@ const OFFICIAL_COLLABORATION_CAPABILITIES: Record<string, OfficialCollaborationC
 export function officialCollaborationVersionOptions(
   model: Model,
   explicitOverrides: Readonly<Record<string, "v1" | "v2">> = {},
+  catalogBaselines: Readonly<Record<string, "v1" | "v2">> = {},
 ) {
   const canonical = normalizeOfficialModelId(model.id);
   const capability = canonical ? OFFICIAL_COLLABORATION_CAPABILITIES[canonical] : undefined;
@@ -184,10 +185,10 @@ export function officialCollaborationVersionOptions(
     return null;
   }
   const explicit = explicitOverrides[canonical];
-  // The catalog row carries the current managed baseline.  Once a user
-  // override is active the row's value is effective, so use the reviewed
-  // baseline only for that explicit state to keep the two values distinct.
-  const baseline = explicit ? capability.baseline : model.multi_agent_version;
+  // The catalog row carries the effective value after an override is applied.
+  // Prefer the separate managed-baseline readback when it is available so a
+  // catalog default change remains visible even while an override is active.
+  const baseline = catalogBaselines[canonical] ?? (explicit ? capability.baseline : model.multi_agent_version);
   if (baseline !== "v1" && baseline !== "v2") {
     return null;
   }

--- a/frontend/src/lib/providerEndpoint.ts
+++ b/frontend/src/lib/providerEndpoint.ts
@@ -50,6 +50,10 @@ export function probeDetectedEndpointFormat(result: UpstreamFormatProbeResult): 
   return normalizedProbeEndpointFormat(result.recommended_format) ?? probeAvailableFormats(result)[0] ?? null;
 }
 
+export function probeSucceeded(result: UpstreamFormatProbeResult): boolean {
+  return !result.model_required && probeDetectedEndpointFormat(result) !== null;
+}
+
 export function normalizedProbeEndpointFormat(value?: string | null): UpstreamFormat | null {
   const normalized = value?.trim().toLowerCase().replace(/[-\s]+/g, "_");
   if (!normalized || normalized === "auto") {
@@ -68,6 +72,9 @@ export function normalizedProbeEndpointFormat(value?: string | null): UpstreamFo
 }
 
 export function applyProviderProbeResult(provider: Provider, result: UpstreamFormatProbeResult): Provider {
+  if (result.model_required) {
+    return provider;
+  }
   const detectedFormat = probeDetectedEndpointFormat(result);
   return {
     ...provider,
@@ -78,6 +85,9 @@ export function applyProviderProbeResult(provider: Provider, result: UpstreamFor
 }
 
 export function applyAddProviderProbeResult<TDraft extends EndpointProbeDraft>(form: TDraft, result: UpstreamFormatProbeResult): TDraft {
+  if (result.model_required) {
+    return form;
+  }
   const detectedFormat = probeDetectedEndpointFormat(result);
   return {
     ...form,

--- a/frontend/src/lib/tauri.ts
+++ b/frontend/src/lib/tauri.ts
@@ -312,11 +312,13 @@ export const api = {
     call<Model>("save_model_metadata_override", { model }),
   saveOfficialMultiAgentVersion: (modelId: string, version: "v1" | "v2" | null) =>
     call<Model>("save_official_multi_agent_version", {
-      model_id: modelId,
+      modelId,
       version,
     }),
   listOfficialMultiAgentOverrides: () =>
     call<Record<string, "v1" | "v2">>("list_official_multi_agent_overrides"),
+  listOfficialMultiAgentBaselines: () =>
+    call<Record<string, "v1" | "v2">>("list_official_multi_agent_baselines"),
   syncHistory: (targetProvider?: string) =>
     call<string>("sync_history", { targetProvider: targetProvider ?? null }),
   reconcileAfterRouteSwitch: (targetProvider?: string) =>

--- a/frontend/src/pages/ProvidersPage.tsx
+++ b/frontend/src/pages/ProvidersPage.tsx
@@ -143,6 +143,9 @@ function ProvidersPageImpl({
   const [officialCollaborationOverrides, setOfficialCollaborationOverrides] = useState<
     Record<string, "v1" | "v2">
   >({});
+  const [officialCollaborationBaselines, setOfficialCollaborationBaselines] = useState<
+    Readonly<Record<string, "v1" | "v2">>
+  >({});
   const [officialUsageSnapshot, setOfficialUsageSnapshot] = useState<OpenAIUsageSnapshot | null>(initialOfficialUsageSnapshot);
   const [officialUsageBusy, setOfficialUsageBusy] = useState(false);
   const [officialUsageError, setOfficialUsageError] = useState<string | null>(null);
@@ -210,17 +213,21 @@ function ProvidersPageImpl({
 
   useEffect(() => {
     let active = true;
-    void api.listOfficialMultiAgentOverrides()
-      .then((overrides) => {
+    void Promise.all([
+      api.listOfficialMultiAgentOverrides(),
+      api.listOfficialMultiAgentBaselines(),
+    ])
+      .then(([overrides, baselines]) => {
         if (active) {
           setOfficialCollaborationOverrides(overrides);
+          setOfficialCollaborationBaselines(baselines);
         }
       })
       .catch(() => undefined);
     return () => {
       active = false;
     };
-  }, []);
+  }, [catalogModels]);
 
   useEffect(() => {
     const normalizedSettings = settingsSnapshot ? withDefaultFastVariants(settingsSnapshot) : null;
@@ -470,7 +477,7 @@ function ProvidersPageImpl({
       return;
     }
     officialModelRefreshStartedRef.current = true;
-    await refreshOfficialModels({ quiet: true });
+    await refreshOfficialModelsAndCollaborationState({ quiet: true });
   }
 
   async function primeOfficialOpenAIUsage() {
@@ -812,6 +819,24 @@ function ProvidersPageImpl({
     );
   }
 
+  async function refreshOfficialModelsAndCollaborationState(
+    options?: { quiet?: boolean; throwOnError?: boolean },
+  ) {
+    const refreshed = await refreshOfficialModels(options);
+    try {
+      const [overrides, baselines] = await Promise.all([
+        api.listOfficialMultiAgentOverrides(),
+        api.listOfficialMultiAgentBaselines(),
+      ]);
+      setOfficialCollaborationOverrides(overrides);
+      setOfficialCollaborationBaselines(baselines);
+    } catch {
+      // The catalog refresh remains usable when the optional selector readback
+      // is unavailable; the next page refresh will retry it.
+    }
+    return refreshed;
+  }
+
   async function deleteProvider(providerId: string) {
     const target = providers.find((provider) => provider.id === providerId);
     if (!target) {
@@ -895,6 +920,7 @@ function ProvidersPageImpl({
                 busy={busy}
                 gatewayContextById={gatewayContextById}
                 models={officialModels}
+                officialCollaborationBaselines={officialCollaborationBaselines}
                 officialCollaborationOverrides={officialCollaborationOverrides}
                 onOfficialCollaborationOverridesChanged={setOfficialCollaborationOverrides}
                 officialDisabledModels={officialDisabledModels}
@@ -903,7 +929,7 @@ function ProvidersPageImpl({
                 onCopyLoginCommand={() => void copyCodexLoginCommand()}
                 onContextGuardChanged={reflectContextGuardSetting}
                 onOpenCodexApp={() => void openCodexAppForLogin()}
-                onRefresh={(options) => refreshOfficialModels(options)}
+                onRefresh={(options) => refreshOfficialModelsAndCollaborationState(options)}
                 onRefreshClients={onRefreshClients}
                 onRefreshAuth={() => void refreshCodexAuthStatus()}
                 onRefreshUsage={() => void loadOfficialOpenAIUsage(true, true)}
@@ -1462,6 +1488,7 @@ function OfficialDetail({
   dirty,
   gatewayContextById,
   models,
+  officialCollaborationBaselines,
   officialCollaborationOverrides,
   onOfficialCollaborationOverridesChanged,
   officialDisabledModels,
@@ -1489,6 +1516,7 @@ function OfficialDetail({
   dirty: boolean;
   gatewayContextById: Map<string, number>;
   models: Model[];
+  officialCollaborationBaselines: Readonly<Record<string, "v1" | "v2">>;
   officialCollaborationOverrides: Readonly<Record<string, "v1" | "v2">>;
   onOfficialCollaborationOverridesChanged: (overrides: Record<string, "v1" | "v2">) => void;
   officialDisabledModels: string[];
@@ -1756,6 +1784,7 @@ function OfficialDetail({
         }
         interactionDisabled={authState !== "authorized"}
         models={models}
+        officialCollaborationBaselines={officialCollaborationBaselines}
         officialCollaborationOverrides={officialCollaborationOverrides}
         officialDisabledModels={officialDisabledModels}
         onRefresh={onRefresh}

--- a/src-python/codex_proxy.py
+++ b/src-python/codex_proxy.py
@@ -7873,6 +7873,49 @@ def _verified_worker_requested_binding(
     return requested, None
 
 
+def _is_legacy_native_worker_spawn_call(
+    item: Mapping[str, Any],
+    arguments: Mapping[str, Any] | None,
+) -> bool:
+    """Recognize the pre-sidecar native V1 worker call shape.
+
+    Beta4 added signed model/reasoning sidecars to worker calls.  Sessions
+    created before that change contain the native CLI's original
+    ``multi_agent_v1.spawn_agent`` item instead, so they cannot be validated
+    against a binding that was never persisted.  The pre-selector native
+    schema omitted ``agent_type`` but included ``fork_context`` and
+    ``message``. Keep this compatibility predicate deliberately exact: only
+    the historical namespace/name and argument shape may bypass the new
+    sidecar contract.
+    """
+    if item.get("namespace") != "multi_agent_v1" or item.get("name") != "spawn_agent":
+        return False
+    if not isinstance(arguments, Mapping):
+        return False
+    if set(arguments) not in (
+        {"fork_context", "message"},
+        {"agent_type", "fork_context", "message"},
+    ):
+        return False
+    if "agent_type" in arguments and arguments.get("agent_type") != "worker":
+        return False
+    return (
+        isinstance(arguments.get("fork_context"), bool)
+        and isinstance(arguments.get("message"), str)
+    )
+
+
+def _is_legacy_native_worker_spawn_readback(value: Any) -> bool:
+    readback = _semantic_strict_json_object(value)
+    return (
+        isinstance(readback, Mapping)
+        and set(readback) == {"agent_id", "nickname"}
+        and isinstance(readback.get("agent_id"), str)
+        and bool(readback.get("agent_id"))
+        and (readback.get("nickname") is None or isinstance(readback.get("nickname"), str))
+    )
+
+
 _WORKER_STREAM_BINDING_STATE_FIELD = "_worker_stream_binding_state"
 
 
@@ -8183,7 +8226,8 @@ def _validate_worker_binding_history(
     if not isinstance(input_items, list):
         return
 
-    worker_calls: dict[str, Mapping[str, Any]] = {}
+    worker_calls: dict[str, Mapping[str, Any] | None] = {}
+    legacy_worker_calls: set[str] = set()
     validated_call_ids: set[str] = set()
     for item in input_items:
         if not isinstance(item, Mapping):
@@ -8194,14 +8238,6 @@ def _validate_worker_binding_history(
             agent_type = arguments.get("agent_type") if arguments is not None else None
             if agent_type in {"general", "default"}:
                 continue
-            selector_validation = _semantic_validate_worker_selector(arguments)
-            if selector_validation.outcome != _BINDING_ACCEPTED:
-                _raise_worker_contract_error(
-                    event="worker_selector_validated",
-                    error_code=WORKER_SELECTOR_ERROR_CODE,
-                    classification=selector_validation.classification,
-                    surface="history",
-                )
             if not isinstance(call_id, str) or not call_id:
                 _raise_worker_contract_error(
                     event="worker_effective_binding_validated",
@@ -8213,6 +8249,22 @@ def _validate_worker_binding_history(
                     event="worker_effective_binding_validated",
                     error_code=WORKER_BINDING_ERROR_CODE,
                     classification="duplicate_worker_call_identity",
+                )
+            legacy_arguments = _semantic_strict_json_object(item.get("arguments"))
+            if (
+                WORKER_REQUESTED_BINDING_FIELD not in item
+                and _is_legacy_native_worker_spawn_call(item, legacy_arguments)
+            ):
+                legacy_worker_calls.add(call_id)
+                worker_calls[call_id] = None
+                continue
+            selector_validation = _semantic_validate_worker_selector(arguments)
+            if selector_validation.outcome != _BINDING_ACCEPTED:
+                _raise_worker_contract_error(
+                    event="worker_selector_validated",
+                    error_code=WORKER_SELECTOR_ERROR_CODE,
+                    classification=selector_validation.classification,
+                    surface="history",
                 )
             requested, sidecar_failure = _verified_worker_requested_binding(
                 item.get(WORKER_REQUESTED_BINDING_FIELD),
@@ -8242,6 +8294,20 @@ def _validate_worker_binding_history(
             )
 
         output = item.get("output")
+        if call_id in legacy_worker_calls:
+            if not _is_legacy_native_worker_spawn_readback(output):
+                _raise_worker_contract_error(
+                    event="worker_effective_binding_validated",
+                    error_code=WORKER_BINDING_ERROR_CODE,
+                    classification="malformed_readback",
+                )
+            write_proxy_event(
+                "worker_effective_binding_validated",
+                outcome="accepted",
+                classification="legacy_native_spawn",
+            )
+            validated_call_ids.add(call_id)
+            continue
         readback = _semantic_strict_json_object(output)
         if readback is None and isinstance(output, str) and output.strip():
             _raise_worker_contract_error(

--- a/src-python/codex_semantic_adapter.py
+++ b/src-python/codex_semantic_adapter.py
@@ -342,7 +342,9 @@ def synthesize_effective_worker_binding_readback(
     if "effective_binding" in readback:
         return readback
     # Require the minimum fields that identify a successful native spawn.
-    if not isinstance(readback.get("agent_id"), str) or not isinstance(readback.get("nickname"), str):
+    if not isinstance(readback.get("agent_id"), str) or not (
+        readback.get("nickname") is None or isinstance(readback.get("nickname"), str)
+    ):
         return readback
     return {
         **readback,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -661,6 +661,11 @@ fn list_official_multi_agent_overrides() -> Result<std::collections::HashMap<Str
 }
 
 #[tauri::command]
+fn list_official_multi_agent_baselines() -> Result<std::collections::HashMap<String, String>, String> {
+    models::list_official_multi_agent_baselines()
+}
+
+#[tauri::command]
 async fn sync_history(target_provider: Option<String>) -> Result<String, String> {
     run_blocking("sync_history", move || {
         history::sync_history(target_provider.as_deref())
@@ -1155,6 +1160,7 @@ fn run_gui() {
             save_model_metadata_override,
             save_official_multi_agent_version,
             list_official_multi_agent_overrides,
+            list_official_multi_agent_baselines,
             sync_history,
             reconcile_after_route_switch,
             migrate_official_history_to_unified,

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -554,6 +554,57 @@ pub fn list_official_multi_agent_overrides() -> Result<HashMap<String, String>, 
     Ok(result)
 }
 
+/// Return the managed catalog baseline for each visible Official model that
+/// supports the Collaboration selector. The generated catalog carries the
+/// effective value after applying a user override, so the UI needs this
+/// separate readback to keep the `(Default)` marker tied to the catalog.
+pub fn list_official_multi_agent_baselines() -> Result<HashMap<String, String>, String> {
+    let paths = ModelPaths::runtime()?;
+    let managed_baseline_exists = paths.managed_catalog_baseline_path().exists();
+    let explicit_overrides = list_official_multi_agent_overrides()?;
+    // Read the published catalog without applying the user-owned override
+    // sidecar.  If there is no managed baseline, use the raw row only when
+    // there is no explicit override; otherwise fall back to the pinned
+    // baseline rather than making an effective override look like a default.
+    let catalog_path = paths.existing_generated_catalog_path();
+    let visible_models = if catalog_path.exists() {
+        read_catalog_models(&catalog_path)?
+    } else {
+        Vec::new()
+    };
+    let mut result = HashMap::new();
+    for model in visible_models {
+        if model.source_kind.as_deref() != Some("official") || !model_is_catalog_visible(&model) {
+            continue;
+        }
+        let canonical = model
+            .id
+            .strip_prefix("openai/")
+            .unwrap_or(model.id.as_str());
+        if qualified_official_code_mode_multi_agent_version(canonical).is_none()
+            || !model_has_exact_official_upstream(&model, canonical)
+        {
+            continue;
+        }
+        let baseline = read_managed_catalog_multi_agent_version(&paths, canonical)
+            .or_else(|| {
+                if managed_baseline_exists || explicit_overrides.contains_key(canonical) {
+                    pinned_official_code_mode_multi_agent_version(canonical).map(str::to_string)
+                } else {
+                    model
+                        .multi_agent_version
+                        .clone()
+                        .filter(|value| *value == "v1" || *value == "v2")
+                }
+            })
+            .or_else(|| pinned_official_code_mode_multi_agent_version(canonical).map(str::to_string));
+        if let Some(baseline) = baseline {
+            result.insert(canonical.to_string(), baseline);
+        }
+    }
+    Ok(result)
+}
+
 #[cfg(test)]
 fn refresh_official_models_from_endpoint(
     endpoint: &str,
@@ -3162,7 +3213,8 @@ mod tests {
     use super::{
         desktop_codex_exe_from_local_appdata, discover_provider_models_with_timeout,
         enrich_models_with_ollama_show, generate_catalog_with_runner, list_model_metadata,
-        list_models, list_official_multi_agent_overrides, load_json_file,
+        list_models, list_official_multi_agent_baselines, list_official_multi_agent_overrides,
+        load_json_file,
         merge_metadata_with_overrides, ollama_show_endpoint,
         provider_api_endpoint,
         provider_models_endpoint, read_models_json, refresh_official_models_from_endpoint,
@@ -4292,6 +4344,158 @@ for line in sys.stdin:
         assert_eq!(
             valid
                 .expect("exact upstream model should be listed")
+                .get("gpt-5.6-luna")
+                .map(String::as_str),
+            Some("v2")
+        );
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn list_official_multi_agent_baselines_reads_managed_value_behind_override() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let previous = std::env::var_os("CODEX_HOME");
+        let root = temp_root("list-catalog-multi-agent-baseline");
+        let codex_home = root.join("codex-home");
+        let paths = test_paths(&root);
+        let catalog_path = paths.generated_catalog_path();
+        let baseline_path = paths.managed_catalog_baseline_path();
+        fs::create_dir_all(catalog_path.parent().unwrap()).unwrap();
+        fs::write(
+            &catalog_path,
+            serde_json::to_vec(&json!({
+                "models": [{
+                    "slug": "gpt-5.6-luna",
+                    "multi_agent_version": "v2",
+                    "codex_proxy_metadata": {
+                        "provider": "openai",
+                        "upstream_name": "official",
+                        "upstream_model": "gpt-5.6-luna"
+                    }
+                }]
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        fs::write(
+            &baseline_path,
+            serde_json::to_vec(&json!({
+                "models": [{
+                    "slug": "gpt-5.6-luna",
+                    "multi_agent_version": "v1",
+                    "codex_proxy_metadata": {
+                        "provider": "openai",
+                        "upstream_name": "official",
+                        "upstream_model": "gpt-5.6-luna"
+                    }
+                }]
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        std::env::set_var("CODEX_HOME", &codex_home);
+
+        let baselines = list_official_multi_agent_baselines();
+
+        restore_env("CODEX_HOME", previous);
+        assert_eq!(
+            baselines
+                .expect("managed catalog baseline should be readable")
+                .get("gpt-5.6-luna")
+                .map(String::as_str),
+            Some("v1")
+        );
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn list_official_multi_agent_baselines_does_not_treat_effective_override_as_default_when_managed_baseline_is_missing() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let previous = std::env::var_os("CODEX_HOME");
+        let root = temp_root("list-catalog-multi-agent-baseline-missing");
+        let codex_home = root.join("codex-home");
+        let paths = test_paths(&root);
+        let catalog_path = paths.generated_catalog_path();
+        let override_path = paths.catalog_overrides_path();
+        fs::create_dir_all(catalog_path.parent().unwrap()).unwrap();
+        fs::write(
+            &catalog_path,
+            serde_json::to_vec(&json!({
+                "models": [{
+                    "slug": "gpt-5.6-luna",
+                    "multi_agent_version": "v2",
+                    "codex_proxy_metadata": {
+                        "provider": "openai",
+                        "upstream_name": "official",
+                        "upstream_model": "gpt-5.6-luna"
+                    }
+                }]
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        fs::write(
+            &override_path,
+            serde_json::to_vec(&json!({
+                "schema_version": 1,
+                "overrides": [{
+                    "provider": "openai",
+                    "upstream_name": "official",
+                    "upstream_model": "gpt-5.6-luna",
+                    "fields": {"multi_agent_version": "v1"}
+                }]
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        std::env::set_var("CODEX_HOME", &codex_home);
+
+        let baselines = list_official_multi_agent_baselines();
+
+        restore_env("CODEX_HOME", previous);
+        assert_eq!(
+            baselines
+                .expect("catalog baseline should be readable")
+                .get("gpt-5.6-luna")
+                .map(String::as_str),
+            Some("v1")
+        );
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn list_official_multi_agent_baselines_uses_catalog_value_when_no_managed_baseline_or_override_exists() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let previous = std::env::var_os("CODEX_HOME");
+        let root = temp_root("list-catalog-multi-agent-baseline-no-override");
+        let codex_home = root.join("codex-home");
+        let paths = test_paths(&root);
+        let catalog_path = paths.generated_catalog_path();
+        fs::create_dir_all(catalog_path.parent().unwrap()).unwrap();
+        fs::write(
+            &catalog_path,
+            serde_json::to_vec(&json!({
+                "models": [{
+                    "slug": "gpt-5.6-luna",
+                    "multi_agent_version": "v2",
+                    "codex_proxy_metadata": {
+                        "provider": "openai",
+                        "upstream_name": "official",
+                        "upstream_model": "gpt-5.6-luna"
+                    }
+                }]
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        std::env::set_var("CODEX_HOME", &codex_home);
+
+        let baselines = list_official_multi_agent_baselines();
+
+        restore_env("CODEX_HOME", previous);
+        assert_eq!(
+            baselines
+                .expect("catalog baseline should be readable")
                 .get("gpt-5.6-luna")
                 .map(String::as_str),
             Some("v2")

--- a/src-tauri/src/web_bridge.rs
+++ b/src-tauri/src/web_bridge.rs
@@ -496,12 +496,8 @@ fn dispatch(request: InvokeRequest, app: Option<AppHandle>) -> Result<Value, Str
             to_value(models::save_model_metadata_override(model))
         }
         "save_official_multi_agent_version" => {
-            let model_id = request
-                .args
-                .get("model_id")
-                .and_then(Value::as_str)
-                .map(str::to_string)
-                .ok_or_else(|| "model_id argument is required".to_string())?;
+            let model_id = optional_string_arg(&request.args, &["modelId", "model_id"])
+                .ok_or_else(|| "modelId argument is required".to_string())?;
             let version = request
                 .args
                 .get("version")
@@ -511,6 +507,9 @@ fn dispatch(request: InvokeRequest, app: Option<AppHandle>) -> Result<Value, Str
         }
         "list_official_multi_agent_overrides" => {
             to_value(models::list_official_multi_agent_overrides())
+        }
+        "list_official_multi_agent_baselines" => {
+            to_value(models::list_official_multi_agent_baselines())
         }
         "sync_history" => {
             let target_provider = request
@@ -719,7 +718,7 @@ impl BridgeResponse {
 
 #[cfg(test)]
 mod tests {
-    use super::{handle_request, origin_allowed, BridgeRequest, BridgeResponse};
+    use super::{handle_request, optional_string_arg, origin_allowed, BridgeRequest, BridgeResponse};
     use serde_json::json;
 
     #[test]
@@ -728,6 +727,18 @@ mod tests {
         assert!(origin_allowed(Some("http://127.0.0.1:1420")));
         assert!(origin_allowed(Some("http://localhost:1420")));
         assert!(!origin_allowed(Some("http://example.com")));
+    }
+
+    #[test]
+    fn official_collaboration_save_accepts_camel_case_and_legacy_model_id() {
+        assert_eq!(
+            optional_string_arg(&json!({"modelId": "gpt-5.6-luna"}), &["modelId", "model_id"]),
+            Some("gpt-5.6-luna".to_string())
+        );
+        assert_eq!(
+            optional_string_arg(&json!({"model_id": "gpt-5.6-luna"}), &["modelId", "model_id"]),
+            Some("gpt-5.6-luna".to_string())
+        );
     }
 
     #[test]

--- a/tests/fixtures/issue_108_tool_surface_replay.json
+++ b/tests/fixtures/issue_108_tool_surface_replay.json
@@ -13,7 +13,7 @@
       "tool_surface_strategy": "eager",
       "namespace_tool_count": 0,
       "source_payload_sha256": "sha256:acb0bc4f028dcb8a6095496bb30e8b40e8972e23f887544efa928f85a578b6a2",
-      "prepared_surface_sha256": "sha256:5dc7c2fdc99cadc1dd8dcb2175e72ff41b83c0d209560ea589685ca74329b899",
+      "prepared_surface_sha256": "sha256:df93cb68f0fab081ecb98c0888f1c1e5620d36f978215778abb1cccd5d91d57d",
       "direct_tool_count": 7,
       "namespace_flattened_count": 0,
       "tool_search_visible": false
@@ -23,7 +23,7 @@
       "tool_surface_strategy": "eager",
       "namespace_tool_count": 200,
       "source_payload_sha256": "sha256:8f5d9c18a8541c1c2ebeac166a91333a0fdf1fefb0dfc3617733f55ba8b70fd2",
-      "prepared_surface_sha256": "sha256:18c4d4bf1571f0dc7c3ca33b1fac816303a815db45a7ce99d872a0546ef60f75",
+      "prepared_surface_sha256": "sha256:273dc528bc3a67d8b92a6e7e4f750e6b328aa8e3b3c1c43ff924112c5de055ac",
       "direct_tool_count": 207,
       "namespace_flattened_count": 200,
       "tool_search_visible": false
@@ -33,7 +33,7 @@
       "tool_surface_strategy": "deferred_core",
       "namespace_tool_count": 200,
       "source_payload_sha256": "sha256:8f5d9c18a8541c1c2ebeac166a91333a0fdf1fefb0dfc3617733f55ba8b70fd2",
-      "prepared_surface_sha256": "sha256:a5232e63e034bdca95f8f733c129cab51be155bf822ab6c5aea679483f37c108",
+      "prepared_surface_sha256": "sha256:5f9e2013b07270135ade621a06acf6dbc0ca682905b5ea4cdbaffbe734ddbb16",
       "direct_tool_count": 8,
       "namespace_flattened_count": 0,
       "tool_search_visible": true

--- a/tests/test_issue_408_worker_binding.py
+++ b/tests/test_issue_408_worker_binding.py
@@ -151,6 +151,21 @@ class Issue408SemanticAdapterTests(unittest.TestCase):
         self.assertEqual(effective["model"], "glm-5.2")
         self.assertEqual(effective["reasoning"], "high")
 
+    def test_synthesize_effective_worker_binding_readback_accepts_nullable_native_nickname(self):
+        requested = {
+            "agent_type": "worker",
+            "model": "glm-5.2",
+            "reasoning": "high",
+        }
+        native_output = {"agent_id": "019f-child", "nickname": None}
+
+        readback = codex_semantic_adapter.synthesize_effective_worker_binding_readback(
+            requested, native_output
+        )
+
+        self.assertIsNotNone(readback)
+        self.assertIn("effective_binding", readback)
+
     def test_synthesize_effective_worker_binding_readback_preserves_existing_readback(self):
         requested = {
             "agent_type": "worker",

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -25721,6 +25721,163 @@ Execution constraints:
                     surface="history",
                 )
 
+    def test_external_worker_binding_history_accepts_pre_sidecar_native_spawn(self):
+        call_id = "legacy-native-worker-call"
+        spawn_call = {
+            "type": "function_call",
+            "id": "fc_legacy_native_worker",
+            "call_id": call_id,
+            "namespace": "multi_agent_v1",
+            "name": "spawn_agent",
+            "arguments": json.dumps(
+                {
+                    "agent_type": "worker",
+                    "fork_context": False,
+                    "message": "legacy worker task",
+                }
+            ),
+        }
+        spawn_output = {
+            "type": "function_call_output",
+            "call_id": call_id,
+            "output": json.dumps({"agent_id": "legacy-agent", "nickname": "worker"}),
+        }
+
+        with patch.object(codex_proxy, "write_proxy_event") as write_event:
+            normalized = compatible_request_body(
+                self._worker_replay_body([spawn_call, spawn_output]),
+                {
+                    "name": "synthetic-provider",
+                    "upstream_model": "synthetic-next-model",
+                    "upstream_format": "responses",
+                    "tool_protocol": "responses_structured",
+                },
+                event_context={},
+            )
+
+        normalized_input = json.loads(normalized)["input"]
+        self.assertEqual(normalized_input[0]["name"], "multi_agent_v1__spawn_agent")
+        self.assertNotIn("namespace", normalized_input[0])
+        self.assertNotIn("id", normalized_input[0])
+        self.assertNotIn("_codexhub_worker_requested_binding", normalized_input[0])
+        self.assertEqual(normalized_input[1], spawn_output)
+        write_event.assert_any_call(
+            "worker_effective_binding_validated",
+            outcome="accepted",
+            classification="legacy_native_spawn",
+        )
+
+    def test_external_worker_binding_history_accepts_pre_selector_native_spawn(self):
+        call_id = "legacy-native-no-selector"
+        spawn_call = {
+            "type": "function_call",
+            "id": "fc_legacy_native_no_selector",
+            "call_id": call_id,
+            "namespace": "multi_agent_v1",
+            "name": "spawn_agent",
+            "arguments": json.dumps(
+                {
+                    "fork_context": False,
+                    "message": "legacy worker task",
+                }
+            ),
+        }
+        spawn_output = {
+            "type": "function_call_output",
+            "call_id": call_id,
+            "output": json.dumps({"agent_id": "legacy-agent", "nickname": None}),
+        }
+
+        with patch.object(codex_proxy, "write_proxy_event") as write_event:
+            normalized = compatible_request_body(
+                self._worker_replay_body([spawn_call, spawn_output]),
+                {
+                    "name": "synthetic-provider",
+                    "upstream_model": "synthetic-next-model",
+                    "upstream_format": "responses",
+                    "tool_protocol": "responses_structured",
+                },
+                event_context={},
+            )
+
+        self.assertEqual(json.loads(normalized)["input"][1], spawn_output)
+        write_event.assert_any_call(
+            "worker_effective_binding_validated",
+            outcome="accepted",
+            classification="legacy_native_spawn",
+        )
+
+    def test_external_worker_binding_history_accepts_nullable_native_nickname(self):
+        call_id = "legacy-native-null-nickname"
+        spawn_call = {
+            "type": "function_call",
+            "id": "fc_legacy_native_null_nickname",
+            "call_id": call_id,
+            "namespace": "multi_agent_v1",
+            "name": "spawn_agent",
+            "arguments": json.dumps(
+                {
+                    "agent_type": "worker",
+                    "fork_context": False,
+                    "message": "legacy worker task",
+                }
+            ),
+        }
+        spawn_output = {
+            "type": "function_call_output",
+            "call_id": call_id,
+            "output": json.dumps({"agent_id": "legacy-agent", "nickname": None}),
+        }
+
+        with patch.object(codex_proxy, "write_proxy_event") as write_event:
+            normalized = compatible_request_body(
+                self._worker_replay_body([spawn_call, spawn_output]),
+                {
+                    "name": "synthetic-provider",
+                    "upstream_model": "synthetic-next-model",
+                    "upstream_format": "responses",
+                    "tool_protocol": "responses_structured",
+                },
+                event_context={},
+            )
+
+        self.assertEqual(json.loads(normalized)["input"][1], spawn_output)
+        write_event.assert_any_call(
+            "worker_effective_binding_validated",
+            outcome="accepted",
+            classification="legacy_native_spawn",
+        )
+
+    def test_external_worker_binding_history_does_not_legacy_accept_extended_spawn(self):
+        call_id = "legacy-extended-worker-call"
+        spawn_call = {
+            "type": "function_call",
+            "id": "fc_legacy_extended_worker",
+            "call_id": call_id,
+            "namespace": "multi_agent_v1",
+            "name": "spawn_agent",
+            "arguments": json.dumps(
+                {
+                    "agent_type": "worker",
+                    "fork_context": False,
+                    "message": "legacy worker task",
+                    "model": "synthetic-model",
+                }
+            ),
+        }
+        self._assert_worker_history_rejected(
+            [
+                spawn_call,
+                {
+                    "type": "function_call_output",
+                    "call_id": call_id,
+                    "output": json.dumps({"agent_id": "legacy-agent", "nickname": "worker"}),
+                },
+            ],
+            "missing_requested_binding_sidecar",
+            event="worker_requested_binding_validated",
+        )
+
     def _normalized_worker_spawn_call(self, *, model, reasoning, call_id="synthetic-bound-call"):
         event_context = {}
         compatible_request_body(


### PR DESCRIPTION
## Summary

- Fix Beta4.1 compatibility for pre-Beta4 V1 worker-binding history and keep the exact native legacy shape accepted for Session resume (#418).
- Fix Luna V1/V2 persistence to use the `modelId` command contract while retaining Rust bridge compatibility for legacy `model_id` payloads (#419).
- Restrict the Luna Collaboration selector to V1/V2 and mark the directory baseline dynamically as `(Default)` (#420).
- Label the single Codex quota card as Weekly (#421).
- Add deterministic regressions and the sanitized CLI E2E qualification plan.

## Validation

- Python core: `2358 passed, 1 skipped, 490 subtests passed`.
- Frontend: production build passed; UI contract suite `156 passed`.
- Rust: `546 passed, 0 failed, 1 ignored`; Clippy passed with `-D warnings`.
- CLI V2 lifecycle E2E: Codex CLI `0.146.1`, candidate `454d1a39840e6ffc41f35c7f8fc9db39d05314d4`, passed with no Gateway errors or V1 observations.
- App-server V2 request-shape/restart E2E: passed.
- `git diff --check` and report-only quality gates passed.

The full six-case real-client Beta4.1 matrix remains an operator check for a dedicated authenticated Windows host, Ollama credentials, machine-bound manifest, and an isolated copy of the historical Session. No user `.codex` data was used.
