### PR TITLE
fix: direct official catalog refresh and prepare 3.20

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,3 +325,20 @@ unpackaged source runs still require the development toolchain.
 ## License
 
 MIT
+
+### Official model refresh
+
+CodexHub reads the account's complete Codex subscription model catalog directly,
+using the existing Codex ChatGPT login and the installed CLI's version. It does
+not use the Platform API model list or modify the CLI binary. The request keeps
+complete model metadata and the server ETag in the private editor cache. Existing
+ordering, enabled states and unsaved edits are retained; only new visible models
+introduce a save requirement on an otherwise unchanged draft.
+
+The default total refresh timeout is 30 seconds. Set
+`CODEXHUB_OFFICIAL_MODELS_TIMEOUT_SECONDS` to an integer from 1 to 300 in the
+CodexHub process environment to change it, then restart **CodexHub** to inherit
+the new environment. Codex Desktop does not need restarting. During refresh,
+the model-list refresh button becomes **Cancel**. Failed, invalid or cancelled
+requests leave the previous editor catalog intact. Startup and offline reads
+continue to use the last validated cache.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codexhub-frontend",
-  "version": "0.1.9-beta.3.19",
+  "version": "0.1.9-beta.3.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codexhub-frontend",
-      "version": "0.1.9-beta.3.19",
+      "version": "0.1.9-beta.3.20",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codexhub-frontend",
   "private": true,
-  "version": "0.1.9-beta.3.19",
+  "version": "0.1.9-beta.3.20",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/frontend/scripts/provider-workspace.test.mjs
+++ b/frontend/scripts/provider-workspace.test.mjs
@@ -313,6 +313,25 @@ test("snapshot receives published metadata without reverting membership, selecti
   assert.equal(state.officialModels[1].context_window, 272000);
 });
 
+test("late saved order survives repeated external synchronization after catalog initialization", async () => {
+  const m = await loadCombinedModule();
+  const models = ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]
+    .map(id => ({ id, visibility: "list", enabled: true }));
+  const settings = { official_model_sort_order: [models[2].id, models[0].id, models[1].id],
+    official_disabled_models: [models[1].id] };
+  let state = { selectedId: "__official__", settings: null, officialModelSnapshot: [],
+    officialModels: [], officialCatalogLoaded: false, officialModelOrderDraft: [], officialDisabledModelsDraft: [] };
+  state = m.providerWorkspaceReducer(state, { type: "initializeOfficialModels", models });
+  for (let i = 0; i < 3; i++) {
+    state = m.providerWorkspaceReducer(state, { type: "syncExternal", providers: [],
+      settings: structuredClone(settings), catalogModels: models, modelMetadata: [] });
+    assert.deepEqual(state.officialModels.map(model => model.id), settings.official_model_sort_order,
+      `saved order after external sync ${i + 1}`);
+    assert.equal(m.selectOfficialModelDraftDirty(state), false);
+    assert.equal(m.selectOfficialEnabledCount(state), 2);
+  }
+});
+
 test("catalogOverrideToastMessage null when all zero", async () => {
   const m = await loadCombinedModule();
   assert.equal(m.catalogOverrideToastMessage({ accepted: 0, rejected: 0, migrated: 0 }, () => "x"), null);

--- a/frontend/src/components/providers/ProviderModelSection.tsx
+++ b/frontend/src/components/providers/ProviderModelSection.tsx
@@ -31,6 +31,7 @@ export function ModelSection({
   onCancelNewModel,
   onDiscover,
   onRefresh,
+  onCancelRefresh,
   onRemove,
   onReorder,
   onTestModel,
@@ -57,6 +58,7 @@ export function ModelSection({
   onAdd?: () => string | undefined;
   onCancelNewModel?: (modelId: string) => void;
   onDiscover?: () => void;
+  onCancelRefresh?: () => void;
   onRefresh?: () => void;
   onRemove?: (modelId: string) => void;
   onReorder: (models: Model[]) => void;
@@ -255,13 +257,13 @@ export function ModelSection({
                 "focus-ring inline-flex shrink-0 items-center justify-center gap-2 border border-line bg-panel px-3 font-semibold hover:bg-slate-100 disabled:bg-slate-100",
                 headerControl ? "h-7 rounded-full text-xs" : "h-9 rounded-md text-sm",
               )}
-              disabled={interactionDisabled || refreshBusy}
-              aria-label={t("common.refresh")}
-              title={t("common.refresh")}
-              onClick={() => onRefresh()}
+              disabled={interactionDisabled || (refreshBusy && !onCancelRefresh)}
+              aria-label={t(refreshBusy && onCancelRefresh ? "common.cancel" : "common.refresh")}
+              title={t(refreshBusy && onCancelRefresh ? "common.cancel" : "common.refresh")}
+              onClick={() => refreshBusy && onCancelRefresh ? onCancelRefresh() : onRefresh()}
             >
-              <RefreshCcw size={16} />
-              {!headerControl && t("common.refresh")}
+              {refreshBusy && onCancelRefresh ? t("common.cancel") : <RefreshCcw size={16} />}
+              {!headerControl && !refreshBusy && t("common.refresh")}
             </button>
           )}
           {onDiscover && (

--- a/frontend/src/hooks/useProviderWorkspace.ts
+++ b/frontend/src/hooks/useProviderWorkspace.ts
@@ -76,6 +76,7 @@ export type ProviderWorkspaceHandle = {
     providerId?: string;
     toastId?: string;
   }) => Promise<ProviderWorkspaceOutcome>;
+  cancelOfficialModelRefresh: () => void;
   refreshOfficialModels: (options?: ProviderRefreshOptions) => Promise<ProviderWorkspaceOutcome>;
   deleteProvider: (providerId: string) => Promise<ProviderWorkspaceOutcome>;
   /** The single dirty-navigation entry point. */
@@ -144,6 +145,7 @@ export function useProviderWorkspace(options: {
   const { getSource, onProvidersChanged, onSettingsChanged, refreshGatewayState, toast, t, tr } = options;
   const { showToast, updateToast } = toast;
   const externalSource = getSource();
+  const officialRefreshId = useRef<string | null>(null);
   const [state, dispatch] = useReducer(providerWorkspaceReducer, externalSource, initialState);
   const dirtyDraftRef = useRef<ProviderDraftState<Provider> | null>(null);
   const sourceRef = useRef(externalSource);
@@ -522,6 +524,9 @@ export function useProviderWorkspace(options: {
           }
         }
         case "refreshOfficialModels": {
+          if (officialRefreshId.current) return { kind: "error", message: "Official refresh is already running" };
+          const requestId = crypto.randomUUID();
+          officialRefreshId.current = requestId;
           const quiet = intent.quiet ?? false;
           let toastId: string | null = null;
           try {
@@ -531,7 +536,7 @@ export function useProviderWorkspace(options: {
             }
             // Refresh reads the current Official model list. Applying a new
             // Codex overlay is a separate, explicitly authorized mutation.
-            const refreshResult = await api.refreshOfficialModels(false);
+            const refreshResult = await api.refreshOfficialModels(false, requestId);
             if (refreshResult.warning?.trim() && !refreshResult.codex_restart_result) {
               throw new Error(refreshResult.warning.trim());
             }
@@ -587,6 +592,7 @@ export function useProviderWorkspace(options: {
             }
             return { kind: "error", message: messageFromError(err) };
           } finally {
+            officialRefreshId.current = null;
             if (!quiet) {
               dispatch({ type: "setBusy", busy: null });
             }
@@ -829,6 +835,10 @@ export function useProviderWorkspace(options: {
     discoverForForm,
     probeProvider,
     refreshOfficialModels,
+    cancelOfficialModelRefresh: () => {
+      const id = officialRefreshId.current;
+      if (id) void api.cancelOfficialModelRefresh(id).catch((error) => showToast(messageFromError(error), "error"));
+    },
     deleteProvider,
     navigation,
     selectedProvider,

--- a/frontend/src/lib/commands.ts
+++ b/frontend/src/lib/commands.ts
@@ -22,6 +22,7 @@ export const COMMANDS = {
   saveSettings: "save_settings",
   getCodexContextGuardStatus: "get_codex_context_guard_status",
   setCodexContextGuard: "set_codex_context_guard",
+  cancelOfficialModelRefresh: "cancel_official_model_refresh",
   refreshOfficialModels: "refresh_official_models",
   openaiUsageCompletions: "openai_usage_completions",
   discoverProviderModels: "discover_provider_models",

--- a/frontend/src/lib/providerWorkspace/core.ts
+++ b/frontend/src/lib/providerWorkspace/core.ts
@@ -196,6 +196,12 @@ export function providerWorkspaceReducer(
       const snapshot = state.officialModelSnapshot == null ? null : reconcileOfficialModelSnapshot(
         state.officialModelSnapshot, intent.catalogModels, intent.modelMetadata,
       );
+      const officialModels = snapshot && JSON.stringify(officialModelOrderDraft) === JSON.stringify(state.officialModelOrderDraft)
+        ? snapshot
+        : sortOfficialModels(
+          snapshot ?? mergeOfficialModelSources(intent.catalogModels, intent.modelMetadata),
+          officialModelOrderDraft,
+        );
       const next = {
         ...state,
         providers: intent.providers,
@@ -205,13 +211,10 @@ export function providerWorkspaceReducer(
         officialModelOrderDraft,
         catalogModels: intent.catalogModels,
         modelMetadata: intent.modelMetadata,
-        officialModelSnapshot: snapshot,
-        officialModels: snapshot && JSON.stringify(officialModelOrderDraft) === JSON.stringify(state.officialModelOrderDraft)
-          ? snapshot
-          : sortOfficialModels(
-          snapshot ?? mergeOfficialModelSources(intent.catalogModels, intent.modelMetadata),
-          officialModelOrderDraft,
-        ),
+        // Keep the snapshot aligned when late settings reorder the list;
+        // the next metadata sync must not restore the previous order.
+        officialModelSnapshot: snapshot === null ? null : officialModels,
+        officialModels,
       };
       const selectedId = intent.selectedId ?? state.selectedId;
       if (

--- a/frontend/src/lib/tauri.ts
+++ b/frontend/src/lib/tauri.ts
@@ -229,6 +229,7 @@ export const api = {
       restartCodex,
       restart_codex: restartCodex,
     }),
+  cancelOfficialModelRefresh: () => call<void>(COMMANDS.cancelOfficialModelRefresh),
   refreshOfficialModels: (restartCodex = false) =>
     call<OfficialRefreshResult>(COMMANDS.refreshOfficialModels, {
       restartCodex,

--- a/frontend/src/lib/tauri.ts
+++ b/frontend/src/lib/tauri.ts
@@ -229,9 +229,11 @@ export const api = {
       restartCodex,
       restart_codex: restartCodex,
     }),
-  cancelOfficialModelRefresh: () => call<void>(COMMANDS.cancelOfficialModelRefresh),
-  refreshOfficialModels: (restartCodex = false) =>
+  cancelOfficialModelRefresh: (requestId: string) => call<void>(COMMANDS.cancelOfficialModelRefresh, { requestId, request_id: requestId }),
+  refreshOfficialModels: (restartCodex = false, requestId?: string) =>
     call<OfficialRefreshResult>(COMMANDS.refreshOfficialModels, {
+      requestId,
+      request_id: requestId,
       restartCodex,
       restart_codex: restartCodex,
     }),

--- a/frontend/src/pages/ProvidersPage.tsx
+++ b/frontend/src/pages/ProvidersPage.tsx
@@ -1882,6 +1882,7 @@ function OfficialDetail({
         officialCollaborationOverrides={officialCollaborationOverrides}
         officialDisabledModels={officialDisabledModels}
         onRefresh={onRefresh}
+        onCancelRefresh={() => { void api.cancelOfficialModelRefresh().catch((error) => showToast(String(error), "error")); }}
         onReorder={onReorder}
         onTestModel={testOfficialModel}
         refreshBusy={busy === "official-refresh"}

--- a/frontend/src/pages/ProvidersPage.tsx
+++ b/frontend/src/pages/ProvidersPage.tsx
@@ -156,6 +156,7 @@ function ProvidersPageImpl({
     discoverForForm: discoverWorkspaceForForm,
     probeProvider,
     refreshOfficialModels,
+    cancelOfficialModelRefresh,
     selectProvider,
     trackProviderDraft,
   } = workspace;
@@ -979,6 +980,7 @@ function ProvidersPageImpl({
                 onContextGuardChanged={reflectContextGuardSetting}
                 onOpenCodexApp={() => void openCodexAppForLogin()}
                 onRefresh={(options) => refreshOfficialModelsAndCollaborationState(options)}
+                onCancelRefresh={cancelOfficialModelRefresh}
                 onRefreshClients={onRefreshClients}
                 onRefreshAuth={() => void refreshCodexAuthStatus()}
                 onRefreshUsage={() => void loadOfficialOpenAIUsage(true, true)}
@@ -1583,6 +1585,7 @@ function OfficialDetail({
   onContextGuardChanged,
   onOpenCodexApp,
   onRefresh,
+  onCancelRefresh,
   onRefreshClients,
   onRefreshAuth,
   onRefreshUsage,
@@ -1611,6 +1614,7 @@ function OfficialDetail({
   onContextGuardChanged: (enabled: boolean) => void;
   onOpenCodexApp: () => void;
   onRefresh: (options?: { quiet?: boolean; throwOnError?: boolean }) => Promise<boolean>;
+  onCancelRefresh: () => void;
   onRefreshClients?: () => Promise<void>;
   onRefreshAuth: () => void;
   onRefreshUsage: () => void;
@@ -1882,7 +1886,7 @@ function OfficialDetail({
         officialCollaborationOverrides={officialCollaborationOverrides}
         officialDisabledModels={officialDisabledModels}
         onRefresh={onRefresh}
-        onCancelRefresh={() => { void api.cancelOfficialModelRefresh().catch((error) => showToast(String(error), "error")); }}
+        onCancelRefresh={onCancelRefresh}
         onReorder={onReorder}
         onTestModel={testOfficialModel}
         refreshBusy={busy === "official-refresh"}

--- a/scripts/check_codex_task_creation_lifecycle.py
+++ b/scripts/check_codex_task_creation_lifecycle.py
@@ -33,8 +33,12 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_EVIDENCE_PATH = (
     REPO_ROOT / "docs" / "evidence" / "issue-106" / "task-creation-lifecycle.json"
 )
-APP_SERVER_PROBE_MARKERS = {
-    Path("src-tauri/src/models.rs"): 'args(["app-server", "--stdio"])',
+# Historical evidence below remains immutable. Check today's ownership boundary
+# separately: model discovery now uses direct HTTP, while usage still probes
+# app-server. Neither path owns native task creation or global MCP settings.
+METADATA_PROBE_MARKERS = {
+    Path("src-tauri/src/models.rs"): "crate::official_catalog::fetch(refresh)?",
+    Path("src-tauri/src/official_catalog.rs"): "refresh.check(deadline)?",
     Path("src-tauri/src/openai_usage.rs"): 'args(["app-server", "--stdio"])',
 }
 OWNERSHIP_BOUNDARY_PATHS = (
@@ -43,7 +47,8 @@ OWNERSHIP_BOUNDARY_PATHS = (
     Path("src-tauri/src/catalog.rs"),
     Path("src-tauri/src/config.rs"),
     Path("src-tauri/src/proxy.rs"),
-    *APP_SERVER_PROBE_MARKERS,
+    Path("src-python/official_catalog.py"),
+    *METADATA_PROBE_MARKERS,
 )
 GLOBAL_MCP_CONFIGURATION_TOKENS = ("openaideveloperdocs", "mcp_servers")
 FORBIDDEN_KEYS = {
@@ -301,10 +306,10 @@ def validate_owned_boundary_sources(repo_root: Path = REPO_ROOT) -> list[str]:
                     "ownership boundary source configures global MCP token "
                     f"{token!r}: {relative_path.as_posix()}"
                 )
-        marker = APP_SERVER_PROBE_MARKERS.get(relative_path)
+        marker = METADATA_PROBE_MARKERS.get(relative_path)
         if marker is not None and marker.lower() not in source:
             mismatches.append(
-                "ownership boundary source missing bounded app-server probe: "
+                "ownership boundary source missing bounded metadata probe: "
                 f"{relative_path.as_posix()}"
             )
     return mismatches

--- a/scripts/check_codex_task_creation_lifecycle.py
+++ b/scripts/check_codex_task_creation_lifecycle.py
@@ -37,7 +37,7 @@ DEFAULT_EVIDENCE_PATH = (
 # separately: model discovery now uses direct HTTP, while usage still probes
 # app-server. Neither path owns native task creation or global MCP settings.
 METADATA_PROBE_MARKERS = {
-    Path("src-tauri/src/models.rs"): "crate::official_catalog::fetch(refresh)?",
+    Path("src-tauri/src/models.rs"): "crate::official_catalog::fetch(&refresh)?",
     Path("src-tauri/src/official_catalog.rs"): "refresh.check(deadline)?",
     Path("src-tauri/src/openai_usage.rs"): 'args(["app-server", "--stdio"])',
 }

--- a/src-python/codex_auth.py
+++ b/src-python/codex_auth.py
@@ -17,7 +17,7 @@ from typing import Any
 from urllib.request import Request, urlopen
 from urllib.error import URLError, HTTPError
 
-from atomic_io import atomic_write_text
+from atomic_io import atomic_write_text, file_lock_for
 
 CODEX_HOME_ENV = "CODEX_HOME"
 CODEX_TARGET_HOME_ENV = "CODEXHUB_CODEX_TARGET_HOME"
@@ -246,7 +246,18 @@ def access_token(
             payload = {}
         exp = payload.get("exp") if isinstance(payload, dict) else None
         if _is_expired(exp, now):
-            token = refresh(auth_data, path, _opener=_opener)
+            target = path or auth_json_path()
+            # Distinct from auth.json's atomic-write lock: refresh() publishes
+            # under that lock, so holding it here would deadlock.
+            with file_lock_for(target.with_name("codexhub-oauth-refresh")):
+                auth_data = load_auth_json(target)
+                token = auth_data["tokens"]["access_token"]
+                try:
+                    payload = decode_jwt_payload(token)
+                except CodexAuthError:
+                    payload = {}
+                if _is_expired(payload.get("exp"), now):
+                    token = refresh(auth_data, target, _opener=_opener)
 
         _cache = auth_data
         return token

--- a/src-python/codex_auth.py
+++ b/src-python/codex_auth.py
@@ -121,7 +121,7 @@ def _persist_auth_json(path: Path, data: dict[str, Any]) -> None:
     )
 
 
-def refresh(
+def _refresh_unlocked(
     auth_data: dict[str, Any],
     path: Path | None = None,
     *,
@@ -207,6 +207,29 @@ def refresh(
     return new_access
 
 
+def refresh(auth_data: dict[str, Any], path: Path | None = None, *,
+            token_url: str = OAUTH_TOKEN_URL, _opener: Any = None) -> str:
+    """Serialize every refresh owner, including forced adapter refreshes."""
+    target = path or auth_json_path()
+    previous = auth_data.get("tokens", {}).get("access_token")
+    # Separate from the auth.json atomic-write lock acquired during publication.
+    with file_lock_for(target.with_name("codexhub-oauth-refresh")):
+        current = load_auth_json(target)
+        token = current["tokens"]["access_token"]
+        try:
+            exp = decode_jwt_payload(token).get("exp")
+        except CodexAuthError:
+            exp = None
+        if token != previous and not _is_expired(exp):
+            auth_data.clear()
+            auth_data.update(current)
+            return token
+        token = _refresh_unlocked(current, target, token_url=token_url, _opener=_opener)
+        auth_data.clear()
+        auth_data.update(current)
+        return token
+
+
 def access_token(
     path: Path | None = None,
     *,
@@ -246,18 +269,7 @@ def access_token(
             payload = {}
         exp = payload.get("exp") if isinstance(payload, dict) else None
         if _is_expired(exp, now):
-            target = path or auth_json_path()
-            # Distinct from auth.json's atomic-write lock: refresh() publishes
-            # under that lock, so holding it here would deadlock.
-            with file_lock_for(target.with_name("codexhub-oauth-refresh")):
-                auth_data = load_auth_json(target)
-                token = auth_data["tokens"]["access_token"]
-                try:
-                    payload = decode_jwt_payload(token)
-                except CodexAuthError:
-                    payload = {}
-                if _is_expired(payload.get("exp"), now):
-                    token = refresh(auth_data, target, _opener=_opener)
+            token = refresh(auth_data, path, _opener=_opener)
 
         _cache = auth_data
         return token

--- a/src-python/official_catalog.py
+++ b/src-python/official_catalog.py
@@ -1,0 +1,84 @@
+"""Read the complete Codex subscription catalog; publication belongs to Rust.
+
+The parent process owns the total deadline and cancellation, including OAuth.
+No credentials or remote error bodies cross the helper's stdout boundary.
+"""
+from __future__ import annotations
+
+from python_runtime_contract import require_python_313
+require_python_313(__file__)
+
+import argparse
+from datetime import datetime, timezone
+import json
+import re
+import sys
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+import codex_auth
+
+MAX_RESPONSE_BYTES = 32 * 1024 * 1024
+ENDPOINT = "https://chatgpt.com/backend-api/codex/models"
+
+
+class CatalogError(RuntimeError):
+    pass
+
+
+class NoRedirect(HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        raise HTTPError(req.full_url, code, "Catalog redirects are not supported", headers, fp)
+
+
+def fetch_catalog(client_version: str, timeout: float, *, opener=None) -> dict:
+    if not re.fullmatch(r"\d+\.\d+\.\d+(?:[-+][a-zA-Z0-9.-]+)?", client_version):
+        raise CatalogError("Cannot determine the installed Codex CLI version")
+    token = codex_auth.access_token()
+    account = codex_auth.account_id()
+    headers = {"Authorization": f"Bearer {token}", "Accept": "application/json"}
+    if account:
+        headers["ChatGPT-Account-Id"] = account
+    request = Request(ENDPOINT + "?" + urlencode({"client_version": client_version}), headers=headers)
+    transport = opener or build_opener(NoRedirect()).open
+    try:
+        with transport(request, timeout=timeout) as response:
+            raw = response.read(MAX_RESPONSE_BYTES + 1)
+            etag = response.headers.get("ETag")
+    except HTTPError as exc:
+        raise CatalogError(f"Official catalog request failed (HTTP {exc.code})") from None
+    except (URLError, TimeoutError, OSError):
+        raise CatalogError("Official catalog request failed or timed out") from None
+    if len(raw) > MAX_RESPONSE_BYTES:
+        raise CatalogError("Official catalog response exceeds the size limit")
+    try:
+        result = json.loads(raw)
+    except (UnicodeDecodeError, ValueError):
+        raise CatalogError("Official catalog returned invalid JSON") from None
+    if not isinstance(result, dict) or not isinstance(result.get("models"), list):
+        raise CatalogError("Official catalog response has no model array")
+    result.update(client_version=client_version, etag=etag,
+                  fetched_at=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"))
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--client-version", required=True)
+    parser.add_argument("--timeout", type=float, required=True)
+    args = parser.parse_args()
+    try:
+        print(json.dumps(fetch_catalog(args.client_version, args.timeout), ensure_ascii=False))
+        return 0
+    except codex_auth.CodexAuthError:
+        print(json.dumps({"error": "Codex subscription login is unavailable; sign in again with Codex"}))
+    except CatalogError as exc:
+        print(json.dumps({"error": str(exc)}))
+    except Exception:
+        print(json.dumps({"error": "Official catalog refresh failed"}))
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src-python/official_catalog.py
+++ b/src-python/official_catalog.py
@@ -17,7 +17,7 @@ from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
 from urllib.request import HTTPRedirectHandler, Request, build_opener
 
-import codex_auth
+from subscription_credential import SubscriptionAuthError, credential_for
 
 MAX_RESPONSE_BYTES = 32 * 1024 * 1024
 ENDPOINT = "https://chatgpt.com/backend-api/codex/models"
@@ -35,11 +35,12 @@ class NoRedirect(HTTPRedirectHandler):
 def fetch_catalog(client_version: str, timeout: float, *, opener=None) -> dict:
     if not re.fullmatch(r"\d+\.\d+\.\d+(?:[-+][a-zA-Z0-9.-]+)?", client_version):
         raise CatalogError("Cannot determine the installed Codex CLI version")
-    token = codex_auth.access_token()
-    account = codex_auth.account_id()
+    credential = credential_for("codex_auth")
+    if credential is None:
+        raise CatalogError("Codex subscription authentication is unavailable")
+    token = credential.access_token()
     headers = {"Authorization": f"Bearer {token}", "Accept": "application/json"}
-    if account:
-        headers["ChatGPT-Account-Id"] = account
+    headers.update(credential.account_headers())
     request = Request(ENDPOINT + "?" + urlencode({"client_version": client_version}), headers=headers)
     transport = opener or build_opener(NoRedirect()).open
     try:
@@ -58,9 +59,37 @@ def fetch_catalog(client_version: str, timeout: float, *, opener=None) -> dict:
         raise CatalogError("Official catalog returned invalid JSON") from None
     if not isinstance(result, dict) or not isinstance(result.get("models"), list):
         raise CatalogError("Official catalog response has no model array")
+    validate_models(result["models"])
     result.update(client_version=client_version, etag=etag,
                   fetched_at=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"))
     return result
+
+
+def validate_models(models: list) -> None:
+    """Require stable ModelInfo wire fields; optional/dynamic budgets may be absent.
+
+    Unknown fields remain untouched. This is deliberately stricter than the
+    startup cache reader, which also supports historical native cache formats.
+    """
+    required = {"slug": str, "display_name": str, "shell_type": str,
+                "visibility": str, "supported_in_api": bool, "priority": int,
+                "supported_reasoning_levels": list, "support_verbosity": bool,
+                "truncation_policy": dict, "experimental_supported_tools": list}
+    seen = set()
+    for model in models:
+        if not isinstance(model, dict) or any(type(model.get(k)) is not kind for k, kind in required.items()):
+            raise CatalogError("Official catalog contains incomplete model metadata")
+        slug = model["slug"]
+        if not slug.strip() or slug in seen or model["visibility"] not in ("list", "hide"):
+            raise CatalogError("Official catalog contains invalid model identities or visibility")
+        seen.add(slug)
+        for level in model["supported_reasoning_levels"]:
+            if not isinstance(level, dict) or not isinstance(level.get("effort"), str) or not isinstance(level.get("description"), str):
+                raise CatalogError("Official catalog contains invalid reasoning metadata")
+        for key in ("context_window", "max_context_window", "auto_compact_token_limit"):
+            value = model.get(key)
+            if value is not None and (type(value) is not int or value <= 0):
+                raise CatalogError("Official catalog contains an invalid context budget")
 
 
 def main() -> int:
@@ -71,7 +100,7 @@ def main() -> int:
     try:
         print(json.dumps(fetch_catalog(args.client_version, args.timeout), ensure_ascii=False))
         return 0
-    except codex_auth.CodexAuthError:
+    except SubscriptionAuthError:
         print(json.dumps({"error": "Codex subscription login is unavailable; sign in again with Codex"}))
     except CatalogError as exc:
         print(json.dumps({"error": str(exc)}))

--- a/src-python/official_catalog.py
+++ b/src-python/official_catalog.py
@@ -98,7 +98,9 @@ def main() -> int:
     parser.add_argument("--timeout", type=float, required=True)
     args = parser.parse_args()
     try:
-        print(json.dumps(fetch_catalog(args.client_version, args.timeout), ensure_ascii=False))
+        # Windows pipes may use a legacy code page. ASCII JSON escapes preserve
+        # all metadata while keeping the parent-facing wire valid UTF-8.
+        print(json.dumps(fetch_catalog(args.client_version, args.timeout), ensure_ascii=True))
         return 0
     except SubscriptionAuthError:
         print(json.dumps({"error": "Codex subscription login is unavailable; sign in again with Codex"}))

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "codexhub"
-version = "0.1.9-beta.3.19"
+version = "0.1.9-beta.3.20"
 dependencies = [
  "cairo-rs",
  "chrono",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -502,6 +502,7 @@ dependencies = [
  "gdk-pixbuf",
  "glib",
  "gtk",
+ "libc",
  "log",
  "reqwest 0.12.28",
  "rusqlite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codexhub"
-version = "0.1.9-beta.3.19"
+version = "0.1.9-beta.3.20"
 description = "CodexHub desktop backend and CLI"
 authors = ["CodexHub"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -39,6 +39,9 @@ chrono = { version = "0.4", default-features = false, features = ["std"] }
 # preserving every user-owned key.
 serde_yaml = "0.9"
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [target.'cfg(target_os = "linux")'.dependencies]
 gtk = { version = "0.18", features = ["v3_24"] }
 glib = "0.18"

--- a/src-tauri/src/app_server.rs
+++ b/src-tauri/src/app_server.rs
@@ -1,4 +1,5 @@
 use serde_json::{json, Value};
+#[cfg(test)]
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Write};
 use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
@@ -133,6 +134,7 @@ impl AppServerSession {
         }
     }
 
+    #[cfg(test)]
     pub fn request(
         &mut self,
         calls: &[AppServerCall],
@@ -192,6 +194,7 @@ impl AppServerSession {
             .map_err(|error| format!("failed to flush codex app-server {purpose} request: {error}"))
     }
 
+    #[cfg(test)]
     fn read_message(&mut self, deadline: Instant, timeout: Duration, purpose: &str) -> Result<Value, String> {
         if Instant::now() >= deadline {
             self.kill();

--- a/src-tauri/src/app_server.rs
+++ b/src-tauri/src/app_server.rs
@@ -254,11 +254,11 @@ fn spawn_line_reader(
 }
 
 #[cfg(windows)]
-struct AppServerJob(windows_sys::Win32::Foundation::HANDLE);
+pub(crate) struct AppServerJob(windows_sys::Win32::Foundation::HANDLE);
 
 #[cfg(windows)]
 impl AppServerJob {
-    fn assign_to(child: &Child) -> Result<Self, String> {
+    pub(crate) fn assign_to(child: &Child) -> Result<Self, String> {
         use std::os::windows::io::AsRawHandle;
         use windows_sys::Win32::System::JobObjects::{
             AssignProcessToJobObject, CreateJobObjectW, JobObjectExtendedLimitInformation,

--- a/src-tauri/src/desktop_commands/handlers.rs
+++ b/src-tauri/src/desktop_commands/handlers.rs
@@ -438,6 +438,11 @@ pub async fn diagnose_conversation_history(
 }
 
 #[tauri::command]
+pub fn cancel_official_model_refresh() -> Result<(), String> {
+    crate::official_catalog::cancel()
+}
+
+#[tauri::command]
 pub async fn refresh_official_models(
     restart_codex: Option<bool>,
 ) -> Result<official_refresh::OfficialRefreshResult, String> {

--- a/src-tauri/src/desktop_commands/handlers.rs
+++ b/src-tauri/src/desktop_commands/handlers.rs
@@ -438,16 +438,20 @@ pub async fn diagnose_conversation_history(
 }
 
 #[tauri::command]
-pub fn cancel_official_model_refresh() -> Result<(), String> {
-    crate::official_catalog::cancel()
+pub fn cancel_official_model_refresh(request_id: String) -> Result<(), String> {
+    crate::official_catalog::cancel(&request_id)
 }
 
 #[tauri::command]
 pub async fn refresh_official_models(
     restart_codex: Option<bool>,
+    request_id: Option<String>,
 ) -> Result<official_refresh::OfficialRefreshResult, String> {
     run_blocking("refresh_official_models", move || {
-        refresh_official_models_coordinated(restart_codex.unwrap_or(false))
+        if !restart_codex.unwrap_or(false) {
+            return official_refresh::refresh_current_models_with_request(request_id.as_deref());
+        }
+        refresh_official_models_coordinated(true)
     })
     .await
 }

--- a/src-tauri/src/desktop_commands/mod.rs
+++ b/src-tauri/src/desktop_commands/mod.rs
@@ -35,6 +35,8 @@ const ALIASES_SWITCH_MODE: &[(&str, &str)] = &[
     ("forceTakeover", "force_takeover"),
     ("restartCodex", "restart_codex"),
 ];
+const ALIASES_REQUEST_ID: &[(&str, &str)] = &[("requestId", "request_id")];
+const ALIASES_OFFICIAL_REFRESH: &[(&str, &str)] = &[("restartCodex", "restart_codex"), ("requestId", "request_id")];
 const ALIASES_RESTART: &[(&str, &str)] = &[("restartCodex", "restart_codex")];
 const ALIASES_USAGE: &[(&str, &str)] = &[
     ("startTime", "start_time"),
@@ -99,8 +101,8 @@ macro_rules! desktop_command_registry {
             SaveSettings => "save_settings" => $crate::desktop_commands::save_settings, true, true, true, false, NO_ALIASES;
             GetCodexContextGuardStatus => "get_codex_context_guard_status" => $crate::desktop_commands::get_codex_context_guard_status, true, true, true, false, NO_ALIASES;
             SetCodexContextGuard => "set_codex_context_guard" => $crate::desktop_commands::set_codex_context_guard, true, true, true, false, ALIASES_RESTART;
-            CancelOfficialModelRefresh => "cancel_official_model_refresh" => $crate::desktop_commands::cancel_official_model_refresh, true, true, true, false, NO_ALIASES;
-            RefreshOfficialModels => "refresh_official_models" => $crate::desktop_commands::refresh_official_models, true, true, true, false, ALIASES_RESTART;
+            CancelOfficialModelRefresh => "cancel_official_model_refresh" => $crate::desktop_commands::cancel_official_model_refresh, true, true, true, false, ALIASES_REQUEST_ID;
+            RefreshOfficialModels => "refresh_official_models" => $crate::desktop_commands::refresh_official_models, true, true, true, false, ALIASES_OFFICIAL_REFRESH;
             OpenaiUsageCompletions => "openai_usage_completions" => $crate::desktop_commands::openai_usage_completions, true, true, true, false, ALIASES_USAGE;
             DiscoverProviderModels => "discover_provider_models" => $crate::desktop_commands::discover_provider_models, true, true, true, false, ALIASES_DISCOVER;
             ProbeUpstreamFormat => "probe_upstream_format" => $crate::desktop_commands::probe_upstream_format, true, true, true, false, ALIASES_BASE_URL_API_KEY;

--- a/src-tauri/src/desktop_commands/mod.rs
+++ b/src-tauri/src/desktop_commands/mod.rs
@@ -99,6 +99,7 @@ macro_rules! desktop_command_registry {
             SaveSettings => "save_settings" => $crate::desktop_commands::save_settings, true, true, true, false, NO_ALIASES;
             GetCodexContextGuardStatus => "get_codex_context_guard_status" => $crate::desktop_commands::get_codex_context_guard_status, true, true, true, false, NO_ALIASES;
             SetCodexContextGuard => "set_codex_context_guard" => $crate::desktop_commands::set_codex_context_guard, true, true, true, false, ALIASES_RESTART;
+            CancelOfficialModelRefresh => "cancel_official_model_refresh" => $crate::desktop_commands::cancel_official_model_refresh, true, true, true, false, NO_ALIASES;
             RefreshOfficialModels => "refresh_official_models" => $crate::desktop_commands::refresh_official_models, true, true, true, false, ALIASES_RESTART;
             OpenaiUsageCompletions => "openai_usage_completions" => $crate::desktop_commands::openai_usage_completions, true, true, true, false, ALIASES_USAGE;
             DiscoverProviderModels => "discover_provider_models" => $crate::desktop_commands::discover_provider_models, true, true, true, false, ALIASES_DISCOVER;

--- a/src-tauri/src/desktop_commands/web_adapter.rs
+++ b/src-tauri/src/desktop_commands/web_adapter.rs
@@ -88,6 +88,7 @@ pub fn dispatch_web(command: &str, args: &Value, app: Option<AppHandle>) -> Resu
                 registry_optional_bool_arg(args, command, "restart_codex").unwrap_or(false);
             to_value(crate::set_codex_context_guard(enabled, Some(restart_codex)))
         }
+        Command::CancelOfficialModelRefresh => to_value(crate::official_catalog::cancel()),
         Command::RefreshOfficialModels => {
             let restart_codex =
                 registry_optional_bool_arg(args, command, "restart_codex").unwrap_or(false);

--- a/src-tauri/src/desktop_commands/web_adapter.rs
+++ b/src-tauri/src/desktop_commands/web_adapter.rs
@@ -88,11 +88,20 @@ pub fn dispatch_web(command: &str, args: &Value, app: Option<AppHandle>) -> Resu
                 registry_optional_bool_arg(args, command, "restart_codex").unwrap_or(false);
             to_value(crate::set_codex_context_guard(enabled, Some(restart_codex)))
         }
-        Command::CancelOfficialModelRefresh => to_value(crate::official_catalog::cancel()),
+        Command::CancelOfficialModelRefresh => {
+            let request_id = registry_optional_string_arg(args, command, "request_id")
+                .ok_or_else(|| "request_id is required".to_string())?;
+            to_value(crate::official_catalog::cancel(&request_id))
+        },
         Command::RefreshOfficialModels => {
             let restart_codex =
                 registry_optional_bool_arg(args, command, "restart_codex").unwrap_or(false);
-            to_value(crate::refresh_official_models_coordinated(restart_codex))
+            if !restart_codex {
+                let request_id = registry_optional_string_arg(args, command, "request_id");
+                to_value(crate::official_refresh::refresh_current_models_with_request(request_id.as_deref()))
+            } else {
+                to_value(crate::refresh_official_models_coordinated(true))
+            }
         }
         Command::OpenaiUsageCompletions => {
             let start_time = registry_optional_u64_arg(args, command, "start_time");

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -24,6 +24,7 @@ mod linux_window;
 mod lock_test_fixtures;
 mod models;
 mod official_refresh;
+mod official_catalog;
 mod openai_usage;
 mod proxy;
 mod routing_owner;

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -59,40 +59,72 @@ const KNOWN_PROVIDER_ENDPOINT_SUFFIXES: &[&str] = &[
     "/models",
 ];
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) struct OfficialModelsAcquisition {
+    refresh: Option<crate::official_catalog::Refresh>,
     subscription_models: Vec<OfficialSubscriptionModel>,
     models: Vec<Model>,
     visibility_diagnostics: Value,
     native_cache: Option<String>,
 }
 
-pub(crate) fn acquire_official_models_direct() -> Result<OfficialModelsAcquisition, String> {
-    let refresh = crate::official_catalog::Refresh::begin()?;
-    acquire_official_catalog(&refresh)
+impl OfficialModelsAcquisition {
+    pub(crate) fn publish<T, E: From<String>>(
+        &self,
+        publish: impl FnOnce() -> Result<T, E>,
+    ) -> Result<T, E> {
+        match &self.refresh {
+            Some(refresh) => refresh.publish(publish),
+            None => publish(), // Legacy conversion fixtures do not start a live refresh.
+        }
+    }
 }
 
-fn acquire_official_catalog(refresh: &crate::official_catalog::Refresh) -> Result<OfficialModelsAcquisition, String> {
-    let text = crate::official_catalog::fetch(refresh)?;
-    let payload: Value = serde_json::from_str(&text).map_err(|_| "Official catalog returned invalid JSON")?;
+pub(crate) fn acquire_official_models_direct() -> Result<OfficialModelsAcquisition, String> {
+    let refresh = crate::official_catalog::Refresh::begin()?;
+    acquire_official_catalog(refresh)
+}
+
+fn acquire_official_catalog(
+    refresh: crate::official_catalog::Refresh,
+) -> Result<OfficialModelsAcquisition, String> {
+    let text = crate::official_catalog::fetch(&refresh)?;
+    let payload: Value =
+        serde_json::from_str(&text).map_err(|_| "Official catalog returned invalid JSON")?;
     validate_official_snapshot(&payload)?;
     let visibility_diagnostics = visibility_diagnostics_from_payload(&payload);
     let subscription_models = subscription_models_from_payload(&payload)?;
     let models = subscription_models_to_metadata_models(&subscription_models);
-    Ok(OfficialModelsAcquisition { subscription_models, models, visibility_diagnostics, native_cache: Some(text) })
+    refresh.check_current()?;
+    Ok(OfficialModelsAcquisition {
+        refresh: Some(refresh),
+        subscription_models,
+        models,
+        visibility_diagnostics,
+        native_cache: Some(text),
+    })
 }
 
 /// Read the current Codex subscription model list without publishing any
 /// CodexHub catalog or touching the running Codex Desktop configuration.
-pub(crate) fn read_official_models_direct() -> Result<Vec<Model>, String> {
-    let refresh = crate::official_catalog::Refresh::begin()?;
-    let acquisition = acquire_official_catalog(&refresh)?;
+pub(crate) fn read_official_models_direct(request_id: Option<&str>) -> Result<Vec<Model>, String> {
+    let refresh = crate::official_catalog::Refresh::begin_for(request_id)?;
+    let acquisition = acquire_official_catalog(refresh)?;
     let paths = ModelPaths::runtime()?;
     let snapshot = match acquisition.native_cache.as_ref() {
         Some(cache) => cache.clone(),
-        None => official_subscription_seed_text(&acquisition.subscription_models, &acquisition.visibility_diagnostics)?,
+        None => official_subscription_seed_text(
+            &acquisition.subscription_models,
+            &acquisition.visibility_diagnostics,
+        )?,
     };
-    refresh.publish(|| safe_file::write_text_atomic_with_mode(&paths.official_editor_cache_path(), &snapshot, Some(0o600)))?;
+    acquisition.publish(|| {
+        safe_file::write_text_atomic_with_mode(
+            &paths.official_editor_cache_path(),
+            &snapshot,
+            Some(0o600),
+        )
+    })?;
     Ok(acquisition.models)
 }
 
@@ -934,6 +966,7 @@ fn acquire_official_models_direct_with_runner(
     let subscription_models = subscription_models_from_app_server_payload(payload)?;
     let models = subscription_models_to_metadata_models(&subscription_models);
     Ok(OfficialModelsAcquisition {
+        refresh: None,
         subscription_models,
         models,
         visibility_diagnostics,

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -1,5 +1,4 @@
 use crate::{
-    app_server::{AppServerCall, AppServerSession},
     config, runtime_paths, safe_file, CatalogVisibility, MetadataProvenance, Model, ModelPricing,
     Settings, UpstreamFormat,
 };
@@ -10,20 +9,21 @@ use serde_json::{json, Map, Value};
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
+#[cfg(test)]
 use std::process::Command;
+#[cfg(test)]
+use crate::app_server::{AppServerCall, AppServerSession};
 use std::sync::OnceLock;
+#[cfg(test)]
 use std::sync::atomic::{AtomicU64, Ordering};
+#[cfg(test)]
 use std::thread;
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+#[cfg(test)]
+use std::time::Instant;
 
 const DISCOVERY_TIMEOUT: Duration = Duration::from_secs(20);
 const MODEL_TEST_TIMEOUT: Duration = Duration::from_secs(8);
-const CODEX_APP_SERVER_MODEL_LIST_TIMEOUT: Duration = Duration::from_secs(8);
-// Codex CLI 0.146 may answer model/list before it atomically publishes the
-// native context cache.  A response that already carries context is a safe
-// direct snapshot and returns immediately; a context-less response needs this
-// bounded grace before the catalog can resolve a safe Official budget.
-const CODEX_APP_SERVER_NATIVE_CACHE_GRACE: Duration = Duration::from_secs(20);
 const MAX_VISIBILITY_DIAGNOSTIC_COUNT: u64 = 100;
 const GENERATED_CATALOG_FILE: &str = "codexhub-model-catalog.json";
 const LEGACY_GENERATED_CATALOG_FILE: &str = "codex-proxy-official-ollama.json";
@@ -68,19 +68,31 @@ pub(crate) struct OfficialModelsAcquisition {
 }
 
 pub(crate) fn acquire_official_models_direct() -> Result<OfficialModelsAcquisition, String> {
-    acquire_official_models_direct_with_runner(&ProcessAppServerModelListRunner)
+    let refresh = crate::official_catalog::Refresh::begin()?;
+    acquire_official_catalog(&refresh)
+}
+
+fn acquire_official_catalog(refresh: &crate::official_catalog::Refresh) -> Result<OfficialModelsAcquisition, String> {
+    let text = crate::official_catalog::fetch(refresh)?;
+    let payload: Value = serde_json::from_str(&text).map_err(|_| "Official catalog returned invalid JSON")?;
+    validate_official_snapshot(&payload)?;
+    let visibility_diagnostics = visibility_diagnostics_from_payload(&payload);
+    let subscription_models = subscription_models_from_payload(&payload)?;
+    let models = subscription_models_to_metadata_models(&subscription_models);
+    Ok(OfficialModelsAcquisition { subscription_models, models, visibility_diagnostics, native_cache: Some(text) })
 }
 
 /// Read the current Codex subscription model list without publishing any
 /// CodexHub catalog or touching the running Codex Desktop configuration.
 pub(crate) fn read_official_models_direct() -> Result<Vec<Model>, String> {
-    let acquisition = acquire_official_models_direct()?;
+    let refresh = crate::official_catalog::Refresh::begin()?;
+    let acquisition = acquire_official_catalog(&refresh)?;
     let paths = ModelPaths::runtime()?;
     let snapshot = match acquisition.native_cache.as_ref() {
         Some(cache) => cache.clone(),
         None => official_subscription_seed_text(&acquisition.subscription_models, &acquisition.visibility_diagnostics)?,
     };
-    safe_file::write_text_atomic_with_mode(&paths.official_editor_cache_path(), &snapshot, Some(0o600))?;
+    refresh.publish(|| safe_file::write_text_atomic_with_mode(&paths.official_editor_cache_path(), &snapshot, Some(0o600)))?;
     Ok(acquisition.models)
 }
 
@@ -860,22 +872,16 @@ fn refresh_official_models_from_endpoint(
     )
 }
 
+#[cfg(test)]
 trait AppServerModelListRunner {
     fn read_model_list(&self) -> Result<AppServerModelListSnapshot, String>;
 }
 
+#[cfg(test)]
 #[derive(Debug, Clone)]
 struct AppServerModelListSnapshot {
     payload: Value,
     native_cache: Option<String>,
-}
-
-struct ProcessAppServerModelListRunner;
-
-impl AppServerModelListRunner for ProcessAppServerModelListRunner {
-    fn read_model_list(&self) -> Result<AppServerModelListSnapshot, String> {
-        read_codex_app_server_model_list()
-    }
 }
 
 #[cfg(test)]
@@ -907,6 +913,7 @@ fn refresh_official_models_direct_with_runner(
     Ok(acquisition.models)
 }
 
+#[cfg(test)]
 fn acquire_official_models_direct_with_runner(
     runner: &dyn AppServerModelListRunner,
 ) -> Result<OfficialModelsAcquisition, String> {
@@ -968,30 +975,12 @@ fn visibility_diagnostics_from_payload(payload: &Value) -> Value {
     Value::Object(counts)
 }
 
-fn read_codex_app_server_model_list() -> Result<AppServerModelListSnapshot, String> {
-    let target_home = runtime_paths::codex_target_home_dir()?;
-    let staging = StagedCodexHome::new(&target_home)?;
-    let mut command = crate::codex_cli::command()?;
-    command.args(["app-server", "--stdio"]);
-    command.env("CODEX_HOME", staging.path());
-    let cache_path = staging.path().join("models_cache.json");
-    let payload = read_codex_app_server_model_list_with_cache_path(
-        command,
-        CODEX_APP_SERVER_MODEL_LIST_TIMEOUT,
-        &cache_path,
-        CODEX_APP_SERVER_NATIVE_CACHE_GRACE,
-    )?;
-    let native_cache = fs::read_to_string(&cache_path).ok();
-    Ok(AppServerModelListSnapshot {
-        payload,
-        native_cache,
-    })
-}
-
+#[cfg(test)]
 struct StagedCodexHome {
     path: PathBuf,
 }
 
+#[cfg(test)]
 impl StagedCodexHome {
     fn new(source_home: &Path) -> Result<Self, String> {
         static NEXT_STAGING_ID: AtomicU64 = AtomicU64::new(1);
@@ -1038,6 +1027,7 @@ impl StagedCodexHome {
     }
 }
 
+#[cfg(test)]
 impl Drop for StagedCodexHome {
     fn drop(&mut self) {
         if let Err(error) = fs::remove_dir_all(&self.path) {
@@ -1054,6 +1044,7 @@ fn read_codex_app_server_model_list_with_command(
     read_codex_app_server_model_list_with_cache_grace(command, timeout, None, Duration::ZERO)
 }
 
+#[cfg(test)]
 fn read_codex_app_server_model_list_with_cache_path(
     command: Command,
     timeout: Duration,
@@ -1068,6 +1059,7 @@ fn read_codex_app_server_model_list_with_cache_path(
     )
 }
 
+#[cfg(test)]
 fn read_codex_app_server_model_list_with_cache_grace(
     command: Command,
     timeout: Duration,
@@ -1131,6 +1123,7 @@ fn read_codex_app_server_model_list_with_cache_grace(
     Ok(result)
 }
 
+#[cfg(test)]
 fn model_list_contains_context_metadata(result: &Value) -> bool {
     let Some(items) = result
         .get("data")
@@ -1164,6 +1157,7 @@ fn model_list_contains_context_metadata(result: &Value) -> bool {
         })
 }
 
+#[cfg(test)]
 fn wait_for_native_model_cache_publication(
     cache_path: &Path,
     grace: Duration,
@@ -1190,6 +1184,7 @@ fn wait_for_native_model_cache_publication(
     }
 }
 
+#[cfg(test)]
 fn readable_native_model_cache(cache_path: &Path) -> Option<Vec<u8>> {
     let bytes = fs::read(cache_path).ok()?;
     let payload: Value = serde_json::from_slice(&bytes).ok()?;
@@ -1226,6 +1221,7 @@ struct ReasoningLevelEntry {
     description: Option<String>,
 }
 
+#[cfg(test)]
 fn subscription_models_from_app_server_payload(
     payload: &Value,
 ) -> Result<Vec<OfficialSubscriptionModel>, String> {
@@ -3445,7 +3441,9 @@ mod tests {
     use std::sync::mpsc::{self, Receiver};
     use std::sync::Mutex;
     use std::thread::{self, JoinHandle};
-    use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+#[cfg(test)]
+use std::time::Instant;
 
     #[test]
     fn official_editor_uses_full_native_membership_not_gateway_export_or_builtin_models() {

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -1775,6 +1775,15 @@ fn official_subscription_seed_text(
 
 fn official_subscription_seed_model(model: &OfficialSubscriptionModel) -> Value {
     let mut payload = model.raw.as_object().cloned().unwrap_or_default();
+    // The subscription endpoint sends ModelInfo (shell_type), unlike the
+    // app-server list DTO. Codex 0.153.4 deserializes an omitted percent as 95
+    // (protocol/src/openai_models.rs). Apply that default only to the derived
+    // seed with a supplied numeric window; keep the raw response untouched.
+    if payload.get("shell_type").and_then(Value::as_str).is_some()
+        && payload.get("context_window").and_then(Value::as_u64).is_some_and(|value| value > 0)
+    {
+        payload.entry("effective_context_window_percent".to_string()).or_insert(json!(95));
+    }
     ensure_responses_lite_opt_in(&mut payload);
     payload.insert("visibility".to_string(), json!(CatalogVisibility::List));
     payload.insert("slug".to_string(), json!(model.slug));
@@ -5123,6 +5132,29 @@ for line in sys.stdin:
                 );
             }
         }
+    }
+
+    #[test]
+    fn subscription_model_info_seed_applies_cli_percent_default_without_changing_raw_response() {
+        for percent in [None, Some(json!(80)), Some(Value::Null)] {
+            let mut row = json!({"slug":"gpt-5.6-luna", "visibility":"list",
+                "display_name":"Luna", "shell_type":"shell_command",
+                "context_window":272000, "max_context_window":872000,
+                "auto_compact_token_limit":null});
+            if let Some(value) = percent.clone() {
+                row["effective_context_window_percent"] = value;
+            }
+            let models = subscription_models_from_payload(&json!({"models":[row]})).unwrap();
+            let seed = super::official_subscription_seed_model(&models[0]);
+            assert_eq!(seed["effective_context_window_percent"], percent.clone().unwrap_or(json!(95)));
+            assert_eq!(models[0].raw.get("effective_context_window_percent"), percent.as_ref());
+        }
+        let models = subscription_models_from_payload(&json!({"models":[{
+            "slug":"gpt-5.6-luna", "visibility":"list", "shell_type":"shell_command"
+        }]})).unwrap();
+        let seed = super::official_subscription_seed_model(&models[0]);
+        assert!(seed.get("context_window").is_none());
+        assert!(seed.get("effective_context_window_percent").is_none());
     }
 
     #[test]

--- a/src-tauri/src/official_catalog.rs
+++ b/src-tauri/src/official_catalog.rs
@@ -131,7 +131,6 @@ fn timeout() -> Result<Duration, String> {
 
 pub(crate) fn fetch(refresh: &Refresh) -> Result<String, String> {
     let deadline = refresh.deadline;
-    let budget = deadline.saturating_duration_since(Instant::now());
     let mut version_command = crate::codex_cli::command()?;
     version_command.arg("--version");
     let output = run(version_command, refresh, deadline, 4096)?;
@@ -150,13 +149,22 @@ pub(crate) fn fetch(refresh: &Refresh) -> Result<String, String> {
             "--client-version",
             version,
             "--timeout",
-            &budget.as_secs().to_string(),
+            &http_timeout_argument(deadline),
         ])
         .env(
             "CODEXHUB_CODEX_TARGET_HOME",
             crate::runtime_paths::codex_target_home_dir()?,
         );
     run(command, refresh, deadline, 33 * 1024 * 1024)
+}
+
+fn http_timeout_argument(deadline: Instant) -> String {
+    // A one-second total budget already has less than one whole second left
+    // after process setup. Preserve fractions instead of making urllib nonblocking.
+    deadline
+        .saturating_duration_since(Instant::now())
+        .as_secs_f64()
+        .to_string()
 }
 
 fn run(
@@ -376,5 +384,15 @@ mod tests {
         assert!(start.elapsed() < Duration::from_secs(2));
         std::thread::sleep(Duration::from_millis(1100));
         assert!(!marker.exists(), "catalog descendant survived its deadline");
+    }
+    #[test]
+    fn one_second_budget_does_not_become_a_zero_http_timeout() {
+        let deadline = Instant::now() + Duration::from_secs(1);
+        std::thread::sleep(Duration::from_millis(5));
+        let seconds: f64 = http_timeout_argument(deadline).parse().unwrap();
+        assert!(
+            seconds > 0.0 && seconds < 1.0,
+            "remaining timeout: {seconds}"
+        );
     }
 }

--- a/src-tauri/src/official_catalog.rs
+++ b/src-tauri/src/official_catalog.rs
@@ -8,26 +8,48 @@ use std::time::{Duration, Instant};
 struct State {
     running: bool,
     cancelled: bool,
+    request_id: Option<String>,
+    early_cancellations: Vec<String>,
 }
 static STATE: Mutex<State> = Mutex::new(State {
     running: false,
     cancelled: false,
+    request_id: None,
+    early_cancellations: Vec::new(),
 });
-pub(crate) struct Refresh;
+#[derive(Debug)]
+pub(crate) struct Refresh {
+    deadline: Instant,
+}
 
 impl Refresh {
     pub(crate) fn begin() -> Result<Self, String> {
+        Self::begin_for(None)
+    }
+    pub(crate) fn begin_for(request_id: Option<&str>) -> Result<Self, String> {
+        if let Some(id) = request_id {
+            validate_request_id(id)?;
+        }
+        let deadline = Instant::now() + timeout()?;
         let mut state = STATE
             .lock()
             .map_err(|_| "Official refresh lock unavailable")?;
+        if let Some(index) =
+            request_id.and_then(|id| state.early_cancellations.iter().position(|v| v == id))
+        {
+            state.early_cancellations.remove(index);
+            return Err("Official model refresh cancelled".into());
+        }
         if state.running {
             return Err("Official refresh is already running".into());
         }
-        *state = State {
-            running: true,
-            cancelled: false,
-        };
-        Ok(Self)
+        state.running = true;
+        state.cancelled = false;
+        state.request_id = request_id.map(str::to_string);
+        Ok(Self { deadline })
+    }
+    pub(crate) fn check_current(&self) -> Result<(), String> {
+        self.check(self.deadline)
     }
     fn check(&self, deadline: Instant) -> Result<(), String> {
         let state = STATE
@@ -36,37 +58,59 @@ impl Refresh {
         if state.cancelled {
             return Err("Official model refresh cancelled".into());
         }
-        if Instant::now() >= deadline {
+        if Instant::now() >= deadline.min(self.deadline) {
             return Err("Official model refresh timed out".into());
         }
         Ok(())
     }
-    pub(crate) fn publish<T>(
+    pub(crate) fn publish<T, E: From<String>>(
         &self,
-        write: impl FnOnce() -> Result<T, String>,
-    ) -> Result<T, String> {
+        write: impl FnOnce() -> Result<T, E>,
+    ) -> Result<T, E> {
         let state = STATE
             .lock()
-            .map_err(|_| "Official refresh lock unavailable")?;
+            .map_err(|_| E::from("Official refresh lock unavailable".to_string()))?;
         if state.cancelled {
-            return Err("Official model refresh cancelled".into());
+            return Err(E::from("Official model refresh cancelled".to_string()));
         }
+        if Instant::now() >= self.deadline {
+            return Err(E::from("Official model refresh timed out".to_string()));
+        }
+        // Commit is the linearization point: later cancellation cannot undo a
+        // completed atomic publication or cancel a different request.
         write()
     }
 }
 impl Drop for Refresh {
     fn drop(&mut self) {
         if let Ok(mut state) = STATE.lock() {
-            *state = State::default();
+            state.running = false;
+            state.cancelled = false;
+            state.request_id = None;
         }
     }
 }
-pub(crate) fn cancel() -> Result<(), String> {
+fn validate_request_id(id: &str) -> Result<(), String> {
+    if id.is_empty() || id.len() > 64 || !id.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'-')
+    {
+        return Err("Invalid Official refresh request id".into());
+    }
+    Ok(())
+}
+pub(crate) fn cancel(request_id: &str) -> Result<(), String> {
+    validate_request_id(request_id)?;
     let mut state = STATE
         .lock()
         .map_err(|_| "Official refresh lock unavailable")?;
-    if state.running {
+    if state.running && state.request_id.as_deref() == Some(request_id) {
         state.cancelled = true;
+    } else if !state.early_cancellations.iter().any(|id| id == request_id) {
+        // Cancellation may reach the worker before its refresh invocation.
+        // IDs are one-shot and this bounded tombstone set cannot affect others.
+        if state.early_cancellations.len() >= 32 {
+            state.early_cancellations.remove(0);
+        }
+        state.early_cancellations.push(request_id.to_string());
     }
     Ok(())
 }
@@ -86,8 +130,8 @@ fn timeout() -> Result<Duration, String> {
 }
 
 pub(crate) fn fetch(refresh: &Refresh) -> Result<String, String> {
-    let budget = timeout()?;
-    let deadline = Instant::now() + budget;
+    let deadline = refresh.deadline;
+    let budget = deadline.saturating_duration_since(Instant::now());
     let mut version_command = crate::codex_cli::command()?;
     version_command.arg("--version");
     let output = run(version_command, refresh, deadline, 4096)?;
@@ -127,6 +171,11 @@ fn run(
         .stdout(Stdio::piped())
         .stderr(Stdio::null());
     crate::runtime_paths::configure_no_window(&mut command);
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        command.process_group(0);
+    }
     let mut child = command
         .spawn()
         .map_err(|_| "Unable to start Official catalog helper")?;
@@ -141,7 +190,7 @@ fn run(
     };
     let stdout = child.stdout.take().expect("piped stdout");
     let (sender, receiver) = mpsc::channel();
-    std::thread::spawn(move || {
+    let reader = std::thread::spawn(move || {
         let mut bytes = Vec::new();
         let result = stdout
             .take(limit + 1)
@@ -190,8 +239,15 @@ fn run(
             }
         }
     })();
+    #[cfg(unix)]
+    unsafe {
+        libc::kill(-(child.id() as libc::pid_t), libc::SIGKILL);
+    }
+    #[cfg(windows)]
+    drop(_job);
     let _ = child.kill();
     let _ = child.wait();
+    let _ = reader.join();
     result
 }
 
@@ -224,10 +280,10 @@ mod tests {
     #[test]
     fn cancellation_stops_child_and_prevents_publication() {
         let _serial = TEST_LOCK.lock().unwrap();
-        let refresh = Refresh::begin().unwrap();
+        let refresh = Refresh::begin_for(Some("cancel-test")).unwrap();
         let canceller = std::thread::spawn(|| {
             std::thread::sleep(Duration::from_millis(150));
-            cancel().unwrap();
+            cancel("cancel-test").unwrap();
         });
         let error = run(
             python("import time; time.sleep(20)"),
@@ -242,7 +298,7 @@ mod tests {
         assert!(refresh
             .publish(|| {
                 published = true;
-                Ok(())
+                Ok::<(), String>(())
             })
             .is_err());
         assert!(!published);
@@ -267,5 +323,58 @@ mod tests {
         assert!(Refresh::begin().is_err());
         drop(refresh);
         assert!(Refresh::begin().is_ok());
+    }
+    #[test]
+    fn delayed_cancel_never_cancels_a_new_request() {
+        let _serial = TEST_LOCK.lock().unwrap();
+        drop(Refresh::begin_for(Some("previous")).unwrap());
+        let current = Refresh::begin_for(Some("current")).unwrap();
+        cancel("previous").unwrap();
+        current.check_current().unwrap();
+        drop(current);
+        cancel("not-started-yet").unwrap();
+        assert!(Refresh::begin_for(Some("not-started-yet"))
+            .unwrap_err()
+            .contains("cancelled"));
+    }
+    #[test]
+    fn deadline_expired_after_fetch_prevents_publication() {
+        let _serial = TEST_LOCK.lock().unwrap();
+        let mut refresh = Refresh::begin().unwrap();
+        refresh.deadline = Instant::now() - Duration::from_millis(1);
+        let mut published = false;
+        let result: Result<(), String> = refresh.publish(|| {
+            published = true;
+            Ok(())
+        });
+        assert!(result.unwrap_err().contains("timed out"));
+        assert!(!published);
+    }
+    #[test]
+    fn cancellation_reaps_a_descendant_that_inherits_stdout() {
+        let _serial = TEST_LOCK.lock().unwrap();
+        let refresh = Refresh::begin().unwrap();
+        let marker =
+            std::env::temp_dir().join(format!("catalog-child-marker-{}", std::process::id()));
+        let _ = std::fs::remove_file(&marker);
+        let child_code = format!(
+            "import time,pathlib; time.sleep(1); pathlib.Path({}).write_text('leaked')",
+            serde_json::to_string(&marker.to_string_lossy()).unwrap()
+        );
+        let code = format!(
+            "import subprocess,sys; subprocess.Popen([sys.executable,'-c',{}])",
+            serde_json::to_string(&child_code).unwrap()
+        );
+        let start = Instant::now();
+        let result = run(
+            python(&code),
+            &refresh,
+            start + Duration::from_millis(300),
+            4096,
+        );
+        assert!(result.unwrap_err().contains("timed out"));
+        assert!(start.elapsed() < Duration::from_secs(2));
+        std::thread::sleep(Duration::from_millis(1100));
+        assert!(!marker.exists(), "catalog descendant survived its deadline");
     }
 }

--- a/src-tauri/src/official_catalog.rs
+++ b/src-tauri/src/official_catalog.rs
@@ -1,0 +1,271 @@
+//! Subscription discovery owns a total deadline and never publishes a cache.
+use std::io::Read;
+use std::process::{Command, Stdio};
+use std::sync::{mpsc, Mutex};
+use std::time::{Duration, Instant};
+
+#[derive(Default)]
+struct State {
+    running: bool,
+    cancelled: bool,
+}
+static STATE: Mutex<State> = Mutex::new(State {
+    running: false,
+    cancelled: false,
+});
+pub(crate) struct Refresh;
+
+impl Refresh {
+    pub(crate) fn begin() -> Result<Self, String> {
+        let mut state = STATE
+            .lock()
+            .map_err(|_| "Official refresh lock unavailable")?;
+        if state.running {
+            return Err("Official refresh is already running".into());
+        }
+        *state = State {
+            running: true,
+            cancelled: false,
+        };
+        Ok(Self)
+    }
+    fn check(&self, deadline: Instant) -> Result<(), String> {
+        let state = STATE
+            .lock()
+            .map_err(|_| "Official refresh lock unavailable")?;
+        if state.cancelled {
+            return Err("Official model refresh cancelled".into());
+        }
+        if Instant::now() >= deadline {
+            return Err("Official model refresh timed out".into());
+        }
+        Ok(())
+    }
+    pub(crate) fn publish<T>(
+        &self,
+        write: impl FnOnce() -> Result<T, String>,
+    ) -> Result<T, String> {
+        let state = STATE
+            .lock()
+            .map_err(|_| "Official refresh lock unavailable")?;
+        if state.cancelled {
+            return Err("Official model refresh cancelled".into());
+        }
+        write()
+    }
+}
+impl Drop for Refresh {
+    fn drop(&mut self) {
+        if let Ok(mut state) = STATE.lock() {
+            *state = State::default();
+        }
+    }
+}
+pub(crate) fn cancel() -> Result<(), String> {
+    let mut state = STATE
+        .lock()
+        .map_err(|_| "Official refresh lock unavailable")?;
+    if state.running {
+        state.cancelled = true;
+    }
+    Ok(())
+}
+
+fn timeout() -> Result<Duration, String> {
+    let seconds = match std::env::var("CODEXHUB_OFFICIAL_MODELS_TIMEOUT_SECONDS") {
+        Ok(value) => value
+            .parse::<u64>()
+            .map_err(|_| "Official model timeout must be 1–300 seconds")?,
+        Err(std::env::VarError::NotPresent) => 30,
+        Err(_) => return Err("Invalid Official model timeout".into()),
+    };
+    if !(1..=300).contains(&seconds) {
+        return Err("Official model timeout must be 1–300 seconds".into());
+    }
+    Ok(Duration::from_secs(seconds))
+}
+
+pub(crate) fn fetch(refresh: &Refresh) -> Result<String, String> {
+    let budget = timeout()?;
+    let deadline = Instant::now() + budget;
+    let mut version_command = crate::codex_cli::command()?;
+    version_command.arg("--version");
+    let output = run(version_command, refresh, deadline, 4096)?;
+    let version = output
+        .trim()
+        .strip_prefix("codex-cli ")
+        .ok_or("Cannot determine the installed Codex CLI version")?
+        .trim();
+    let root = crate::runtime_paths::resource_root()?;
+    let python = crate::runtime_paths::find_python(Some(&root))?;
+    refresh.check(deadline)?;
+    let mut command = crate::runtime_paths::configured_python_command(&python);
+    command
+        .arg(root.join("src-python/official_catalog.py"))
+        .args([
+            "--client-version",
+            version,
+            "--timeout",
+            &budget.as_secs().to_string(),
+        ])
+        .env(
+            "CODEXHUB_CODEX_TARGET_HOME",
+            crate::runtime_paths::codex_target_home_dir()?,
+        );
+    run(command, refresh, deadline, 33 * 1024 * 1024)
+}
+
+fn run(
+    mut command: Command,
+    refresh: &Refresh,
+    deadline: Instant,
+    limit: u64,
+) -> Result<String, String> {
+    refresh.check(deadline)?;
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+    crate::runtime_paths::configure_no_window(&mut command);
+    let mut child = command
+        .spawn()
+        .map_err(|_| "Unable to start Official catalog helper")?;
+    #[cfg(windows)]
+    let _job = match crate::app_server::AppServerJob::assign_to(&child) {
+        Ok(job) => job,
+        Err(error) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(error);
+        }
+    };
+    let stdout = child.stdout.take().expect("piped stdout");
+    let (sender, receiver) = mpsc::channel();
+    std::thread::spawn(move || {
+        let mut bytes = Vec::new();
+        let result = stdout
+            .take(limit + 1)
+            .read_to_end(&mut bytes)
+            .map_err(|_| "Cannot read Official catalog helper output".to_string())
+            .and_then(|_| {
+                if bytes.len() as u64 > limit {
+                    Err("Official catalog response exceeds the size limit".into())
+                } else {
+                    String::from_utf8(bytes)
+                        .map_err(|_| "Invalid Official catalog helper output".into())
+                }
+            });
+        let _ = sender.send(result);
+    });
+    let result = (|| {
+        loop {
+            refresh.check(deadline)?;
+            match receiver.recv_timeout(Duration::from_millis(25)) {
+                Ok(output) => {
+                    let output = output?;
+                    // stdout EOF need not mean process exit. Keep the same deadline.
+                    loop {
+                        refresh.check(deadline)?;
+                        if let Some(status) = child
+                            .try_wait()
+                            .map_err(|_| "Cannot inspect Official catalog helper")?
+                        {
+                            if status.success() {
+                                return Ok(output);
+                            }
+                            // Only the helper's small, sanitized error field is surfaced.
+                            let error = serde_json::from_str::<serde_json::Value>(&output)
+                                .ok()
+                                .and_then(|v| {
+                                    v.get("error").and_then(|v| v.as_str()).map(str::to_string)
+                                })
+                                .unwrap_or_else(|| "Official catalog helper failed".into());
+                            return Err(error);
+                        }
+                        std::thread::sleep(Duration::from_millis(10));
+                    }
+                }
+                Err(mpsc::RecvTimeoutError::Timeout) => {}
+                Err(_) => return Err("Official catalog helper closed unexpectedly".into()),
+            }
+        }
+    })();
+    let _ = child.kill();
+    let _ = child.wait();
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+    fn python(code: &str) -> Command {
+        let root = crate::runtime_paths::resource_root().unwrap();
+        let python = crate::runtime_paths::find_python(Some(&root)).unwrap();
+        let mut command = crate::runtime_paths::configured_python_command(&python);
+        command.args(["-c", code]);
+        command
+    }
+    #[test]
+    fn total_deadline_terminates_stalled_child() {
+        let _serial = TEST_LOCK.lock().unwrap();
+        let refresh = Refresh::begin().unwrap();
+        let start = Instant::now();
+        let error = run(
+            python("import time; time.sleep(20)"),
+            &refresh,
+            start + Duration::from_millis(250),
+            4096,
+        )
+        .unwrap_err();
+        assert!(error.contains("timed out"), "{error}");
+        assert!(start.elapsed() < Duration::from_secs(3));
+    }
+    #[test]
+    fn cancellation_stops_child_and_prevents_publication() {
+        let _serial = TEST_LOCK.lock().unwrap();
+        let refresh = Refresh::begin().unwrap();
+        let canceller = std::thread::spawn(|| {
+            std::thread::sleep(Duration::from_millis(150));
+            cancel().unwrap();
+        });
+        let error = run(
+            python("import time; time.sleep(20)"),
+            &refresh,
+            Instant::now() + Duration::from_secs(30),
+            4096,
+        )
+        .unwrap_err();
+        canceller.join().unwrap();
+        assert!(error.contains("cancelled"));
+        let mut published = false;
+        assert!(refresh
+            .publish(|| {
+                published = true;
+                Ok(())
+            })
+            .is_err());
+        assert!(!published);
+    }
+    #[test]
+    fn excessive_output_fails_without_waiting_for_process_exit() {
+        let _serial = TEST_LOCK.lock().unwrap();
+        let refresh = Refresh::begin().unwrap();
+        let error = run(
+            python("import sys,time; print('x'*10000); sys.stdout.flush(); time.sleep(20)"),
+            &refresh,
+            Instant::now() + Duration::from_secs(5),
+            4096,
+        )
+        .unwrap_err();
+        assert!(error.contains("size limit"), "{error}");
+    }
+    #[test]
+    fn only_one_refresh_can_own_cancellation() {
+        let _serial = TEST_LOCK.lock().unwrap();
+        let refresh = Refresh::begin().unwrap();
+        assert!(Refresh::begin().is_err());
+        drop(refresh);
+        assert!(Refresh::begin().is_ok());
+    }
+}

--- a/src-tauri/src/official_refresh.rs
+++ b/src-tauri/src/official_refresh.rs
@@ -230,6 +230,10 @@ pub(crate) fn refresh_manual(
 /// the Codex Desktop process. This is the manual Refresh path while Codex is
 /// running; applying a new managed overlay remains a separate mutating flow.
 pub(crate) fn refresh_current_models() -> Result<OfficialRefreshResult, String> {
+    refresh_current_models_with_request(None)
+}
+
+pub(crate) fn refresh_current_models_with_request(request_id: Option<&str>) -> Result<OfficialRefreshResult, String> {
     if !config::get_settings()?.include_official_models {
         return Ok(OfficialRefreshResult {
             models: Vec::new(),
@@ -239,7 +243,7 @@ pub(crate) fn refresh_current_models() -> Result<OfficialRefreshResult, String> 
         });
     }
     read_only_refresh_result(
-        models::read_official_models_direct(),
+        models::read_official_models_direct(request_id),
         models::list_cached_official_models,
     )
 }
@@ -452,7 +456,7 @@ fn refresh_once(
             let (files, budgets) = prepare_catalog_publication(&overlays).map_err(|error| {
                 persist_failed_publication_if_stopped(&state_path, &mut state, error)
             })?;
-            let committed = commit_refresh_if_codex_stopped(|| {
+            let committed = acquisition.publish(|| commit_refresh_if_codex_stopped(|| {
                 publish_prepared_snapshot(
                     &state_path,
                     &mut state,
@@ -461,7 +465,7 @@ fn refresh_once(
                     &files,
                     budgets,
                 )
-            });
+            }));
             let publication = match committed {
                 Ok(Some(publication)) => publication,
                 Ok(None) => return Err(commit_race_error().into()),
@@ -485,55 +489,9 @@ fn refresh_once(
                 warning: publication.warning,
             })
         }
-        Err(direct_error) => {
-            let models = models::list_cached_official_models().unwrap_or_default();
-            let (files, budgets) = prepare_catalog_publication(&[]).map_err(|error| {
-                persist_failed_publication_if_stopped(
-                    &state_path,
-                    &mut state,
-                    direct_official_refresh_failure_message(&direct_error, Some(&error)),
-                )
-            })?;
-            let committed = commit_refresh_if_codex_stopped(|| {
-                publish_prepared_snapshot(
-                    &state_path,
-                    &mut state,
-                    now,
-                    false,
-                    &files,
-                    budgets,
-                )
-            });
-            let publication = match committed {
-                Ok(Some(publication)) => publication,
-                Ok(None) => return Err(commit_race_error().into()),
-                Err(publication_error) if publication_error.rollback_failed() => {
-                    return Err(publication_error);
-                }
-                Err(publication_error) => {
-                    let error = direct_official_refresh_failure_message(
-                        &direct_error,
-                        Some(&publication_error.to_string()),
-                    );
-                    return Err(persist_failed_publication_if_stopped(
-                        &state_path,
-                        &mut state,
-                        error,
-                    )
-                    .into());
-                }
-            };
-            if !current_published_snapshot_available(&state) {
-                return Err(direct_official_refresh_failure_message(&direct_error, None).into());
-            }
-            Ok(RefreshOutcome {
-                trigger,
-                snapshot_available: true,
-                models,
-                restart_required: publication.restart_required,
-                warning: publication.warning,
-            })
-        }
+        // An unsuccessful discovery must never publish a degraded replacement.
+        // Existing validated caches remain available through the read paths.
+        Err(direct_error) => Err(direct_official_refresh_failure_message(&direct_error, None).into()),
     }
 }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "CodexHub",
-  "version": "0.1.9-beta.3.19",
+  "version": "0.1.9-beta.3.20",
   "identifier": "com.codexhub.app",
   "build": {
     "frontendDist": "../frontend/dist",

--- a/tests/test_codex_auth.py
+++ b/tests/test_codex_auth.py
@@ -157,7 +157,7 @@ class AccessTokenTests(unittest.TestCase):
                 _make_auth_json(Path(tmp), access_token=new, refresh_token="rotated")
                 yield lambda: None
             with patch("codex_auth.file_lock_for", another_owner_publishes), \
-                 patch("codex_auth.refresh") as refresh:
+                 patch("codex_auth.urlopen") as refresh:
                 self.assertEqual(codex_auth.access_token(path), new)
                 refresh.assert_not_called()
 

--- a/tests/test_codex_auth.py
+++ b/tests/test_codex_auth.py
@@ -145,6 +145,22 @@ class AccessTokenTests(unittest.TestCase):
             self.assertEqual(written["tokens"]["access_token"], new_token)
             self.assertEqual(written["tokens"]["refresh_token"], "rt.new")
 
+    def test_waiting_refresh_reuses_tokens_published_by_other_process(self):
+        from contextlib import contextmanager
+        old = _make_jwt({"exp": 1, "client_id": "app_x"})
+        new = _make_jwt({"exp": int(time.time()) + 3600, "client_id": "app_x"})
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _make_auth_json(Path(tmp), access_token=old)
+            @contextmanager
+            def another_owner_publishes(lock_target):
+                self.assertNotEqual(lock_target, path)
+                _make_auth_json(Path(tmp), access_token=new, refresh_token="rotated")
+                yield lambda: None
+            with patch("codex_auth.file_lock_for", another_owner_publishes), \
+                 patch("codex_auth.refresh") as refresh:
+                self.assertEqual(codex_auth.access_token(path), new)
+                refresh.assert_not_called()
+
     def test_access_token_no_exp_refreshes_defensively(self):
         token = _make_jwt({"client_id": "app_x"})  # no exp
         new_token = _make_jwt({"exp": int(time.time()) + 3600, "client_id": "app_x"})

--- a/tests/test_issue_106_task_creation_lifecycle.py
+++ b/tests/test_issue_106_task_creation_lifecycle.py
@@ -115,7 +115,9 @@ def test_task_creation_evidence_reports_unavailable_boundary_sources_without_loc
     assert str(tmp_path) not in rendered
 
 
-def test_task_creation_boundary_guard_covers_bounded_app_server_probe_sites() -> None:
+def test_task_creation_boundary_guard_covers_both_metadata_transports() -> None:
+    assert Path("src-tauri/src/official_catalog.rs") in CHECKER.OWNERSHIP_BOUNDARY_PATHS
+    assert Path("src-python/official_catalog.py") in CHECKER.OWNERSHIP_BOUNDARY_PATHS
     assert Path("src-tauri/src/models.rs") in CHECKER.OWNERSHIP_BOUNDARY_PATHS
     assert Path("src-tauri/src/openai_usage.rs") in CHECKER.OWNERSHIP_BOUNDARY_PATHS
     assert CHECKER.validate_owned_boundary_sources(ROOT) == []

--- a/tests/test_official_catalog.py
+++ b/tests/test_official_catalog.py
@@ -92,3 +92,16 @@ def test_remote_errors_do_not_include_response_body():
 def test_identity_only_catalog_is_rejected():
     with pytest.raises(official_catalog.CatalogError, match="incomplete"):
         official_catalog.validate_models([{"slug": "gpt-new", "visibility": "list"}])
+
+
+def test_helper_serializes_unicode_metadata_on_legacy_windows_stdout():
+    document = {"models": [{"slug": "example", "display_name": "模型 ✨"}]}
+    buffer = io.BytesIO()
+    output = io.TextIOWrapper(buffer, encoding="cp1252")
+    with patch.object(official_catalog, "fetch_catalog", return_value=document), \
+         patch.object(official_catalog.sys, "argv", ["official_catalog.py", "--client-version", "0.153.4", "--timeout", "30"]), \
+         patch.object(official_catalog.sys, "stdout", output):
+        status = official_catalog.main()
+    output.flush()
+    assert status == 0
+    assert json.loads(buffer.getvalue().decode("utf-8")) == document

--- a/tests/test_official_catalog.py
+++ b/tests/test_official_catalog.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import pytest
 import official_catalog
+import codex_auth
 
 
 class Response(io.BytesIO):
@@ -13,15 +14,18 @@ class Response(io.BytesIO):
 
 def test_catalog_preserves_full_metadata_and_uses_subscription_auth():
     row = {"slug": "example", "visibility": "list", "context_window": 272000,
-           "future_metadata": {"nested": True}}
+           "future_metadata": {"nested": True}, "display_name": "Example", "shell_type": "shell_command",
+           "supported_in_api": True, "priority": 1, "supported_reasoning_levels": [],
+           "support_verbosity": False, "truncation_policy": {"mode": "bytes", "limit": 10000},
+           "experimental_supported_tools": []}
     def open_request(request, timeout):
         assert request.full_url.endswith("models?client_version=0.153.4")
         assert request.get_header("Authorization") == "Bearer test-secret"
         assert request.get_header("Chatgpt-account-id") == "account"
         assert timeout == 30
         return Response(json.dumps({"models": [row]}).encode())
-    with patch.object(official_catalog.codex_auth, "access_token", return_value="test-secret"), \
-         patch.object(official_catalog.codex_auth, "account_id", return_value="account"):
+    with patch.object(codex_auth, "access_token", return_value="test-secret"), \
+         patch.object(codex_auth, "account_id", return_value="account"):
         result = official_catalog.fetch_catalog("0.153.4", 30, opener=open_request)
     assert result["models"] == [row]
     assert result["etag"] == '"revision-1"'
@@ -31,8 +35,8 @@ def test_catalog_preserves_full_metadata_and_uses_subscription_auth():
 
 @pytest.mark.parametrize("body", [b'{}', b'{"models":null}', b'invalid'])
 def test_rejects_invalid_document(body):
-    with patch.object(official_catalog.codex_auth, "access_token", return_value="secret"), \
-         patch.object(official_catalog.codex_auth, "account_id", return_value=None):
+    with patch.object(codex_auth, "access_token", return_value="secret"), \
+         patch.object(codex_auth, "account_id", return_value=None):
         with pytest.raises(official_catalog.CatalogError):
             official_catalog.fetch_catalog("0.153.4", 30, opener=lambda *a, **k: Response(body))
 
@@ -65,8 +69,8 @@ def test_response_slower_than_cli_five_second_limit_is_accepted():
     thread.start()
     try:
         with patch.object(official_catalog, "ENDPOINT", f"http://127.0.0.1:{server.server_port}/models"), \
-             patch.object(official_catalog.codex_auth, "access_token", return_value="fake"), \
-             patch.object(official_catalog.codex_auth, "account_id", return_value=None):
+             patch.object(codex_auth, "access_token", return_value="fake"), \
+             patch.object(codex_auth, "account_id", return_value=None):
             result = official_catalog.fetch_catalog("0.153.4", 30, opener=build_opener().open)
         assert result["models"] == []
         assert result["etag"] == "slow-catalog"
@@ -79,7 +83,12 @@ def test_remote_errors_do_not_include_response_body():
     from urllib.error import HTTPError
     def fail(*args, **kwargs):
         raise HTTPError("https://chatgpt.com", 401, "secret", {}, io.BytesIO(b"private response"))
-    with patch.object(official_catalog.codex_auth, "access_token", return_value="secret"), \
-         patch.object(official_catalog.codex_auth, "account_id", return_value=None):
+    with patch.object(codex_auth, "access_token", return_value="secret"), \
+         patch.object(codex_auth, "account_id", return_value=None):
         with pytest.raises(official_catalog.CatalogError, match=r"^Official catalog request failed \(HTTP 401\)$"):
             official_catalog.fetch_catalog("0.153.4", 30, opener=fail)
+
+
+def test_identity_only_catalog_is_rejected():
+    with pytest.raises(official_catalog.CatalogError, match="incomplete"):
+        official_catalog.validate_models([{"slug": "gpt-new", "visibility": "list"}])

--- a/tests/test_official_catalog.py
+++ b/tests/test_official_catalog.py
@@ -1,0 +1,85 @@
+"""Direct subscription discovery must preserve the complete server document."""
+import io
+import json
+from unittest.mock import patch
+
+import pytest
+import official_catalog
+
+
+class Response(io.BytesIO):
+    headers = {"ETag": '"revision-1"'}
+
+
+def test_catalog_preserves_full_metadata_and_uses_subscription_auth():
+    row = {"slug": "example", "visibility": "list", "context_window": 272000,
+           "future_metadata": {"nested": True}}
+    def open_request(request, timeout):
+        assert request.full_url.endswith("models?client_version=0.153.4")
+        assert request.get_header("Authorization") == "Bearer test-secret"
+        assert request.get_header("Chatgpt-account-id") == "account"
+        assert timeout == 30
+        return Response(json.dumps({"models": [row]}).encode())
+    with patch.object(official_catalog.codex_auth, "access_token", return_value="test-secret"), \
+         patch.object(official_catalog.codex_auth, "account_id", return_value="account"):
+        result = official_catalog.fetch_catalog("0.153.4", 30, opener=open_request)
+    assert result["models"] == [row]
+    assert result["etag"] == '"revision-1"'
+    assert result["client_version"] == "0.153.4"
+    assert result["fetched_at"].endswith("Z")
+
+
+@pytest.mark.parametrize("body", [b'{}', b'{"models":null}', b'invalid'])
+def test_rejects_invalid_document(body):
+    with patch.object(official_catalog.codex_auth, "access_token", return_value="secret"), \
+         patch.object(official_catalog.codex_auth, "account_id", return_value=None):
+        with pytest.raises(official_catalog.CatalogError):
+            official_catalog.fetch_catalog("0.153.4", 30, opener=lambda *a, **k: Response(body))
+
+
+def test_redirects_are_not_followed_with_credentials():
+    from urllib.request import Request
+    from urllib.error import HTTPError
+    with pytest.raises(HTTPError):
+        official_catalog.NoRedirect().redirect_request(
+            Request("https://chatgpt.com", headers={"Authorization": "Bearer secret"}),
+            None, 302, "redirect", {}, "https://elsewhere.example")
+
+
+def test_response_slower_than_cli_five_second_limit_is_accepted():
+    import threading
+    import time
+    from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+    from urllib.request import build_opener
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            time.sleep(5.1)
+            self.send_response(200)
+            self.send_header("ETag", "slow-catalog")
+            self.end_headers()
+            self.wfile.write(b'{"models":[]}')
+        def log_message(self, *args):
+            pass
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        with patch.object(official_catalog, "ENDPOINT", f"http://127.0.0.1:{server.server_port}/models"), \
+             patch.object(official_catalog.codex_auth, "access_token", return_value="fake"), \
+             patch.object(official_catalog.codex_auth, "account_id", return_value=None):
+            result = official_catalog.fetch_catalog("0.153.4", 30, opener=build_opener().open)
+        assert result["models"] == []
+        assert result["etag"] == "slow-catalog"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_remote_errors_do_not_include_response_body():
+    from urllib.error import HTTPError
+    def fail(*args, **kwargs):
+        raise HTTPError("https://chatgpt.com", 401, "secret", {}, io.BytesIO(b"private response"))
+    with patch.object(official_catalog.codex_auth, "access_token", return_value="secret"), \
+         patch.object(official_catalog.codex_auth, "account_id", return_value=None):
+        with pytest.raises(official_catalog.CatalogError, match=r"^Official catalog request failed \(HTTP 401\)$"):
+            official_catalog.fetch_catalog("0.153.4", 30, opener=fail)

--- a/tests/test_python_runtime.py
+++ b/tests/test_python_runtime.py
@@ -27,6 +27,7 @@ DIRECT_PYTHON_ENTRYPOINTS = (
     "src-python/global_state_repair.py",
     "src-python/history_consolidate.py",
     "src-python/history_overlay.py",
+    "src-python/official_catalog.py",
     "src-python/probe_upstream_format.py",
     "scripts/analyze_transport_failures.py",
     "scripts/audit_issue_62_runtime_artifacts.py",

--- a/tests/test_python_runtime.py
+++ b/tests/test_python_runtime.py
@@ -326,7 +326,7 @@ def test_relative_windows_entrypoints_keep_the_repository_runtime_contract() -> 
         "-DryRun",
     )
     assert portable_plan.returncode == 0, portable_plan.stdout + portable_plan.stderr
-    assert '"version":"0.1.9-beta.3.19"' in portable_plan.stdout
+    assert '"version":"0.1.9-beta.3.20"' in portable_plan.stdout
 
     runtime_check = _run_relative_powershell_script(
         r".\scripts\Prepare-PythonRuntime.ps1", "-CheckOnly"

--- a/tests/test_release_channel_scripts.py
+++ b/tests/test_release_channel_scripts.py
@@ -44,7 +44,7 @@ def test_official_transport_wheel_is_pinned_and_packaged():
 
 
 def test_release_version_is_consistent_across_manifests():
-    expected = "0.1.9-beta.3.19"
+    expected = "0.1.9-beta.3.20"
     tauri = json.loads((ROOT / "src-tauri" / "tauri.conf.json").read_text(encoding="utf-8"))
     cargo = tomllib.loads((ROOT / "src-tauri" / "Cargo.toml").read_text(encoding="utf-8"))
     cargo_lock = tomllib.loads((ROOT / "src-tauri" / "Cargo.lock").read_text(encoding="utf-8"))


### PR DESCRIPTION
CodexHub 的官方模型刷新此前依赖 CLI 固定 5 秒超时，网络较慢时无法取得完整目录。本次复用现有 Codex ChatGPT 订阅登录直接请求完整目录，提供默认 30 秒的可配置总超时和取消，并在验证元数据后才发布缓存。

刷新保留排序、开关和未保存编辑；失败不覆盖已有目录，没有新可见模型时不产生保存提示。修复重新打开后旧快照覆盖保存顺序的问题，以及 Windows Unicode 管道输出和订阅目录缺省上下文百分比的兼容问题。版本为 0.1.9-beta.3.20。

验证：双平台 Python/Rust/Clippy 基线检查通过；最终增量 Rust Linux 694 项、Windows 696 项通过，目录模块 9 项在双平台通过。前端 82 项、Linux 模型工作流 E2E 15 项和原生窗口输入通过。候选实际 CLI 矩阵双平台各 8/8，Windows 从空缓存初始化。候选 15 个文件、四个签名及跨平台更新清单通过核验。未新增 Windows UI E2E。

合入后将绑定最终 main SHA 重建并验证正式发布产物。未更改用户安装，不强制重启 Codex App。

Fixes #502
