### PR TITLE
test(release): update beta3.2 runtime contract

### DIFF
--- a/tests/test_python_runtime.py
+++ b/tests/test_python_runtime.py
@@ -272,7 +272,7 @@ def test_relative_windows_entrypoints_keep_the_repository_runtime_contract() -> 
         "-DryRun",
     )
     assert portable_plan.returncode == 0, portable_plan.stdout + portable_plan.stderr
-    assert '"version":"0.1.9-beta.3.1"' in portable_plan.stdout
+    assert '"version":"0.1.9-beta.3.2"' in portable_plan.stdout
 
     runtime_check = _run_relative_powershell_script(
         r".\scripts\Prepare-PythonRuntime.ps1", "-CheckOnly"


### PR DESCRIPTION
Fix the frozen beta.3.2 release contract after the candidate full-suite check found one stale expected version.

- updates `tests/test_python_runtime.py` from beta.3.1 to beta.3.2
- runtime contract suite: 90 passed, 2 skipped
- no production behavior change

The release candidate source SHA after this PR is the merge commit; issue-369 `candidate_revision` must be refreshed to that final candidate SHA before publication.