### PR TITLE
release: prepare 0.1.9-beta.3.7

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codexhub-frontend",
-  "version": "0.1.9-beta.3.6",
+  "version": "0.1.9-beta.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codexhub-frontend",
-      "version": "0.1.9-beta.3.6",
+      "version": "0.1.9-beta.3.7",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codexhub-frontend",
   "private": true,
-  "version": "0.1.9-beta.3.6",
+  "version": "0.1.9-beta.3.7",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "codexhub"
-version = "0.1.9-beta.3.6"
+version = "0.1.9-beta.3.7"
 dependencies = [
  "dirs 5.0.1",
  "glib",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codexhub"
-version = "0.1.9-beta.3.6"
+version = "0.1.9-beta.3.7"
 description = "CodexHub desktop backend and CLI"
 authors = ["CodexHub"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "CodexHub",
-  "version": "0.1.9-beta.3.6",
+  "version": "0.1.9-beta.3.7",
   "identifier": "com.codexhub.app",
   "build": {
     "frontendDist": "../frontend/dist",

--- a/tests/test_python_runtime.py
+++ b/tests/test_python_runtime.py
@@ -279,7 +279,7 @@ def test_relative_windows_entrypoints_keep_the_repository_runtime_contract() -> 
         "-DryRun",
     )
     assert portable_plan.returncode == 0, portable_plan.stdout + portable_plan.stderr
-    assert '"version":"0.1.9-beta.3.6"' in portable_plan.stdout
+    assert '"version":"0.1.9-beta.3.7"' in portable_plan.stdout
 
     runtime_check = _run_relative_powershell_script(
         r".\scripts\Prepare-PythonRuntime.ps1", "-CheckOnly"

--- a/tests/test_release_channel_scripts.py
+++ b/tests/test_release_channel_scripts.py
@@ -44,7 +44,7 @@ def test_official_transport_wheel_is_pinned_and_packaged():
 
 
 def test_release_version_is_consistent_across_manifests():
-    expected = "0.1.9-beta.3.6"
+    expected = "0.1.9-beta.3.7"
     tauri = json.loads((ROOT / "src-tauri" / "tauri.conf.json").read_text(encoding="utf-8"))
     cargo = tomllib.loads((ROOT / "src-tauri" / "Cargo.toml").read_text(encoding="utf-8"))
     cargo_lock = tomllib.loads((ROOT / "src-tauri" / "Cargo.lock").read_text(encoding="utf-8"))


### PR DESCRIPTION
Prepare the Linux candidate release after #481.

Validation:
- `./scripts/codexhub-python.sh -m pytest -q tests/test_release_channel_scripts.py tests/test_python_runtime.py` — 17 passed, 99 skipped
- `npm run build` — passed (existing Vite chunk-size warning)
- normal/debug Linux portable dry-run — passed
- `git diff --check` — passed
- Linux GUI real-client E2E on #481 — passed with no failures

This PR only aligns the shared release version and its contract tests. After merge, the exact main SHA will be used for signed Linux normal/debug AppImage, deb, portable, and updater manifests. The GitHub release will remain a prerelease and will not replace Latest.