### PR TITLE
fix(ui): stop idle WebView jank on the main shell

### DIFF
--- a/frontend/scripts/runtime-store.test.mjs
+++ b/frontend/scripts/runtime-store.test.mjs
@@ -15,3 +15,19 @@ test("runtime store writes one key without copying sibling snapshots", () => {
   assert.equal(failed.status.error, "offline");
   assert.equal(failed.settings.data?.locale, "en-US");
 });
+
+test("runtime store keeps the snapshot when the payload is unchanged", () => {
+  const start = createEmptyRuntimeSnapshot();
+  const first = setCacheData(start, "settings", { locale: "en-US" });
+  const second = setCacheData(first, "settings", { locale: "en-US" });
+  assert.equal(second, first);
+  assert.equal(second.settings.updatedAt, first.settings.updatedAt);
+});
+
+test("runtime store writes a new snapshot when the payload changes", () => {
+  const start = createEmptyRuntimeSnapshot();
+  const first = setCacheData(start, "settings", { locale: "en-US" });
+  const next = setCacheData(first, "settings", { locale: "zh-CN" });
+  assert.notEqual(next, first);
+  assert.equal(next.settings.data?.locale, "zh-CN");
+});

--- a/frontend/scripts/ui-contract.test.mjs
+++ b/frontend/scripts/ui-contract.test.mjs
@@ -239,10 +239,12 @@ test("main tabs use persistent panes and tab clicks do not reload runtime data",
   assert.match(appSource, /setActiveTab\(tabId\);[\s\S]*setVisibleTab\(tabId\);[\s\S]*setMountedTabs/);
   const selectTabSource = appSource.match(/const selectTab = useCallback[\s\S]*?\}, \[\]\);/)?.[0] ?? "";
   const gatewayTelemetryEffect = appSource.match(/useEffect\(\(\) => \{[\s\S]*?refreshGatewayTelemetry[\s\S]*?\}, \[gatewayVisited, loadGatewayClients, refreshGatewayTelemetry, visibleTab\]\);/)?.[0] ?? "";
-  assert.match(appSource, /setMountedTabs\(\(current\) => \(current\.gateway \? current : \{ \.\.\.current, gateway: true \}\)\)/);
+  assert.match(appSource, /setMountedTabs\(\(current\) => \(current\[tabId\] \? current : \{ \.\.\.current, \[tabId\]: true \}\)\)/);
+  assert.doesNotMatch(appSource, /setTimeout\(\(\) => \{\s*setMountedTabs\(\(current\) => \(current\.gateway/);
   assert.match(appSource, /function tabPaneClass\(active: boolean\)/);
   assert.match(appSource, /"absolute inset-0 min-h-0 min-w-0 p-4 \[contain:layout_paint_style\]"/);
-  assert.match(appSource, /"visible z-10 opacity-100 \[content-visibility:visible\] \[will-change:opacity\]"/);
+  assert.match(appSource, /"visible z-10 opacity-100 \[content-visibility:visible\]"/);
+  assert.doesNotMatch(appSource, /will-change:opacity/);
   assert.match(appSource, /"invisible z-0 opacity-0 pointer-events-none \[content-visibility:hidden\]"/);
   assert.match(appSource, /mountedTabs\.codexhub &&/);
   assert.match(appSource, /mountedTabs\.gateway &&/);
@@ -2823,7 +2825,8 @@ test("Codex Hub connection CTA is prominent and has a connecting state", async (
   assert.match(css, /@keyframes codexhub-flow-up/);
   assert.match(css, /transform:\s*translate\(-50%, var\(--flow-distance, 92px\)\)/);
   assert.match(css, /transform:\s*translate\(-50%, -44px\)/);
-  assert.match(css, /filter:\s*blur\(1\.5px\)/);
+  assert.doesNotMatch(css, /filter:\s*blur\(/);
+  assert.match(css, /prefers-reduced-motion:\s*reduce/);
   assert.match(providersSource, /function ConnectedSurfaceFlow/);
   assert.match(providersSource, /codexhub-card-flow absolute left-0 top-0 h-px w-1\/2/);
   assert.match(providersSource, /codexhub-card-flow codexhub-card-flow-delay absolute bottom-0 left-0 h-px w-1\/2/);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -231,7 +231,7 @@ function tabPaneClass(active: boolean) {
   return cx(
     "absolute inset-0 min-h-0 min-w-0 p-4 [contain:layout_paint_style]",
     active
-      ? "visible z-10 opacity-100 [content-visibility:visible] [will-change:opacity]"
+      ? "visible z-10 opacity-100 [content-visibility:visible]"
       : "invisible z-0 opacity-0 pointer-events-none [content-visibility:hidden]",
   );
 }
@@ -740,13 +740,6 @@ export default function App() {
       unlisten?.();
     };
   }, [showToast, updateToast]);
-
-  useEffect(() => {
-    const timer = window.setTimeout(() => {
-      setMountedTabs((current) => (current.gateway ? current : { ...current, gateway: true }));
-    }, 250);
-    return () => window.clearTimeout(timer);
-  }, []);
 
   useEffect(() => {
     if (startupUpdateCheckStarted.current || !settingsLoaded) {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -189,7 +189,6 @@ html.sortable-list-dragging * {
     rgba(16, 185, 129, 0)
   );
   border-radius: 999px;
-  filter: blur(1.5px);
 }
 
 .codexhub-flow-beam-delay {
@@ -204,7 +203,6 @@ html.sortable-list-dragging * {
     rgba(16, 185, 129, 0.65),
     rgba(16, 185, 129, 0)
   );
-  filter: blur(0.4px);
 }
 
 .codexhub-card-flow-delay {
@@ -242,5 +240,12 @@ html.sortable-list-dragging * {
   100% {
     opacity: 0;
     transform: translateX(240%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .codexhub-flow-beam,
+  .codexhub-card-flow {
+    animation: none;
   }
 }

--- a/frontend/src/lib/runtimeStore.ts
+++ b/frontend/src/lib/runtimeStore.ts
@@ -76,12 +76,31 @@ export function setCacheLoading(current: RuntimeSnapshot, key: RuntimeCacheKey):
   } as RuntimeSnapshot;
 }
 
+function stableEqual(left: unknown, right: unknown): boolean {
+  if (left === right) {
+    return true;
+  }
+  try {
+    return JSON.stringify(left) === JSON.stringify(right);
+  } catch {
+    return false;
+  }
+}
+
 export function setCacheData<K extends RuntimeCacheKey>(
   current: RuntimeSnapshot,
   key: K,
   data: RuntimeData<K>,
 ): RuntimeSnapshot {
   const cache = current[key] as RuntimeCache<RuntimeData<K>>;
+  if (
+    cache.loading === false &&
+    cache.error === null &&
+    cache.data !== null &&
+    stableEqual(cache.data, data)
+  ) {
+    return current;
+  }
   return {
     ...current,
     [key]: {


### PR DESCRIPTION
## Summary
The Windows desktop shell was burning WebView GPU (~13%) and renderer (~10%) while idle with Codex connected. This PR keeps the connected-state motion cue but stops forcing a full-page raster every frame, and skips 5s runtime cache writes when the payload is unchanged.

- Drop `filter: blur()` from `.codexhub-flow-beam` / `.codexhub-card-flow`; honor `prefers-reduced-motion`
- Remove always-on `will-change: opacity` from the active tab pane
- Mount the Gateway tab on first visit instead of 250ms after startup
- `setCacheData` returns the current snapshot when JSON payload, loading, and error are unchanged

## Verification
- `npm run test:ui-contract` in `frontend/` (183 tests)
- `npm run build` in `frontend/`

Windows 3.6 packaging is a follow-up after this lands. Do not retag 3.5.

## Test plan
- [x] UI contract + runtime-store tests
- [x] Frontend production build
- [ ] Live CPU sample after the 3.6 candidate is installed