### PR TITLE
Echo portable official reasoning into Chat Completions

### DIFF
--- a/docs/evidence/issue-66/chat-conversion-matrix.json
+++ b/docs/evidence/issue-66/chat-conversion-matrix.json
@@ -11,7 +11,7 @@
     },
     "protocol_translation": {
       "file": "src-python/protocol_translation.py",
-      "sha256": "edd4c19b638fe616bf32695129160f675ce272ba4b0ff23ffccc3a75d28a4b2e"
+      "sha256": "173492516bd13f62bd4f67b186206d1e2180264d305f6931696a52a9c4f91145"
     },
     "source_contract": {
       "file": "collaboration-runtime-contract.json",

--- a/src-python/gateway_relay.py
+++ b/src-python/gateway_relay.py
@@ -971,32 +971,17 @@ def relay_upstream_response(
                         preserve_reasoning_history=preserve_reasoning_history,
                     )
                 else:
-                    exchange = relay_context.prepared_exchange
-                    if not isinstance(exchange, PreparedExchange):
-                        exchange = PreparedExchange(
-                            inbound_format,
-                            upstream_format,
-                            b"",
-                            False,
+                    mutated_body = body
+                    if response_mutation_policy != MutationPolicy.TRANSPARENT:
+                        mutated_body = compatible_response_body(
+                            body,
+                            upstream_name,
+                            event_context=compatibility_event_context,
                         )
-                    def decode_to_caller(payload: bytes) -> bytes:
-                        try:
-                            return exchange.decode_response(
-                                payload,
-                                function_name_from_response_item=gateway_stream_semantics._chat_function_name_from_response_item,
-                            )
-                        except NonForwardable as exc:
-                            raise UpstreamProtocolTranslationError(exc) from exc
-                    if response_mutation_policy == MutationPolicy.TRANSPARENT:
-                        body = decode_to_caller(body)
-                    else:
-                        body = decode_to_caller(
-                            compatible_response_body(
-                                body,
-                                upstream_name,
-                                event_context=compatibility_event_context,
-                            )
-                        )
+                    body = _response_body_to_chat_completion_body(
+                        mutated_body,
+                        preserve_reasoning_history=preserve_reasoning_history,
+                    )
             elif upstream_format == "chat_completions":
                 if buffered_chat_sse_to_responses:
                     converted_body = body

--- a/src-python/protocol_translation.py
+++ b/src-python/protocol_translation.py
@@ -164,8 +164,26 @@ def _responses_reasoning_text(item: Mapping[str, Any]) -> str:
     request cannot cross the seam losslessly and must fail closed.
     """
 
+    text = _portable_output_reasoning_text(item, drop_encrypted=False)
+    if text is None:
+        raise UnsupportedProtocolTranslationError(
+            "unsupported_protocol_semantics",
+            "Cannot translate an empty Responses reasoning item to Chat Completions.",
+        )
+    return text
+
+
+def _portable_output_reasoning_text(
+    item: Mapping[str, Any],
+    *,
+    drop_encrypted: bool,
+) -> str | None:
+    """Return portable Chat reasoning text, or None when ciphertext-only output may be skipped."""
+
     summary = item.get("summary")
-    if not isinstance(summary, list):
+    if summary is None:
+        summary = []
+    elif not isinstance(summary, list):
         raise UnsupportedProtocolTranslationError(
             "unsupported_protocol_semantics",
             "Cannot translate a Responses reasoning item without a summary list.",
@@ -217,17 +235,19 @@ def _responses_reasoning_text(item: Mapping[str, Any]) -> str:
             if text and text not in texts:
                 texts.append(text)
     encrypted = item.get("encrypted_content")
-    if encrypted not in (None, ""):
+    if encrypted not in (None, "") and not drop_encrypted:
         raise UnsupportedProtocolTranslationError(
             "unsupported_protocol_semantics",
             "Cannot translate encrypted Responses reasoning content to Chat Completions.",
         )
-    if not texts:
-        raise UnsupportedProtocolTranslationError(
-            "unsupported_protocol_semantics",
-            "Cannot translate an empty Responses reasoning item to Chat Completions.",
-        )
-    return "\n".join(texts)
+    if texts:
+        return "\n".join(texts)
+    if drop_encrypted:
+        return None
+    raise UnsupportedProtocolTranslationError(
+        "unsupported_protocol_semantics",
+        "Cannot translate an empty Responses reasoning item to Chat Completions.",
+    )
 
 
 def _require_supported_chat_message_fields(message: Mapping[str, Any], label: str) -> None:
@@ -1756,7 +1776,9 @@ def response_body_to_chat_completion_body(
                     {"id", "type", "status", "summary", "content", "encrypted_content"},
                     "Responses output reasoning item",
                 )
-                reasoning_parts.append(_responses_reasoning_text(item))
+                portable = _portable_output_reasoning_text(item, drop_encrypted=True)
+                if portable:
+                    reasoning_parts.append(portable)
             elif item.get("type") == "message":
                 _require_supported_fields(
                     item,
@@ -1818,6 +1840,17 @@ def response_body_to_chat_completion_body(
                     "unsupported_protocol_semantics",
                     f"Cannot translate Responses output item type {item.get('type')!r} to Chat Completions.",
                 )
+
+    if not text_parts and not tool_calls and not reasoning_parts:
+        had_reasoning = any(
+            isinstance(item, dict) and item.get("type") == "reasoning"
+            for item in (output if isinstance(output, list) else [])
+        )
+        if had_reasoning:
+            raise UnsupportedProtocolTranslationError(
+                "unsupported_protocol_semantics",
+                "Cannot translate Responses output to Chat Completions without portable text, tools, or reasoning.",
+            )
 
     message: dict[str, Any] = {"role": "assistant", "content": "".join(text_parts) or None}
     if tool_calls:
@@ -3014,6 +3047,7 @@ class ResponsesToChatStreamConverter:
         self.completed = False
         self.preserve_reasoning_history = preserve_reasoning_history
         self._reasoning_texts_emitted: set[str] = set()
+        self._visible_output = False
 
     def _tool_state(self, item_id: str) -> dict[str, Any]:
         if item_id not in self.tool_states:
@@ -3028,6 +3062,8 @@ class ResponsesToChatStreamConverter:
         return self.tool_states[item_id]
 
     def _chunk(self, delta: Mapping[str, Any], finish_reason: str | None = None) -> dict[str, Any]:
+        if any(key in delta for key in ("content", "reasoning_content", "tool_calls")):
+            self._visible_output = True
         return {
             "id": self.response_id or f"chatcmpl_{uuid.uuid4().hex[:12]}",
             "object": "chat.completion.chunk",
@@ -3338,6 +3374,17 @@ class ResponsesToChatStreamConverter:
                             )
                     if any(isinstance(item, Mapping) and item.get("type") == "function_call" for item in output):
                         finish_reason = "tool_calls"
+            had_reasoning = False
+            if isinstance(response_obj, Mapping) and isinstance(response_obj.get("output"), list):
+                had_reasoning = any(
+                    isinstance(item, Mapping) and item.get("type") == "reasoning"
+                    for item in response_obj["output"]
+                )
+            if had_reasoning and not self._visible_output:
+                raise UnsupportedProtocolTranslationError(
+                    "unsupported_protocol_semantics",
+                    "Cannot translate Responses output to Chat Completions without portable text, tools, or reasoning.",
+                )
             self.completed = True
             chunks.append(self._chunk({}, finish_reason=finish_reason))
             usage = response_obj.get("usage") if isinstance(response_obj, Mapping) else None
@@ -3817,6 +3864,7 @@ def events_to_responses_body(
     response_id = f"resp_{uuid.uuid4().hex[:12]}"
     model: str | None = None
     text_parts: list[str] = []
+    reasoning_summary_parts: list[str] = []
     current_item: dict[str, Any] | None = None
     usage: Mapping[str, Any] | None = None
     response_payload: dict[str, Any] = {}
@@ -3840,6 +3888,14 @@ def events_to_responses_body(
             delta = event.get("delta")
             if isinstance(delta, str):
                 text_parts.append(delta)
+        elif event_type == "response.reasoning_summary_text.delta":
+            delta = event.get("delta")
+            if isinstance(delta, str) and delta:
+                reasoning_summary_parts.append(delta)
+        elif event_type == "response.reasoning_summary_text.done":
+            text = event.get("text")
+            if isinstance(text, str) and text and not reasoning_summary_parts:
+                reasoning_summary_parts.append(text)
         elif event_type == "response.output_item.done":
             item = event.get("item")
             if isinstance(item, dict):
@@ -3868,6 +3924,19 @@ def events_to_responses_body(
                 if event_type == "response.incomplete"
                 else "completed"
             )
+
+    joined_reasoning = "".join(reasoning_summary_parts)
+    if joined_reasoning:
+        for item in output:
+            if not isinstance(item, dict) or item.get("type") != "reasoning":
+                continue
+            summary = item.get("summary")
+            has_text = isinstance(summary, list) and any(
+                isinstance(part, Mapping) and isinstance(part.get("text"), str) and part["text"]
+                for part in summary
+            )
+            if not has_text:
+                item["summary"] = [{"type": "summary_text", "text": joined_reasoning}]
 
     if text_parts and not any(item.get("type") == "message" for item in output):
         output.append(

--- a/src-python/route_plan.py
+++ b/src-python/route_plan.py
@@ -1742,9 +1742,9 @@ def route_plan_for_request(
                     else "none"
                 ),
                 preserve_reasoning_history=(
-                    _external_requires_reasoning_content_history(attempt_upstream)
-                    if upstream_name != "official"
-                    else False
+                    inbound_format == RouteProtocol.CHAT_COMPLETIONS.value
+                    if upstream_name == "official"
+                    else _external_requires_reasoning_content_history(attempt_upstream)
                 ),
                 named_mutations=frozenset(attempt_mutations),
                 fallback_http_statuses=(

--- a/tests/test_chat_completions_gateway.py
+++ b/tests/test_chat_completions_gateway.py
@@ -1118,7 +1118,7 @@ class ChatCompletionsEndpointTests(unittest.TestCase):
         self.assertEqual(result["choices"][0]["finish_reason"], "stop")
         self.assertEqual(handler._fake.status, 200)
 
-    def test_post_chat_completions_rejects_unsupported_upstream_response_semantics(self):
+    def test_post_chat_completions_maps_official_reasoning_summary_with_message(self):
         body = json.dumps({
             "model": "gpt-5.5",
             "messages": [{"role": "user", "content": "Hello"}],
@@ -1130,7 +1130,69 @@ class ChatCompletionsEndpointTests(unittest.TestCase):
             "object": "response",
             "status": "completed",
             "model": "gpt-5.5",
-            "output": [{"type": "reasoning", "summary": [{"type": "summary_text", "text": "private"}]}],
+            "output": [
+                {"type": "reasoning", "summary": [{"type": "summary_text", "text": "think first"}]},
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "Hi there!", "annotations": []}],
+                },
+            ],
+        }).encode("utf-8")
+
+        with patch("gateway_transport.official_urlopen", return_value=_FakeJsonResponse(upstream_body)):
+            CodexProxyHandler.do_POST(handler)
+
+        result = json.loads(b"".join(handler.wfile.writes))
+        self.assertEqual(handler._fake.status, 200)
+        message = result["choices"][0]["message"]
+        self.assertEqual(message["content"], "Hi there!")
+        self.assertEqual(message["reasoning_content"], "think first")
+
+    def test_post_chat_completions_drops_official_encrypted_reasoning_when_message_present(self):
+        body = json.dumps({
+            "model": "gpt-5.5",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "stream": False,
+        }).encode("utf-8")
+        handler = self._make_handler(body)
+        upstream_body = json.dumps({
+            "id": "resp_encrypted",
+            "object": "response",
+            "status": "completed",
+            "model": "gpt-5.5",
+            "output": [
+                {"type": "reasoning", "summary": [], "encrypted_content": "gAAAA ciphertext"},
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "Hi there!", "annotations": []}],
+                },
+            ],
+        }).encode("utf-8")
+
+        with patch("gateway_transport.official_urlopen", return_value=_FakeJsonResponse(upstream_body)):
+            CodexProxyHandler.do_POST(handler)
+
+        result = json.loads(b"".join(handler.wfile.writes))
+        self.assertEqual(handler._fake.status, 200)
+        message = result["choices"][0]["message"]
+        self.assertEqual(message["content"], "Hi there!")
+        self.assertNotIn("reasoning_content", message)
+
+    def test_post_chat_completions_rejects_ciphertext_only_official_reasoning(self):
+        body = json.dumps({
+            "model": "gpt-5.5",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "stream": False,
+        }).encode("utf-8")
+        handler = self._make_handler(body)
+        upstream_body = json.dumps({
+            "id": "resp_reasoning",
+            "object": "response",
+            "status": "completed",
+            "model": "gpt-5.5",
+            "output": [{"type": "reasoning", "summary": [], "encrypted_content": "gAAAA ciphertext"}],
         }).encode("utf-8")
 
         with patch("gateway_transport.official_urlopen", return_value=_FakeJsonResponse(upstream_body)):
@@ -1144,6 +1206,48 @@ class ChatCompletionsEndpointTests(unittest.TestCase):
             route_primitives.RETRY_FAILURE_PERMANENT,
         )
         self.assertFalse(result["codexhub_error"]["retryable"])
+
+    def test_post_chat_completions_streams_official_reasoning_summary_deltas(self):
+        body = json.dumps({
+            "model": "gpt-5.5",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "stream": True,
+        }).encode("utf-8")
+        handler = self._make_handler(body)
+        reasoning_item = {"id": "rs_1", "type": "reasoning", "status": "completed", "summary": []}
+        message = {
+            "id": "msg_1",
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "Hi there!", "annotations": []}],
+        }
+        events = [
+            {"type": "response.created", "response": {"id": "resp_stream", "model": "gpt-5.5"}},
+            {"type": "response.output_item.added", "item": reasoning_item},
+            {"type": "response.reasoning_summary_text.delta", "delta": "think "},
+            {"type": "response.reasoning_summary_text.delta", "delta": "first"},
+            {"type": "response.output_text.delta", "delta": "Hi there!"},
+            {"type": "response.completed", "response": {
+                "id": "resp_stream",
+                "status": "completed",
+                "model": "gpt-5.5",
+                "output": [reasoning_item, message],
+            }},
+        ]
+        stream = []
+        for event in events:
+            stream.extend([f"data: {json.dumps(event)}\n".encode(), b"\n"])
+        stream.append(b"")
+
+        with patch("gateway_transport.official_urlopen", return_value=_FakeSseResponse(stream)):
+            CodexProxyHandler.do_POST(handler)
+
+        written = b"".join(handler.wfile.writes)
+        self.assertEqual(handler._fake.status, 200)
+        self.assertIn(b"reasoning_content", written)
+        self.assertIn(b"think first", written)
+        self.assertIn(b"Hi there!", written)
+        self.assertIn(b"data: [DONE]", written)
 
     def test_post_chat_completions_events_use_proxy_request_kind(self):
         body = json.dumps({

--- a/tests/test_protocol_translation.py
+++ b/tests/test_protocol_translation.py
@@ -101,6 +101,107 @@ class ProtocolTranslationTests(unittest.TestCase):
         ]
         assert translated["messages"][1]["tool_call_id"] == "call_123"
 
+    def test_chat_output_maps_portable_reasoning_and_drops_ciphertext(self):
+        body = {
+            "id": "resp_out",
+            "status": "completed",
+            "model": "example-model",
+            "output": [
+                {
+                    "type": "reasoning",
+                    "summary": [{"type": "summary_text", "text": "think first"}],
+                    "encrypted_content": "gAAAA ciphertext",
+                },
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "hello"}],
+                },
+            ],
+        }
+        translated = json.loads(
+            protocol_translation.response_body_to_chat_completion_body(
+                json.dumps(body).encode("utf-8"),
+                preserve_reasoning_history=True,
+            )
+        )
+        message = translated["choices"][0]["message"]
+        self.assertEqual(message["content"], "hello")
+        self.assertEqual(message["reasoning_content"], "think first")
+
+    def test_chat_output_skips_ciphertext_only_reasoning_when_message_present(self):
+        body = {
+            "id": "resp_out",
+            "status": "completed",
+            "model": "example-model",
+            "output": [
+                {"type": "reasoning", "summary": [], "encrypted_content": "gAAAA ciphertext"},
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "hello"}],
+                },
+            ],
+        }
+        translated = json.loads(
+            protocol_translation.response_body_to_chat_completion_body(
+                json.dumps(body).encode("utf-8"),
+                preserve_reasoning_history=True,
+            )
+        )
+        message = translated["choices"][0]["message"]
+        self.assertEqual(message["content"], "hello")
+        self.assertNotIn("reasoning_content", message)
+
+    def test_chat_output_rejects_ciphertext_only_reasoning(self):
+        body = {
+            "id": "resp_out",
+            "status": "completed",
+            "model": "example-model",
+            "output": [{"type": "reasoning", "summary": [], "encrypted_content": "gAAAA ciphertext"}],
+        }
+        with self.assertRaises(protocol_translation.UnsupportedProtocolTranslationError) as raised:
+            protocol_translation.response_body_to_chat_completion_body(
+                json.dumps(body).encode("utf-8"),
+                preserve_reasoning_history=True,
+            )
+        self.assertEqual(raised.exception.code, "unsupported_protocol_semantics")
+
+    def test_chat_stream_emits_reasoning_content_deltas(self):
+        converter = protocol_translation.ResponsesToChatStreamConverter(
+            preserve_reasoning_history=True,
+        )
+        events = [
+            {"type": "response.created", "response": {"id": "resp_1", "model": "example-model"}},
+            {"type": "response.output_item.added", "item": {"id": "rs_1", "type": "reasoning", "summary": []}},
+            {"type": "response.reasoning_summary_text.delta", "delta": "think"},
+            {"type": "response.output_text.delta", "delta": "hi"},
+            {
+                "type": "response.completed",
+                "response": {
+                    "id": "resp_1",
+                    "output": [
+                        {"id": "rs_1", "type": "reasoning", "summary": [{"type": "summary_text", "text": "think"}]},
+                        {
+                            "type": "message",
+                            "role": "assistant",
+                            "content": [{"type": "output_text", "text": "hi"}],
+                        },
+                    ],
+                },
+            },
+        ]
+        deltas = []
+        for event in events:
+            for chunk in converter.chunks_for_event(event):
+                delta = chunk["choices"][0]["delta"]
+                if "reasoning_content" in delta or "content" in delta:
+                    deltas.append(delta)
+        self.assertEqual(
+            deltas,
+            [{"reasoning_content": "think"}, {"content": "hi"}],
+        )
+
     def test_responses_reasoning_history_requires_explicit_capability(self):
         body = {
             "model": "example-model",
@@ -2637,6 +2738,46 @@ class ProtocolTranslationTests(unittest.TestCase):
         self.assertEqual(input_done["item_id"], item["id"])
         self.assertEqual(input_done["input"], item["input"])
         self.assertEqual(reconstructed["output"], [item])
+
+    def test_events_to_responses_body_folds_reasoning_summary_deltas(self):
+        reconstructed = json.loads(
+            protocol_translation.events_to_responses_body(
+                [
+                    {
+                        "type": "response.output_item.done",
+                        "item": {"id": "rs_1", "type": "reasoning", "summary": []},
+                    },
+                    {"type": "response.reasoning_summary_text.delta", "delta": "think "},
+                    {"type": "response.reasoning_summary_text.delta", "delta": "first"},
+                    {
+                        "type": "response.output_item.done",
+                        "item": {
+                            "type": "message",
+                            "role": "assistant",
+                            "content": [{"type": "output_text", "text": "hi"}],
+                        },
+                    },
+                    {
+                        "type": "response.completed",
+                        "response": {
+                            "id": "resp_1",
+                            "status": "completed",
+                            "output": [
+                                {"id": "rs_1", "type": "reasoning", "summary": []},
+                                {
+                                    "type": "message",
+                                    "role": "assistant",
+                                    "content": [{"type": "output_text", "text": "hi"}],
+                                },
+                            ],
+                        },
+                    },
+                ],
+                require_completed=True,
+            )
+        )
+        reasoning = next(item for item in reconstructed["output"] if item["type"] == "reasoning")
+        self.assertEqual(reasoning["summary"], [{"type": "summary_text", "text": "think first"}])
 
     def test_events_to_responses_body_terminal_type_is_authoritative(self):
         cases = (

--- a/tests/test_route_plan_seam.py
+++ b/tests/test_route_plan_seam.py
@@ -41,6 +41,20 @@ class RoutePlanSeamTests(unittest.TestCase):
             route_primitives.BEHAVIOR_OFFICIAL_GATEWAY_COMPAT,
         )
 
+    def test_official_chat_inbound_preserves_reasoning_history(self):
+        chat_plan = route_plan.route_plan_for_request(
+            {"name": "official", "upstream_format": "responses"},
+            {"client_id": "zcode"},
+            inbound_format="chat_completions",
+        )
+        responses_plan = route_plan.route_plan_for_request(
+            {"name": "official", "upstream_format": "responses"},
+            {"client_id": "unknown"},
+            inbound_format="responses",
+        )
+        self.assertTrue(chat_plan.attempts[0].preserve_reasoning_history)
+        self.assertFalse(responses_plan.attempts[0].preserve_reasoning_history)
+
     def test_official_unknown_client_uses_gateway_compat_profile(self):
         upstream = {"name": "official"}
         context = {"client_id": "unknown"}


### PR DESCRIPTION
## Summary
- Official Chat inbound now preserves reasoning history so portable `summary` / `reasoning_text` maps to `reasoning_content` instead of 400ing.
- Ciphertext-only reasoning is dropped when assistant text or a tool call remains, and still fails closed when nothing portable is left.
- GATEWAY_ADAPTED SSE reconstruction folds `reasoning_summary_text` deltas into the Chat body.

Fixes part of #509 (acceptance 1).

## Test plan
- [x] Targeted: `./scripts/codexhub-python.sh -m pytest -q tests/test_protocol_translation.py tests/test_route_plan_seam.py tests/test_chat_completions_gateway.py tests/test_gateway_relay.py --ignore=tests/test_real_client_e2e.py`
- [x] Linux Python core: `./scripts/codexhub-python.sh -m pytest -q --ignore=tests/test_real_client_e2e.py`


Made with [Cursor](https://cursor.com)