### PR TITLE
release: prepare 0.1.8-beta.4.1

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codexhub-frontend",
-  "version": "0.1.8-beta.4",
+  "version": "0.1.8-beta.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codexhub-frontend",
-      "version": "0.1.8-beta.4",
+      "version": "0.1.8-beta.4.1",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codexhub-frontend",
   "private": true,
-  "version": "0.1.8-beta.4",
+  "version": "0.1.8-beta.4.1",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "codexhub"
-version = "0.1.8-beta.4"
+version = "0.1.8-beta.4.1"
 dependencies = [
  "dirs 5.0.1",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codexhub"
-version = "0.1.8-beta.4"
+version = "0.1.8-beta.4.1"
 description = "CodexHub desktop backend and CLI"
 authors = ["CodexHub"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "CodexHub",
-  "version": "0.1.8-beta.4",
+  "version": "0.1.8-beta.4.1",
   "identifier": "com.codexhub.app",
   "build": {
     "frontendDist": "../frontend/dist",

--- a/tests/test_release_channel_scripts.py
+++ b/tests/test_release_channel_scripts.py
@@ -20,7 +20,7 @@ def test_official_transport_wheel_is_pinned_and_packaged():
 
 
 def test_release_version_is_consistent_across_manifests():
-    expected = "0.1.8-beta.4"
+    expected = "0.1.8-beta.4.1"
     tauri = json.loads((ROOT / "src-tauri" / "tauri.conf.json").read_text(encoding="utf-8"))
     cargo = tomllib.loads((ROOT / "src-tauri" / "Cargo.toml").read_text(encoding="utf-8"))
     cargo_lock = tomllib.loads((ROOT / "src-tauri" / "Cargo.lock").read_text(encoding="utf-8"))
@@ -356,7 +356,7 @@ def test_release_plan_places_both_flavors_in_one_immutable_release(tmp_path):
 def test_release_plan_marks_semver_prerelease_versions_as_prereleases(tmp_path):
     repo, main_commit, _ = _release_repo(tmp_path)
 
-    result = _plan(repo, "normal", "0.1.8-beta.4", main_commit)
+    result = _plan(repo, "normal", "0.1.8-beta.4.1", main_commit)
 
     assert result.returncode == 0, result.stderr
     plan = json.loads(result.stdout)
@@ -364,18 +364,18 @@ def test_release_plan_marks_semver_prerelease_versions_as_prereleases(tmp_path):
         "name": "latest.json",
         "asset_url": (
             "https://github.com/NOirBRight/CodexHub/releases/download/"
-            "v0.1.8-beta.4/CodexHub_0.1.8-beta.4_x64-setup.exe"
+            "v0.1.8-beta.4.1/CodexHub_0.1.8-beta.4.1_x64-setup.exe"
         ),
     }
-    assert plan["immutable_release"]["tag"] == "v0.1.8-beta.4"
+    assert plan["immutable_release"]["tag"] == "v0.1.8-beta.4.1"
     assert plan["immutable_release"]["prerelease"] is True
     assert plan["immutable_release"]["assets"] == [
-        "CodexHub_0.1.8-beta.4_x64-setup.exe",
-        "CodexHub_0.1.8-beta.4_x64-setup.exe.sig",
+        "CodexHub_0.1.8-beta.4.1_x64-setup.exe",
+        "CodexHub_0.1.8-beta.4.1_x64-setup.exe.sig",
         "latest.json",
-        f"CodexHub_0.1.8-beta.4_portable_{main_commit[:8]}.zip",
-        "CodexHub_0.1.8-beta.4_debug_x64-setup.exe",
-        "CodexHub_0.1.8-beta.4_debug_x64-setup.exe.sig",
+        f"CodexHub_0.1.8-beta.4.1_portable_{main_commit[:8]}.zip",
+        "CodexHub_0.1.8-beta.4.1_debug_x64-setup.exe",
+        "CodexHub_0.1.8-beta.4.1_debug_x64-setup.exe.sig",
         "latest-debug.json",
     ]
 


### PR DESCRIPTION
## Summary

Prepare the merged Beta4.1 fixes for an immutable `v0.1.8-beta.4.1` release by aligning the frontend, Tauri, Cargo lock, and release-contract versions.

## Validation

- `tests/test_release_channel_scripts.py`: 17 passed.
- Frontend production build passed.
- Frontend UI contract suite: 156 passed.
- `git diff --check` passed.

The release assets and updater manifests will be built from the resulting `main` commit and uploaded to the matching immutable tag.
