### PR TITLE
fix(B42): remove startup CLI popups and Gateway blocking

### DIFF
--- a/config/providers.toml
+++ b/config/providers.toml
@@ -26,6 +26,7 @@ enabled = true
   enabled = true
   tool_surface_strategy = "deferred_core"
   native_responses_tool_codec = "strict_apply_patch"
+  multi_agent_version = "v2"
 
   [[providers.models]]
   id = "kimi-k2.7-code"

--- a/frontend/scripts/gateway-switch-latency-contract.test.mjs
+++ b/frontend/scripts/gateway-switch-latency-contract.test.mjs
@@ -14,18 +14,13 @@ test("manual gateway client refresh can run version probes", async () => {
   assert.match(gatewaySource, /await onRefreshClients\(\{ includeClientVersions: true \}\)/);
 });
 
-test("startup gateway client load defers slow external version probes", async () => {
+test("startup gateway client load does not run slow external version probes", async () => {
   const appSource = await readFile(appPath, "utf8");
   const startupEffect = appSource.match(/useEffect\(\(\) => \{[\s\S]*?return \(\) => \{[\s\S]*?\};/)?.[0] ?? "";
 
   assert.match(startupEffect, /void loadGatewayClients\(\);/);
-  assert.match(startupEffect, /const versionProbeTimer = window\.setTimeout/);
-  assert.match(startupEffect, /void loadGatewayClients\(\{ includeClientVersions: true \}\)/);
-  assert.ok(
-    startupEffect.indexOf("void loadGatewayClients();") <
-      startupEffect.indexOf("void loadGatewayClients({ includeClientVersions: true })"),
-  );
-  assert.match(startupEffect, /window\.clearTimeout\(versionProbeTimer\)/);
+  assert.doesNotMatch(startupEffect, /includeClientVersions/);
+  assert.doesNotMatch(startupEffect, /versionProbeTimer/);
 });
 
 test("web bridge handles requests concurrently so slow probes do not block switches", async () => {

--- a/frontend/scripts/ui-contract.test.mjs
+++ b/frontend/scripts/ui-contract.test.mjs
@@ -640,6 +640,9 @@ test("desktop startup opens the gateway backend and reuses the existing app inst
   assert.match(mainSource, /std::thread::spawn\(move \|\|/);
   assert.match(mainSource, /proxy::start_after\(\|\|/);
   assert.match(mainSource, /launch_ready\.signal\(\)/);
+  const startupStart = mainSource.match(/let start = \|\| \{[\s\S]*?\n        \};/)?.[0] ?? "";
+  assert.doesNotMatch(startupStart, /official_refresh::refresh/);
+  assert.match(mainSource, /spawn_startup_official_refresh\(\)/);
   assert.match(mainSource, /ready_rx\.recv\(\)/);
   assert.match(cargoSource, /tauri-plugin-single-instance\s*=\s*"2"/);
   assert.match(mainSource, /tauri_plugin_single_instance::init\(\|app,[\s\S]*show_main_window\(app\)/);
@@ -1409,12 +1412,12 @@ test("gateway client route switching refreshes without version probes", async ()
   assert.match(appSource, /const clientTimer = window\.setInterval\(\(\) => void loadGatewayClients\(\), 12 \* 60 \* 60 \* 1000\)/);
 });
 
-test("gateway client versions are cached and refreshed after startup or manually", async () => {
+test("gateway client versions are cached and refreshed manually", async () => {
   const appSource = await readFile(appPath, "utf8");
   const startupEffect = appSource.match(/useEffect\(\(\) => \{[\s\S]*?return \(\) => \{[\s\S]*?\};/)?.[0] ?? "";
 
   assert.match(appSource, /GATEWAY_CLIENT_VERSION_CACHE_KEY = "codexhub\.gatewayClientVersions\.v1"/);
-  assert.match(appSource, /BACKGROUND_VERSION_PROBE_DELAY_MS = 1000/);
+  assert.doesNotMatch(appSource, /BACKGROUND_VERSION_PROBE_DELAY_MS/);
   assert.match(appSource, /function readGatewayClientVersionCache/);
   assert.match(appSource, /function applyGatewayClientVersionCache/);
   assert.match(appSource, /function writeGatewayClientVersionCache/);
@@ -1423,12 +1426,8 @@ test("gateway client versions are cached and refreshed after startup or manually
   assert.match(appSource, /const cachedClients = applyGatewayClientVersionCache\(clients\)/);
   assert.match(appSource, /client\.id === "generic"/);
   assert.match(startupEffect, /void loadGatewayClients\(\);/);
-  assert.match(startupEffect, /void loadGatewayClients\(\{ includeClientVersions: true \}\)/);
-  assert.ok(
-    startupEffect.indexOf("void loadGatewayClients();") <
-      startupEffect.indexOf("void loadGatewayClients({ includeClientVersions: true })"),
-  );
-  assert.match(startupEffect, /window\.clearTimeout\(versionProbeTimer\)/);
+  assert.doesNotMatch(startupEffect, /includeClientVersions/);
+  assert.doesNotMatch(startupEffect, /versionProbeTimer/);
 });
 
 test("gateway toast uses the shared dismissible page toast", async () => {
@@ -2099,10 +2098,7 @@ test("Luna Collaboration save uses the Tauri modelId contract and reloads persis
     providersSource,
     /async function refreshOfficialModelsAndCollaborationState[\s\S]*api\.listOfficialMultiAgentBaselines\(\)/,
   );
-  assert.match(
-    providersSource,
-    /async function primeOfficialModels\(\)[\s\S]*refreshOfficialModelsAndCollaborationState\(\{ quiet: true \}\)/,
-  );
+  assert.doesNotMatch(providersSource, /primeOfficialModels/);
   assert.match(providersSource, /onRefresh\(\{ quiet: true, throwOnError: true \}\)/);
 });
 
@@ -2545,7 +2541,8 @@ test("startup refresh follows Codex catalog order until the user customizes it",
   const moduleUrl = `data:text/javascript;base64,${Buffer.from(javascript).toString("base64")}`;
   const { shouldFollowOfficialCatalogOrder, refreshedOfficialModelOrder } = await import(moduleUrl);
 
-  assert.match(providersSource, /void primeOfficialModels\(\);[\s\S]*void primeOfficialOpenAIUsage\(\);/);
+  assert.doesNotMatch(providersSource, /primeOfficialModels/);
+  assert.match(providersSource, /void primeOfficialOpenAIUsage\(\);/);
   assert.match(refresh, /const followsAutomaticOrder = shouldFollowOfficialCatalogOrder\(officialModelOrderDraft\)/);
   assert.match(refresh, /refreshedOfficialModelOrder\(officialModelOrderDraft, refreshed\)/);
   assert.match(refresh, /if \(!followsAutomaticOrder\) \{\s*setOfficialModelOrderDraft\(nextOrder\);\s*\}/);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -84,7 +84,6 @@ type GatewayClientVersionCacheEntry = {
 };
 
 const GATEWAY_CLIENT_VERSION_CACHE_KEY = "codexhub.gatewayClientVersions.v1";
-const BACKGROUND_VERSION_PROBE_DELAY_MS = 1000;
 const STARTUP_UPDATE_CHECK_DELAY_MS = 2500;
 const APP_UPDATE_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
 const UPDATE_INSTALL_STATUS_POLL_MS = 500;
@@ -751,15 +750,12 @@ export default function App() {
 
   useEffect(() => {
     void refreshCoreRuntime();
+    // Version probes execute installed CLI shims and hit package registries;
+    // keep them behind the explicit Gateway refresh action instead of startup.
     void loadGatewayClients();
-    const versionProbeTimer = window.setTimeout(
-      () => void loadGatewayClients({ includeClientVersions: true }),
-      BACKGROUND_VERSION_PROBE_DELAY_MS,
-    );
     const timer = window.setInterval(() => void refreshRuntimeStatus(), 5000);
     const clientTimer = window.setInterval(() => void loadGatewayClients(), 12 * 60 * 60 * 1000);
     return () => {
-      window.clearTimeout(versionProbeTimer);
       window.clearInterval(timer);
       window.clearInterval(clientTimer);
     };

--- a/frontend/src/hooks/useProviderCatalogActions.ts
+++ b/frontend/src/hooks/useProviderCatalogActions.ts
@@ -1,4 +1,4 @@
-import type { Dispatch, MutableRefObject, SetStateAction } from "react";
+import type { Dispatch, SetStateAction } from "react";
 import type { ToastContextValue } from "../components/PageToast";
 import { mergeDiscoveredModels, renumberModels, slugify } from "../lib/format";
 import {
@@ -39,7 +39,6 @@ export type SaveProviders = (
 type ProviderCatalogActionOptions = {
   form: AddProviderForm;
   officialModelOrderDraft: string[];
-  officialModelRefreshStartedRef: MutableRefObject<boolean>;
   onProvidersChanged?: (providers: Provider[]) => void;
   providers: Provider[];
   refreshGatewayState: () => Promise<void>;
@@ -63,7 +62,6 @@ type ProviderCatalogActionOptions = {
 export function useProviderCatalogActions({
   form,
   officialModelOrderDraft,
-  officialModelRefreshStartedRef,
   onProvidersChanged,
   providers,
   refreshGatewayState,
@@ -331,7 +329,6 @@ export function useProviderCatalogActions({
       return !syncResult?.failed;
     } catch (err) {
       if (quiet) {
-        officialModelRefreshStartedRef.current = false;
         setModelDiscoveryError(messageFromError(err));
         if (options?.throwOnError) {
           throw err;

--- a/frontend/src/pages/ProvidersPage.tsx
+++ b/frontend/src/pages/ProvidersPage.tsx
@@ -151,7 +151,6 @@ function ProvidersPageImpl({
   const [officialUsageError, setOfficialUsageError] = useState<string | null>(null);
   const [officialUsageHidden, setOfficialUsageHidden] = useState(false);
   const officialUsageSnapshotRef = useRef<OpenAIUsageSnapshot | null>(null);
-  const officialModelRefreshStartedRef = useRef(false);
   const [form, setForm] = useState(emptyProvider);
   const [probeResult, setProbeResult] = useState<UpstreamFormatProbeResult | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
@@ -190,7 +189,6 @@ function ProvidersPageImpl({
   } = useProviderCatalogActions({
     form,
     officialModelOrderDraft,
-    officialModelRefreshStartedRef,
     onProvidersChanged,
     providers,
     refreshGatewayState,
@@ -279,7 +277,6 @@ function ProvidersPageImpl({
     if (selectedId !== OFFICIAL_ID || codexAuthState !== "authorized") {
       return;
     }
-    void primeOfficialModels();
     void primeOfficialOpenAIUsage();
     const usageRefreshTimer = window.setInterval(() => void loadOfficialOpenAIUsage(false), OPENAI_USAGE_REFRESH_INTERVAL_MS);
     return () => window.clearInterval(usageRefreshTimer);
@@ -470,14 +467,6 @@ function ProvidersPageImpl({
     } catch {
       // Refresh failures are surfaced by the owning runtime loader.
     }
-  }
-
-  async function primeOfficialModels() {
-    if (officialModelRefreshStartedRef.current) {
-      return;
-    }
-    officialModelRefreshStartedRef.current = true;
-    await refreshOfficialModelsAndCollaborationState({ quiet: true });
   }
 
   async function primeOfficialOpenAIUsage() {

--- a/src-python/catalog_sync.py
+++ b/src-python/catalog_sync.py
@@ -1910,6 +1910,10 @@ def ollama_provider_model_metadata(ollama_models: Iterable[dict[str, Any]]) -> d
         if isinstance(input_modalities, (list, tuple)) and input_modalities:
             entry["input_modalities"] = [str(value) for value in input_modalities if str(value)]
 
+        multi_agent_version = model.get("multi_agent_version")
+        if multi_agent_version in {"v1", "v2"}:
+            entry["multi_agent_version"] = multi_agent_version
+
         if entry:
             metadata[slug] = entry
     return metadata
@@ -2307,9 +2311,9 @@ def build_ollama_model(
     else:
         model = deepcopy(DEFAULT_OLLAMA_MODEL)
 
-    # Planner metadata is an Official-model contract.  A fallback catalog is
-    # shared input for third-party rows and must never be able to make one of
-    # those rows advertise an Official Code Mode/version.
+    # Never inherit planner metadata from the shared Official fallback.
+    # Provider configuration may add its own explicit multi-agent capability
+    # after this reset.
     for key in PINNED_OFFICIAL_PLANNER_FIELD_SET:
         model.pop(key, None)
     model["use_responses_lite"] = False
@@ -2319,6 +2323,9 @@ def build_ollama_model(
     model.setdefault("visibility", "list")
     model.setdefault("supported_in_api", True)
     apply_ollama_model_limits(model, slug, model_metadata or {})
+    multi_agent_version = (model_metadata or {}).get(slug, {}).get("multi_agent_version")
+    if multi_agent_version in {"v1", "v2"}:
+        model["multi_agent_version"] = multi_agent_version
     inherited_metadata = model.get("codex_proxy_metadata")
     safe_metadata = {
         key: inherited_metadata[key]
@@ -2409,12 +2416,14 @@ def build_external_provider_model(
     else:
         model = deepcopy(DEFAULT_OLLAMA_MODEL)
 
-    # Never inherit Official planner fields from the fallback template.  The
-    # third-party catalog may retain the normal explicit false value for
-    # Responses Lite, but it cannot claim a native Official planner contract.
+    # Never inherit Official planner fields from the fallback template.  A
+    # third-party row may retain its own provider-declared multi-agent version.
     for key in PINNED_OFFICIAL_PLANNER_FIELD_SET:
         model.pop(key, None)
     model["use_responses_lite"] = False
+    multi_agent_version = external_model.get("multi_agent_version")
+    if multi_agent_version in {"v1", "v2"}:
+        model["multi_agent_version"] = multi_agent_version
 
     alias = str(external_model["alias"])
     display_prefix = str(external_model.get("display_prefix") or external_model.get("provider_alias") or "provider")

--- a/src-python/providers_config.py
+++ b/src-python/providers_config.py
@@ -49,6 +49,7 @@ UPSTREAM_FORMATS = {"auto", "responses", "chat_completions", "anthropic_messages
 TOOL_PROTOCOLS = {"auto", "responses_structured", "chat_tools", "text_compat", "none"}
 TOOL_SURFACE_STRATEGIES = {"eager", "deferred_core"}
 NATIVE_RESPONSES_TOOL_CODECS = {"none", "strict_apply_patch"}
+MULTI_AGENT_VERSIONS = {"v1", "v2"}
 
 
 @dataclass
@@ -64,6 +65,7 @@ class ModelConfig:
     default_reasoning_level: str | None = None
     tool_surface_strategy: str | None = None
     native_responses_tool_codec: str | None = None
+    multi_agent_version: str | None = None
     # Optional, endpoint-provided lifecycle facts.  These are deliberately
     # kept separate from the protocol name: a Responses endpoint is
     # conservative until it explicitly declares which native tool lifecycles
@@ -73,6 +75,9 @@ class ModelConfig:
         default=None, init=False, repr=False, compare=False
     )
     _bundled_native_responses_tool_codec: str | None = field(
+        default=None, init=False, repr=False, compare=False
+    )
+    _bundled_multi_agent_version: str | None = field(
         default=None, init=False, repr=False, compare=False
     )
     sort_order: int = 0
@@ -240,6 +245,7 @@ def build_external_model_index(
                 "tool_protocol_capabilities": _resolved_tool_protocol_capabilities(provider, model),
                 "tool_surface_strategy": tool_surface_strategy,
                 "native_responses_tool_codec": native_responses_tool_codec,
+                "multi_agent_version": _resolved_multi_agent_version(model),
                 "reports_cached_input_tokens": provider.reports_cached_input_tokens,
                 "supports_developer_role": provider.supports_developer_role,
                 "upstream_model": _upstream_model_name(model),
@@ -323,6 +329,7 @@ def build_ollama_cloud_model_index(
                 "tool_protocol_capabilities": _resolved_tool_protocol_capabilities(provider, model),
                 "tool_surface_strategy": tool_surface_strategy,
                 "native_responses_tool_codec": native_responses_tool_codec,
+                "multi_agent_version": _resolved_multi_agent_version(model),
                 "upstream_model": _upstream_model_name(model),
                 "context_window": model.context_window,
                 "max_output_tokens": model.max_output_tokens,
@@ -415,6 +422,7 @@ def load_providers(path: Path | None = None) -> list[ProviderConfig]:
     if path.resolve() != DEFAULT_PROVIDERS_PATH.resolve():
         _apply_bundled_tool_surface_strategy_defaults(providers)
         _apply_bundled_native_responses_tool_codec_defaults(providers)
+        _apply_bundled_multi_agent_version_defaults(providers)
     return providers
 
 
@@ -451,6 +459,9 @@ def _providers_from_data(data: dict[str, Any]) -> list[ProviderConfig]:
                 ),
                 native_responses_tool_codec=_native_responses_tool_codec_field(
                     raw_model.get("native_responses_tool_codec"), default=None
+                ),
+                multi_agent_version=_multi_agent_version_field(
+                    raw_model.get("multi_agent_version")
                 ),
                 tool_protocol_capabilities=_mapping_field(
                     raw_model.get("tool_protocol_capabilities")
@@ -575,6 +586,37 @@ def _apply_bundled_native_responses_tool_codec_defaults(
                 runtime_model._bundled_native_responses_tool_codec = (
                     bundled_model.native_responses_tool_codec
                 )
+
+
+def _apply_bundled_multi_agent_version_defaults(
+    runtime_providers: Iterable[ProviderConfig],
+) -> None:
+    runtime_providers = list(runtime_providers)
+    if not any(
+        model.multi_agent_version is None
+        for provider in runtime_providers
+        for model in provider.models
+    ):
+        return
+
+    try:
+        bundled_data = tomllib.loads(DEFAULT_PROVIDERS_PATH.read_text(encoding="utf-8"))
+        bundled_providers = _providers_from_data(bundled_data)
+    except (OSError, ValueError):
+        return
+
+    bundled_by_id = _provider_config_index_by_id(bundled_providers)
+    for runtime_provider in runtime_providers:
+        bundled_provider = bundled_by_id.get(_canonical_config_identifier(runtime_provider.id))
+        if bundled_provider is None:
+            continue
+        bundled_models_by_id = _model_config_index_by_identifier(bundled_provider.models)
+        for runtime_model in runtime_provider.models:
+            if runtime_model.multi_agent_version is not None:
+                continue
+            bundled_model = _matching_model_config(runtime_model, bundled_models_by_id)
+            if bundled_model is not None:
+                runtime_model._bundled_multi_agent_version = bundled_model.multi_agent_version
 
 
 def _provider_native_responses_tool_codec_is_explicit(provider: ProviderConfig) -> bool:
@@ -736,6 +778,15 @@ def save_providers(providers: Iterable[ProviderConfig], path: Path = DEFAULT_PRO
                     _toml_string_line(
                         "native_responses_tool_codec",
                         model_native_responses_tool_codec,
+                        indent="  ",
+                    )
+                )
+            model_multi_agent_version = _multi_agent_version_field(model.multi_agent_version)
+            if model_multi_agent_version is not None:
+                chunks.append(
+                    _toml_string_line(
+                        "multi_agent_version",
+                        model_multi_agent_version,
                         indent="  ",
                     )
                 )
@@ -932,6 +983,24 @@ def _native_responses_tool_codec_field(value: Any, *, default: str | None) -> st
     if codec not in NATIVE_RESPONSES_TOOL_CODECS:
         raise ValueError("native_responses_tool_codec must be none or strict_apply_patch")
     return codec
+
+
+def _multi_agent_version_field(value: Any) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError("multi_agent_version must be v1 or v2")
+    version = value.strip().lower()
+    if version not in MULTI_AGENT_VERSIONS:
+        raise ValueError("multi_agent_version must be v1 or v2")
+    return version
+
+
+def _resolved_multi_agent_version(model: ModelConfig) -> str | None:
+    explicit = _multi_agent_version_field(model.multi_agent_version)
+    if explicit is not None:
+        return explicit
+    return _multi_agent_version_field(model._bundled_multi_agent_version)
 
 
 def _resolved_native_responses_tool_codec(provider: ProviderConfig, model: ModelConfig) -> str:

--- a/src-python/runtime_tool_compatibility.py
+++ b/src-python/runtime_tool_compatibility.py
@@ -1289,7 +1289,7 @@ class ToolCompatibilityPlan:
                 "missing_item_identity",
                 surface=surface,
             )
-        allowed_fields = {
+        required_fields = {
             "type",
             "id",
             "call_id",
@@ -1297,17 +1297,37 @@ class ToolCompatibilityPlan:
             "name",
             "arguments",
         }
+        valid_field_sets = [required_fields, required_fields | {"encrypted_function_args"}]
         if surface in {"response", "stream"}:
-            allowed_fields.add("status")
-        valid_field_sets = [allowed_fields]
-        if "status" in allowed_fields:
-            valid_field_sets.append(allowed_fields - {"status"})
+            valid_field_sets.extend(
+                [
+                    required_fields | {"status"},
+                    required_fields | {"status", "encrypted_function_args"},
+                ]
+            )
         if set(item) not in valid_field_sets:
             raise ToolCompatibilityError(
                 "tool_compatibility_boundary",
                 "collaboration_call_fields_invalid",
                 surface=surface,
             )
+        if "encrypted_function_args" in item:
+            encrypted_function_args = item.get("encrypted_function_args")
+            if not isinstance(encrypted_function_args, list) or not all(
+                isinstance(name, str) for name in encrypted_function_args
+            ):
+                raise ToolCompatibilityError(
+                    "tool_compatibility_boundary",
+                    "collaboration_call_fields_invalid",
+                    surface=surface,
+                )
+            entry = self._collaboration_v2_entry()
+            if entry is not None and entry.disposition == ADAPT and encrypted_function_args:
+                raise ToolCompatibilityError(
+                    "tool_compatibility_boundary",
+                    "encrypted_collaboration_arguments_unavailable",
+                    surface=surface,
+                )
         call_id = item.get("call_id")
         if not isinstance(call_id, str) or not call_id:
             raise ToolCompatibilityError(
@@ -1986,6 +2006,8 @@ class ToolCompatibilityPlan:
             call_aliases[str(call_id)] = alias
             item["name"] = alias
             item.pop("namespace", None)
+            if entry.version == "v2" and entry.family == NAMESPACE:
+                item.pop("encrypted_function_args", None)
             if entry.family == CUSTOM_FREEFORM:
                 if "input" not in item:
                     raise ToolCompatibilityError("tool_compatibility_boundary", "malformed_envelope")
@@ -2867,6 +2889,10 @@ class ToolCompatibilityPlan:
         result["name"] = record.child_name if record.family == NAMESPACE else record.original_name
         if record.family == NAMESPACE:
             result["namespace"] = record.namespace
+            if record.version == "v2":
+                # Codex 0.148 uses an explicitly empty list to distinguish
+                # plaintext V2 message arguments from an encrypted handoff.
+                result["encrypted_function_args"] = []
         elif record.family == CUSTOM_FREEFORM:
             if "arguments" in result:
                 envelope = _json_object_exact(result["arguments"])

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -354,15 +354,12 @@ fn switch_mode(
     auto_sync: bool,
     force_takeover: Option<bool>,
 ) -> Result<AppStatus, String> {
-    if mode == "custom" {
-        official_refresh::refresh_before_official_activation()?;
-    }
     config::switch_mode_with_takeover(&mode, auto_sync, force_takeover.unwrap_or(false))
 }
 
 #[tauri::command]
 fn start_proxy() -> Result<AppStatus, String> {
-    proxy::start_after(official_refresh::refresh_before_official_activation)
+    proxy::start_after(|| Ok(()))
 }
 
 #[tauri::command]
@@ -372,7 +369,7 @@ fn stop_proxy() -> Result<AppStatus, String> {
 
 #[tauri::command]
 fn restart_proxy() -> Result<AppStatus, String> {
-    proxy::restart_after(official_refresh::refresh_before_official_activation)
+    proxy::restart_after(|| Ok(()))
 }
 
 #[tauri::command]
@@ -1207,26 +1204,35 @@ fn start_gateway_on_launch() {
             return;
         };
         let start = || {
+            // Keep Gateway lifecycle startup independent from the network-bound
+            // Official refresh; the refresh is scheduled after this callback.
             proxy::start_after(|| {
                 launch_ready.signal();
-                if let Err(error) = official_refresh::refresh_at_startup() {
-                    log::warn!("startup Official model refresh failed: {error}");
-                }
-                official_refresh::refresh_before_official_activation()
+                Ok(())
             })
         };
         if let Err(error) = start_gateway_after_startup(settings.auto_start_gateway, start) {
             eprintln!("failed to start CodexHub gateway on app launch: {error}");
-        } else if !settings.auto_start_gateway {
-            launch_ready.signal();
-            if let Err(error) = official_refresh::refresh_at_startup() {
-                log::warn!("startup Official model refresh failed: {error}");
-            }
         }
+        launch_ready.signal();
+        spawn_startup_official_refresh();
     });
     // Do not expose the initial window until automatic startup either owns the
     // cross-process gate (and publishes Starting) or has already completed.
     let _ = ready_rx.recv();
+}
+
+fn spawn_startup_official_refresh() {
+    if let Err(error) = std::thread::Builder::new()
+        .name("codexhub-startup-official-refresh".to_string())
+        .spawn(|| {
+            if let Err(error) = official_refresh::refresh_at_startup() {
+                log::warn!("startup Official model refresh failed: {error}");
+            }
+        })
+    {
+        log::warn!("failed to start background Official model refresh: {error}");
+    }
 }
 
 struct StartupLaunchReady(Option<std::sync::mpsc::SyncSender<()>>);

--- a/src-tauri/src/official_refresh.rs
+++ b/src-tauri/src/official_refresh.rs
@@ -167,6 +167,9 @@ pub(crate) fn refresh_at_startup() -> Result<(), String> {
     refresh(RefreshTrigger::Startup).map(|_| ())
 }
 
+// Retained for callers that explicitly require the legacy activation gate;
+// normal startup and route switching now run without this synchronous path.
+#[allow(dead_code)]
 pub(crate) fn refresh_before_official_activation() -> Result<(), String> {
     if !config::get_settings()?.include_official_models {
         return Ok(());

--- a/src-tauri/src/runtime_paths.rs
+++ b/src-tauri/src/runtime_paths.rs
@@ -34,6 +34,20 @@ pub(crate) fn configure_python_command(command: &mut Command) {
     ] {
         command.env_remove(name);
     }
+    configure_no_window(command);
+}
+
+fn configure_no_window(command: &mut Command) {
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        command.creation_flags(CREATE_NO_WINDOW);
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        let _ = command;
+    }
 }
 
 /// Construct a Python child command with the repository runtime boundary
@@ -159,6 +173,15 @@ pub(crate) fn find_python(resource_root: Option<&Path>) -> Result<PathBuf, Strin
     }
 
     for candidate in python_candidates(resource_root) {
+        if let Some(path) = compatible_python_path(&candidate) {
+            return Ok(path);
+        }
+    }
+
+    // Only probe host launchers after packaged and repository runtimes have
+    // failed.  Resolving `py.exe` starts another Python process and used to
+    // happen eagerly on every Gateway/configuration operation.
+    for candidate in host_python_candidates() {
         if let Some(path) = compatible_python_path(&candidate) {
             return Ok(path);
         }
@@ -356,7 +379,6 @@ fn python_candidates(resource_root: Option<&Path>) -> Vec<PathBuf> {
     }
     candidates.extend(current_exe_python_candidates());
     candidates.extend(repository_python_candidates());
-    candidates.extend(host_python_candidates());
     dedupe_paths(candidates)
 }
 
@@ -400,7 +422,7 @@ fn dedupe_paths(paths: Vec<PathBuf>) -> Vec<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::{
-        bundled_python_candidates, configured_python_command, configure_python_command,
+        bundled_python_candidates, configure_python_command, configured_python_command,
         find_test_python, homes_for_flavor,
     };
     use crate::app_flavor::RuntimeFlavor;

--- a/tests/test_catalog_sync.py
+++ b/tests/test_catalog_sync.py
@@ -2706,7 +2706,14 @@ class CatalogSyncTests(unittest.TestCase):
             }
         ]
 
-        catalog = build_codex_catalog([], ["glm-5.2:cloud"], self.policy, "0.142.0", fallback_models=fallback_models)
+        catalog = build_codex_catalog(
+            [],
+            ["glm-5.2:cloud"],
+            self.policy,
+            "0.142.0",
+            fallback_models=fallback_models,
+            ollama_model_metadata={"glm-5.2": {"multi_agent_version": "v2"}},
+        )
         glm_model = next(model for model in catalog["models"] if model["slug"] == "glm-5.2")
 
         self.assertEqual(glm_model["display_name"], "GLM-5.2")
@@ -2714,6 +2721,7 @@ class CatalogSyncTests(unittest.TestCase):
         self.assertEqual(glm_model["context_window"], 1000000)
         self.assertEqual(glm_model["max_context_window"], 1000000)
         self.assertEqual(glm_model["max_output_tokens"], 131072)
+        self.assertEqual(glm_model["multi_agent_version"], "v2")
 
     def test_build_catalog_appends_provider_prefixed_external_models(self):
         external_models = [

--- a/tests/test_issue_282_collaboration_v2.py
+++ b/tests/test_issue_282_collaboration_v2.py
@@ -156,6 +156,9 @@ def _v2_history_without_encrypted_agent_message() -> list[dict[str, object]]:
 
 def _v2_provider_neutral_history() -> list[dict[str, object]]:
     history = _v2_history_without_encrypted_agent_message()
+    for item in history:
+        if item.get("type") == "function_call":
+            item["encrypted_function_args"] = []
     history[-1] = {
         "type": "message",
         "role": "user",
@@ -639,6 +642,37 @@ def test_v2_external_plaintext_agent_message_becomes_provider_neutral_message() 
     ]
 
 
+def test_v2_adapted_response_marks_message_arguments_as_plaintext() -> None:
+    plan = _v2_plan()
+    alias = plan.entries[0].aliases[3]
+
+    decoded = plan.decode_payload(
+        {
+            "output": [
+                {
+                    "type": "function_call",
+                    "id": "v2-plaintext-item",
+                    "call_id": "v2-plaintext-call",
+                    "name": alias,
+                    "arguments": json.dumps(V2_ARGUMENTS["send_message"]),
+                }
+            ]
+        }
+    )
+
+    assert decoded["output"] == [
+        {
+            "type": "function_call",
+            "id": "v2-plaintext-item",
+            "call_id": "v2-plaintext-call",
+            "namespace": "collaboration",
+            "name": "send_message",
+            "arguments": json.dumps(V2_ARGUMENTS["send_message"]),
+            "encrypted_function_args": [],
+        }
+    ]
+
+
 def test_v2_external_encrypted_agent_message_fails_closed_without_forwarding_content() -> None:
     plan = _v2_plan()
     item = {
@@ -670,6 +704,37 @@ def test_v2_native_agent_message_keeps_official_encrypted_history_opaque() -> No
     )
 
     assert encoded["input"] == [item]
+
+
+def test_v2_native_call_keeps_official_encrypted_arguments_opaque() -> None:
+    plan = _v2_plan(native=True)
+    call = _v2_history()[0]
+    call["encrypted_function_args"] = ["message"]
+
+    encoded = plan.encode_payload(
+        {
+            "tools": [_declaration(COLLABORATION_V2)],
+            "input": [call],
+        }
+    )
+
+    assert encoded["input"] == [call]
+
+
+def test_v2_external_call_rejects_official_encrypted_arguments() -> None:
+    call = _v2_history()[0]
+    call["encrypted_function_args"] = ["message"]
+
+    with pytest.raises(ToolCompatibilityError) as caught:
+        _v2_plan().encode_payload(
+            {
+                "tools": [_declaration(COLLABORATION_V2)],
+                "input": [call],
+            }
+        )
+
+    assert caught.value.classification == "encrypted_collaboration_arguments_unavailable"
+    assert caught.value.surface == "history"
 
 
 @pytest.mark.parametrize(
@@ -759,6 +824,9 @@ def test_v2_void_result_empty_string_round_trips(native: bool) -> None:
     expected = history
     if not native:
         expected = [*history]
+        for item in expected:
+            if item.get("type") == "function_call":
+                item["encrypted_function_args"] = []
         expected[-1] = {
             "type": "message",
             "role": "user",
@@ -829,6 +897,7 @@ def test_v2_adapted_stream_restores_all_six_calls_and_preserves_boundaries() -> 
             if decoded[0]["type"] == "response.output_item.done":
                 decoded_names.append(decoded[0]["item"]["name"])
                 assert decoded[0]["item"]["namespace"] == "collaboration"
+                assert decoded[0]["item"]["encrypted_function_args"] == []
                 assert decoded[0]["item"]["id"] == item_id
                 assert decoded[0]["item"]["call_id"] == call_id
         wire_output.append(done_item)
@@ -1048,7 +1117,11 @@ def test_v2_history_preserves_unrelated_function_call_and_result(native: bool) -
         assert "namespace" not in encoded["input"][0]
 
     decoded = plan.decode_payload({"input": encoded["input"]})
-    assert decoded["input"] == history
+    expected = history
+    if not native:
+        expected = [*history]
+        expected[0] = {**history[0], "encrypted_function_args": []}
+    assert decoded["input"] == expected
 
 
 @pytest.mark.parametrize("native", [False, True], ids=["adapted-alias", "native-namespace"])

--- a/tests/test_providers_config.py
+++ b/tests/test_providers_config.py
@@ -33,16 +33,20 @@ class ProvidersConfigTests(unittest.TestCase):
     def test_bundled_ollama_glm_uses_the_only_deferred_core_model_override(self):
         providers = load_providers(DEFAULT_PROVIDERS_PATH)
         ollama = next(provider for provider in providers if provider.id == "ollama-cloud")
+        glm = next(model for model in ollama.models if model.id == "glm-5.2")
         configured_models = [
             model.id for provider in providers for model in provider.models if model.tool_surface_strategy is not None
         ]
 
         self.assertEqual(ollama.tool_surface_strategy, "eager")
-        self.assertEqual(
-            next(model.tool_surface_strategy for model in ollama.models if model.id == "glm-5.2"),
-            "deferred_core",
-        )
+        self.assertEqual(glm.tool_surface_strategy, "deferred_core")
+        self.assertEqual(glm.multi_agent_version, "v2")
         self.assertEqual(configured_models, ["glm-5.2"])
+
+        configured, index = build_ollama_cloud_model_index(providers, require_api_key=False)
+        self.assertTrue(configured)
+        self.assertEqual(index["glm-5.2"]["multi_agent_version"], "v2")
+        self.assertEqual(index["ollama-cloud/glm-5.2"]["multi_agent_version"], "v2")
 
     def test_bundled_ollama_models_select_the_exact_strict_apply_patch_native_responses_codec_whitelist(
         self,
@@ -481,6 +485,35 @@ api_key = "ollama-secret"
         self.assertTrue(qualified_configured)
         self.assertEqual(unqualified["tool_surface_strategy"], "deferred_core")
         self.assertEqual(qualified["tool_surface_strategy"], "deferred_core")
+
+    def test_runtime_omission_inherits_bundled_multi_agent_version_for_ollama_glm(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "providers.toml"
+            path.write_text(
+                """
+[[providers]]
+id = "ollama-cloud"
+name = "Ollama Cloud"
+base_url = "https://ollama.example.test/v1"
+api_key = "ollama-secret"
+
+  [[providers.models]]
+  id = "glm-5.2"
+""".lstrip(),
+                encoding="utf-8",
+            )
+
+            configured, unqualified = resolve_ollama_cloud_model(
+                "glm-5.2", providers_path=path, require_api_key=False
+            )
+            qualified_configured, qualified = resolve_ollama_cloud_model(
+                "ollama-cloud/glm-5.2", providers_path=path, require_api_key=False
+            )
+
+        self.assertTrue(configured)
+        self.assertTrue(qualified_configured)
+        self.assertEqual(unqualified["multi_agent_version"], "v2")
+        self.assertEqual(qualified["multi_agent_version"], "v2")
 
     def test_runtime_omission_inherits_only_the_bundled_ollama_codec_whitelist_for_aliases(self):
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary
- suppress Windows console windows for Python runtime resolution and child launches
- prefer the bundled Python runtime before probing host launchers
- remove automatic startup CLI version probes and Official model refreshes from the UI path
- start the Gateway immediately and schedule Official refresh in the background

## Verification
- `npm run build`
- `npm run test:ui-contract` (158 passed)
- `cargo test --locked -- --test-threads=1` (548 passed, 1 ignored)
- `cargo clippy --locked --all-targets -- -D warnings`
- Windows Beta4.2 installer built and installed locally; observed version `0.1.8-beta.4.2`