### PR TITLE
Expand Chat Collaboration V2 into the official namespace

### DIFF
--- a/src-python/gateway_compat/official_passthrough.py
+++ b/src-python/gateway_compat/official_passthrough.py
@@ -337,6 +337,8 @@ def _runtime_tool_protocol_capabilities(
             baseline_protocol = tool_protocol
         if facts is not None:
             return RuntimeProtocolCapabilities.for_protocol(baseline_protocol, facts)
+        if str(upstream.get("name") or "").strip() == "official":
+            return RuntimeProtocolCapabilities.responses_structured()
         if baseline_protocol in {"chat_tools", "chat", "chat_completions"}:
             return RuntimeProtocolCapabilities.chat_tools()
         return RuntimeProtocolCapabilities()

--- a/src-python/gateway_compat/request.py
+++ b/src-python/gateway_compat/request.py
@@ -43,6 +43,10 @@ from runtime_tool_compatibility import (
     ToolCompatibilityPlan as RuntimeToolCompatibilityPlan,
     build_tool_compatibility_plan,
 )
+from tool_compatibility.collab_v2 import (
+    collapse_official_v2_names_for_chat as _collapse_official_v2_names_for_chat,
+    expand_chat_v2_for_official as _expand_chat_v2_for_official,
+)
 from tool_surface_adapter import (
     APPLY_PATCH_FUNCTION_NAME,
     INTERNAL_INPUT_ITEM_TYPES,
@@ -147,6 +151,9 @@ def compatible_request_body(
     if not isinstance(payload, dict):
         return body
 
+    if upstream_name == "official":
+        inject_codex_tools = False
+
     upstream_model = upstream.get("upstream_model")
     requested_model = payload.get("model")
     requested_reasoning = _official_passthrough._requested_reasoning_effort(payload)
@@ -194,11 +201,18 @@ def compatible_request_body(
             changed = True
         if _response._sanitize_official_system_messages(payload):
             changed = True
-        if not changed:
-            return body
-        return json.dumps(payload, ensure_ascii=True, separators=(",", ":")).encode("utf-8")
+        try:
+            if _expand_chat_v2_for_official(payload, event_context if isinstance(event_context, dict) else None):
+                changed = True
+                collaboration_protocol = _collaboration_adapter_module.resolve_boundary(
+                    payload,
+                    event_context,
+                    surface="request",
+                )
+        except RuntimeToolCompatibilityError as exc:
+            _official_passthrough._raise_runtime_tool_compatibility_error(exc)
 
-    if host._strip_reasoning_encrypted_content(payload):
+    if upstream_name != "official" and host._strip_reasoning_encrypted_content(payload):
         changed = True
 
     raw_provider_probe = _official_passthrough._is_raw_provider_probe_context(event_context)
@@ -220,7 +234,7 @@ def compatible_request_body(
     )
     if isinstance(event_context, dict):
         event_context["tool_protocol"] = tool_protocol
-    if not raw_provider_probe and not collaboration_v2:
+    if upstream_name != "official" and not raw_provider_probe and not collaboration_v2:
         if _multi_agent._validate_worker_binding_history(payload):
             changed = True
     bounded_tool_search_terminal_calls = (
@@ -274,7 +288,7 @@ def compatible_request_body(
         # direct helper caller does not provide a mutable event context.  If
         # this remains behind the ``dict`` check, a runtime plan can see the
         # original namespace and re-expand every child into aliases (#425).
-        if tool_surface_strategy == "deferred_core" or collaboration_v2:
+        if upstream_name != "official" and (tool_surface_strategy == "deferred_core" or collaboration_v2):
             # ``additional_tools`` is an internal carrier.  Only deferred
             # external routes, or the client-owned V2 adapter, need it
             # promoted so namespace pruning/runtime planning can inspect the
@@ -282,7 +296,7 @@ def compatible_request_body(
             # carrier byte-for-byte (#425).
             if _official_passthrough._hoist_additional_tools_input_items(payload):
                 changed = True
-        if tool_surface_strategy == "deferred_core" and isinstance(payload.get("tools"), list):
+        if upstream_name != "official" and tool_surface_strategy == "deferred_core" and isinstance(payload.get("tools"), list):
             tools = payload["tools"]
             tool_surface_source_tools = list(tools)
             deferred_namespace_tools = [
@@ -355,7 +369,7 @@ def compatible_request_body(
             runtime_tool_plan = _official_passthrough._runtime_tool_compatibility_plan(runtime_plan_context)
     if raw_provider_probe:
         pass
-    elif collaboration_v2:
+    elif collaboration_v2 and upstream_name != "official":
         # V2 must not run V1 semantic repair, but a third-party structured
         # Responses endpoint still cannot consume Codex's freeform
         # ``apply_patch`` history items. Keep this wire-only inverse adapter
@@ -389,7 +403,7 @@ def compatible_request_body(
             )
         ):
             changed = True
-    else:
+    elif upstream_name != "official":
         # ``additional_tools`` is a legacy Codex input carrier. Preserve it
         # byte-for-byte for eager providers; deferred_core alone promotes it
         # so the selected external surface policy can inspect namespaces.
@@ -632,7 +646,7 @@ def compatible_request_body(
 
     if _response._sanitize_unsupported_compaction_input_items(payload):
         changed = True
-    if host._sanitize_third_party_reasoning_items(
+    if upstream_name != "official" and host._sanitize_third_party_reasoning_items(
         payload,
         preserve_collaboration_agent_message_encryption=(
             collaboration_protocol == _COLLABORATION_V2

--- a/src-python/gateway_compat/response.py
+++ b/src-python/gateway_compat/response.py
@@ -42,6 +42,9 @@ from runtime_tool_compatibility import (
     ToolCompatibilityPlan as RuntimeToolCompatibilityPlan,
     build_tool_compatibility_plan,
 )
+from tool_compatibility.collab_v2 import (
+    collapse_official_v2_names_for_chat as _collapse_official_v2_names_for_chat,
+)
 from tool_surface_adapter import (
     APPLY_PATCH_FUNCTION_NAME,
     INTERNAL_INPUT_ITEM_TYPES,
@@ -506,7 +509,18 @@ def compatible_response_body(
 ) -> bytes:
     if upstream_name == "official":
         from . import collaboration_delivery
-        return collaboration_delivery.decode_body(body, event_context)
+        body = collaboration_delivery.decode_body(body, event_context)
+        try:
+            payload = json.loads(body.decode("utf-8-sig"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return body
+        if isinstance(payload, dict):
+            try:
+                if _collapse_official_v2_names_for_chat(payload, event_context):
+                    return json.dumps(payload, ensure_ascii=True, separators=(",", ":")).encode("utf-8")
+            except RuntimeToolCompatibilityError as exc:
+                _official_passthrough._raise_runtime_tool_compatibility_error(exc)
+        return body
     if _official_passthrough._is_raw_provider_probe_context(event_context):
         return body
 

--- a/src-python/tool_compatibility/collab_v2.py
+++ b/src-python/tool_compatibility/collab_v2.py
@@ -5,11 +5,15 @@ This module must not import the V1 adapter. V2 adaptation cannot execute V1 path
 
 from __future__ import annotations
 
+import copy
 import json
 from typing import Any, Mapping
 
 from collaboration_runtime_contract import (
     COLLABORATION_V2,
+    EXPECTED_PARAMETER_SCHEMAS,
+    V1_TOOLS,
+    V2_TOOLS,
     failed_argument_call_ids,
     CollaborationContractError,
     normalize_collaboration_arguments,
@@ -51,6 +55,289 @@ def strip_encrypted_annotations(value: Any) -> Any:
     if isinstance(value, list):
         return [strip_encrypted_annotations(child) for child in value]
     return value
+
+
+CHAT_OFFICIAL_V2_NAME_MAP_KEY = "_chat_official_v2_name_map"
+_V1_ONLY_TOOLS = frozenset(V1_TOOLS) - V2_NAMES
+
+
+def _v2_alias_to_name() -> dict[str, str]:
+    from .registry import RequestScopedToolAliasRegistry
+
+    registry = RequestScopedToolAliasRegistry(request_token="request")
+    mapping: dict[str, str] = {}
+    for index, name in enumerate(V2_TOOLS):
+        alias = registry.allocate_namespace(
+            declaration_index=0,
+            namespace=V2_NAMESPACE,
+            child_index=index,
+            child_name=name,
+            version="v2",
+        )
+        mapping[alias] = name
+    return mapping
+
+
+def _function_tool_name(declaration: Mapping[str, Any]) -> str | None:
+    name = declaration.get("name")
+    if isinstance(name, str) and name:
+        return name
+    function = declaration.get("function")
+    if isinstance(function, Mapping):
+        nested = function.get("name")
+        if isinstance(nested, str) and nested:
+            return nested
+    return None
+
+
+def _canonical_v2_name(name: str | None, alias_to_name: Mapping[str, str]) -> str | None:
+    if not isinstance(name, str) or not name:
+        return None
+    if name in V2_NAMES:
+        return name
+    return alias_to_name.get(name)
+
+
+def _official_v2_namespace(source_by_name: Mapping[str, Mapping[str, Any]]) -> dict[str, Any]:
+    children: list[dict[str, Any]] = []
+    schemas = EXPECTED_PARAMETER_SCHEMAS[COLLABORATION_V2]
+    for name in V2_TOOLS:
+        source = source_by_name[name]
+        description = source.get("description")
+        nested = source.get("function")
+        if not isinstance(description, str) and isinstance(nested, Mapping):
+            description = nested.get("description")
+        parameters = copy.deepcopy(schemas[name])
+        children.append(
+            {
+                "type": "function",
+                "name": name,
+                "description": description if isinstance(description, str) else name,
+                "strict": False,
+                "parameters": parameters,
+            }
+        )
+    return {
+        "type": "namespace",
+        "name": V2_NAMESPACE,
+        "description": V2_NAMESPACE,
+        "tools": children,
+    }
+
+
+def _expand_plaintext_agent_message(item: Mapping[str, Any]) -> tuple[dict[str, Any], bool]:
+    if item.get("type") != "message" or item.get("role") != "user":
+        return _copy_mapping(item), False
+    content = item.get("content")
+    if not isinstance(content, list) or len(content) != 1:
+        return _copy_mapping(item), False
+    part = content[0]
+    if not isinstance(part, Mapping):
+        return _copy_mapping(item), False
+    text = part.get("text")
+    if not isinstance(text, str) or not text.startswith(AGENT_MESSAGE_ENVELOPE_PREFIX):
+        return _copy_mapping(item), False
+    try:
+        original = json.loads(text[len(AGENT_MESSAGE_ENVELOPE_PREFIX) :])
+    except (TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise ToolCompatibilityError(
+            "tool_compatibility_boundary",
+            "unknown_agent_message_envelope",
+            surface="history",
+        ) from exc
+    if not isinstance(original, dict):
+        raise ToolCompatibilityError(
+            "tool_compatibility_boundary",
+            "unknown_agent_message_envelope",
+            surface="history",
+        )
+    try:
+        validate_agent_message(original)
+    except CollaborationContractError as exc:
+        raise ToolCompatibilityError(
+            "tool_compatibility_boundary",
+            exc.classification,
+            surface="history",
+        ) from exc
+    content_parts = original.get("content")
+    if isinstance(content_parts, list) and any(
+        isinstance(part, Mapping) and part.get("type") == "encrypted_content"
+        for part in content_parts
+    ):
+        raise ToolCompatibilityError(
+            "tool_compatibility_boundary",
+            "encrypted_agent_message_unavailable",
+            surface="history",
+        )
+    return original, True
+
+
+def expand_chat_v2_for_official(
+    payload: dict[str, Any],
+    event_context: Mapping[str, Any] | None = None,
+) -> bool:
+    """Fold a complete Chat V2 six-pack (or aliases) into the native namespace."""
+
+    tools = payload.get("tools")
+    if not isinstance(tools, list):
+        tools = []
+    alias_to_name = _v2_alias_to_name()
+    v2_sources: dict[str, Mapping[str, Any]] = {}
+    remaining: list[Any] = []
+    saw_v1 = False
+    saw_v2_name = False
+    for tool in tools:
+        if not isinstance(tool, Mapping):
+            remaining.append(tool)
+            continue
+        name = _function_tool_name(tool)
+        if name in _V1_ONLY_TOOLS:
+            saw_v1 = True
+            remaining.append(tool)
+            continue
+        canonical = _canonical_v2_name(name, alias_to_name)
+        if canonical is None:
+            remaining.append(tool)
+            continue
+        saw_v2_name = True
+        if canonical in v2_sources:
+            raise ToolCompatibilityError(
+                "tool_compatibility_boundary",
+                "namespace_child_duplicate",
+                surface="request",
+            )
+        v2_sources[canonical] = tool
+    if saw_v1:
+        raise ToolCompatibilityError(
+            "tool_compatibility_boundary",
+            "mixed_v1_v2",
+            surface="request",
+        )
+    if not saw_v2_name and not v2_sources:
+        input_items = payload.get("input")
+        if isinstance(input_items, list):
+            for item in input_items:
+                if not isinstance(item, Mapping):
+                    continue
+                if item.get("type") == "function_call":
+                    name = item.get("name")
+                    if name in _V1_ONLY_TOOLS:
+                        raise ToolCompatibilityError(
+                            "tool_compatibility_boundary",
+                            "mixed_v1_v2",
+                            surface="history",
+                        )
+                    if _canonical_v2_name(name if isinstance(name, str) else None, alias_to_name):
+                        raise ToolCompatibilityError(
+                            "tool_compatibility_boundary",
+                            "namespace_child_set_invalid",
+                            surface="history",
+                        )
+        return False
+    if set(v2_sources) != V2_NAMES:
+        raise ToolCompatibilityError(
+            "tool_compatibility_boundary",
+            "namespace_child_set_invalid",
+            surface="request",
+        )
+    if payload.get("tool_choice") not in (None, "auto"):
+        raise ToolCompatibilityError(
+            "tool_compatibility_boundary",
+            "tool_choice_invalid",
+            surface="request",
+        )
+    payload["tool_choice"] = "auto"
+    payload["tools"] = [_official_v2_namespace(v2_sources), *remaining]
+    name_map = {
+        canonical: _function_tool_name(source) or canonical
+        for canonical, source in v2_sources.items()
+    }
+    if isinstance(event_context, dict):
+        event_context[CHAT_OFFICIAL_V2_NAME_MAP_KEY] = name_map
+
+    input_items = payload.get("input")
+    if isinstance(input_items, list):
+        rewritten: list[Any] = []
+        for item in input_items:
+            if not isinstance(item, Mapping):
+                rewritten.append(item)
+                continue
+            if item.get("type") == "function_call":
+                next_item = _copy_mapping(item)
+                canonical = _canonical_v2_name(
+                    next_item.get("name") if isinstance(next_item.get("name"), str) else None,
+                    alias_to_name,
+                )
+                if canonical is None:
+                    if next_item.get("name") in _V1_ONLY_TOOLS:
+                        raise ToolCompatibilityError(
+                            "tool_compatibility_boundary",
+                            "mixed_v1_v2",
+                            surface="history",
+                        )
+                    rewritten.append(next_item)
+                    continue
+                encrypted_args = next_item.get("encrypted_function_args")
+                if encrypted_args not in (None, []):
+                    raise ToolCompatibilityError(
+                        "tool_compatibility_boundary",
+                        "encrypted_collaboration_arguments_unavailable",
+                        surface="history",
+                    )
+                arguments = next_item.get("arguments")
+                if isinstance(arguments, str) and arguments:
+                    try:
+                        parsed = json.loads(arguments)
+                    except (TypeError, ValueError, json.JSONDecodeError):
+                        parsed = None
+                    if isinstance(parsed, Mapping):
+                        validate_v2_fields(parsed)
+                next_item["name"] = canonical
+                next_item["namespace"] = V2_NAMESPACE
+                next_item["encrypted_function_args"] = []
+                rewritten.append(next_item)
+                continue
+            decoded, changed_item = _expand_plaintext_agent_message(item)
+            rewritten.append(decoded)
+        payload["input"] = rewritten
+    return True
+
+
+def collapse_official_v2_names_for_chat(
+    payload: dict[str, Any],
+    event_context: Mapping[str, Any] | None,
+) -> bool:
+    """Rewrite Official namespace names back to the Chat-declared spelling."""
+
+    name_map = (event_context or {}).get(CHAT_OFFICIAL_V2_NAME_MAP_KEY)
+    if not isinstance(name_map, Mapping) or not name_map:
+        return False
+    changed = False
+    output = payload.get("output")
+    if not isinstance(output, list):
+        return False
+    for item in output:
+        if not isinstance(item, dict) or item.get("type") != "function_call":
+            continue
+        original = item.get("name")
+        chat_name = name_map.get(original)
+        if isinstance(chat_name, str) and chat_name and chat_name != original:
+            item["name"] = chat_name
+            changed = True
+        encrypted_args = item.get("encrypted_function_args")
+        if encrypted_args not in (None, []):
+            raise ToolCompatibilityError(
+                "tool_compatibility_boundary",
+                "encrypted_collaboration_arguments_unavailable",
+                surface="response",
+            )
+        if "encrypted_function_args" in item:
+            item.pop("encrypted_function_args")
+            changed = True
+        if item.get("namespace") == V2_NAMESPACE:
+            item.pop("namespace", None)
+            changed = True
+    return changed
 
 
 def apply_v2_namespace_decode(result: dict[str, Any], record: Any) -> None:

--- a/tests/test_chat_completions_gateway.py
+++ b/tests/test_chat_completions_gateway.py
@@ -1160,6 +1160,59 @@ class ChatCompletionsEndpointTests(unittest.TestCase):
         self.assertEqual(handler._fake.status, 400)
         self.assertIn(b"prompt_cache_options", b"".join(handler.wfile.writes))
 
+    def test_post_chat_completions_expands_official_collaboration_v2_namespace(self):
+        from collaboration_runtime_contract import COLLABORATION_V2, EXPECTED_PARAMETER_SCHEMAS, V2_TOOLS
+
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": name,
+                    "description": name,
+                    "parameters": schema,
+                    "strict": False,
+                },
+            }
+            for name, schema in EXPECTED_PARAMETER_SCHEMAS[COLLABORATION_V2].items()
+        ]
+        body = json.dumps({
+            "model": "gpt-5.5",
+            "messages": [{"role": "user", "content": "delegate"}],
+            "tools": tools,
+            "tool_choice": "auto",
+            "stream": False,
+        }).encode("utf-8")
+        handler = self._make_handler(body)
+        call = {
+            "type": "function_call",
+            "id": "fc_spawn",
+            "call_id": "call_spawn",
+            "namespace": "collaboration",
+            "name": "spawn_agent",
+            "arguments": '{"task_name":"worker","message":"inspect"}',
+            "encrypted_function_args": [],
+        }
+        upstream_body = json.dumps({
+            "id": "resp_v2",
+            "object": "response",
+            "status": "completed",
+            "model": "gpt-5.5",
+            "output": [call],
+        }).encode("utf-8")
+
+        with patch("gateway_transport.official_urlopen", return_value=_FakeJsonResponse(upstream_body)) as mock_urlopen:
+            CodexProxyHandler.do_POST(handler)
+
+        sent_payload = json.loads(mock_urlopen.call_args.args[0].data)
+        self.assertEqual(sent_payload["tools"][0]["type"], "namespace")
+        self.assertEqual(sent_payload["tools"][0]["name"], "collaboration")
+        self.assertEqual({child["name"] for child in sent_payload["tools"][0]["tools"]}, set(V2_TOOLS))
+        result = json.loads(b"".join(handler.wfile.writes))
+        self.assertEqual(handler._fake.status, 200)
+        tool_call = result["choices"][0]["message"]["tool_calls"][0]
+        self.assertEqual(tool_call["id"], "call_spawn")
+        self.assertEqual(tool_call["function"]["name"], "spawn_agent")
+
     def test_post_chat_completions_maps_official_reasoning_summary_with_message(self):
         body = json.dumps({
             "model": "gpt-5.5",

--- a/tests/test_issue_509_chat_official_v2.py
+++ b/tests/test_issue_509_chat_official_v2.py
@@ -1,0 +1,334 @@
+from __future__ import annotations
+
+import copy
+import json
+
+import pytest
+
+from collaboration_runtime_contract import (
+    COLLABORATION_V2,
+    EXPECTED_PARAMETER_SCHEMAS,
+    V2_TOOLS,
+)
+from protocol_translation import (
+    chat_completion_to_response_body,
+    chat_completions_request_to_responses_body,
+    prepare_exchange,
+)
+from tool_compatibility.collab_v2 import AGENT_MESSAGE_ENVELOPE_PREFIX
+import gateway_compat
+import gateway_errors
+
+
+ARGUMENTS = {
+    "followup_task": {"target": "agent/root/worker", "message": "continue"},
+    "interrupt_agent": {"target": "agent/root/worker"},
+    "list_agents": {},
+    "send_message": {"target": "agent/root/worker", "message": "status"},
+    "spawn_agent": {"task_name": "worker", "message": "inspect"},
+    "wait_agent": {},
+}
+RESULTS = {
+    "followup_task": "",
+    "interrupt_agent": json.dumps({"previous_status": "running"}),
+    "list_agents": json.dumps({"agents": [{"agent_name": "worker", "agent_status": "running"}]}),
+    "send_message": "",
+    "spawn_agent": json.dumps({"task_name": "worker"}),
+    "wait_agent": json.dumps({"message": "done", "timed_out": False}),
+}
+
+
+def _official() -> dict:
+    return {"name": "official", "upstream_format": "responses"}
+
+
+def _chat_v2_functions() -> list[dict]:
+    tools = []
+    for name, schema in EXPECTED_PARAMETER_SCHEMAS[COLLABORATION_V2].items():
+        parameters = copy.deepcopy(schema)
+        tools.append(
+            {
+                "type": "function",
+                "name": name,
+                "description": name,
+                "strict": False,
+                "parameters": parameters,
+            }
+        )
+    return tools
+
+
+def _chat_request(*, tools: list | None = None, input_items: object = "use collaboration") -> bytes:
+    return json.dumps(
+        {
+            "model": "placeholder",
+            "messages": [{"role": "user", "content": "delegate"}],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": tool["name"],
+                        "description": tool["description"],
+                        "parameters": tool["parameters"],
+                        "strict": False,
+                    },
+                }
+                for tool in (tools if tools is not None else _chat_v2_functions())
+            ],
+            "tool_choice": "auto",
+        }
+    ).encode()
+
+
+def _prepared_official(*, tools: list | None = None, input_items: object | None = None) -> tuple[dict, dict]:
+    converted = chat_completions_request_to_responses_body(_chat_request(tools=tools))
+    payload = json.loads(converted)
+    if input_items is not None:
+        payload["input"] = input_items
+    context: dict = {}
+    prepared = gateway_compat.compatible_request_body(
+        json.dumps(payload).encode(),
+        _official(),
+        event_context=context,
+        inject_codex_tools=False,
+    )
+    return json.loads(prepared), context
+
+
+def test_chat_v2_functions_expand_to_official_namespace() -> None:
+    first, _ = _prepared_official()
+    second, _ = _prepared_official()
+    assert first["tools"][0]["type"] == "namespace"
+    assert first["tools"][0]["name"] == "collaboration"
+    assert {child["name"] for child in first["tools"][0]["tools"]} == set(V2_TOOLS)
+    assert first["tools"] == second["tools"]
+    assert first["tool_choice"] == "auto"
+
+
+def test_responses_inbound_official_keeps_native_namespace() -> None:
+    children = []
+    for name, schema in EXPECTED_PARAMETER_SCHEMAS[COLLABORATION_V2].items():
+        parameters = copy.deepcopy(schema)
+        children.append(
+            {
+                "type": "function",
+                "name": name,
+                "description": name,
+                "strict": False,
+                "parameters": parameters,
+            }
+        )
+    namespace = {
+        "type": "namespace",
+        "name": "collaboration",
+        "description": "collaboration",
+        "tools": children,
+    }
+    context: dict = {}
+    prepared = json.loads(
+        gateway_compat.compatible_request_body(
+            json.dumps(
+                {
+                    "model": "placeholder",
+                    "input": "delegate",
+                    "tools": [namespace],
+                    "tool_choice": "auto",
+                }
+            ).encode(),
+            _official(),
+            event_context=context,
+            inject_codex_tools=False,
+        )
+    )
+    assert prepared["tools"][0]["type"] == "namespace"
+    assert prepared["tools"][0]["name"] == "collaboration"
+    assert not any(
+        isinstance(tool, dict) and str(tool.get("name", "")).startswith("__codexhub_ns_")
+        for tool in prepared["tools"]
+    )
+
+
+@pytest.mark.parametrize("name", V2_TOOLS)
+def test_official_namespace_calls_collapse_to_chat_function_names(name: str) -> None:
+    official_request, context = _prepared_official()
+    call = {
+        "type": "function_call",
+        "id": f"fc_{name}",
+        "call_id": f"call_{name}",
+        "namespace": "collaboration",
+        "name": name,
+        "arguments": json.dumps(ARGUMENTS[name]),
+        "encrypted_function_args": [],
+    }
+    decoded = json.loads(
+        gateway_compat.compatible_response_body(
+            json.dumps({"output": [call]}).encode(),
+            "official",
+            context,
+        )
+    )
+    item = decoded["output"][0]
+    assert item["name"] == name
+    chat = json.loads(chat_completion_to_response_body(json.dumps({
+        "id": "chatcmpl-v2",
+        "object": "chat.completion",
+        "created": 1,
+        "model": "placeholder",
+        "choices": [{
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{
+                    "id": f"call_{name}",
+                    "type": "function",
+                    "function": {"name": item["name"], "arguments": json.dumps(ARGUMENTS[name])},
+                }],
+            },
+            "finish_reason": "tool_calls",
+        }],
+    }).encode()))
+    assert chat["output"][0]["name"] == name
+    assert chat["output"][0]["call_id"] == f"call_{name}"
+
+
+def test_chat_v2_history_gains_official_namespace() -> None:
+    call_id = "call_spawn_agent"
+    input_items = [
+        {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "continue"}]},
+        {
+            "type": "function_call",
+            "id": "item_spawn_agent",
+            "call_id": call_id,
+            "name": "spawn_agent",
+            "arguments": json.dumps(ARGUMENTS["spawn_agent"]),
+        },
+        {
+            "type": "function_call_output",
+            "id": "result_spawn_agent",
+            "call_id": call_id,
+            "output": RESULTS["spawn_agent"],
+        },
+    ]
+    prepared, _ = _prepared_official(input_items=input_items)
+    call = next(item for item in prepared["input"] if item.get("type") == "function_call")
+    assert call["namespace"] == "collaboration"
+    assert call["name"] == "spawn_agent"
+    assert call["encrypted_function_args"] == []
+
+
+def test_incomplete_v2_six_pack_fails_closed() -> None:
+    tools = _chat_v2_functions()[:-1]
+    with pytest.raises(gateway_errors.UpstreamProtocolTranslationError):
+        _prepared_official(tools=tools)
+
+
+def test_v1_only_chat_tools_fail_closed_on_official() -> None:
+    tools = [
+        {
+            "type": "function",
+            "name": "close_agent",
+            "description": "close",
+            "strict": False,
+            "parameters": {"type": "object", "properties": {}, "additionalProperties": False},
+        }
+    ]
+    with pytest.raises(gateway_errors.UpstreamProtocolTranslationError):
+        _prepared_official(tools=tools)
+
+
+def test_plaintext_agent_message_envelope_expands_on_official() -> None:
+    original = {
+        "type": "agent_message",
+        "id": "agent_message_child",
+        "author": "agent/root",
+        "recipient": "agent/root/worker",
+        "content": [{"type": "input_text", "text": "child task"}],
+    }
+    envelope = AGENT_MESSAGE_ENVELOPE_PREFIX + json.dumps(
+        original,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    prepared, context = _prepared_official(
+        input_items=[
+            {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": envelope}],
+            }
+        ]
+    )
+    assert context["collaboration_protocol"] == COLLABORATION_V2
+    assert prepared["input"][0]["type"] == "agent_message"
+    assert prepared["input"][0]["id"] == "agent_message_child"
+
+
+def test_encrypted_agent_message_envelope_fails_closed() -> None:
+    original = {
+        "type": "agent_message",
+        "id": "agent_message_child",
+        "author": "agent/root",
+        "recipient": "agent/root/worker",
+        "content": [{"type": "encrypted_content", "encrypted_content": "secret"}],
+    }
+    envelope = AGENT_MESSAGE_ENVELOPE_PREFIX + json.dumps(
+        original,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    converted = chat_completions_request_to_responses_body(_chat_request())
+    payload = json.loads(converted)
+    payload["input"] = [
+        {
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": envelope}],
+        }
+    ]
+    with pytest.raises(gateway_errors.UpstreamProtocolTranslationError):
+        gateway_compat.compatible_request_body(
+            json.dumps(payload).encode(),
+            _official(),
+            event_context={},
+            inject_codex_tools=False,
+        )
+
+
+def test_prepare_exchange_then_official_expand_round_trips_cache_key() -> None:
+    body = json.dumps(
+        {
+            "model": "placeholder",
+            "messages": [{"role": "user", "content": "delegate"}],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": tool["name"],
+                        "description": tool["description"],
+                        "parameters": tool["parameters"],
+                        "strict": False,
+                    },
+                }
+                for tool in _chat_v2_functions()
+            ],
+            "prompt_cache_key": "stable-session",
+        }
+    ).encode()
+    exchange = prepare_exchange(
+        body,
+        inbound_format="chat_completions",
+        outbound_format="responses",
+    )
+    context: dict = {}
+    prepared = json.loads(
+        gateway_compat.compatible_request_body(
+            exchange.upstream_body,
+            _official(),
+            event_context=context,
+            inject_codex_tools=False,
+        )
+    )
+    assert prepared["tools"][0]["name"] == "collaboration"


### PR DESCRIPTION
## Summary
- Official gateway-compat no longer returns before `runtime_tool_compatibility`.
- Chat→official expands a complete V2 six-tool set (or existing aliases) into `{type: namespace, name: collaboration}`.
- Official namespace calls collapse back to Chat `function_call` / `tool_call_id`.
- Encrypted handoff, V1 tools, and an incomplete six-pack fail closed. Responses inbound stays native.

Stacked on #511. Fixes part of #509 (acceptance 3).

## Test plan
- [x] Targeted: `./scripts/codexhub-python.sh -m pytest -q tests/test_issue_509_chat_official_v2.py tests/test_chat_completions_gateway.py tests/test_issue_394_chat_collaboration_v2.py tests/test_issue_282_collaboration_v2.py tests/test_issue_198_v1_v2_isolation.py tests/test_runtime_tool_compatibility_integration.py tests/test_compaction_request_compatibility.py tests/test_subagent_execution_regressions.py tests/test_issue_283_v2_lifecycle_fixture.py tests/test_collaboration_timeout_contract.py --ignore=tests/test_real_client_e2e.py`
- [x] Linux Python core: `./scripts/codexhub-python.sh -m pytest -q --ignore=tests/test_real_client_e2e.py`


Made with [Cursor](https://cursor.com)