### PR TITLE
fix(linux): pin package launcher upgrades

### DIFF
--- a/docs/agents/linux-packaging.md
+++ b/docs/agents/linux-packaging.md
@@ -19,10 +19,16 @@ replace the installed package instead of creating side-by-side versions. The
 package owns the single `/usr/share/applications/CodexHub.desktop` launcher.
 Its recoverable post-install migration archives exact legacy CodexHub-generated
 user launchers as `*.codexhub-legacy-backup`; customized desktop entries are
-left untouched. The root package hook only enumerates eligible accounts; it
-drops to each target UID/GID with cleared groups and capabilities before
-touching that user's launcher directory. AppImage upgrades likewise rewrite
-one stable managed user launcher rather than adding per-version entries.
+left untouched. The package launcher is atomically normalized to
+`Exec=/usr/bin/codexhub`, so a stale user `PATH` entry cannot redirect desktop
+launches to an older AppImage. If `~/.local/bin/codexhub` is a user-owned link
+that resolves exactly to `~/Applications/CodexHub.AppImage`, the hook archives
+only that link with the same recoverable suffix. It retains the AppImage
+payload and preserves every custom command target. The root package hook only
+enumerates eligible accounts; it drops to each target UID/GID with cleared
+groups and capabilities before touching that user's launcher directory.
+AppImage upgrades likewise rewrite one stable managed user launcher rather
+than adding per-version entries.
 
 Updater platform key: `linux-x86_64`. Add that platform to the existing
 `latest.json` / `latest-debug.json` payload; do not invent a second product

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codexhub-frontend",
-  "version": "0.1.9-beta.3.8",
+  "version": "0.1.9-beta.3.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codexhub-frontend",
-      "version": "0.1.9-beta.3.8",
+      "version": "0.1.9-beta.3.9",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codexhub-frontend",
   "private": true,
-  "version": "0.1.9-beta.3.8",
+  "version": "0.1.9-beta.3.9",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "codexhub"
-version = "0.1.9-beta.3.8"
+version = "0.1.9-beta.3.9"
 dependencies = [
  "cairo-rs",
  "dirs 5.0.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codexhub"
-version = "0.1.9-beta.3.8"
+version = "0.1.9-beta.3.9"
 description = "CodexHub desktop backend and CLI"
 authors = ["CodexHub"]
 license = "MIT"

--- a/src-tauri/linux/deb-postinstall.sh
+++ b/src-tauri/linux/deb-postinstall.sh
@@ -4,6 +4,36 @@
 # migration. Backups deliberately do not end in .desktop, so menus ignore them.
 set -eu
 
+write_package_launcher() {
+  path=$1
+  parent=${path%/*}
+  [ "$parent" != "$path" ] || return 1
+  [ -d "$parent" ] || return 1
+  [ ! -L "$parent" ] || return 1
+  [ ! -L "$path" ] || return 1
+
+  temporary=$(mktemp "$parent/.CodexHub.desktop.XXXXXX") || return 1
+  if ! {
+    printf '%s\n' \
+      '[Desktop Entry]' \
+      'Type=Application' \
+      'Name=CodexHub' \
+      'Comment=CodexHub desktop backend and CLI' \
+      'Exec=/usr/bin/codexhub' \
+      'Icon=codexhub' \
+      'Terminal=false' \
+      'Categories=Development;' \
+      'StartupNotify=true' \
+      'StartupWMClass=com.codexhub.app' \
+      'X-GNOME-UsesNotifications=true' > "$temporary" &&
+      chmod 0644 "$temporary" &&
+      mv -f -- "$temporary" "$path"
+  }; then
+    rm -f -- "$temporary"
+    return 1
+  fi
+}
+
 is_codexhub_generated_launcher() {
   awk '
     {
@@ -61,17 +91,54 @@ archive_launcher() {
   return 1
 }
 
+archive_legacy_command() {
+  home=$1
+  expected_uid=$2
+  directory="$home/.local/bin"
+  path="$directory/codexhub"
+  [ -d "$directory" ] || return 0
+  [ ! -L "$directory" ] || return 0
+  [ "$(stat -c %u "$directory")" = "$expected_uid" ] || return 0
+  [ -L "$path" ] || return 0
+  [ "$(stat -c %u "$path")" = "$expected_uid" ] || return 0
+
+  resolved=$(readlink -f -- "$path" 2>/dev/null || true)
+  expected=$(readlink -f -- "$home/Applications/CodexHub.AppImage" 2>/dev/null || true)
+  [ -n "$expected" ] || return 0
+  [ "$resolved" = "$expected" ] || return 0
+
+  index=0
+  while [ "$index" -lt 100 ]; do
+    suffix=""
+    [ "$index" -eq 0 ] || suffix=".$index"
+    backup="$path.codexhub-legacy-backup$suffix"
+    if [ ! -e "$backup" ] && [ ! -L "$backup" ]; then
+      mv -- "$path" "$backup"
+      return 0
+    fi
+    index=$((index + 1))
+  done
+  return 1
+}
+
 cleanup_home() {
   home=$1
   expected_uid=$2
-  apps="$home/.local/share/applications"
-  for directory in "$home" "$home/.local" "$home/.local/share" "$apps"; do
+  for directory in "$home" "$home/.local"; do
     [ -d "$directory" ] || return 0
     [ ! -L "$directory" ] || return 0
     [ "$(stat -c %u "$directory")" = "$expected_uid" ] || return 0
   done
-  archive_launcher "$apps/codexhub.desktop"
-  archive_launcher "$apps/com.codexhub.app.desktop"
+
+  apps="$home/.local/share/applications"
+  if [ -d "$home/.local/share" ] && [ -d "$apps" ] &&
+    [ ! -L "$home/.local/share" ] && [ ! -L "$apps" ] &&
+    [ "$(stat -c %u "$home/.local/share")" = "$expected_uid" ] &&
+    [ "$(stat -c %u "$apps")" = "$expected_uid" ]; then
+    archive_launcher "$apps/codexhub.desktop"
+    archive_launcher "$apps/com.codexhub.app.desktop"
+  fi
+  archive_legacy_command "$home" "$expected_uid"
 }
 
 dispatch_cleanup() {
@@ -132,11 +199,19 @@ if [ "${1-}" = "--test-home" ]; then
   exit 0
 fi
 
+if [ "${1-}" = "--test-system-launcher" ]; then
+  [ "$#" -eq 2 ] || exit 2
+  write_package_launcher "$2"
+  exit 0
+fi
+
 if [ "${1-}" = "--test-passwd" ]; then
   [ "$#" -eq 3 ] || exit 2
   cleanup_passwd_users "$3" 0 < "$2"
   exit 0
 fi
+
+write_package_launcher /usr/share/applications/CodexHub.desktop
 
 invoking_uid=${PKEXEC_UID:-${SUDO_UID:-}}
 case "$invoking_uid" in

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "CodexHub",
-  "version": "0.1.9-beta.3.8",
+  "version": "0.1.9-beta.3.9",
   "identifier": "com.codexhub.app",
   "build": {
     "frontendDist": "../frontend/dist",

--- a/tests/test_linux_window_input_contract.py
+++ b/tests/test_linux_window_input_contract.py
@@ -82,6 +82,88 @@ X-GNOME-UsesNotifications=true
         assert (apps / f"{name}.codexhub-legacy-backup").read_text(encoding="utf-8") == legacy
 
 
+def test_deb_postinstall_pins_the_package_launcher_to_usr_bin(tmp_path: Path) -> None:
+    hook = ROOT / "src-tauri" / "linux" / "deb-postinstall.sh"
+    launcher = tmp_path / "CodexHub.desktop"
+    launcher.write_text(
+        """[Desktop Entry]
+Categories=
+Comment=CodexHub desktop backend and CLI
+Exec=codexhub
+StartupWMClass=codexhub
+Icon=codexhub
+Name=CodexHub
+Terminal=false
+Type=Application
+""",
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        ["sh", str(hook), "--test-system-launcher", str(launcher)],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    content = launcher.read_text(encoding="utf-8")
+    assert "Exec=/usr/bin/codexhub\n" in content
+    assert "StartupWMClass=com.codexhub.app\n" in content
+    assert "Exec=codexhub\n" not in content
+
+
+def test_deb_launcher_migration_archives_the_owned_legacy_appimage_command(tmp_path: Path) -> None:
+    hook = ROOT / "src-tauri" / "linux" / "deb-postinstall.sh"
+    (tmp_path / ".local" / "share" / "applications").mkdir(parents=True)
+    local_bin = tmp_path / ".local" / "bin"
+    local_bin.mkdir()
+    applications = tmp_path / "Applications"
+    applications.mkdir()
+    appimage = applications / "CodexHub.AppImage"
+    appimage.write_bytes(b"legacy appimage")
+    command = local_bin / "codexhub"
+    command.symlink_to(appimage)
+
+    result = subprocess.run(
+        ["sh", str(hook), "--test-home", str(tmp_path)],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert not command.exists()
+    backup = command.with_name("codexhub.codexhub-legacy-backup")
+    assert backup.is_symlink()
+    assert backup.resolve() == appimage
+    assert appimage.read_bytes() == b"legacy appimage"
+
+
+def test_deb_launcher_migration_preserves_a_custom_local_command(tmp_path: Path) -> None:
+    hook = ROOT / "src-tauri" / "linux" / "deb-postinstall.sh"
+    (tmp_path / ".local" / "share" / "applications").mkdir(parents=True)
+    local_bin = tmp_path / ".local" / "bin"
+    local_bin.mkdir()
+    command = local_bin / "codexhub"
+    command.symlink_to("/custom/codexhub")
+
+    result = subprocess.run(
+        ["sh", str(hook), "--test-home", str(tmp_path)],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert command.is_symlink()
+    assert os.readlink(command) == "/custom/codexhub"
+    assert not command.with_name("codexhub.codexhub-legacy-backup").exists()
+
+
 def test_deb_launcher_migration_refuses_symlinked_home_ancestors(tmp_path: Path) -> None:
     hook = ROOT / "src-tauri" / "linux" / "deb-postinstall.sh"
     home = tmp_path / "home"

--- a/tests/test_python_runtime.py
+++ b/tests/test_python_runtime.py
@@ -280,7 +280,7 @@ def test_relative_windows_entrypoints_keep_the_repository_runtime_contract() -> 
         "-DryRun",
     )
     assert portable_plan.returncode == 0, portable_plan.stdout + portable_plan.stderr
-    assert '"version":"0.1.9-beta.3.8"' in portable_plan.stdout
+    assert '"version":"0.1.9-beta.3.9"' in portable_plan.stdout
 
     runtime_check = _run_relative_powershell_script(
         r".\scripts\Prepare-PythonRuntime.ps1", "-CheckOnly"

--- a/tests/test_release_channel_scripts.py
+++ b/tests/test_release_channel_scripts.py
@@ -44,7 +44,7 @@ def test_official_transport_wheel_is_pinned_and_packaged():
 
 
 def test_release_version_is_consistent_across_manifests():
-    expected = "0.1.9-beta.3.8"
+    expected = "0.1.9-beta.3.9"
     tauri = json.loads((ROOT / "src-tauri" / "tauri.conf.json").read_text(encoding="utf-8"))
     cargo = tomllib.loads((ROOT / "src-tauri" / "Cargo.toml").read_text(encoding="utf-8"))
     cargo_lock = tomllib.loads((ROOT / "src-tauri" / "Cargo.lock").read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary
- bump the corrected candidate to 0.1.9-beta.3.9 instead of mutating published 3.8 assets
- atomically normalize the package-owned desktop entry to Exec=/usr/bin/codexhub and the stable WM class
- recoverably archive only a user-owned ~/.local/bin/codexhub link that resolves exactly to ~/Applications/CodexHub.AppImage
- preserve the old AppImage payload and all custom command targets

## Root cause
The deb package used a stable package identity, but Tauri generated Exec=codexhub. This host still had ~/.local/bin/codexhub pointing to an older AppImage, so desktop PATH resolution could launch version 3.5 even after the deb was upgraded.

## Verification
- TDD red: package launcher test and exact legacy AppImage command migration test failed before implementation
- targeted: 28 passed, 100 skipped
- full ./scripts/verify-linux.sh: PASS
  - Python 2080 passed, 111 skipped, 285 subtests
  - 2341/2341 partition coverage, disjoint and complete
  - Rust 597 passed, 4 ignored
  - clippy passed
  - physical pointer E2E passed, 13 clicks, full 820x620 input region
- shellcheck passed
- built 3.9 deb, extracted its packaged postinst, executed the packaged test entrypoint against its desktop file, and verified Exec=/usr/bin/codexhub plus mode 0644

GitHub Actions CI is currently disabled manually for this repository; the documented full local Linux gate was used.