### PR TITLE
release: prepare 0.1.9-beta.3.6

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codexhub-frontend",
-  "version": "0.1.9-beta.3.5",
+  "version": "0.1.9-beta.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codexhub-frontend",
-      "version": "0.1.9-beta.3.5",
+      "version": "0.1.9-beta.3.6",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codexhub-frontend",
   "private": true,
-  "version": "0.1.9-beta.3.5",
+  "version": "0.1.9-beta.3.6",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "codexhub"
-version = "0.1.9-beta.3.5"
+version = "0.1.9-beta.3.6"
 dependencies = [
  "dirs 5.0.1",
  "glib",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codexhub"
-version = "0.1.9-beta.3.5"
+version = "0.1.9-beta.3.6"
 description = "CodexHub desktop backend and CLI"
 authors = ["CodexHub"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "CodexHub",
-  "version": "0.1.9-beta.3.5",
+  "version": "0.1.9-beta.3.6",
   "identifier": "com.codexhub.app",
   "build": {
     "frontendDist": "../frontend/dist",

--- a/tests/test_python_runtime.py
+++ b/tests/test_python_runtime.py
@@ -279,7 +279,7 @@ def test_relative_windows_entrypoints_keep_the_repository_runtime_contract() -> 
         "-DryRun",
     )
     assert portable_plan.returncode == 0, portable_plan.stdout + portable_plan.stderr
-    assert '"version":"0.1.9-beta.3.5"' in portable_plan.stdout
+    assert '"version":"0.1.9-beta.3.6"' in portable_plan.stdout
 
     runtime_check = _run_relative_powershell_script(
         r".\scripts\Prepare-PythonRuntime.ps1", "-CheckOnly"

--- a/tests/test_release_channel_scripts.py
+++ b/tests/test_release_channel_scripts.py
@@ -44,7 +44,7 @@ def test_official_transport_wheel_is_pinned_and_packaged():
 
 
 def test_release_version_is_consistent_across_manifests():
-    expected = "0.1.9-beta.3.5"
+    expected = "0.1.9-beta.3.6"
     tauri = json.loads((ROOT / "src-tauri" / "tauri.conf.json").read_text(encoding="utf-8"))
     cargo = tomllib.loads((ROOT / "src-tauri" / "Cargo.toml").read_text(encoding="utf-8"))
     cargo_lock = tomllib.loads((ROOT / "src-tauri" / "Cargo.lock").read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary
Bump the shared version after #477. Windows candidate packaging is next. This tag must stay a **prerelease** until the candidate is accepted; do not flip GitHub Latest.

Same five manifests plus the two version-pin tests as 3.5:
- frontend/package.json, package-lock.json
- src-tauri/Cargo.toml, Cargo.lock, tauri.conf.json
- tests/test_release_channel_scripts.py, tests/test_python_runtime.py

## Verification
- `test_release_version_is_consistent_across_manifests` is in the passing set of `tests/test_release_channel_scripts.py`
- Unrelated pre-existing failures in that file (PowerShell stderr encoding) and one 3.11 entrypoint SyntaxError were not introduced by this bump