### PR TITLE
fix: ship 0.1.9-beta.3.11 xAI, Gateway, and Linux desktop follow-ups

### DIFF
--- a/docs/agents/linux-packaging.md
+++ b/docs/agents/linux-packaging.md
@@ -16,7 +16,9 @@ Each flavor produces:
 
 The Debian package identity is always `codex-hub`, so `apt`/`dpkg` upgrades
 replace the installed package instead of creating side-by-side versions. The
-package owns the single `/usr/share/applications/CodexHub.desktop` launcher.
+package owns the visible `/usr/share/applications/CodexHub.desktop` launcher
+and hidden identity files `com.codexhub.app.desktop` and `codexhub.desktop`
+so GNOME can map the running Wayland window without a second app-grid entry.
 Its recoverable post-install migration archives exact legacy CodexHub-generated
 user launchers as `*.codexhub-legacy-backup`; customized desktop entries are
 left untouched. The package launcher is atomically normalized to

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codexhub-frontend",
-  "version": "0.1.9-beta.3.10",
+  "version": "0.1.9-beta.3.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codexhub-frontend",
-      "version": "0.1.9-beta.3.10",
+      "version": "0.1.9-beta.3.11",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codexhub-frontend",
   "private": true,
-  "version": "0.1.9-beta.3.10",
+  "version": "0.1.9-beta.3.11",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/frontend/scripts/ui-contract.test.mjs
+++ b/frontend/scripts/ui-contract.test.mjs
@@ -1228,11 +1228,14 @@ test("official OpenAI usage chart reads cached Codex account usage only on the o
   assert.match(providersSource, /storeOfficialOpenAIUsageSnapshot\(snapshot\)/);
   assert.match(providersSource, /async function primeOfficialOpenAIUsage\(\)/);
   assert.match(providersSource, /await loadOfficialOpenAIUsage\(false, false, undefined, \{ showBusy: false \}\)/);
-  assert.match(providersSource, /void loadOfficialOpenAIUsage\(false\)/);
+  assert.match(providersSource, /void loadOfficialOpenAIUsage\(false, false, undefined, \{ showBusy: false \}\)/);
   assert.match(providersSource, /async function loadOfficialOpenAIUsage\([\s\S]*forceRefresh = true[\s\S]*notify = false[\s\S]*toastId\?: string[\s\S]*options\?: \{ showBusy\?: boolean \}/);
   assert.match(providersSource, /api\.openaiUsageCompletions\(\{[\s\S]*forceRefresh[\s\S]*\}\)/);
   assert.match(providersSource, /void primeOfficialOpenAIUsage\(\)/);
-  assert.match(providersSource, /window\.setInterval\(\(\) => void loadOfficialOpenAIUsage\(false\), OPENAI_USAGE_REFRESH_INTERVAL_MS\)/);
+  assert.match(
+    providersSource,
+    /window\.setInterval\(\s*\(\) => void loadOfficialOpenAIUsage\(false, false, undefined, \{ showBusy: false \}\),\s*OPENAI_USAGE_REFRESH_INTERVAL_MS,\s*\)/,
+  );
   assert.match(providersSource, /if \(officialUsageSnapshotRef\.current\) \{[\s\S]*setOfficialUsageError\(null\);[\s\S]*setOfficialUsageHidden\(false\);[\s\S]*return;[\s\S]*\}/);
   assert.match(providersSource, /selectedId === OFFICIAL_ID[\s\S]*loadOfficialOpenAIUsage/);
   assert.match(providersSource, /if \(selectedId !== OFFICIAL_ID \|\| codexAuthState !== "authorized"\) \{/);
@@ -2028,6 +2031,12 @@ test("settings save restarts running gateway when retry or image proxy runtime s
   assert.doesNotMatch(appSource, /setBanner\(saveMessage\)/);
 });
 
+test("gateway client card shows the Codex App logo", async () => {
+  const cardSource = await readFile(gatewayClientCardPath, "utf8");
+  assert.match(cardSource, /import codexIcon from "\.\.\/assets\/codex-logo\.svg"/);
+  assert.match(cardSource, /case "codex":/);
+});
+
 test("gateway client card does not render a disabled fake updater", async () => {
   const cardSource = await readFile(gatewayClientCardPath, "utf8");
 
@@ -2332,13 +2341,17 @@ test("Luna Collaboration selector shows only V1/V2 and marks the live catalog de
   ]);
   const modelSection = providersSource.match(/function ModelSection[\s\S]*?function providerQualifiedModelId/)?.[0] ?? "";
 
-  assert.match(modelSection, /value=\{collaboration\.effective\}/);
+  assert.match(modelSection, /data-value=\{collaboration\.effective\}/);
   assert.match(modelSection, /officialCollaborationVersionOptions\([\s\S]*officialCollaborationBaselines/);
-  assert.equal([...modelSection.matchAll(/<option value="v[12]">/g)].length, 2);
-  assert.doesNotMatch(modelSection, /<option value="">/);
+  const collaborationChip = modelSection.match(/function CollaborationVersionChip[\s\S]*?function ModelCapabilityChip/)?.[0] ?? "";
+  assert.ok(collaborationChip, "CollaborationVersionChip should be present");
+  assert.doesNotMatch(collaborationChip, /<select/);
+  assert.match(collaborationChip, /<ChevronDown/);
+  assert.match(modelSection, /rounded-panel bg-surface p-1 shadow-floating/);
+  assert.equal([...modelSection.matchAll(/value: "v[12]" as const/g)].length, 2);
   assert.match(modelSection, /collaboration\.baseline === "v1"/);
   assert.match(modelSection, /collaboration\.baseline === "v2"/);
-  assert.match(modelSection, /selected === collaboration\.baseline \? null : selected/);
+  assert.match(modelSection, /selectedVersion === collaboration\.baseline \? null : selectedVersion/);
   assert.match(enSource, /collaborationVersionDefault: "\(Default\)"/);
   assert.match(zhSource, /collaborationVersionDefault: "（默认）"/);
 });

--- a/frontend/src/components/GatewayClientCard.tsx
+++ b/frontend/src/components/GatewayClientCard.tsx
@@ -5,6 +5,7 @@ import opencodeIcon from "../assets/opencode-icon.png";
 import piIcon from "../assets/pi-icon.png";
 import dshIcon from "../assets/dsh-icon.svg";
 import zcodeIcon from "../assets/zcode-icon.png";
+import codexIcon from "../assets/codex-logo.svg";
 import { cx } from "../lib/format";
 import type { GatewayClientContract, GatewayClientInfo } from "../lib/types";
 import { SwitchControl } from "./SettingsDrawer";
@@ -204,6 +205,10 @@ function ClientLogo({ id, name }: { id: string; name: string }) {
 
 function clientIcon(id: string) {
   switch (id) {
+    case "codex":
+    case "codex-app":
+    case "chatgpt":
+      return codexIcon;
     case "dsh":
       return dshIcon;
     case "opencode":
@@ -220,7 +225,7 @@ function clientIcon(id: string) {
 }
 
 function clientIconClass(id: string) {
-  if (id === "dsh") {
+  if (id === "codex" || id === "dsh") {
     return "h-8 w-8 object-contain";
   }
   if (id === "pi") {

--- a/frontend/src/components/providers/ProviderModelSection.tsx
+++ b/frontend/src/components/providers/ProviderModelSection.tsx
@@ -1,6 +1,6 @@
-import { Brain, Cable, Check, Copy, Eye, Plus, RefreshCcw, Trash2, X } from "lucide-react";
+import { Brain, Cable, Check, ChevronDown, Copy, Eye, Plus, RefreshCcw, Trash2, X } from "lucide-react";
 import type * as React from "react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { SortableList } from "../SortableList";
 import { useVerticalOverflow } from "../../hooks/useVerticalOverflow";
@@ -156,42 +156,13 @@ export function ModelSection({
           if (!collaboration) {
             return null;
           }
-          const overridden = collaboration.explicit !== null;
           return (
-            <label
-              className={cx(
-                "inline-flex h-7 items-center gap-1 rounded-full border px-2 text-[11px] font-semibold",
-                overridden
-                  ? "border-action/40 bg-blue-50 text-action"
-                  : "border-line bg-panel text-slate-600",
-              )}
-              title={t("providers.collaborationVersionDetails", {
-                baseline: collaboration.baseline,
-                effective: collaboration.effective,
-              })}
-              onClick={(event) => event.stopPropagation()}
-            >
-              <span>{t("providers.collaborationVersion")}</span>
-              <select
-                className="h-5 bg-transparent text-[11px] font-semibold outline-none"
-                value={collaboration.effective}
-                disabled={interactionDisabled}
-                aria-label={t("providers.collaborationVersionForModel", { model: model.id })}
-                onChange={(event) => {
-                  event.stopPropagation();
-                  const selected = event.target.value === "v1" || event.target.value === "v2"
-                    ? event.target.value
-                    : null;
-                  onOfficialCollaborationVersionChange(
-                    model.id,
-                    selected === collaboration.baseline ? null : selected,
-                  );
-                }}
-              >
-                <option value="v1">V1{collaboration.baseline === "v1" ? ` ${t("providers.collaborationVersionDefault")}` : ""}</option>
-                <option value="v2">V2{collaboration.baseline === "v2" ? ` ${t("providers.collaborationVersionDefault")}` : ""}</option>
-              </select>
-            </label>
+            <CollaborationVersionChip
+              collaboration={collaboration}
+              disabled={interactionDisabled}
+              modelId={model.id}
+              onChange={onOfficialCollaborationVersionChange}
+            />
           );
         })()}
         {disabled && onToggleOfficialModel && (
@@ -664,6 +635,102 @@ function CapabilityChip({ icon, label, title }: { icon?: React.ReactNode; label:
       {icon}
       {label}
     </span>
+  );
+}
+
+function CollaborationVersionChip({
+  collaboration,
+  disabled,
+  modelId,
+  onChange,
+}: {
+  collaboration: { baseline: "v1" | "v2"; effective: "v1" | "v2"; explicit: "v1" | "v2" | null };
+  disabled: boolean;
+  modelId: string;
+  onChange: (modelId: string, version: "v1" | "v2" | null) => void;
+}) {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const overridden = collaboration.explicit !== null;
+  const options = [
+    { value: "v1" as const, label: `V1${collaboration.baseline === "v1" ? ` ${t("providers.collaborationVersionDefault")}` : ""}` },
+    { value: "v2" as const, label: `V2${collaboration.baseline === "v2" ? ` ${t("providers.collaborationVersionDefault")}` : ""}` },
+  ];
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    function onPointerDown(event: PointerEvent) {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("pointerdown", onPointerDown);
+    return () => document.removeEventListener("pointerdown", onPointerDown);
+  }, [open]);
+
+  return (
+    <div
+      ref={rootRef}
+      className="relative"
+      data-value={collaboration.effective}
+      onClick={(event) => event.stopPropagation()}
+      onKeyDown={(event) => event.stopPropagation()}
+    >
+      <button
+        type="button"
+        className={cx(
+          "inline-flex h-6 items-center gap-1 rounded-full border px-2 text-[11px] font-semibold leading-none",
+          overridden ? "border-action/40 bg-blue-50 text-action" : "border-line bg-panel text-slate-600",
+        )}
+        disabled={disabled}
+        aria-expanded={open}
+        aria-haspopup="listbox"
+        aria-label={t("providers.collaborationVersionForModel", { model: modelId })}
+        title={t("providers.collaborationVersionDetails", {
+          baseline: collaboration.baseline,
+          effective: collaboration.effective,
+        })}
+        onClick={() => setOpen((current) => !current)}
+      >
+        <span className="leading-none">{t("providers.collaborationVersion")}</span>
+        <span className="leading-none text-ink">{collaboration.effective.toUpperCase()}</span>
+        <ChevronDown size={12} className={cx("text-slate-500 transition-transform", open && "rotate-180")} />
+      </button>
+      {open && (
+        <div
+          className="absolute right-0 top-7 z-20 min-w-[136px] space-y-1 rounded-panel bg-surface p-1 shadow-floating"
+          role="listbox"
+        >
+          {options.map((option) => {
+            const selected = collaboration.effective === option.value;
+            return (
+              <button
+                key={option.value}
+                type="button"
+                role="option"
+                aria-selected={selected}
+                className={
+                  selected
+                    ? "flex h-7 w-full items-center justify-between rounded-control bg-panel px-2.5 text-left text-[11px] font-semibold text-ink"
+                    : "flex h-7 w-full items-center justify-between rounded-control px-2.5 text-left text-[11px] font-semibold text-ink hover:bg-panel"
+                }
+                onClick={() => {
+                  setOpen(false);
+                  const selectedVersion = option.value;
+                  onChange(modelId, selectedVersion === collaboration.baseline ? null : selectedVersion);
+                }}
+              >
+                {option.label}
+                {selected ? <Check size={14} /> : null}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/frontend/src/pages/ProvidersPage.tsx
+++ b/frontend/src/pages/ProvidersPage.tsx
@@ -294,7 +294,10 @@ function ProvidersPageImpl({
       return;
     }
     void primeOfficialOpenAIUsage();
-    const usageRefreshTimer = window.setInterval(() => void loadOfficialOpenAIUsage(false), OPENAI_USAGE_REFRESH_INTERVAL_MS);
+    const usageRefreshTimer = window.setInterval(
+      () => void loadOfficialOpenAIUsage(false, false, undefined, { showBusy: false }),
+      OPENAI_USAGE_REFRESH_INTERVAL_MS,
+    );
     return () => window.clearInterval(usageRefreshTimer);
   }, [codexAuthState, selectedId]);
 
@@ -499,7 +502,7 @@ function ProvidersPageImpl({
     if (!officialUsageSnapshotRef.current) {
       await loadOfficialOpenAIUsage(false, false, undefined, { showBusy: false });
     }
-    void loadOfficialOpenAIUsage(false);
+    void loadOfficialOpenAIUsage(false, false, undefined, { showBusy: false });
   }
 
   async function loadOfficialOpenAIUsage(

--- a/src-python/config_overlay.py
+++ b/src-python/config_overlay.py
@@ -1084,6 +1084,20 @@ def apply_overlay(
     ) + cleaned.lstrip()
     updated = insert_provider_section(updated, build_provider_section(base_url, gateway_key))
     atomic_write_text(config_path, updated, encoding="utf-8")
+    _repair_codex_desktop_global_state(config_path, backup_path)
+
+
+def _repair_codex_desktop_global_state(config_path: Path, backup_path: Path) -> None:
+    # Codex Desktop stores the selected remote host outside config.toml. Leaving
+    # a stale remote-ssh/remote-control selection after Gateway overlay makes
+    # the App keep retrying chatgpt.com remote-control websockets and show a
+    # connection timeout even though the local Gateway is healthy.
+    state_path = config_path.parent / ".codex-global-state.json"
+    if not state_path.exists():
+        return
+    from global_state_repair import repair_global_state
+
+    repair_global_state(state_path, backup_path.parent / f"{backup_path.name}.global-state")
 
 
 def _preserve_user_catalog_path(current: str, restored: str) -> str:

--- a/src-python/gateway_compat/host.py
+++ b/src-python/gateway_compat/host.py
@@ -15,6 +15,7 @@ from gateway_request import (
     reasoning_param_is_unsupported as _reasoning_param_is_unsupported,
     sanitize_official_input_reasoning_items as _sanitize_official_input_reasoning_items,
     sanitize_official_reasoning_items as _sanitize_official_reasoning_items,
+    sanitize_third_party_reasoning_items as _sanitize_third_party_reasoning_items,
     strip_reasoning_encrypted_content as _strip_reasoning_encrypted_content,
 )
 from gateway_stream_semantics import (

--- a/src-python/gateway_compat/request.py
+++ b/src-python/gateway_compat/request.py
@@ -975,6 +975,11 @@ def compatible_request_body(
         if _official_passthrough._apply_ollama_reasoning_effort_alias(payload):
             changed = True
 
+    if _response._sanitize_unsupported_compaction_input_items(payload):
+        changed = True
+    if host._sanitize_third_party_reasoning_items(payload):
+        changed = True
+
     if not changed:
         return body
     return json.dumps(payload, ensure_ascii=True, separators=(",", ":")).encode("utf-8")

--- a/src-python/gateway_request.py
+++ b/src-python/gateway_request.py
@@ -263,6 +263,90 @@ def strip_reasoning_encrypted_content(value: Any) -> bool:
 _strip_reasoning_encrypted_content = strip_reasoning_encrypted_content
 
 
+def _third_party_reasoning_part_text(part: Any) -> str | None:
+    if isinstance(part, str) and part:
+        return part
+    if not isinstance(part, dict):
+        return None
+    for key in ("text", "summary"):
+        value = part.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def _third_party_reasoning_summary_parts(value: Any) -> list[dict[str, str]]:
+    if value is None:
+        return []
+    if isinstance(value, str) and value:
+        return [{"type": "summary_text", "text": value}]
+    if not isinstance(value, list):
+        return []
+    parts: list[dict[str, str]] = []
+    for item in value:
+        text = _third_party_reasoning_part_text(item)
+        if text:
+            parts.append({"type": "summary_text", "text": text})
+    return parts
+
+
+def sanitize_third_party_reasoning_items(value: Any) -> bool:
+    # Codex App history stores Official/xAI reasoning blobs that other
+    # Responses providers cannot decrypt, plus content: null which xAI rejects
+    # as "invalid type: null, expected a sequence".
+    changed = False
+
+    if isinstance(value, list):
+        index = 0
+        while index < len(value):
+            item = value[index]
+            if isinstance(item, dict) and item.get("type") == "encrypted_content":
+                del value[index]
+                changed = True
+                continue
+            if sanitize_third_party_reasoning_items(item):
+                changed = True
+            index += 1
+        return changed
+
+    if not isinstance(value, dict):
+        return False
+
+    include = value.get("include")
+    if isinstance(include, list):
+        filtered = [item for item in include if item != "reasoning.encrypted_content"]
+        if len(filtered) != len(include):
+            if filtered:
+                value["include"] = filtered
+            else:
+                value.pop("include", None)
+            changed = True
+
+    if value.get("type") == "reasoning":
+        if "encrypted_content" in value:
+            value.pop("encrypted_content", None)
+            changed = True
+        summary_parts = _third_party_reasoning_summary_parts(value.get("summary"))
+        content_parts = _third_party_reasoning_summary_parts(value.get("content"))
+        if not summary_parts:
+            summary_parts = content_parts
+        if value.get("content") != []:
+            value["content"] = []
+            changed = True
+        if value.get("summary") != summary_parts:
+            value["summary"] = summary_parts
+            changed = True
+
+    for nested in list(value.values()):
+        if sanitize_third_party_reasoning_items(nested):
+            changed = True
+
+    return changed
+
+
+_sanitize_third_party_reasoning_items = sanitize_third_party_reasoning_items
+
+
 def has_browser_context_signal(value: Any) -> bool:
     for fragment in _stream_semantics.collect_text_fragments(value):
         lowered = fragment.lower()

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -494,10 +494,11 @@ dependencies = [
 
 [[package]]
 name = "codexhub"
-version = "0.1.9-beta.3.10"
+version = "0.1.9-beta.3.11"
 dependencies = [
  "cairo-rs",
  "dirs 5.0.1",
+ "gdk-pixbuf",
  "glib",
  "gtk",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codexhub"
-version = "0.1.9-beta.3.10"
+version = "0.1.9-beta.3.11"
 description = "CodexHub desktop backend and CLI"
 authors = ["CodexHub"]
 license = "MIT"
@@ -44,6 +44,7 @@ serde_yaml = "0.9"
 gtk = { version = "0.18", features = ["v3_24"] }
 glib = "0.18"
 cairo-rs = "0.18"
+gdk-pixbuf = "0.18"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.59", features = [

--- a/src-tauri/linux/deb-postinstall.sh
+++ b/src-tauri/linux/deb-postinstall.sh
@@ -212,6 +212,22 @@ if [ "${1-}" = "--test-passwd" ]; then
 fi
 
 write_package_launcher /usr/share/applications/CodexHub.desktop
+write_package_launcher /usr/share/applications/com.codexhub.app.desktop
+write_package_launcher /usr/share/applications/codexhub.desktop
+for identity in /usr/share/applications/com.codexhub.app.desktop /usr/share/applications/codexhub.desktop; do
+  if [ -f "$identity" ] && ! grep -q '^NoDisplay=' "$identity"; then
+    printf '%s
+' 'NoDisplay=true' >> "$identity"
+  fi
+done
+for icon in /usr/share/icons/hicolor/*/apps/codexhub.png; do
+  [ -f "$icon" ] || continue
+  cp -f -- "$icon" "${icon%/*}/com.codexhub.app.png"
+done
+if [ -f /usr/share/icons/hicolor/index.theme ]; then
+  gtk-update-icon-cache -f /usr/share/icons/hicolor >/dev/null 2>&1 || true
+fi
+update-desktop-database /usr/share/applications >/dev/null 2>&1 || true
 
 invoking_uid=${PKEXEC_UID:-${SUDO_UID:-}}
 case "$invoking_uid" in

--- a/src-tauri/src/linux_window.rs
+++ b/src-tauri/src/linux_window.rs
@@ -14,8 +14,9 @@ const APPIMAGE_DESKTOP_FILE: &str = "com.codexhub.app.desktop";
 const LEGACY_DESKTOP_FILE: &str = "codexhub.desktop";
 
 pub fn install(app: &tauri::App) {
-    glib::set_prgname(Some("codexhub"));
+    glib::set_prgname(Some("com.codexhub.app"));
     glib::set_application_name("CodexHub");
+    gdk::set_program_class("com.codexhub.app");
     install_desktop_entry();
     install_hicolor_icon();
     let Some(window) = app.get_webview_window("main") else {
@@ -52,6 +53,7 @@ fn configure_shell(window: &WebviewWindow) -> Result<(), String> {
         }
     }
     let _ = window.set_skip_taskbar(false);
+    apply_window_icon(&gtk_window);
     apply_opaque_window_css(&gtk_window);
     hook_full_input_region(&gtk_window);
     fill_webview_on_resize(&gtk_window);
@@ -157,6 +159,15 @@ fn resize_native_children(gtk_window: &gtk::ApplicationWindow, width: i32, heigh
     };
     for child in gdk_window.children() {
         child.move_resize(0, 0, width, height);
+    }
+}
+
+fn apply_window_icon(gtk_window: &gtk::ApplicationWindow) {
+    gtk::Window::set_default_icon_name("codexhub");
+    gtk_window.set_icon_name(Some("codexhub"));
+    if let Ok(pixbuf) = gdk_pixbuf::Pixbuf::from_read(std::io::Cursor::new(APP_ICON_PNG)) {
+        gtk::Window::set_default_icon(&pixbuf);
+        gtk_window.set_icon(Some(&pixbuf));
     }
 }
 

--- a/src-tauri/src/openai_usage.rs
+++ b/src-tauri/src/openai_usage.rs
@@ -411,7 +411,7 @@ fn enrich_usage_with_local_rate_limits(
     usage: &mut CodexAccountUsageResponse,
     rate_limit_dir: Option<&Path>,
 ) {
-    if response_has_usage_limits(usage) {
+    if usage_has_windowed_quotas(usage) {
         return;
     }
     let Some(codex_dir) = rate_limit_dir else {
@@ -422,16 +422,27 @@ fn enrich_usage_with_local_rate_limits(
     }
 }
 
-fn response_has_usage_limits(usage: &CodexAccountUsageResponse) -> bool {
+fn usage_has_windowed_quotas(usage: &CodexAccountUsageResponse) -> bool {
+    fn is_windowed(limit: &CodexAccountUsageLimit) -> bool {
+        let text = format!(
+            "{} {} {}",
+            limit.id.as_deref().unwrap_or(""),
+            limit.period.as_deref().unwrap_or(""),
+            limit.name.as_deref().unwrap_or("")
+        )
+        .to_ascii_lowercase();
+        text.contains("week")
+            || ((text.contains('5') || text.contains("five")) && text.contains("hour"))
+    }
     usage
         .usage_limits
         .as_ref()
-        .is_some_and(|limits| !limits.is_empty())
+        .is_some_and(|limits| limits.iter().any(is_windowed))
         || usage
             .summary
             .usage_limits
             .as_ref()
-            .is_some_and(|limits| !limits.is_empty())
+            .is_some_and(|limits| limits.iter().any(is_windowed))
 }
 
 #[derive(Debug)]
@@ -1500,6 +1511,49 @@ mod tests {
         assert_eq!(snapshot.limits.len(), 2);
         assert_eq!(snapshot.limits[0].period, "five_hours");
         assert_eq!(snapshot.limits[0].used, Some(26.0));
+        assert_eq!(snapshot.limits[1].period, "week");
+        assert_eq!(snapshot.limits[1].remaining, Some(96.0));
+    }
+
+    #[test]
+    fn primary_credits_account_limits_still_enrich_windowed_local_quotas() {
+        let root = temp_root("openai-usage-primary-credits-enrich");
+        let cache_path = root.join("proxy").join("usage-cache.json");
+        let sessions_dir = root.join("sessions").join("2026").join("07").join("07");
+        fs::create_dir_all(&sessions_dir).unwrap();
+        fs::write(
+            sessions_dir.join("rollout.jsonl"),
+            r#"{"timestamp":"2026-07-07T03:55:58.964Z","type":"event_msg","payload":{"type":"token_count","rate_limits":{"limit_id":"codex","primary":{"used_percent":26,"window_minutes":300,"resets_at":1783406493},"secondary":{"used_percent":4,"window_minutes":10080,"resets_at":1783993293},"plan_type":"pro"}}}"#,
+        )
+        .unwrap();
+        write_test_cache(
+            &cache_path,
+            10_000,
+            r#"{
+              "summary": { "lifetimeTokens": 41 },
+              "usageLimits": [
+                {"id": "primary", "period": "primary", "limit": 100, "used": 3, "remaining": 97, "resetsAt": "1788643292"},
+                {"id": "credits", "period": "credits", "limit": 100, "used": 0, "remaining": 100}
+              ],
+              "dailyUsageBuckets": [
+                {"startDate": "2026-07-06", "tokens": 41}
+              ]
+            }"#,
+        );
+
+        let snapshot = openai_usage_completions_with_cache_and_rate_limit_dir(
+            1_783_296_000,
+            1_783_382_400,
+            false,
+            &cache_path,
+            Some(&root),
+            10_000,
+            || panic!("fresh cache should not refresh"),
+        )
+        .expect("primary/credits cache should still overlay week/five-hour windows");
+
+        assert_eq!(snapshot.limits.len(), 2);
+        assert_eq!(snapshot.limits[0].period, "five_hours");
         assert_eq!(snapshot.limits[1].period, "week");
         assert_eq!(snapshot.limits[1].remaining, Some(96.0));
     }

--- a/src-tauri/src/proxy.rs
+++ b/src-tauri/src/proxy.rs
@@ -3160,12 +3160,25 @@ fn child_process_start_id(child: &Child) -> Result<String, String> {
 
 #[cfg(not(windows))]
 fn child_process_start_id(child: &Child) -> Result<String, String> {
-    match inspect_process(child.id())? {
-        InspectedProcess::Running(info) => info
-            .process_start_id
-            .ok_or_else(|| "spawned Gateway process has no process creation identity".to_string()),
-        InspectedProcess::Missing => Err("spawned Gateway process disappeared".to_string()),
-    }
+    linux_process_start_id(child.id())
+}
+
+#[cfg(not(windows))]
+fn linux_process_start_id(pid: u32) -> Result<String, String> {
+    let stat = match fs::read_to_string(format!("/proc/{pid}/stat")) {
+        Ok(stat) => stat,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            return Err(format!("Gateway process {pid} disappeared"));
+        }
+        Err(error) => {
+            return Err(format!(
+                "failed to read Gateway process creation identity from /proc/{pid}/stat: {error}"
+            ));
+        }
+    };
+    process_start_ticks(&stat)
+        .map(|ticks| format!("proc-start-ticks:{ticks}"))
+        .ok_or_else(|| format!("Gateway process {pid} /proc/stat is missing starttime"))
 }
 
 #[cfg(windows)]
@@ -3343,23 +3356,19 @@ fn inspect_process(pid: u32) -> Result<InspectedProcess, String> {
         }
     };
 
-    if bytes.is_empty() {
-        return Ok(InspectedProcess::Running(
-            ProcessInfo::from_args(Vec::new()),
-        ));
-    }
-
     let args = bytes
         .split(|byte| *byte == 0)
         .filter(|part| !part.is_empty())
         .map(|part| String::from_utf8_lossy(part).to_string())
         .collect::<Vec<_>>();
-    let process_start_id = fs::read_to_string(format!("/proc/{pid}/stat"))
-        .ok()
-        .and_then(|stat| process_start_ticks(&stat).map(str::to_string))
-        .map(|ticks| format!("proc-start-ticks:{ticks}"));
     let mut info = ProcessInfo::from_args(args);
-    info.process_start_id = process_start_id;
+    // Command line can be empty for zombies, mid-exec children, and some
+    // Python shutdown races. Creation identity still lives in /proc/pid/stat.
+    info.process_start_id = match linux_process_start_id(pid) {
+        Ok(process_start_id) => Some(process_start_id),
+        Err(_) if bytes.is_empty() => None,
+        Err(error) => return Err(error),
+    };
     Ok(InspectedProcess::Running(info))
 }
 
@@ -3535,6 +3544,90 @@ mod tests {
             }
             panic!("process {pid} did not disappear within the bounded window: {last}");
         }
+    }
+
+    #[cfg(not(windows))]
+    fn spawn_unreaped_child(program: &str, args: &[&str]) -> std::process::Child {
+        std::process::Command::new(program)
+            .args(args)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .unwrap_or_else(|error| panic!("failed to spawn {program}: {error}"))
+    }
+
+    #[cfg(not(windows))]
+    fn wait_until_zombie(pid: u32) {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while Instant::now() < deadline {
+            if let Ok(stat) = fs::read_to_string(format!("/proc/{pid}/stat")) {
+                if super::process_start_ticks(&stat).is_some()
+                    && stat
+                        .rsplit_once(')')
+                        .and_then(|(_, rest)| rest.split_whitespace().next())
+                        == Some("Z")
+                {
+                    return;
+                }
+            }
+            thread::sleep(Duration::from_millis(5));
+        }
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn linux_spawned_child_has_process_creation_identity() {
+        let mut child = spawn_unreaped_child("sleep", &["5"]);
+        let start_id = super::child_process_start_id(&child);
+        let _ = child.kill();
+        let _ = child.wait();
+        let start_id = start_id.expect("spawned child should have a process creation identity");
+        assert!(
+            start_id.starts_with("proc-start-ticks:"),
+            "unexpected start identity {start_id}"
+        );
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn linux_spawned_zombie_keeps_process_creation_identity() {
+        let mut child = spawn_unreaped_child("true", &[]);
+        let pid = child.id();
+        wait_until_zombie(pid);
+        let cmdline = fs::read(format!("/proc/{pid}/cmdline")).unwrap_or_default();
+        assert!(
+            cmdline.is_empty(),
+            "zombie cmdline should be empty so this matches the Linux spawn race; got {cmdline:?}"
+        );
+        let start_id = super::child_process_start_id(&child);
+        let inspected = super::inspect_process(pid);
+        let _ = child.wait();
+        let start_id = start_id.unwrap_or_else(|error| {
+            panic!("spawned Gateway process has no process creation identity: {error}")
+        });
+        assert!(
+            start_id.starts_with("proc-start-ticks:"),
+            "unexpected start identity {start_id}"
+        );
+        match inspected.expect("zombie /proc entry should still be inspectable") {
+            InspectedProcess::Running(info) => {
+                assert_eq!(info.process_start_id.as_deref(), Some(start_id.as_str()));
+            }
+            InspectedProcess::Missing => {
+                panic!("zombie should not be reported missing before wait")
+            }
+        }
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn process_start_ticks_reads_starttime_after_comm() {
+        let stat = "1234 (python3.13) S 1 1 1 0 -1 4194304 0 0 0 0 0 0 0 0 20 0 1 0 987654 0 0\n";
+        assert_eq!(super::process_start_ticks(stat), Some("987654"));
+        let live = fs::read_to_string("/proc/self/stat").expect("read /proc/self/stat");
+        let ticks = super::process_start_ticks(&live).expect("self stat should include starttime");
+        assert!(ticks.chars().all(|ch| ch.is_ascii_digit()), "{ticks}");
     }
 
     #[cfg(windows)]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "CodexHub",
-  "version": "0.1.9-beta.3.10",
+  "version": "0.1.9-beta.3.11",
   "identifier": "com.codexhub.app",
   "build": {
     "frontendDist": "../frontend/dist",

--- a/tests/test_config_overlay.py
+++ b/tests/test_config_overlay.py
@@ -1832,6 +1832,30 @@ class ConfigOverlayTests(unittest.TestCase):
             self.assertIn("# owner = beta", text)
             self.assertIn("http://127.0.0.1:9109/v1", text)
 
+    def test_apply_overlay_clears_stale_remote_host_selection(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            config = tmp / "config.toml"
+            backup = tmp / "backup.toml"
+            catalog = tmp / "catalog.json"
+            state = tmp / ".codex-global-state.json"
+            state.write_text(
+                json.dumps(
+                    {
+                        "selected-remote-host-id": "remote-ssh-discovered:am01",
+                        "project-order": ["keep-me"],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            apply_overlay(config, backup, catalog, "http://127.0.0.1:9099")
+
+            repaired = json.loads(state.read_text(encoding="utf-8"))
+            self.assertNotIn("selected-remote-host-id", repaired)
+            self.assertEqual(repaired["project-order"], ["keep-me"])
+            self.assertTrue((tmp / "backup.toml.global-state").exists())
+
     def test_apply_overlay_rejects_unknown_custom_provider_without_mutation(self):
         original = "\n".join(
             [

--- a/tests/test_python_runtime.py
+++ b/tests/test_python_runtime.py
@@ -304,7 +304,7 @@ def test_relative_windows_entrypoints_keep_the_repository_runtime_contract() -> 
         "-DryRun",
     )
     assert portable_plan.returncode == 0, portable_plan.stdout + portable_plan.stderr
-    assert '"version":"0.1.9-beta.3.10"' in portable_plan.stdout
+    assert '"version":"0.1.9-beta.3.11"' in portable_plan.stdout
 
     runtime_check = _run_relative_powershell_script(
         r".\scripts\Prepare-PythonRuntime.ps1", "-CheckOnly"

--- a/tests/test_release_channel_scripts.py
+++ b/tests/test_release_channel_scripts.py
@@ -44,7 +44,7 @@ def test_official_transport_wheel_is_pinned_and_packaged():
 
 
 def test_release_version_is_consistent_across_manifests():
-    expected = "0.1.9-beta.3.10"
+    expected = "0.1.9-beta.3.11"
     tauri = json.loads((ROOT / "src-tauri" / "tauri.conf.json").read_text(encoding="utf-8"))
     cargo = tomllib.loads((ROOT / "src-tauri" / "Cargo.toml").read_text(encoding="utf-8"))
     cargo_lock = tomllib.loads((ROOT / "src-tauri" / "Cargo.lock").read_text(encoding="utf-8"))

--- a/tests/test_third_party_reasoning_request.py
+++ b/tests/test_third_party_reasoning_request.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import copy
+import json
+import os
+import urllib.error
+import urllib.request
+
+import gateway_compat
+import gateway_request
+from collaboration_runtime_contract import COLLABORATION_V2, EXPECTED_PARAMETER_SCHEMAS
+
+
+PATCH = "*** Begin Patch\n*** Update File: target.txt\n@@\n-before\n+after\n*** End Patch"
+
+
+def _xai_upstream() -> dict[str, str]:
+    return {
+        "name": "xai",
+        "upstream_model": "grok-4.6",
+        "upstream_format": "responses",
+        "tool_protocol": "responses_structured",
+        "tool_surface_strategy": "eager",
+    }
+
+
+def _v2_namespace() -> dict:
+    children = []
+    for name, schema in EXPECTED_PARAMETER_SCHEMAS[COLLABORATION_V2].items():
+        parameters = copy.deepcopy(schema)
+        if not parameters.get("required"):
+            parameters.pop("required", None)
+        children.append(
+            {
+                "type": "function",
+                "name": name,
+                "description": "runtime",
+                "strict": False,
+                "parameters": parameters,
+            }
+        )
+    return {
+        "type": "namespace",
+        "name": "collaboration",
+        "description": "runtime",
+        "tools": children,
+    }
+
+
+def _codex_app_xai_history_request() -> dict:
+    return {
+        "model": "xai/grok-4.6",
+        "include": ["reasoning.encrypted_content"],
+        "tools": [
+            _v2_namespace(),
+            {
+                "type": "function",
+                "name": "shell",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"command": {"type": "string"}},
+                    "required": ["command"],
+                },
+            },
+        ],
+        "tool_choice": "auto",
+        "input": [
+            {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "hi"}],
+            },
+            {
+                "type": "compaction",
+                "summary": {
+                    "content": [
+                        {"type": "input_text", "text": "Earlier nested context."},
+                    ]
+                },
+            },
+            {"type": "compaction_trigger"},
+            {
+                "type": "reasoning",
+                "id": "rs_21",
+                "content": None,
+                "encrypted_content": "gAAAA-official-blob",
+                "summary": [{"type": "summary_text", "text": "thought"}],
+            },
+            {
+                "type": "reasoning",
+                "id": "rs_22",
+                "content": [
+                    {"type": "encrypted_content", "encrypted_content": "part-blob"},
+                    {"type": "reasoning_text", "text": "visible"},
+                ],
+                "summary": None,
+            },
+            {
+                "type": "function_call",
+                "name": "shell",
+                "call_id": "call_shell",
+                "arguments": json.dumps({"command": "pwd"}),
+            },
+            {
+                "type": "function_call_output",
+                "call_id": "call_shell",
+                "output": "/tmp",
+            },
+            {
+                "type": "custom_tool_call",
+                "status": "completed",
+                "call_id": "call_patch",
+                "name": "apply_patch",
+                "input": PATCH,
+            },
+            {
+                "type": "custom_tool_call_output",
+                "call_id": "call_patch",
+                "output": "Success. Updated target.txt",
+            },
+            {
+                "type": "agent_message",
+                "id": "am1",
+                "author": "agent/root",
+                "recipient": "agent/root/worker",
+                "content": [{"type": "input_text", "text": "inspect"}],
+            },
+            {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "Reply with exactly: E2E_OK"}],
+            },
+        ],
+        "stream": True,
+    }
+
+
+def test_sanitize_third_party_reasoning_items_replaces_null_content_with_empty_sequence():
+    payload = {
+        "input": [
+            {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hi"}]},
+            {
+                "type": "reasoning",
+                "id": "rs_21",
+                "content": None,
+                "summary": [{"type": "summary_text", "text": "thought"}],
+            },
+        ]
+    }
+
+    changed = gateway_request.sanitize_third_party_reasoning_items(payload)
+
+    assert changed is True
+    item = payload["input"][1]
+    assert item["content"] == []
+    assert item["summary"][0]["text"] == "thought"
+
+
+def test_sanitize_third_party_reasoning_items_replaces_null_summary_with_empty_sequence():
+    payload = {"input": [{"type": "reasoning", "id": "rs_null_summary", "summary": None}]}
+
+    changed = gateway_request.sanitize_third_party_reasoning_items(payload)
+
+    assert changed is True
+    assert payload["input"][0]["summary"] == []
+
+
+def test_sanitize_third_party_reasoning_items_strips_encrypted_content_everywhere():
+    payload = {
+        "include": ["reasoning.encrypted_content"],
+        "input": [
+            {
+                "type": "reasoning",
+                "encrypted_content": "gAAAA-blob",
+                "content": [
+                    {"type": "encrypted_content", "encrypted_content": "part-blob"},
+                    {"type": "reasoning_text", "text": "keep"},
+                ],
+            }
+        ],
+    }
+
+    changed = gateway_request.sanitize_third_party_reasoning_items(payload)
+
+    assert changed is True
+    assert "include" not in payload
+    assert "encrypted_content" not in json.dumps(payload)
+    assert payload["input"][0]["content"] == []
+    assert payload["input"][0]["summary"] == [{"type": "summary_text", "text": "keep"}]
+
+
+def test_xai_v2_codex_app_history_is_safe_for_strict_responses_deserializers():
+    context: dict = {}
+    transformed = json.loads(
+        gateway_compat.compatible_request_body(
+            json.dumps(_codex_app_xai_history_request()).encode(),
+            _xai_upstream(),
+            event_context=context,
+            inject_codex_tools=False,
+            behavior_profile="codex_app_external_adapter",
+        )
+    )
+
+    dumped = json.dumps(transformed)
+    assert "encrypted_content" not in dumped
+    assert "include" not in transformed
+    assert context.get("collaboration_protocol") == COLLABORATION_V2
+    types = [item.get("type") for item in transformed["input"]]
+    assert "compaction" not in types
+    assert "compaction_trigger" not in types
+    assert any(
+        item.get("type") == "message"
+        and item.get("role") == "developer"
+        and "Earlier nested context." in str(item.get("content"))
+        for item in transformed["input"]
+    )
+    assert "reasoning" in types
+    assert "function_call" in types
+    assert "function_call_output" in types
+    assert any(item.get("name") == "apply_patch" for item in transformed["input"] if isinstance(item, dict))
+    for item in transformed["input"]:
+        if item.get("type") == "reasoning":
+            assert item.get("content") == []
+            assert isinstance(item.get("summary"), list)
+            for part in item["summary"]:
+                assert part.get("type") == "summary_text"
+                assert isinstance(part.get("text"), str)
+
+
+def test_live_gateway_accepts_sanitized_xai_codex_app_history():
+    if os.environ.get("CODEXHUB_SKIP_LIVE_XAI_E2E") == "1":
+        return
+    body = json.dumps(_codex_app_xai_history_request()).encode()
+    req = urllib.request.Request(
+        "http://127.0.0.1:9099/v1/responses",
+        data=body,
+        headers={
+            "Authorization": "Bearer codexhub-proxy",
+            "Content-Type": "application/json",
+            "User-Agent": "codex-app",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=45) as resp:
+            raw = resp.read(8000).decode("utf-8", "replace")
+            assert resp.status == 200
+            assert "encrypted_content" not in raw.lower() or "error" not in raw.lower()
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", "replace")
+        raise AssertionError(f"live xAI E2E HTTP {exc.code}: {detail[:2000]}") from exc
+    except urllib.error.URLError as exc:
+        raise AssertionError(f"live Gateway unavailable for xAI E2E: {exc}") from exc


### PR DESCRIPTION
## Summary
- Keep Linux Gateway spawn identity from `/proc/stat` so empty cmdline no longer fails connect.
- Sanitize third-party/xAI V2 reasoning and compaction so grok-4.6 accepts Codex APP history and subagent tools.
- Restore official usage window bars, custom Collab V1/V2 menu, Codex APP client icon, and GNOME dock identity without a duplicate app-grid entry.
- Bump to `0.1.9-beta.3.11` so the Debian package upgrades over the broken 3.10 build.

## Test plan
- [x] `openai_usage` Rust tests
- [x] Linux launcher postinstall tests
- [x] UI contract (Collab menu, Codex icon, usage refresh)
- [x] live xAI V1/V2 spawn_agent through Gateway
- [ ] install 3.11 deb and confirm one CodexHub in the app grid with a dock icon