### PR TITLE
fix: unify Official model state for release 0.1.9-beta.3.19

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codexhub-frontend",
-  "version": "0.1.9-beta.3.18",
+  "version": "0.1.9-beta.3.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codexhub-frontend",
-      "version": "0.1.9-beta.3.18",
+      "version": "0.1.9-beta.3.19",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codexhub-frontend",
   "private": true,
-  "version": "0.1.9-beta.3.18",
+  "version": "0.1.9-beta.3.19",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/frontend/scripts/provider-workspace.test.mjs
+++ b/frontend/scripts/provider-workspace.test.mjs
@@ -174,6 +174,90 @@ test("save readback preserves live models, selection and custom order over an ol
   assert.deepEqual(state.officialModels.map((m) => m.id), ["gpt-6-astra"]);
 });
 
+test("asynchronous settings load initializes Official drafts before refresh", async () => {
+  const m = await loadCombinedModule();
+  const settings = { official_disabled_models: ["gpt-5.5"], official_model_sort_order: ["gpt-5.6-luna", "gpt-5.5"] };
+  let state = { selectedId: "__official__", settings: null, officialModelSnapshot: null,
+    officialDisabledModelsDraft: [], officialModelOrderDraft: [], officialModels: [] };
+  state = m.providerWorkspaceReducer(state, { type: "syncExternal", providers: [], settings,
+    catalogModels: [], modelMetadata: [] });
+  assert.deepEqual(state.officialDisabledModelsDraft, settings.official_disabled_models);
+  assert.deepEqual(state.officialModelOrderDraft, settings.official_model_sort_order);
+  assert.equal(m.selectOfficialModelDraftDirty(state), false);
+  state = m.providerWorkspaceReducer(state, { type: "setOfficialModels", models: [
+    { id: "gpt-5.6-luna", enabled: true }, { id: "gpt-5.5", enabled: true },
+  ] });
+  assert.equal(m.selectOfficialEnabledCount(state), 1);
+  state = m.providerWorkspaceReducer(state, { type: "reorderOfficialModels", models: [...state.officialModels].reverse() });
+  state = m.providerWorkspaceReducer(state, { type: "syncExternal", providers: [], settings,
+    catalogModels: [], modelMetadata: [] });
+  assert.deepEqual(state.officialModelOrderDraft, ["gpt-5.5", "gpt-5.6-luna"]);
+  state = m.providerWorkspaceReducer(state, { type: "toggleOfficialModel", modelId: "gpt-5.5", enabled: true });
+  assert.equal(m.selectOfficialModelDraftDirty(state), true);
+  state = m.providerWorkspaceReducer(state, { type: "syncExternal", providers: [], settings,
+    catalogModels: [], modelMetadata: [] });
+  assert.deepEqual(state.officialDisabledModelsDraft, []);
+  assert.equal(m.selectOfficialModelDraftDirty(state), true);
+  state = m.providerWorkspaceReducer(state, { type: "setSettings", settings: {
+    official_disabled_models: state.officialDisabledModelsDraft,
+    official_model_sort_order: state.officialModelOrderDraft,
+  } });
+  assert.equal(m.selectOfficialModelDraftDirty(state), false);
+});
+
+test("refresh preserves edits and only new visible identities create a save change", async () => {
+  const m = await loadCombinedModule();
+  const model = (id) => ({ id, visibility: "list", enabled: true });
+  const settings = { official_disabled_models: ["gpt-b"], official_model_sort_order: [] };
+  let state = { settings, officialDisabledModelsDraft: ["gpt-b"], officialModelOrderDraft: [],
+    officialModels: [model("gpt-b"), model("gpt-a")], officialModelSnapshot: null };
+  const refresh = (models) => { state = m.providerWorkspaceReducer(state, { type: "applyOfficialRefresh", models }); };
+  refresh([{ ...model("gpt-a"), name: "Updated" }, model("gpt-b")]);
+  assert.deepEqual(state.officialModels.map(m => m.id), ["gpt-b", "gpt-a"]);
+  assert.equal(state.officialModels[1].name, "Updated");
+  assert.equal(m.selectOfficialModelDraftDirty(state), false);
+  refresh([model("gpt-a")]);
+  assert.equal(m.selectOfficialModelDraftDirty(state), false);
+  refresh([model("gpt-a"), { ...model("gpt-hidden"), visibility: "hide" }]);
+  assert.equal(m.selectOfficialModelDraftDirty(state), false);
+  state = m.providerWorkspaceReducer(state, { type: "toggleOfficialModel", modelId: "gpt-a", enabled: false });
+  refresh([model("gpt-new"), model("gpt-a")]);
+  assert.deepEqual(state.officialModels.map(m => m.id), ["gpt-a", "gpt-new"]);
+  assert.deepEqual(state.officialModelOrderDraft, ["gpt-a", "gpt-new"]);
+  assert.deepEqual(state.officialDisabledModelsDraft, ["gpt-b", "gpt-a"]);
+  assert.equal(m.selectOfficialModelDraftDirty(state), true);
+});
+
+test("refresh never prunes saved order or mistakes known disabled models for new ones", async () => {
+  const m = await loadCombinedModule();
+  const model = (id) => ({ id, visibility: "list", enabled: true });
+  const settings = { official_disabled_models: ["gpt-b"], official_model_sort_order: ["gpt-a", "gpt-b", "gpt-old"] };
+  let state = { settings, officialDisabledModelsDraft: ["gpt-b"], officialModelOrderDraft: settings.official_model_sort_order,
+    officialModels: [model("gpt-a")], officialModelSnapshot: null };
+  state = m.providerWorkspaceReducer(state, { type: "applyOfficialRefresh", models: [model("gpt-b"), model("gpt-a")] });
+  assert.deepEqual(state.officialModels.map(m => m.id), ["gpt-a", "gpt-b"]);
+  assert.equal(m.selectOfficialModelDraftDirty(state), false);
+});
+
+test("new model alone enables Save and refresh keeps an in-flight reorder", async () => {
+  const m = await loadCombinedModule();
+  const model = (id) => ({ id, visibility: "list", enabled: true });
+  const settings = { official_disabled_models: [], official_model_sort_order: [] };
+  let state = { settings, officialDisabledModelsDraft: [], officialModelOrderDraft: [],
+    officialModels: [model("gpt-5.6-luna"), model("gpt-5.6-sol")], officialModelSnapshot: null };
+  state = m.providerWorkspaceReducer(state, { type: "applyOfficialRefresh", models: [model("gpt-5.6-sol"), model("gpt-5.6-luna")] });
+  state = m.providerWorkspaceReducer(state, { type: "syncExternal", providers: [], settings: structuredClone(settings), catalogModels: [], modelMetadata: [] });
+  assert.deepEqual(state.officialModels.map(m => m.id), ["gpt-5.6-luna", "gpt-5.6-sol"]);
+  assert.equal(m.selectOfficialModelDraftDirty(state), false);
+  state = m.providerWorkspaceReducer(state, { type: "applyOfficialRefresh", models: [model("gpt-new"), ...state.officialModels] });
+  assert.equal(m.selectOfficialModelDraftDirty(state), true);
+  assert.deepEqual(state.officialModelOrderDraft, ["gpt-5.6-luna", "gpt-5.6-sol", "gpt-new"]);
+  state = m.providerWorkspaceReducer(state, { type: "reorderOfficialModels", models: [...state.officialModels].reverse() });
+  const order = state.officialModelOrderDraft;
+  state = m.providerWorkspaceReducer(state, { type: "applyOfficialRefresh", models: [model("gpt-5.6-sol"), model("gpt-new"), model("gpt-5.6-luna")] });
+  assert.deepEqual(state.officialModels.map(m => m.id), order);
+});
+
 test("workspace without a live snapshot still receives catalog updates", async () => {
   const { providerWorkspaceReducer: reduce } = await loadCombinedModule();
   const next = reduce({ selectedId: "__official__", officialModelSnapshot: null }, {
@@ -181,6 +265,24 @@ test("workspace without a live snapshot still receives catalog updates", async (
     catalogModels: [{ id: "gpt-6-astra", visibility: "list", enabled: true }],
   });
   assert.deepEqual(next.officialModels.map((m) => m.id), ["gpt-6-astra"]);
+});
+
+test("Official initialization uses its full catalog without changing preferences or overwriting a completed refresh", async () => {
+  const m = await loadCombinedModule();
+  const model = id => ({ id, visibility: "list", enabled: true });
+  const settings = { official_disabled_models: ["gpt-5.5"], official_model_sort_order: ["gpt-6-astra", "gpt-5.5"] };
+  let state = { settings, officialDisabledModelsDraft: settings.official_disabled_models,
+    officialModelOrderDraft: settings.official_model_sort_order, officialModelSnapshot: [], officialModels: [], officialCatalogLoaded: false };
+  state = m.providerWorkspaceReducer(state, { type: "initializeOfficialModels", models: [model("gpt-6-astra"), model("gpt-5.5")] });
+  state = m.providerWorkspaceReducer(state, { type: "syncExternal", providers: [], settings,
+    catalogModels: [model("gpt-5.4")], modelMetadata: [model("gpt-5.4")] });
+  assert.deepEqual(state.officialModels.map(m => m.id), ["gpt-6-astra", "gpt-5.5"]);
+  assert.equal(m.selectOfficialEnabledCount(state), 1);
+  assert.equal(m.selectOfficialModelDraftDirty(state), false);
+  state = m.providerWorkspaceReducer(state, { type: "applyOfficialRefresh", models: [model("gpt-new"), ...state.officialModels] });
+  const current = state;
+  state = m.providerWorkspaceReducer(state, { type: "initializeOfficialModels", models: [model("gpt-5.4")] });
+  assert.equal(state, current);
 });
 
 test("snapshot receives published metadata without reverting membership, selection or order", async () => {

--- a/frontend/src/hooks/useProviderWorkspace.ts
+++ b/frontend/src/hooks/useProviderWorkspace.ts
@@ -15,7 +15,6 @@ import {
   buildOfficialRefreshIntent,
   buildNextProviderFromForm,
   providerWorkspaceReducer,
-  resolveOfficialRefresh,
   selectSelectedProvider,
   formProbeModelFor,
   providerProbeModelFor,
@@ -27,7 +26,6 @@ import {
   type ProviderWorkspaceState,
 } from "../lib/providerWorkspace/core";
 import { catalogOverrideToastMessage } from "../lib/providerWorkspace/feedback";
-import { mergeOfficialModelSources, sortOfficialModels } from "../lib/officialModels";
 
 type Translate = (key: string, options?: Record<string, unknown>) => string;
 
@@ -121,11 +119,9 @@ function initialState(source: WorkspaceSource): ProviderWorkspaceState {
     modelMetadata: source.modelMetadata,
     officialDisabledModelsDraft: source.settings?.official_disabled_models ?? [],
     officialModelOrderDraft: source.settings?.official_model_sort_order ?? [],
-    officialModelSnapshot: null,
-    officialModels: sortOfficialModels(
-      mergeOfficialModelSources(source.catalogModels, source.modelMetadata),
-      source.settings?.official_model_sort_order ?? [],
-    ),
+    officialModelSnapshot: [],
+    officialModels: [],
+    officialCatalogLoaded: false,
     pendingNavigation: null,
     pendingNewProvider: null,
     probeResult: null,
@@ -152,6 +148,20 @@ export function useProviderWorkspace(options: {
   const dirtyDraftRef = useRef<ProviderDraftState<Provider> | null>(null);
   const sourceRef = useRef(externalSource);
   sourceRef.current = externalSource;
+
+  useEffect(() => {
+    let cancelled = false;
+    api.listOfficialModels().then(models => {
+      if (!cancelled) dispatch({ type: "initializeOfficialModels", models });
+    }).catch(error => {
+      if (!cancelled) {
+        const message = messageFromError(error);
+        dispatch({ type: "setDiscoveryError", error: message });
+        showToast(message, "error");
+      }
+    });
+    return () => { cancelled = true; };
+  }, []);
 
   const saveCoordinator = useRef(createWorkspaceSaveCoordinator()).current;
 
@@ -522,11 +532,10 @@ export function useProviderWorkspace(options: {
             // Refresh reads the current Official model list. Applying a new
             // Codex overlay is a separate, explicitly authorized mutation.
             const refreshResult = await api.refreshOfficialModels(false);
-            const resolved = resolveOfficialRefresh(state.officialModelOrderDraft, refreshResult.models);
-            if (!resolved.followsAutomatic) {
-              dispatch({ type: "setOfficialModelOrderDraft", order: resolved.nextOrder });
+            if (refreshResult.warning?.trim() && !refreshResult.codex_restart_result) {
+              throw new Error(refreshResult.warning.trim());
             }
-            dispatch({ type: "setOfficialModels", models: resolved.sortedModels });
+            dispatch({ type: "applyOfficialRefresh", models: refreshResult.models });
             if (quiet) {
               await refreshGatewayState();
               dispatch({ type: "setDiscoveryError", error: null });

--- a/frontend/src/lib/commands.ts
+++ b/frontend/src/lib/commands.ts
@@ -53,6 +53,7 @@ export const COMMANDS = {
   generateCatalog: "generate_catalog",
   getCatalogOverrideDiagnostics: "get_catalog_override_diagnostics",
   listModels: "list_models",
+  listOfficialModels: "list_official_models",
   refreshModelMetadata: "refresh_model_metadata",
   listModelMetadata: "list_model_metadata",
   saveModelMetadataOverride: "save_model_metadata_override",

--- a/frontend/src/lib/providerWorkspace/core.ts
+++ b/frontend/src/lib/providerWorkspace/core.ts
@@ -9,8 +9,7 @@ import {
 import { mergeDiscoveredModels, renumberModels, slugify } from "../format";
 import {
   filterCodexVisibleOfficialModels,
-  refreshedOfficialModelOrder,
-  shouldFollowOfficialCatalogOrder,
+  officialModelSortKeys,
   sortOfficialModels,
   mergeOfficialModelSources,
   reconcileOfficialModelSnapshot,
@@ -43,6 +42,7 @@ export type ProviderWorkspaceState = {
   // A refreshed/edited list belongs to this workspace. Generated catalogs can
   // lag behind live discovery and must not replace it during settings readback.
   officialModelSnapshot: Model[] | null;
+  officialCatalogLoaded?: boolean;
   pendingNavigation: PendingProviderNavigation<Provider, AddProviderForm> | null;
   pendingNewProvider: Provider | null;
   probeResult: UpstreamFormatProbeResult | null;
@@ -71,6 +71,8 @@ export type ProviderEditIntent =
   | { type: "setPendingNewProvider"; provider: Provider | null }
   | { type: "setPendingNavigation"; pending: PendingProviderNavigation<Provider, AddProviderForm> | null }
   | { type: "setOfficialModels"; models: Model[] }
+  | { type: "applyOfficialRefresh"; models: Model[] }
+  | { type: "initializeOfficialModels"; models: Model[] }
   | { type: "setOfficialModelOrderDraft"; order: string[] }
   | { type: "setOfficialDisabledModelsDraft"; disabled: string[] }
   | { type: "setProviders"; providers: Provider[] }
@@ -125,6 +127,17 @@ export function providerWorkspaceReducer(
       return { ...state, pendingNavigation: intent.pending };
     case "setOfficialModels":
       return { ...state, officialModels: intent.models, officialModelSnapshot: intent.models };
+    case "initializeOfficialModels": {
+      if (state.officialCatalogLoaded) return state;
+      const models = sortOfficialModels(filterCodexVisibleOfficialModels(intent.models), state.officialModelOrderDraft);
+      return { ...state, officialModels: models, officialModelSnapshot: models, officialCatalogLoaded: true };
+    }
+    case "applyOfficialRefresh": {
+      const resolved = resolveOfficialRefresh(state.officialModelOrderDraft, intent.models,
+        state.officialModels, state.officialDisabledModelsDraft);
+      return { ...state, officialModels: resolved.sortedModels, officialCatalogLoaded: true,
+        officialModelSnapshot: resolved.sortedModels, officialModelOrderDraft: resolved.nextOrder };
+    }
     case "setOfficialModelOrderDraft":
       return { ...state, officialModelOrderDraft: intent.order };
     case "setOfficialDisabledModelsDraft":
@@ -170,6 +183,16 @@ export function providerWorkspaceReducer(
       };
     }
     case "syncExternal": {
+      // Settings arrive after the first render. Adopt persisted values only
+      // for fields still equal to their previous baseline; keep local edits.
+      const officialDisabledModelsDraft = JSON.stringify(state.officialDisabledModelsDraft ?? []) ===
+        JSON.stringify(state.settings?.official_disabled_models ?? [])
+        ? intent.settings?.official_disabled_models ?? []
+        : state.officialDisabledModelsDraft;
+      const officialModelOrderDraft = JSON.stringify(state.officialModelOrderDraft ?? []) ===
+        JSON.stringify(state.settings?.official_model_sort_order ?? [])
+        ? intent.settings?.official_model_sort_order ?? []
+        : state.officialModelOrderDraft;
       const snapshot = state.officialModelSnapshot == null ? null : reconcileOfficialModelSnapshot(
         state.officialModelSnapshot, intent.catalogModels, intent.modelMetadata,
       );
@@ -178,14 +201,16 @@ export function providerWorkspaceReducer(
         providers: intent.providers,
         settings: intent.settings,
         settingsDraft: intent.settings,
+        officialDisabledModelsDraft,
+        officialModelOrderDraft,
         catalogModels: intent.catalogModels,
         modelMetadata: intent.modelMetadata,
         officialModelSnapshot: snapshot,
-        officialModels: sortOfficialModels(
+        officialModels: snapshot && JSON.stringify(officialModelOrderDraft) === JSON.stringify(state.officialModelOrderDraft)
+          ? snapshot
+          : sortOfficialModels(
           snapshot ?? mergeOfficialModelSources(intent.catalogModels, intent.modelMetadata),
-          state.officialModelSnapshot != null
-            ? state.officialModelOrderDraft
-            : intent.settings?.official_model_sort_order ?? [],
+          officialModelOrderDraft,
         ),
       };
       const selectedId = intent.selectedId ?? state.selectedId;
@@ -295,13 +320,34 @@ export function applyProbeToProvider(
 export function resolveOfficialRefresh(
   currentOrder: string[],
   refreshedModels: Model[],
-): { followsAutomatic: boolean; nextOrder: string[]; sortedModels: Model[] } {
-  const followsAutomatic = shouldFollowOfficialCatalogOrder(currentOrder);
-  const nextOrder = followsAutomatic
-    ? currentOrder
-    : refreshedOfficialModelOrder(currentOrder, refreshedModels);
+  currentModels: Model[],
+  disabledModels: string[],
+): { nextOrder: string[]; sortedModels: Model[] } {
   const filtered = filterCodexVisibleOfficialModels(refreshedModels);
-  return { followsAutomatic, nextOrder, sortedModels: sortOfficialModels(filtered, nextOrder) };
+  const known = new Set([...currentOrder, ...disabledModels, ...currentModels.map(m => m.id)]
+    .flatMap(officialModelSortKeys));
+  const additions = filtered.filter(model => !officialModelSortKeys(model.id).some(key => known.has(key)));
+  // Missing models must not rewrite user preferences. Keep the currently
+  // rendered order even when the server changes its default ordering.
+  const displayOrder = [...currentModels.map(m => m.id), ...currentOrder, ...disabledModels];
+  const ranks = new Map<string, number>();
+  displayOrder.forEach((id, index) => officialModelSortKeys(id).forEach(key => {
+    if (!ranks.has(key)) ranks.set(key, index);
+  }));
+  const rank = (model: Model) => Math.min(...officialModelSortKeys(model.id).map(key => ranks.get(key) ?? Number.MAX_SAFE_INTEGER));
+  const sortedModels = [...filtered].sort((a, b) => rank(a) - rank(b));
+  let nextOrder = currentOrder;
+  if (additions.length) {
+    nextOrder = [...currentOrder];
+    const ordered = new Set(nextOrder.flatMap(officialModelSortKeys));
+    for (const model of [...currentModels, ...additions]) {
+      const keys = officialModelSortKeys(model.id);
+      if (keys.some(key => ordered.has(key))) continue;
+      nextOrder.push(model.id);
+      keys.forEach(key => ordered.add(key));
+    }
+  }
+  return { nextOrder, sortedModels };
 }
 
 export function providerProbeModelFor(provider: Provider): string | null {

--- a/frontend/src/lib/tauri.ts
+++ b/frontend/src/lib/tauri.ts
@@ -342,6 +342,7 @@ export const api = {
   catalogOverrideDiagnostics: () =>
     call<CatalogOverrideDiagnostics>(COMMANDS.getCatalogOverrideDiagnostics),
   listModels: () => call<Model[]>(COMMANDS.listModels),
+  listOfficialModels: () => call<Model[]>(COMMANDS.listOfficialModels),
   refreshModelMetadata: () => call<Model[]>(COMMANDS.refreshModelMetadata),
   listModelMetadata: () => call<Model[]>(COMMANDS.listModelMetadata),
   saveModelMetadataOverride: (model: Model) =>

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -494,9 +494,10 @@ dependencies = [
 
 [[package]]
 name = "codexhub"
-version = "0.1.9-beta.3.18"
+version = "0.1.9-beta.3.19"
 dependencies = [
  "cairo-rs",
+ "chrono",
  "dirs 5.0.1",
  "gdk-pixbuf",
  "glib",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codexhub"
-version = "0.1.9-beta.3.18"
+version = "0.1.9-beta.3.19"
 description = "CodexHub desktop backend and CLI"
 authors = ["CodexHub"]
 license = "MIT"
@@ -33,6 +33,7 @@ rusqlite = { version = "0.32", features = ["bundled"] }
 sha2 = "0.10"
 which = "6"
 log = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["std"] }
 # YAML strategy for the injection descriptor engine (#432): DSH settings and
 # credentials are YAML; the engine parses and re-serializes mappings while
 # preserving every user-owned key.

--- a/src-tauri/src/catalog.rs
+++ b/src-tauri/src/catalog.rs
@@ -40,6 +40,10 @@ pub(crate) fn sync_catalog_with_existing_lock() -> Result<String, String> {
     let python = config::find_python()?;
     let runner = ProcessCatalogSyncCommandRunner;
 
+    if let Some(seed) = models::prepare_official_editor_seed()? {
+        crate::safe_file::write_text_atomic(&seed.path, &seed.text)?;
+    }
+
     sync_catalog_with_paths(&paths, &python, &runner)
 }
 
@@ -66,9 +70,16 @@ pub(crate) fn prepare_catalog(
 ) -> Result<PreparedCatalogPublication, String> {
     let actual = CatalogPaths::runtime()?;
     let python = config::find_python()?;
+    let mut inputs = overlays.to_vec();
+    let seed_path = actual.codex_dir.join("model-catalogs/openai-plus-ollama-cloud.json");
+    if !inputs.iter().any(|input| input.path == seed_path) {
+        if let Some(seed) = models::prepare_official_editor_seed()? {
+            inputs.push(seed);
+        }
+    }
     prepare_catalog_with_paths(
         &actual,
-        overlays,
+        &inputs,
         &python,
         &ProcessCatalogSyncCommandRunner,
     )

--- a/src-tauri/src/catalog.rs
+++ b/src-tauri/src/catalog.rs
@@ -41,7 +41,7 @@ pub(crate) fn sync_catalog_with_existing_lock() -> Result<String, String> {
     let runner = ProcessCatalogSyncCommandRunner;
 
     if let Some(seed) = models::prepare_official_editor_seed()? {
-        crate::safe_file::write_text_atomic(&seed.path, &seed.text)?;
+        crate::safe_file::write_text_atomic_with_mode(&seed.path, &seed.text, seed.unix_mode)?;
     }
 
     sync_catalog_with_paths(&paths, &python, &runner)

--- a/src-tauri/src/desktop_commands/handlers.rs
+++ b/src-tauri/src/desktop_commands/handlers.rs
@@ -83,6 +83,11 @@ pub fn refresh_model_metadata() -> Result<Vec<Model>, String> {
 }
 
 #[tauri::command]
+pub fn list_official_models() -> Result<Vec<Model>, String> {
+    models::list_official_models()
+}
+
+#[tauri::command]
 pub fn list_model_metadata() -> Result<Vec<Model>, String> {
     models::list_model_metadata()
 }

--- a/src-tauri/src/desktop_commands/mod.rs
+++ b/src-tauri/src/desktop_commands/mod.rs
@@ -131,6 +131,7 @@ macro_rules! desktop_command_registry {
             GenerateCatalog => "generate_catalog" => $crate::desktop_commands::generate_catalog, true, true, true, false, ALIASES_RESTART;
             GetCatalogOverrideDiagnostics => "get_catalog_override_diagnostics" => $crate::desktop_commands::get_catalog_override_diagnostics, true, true, true, false, NO_ALIASES;
             ListModels => "list_models" => $crate::desktop_commands::list_models, true, true, true, false, NO_ALIASES;
+            ListOfficialModels => "list_official_models" => $crate::desktop_commands::list_official_models, true, true, true, false, NO_ALIASES;
             RefreshModelMetadata => "refresh_model_metadata" => $crate::desktop_commands::refresh_model_metadata, true, true, true, false, NO_ALIASES;
             ListModelMetadata => "list_model_metadata" => $crate::desktop_commands::list_model_metadata, true, true, true, false, NO_ALIASES;
             SaveModelMetadataOverride => "save_model_metadata_override" => $crate::desktop_commands::save_model_metadata_override, true, true, true, false, NO_ALIASES;

--- a/src-tauri/src/desktop_commands/web_adapter.rs
+++ b/src-tauri/src/desktop_commands/web_adapter.rs
@@ -263,6 +263,7 @@ pub fn dispatch_web(command: &str, args: &Value, app: Option<AppHandle>) -> Resu
         }
         Command::GetCatalogOverrideDiagnostics => to_value(catalog::catalog_override_diagnostics()),
         Command::ListModels => to_value(models::list_models()),
+        Command::ListOfficialModels => to_value(models::list_official_models()),
         Command::RefreshModelMetadata => to_value(models::refresh_model_metadata()),
         Command::ListModelMetadata => to_value(models::list_model_metadata()),
         Command::SaveModelMetadataOverride => {

--- a/src-tauri/src/file_transaction.rs
+++ b/src-tauri/src/file_transaction.rs
@@ -83,6 +83,13 @@ impl PreparedTextFile {
         }
     }
 
+    pub(crate) fn runtime_owner_only(path: PathBuf, text: String) -> Self {
+        Self {
+            namespace: PreparedFileNamespace::Runtime,
+            ..Self::owner_only(path, text)
+        }
+    }
+
     pub(crate) fn codex_target_owner_only(path: PathBuf, text: String) -> Self {
         Self {
             path,

--- a/src-tauri/src/gateway/tests/body_01.rs
+++ b/src-tauri/src/gateway/tests/body_01.rs
@@ -1393,6 +1393,11 @@ fn legacy_official_client_selection_resolves_to_exported_bare_id() {
 
 #[test]
 fn opencode_config_exports_all_active_gateway_models() {
+    let _env_guard = TEST_ENV_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    let _official_home = isolated_official_models_home();
     let settings = Settings::default();
     let providers = client_export_test_providers();
 
@@ -1829,6 +1834,11 @@ fn client_config_keeps_official_fast_selection_as_client_pseudo_model() {
 
 #[test]
 fn pi_config_exports_all_active_gateway_models() {
+    let _env_guard = TEST_ENV_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    let _official_home = isolated_official_models_home();
     let root = unique_temp_dir("codexhub-pi-export");
     let settings_path = root.join("settings.json");
     let models_path = root.join("models.json");

--- a/src-tauri/src/gateway/tests/body_02.rs
+++ b/src-tauri/src/gateway/tests/body_02.rs
@@ -866,6 +866,11 @@ fn opencode_apply_creates_backup_before_managed_overwrite() {
 
 #[test]
 fn opencode_apply_does_not_back_up_managed_config() {
+    let _env_guard = TEST_ENV_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    let _official_home = isolated_official_models_home();
     let root = unique_temp_dir("codexhub-opencode-managed");
     let config_path = root.join("opencode.json");
     let backup_root = root.join("backups");
@@ -992,6 +997,7 @@ fn opencode_official_restore_survives_stable_then_beta_takeover() {
         .get_or_init(|| Mutex::new(()))
         .lock()
         .unwrap_or_else(|e| e.into_inner());
+    let _official_home = isolated_official_models_home();
     let previous_provenance = std::env::var_os("CODEXHUB_ROLLBACK_PROVENANCE_DIR");
     let root = unique_temp_dir("codexhub-opencode-cross-channel-restore");
     let config_path = root.join("opencode.json");
@@ -1761,6 +1767,7 @@ fn opencode_reapply_preserves_original_canonical_baseline() {
         .get_or_init(|| Mutex::new(()))
         .lock()
         .unwrap_or_else(|e| e.into_inner());
+    let _official_home = isolated_official_models_home();
     let previous_provenance = std::env::var_os("CODEXHUB_ROLLBACK_PROVENANCE_DIR");
     let root = unique_temp_dir("codexhub-opencode-reapply-baseline");
     let config_path = root.join("opencode.json");
@@ -1810,6 +1817,7 @@ fn pi_reapply_preserves_original_canonical_baseline() {
         .get_or_init(|| Mutex::new(()))
         .lock()
         .unwrap_or_else(|e| e.into_inner());
+    let _official_home = isolated_official_models_home();
     let previous_provenance = std::env::var_os("CODEXHUB_ROLLBACK_PROVENANCE_DIR");
     let root = unique_temp_dir("codexhub-pi-reapply-baseline");
     let settings_path = root.join("settings.json");

--- a/src-tauri/src/gateway/tests/body_03.rs
+++ b/src-tauri/src/gateway/tests/body_03.rs
@@ -1405,6 +1405,7 @@ fn opencode_first_baseline_creation_is_process_atomic() {
         .get_or_init(|| Mutex::new(()))
         .lock()
         .unwrap_or_else(|e| e.into_inner());
+    let _official_home = isolated_official_models_home();
     let previous_provenance = std::env::var_os("CODEXHUB_ROLLBACK_PROVENANCE_DIR");
     let root = unique_temp_dir("codexhub-opencode-concurrent-baseline");
     let config_path = root.join("opencode.json");
@@ -1457,6 +1458,7 @@ fn pi_first_baseline_creation_is_process_atomic() {
         .get_or_init(|| Mutex::new(()))
         .lock()
         .unwrap_or_else(|e| e.into_inner());
+    let _official_home = isolated_official_models_home();
     let previous_provenance = std::env::var_os("CODEXHUB_ROLLBACK_PROVENANCE_DIR");
     let root = unique_temp_dir("codexhub-pi-concurrent-baseline");
     let settings_path = root.join("settings.json");
@@ -1974,6 +1976,11 @@ fn plan_zcode_apply_does_not_write_or_backup() {
 
 #[test]
 fn zcode_apply_writes_user_catalog_with_schema_safe_provider() {
+    let _env_guard = TEST_ENV_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    let _official_home = isolated_official_models_home();
     let root = unique_temp_dir("codexhub-zcode");
     let catalog_path = root.join("model-providers").join("codexhub.json");
     let v2_config_path = root.join("v2").join("config.json");

--- a/src-tauri/src/gateway/tests/helpers.rs
+++ b/src-tauri/src/gateway/tests/helpers.rs
@@ -1,5 +1,93 @@
 static TEST_ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
+/// Keep Gateway client export tests independent from the developer's current
+/// Codex subscription cache.  The production exporter intentionally treats
+/// that cache as the Official membership authority, so a host with a newer or
+/// older model list must not change these tests' expected gpt-5.4 assertions.
+struct OfficialModelsTestHome {
+    root: PathBuf,
+    previous_codex_home: Option<std::ffi::OsString>,
+    previous_runtime_home: Option<std::ffi::OsString>,
+}
+
+impl OfficialModelsTestHome {
+    fn new() -> Self {
+        let root = unique_temp_dir("codexhub-gateway-official-home");
+        let catalogs = root.join("model-catalogs");
+        fs::create_dir_all(&catalogs).unwrap();
+
+        let official_models = ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex-spark"];
+        let subscription_models = official_models
+            .iter()
+            .map(|slug| {
+                json!({
+                    "slug": slug,
+                    "display_name": slug,
+                    "visibility": "list",
+                })
+            })
+            .collect::<Vec<_>>();
+        let published_models = official_models
+            .iter()
+            .map(|slug| {
+                json!({
+                    "slug": slug,
+                    "codex_proxy_metadata": {
+                        "provider": "openai",
+                        "upstream_name": "official",
+                        "official_context_budget": {
+                            "source": "degraded_last_known_official",
+                            "freshness": "stale",
+                            "model_context_window": 272000,
+                            "effective_context_window_percent": 95,
+                            "effective_context_window": 258400,
+                            "model_auto_compact_token_limit": 244800,
+                        },
+                    },
+                })
+            })
+            .collect::<Vec<_>>();
+
+        fs::write(
+            catalogs.join("openai-plus-ollama-cloud.json"),
+            serde_json::to_vec_pretty(&json!({
+                "fetched_at": "2026-01-01T00:00:00Z",
+                "models": subscription_models,
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        fs::write(
+            catalogs.join("codexhub-model-catalog.json"),
+            serde_json::to_vec_pretty(&json!({ "models": published_models })).unwrap(),
+        )
+        .unwrap();
+
+        let previous_codex_home = std::env::var_os("CODEX_HOME");
+        let previous_runtime_home = std::env::var_os("CODEXHUB_RUNTIME_HOME");
+        std::env::set_var("CODEX_HOME", &root);
+        std::env::set_var("CODEXHUB_RUNTIME_HOME", &root);
+
+        Self {
+            root,
+            previous_codex_home,
+            previous_runtime_home,
+        }
+    }
+}
+
+impl Drop for OfficialModelsTestHome {
+    fn drop(&mut self) {
+        restore_env("CODEX_HOME", self.previous_codex_home.take());
+        restore_env("CODEXHUB_RUNTIME_HOME", self.previous_runtime_home.take());
+        let _ = fs::remove_dir_all(&self.root);
+    }
+}
+
+fn isolated_official_models_home() -> OfficialModelsTestHome {
+    OfficialModelsTestHome::new()
+}
+
 fn published_context_windows(entries: &[(&str, u32)]) -> BTreeMap<String, u32> {
     entries
         .iter()

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -379,7 +379,7 @@ fn validate_official_snapshot(payload: &Value) -> Result<(), String> {
             .ok_or_else(|| "Official snapshot contains a non-object model".to_string())?;
         let identity = object.get("slug").or_else(|| object.get("id"))
             .or_else(|| object.get("model")).or_else(|| object.get("name"));
-        if !identity.and_then(Value::as_str).is_some_and(|id| !id.trim().is_empty()) {
+        if identity.and_then(Value::as_str).is_none_or(|id| id.trim().is_empty()) {
             return Err("Official snapshot contains a model without an identity".to_string());
         }
         if !item_has_internal_identity(object)
@@ -1193,10 +1193,7 @@ fn wait_for_native_model_cache_publication(
 fn readable_native_model_cache(cache_path: &Path) -> Option<Vec<u8>> {
     let bytes = fs::read(cache_path).ok()?;
     let payload: Value = serde_json::from_slice(&bytes).ok()?;
-    let models = payload.get("models")?.as_array()?;
-    if models.is_empty() || models.iter().any(|item| !item.is_object()) {
-        return None;
-    }
+    validate_official_snapshot(&payload).ok()?;
     // Detailed freshness, identity, and comp_hash authority remains in
     // catalog_sync.py.  This seam only proves that a stable JSON cache was
     // atomically published; the caller separately requires it to differ from
@@ -3604,6 +3601,10 @@ mod tests {
             std::io::stdout()
                 .flush()
                 .expect("flush app-server model-list test response");
+            if let Some(path) = std::env::var_os("CODEXHUB_APP_SERVER_TEST_EMPTY_CACHE") {
+                crate::safe_file::write_text_atomic(Path::new(&path), r#"{"models":[]}"#)
+                    .expect("publish empty native cache");
+            }
         }
         loop {
             thread::park();
@@ -3836,10 +3837,12 @@ for line in sys.stdin:
         let cases = [
             ("invalid-json", "{not-json", false),
             ("missing-models", "{}", false),
-            ("empty-models", r#"{"models":[]}"#, false),
+            ("empty-models", r#"{"models":[]}"#, true),
             ("null-model", r#"{"models":[null]}"#, false),
             ("string-model", r#"{"models":["gpt-5.6-terra"]}"#, false),
-            ("object-model", r#"{"models":[{"slug":"gpt-5.6-terra"}]}"#, true),
+            ("missing-visibility", r#"{"models":[{"slug":"gpt-5.6-terra"}]}"#, false),
+            ("object-model", r#"{"models":[{"slug":"gpt-5.6-terra","visibility":"list"}]}"#, true),
+            ("hidden-model", r#"{"models":[{"slug":"gpt-5.6-terra","visibility":"hide"}]}"#, true),
         ];
 
         for (name, payload, expected_readable) in cases {
@@ -3931,6 +3934,27 @@ for line in sys.stdin:
     }
 
     #[test]
+    fn app_server_model_list_accepts_new_empty_native_cache_without_context() {
+        let root = temp_root("app-server-empty-cache");
+        let cache_path = root.join("models_cache.json");
+        let helper_liveness_path = root.join("helper-liveness.lock");
+        let mut command = responding_app_server_test_process_command(&helper_liveness_path);
+        command.env(APP_SERVER_TEST_PROCESS_ENV, "respond-without-context")
+            .env("CODEXHUB_APP_SERVER_TEST_EMPTY_CACHE", &cache_path);
+        let result = super::read_codex_app_server_model_list_with_cache_path(
+            command, Duration::from_secs(5), &cache_path, Duration::from_secs(1),
+        ).expect("new valid empty cache must satisfy a context-less refresh");
+        let runner = StaticAppServerModelListRunner::ok_with_cache(
+            result, &fs::read_to_string(&cache_path).unwrap(),
+        );
+        let acquired = super::acquire_official_models_direct_with_runner(&runner).unwrap();
+        assert!(acquired.models.is_empty());
+        assert!(acquired.native_cache.is_some());
+        assert_app_server_test_process_stopped(&helper_liveness_path);
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
     fn app_server_model_list_waits_for_cache_when_context_metadata_is_partial() {
         let root = temp_root("app-server-context-cache-grace");
         let script = root.join("fake-codex-app-server.py");
@@ -3976,6 +4000,7 @@ for line in sys.stdin:
             "client_version": "0.146.0",
             "models": [{
                 "slug": "gpt-5.6-terra",
+                "visibility": "list",
                 "context_window": 272000,
                 "max_context_window": 272000,
                 "effective_context_window_percent": 95,

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -80,7 +80,7 @@ pub(crate) fn read_official_models_direct() -> Result<Vec<Model>, String> {
         Some(cache) => cache.clone(),
         None => official_subscription_seed_text(&acquisition.subscription_models, &acquisition.visibility_diagnostics)?,
     };
-    safe_file::write_text_atomic(&paths.official_editor_cache_path(), &snapshot)?;
+    safe_file::write_text_atomic_with_mode(&paths.official_editor_cache_path(), &snapshot, Some(0o600))?;
     Ok(acquisition.models)
 }
 
@@ -96,14 +96,14 @@ pub(crate) fn prepare_official_models_acquisition(
     )?;
     let editor_text = acquisition.native_cache.clone().unwrap_or_else(|| seed_text.clone());
     let mut files = vec![
-        crate::file_transaction::PreparedTextFile::runtime(
+        crate::file_transaction::PreparedTextFile::runtime_owner_only(
             paths.official_editor_cache_path(), editor_text,
         ),
         crate::file_transaction::PreparedTextFile::runtime(
             paths.metadata_cache_path(),
             format!("{metadata_text}\n"),
         ),
-        crate::file_transaction::PreparedTextFile::runtime(
+        crate::file_transaction::PreparedTextFile::runtime_owner_only(
             paths.official_subscription_cache_path(),
             seed_text,
         ),
@@ -386,7 +386,7 @@ fn prepare_official_editor_seed_at(native: &Path, paths: &ModelPaths) -> Result<
     payload["visibility_diagnostics"] = visibility_diagnostics_from_payload(&payload);
     payload["models"] = json!(models.iter().map(official_subscription_seed_model).collect::<Vec<_>>());
     let text = serde_json::to_string_pretty(&payload).map_err(|error| format!("failed to serialize Official editor catalog: {error}"))?;
-    Ok(Some(crate::file_transaction::PreparedTextFile::runtime(paths.official_subscription_cache_path(), text)))
+    Ok(Some(crate::file_transaction::PreparedTextFile::runtime_owner_only(paths.official_subscription_cache_path(), text)))
 }
 
 pub(crate) fn list_models_with_presence() -> Result<Option<Vec<Model>>, String> {
@@ -3477,6 +3477,12 @@ mod tests {
         assert_eq!(payload["models"].as_array().unwrap().len(), 1);
         assert_eq!(payload["models"][0]["slug"], "gpt-6-astra");
         assert_eq!(seed.path, paths.official_subscription_cache_path());
+        crate::file_transaction::publish_prepared_text_files(std::slice::from_ref(&seed)).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(fs::metadata(&seed.path).unwrap().permissions().mode() & 0o777, 0o600);
+        }
         // Rewriting an older native snapshot must not supersede a newer
         // successful refresh merely because its filesystem mtime changed.
         fs::write(&native, json!({"fetched_at":"2025-12-01T00:00:00Z", "models":[

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -74,7 +74,14 @@ pub(crate) fn acquire_official_models_direct() -> Result<OfficialModelsAcquisiti
 /// Read the current Codex subscription model list without publishing any
 /// CodexHub catalog or touching the running Codex Desktop configuration.
 pub(crate) fn read_official_models_direct() -> Result<Vec<Model>, String> {
-    acquire_official_models_direct().map(|acquisition| acquisition.models)
+    let acquisition = acquire_official_models_direct()?;
+    let paths = ModelPaths::runtime()?;
+    let snapshot = match acquisition.native_cache.as_ref() {
+        Some(cache) => cache.clone(),
+        None => official_subscription_seed_text(&acquisition.subscription_models, &acquisition.visibility_diagnostics)?,
+    };
+    safe_file::write_text_atomic(&paths.official_editor_cache_path(), &snapshot)?;
+    Ok(acquisition.models)
 }
 
 pub(crate) fn prepare_official_models_acquisition(
@@ -87,7 +94,11 @@ pub(crate) fn prepare_official_models_acquisition(
         &acquisition.subscription_models,
         &acquisition.visibility_diagnostics,
     )?;
+    let editor_text = acquisition.native_cache.clone().unwrap_or_else(|| seed_text.clone());
     let mut files = vec![
+        crate::file_transaction::PreparedTextFile::runtime(
+            paths.official_editor_cache_path(), editor_text,
+        ),
         crate::file_transaction::PreparedTextFile::runtime(
             paths.metadata_cache_path(),
             format!("{metadata_text}\n"),
@@ -308,6 +319,74 @@ fn model_test_payload(
 
 pub fn list_models() -> Result<Vec<Model>, String> {
     Ok(list_models_with_presence()?.unwrap_or_default())
+}
+
+/// The Official editor needs the complete subscription catalog, not the
+/// enabled-only Gateway export. Native discovery owns membership; metadata
+/// defaults and user overrides must never resurrect an absent model.
+pub fn list_official_models() -> Result<Vec<Model>, String> {
+    let paths = ModelPaths::runtime()?;
+    let native_path = runtime_paths::codex_target_home_dir()?.join("models_cache.json");
+    let mut models = official_editor_models(&native_path, &paths)?;
+    apply_catalog_multi_agent_overrides(&paths, &mut models);
+    Ok(models)
+}
+
+fn official_editor_models(native_path: &Path, paths: &ModelPaths) -> Result<Vec<Model>, String> {
+    if let Some(payload) = official_editor_payload(native_path, paths)? {
+        let subscription = subscription_models_from_payload(&payload)?;
+        return Ok(subscription_models_to_metadata_models(&subscription));
+    }
+    Ok(read_official_subscription_models_from_cache_with_presence(paths)?.unwrap_or_default())
+}
+
+fn official_editor_payload(native_path: &Path, paths: &ModelPaths) -> Result<Option<Value>, String> {
+    let editor_path = paths.official_editor_cache_path();
+    let mut snapshots = Vec::new();
+    let mut errors = Vec::new();
+    for path in [native_path, editor_path.as_path()] {
+        if !path.exists() { continue; }
+        match load_json_file(path).and_then(|payload| {
+            subscription_models_from_payload(&payload)?;
+            Ok(payload)
+        }) {
+            Ok(payload) => {
+                let fetched = payload.get("fetched_at");
+                let timestamp = fetched.and_then(Value::as_i64).and_then(|s| s.checked_mul(1000))
+                    .or_else(|| fetched.and_then(Value::as_str).and_then(|s|
+                        chrono::DateTime::parse_from_rfc3339(s).ok().map(|t| t.timestamp_millis())))
+                    .unwrap_or_else(|| fs::metadata(path).ok().and_then(|m| m.modified().ok())
+                        .and_then(|t| t.duration_since(UNIX_EPOCH).ok()).map(|d| d.as_millis() as i64).unwrap_or(0));
+                snapshots.push((timestamp, payload));
+            }
+            Err(error) => errors.push(error),
+        }
+    }
+    if let Some((_, payload)) = snapshots.into_iter().max_by_key(|(timestamp, _)| *timestamp) {
+        return Ok(Some(payload));
+    }
+    if let Some(error) = errors.into_iter().next() { return Err(error); }
+    Ok(None)
+}
+
+/// Feed publication the same complete membership as the editor. Preserve the
+/// acquisition timestamp: reading a cached list does not make it fresh.
+pub(crate) fn prepare_official_editor_seed() -> Result<Option<crate::file_transaction::PreparedTextFile>, String> {
+    if !config::get_settings()?.include_official_models {
+        return Ok(None);
+    }
+    let paths = ModelPaths::runtime()?;
+    let native = runtime_paths::codex_target_home_dir()?.join("models_cache.json");
+    prepare_official_editor_seed_at(&native, &paths)
+}
+
+fn prepare_official_editor_seed_at(native: &Path, paths: &ModelPaths) -> Result<Option<crate::file_transaction::PreparedTextFile>, String> {
+    let Some(mut payload) = official_editor_payload(native, paths)? else { return Ok(None) };
+    let models = subscription_models_from_payload(&payload)?;
+    payload["visibility_diagnostics"] = visibility_diagnostics_from_payload(&payload);
+    payload["models"] = json!(models.iter().map(official_subscription_seed_model).collect::<Vec<_>>());
+    let text = serde_json::to_string_pretty(&payload).map_err(|error| format!("failed to serialize Official editor catalog: {error}"))?;
+    Ok(Some(crate::file_transaction::PreparedTextFile::runtime(paths.official_subscription_cache_path(), text)))
 }
 
 pub(crate) fn list_models_with_presence() -> Result<Option<Vec<Model>>, String> {
@@ -810,14 +889,27 @@ fn acquire_official_models_direct_with_runner(
     runner: &dyn AppServerModelListRunner,
 ) -> Result<OfficialModelsAcquisition, String> {
     let snapshot = runner.read_model_list()?;
-    let visibility_diagnostics = visibility_diagnostics_from_payload(&snapshot.payload);
-    let subscription_models = subscription_models_from_app_server_payload(&snapshot.payload)?;
+    let mut native_cache = snapshot.native_cache;
+    let native_payload = native_cache.as_ref().and_then(|text| serde_json::from_str::<Value>(text).ok())
+        .filter(|payload| payload.get("models").and_then(Value::as_array)
+            .is_some_and(|models| !models.is_empty() && models.iter().all(Value::is_object)));
+    if native_cache.is_some() && native_payload.is_none() {
+        if !model_list_contains_context_metadata(&snapshot.payload) {
+            return Err("Official refresh returned an invalid native model cache without complete model metadata".to_string());
+        }
+        native_cache = None;
+    }
+    // model/list may have returned fallback presets before the native online
+    // fetch completed. Use the validated fresh native snapshot consistently.
+    let payload = native_payload.as_ref().unwrap_or(&snapshot.payload);
+    let visibility_diagnostics = visibility_diagnostics_from_payload(payload);
+    let subscription_models = subscription_models_from_app_server_payload(payload)?;
     let models = subscription_models_to_metadata_models(&subscription_models);
     Ok(OfficialModelsAcquisition {
         subscription_models,
         models,
         visibility_diagnostics,
-        native_cache: snapshot.native_cache,
+        native_cache,
     })
 }
 
@@ -2501,6 +2593,10 @@ impl ModelPaths {
             .join("model-metadata-cache.json")
     }
 
+    fn official_editor_cache_path(&self) -> PathBuf {
+        self.codex_dir.join("proxy").join("official-editor-catalog.json")
+    }
+
     fn metadata_overrides_path(&self) -> PathBuf {
         self.codex_dir
             .join("proxy")
@@ -3333,6 +3429,69 @@ mod tests {
     use std::thread::{self, JoinHandle};
     use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
+    #[test]
+    fn official_editor_uses_full_native_membership_not_gateway_export_or_builtin_models() {
+        let root = temp_root("official-editor-membership");
+        let paths = test_paths(&root);
+        fs::create_dir_all(paths.generated_catalog_path().parent().unwrap()).unwrap();
+        fs::write(paths.generated_catalog_path(), json!({"models": [
+            {"slug": "gpt-5.4", "visibility": "list"}
+        ]}).to_string()).unwrap();
+        fs::write(paths.official_subscription_cache_path(), json!({"models": [
+            {"slug": "gpt-5.4", "visibility": "list"}
+        ]}).to_string()).unwrap();
+        let native = root.join("models_cache.json");
+        fs::write(&native, json!({"models": [
+            {"slug": "gpt-6-astra", "visibility": "list", "context_window": 1000000},
+            {"slug": "gpt-5.5", "visibility": "list"},
+            {"slug": "gpt-hidden", "visibility": "hide"}
+        ]}).to_string()).unwrap();
+        let models = super::official_editor_models(&native, &paths).unwrap();
+        assert_eq!(models.iter().map(|m| m.id.as_str()).collect::<Vec<_>>(), ["gpt-6-astra", "gpt-5.5"]);
+        fs::write(&native, "{\"models\":[]}").unwrap();
+        assert!(super::official_editor_models(&native, &paths).unwrap().is_empty());
+        fs::write(&native, "invalid").unwrap();
+        assert!(super::official_editor_models(&native, &paths).is_err());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn official_editor_refresh_snapshot_drives_reopen_and_save_without_renewing_freshness() {
+        let root = temp_root("official-editor-reopen");
+        fs::create_dir_all(&root).unwrap();
+        let paths = test_paths(&root);
+        let native = root.join("models_cache.json");
+        fs::write(&native, json!({"models": [{"slug":"gpt-5.4","visibility":"list"}]}).to_string()).unwrap();
+        fs::File::open(&native).unwrap().set_modified(UNIX_EPOCH + Duration::from_secs(100)).unwrap();
+        let snapshot = paths.official_editor_cache_path();
+        crate::safe_file::write_text_atomic(&snapshot, &json!({
+            "fetched_at": "2026-01-01T00:00:00Z", "client_version": "0.153.4",
+            "models": [{"slug":"gpt-6-astra","visibility":"list"}, {"slug":"gpt-hidden","visibility":"hide"}]
+        }).to_string()).unwrap();
+        fs::File::open(&snapshot).unwrap().set_modified(UNIX_EPOCH + Duration::from_secs(200)).unwrap();
+        let models = super::official_editor_models(&native, &paths).unwrap();
+        assert_eq!(models.iter().map(|m| m.id.as_str()).collect::<Vec<_>>(), ["gpt-6-astra"]);
+        let seed = super::prepare_official_editor_seed_at(&native, &paths).unwrap().unwrap();
+        let payload: Value = serde_json::from_str(&seed.text).unwrap();
+        assert_eq!(payload["fetched_at"], "2026-01-01T00:00:00Z");
+        assert_eq!(payload["models"].as_array().unwrap().len(), 1);
+        assert_eq!(payload["models"][0]["slug"], "gpt-6-astra");
+        assert_eq!(seed.path, paths.official_subscription_cache_path());
+        // Rewriting an older native snapshot must not supersede a newer
+        // successful refresh merely because its filesystem mtime changed.
+        fs::write(&native, json!({"fetched_at":"2025-12-01T00:00:00Z", "models":[
+            {"slug":"gpt-5.4", "visibility":"list"}
+        ]}).to_string()).unwrap();
+        assert_eq!(super::official_editor_models(&native, &paths).unwrap()[0].id, "gpt-6-astra");
+        fs::write(&native, "invalid").unwrap();
+        assert_eq!(super::official_editor_models(&native, &paths).unwrap()[0].id, "gpt-6-astra");
+        // A later native refresh supersedes the editor snapshot, including
+        // a valid empty catalog; removed models must not be resurrected.
+        fs::write(&native, "{\"models\":[]}").unwrap();
+        assert!(super::official_editor_models(&native, &paths).unwrap().is_empty());
+        fs::remove_dir_all(root).unwrap();
+    }
+
     static ENV_LOCK: Mutex<()> = Mutex::new(());
     const APP_SERVER_TEST_PROCESS_ENV: &str = "CODEXHUB_APP_SERVER_TEST_PROCESS";
     const APP_SERVER_TEST_PROCESS_LIVENESS_ENV: &str =
@@ -3936,7 +4095,7 @@ for line in sys.stdin:
                     "effective_context_window_percent": 95
                 }]
             }),
-            r#"{"etag":"fresh","models":[]}"#,
+            r#"{"etag":"fresh","models":[{"slug":"gpt-6-astra","visibility":"list","context_window":1000000,"effective_context_window_percent":95}]}"#,
         );
 
         let acquisition = super::acquire_official_models_direct_with_runner(&runner)
@@ -3944,8 +4103,20 @@ for line in sys.stdin:
 
         assert_eq!(
             acquisition.native_cache.as_deref(),
-            Some(r#"{"etag":"fresh","models":[]}"#)
+            Some(r#"{"etag":"fresh","models":[{"slug":"gpt-6-astra","visibility":"list","context_window":1000000,"effective_context_window_percent":95}]}"#)
         );
+        assert_eq!(acquisition.models[0].id, "gpt-6-astra");
+    }
+
+    #[test]
+    fn direct_acquisition_never_publishes_malformed_native_cache() {
+        let complete = json!({"models":[{"slug":"gpt-6-astra", "visibility":"list", "context_window":1000000, "effective_context_window_percent":95}]});
+        let runner = StaticAppServerModelListRunner::ok_with_cache(complete, "{partial");
+        let acquired = super::acquire_official_models_direct_with_runner(&runner).unwrap();
+        assert!(acquired.native_cache.is_none());
+        assert_eq!(acquired.models[0].id, "gpt-6-astra");
+        let runner = StaticAppServerModelListRunner::ok_with_cache(json!({"models":[{"slug":"gpt-5.4", "visibility":"list"}]}), "{partial");
+        assert!(super::acquire_official_models_direct_with_runner(&runner).is_err());
     }
 
     #[test]

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -347,7 +347,7 @@ fn official_editor_payload(native_path: &Path, paths: &ModelPaths) -> Result<Opt
     for path in [native_path, editor_path.as_path()] {
         if !path.exists() { continue; }
         match load_json_file(path).and_then(|payload| {
-            subscription_models_from_payload(&payload)?;
+            validate_official_snapshot(&payload)?;
             Ok(payload)
         }) {
             Ok(payload) => {
@@ -367,6 +367,28 @@ fn official_editor_payload(native_path: &Path, paths: &ModelPaths) -> Result<Opt
     }
     if let Some(error) = errors.into_iter().next() { return Err(error); }
     Ok(None)
+}
+
+fn validate_official_snapshot(payload: &Value) -> Result<(), String> {
+    let items = payload.get("models").and_then(Value::as_array)
+        .ok_or_else(|| "Official snapshot did not contain a model array".to_string())?;
+    // An explicitly empty (or entirely hidden) catalog is valid. Missing
+    // identity/visibility fields are not evidence that models were removed.
+    for item in items {
+        let object = item.as_object()
+            .ok_or_else(|| "Official snapshot contains a non-object model".to_string())?;
+        let identity = object.get("slug").or_else(|| object.get("id"))
+            .or_else(|| object.get("model")).or_else(|| object.get("name"));
+        if !identity.and_then(Value::as_str).is_some_and(|id| !id.trim().is_empty()) {
+            return Err("Official snapshot contains a model without an identity".to_string());
+        }
+        if !item_has_internal_identity(object)
+            && catalog_visibility_from_item(object) == CatalogVisibility::Unknown {
+            return Err("Official snapshot contains a model without known visibility".to_string());
+        }
+    }
+    subscription_models_from_payload(payload)?;
+    Ok(())
 }
 
 /// Feed publication the same complete membership as the editor. Preserve the
@@ -891,8 +913,7 @@ fn acquire_official_models_direct_with_runner(
     let snapshot = runner.read_model_list()?;
     let mut native_cache = snapshot.native_cache;
     let native_payload = native_cache.as_ref().and_then(|text| serde_json::from_str::<Value>(text).ok())
-        .filter(|payload| payload.get("models").and_then(Value::as_array)
-            .is_some_and(|models| !models.is_empty() && models.iter().all(Value::is_object)));
+        .filter(|payload| validate_official_snapshot(payload).is_ok());
     if native_cache.is_some() && native_payload.is_none() {
         if !model_list_contains_context_metadata(&snapshot.payload) {
             return Err("Official refresh returned an invalid native model cache without complete model metadata".to_string());
@@ -3462,13 +3483,13 @@ mod tests {
         let paths = test_paths(&root);
         let native = root.join("models_cache.json");
         fs::write(&native, json!({"models": [{"slug":"gpt-5.4","visibility":"list"}]}).to_string()).unwrap();
-        fs::File::open(&native).unwrap().set_modified(UNIX_EPOCH + Duration::from_secs(100)).unwrap();
+        fs::OpenOptions::new().write(true).open(&native).unwrap().set_modified(UNIX_EPOCH + Duration::from_secs(100)).unwrap();
         let snapshot = paths.official_editor_cache_path();
         crate::safe_file::write_text_atomic(&snapshot, &json!({
             "fetched_at": "2026-01-01T00:00:00Z", "client_version": "0.153.4",
             "models": [{"slug":"gpt-6-astra","visibility":"list"}, {"slug":"gpt-hidden","visibility":"hide"}]
         }).to_string()).unwrap();
-        fs::File::open(&snapshot).unwrap().set_modified(UNIX_EPOCH + Duration::from_secs(200)).unwrap();
+        fs::OpenOptions::new().write(true).open(&snapshot).unwrap().set_modified(UNIX_EPOCH + Duration::from_secs(200)).unwrap();
         let models = super::official_editor_models(&native, &paths).unwrap();
         assert_eq!(models.iter().map(|m| m.id.as_str()).collect::<Vec<_>>(), ["gpt-6-astra"]);
         let seed = super::prepare_official_editor_seed_at(&native, &paths).unwrap().unwrap();
@@ -3490,6 +3511,14 @@ mod tests {
         ]}).to_string()).unwrap();
         assert_eq!(super::official_editor_models(&native, &paths).unwrap()[0].id, "gpt-6-astra");
         fs::write(&native, "invalid").unwrap();
+        assert_eq!(super::official_editor_models(&native, &paths).unwrap()[0].id, "gpt-6-astra");
+        // A newer cache with missing visibility is incomplete, not an empty
+        // catalog. Keep the last complete snapshot instead of dropping rows.
+        fs::write(&native, include_str!("../../tests/fixtures/codex_0_144_2_direct_models_cache.json")).unwrap();
+        assert_eq!(super::official_editor_models(&native, &paths).unwrap()[0].id, "gpt-6-astra");
+        fs::write(&native, json!({"models":[
+            {"slug":"gpt-5.4", "visibility":"list"}, {"slug":"gpt-6-astra"}
+        ]}).to_string()).unwrap();
         assert_eq!(super::official_editor_models(&native, &paths).unwrap()[0].id, "gpt-6-astra");
         // A later native refresh supersedes the editor snapshot, including
         // a valid empty catalog; removed models must not be resurrected.
@@ -4117,12 +4146,15 @@ for line in sys.stdin:
     #[test]
     fn direct_acquisition_never_publishes_malformed_native_cache() {
         let complete = json!({"models":[{"slug":"gpt-6-astra", "visibility":"list", "context_window":1000000, "effective_context_window_percent":95}]});
-        let runner = StaticAppServerModelListRunner::ok_with_cache(complete, "{partial");
-        let acquired = super::acquire_official_models_direct_with_runner(&runner).unwrap();
-        assert!(acquired.native_cache.is_none());
-        assert_eq!(acquired.models[0].id, "gpt-6-astra");
-        let runner = StaticAppServerModelListRunner::ok_with_cache(json!({"models":[{"slug":"gpt-5.4", "visibility":"list"}]}), "{partial");
-        assert!(super::acquire_official_models_direct_with_runner(&runner).is_err());
+        for invalid in ["{partial", "{\"models\":[{\"visibility\":\"list\"}]}",
+            include_str!("../../tests/fixtures/codex_0_144_2_direct_models_cache.json")] {
+            let runner = StaticAppServerModelListRunner::ok_with_cache(complete.clone(), invalid);
+            let acquired = super::acquire_official_models_direct_with_runner(&runner).unwrap();
+            assert!(acquired.native_cache.is_none());
+            assert_eq!(acquired.models[0].id, "gpt-6-astra");
+            let runner = StaticAppServerModelListRunner::ok_with_cache(json!({"models":[{"slug":"gpt-5.4", "visibility":"list"}]}), invalid);
+            assert!(super::acquire_official_models_direct_with_runner(&runner).is_err());
+        }
     }
 
     #[test]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "CodexHub",
-  "version": "0.1.9-beta.3.18",
+  "version": "0.1.9-beta.3.19",
   "identifier": "com.codexhub.app",
   "build": {
     "frontendDist": "../frontend/dist",

--- a/tests/test_python_runtime.py
+++ b/tests/test_python_runtime.py
@@ -325,7 +325,7 @@ def test_relative_windows_entrypoints_keep_the_repository_runtime_contract() -> 
         "-DryRun",
     )
     assert portable_plan.returncode == 0, portable_plan.stdout + portable_plan.stderr
-    assert '"version":"0.1.9-beta.3.18"' in portable_plan.stdout
+    assert '"version":"0.1.9-beta.3.19"' in portable_plan.stdout
 
     runtime_check = _run_relative_powershell_script(
         r".\scripts\Prepare-PythonRuntime.ps1", "-CheckOnly"

--- a/tests/test_release_channel_scripts.py
+++ b/tests/test_release_channel_scripts.py
@@ -44,7 +44,7 @@ def test_official_transport_wheel_is_pinned_and_packaged():
 
 
 def test_release_version_is_consistent_across_manifests():
-    expected = "0.1.9-beta.3.18"
+    expected = "0.1.9-beta.3.19"
     tauri = json.loads((ROOT / "src-tauri" / "tauri.conf.json").read_text(encoding="utf-8"))
     cargo = tomllib.loads((ROOT / "src-tauri" / "Cargo.toml").read_text(encoding="utf-8"))
     cargo_lock = tomllib.loads((ROOT / "src-tauri" / "Cargo.lock").read_text(encoding="utf-8"))


### PR DESCRIPTION
## Problem and behavior

The Official editor opened from an enabled-only Gateway export, so startup could show an old four-model list while refresh discovered a different catalog. Async settings hydration and refresh could also reset draft preferences or incorrectly change Save availability.

Use one complete, validated Official snapshot for initial loading and catalog publication. Refresh preserves existing ordering, enabled states and in-flight edits; only newly discovered visible models add dirty state. Failed refresh preserves the current list. Successful snapshots persist with acquisition timestamps and owner-only permissions. Incomplete snapshots are rejected without treating them as model removals; valid empty catalogs remain authoritative.

Closes #500.

## Validation

Reviewed candidate: `7f773d11272ded8222a72a9ce0111f1ea18752ae`. Standards/Spec review and repair loop complete, no remaining P1/P2.

- Linux complete gate: Python 2081 passed / 164 skipped / 263 subtests; physical pointer E2E and clippy passed. Final Rust delta: 685 passed / 4 ignored.
- Windows: Python core 2211 passed / 34 skipped / 263 subtests; final Rust 687 passed / 3 ignored; clippy passed.
- Frontend build and all 81 UI contract checks passed.
- Windows watchdog synthetic suite: 151 passed in 1757.33 seconds; partition completeness passed. Its Python/scripts dependency tree remained unchanged across the Rust-only repair commits.
- Candidate builds: normal/debug Linux AppImage, deb and portable; normal/debug Windows NSIS and portable. All four installer signatures cryptographically verified.
- Live CLI: 8/8 on Linux and 8/8 on Windows, against the exact candidate. Codex CLI 0.153.4 remains npm latest on both hosts.

Retained completed full suites for unchanged boundaries; verified later Rust deltas per repository policy. Windows gate failures exposed host-dependent catalog fixtures and a read-only timestamp handle; both repaired and revalidated without changing production model membership to satisfy fixtures.

Final main `3dac567469513b564986dd984c80933c885c5318` has the same tree as the validated candidate. Both platforms were rebuilt from final main; the eight-case live matrix passed again on each OS. All four final installer signatures and 15 remote asset digests passed verification. Published [v0.1.9-beta.3.19](https://github.com/NOirBRight/CodexHub/releases/tag/v0.1.9-beta.3.19) as Latest; both actual updater manifest downloads match the signed release artifacts. GitHub Actions is disabled for this repository.

Known limitation: Codex CLI 0.153.4 retains its upstream fixed five-second online model-list timeout. This release addresses catalog/state correctness and truthful failure handling; it does not claim to remove the timeout.
